### PR TITLE
Fix: Task tool unknown task_id + Daytona snapshot wedge

### DIFF
--- a/tests/test_daytona_snapshot_recovery.py
+++ b/tests/test_daytona_snapshot_recovery.py
@@ -1,0 +1,59 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from sandbox.runtime import DaytonaSessionRuntime, ExecuteResult
+from sandbox.terminal import TerminalState
+
+
+class _DummyTerminal:
+    def __init__(self, db_path: Path):
+        self.terminal_id = "term-1"
+        self.thread_id = "thread-1"
+        self.lease_id = "lease-1"
+        self.db_path = db_path
+        self._state = TerminalState(cwd="/home/daytona", env_delta={})
+
+    def get_state(self) -> TerminalState:
+        return self._state
+
+    def update_state(self, state: TerminalState) -> None:
+        self._state = state
+
+
+@pytest.mark.asyncio
+async def test_snapshot_error_infra_does_not_wedge_runtime():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+
+    try:
+        terminal = _DummyTerminal(db_path)
+        lease = object()
+        provider = object()
+        runtime = DaytonaSessionRuntime(terminal, lease, provider)
+
+        # Simulate a prior async snapshot failure (seen in production threads).
+        runtime._snapshot_error = "Command timed out after 3.0s"
+
+        calls: list[str] = []
+        runtime._recover_infra = lambda: calls.append("recover")  # type: ignore[method-assign]
+        runtime._close_shell_sync = lambda: calls.append("close")  # type: ignore[method-assign]
+
+        def _execute_once_sync(_cmd: str, _timeout: float | None, _on=None) -> ExecuteResult:
+            return ExecuteResult(exit_code=0, stdout="ok", stderr="")
+
+        runtime._execute_once_sync = _execute_once_sync  # type: ignore[method-assign]
+
+        snapshot_timeouts: list[float | None] = []
+        runtime._schedule_snapshot = lambda _gen, t: snapshot_timeouts.append(t)  # type: ignore[method-assign]
+
+        result = await runtime.execute("echo hi", timeout=1.0)
+
+        assert result.exit_code == 0
+        assert runtime._snapshot_error is None
+        assert calls == ["recover", "close"]
+        assert snapshot_timeouts, "should schedule a fresh snapshot after command"
+        assert snapshot_timeouts[-1] is not None and snapshot_timeouts[-1] >= 10.0
+    finally:
+        db_path.unlink(missing_ok=True)

--- a/tests/test_task_streaming_persists_result.py
+++ b/tests/test_task_streaming_persists_result.py
@@ -1,0 +1,77 @@
+import asyncio
+
+import pytest
+
+from middleware.task.subagent import SubagentRunner
+from middleware.task.types import AgentConfig
+
+
+class _StubAgent:
+    def __init__(self):
+        self._chunks = []
+
+    async def astream(self, _input, *, config, stream_mode):
+        # Emit one token chunk and then end.
+        yield (
+            "messages",
+            (
+                type("AIMessageChunk", (), {"content": "hello"})(),
+                {},
+            ),
+        )
+        yield (
+            "updates",
+            {
+                "node": {
+                    "messages": [type("AIMessage", (), {"tool_calls": []})()],
+                }
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_stores_task_result(monkeypatch, tmp_path):
+    agents = {
+        "general": AgentConfig(
+            name="general",
+            description="stub",
+            system_prompt="stub",
+            tools=[],
+            model=None,
+            max_turns=1,
+        )
+    }
+
+    runner = SubagentRunner(
+        agents=agents,
+        parent_model="gpt-4",
+        workspace_root=tmp_path,
+        api_key="test",
+        model_kwargs={},
+    )
+
+    # Avoid real model/agent construction.
+    monkeypatch.setattr("middleware.task.subagent.init_chat_model", lambda *a, **k: object())
+    monkeypatch.setattr("middleware.task.subagent.create_agent", lambda *a, **k: _StubAgent())
+
+    params = {"SubagentType": "general", "Prompt": "hi"}
+    events = []
+    async for ev in runner.run_streaming(params=params, all_middleware=[], checkpointer=None):
+        events.append(ev)
+
+    assert any(e["event"] == "task_start" for e in events)
+    assert any(e["event"] == "task_text" for e in events)
+    assert any(e["event"] == "task_done" for e in events)
+
+    task_id = None
+    for e in events:
+        if e["event"] == "task_start":
+            import json
+
+            task_id = json.loads(e["data"])["task_id"]
+            break
+    assert task_id
+
+    result = runner.get_task_status(task_id)
+    assert result.status == "completed"
+    assert (result.result or "").startswith("hello")


### PR DESCRIPTION
## Crime Scene (Alibaba Thread)
Thread `604fa707-55d7-402a-8249-02e015374076` shows two severe tool-path failures:

1. **Task tool returns `Error: Unknown task_id ...` even though it just started a task**.
2. **Daytona command execution wedges permanently after an async snapshot timeout**, causing every subsequent `run_command` to return:
   `Error: snapshot failed: Command timed out after 3.0s`

## Root Causes
### 1) Task tool (streaming path)
`TaskMiddleware._handle_task()` always uses `runner.run_streaming()` and then calls `runner.get_task_status(task_id)`.
But `SubagentRunner.run_streaming()` never stored any `TaskResult` into `_task_results` or `_active_tasks`, so `get_task_status()` could only return `Unknown task_id`.

### 2) Daytona snapshot wedge
`DaytonaSessionRuntime` schedules a background snapshot after each command.

- Snapshot inherited the *user command timeout* (e.g. 3s).
- If snapshot timed out once, `_snapshot_error` was set.
- On the next command, runtime returned early with `snapshot failed`, without attempting infra recovery or resnapshot.

This matches the long thread where a single snapshot timeout permanently killed terminal usability.

## Fix
### Task
- Persist `TaskResult` for `run_streaming()` so `get_task_status()` works.
- For `RunInBackground`, use `runner.run()` (which registers `_active_tasks`) so `TaskOutput` polling is valid.

### Daytona
- Snapshot always re-ensures a PTY handle (after infra recovery).
- On snapshot failure that looks infra: `_recover_infra` + close PTY + retry snapshot once.
- If a prior snapshot failure exists and looks infra: auto-recover instead of wedging forever.
- Decouple snapshot timeout from user command timeout: `snapshot_timeout = max(timeout, 10s)`.

## Tests
- `tests/test_task_streaming_persists_result.py`
- `tests/test_daytona_snapshot_recovery.py`
