### PR TITLE
fix: normalize OpenAI GPT-5 token parameter

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -30,6 +30,7 @@ if _env_file.exists():
 
 from agent_profile import AgentProfile
 from middleware.command import CommandMiddleware
+from model_params import normalize_model_kwargs
 
 # 导入 hooks
 from middleware.command.hooks.dangerous_commands import DangerousCommandsHook
@@ -336,7 +337,7 @@ class LeonAgent:
 
     def _create_model(self):
         """Initialize model with all parameters passed to init_chat_model."""
-        kwargs = self._build_model_kwargs()
+        kwargs = normalize_model_kwargs(self.model_name, self._build_model_kwargs())
         return init_chat_model(self.model_name, api_key=self.api_key, **kwargs)
 
     def _build_model_kwargs(self) -> dict:

--- a/middleware/task/subagent.py
+++ b/middleware/task/subagent.py
@@ -10,6 +10,7 @@ from typing import Any
 from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 from langchain_core.tools import tool
+from model_params import normalize_model_kwargs
 
 from .types import AgentConfig, TaskParams, TaskResult
 
@@ -170,7 +171,8 @@ class SubagentRunner:
         model_name = params.get("Model") or config.model or self.parent_model
 
         # Build model (unified path via init_chat_model)
-        model = init_chat_model(model_name, api_key=self.api_key, **self.model_kwargs)
+        model_kwargs = normalize_model_kwargs(model_name, self.model_kwargs)
+        model = init_chat_model(model_name, api_key=self.api_key, **model_kwargs)
 
         # Build filtered middleware
         middleware = self._build_subagent_middleware(config, all_middleware)
@@ -253,7 +255,8 @@ class SubagentRunner:
         model_name = params.get("Model") or config.model or self.parent_model
 
         # Build model
-        model = init_chat_model(model_name, api_key=self.api_key, **self.model_kwargs)
+        model_kwargs = normalize_model_kwargs(model_name, self.model_kwargs)
+        model = init_chat_model(model_name, api_key=self.api_key, **model_kwargs)
 
         # Build filtered middleware
         middleware = self._build_subagent_middleware(config, all_middleware)

--- a/model_params.py
+++ b/model_params.py
@@ -1,0 +1,26 @@
+"""Model parameter normalization for provider/model-specific compatibility."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_model_kwargs(model_name: str, model_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return model kwargs normalized for the target model/provider behavior."""
+    kwargs = dict(model_kwargs)
+    provider = str(kwargs.get("model_provider") or "")
+    name = (model_name or "").strip().lower()
+
+    # @@@openai-gpt5-token-param - OpenAI GPT-5 chat completions reject max_tokens and require max_completion_tokens.
+    if provider == "openai" and _is_openai_gpt5(name):
+        if "max_completion_tokens" not in kwargs and "max_tokens" in kwargs:
+            kwargs["max_completion_tokens"] = kwargs["max_tokens"]
+        kwargs.pop("max_tokens", None)
+
+    return kwargs
+
+
+def _is_openai_gpt5(model_name: str) -> bool:
+    bare_name = model_name.split("/")[-1]
+    return bare_name.startswith("gpt-5")
+

--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -1,0 +1,40 @@
+"""Tests for model parameter normalization."""
+
+from model_params import normalize_model_kwargs
+
+
+def test_openai_gpt5_moves_max_tokens_to_max_completion_tokens() -> None:
+    kwargs = {"model_provider": "openai", "max_tokens": 256, "base_url": "https://api.openai.com/v1"}
+    out = normalize_model_kwargs("gpt-5.2", kwargs)
+    assert "max_tokens" not in out
+    assert out["max_completion_tokens"] == 256
+    assert out["base_url"] == "https://api.openai.com/v1"
+
+
+def test_openai_prefixed_gpt5_model_name_is_detected() -> None:
+    kwargs = {"model_provider": "openai", "max_tokens": 128}
+    out = normalize_model_kwargs("openai/gpt-5.1", kwargs)
+    assert "max_tokens" not in out
+    assert out["max_completion_tokens"] == 128
+
+
+def test_existing_max_completion_tokens_wins_for_openai_gpt5() -> None:
+    kwargs = {"model_provider": "openai", "max_tokens": 256, "max_completion_tokens": 64}
+    out = normalize_model_kwargs("gpt-5.2", kwargs)
+    assert "max_tokens" not in out
+    assert out["max_completion_tokens"] == 64
+
+
+def test_non_gpt5_openai_model_keeps_max_tokens() -> None:
+    kwargs = {"model_provider": "openai", "max_tokens": 256}
+    out = normalize_model_kwargs("gpt-4o", kwargs)
+    assert out["max_tokens"] == 256
+    assert "max_completion_tokens" not in out
+
+
+def test_non_openai_provider_keeps_max_tokens() -> None:
+    kwargs = {"model_provider": "anthropic", "max_tokens": 256}
+    out = normalize_model_kwargs("gpt-5.2", kwargs)
+    assert out["max_tokens"] == 256
+    assert "max_completion_tokens" not in out
+


### PR DESCRIPTION
## Why
OpenAI GPT-5 chat models reject `max_tokens` and require `max_completion_tokens`.

## What
- add a single normalization point (`model_params.py`)
- apply it in both main agent and sub-agent model init paths
- add focused unit tests

## Scope
Small isolated fix only; no runtime/sandbox behavior changes.
