### PR TITLE
Fix: thread not runnable after mid-run error

### DIFF
--- a/services/web/main.py
+++ b/services/web/main.py
@@ -1272,7 +1272,11 @@ async def run_thread(thread_id: str, payload: RunRequest) -> EventSourceResponse
     lock = await _get_thread_lock(app, thread_id)
     async with lock:
         if hasattr(agent, "runtime") and not agent.runtime.transition(AgentState.ACTIVE):
-            raise HTTPException(status_code=409, detail="Thread is already running")
+            # Transition can fail for reasons other than "already running" (e.g. error/terminated states).
+            state = getattr(getattr(agent, "runtime", None), "current_state", None)
+            if state == AgentState.ACTIVE:
+                raise HTTPException(status_code=409, detail="Thread is already running")
+            raise HTTPException(status_code=409, detail=f"Thread cannot start run from state={getattr(state, 'value', state)}")
 
     async def event_stream() -> AsyncGenerator[dict[str, str], None]:
         try:

--- a/tests/test_state_monitor_error_recovery.py
+++ b/tests/test_state_monitor_error_recovery.py
@@ -1,0 +1,26 @@
+from middleware.monitor.state_monitor import AgentState, StateMonitor
+
+
+def test_mark_error_while_active_returns_to_idle_and_preserves_error_flag() -> None:
+    monitor = StateMonitor()
+    assert monitor.transition(AgentState.READY)
+    assert monitor.transition(AgentState.ACTIVE)
+    assert monitor.state == AgentState.ACTIVE
+
+    err = RuntimeError("boom")
+    assert monitor.mark_error(err)
+
+    # Regression: previously transitioned ACTIVE -> ERROR and stayed wedged, blocking new runs.
+    assert monitor.state == AgentState.IDLE
+    assert monitor.flags.hasError is True
+    assert monitor.last_error_type == "RuntimeError"
+    assert monitor.last_error_message == "boom"
+    assert monitor.last_error_at is not None
+
+
+def test_mark_error_outside_active_transitions_to_error_state() -> None:
+    monitor = StateMonitor()
+    err = ValueError("init fail")
+    assert monitor.mark_error(err)
+    assert monitor.state == AgentState.ERROR
+    assert monitor.flags.hasError is True


### PR DESCRIPTION
## Root Cause
When a run hits an exception mid-stream (e.g. quota/429), `MonitorMiddleware` calls `StateMonitor.mark_error()`.

Previously this transitioned `ACTIVE -> ERROR`. `ERROR` cannot transition back to `ACTIVE`, and `/runs` cleanup only resets to `IDLE` if state is still `ACTIVE`, so the thread becomes permanently unable to start new runs and the backend returns a misleading `409`.

## Change
- If `mark_error()` is invoked while state is `ACTIVE`, transition back to `IDLE` while preserving `hasError=true` and recording a `last_error_*` snapshot for debugging.
- Improve `/runs` 409 detail to include current state when the failure is not due to `ACTIVE`.

## Tests
- Added regression: `tests/test_state_monitor_error_recovery.py`
