### PR TITLE
refactor: use langchain configurable_fields for dynamic model switching

### DIFF
--- a/backend/web/models/requests.py
+++ b/backend/web/models/requests.py
@@ -11,6 +11,7 @@ class CreateThreadRequest(BaseModel):
 class RunRequest(BaseModel):
     message: str
     enable_trajectory: bool = False
+    model: str | None = None
 
 
 class SteerRequest(BaseModel):

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -263,6 +263,11 @@ async def run_thread(
     sandbox_type = resolve_thread_sandbox(app, thread_id)
     set_current_thread_id(thread_id)
     agent = await get_or_create_agent(app, sandbox_type, thread_id=thread_id)
+
+    # Per-request model override (lightweight, no rebuild)
+    if payload.model:
+        await asyncio.to_thread(agent.update_config, model=payload.model)
+
     lock = await get_thread_lock(app, thread_id)
     async with lock:
         if hasattr(agent, "runtime") and not agent.runtime.transition(AgentState.ACTIVE):

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -132,6 +132,9 @@ async def stream_agent_execution(
     stream_gen = None
     try:
         config = {"configurable": {"thread_id": thread_id}}
+        # Inject current model config for configurable_fields model
+        if hasattr(agent, "_current_model_config"):
+            config["configurable"].update(agent._current_model_config)
         set_current_thread_id(thread_id)
 
         # Trajectory tracing (eval system)

--- a/core/monitor/middleware.py
+++ b/core/monitor/middleware.py
@@ -61,6 +61,10 @@ class MonitorMiddleware(AgentMiddleware):
         """添加自定义 Monitor"""
         self._monitors.append(monitor)
 
+    def update_model(self, model_name: str) -> None:
+        """更新 cost calculator（不重建 middleware）"""
+        self._token_monitor.cost_calculator = CostCalculator(model_name)
+
     def mark_ready(self) -> None:
         """标记 Agent 就绪（初始化完成后调用）"""
         self._state_monitor.mark_ready()


### PR DESCRIPTION
Replace heavyweight update_config (rebuild middleware stack + graph + state machine) with lightweight config update via init_chat_model configurable_fields.

## Changes
- agent.py: _create_model uses configurable_fields; __init__ stores _current_model_config; update_config stripped from 75 lines to 35
- core/monitor/middleware.py: added update_model() for lightweight cost calculator swap
- backend/web/services/streaming_service.py: injects _current_model_config into astream config
- backend/web/models/requests.py: RunRequest gains optional model field
- backend/web/routers/threads.py: runs endpoint applies per-request model override

## Impact
- Eliminates 409 Conflict from stale StateMonitor during model switches
- No more middleware/graph/state machine rebuild overhead
- Model/provider/api_key/base_url injected per-request through LangGraph config

## Testing
- ✅ Default model message works
- ✅ Model switch via settings endpoint (no 409)
- ✅ Message after switch works
- ✅ Per-request model override works
- ✅ Rapid model switching (4 switches) all succeed
- ✅ MonitorMiddleware initialized only once (no rebuilds)

5 files changed, +70/-55 lines