### PR TITLE
Fix sticky ERROR state blocking new runs

### DIFF
--- a/tests/test_state_monitor_error_recovery.py
+++ b/tests/test_state_monitor_error_recovery.py
@@ -1,0 +1,26 @@
+from middleware.monitor.state_monitor import AgentState, StateMonitor
+
+
+def test_mark_error_while_active_returns_to_idle_and_preserves_error_flag() -> None:
+    monitor = StateMonitor()
+    assert monitor.transition(AgentState.READY)
+    assert monitor.transition(AgentState.ACTIVE)
+    assert monitor.state == AgentState.ACTIVE
+
+    err = RuntimeError("boom")
+    assert monitor.mark_error(err)
+
+    # Regression: previously transitioned ACTIVE -> ERROR and stayed wedged, blocking new runs.
+    assert monitor.state == AgentState.IDLE
+    assert monitor.flags.hasError is True
+    assert monitor.last_error_type == "RuntimeError"
+    assert monitor.last_error_message == "boom"
+    assert monitor.last_error_at is not None
+
+
+def test_mark_error_outside_active_transitions_to_error_state() -> None:
+    monitor = StateMonitor()
+    err = ValueError("init fail")
+    assert monitor.mark_error(err)
+    assert monitor.state == AgentState.ERROR
+    assert monitor.flags.hasError is True


### PR DESCRIPTION
## Root Cause\nWhen a run hits an exception mid-stream (e.g. OpenAI quota/429), MonitorMiddleware calls StateMonitor.mark_error(), which previously transitioned ACTIVE -> ERROR. ERROR cannot transition back to ACTIVE per VALID_TRANSITIONS, and /runs cleanup only resets to IDLE if still ACTIVE, so the thread stays wedged and /runs returns 409 with a misleading message.\n\n## Change\n- If mark_error() is invoked while state is ACTIVE, transition back to IDLE (keep agent runnable) while preserving hasError and capturing last_error_* snapshot for debugging.\n- Improve /runs 409 detail: if not actually ACTIVE, return the current state in the message.\n\n## Tests\n- Added regression: tests/test_state_monitor_error_recovery.py (fails on old behavior, passes now).