### PR TITLE
feat: external idle reaper pauses lease and closes chat session

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -51,7 +51,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 class ChatSessionPolicy:
     """Policy configuration for ChatSession lifecycle."""
 
-    idle_ttl_sec: int = 600
+    idle_ttl_sec: int = 300
     max_duration_sec: int = 86400
 
 
@@ -441,7 +441,8 @@ class ChatSessionManager:
             rows = conn.execute(
                 """
                 SELECT chat_session_id AS session_id, thread_id, terminal_id, lease_id,
-                       runtime_id, status, budget_json, started_at, last_active_at,
+                       runtime_id, status, idle_ttl_sec, max_duration_sec,
+                       budget_json, started_at, last_active_at,
                        ended_at, close_reason
                 FROM chat_sessions
                 WHERE status IN ('active', 'idle', 'paused')

--- a/services/web/main.py
+++ b/services/web/main.py
@@ -28,6 +28,7 @@ from tui.config import ConfigManager
 DB_PATH = Path.home() / ".leon" / "leon.db"
 SANDBOXES_DIR = Path.home() / ".leon" / "sandboxes"
 LOCAL_WORKSPACE_ROOT = Path.cwd().resolve()
+IDLE_REAPER_INTERVAL_SEC = 30
 
 
 # --- Request models ---
@@ -228,6 +229,42 @@ def _is_virtual_thread_id(thread_id: str | None) -> bool:
     return bool(thread_id) and thread_id.startswith("(") and thread_id.endswith(")")
 
 
+def _run_idle_reaper_once(app_obj: FastAPI) -> int:
+    """External idle manager: enforce idle timeout across providers."""
+    total = 0
+    managed_providers: set[str] = set()
+
+    # First use live managers from resident agents (can close live runtimes safely).
+    for agent in app_obj.state.agent_pool.values():
+        sandbox = getattr(agent, "_sandbox", None)
+        manager = getattr(sandbox, "manager", None)
+        if manager is None:
+            continue
+        provider_name = str(getattr(manager.provider, "name", ""))
+        managed_providers.add(provider_name)
+        total += manager.enforce_idle_timeouts()
+
+    # Then cover providers without resident agent (DB-only cleanup).
+    _, managers = _init_providers_and_managers()
+    for provider_name, manager in managers.items():
+        if provider_name in managed_providers:
+            continue
+        total += manager.enforce_idle_timeouts()
+
+    return total
+
+
+async def _idle_reaper_loop(app_obj: FastAPI) -> None:
+    while True:
+        try:
+            count = await asyncio.to_thread(_run_idle_reaper_once, app_obj)
+            if count > 0:
+                print(f"[idle-reaper] paused+closed {count} expired chat session(s)")
+        except Exception as e:
+            print(f"[idle-reaper] error: {e}")
+        await asyncio.sleep(IDLE_REAPER_INTERVAL_SEC)
+
+
 # --- Lifespan + App ---
 
 @asynccontextmanager
@@ -239,10 +276,19 @@ async def lifespan(app: FastAPI):
     app.state.thread_sandbox: dict[str, str] = {}
     app.state.thread_locks: dict[str, asyncio.Lock] = {}
     app.state.thread_locks_guard = asyncio.Lock()
+    app.state.idle_reaper_task: asyncio.Task | None = None
 
     try:
+        app.state.idle_reaper_task = asyncio.create_task(_idle_reaper_loop(app))
         yield
     finally:
+        task = app.state.idle_reaper_task
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         for agent in app.state.agent_pool.values():
             try:
                 agent.close()
@@ -902,11 +948,15 @@ async def run_thread(thread_id: str, payload: RunRequest) -> EventSourceResponse
                 if hasattr(agent, "_sandbox"):
                     def _prime_sandbox() -> None:
                         mgr = agent._sandbox.manager
-                        session = mgr.session_manager.get(thread_id)
-                        if session and session.status == "paused":
-                            if not agent._sandbox.resume_thread(thread_id):
-                                raise RuntimeError(f"Failed to auto-resume paused sandbox for thread {thread_id}")
+                        mgr.enforce_idle_timeouts()
                         agent._sandbox.ensure_session(thread_id)
+                        terminal = mgr.terminal_store.get(thread_id)
+                        lease = mgr.lease_store.get(terminal.lease_id) if terminal else None
+                        if lease and mgr.provider.name != "local":
+                            lease_status = lease.refresh_instance_status(mgr.provider)
+                            if lease_status == "paused":
+                                if not agent._sandbox.resume_thread(thread_id):
+                                    raise RuntimeError(f"Failed to auto-resume paused sandbox for thread {thread_id}")
 
                     await asyncio.to_thread(_prime_sandbox)
 

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -60,7 +60,7 @@ class TestChatSessionPolicy:
     def test_default_policy(self):
         """Test default policy values."""
         policy = ChatSessionPolicy()
-        assert policy.idle_ttl_sec == 600
+        assert policy.idle_ttl_sec == 300
         assert policy.max_duration_sec == 86400
 
     def test_custom_policy(self):

--- a/tests/test_manager_ground_truth.py
+++ b/tests/test_manager_ground_truth.py
@@ -1,6 +1,9 @@
 """Tests for SandboxManager inspect ground-truth behavior."""
 
+import asyncio
+from datetime import datetime, timedelta
 from pathlib import Path
+import sqlite3
 import tempfile
 import uuid
 
@@ -102,5 +105,35 @@ def test_list_sessions_includes_provider_orphan() -> None:
             r["instance_id"] == orphan.session_id and r["source"] == "provider_orphan"
             for r in rows
         )
+    finally:
+        db.unlink(missing_ok=True)
+
+
+def test_enforce_idle_timeouts_pauses_lease_and_closes_session() -> None:
+    db = _temp_db()
+    try:
+        provider = FakeProvider()
+        mgr = SandboxManager(provider=provider, db_path=db)
+
+        capability = mgr.get_sandbox("thread-1")
+        asyncio.run(capability.command.execute("echo hi"))
+        session_id = capability._session.session_id
+        instance_id = capability._session.lease.get_instance().instance_id
+
+        with sqlite3.connect(str(db)) as conn:
+            conn.execute(
+                """
+                UPDATE chat_sessions
+                SET idle_ttl_sec = 1, last_active_at = ?
+                WHERE chat_session_id = ?
+                """,
+                ((datetime.now() - timedelta(seconds=5)).isoformat(), session_id),
+            )
+            conn.commit()
+
+        count = mgr.enforce_idle_timeouts()
+        assert count == 1
+        assert provider.get_session_status(instance_id) == "paused"
+        assert mgr.session_manager.get("thread-1") is None
     finally:
         db.unlink(missing_ok=True)


### PR DESCRIPTION
Scope: implement idle-timeout auto pause behavior.\n\nChanges:\n- add SandboxManager.enforce_idle_timeouts\n- for expired chat sessions: pause remote lease instance first, then close chat session runtime\n- add background idle reaper loop in web backend lifespan\n- enforce idle-timeout convergence before each run execution\n- set default ChatSessionPolicy idle_ttl_sec to 300 seconds\n- add regression tests for policy default and manager idle-timeout behavior\n\nValidation:\n- .venv/bin/pytest -q tests/test_chat_session.py tests/test_manager_ground_truth.py tests/test_integration_new_arch.py\n- real Daytona e2e in local environment