### PR TITLE
test: [proposer:taotao-db] trim SSE refactor tests to maintainable core

### DIFF
--- a/tests/test_sse_refactor.py
+++ b/tests/test_sse_refactor.py
@@ -1,523 +1,151 @@
-"""End-to-end tests for the SSE architecture refactoring.
+"""Focused regression tests for backend SSE execution path."""
 
-Covers:
-1. RunEventBuffer.read_with_timeout (heartbeat prerequisite)
-2. observe_run_events: retry field, heartbeat, id injection, after filtering
-3. POST /runs returns JSON (not SSE)
-4. GET /runs/events returns SSE with proper headers
-5. Reconnection: Last-Event-ID + ?after= cursor
-6. Task agent buffer-based execution
-7. Historical pain points: done event stops stream, streaming state sync,
-   thread switch cleanup, finally ordering
-
-Requires: uv run pytest tests/test_sse_refactor.py -x -v
-"""
-
-import asyncio
 import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
+from sse_starlette.sse import EventSourceResponse
 
-from backend.web.services.event_buffer import RunEventBuffer
+from backend.web.models.requests import RunRequest
+from backend.web.services.streaming_service import stream_agent_execution
+from core.monitor import AgentState
 
-# ---------------------------------------------------------------------------
-# 1. RunEventBuffer.read_with_timeout
-# ---------------------------------------------------------------------------
 
+class AIMessageChunk:
+    def __init__(self, content: str):
+        self.content = content
 
-class TestReadWithTimeout:
-    """read_with_timeout returns (None, cursor) on timeout, not blocking forever."""
 
-    def test_returns_events_immediately_when_available(self):
-        async def _run():
-            buf = RunEventBuffer()
-            await buf.put({"event": "text", "data": '{"x":1}'})
-            result, cursor = await buf.read_with_timeout(0, timeout=1)
-            assert result is not None
-            assert len(result) == 1
-            assert cursor == 1
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.current_state = AgentState.ACTIVE
+        self.transitions: list[AgentState] = []
 
-        asyncio.run(_run())
+    def transition(self, state: AgentState) -> bool:
+        self.transitions.append(state)
+        self.current_state = state
+        return True
 
-    def test_returns_none_on_timeout(self):
-        async def _run():
-            buf = RunEventBuffer()
-            result, cursor = await buf.read_with_timeout(0, timeout=0.1)
-            assert result is None
-            assert cursor == 0
+    def get_pending_subagent_events(self):
+        return []
 
-        asyncio.run(_run())
+    def get_status_dict(self):
+        return {"state": self.current_state.value}
 
-    def test_returns_empty_when_finished(self):
-        async def _run():
-            buf = RunEventBuffer()
-            await buf.mark_done()
-            result, cursor = await buf.read_with_timeout(0, timeout=1)
-            assert result == []
-            assert cursor == 0
 
-        asyncio.run(_run())
+class _FakeLock:
+    async def __aenter__(self):
+        return self
 
-    def test_wakes_on_new_event_before_timeout(self):
-        async def _run():
-            buf = RunEventBuffer()
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
-            async def delayed_put():
-                await asyncio.sleep(0.05)
-                await buf.put({"event": "text", "data": '{"late":true}'})
 
-            task = asyncio.create_task(delayed_put())
-            result, cursor = await buf.read_with_timeout(0, timeout=5)
-            await task
-            assert result is not None
-            assert len(result) == 1
-            assert cursor == 1
+def _make_app():
+    return SimpleNamespace(state=SimpleNamespace(thread_tasks={}))
 
-        asyncio.run(_run())
 
-    def test_returns_events_accumulated_during_wait(self):
-        """If multiple events arrive while waiting, return all of them."""
+def _import_threads_module():
+    project_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(project_root))
+    loaded = sys.modules.get("config")
+    if loaded and "tests/config" in str(getattr(loaded, "__file__", "")):
+        del sys.modules["config"]
+    from backend.web.routers import threads as threads_module
 
-        async def _run():
-            buf = RunEventBuffer()
+    return threads_module
 
-            async def multi_put():
-                await asyncio.sleep(0.02)
-                await buf.put({"event": "text", "data": '{"n":1}'})
-                await buf.put({"event": "text", "data": '{"n":2}'})
-                await buf.put({"event": "text", "data": '{"n":3}'})
 
-            task = asyncio.create_task(multi_put())
-            # Wait a bit longer than the puts
-            await asyncio.sleep(0.05)
-            result, cursor = await buf.read_with_timeout(0, timeout=1)
-            await task
-            assert result is not None
-            assert len(result) == 3
-            assert cursor == 3
+@pytest.mark.asyncio
+async def test_stream_agent_execution_emits_text_status_done_and_cleans_task():
+    runtime = _FakeRuntime()
 
-        asyncio.run(_run())
+    class _InnerAgent:
+        async def astream(self, *_args, **_kwargs):
+            yield ("messages", (AIMessageChunk("hello"), {}))
 
+    agent = SimpleNamespace(agent=_InnerAgent(), runtime=runtime)
+    app = _make_app()
 
-# ---------------------------------------------------------------------------
-# 2. observe_run_events: retry, heartbeat, id, after
-# ---------------------------------------------------------------------------
+    events = []
+    # @@@stream-drain - Exhaust async SSE generator to assert ordering + cleanup side effects.
+    async for event in stream_agent_execution(agent, "t-1", "ping", app):
+        events.append(event)
 
+    assert [e["event"] for e in events] == ["text", "status", "done"]
+    assert json.loads(events[0]["data"]) == {"content": "hello"}
+    assert json.loads(events[2]["data"]) == {"thread_id": "t-1"}
+    assert app.state.thread_tasks == {}
+    assert runtime.transitions[-1] == AgentState.IDLE
 
-class TestObserveRunEventsRefactored:
-    """observe_run_events now yields retry, heartbeat comments, and id fields."""
 
-    def test_first_event_is_retry(self):
-        """First yielded dict must be {retry: 5000} for browser reconnect interval."""
+@pytest.mark.asyncio
+async def test_stream_agent_execution_surfaces_error_event_when_stream_fails():
+    runtime = _FakeRuntime()
 
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
+    class _InnerAgent:
+        async def astream(self, *_args, **_kwargs):
+            raise RuntimeError("boom")
+            yield  # pragma: no cover
 
-            buf = RunEventBuffer()
-            await buf.put({"event": "done", "data": json.dumps({"_seq": 1})})
-            await buf.mark_done()
+    agent = SimpleNamespace(agent=_InnerAgent(), runtime=runtime)
+    app = _make_app()
 
-            events = []
-            async for ev in observe_run_events(buf):
-                events.append(ev)
-            assert events[0] == {"retry": 5000}
+    events = []
+    async for event in stream_agent_execution(agent, "t-2", "ping", app):
+        events.append(event)
 
-        asyncio.run(_run())
+    assert events[0]["event"] == "error"
+    assert "boom" in json.loads(events[0]["data"])["error"]
+    assert events[-1]["event"] == "done"
+    assert app.state.thread_tasks == {}
 
-    def test_events_have_id_field_from_seq(self):
-        """Each event with _seq should get an 'id' field for Last-Event-ID."""
 
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            await buf.put({"event": "text", "data": json.dumps({"content": "hi", "_seq": 42})})
-            await buf.put({"event": "done", "data": json.dumps({"_seq": 43})})
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf):
-                events.append(ev)
-            # events[0] = retry, events[1] = text, events[2] = done
-            assert events[1].get("id") == "42"
-            assert events[2].get("id") == "43"
-
-        asyncio.run(_run())
-
-    def test_after_skips_old_events_with_retry(self):
-        """after=N skips events with _seq <= N; retry is still first."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            await buf.put({"event": "text", "data": json.dumps({"_seq": 5, "old": True})})
-            await buf.put({"event": "text", "data": json.dumps({"_seq": 10, "new": True})})
-            await buf.put({"event": "done", "data": json.dumps({"_seq": 11})})
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf, after=5):
-                events.append(ev)
-            # retry + 2 events (seq 10 and 11)
-            assert len(events) == 3
-            assert events[0] == {"retry": 5000}
-            data1 = json.loads(events[1]["data"])
-            assert data1["_seq"] == 10
-
-        asyncio.run(_run())
-
-    def test_heartbeat_on_timeout(self):
-        """When no events arrive within timeout, yield a keepalive comment."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            events = []
-
-            async def consumer():
-                async for ev in observe_run_events(buf):
-                    events.append(ev)
-                    # After getting retry + keepalive, stop
-                    if ev.get("comment") == "keepalive":
-                        break
-
-            async def finish_later():
-                # Wait longer than the 0.2s timeout we'll patch
-                await asyncio.sleep(0.5)
-                await buf.mark_done()
-
-            # Patch timeout to be very short for testing
-            original = buf.read_with_timeout
-
-            async def fast_timeout(cursor, timeout=30):
-                return await original(cursor, timeout=0.1)
-
-            buf.read_with_timeout = fast_timeout
-
-            finish_task = asyncio.create_task(finish_later())
-            await consumer()
-            finish_task.cancel()
-
-            # Should have: retry, keepalive
-            assert events[0] == {"retry": 5000}
-            assert events[1] == {"comment": "keepalive"}
-
-        asyncio.run(_run())
-
-    def test_events_without_seq_still_yielded(self):
-        """Events with non-JSON data bypass the after filter."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            await buf.put({"event": "done", "data": "not-json"})
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf, after=999):
-                events.append(ev)
-            # retry + the non-JSON event (bypasses filter)
-            assert len(events) == 2
-            assert events[1]["event"] == "done"
-
-        asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# 3. Producer-consumer: concurrent writes + reads
-# ---------------------------------------------------------------------------
-
-
-class TestConcurrentProducerConsumer:
-    """Verify no data loss under concurrent producer/consumer."""
-
-    def test_50_events_no_loss(self):
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            total = 50
-
-            async def producer():
-                for i in range(total):
-                    await buf.put({"event": "text", "data": json.dumps({"_seq": i + 1})})
-                    await asyncio.sleep(0.001)
-                await buf.put({"event": "done", "data": json.dumps({"_seq": total + 1})})
-                await buf.mark_done()
-
-            consumed = []
-
-            async def consumer():
-                async for ev in observe_run_events(buf):
-                    consumed.append(ev)
-
-            await asyncio.gather(producer(), consumer())
-            # retry + 50 text + 1 done = 52
-            assert len(consumed) == total + 2
-
-        asyncio.run(_run())
-
-    def test_reconnect_from_midpoint(self):
-        """Simulate disconnect at seq=25, reconnect with after=25."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            for i in range(50):
-                await buf.put({"event": "text", "data": json.dumps({"_seq": i + 1})})
-            await buf.put({"event": "done", "data": json.dumps({"_seq": 51})})
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf, after=25):
-                events.append(ev)
-            # retry + 25 remaining text events + done = 27
-            assert len(events) == 27
-            # First real event should be seq 26
-            first_data = json.loads(events[1]["data"])
-            assert first_data["_seq"] == 26
-
-        asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# 4. Finally ordering: mark_done before pop
-# ---------------------------------------------------------------------------
-
-
-class TestFinallyOrdering:
-    """Verify mark_done fires before buffer is removed from registry."""
-
-    def test_mark_done_before_pop(self):
-        """A consumer waiting on read should be unblocked even if buffer is popped."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            registry = {"thread-1": buf}
-
-            consumed = []
-
-            async def consumer():
-                async for ev in observe_run_events(buf):
-                    consumed.append(ev)
-
-            async def simulate_finally():
-                await asyncio.sleep(0.05)
-                # This is the new order: mark_done first
-                await buf.mark_done()
-                registry.pop("thread-1", None)
-
-            await asyncio.gather(consumer(), simulate_finally())
-            # Consumer should have gotten retry and exited cleanly
-            assert len(consumed) >= 1  # at least retry
-            assert "thread-1" not in registry
-
-        asyncio.run(_run())
-
-    def test_pending_tool_calls_initialized_before_try(self):
-        """pending_tool_calls must be accessible in CancelledError handler."""
-        # This is a static analysis test — verify the variable is defined
-        # before the try block in _run_agent_to_buffer
-        import inspect
-
-        from backend.web.services.streaming_service import _run_agent_to_buffer
-
-        source = inspect.getsource(_run_agent_to_buffer)
-        # Not applicable to _run_agent_to_buffer (task agent), but verify
-        # the main producer has it right
-        from backend.web.services.streaming_service import _run_agent_to_buffer as _  # noqa
-
-        # Check the actual producer function
-        import ast
-        from backend.web.services import streaming_service
-
-        module_source = inspect.getsource(streaming_service)
-        # Find pending_tool_calls assignment — it should be before the try block
-        tree = ast.parse(module_source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_run_agent_to_buffer":
-                # Find the position of pending_tool_calls assignment
-                ptc_line = None
-                try_line = None
-                for child in ast.walk(node):
-                    if isinstance(child, ast.AnnAssign):
-                        target = child.target
-                        if isinstance(target, ast.Name) and target.id == "pending_tool_calls":
-                            ptc_line = child.lineno
-                    if isinstance(child, ast.Try) and try_line is None:
-                        try_line = child.lineno
-                if ptc_line and try_line:
-                    assert ptc_line < try_line, (
-                        f"pending_tool_calls (line {ptc_line}) must be before try (line {try_line})"
-                    )
-
-
-# ---------------------------------------------------------------------------
-# 5. Edge cases: empty buffer, cancelled events, done semantics
-# ---------------------------------------------------------------------------
-
-
-class TestEdgeCases:
-    """Edge cases that caused historical bugs."""
-
-    def test_empty_buffer_finishes_immediately(self):
-        """Buffer with no events + mark_done should yield only retry."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf):
-                events.append(ev)
-            assert len(events) == 1
-            assert events[0] == {"retry": 5000}
-
-        asyncio.run(_run())
-
-    def test_done_event_is_terminal(self):
-        """Events after 'done' should not be yielded (historical bug ef2bae8)."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            await buf.put({"event": "text", "data": json.dumps({"_seq": 1, "content": "hi"})})
-            await buf.put({"event": "done", "data": json.dumps({"_seq": 2})})
-            # These should NOT be yielded — done is terminal
-            await buf.put({"event": "text", "data": json.dumps({"_seq": 3, "content": "ghost"})})
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf):
-                events.append(ev)
-            # retry + text + done = 3 (no ghost event)
-            # Note: observe_run_events doesn't filter post-done events itself,
-            # but the frontend streamEvents() breaks on done/cancelled.
-            # The buffer consumer reads all events from the buffer.
-            # This test documents the current behavior.
-            event_types = [ev.get("event") for ev in events if "event" in ev]
-            assert "done" in event_types
-
-        asyncio.run(_run())
-
-    def test_cancelled_event_includes_tool_call_ids(self):
-        """Cancelled events should carry cancelled_tool_call_ids."""
-
-        async def _run():
-            from backend.web.services.streaming_service import observe_run_events
-
-            buf = RunEventBuffer()
-            await buf.put(
-                {
-                    "event": "cancelled",
-                    "data": json.dumps(
-                        {
-                            "message": "Run cancelled by user",
-                            "cancelled_tool_call_ids": ["call_abc", "call_def"],
-                            "_seq": 1,
-                        }
-                    ),
-                }
-            )
-            await buf.mark_done()
-
-            events = []
-            async for ev in observe_run_events(buf):
-                events.append(ev)
-            # Find the cancelled event
-            cancelled = [e for e in events if e.get("event") == "cancelled"]
-            assert len(cancelled) == 1
-            data = json.loads(cancelled[0]["data"])
-            assert data["cancelled_tool_call_ids"] == ["call_abc", "call_def"]
-
-        asyncio.run(_run())
-
-    def test_buffer_run_id_propagation(self):
-        """start_agent_run should set buf.run_id."""
-        buf = RunEventBuffer()
-        assert buf.run_id == ""
-        buf.run_id = "run-xyz-123"
-        assert buf.run_id == "run-xyz-123"
-
-
-# ---------------------------------------------------------------------------
-# 6. HTTP endpoint tests (using FastAPI TestClient)
-# ---------------------------------------------------------------------------
-
-
-class TestHTTPEndpoints:
-    """Test the actual HTTP endpoints with FastAPI TestClient."""
-
-    @pytest.fixture()
-    def client(self):
-        """Create a test client with minimal app state."""
-
-        from fastapi import FastAPI
-        from fastapi.testclient import TestClient
-
-        from backend.web.routers.threads import router
-
-        app = FastAPI()
-        app.include_router(router)
-
-        # Mock app state
-        app.state.thread_sandbox = {}
-        app.state.thread_cwd = {}
-        app.state.thread_event_buffers = {}
-        app.state.thread_tasks = {}
-        app.state.agent_pool = {}
-        app.state.thread_locks = {}
-
-        return TestClient(app)
-
-    def test_post_runs_returns_json_not_sse(self, client):
-        """POST /runs should return JSON {run_id, thread_id}, not SSE stream."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        mock_buf = RunEventBuffer()
-        mock_buf.run_id = "test-run-id"
-
-        with (
-            patch("backend.web.routers.threads.resolve_thread_sandbox", return_value="local"),
-            patch("backend.web.routers.threads.get_or_create_agent") as mock_agent,
-            patch("backend.web.routers.threads.get_thread_lock") as mock_lock,
-            patch("backend.web.routers.threads.start_agent_run", return_value=mock_buf),
-            patch("backend.web.routers.threads.set_current_thread_id"),
-        ):
-            agent = MagicMock()
-            agent.runtime.transition.return_value = True
-            mock_agent.return_value = agent
-
-            lock = AsyncMock()
-            lock.__aenter__ = AsyncMock()
-            lock.__aexit__ = AsyncMock()
-            mock_lock.return_value = lock
-
-            response = client.post(
-                "/api/threads/test-thread/runs",
-                json={"message": "hello"},
-            )
-
-            assert response.status_code == 200
-            data = response.json()
-            assert data["run_id"] == "test-run-id"
-            assert data["thread_id"] == "test-thread"
-            # Verify it's JSON, not SSE
-            assert response.headers["content-type"].startswith("application/json")
-
-    def test_post_runs_empty_message_400(self, client):
-        """POST /runs with empty message should return 400."""
-        response = client.post(
-            "/api/threads/test-thread/runs",
-            json={"message": "   "},
-        )
-        assert response.status_code == 400
+@pytest.mark.asyncio
+async def test_run_thread_rejects_empty_message():
+    threads = _import_threads_module()
+    with pytest.raises(HTTPException) as exc:
+        await threads.run_thread("thread-1", RunRequest(message="   "), app=_make_app())
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "message cannot be empty"
+
+
+@pytest.mark.asyncio
+async def test_run_thread_returns_sse_response_and_applies_model_override(monkeypatch):
+    threads = _import_threads_module()
+    lock = _FakeLock()
+    runtime = _FakeRuntime()
+    override_calls: list[str] = []
+
+    def _update_config(*, model: str):
+        override_calls.append(model)
+
+    agent = SimpleNamespace(runtime=runtime, update_config=_update_config)
+
+    async def _fake_get_agent(*_args, **_kwargs):
+        return agent
+
+    async def _fake_get_lock(*_args, **_kwargs):
+        return lock
+
+    async def _fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(threads, "resolve_thread_sandbox", lambda *_args, **_kwargs: "local")
+    monkeypatch.setattr(threads, "get_or_create_agent", _fake_get_agent)
+    monkeypatch.setattr(threads, "get_thread_lock", _fake_get_lock)
+    monkeypatch.setattr(threads.asyncio, "to_thread", _fake_to_thread)
+
+    app = _make_app()
+    response = await threads.run_thread(
+        "thread-2",
+        RunRequest(message="hello", model="openai/gpt-5-mini"),
+        app=app,
+    )
+
+    assert isinstance(response, EventSourceResponse)
+    assert override_calls == ["openai/gpt-5-mini"]
+    assert runtime.transitions[0] == AgentState.ACTIVE


### PR DESCRIPTION
[proposer:taotao-db]

## Summary
- Reduced PR #50 to minimum maintainable scope: only `tests/test_sse_refactor.py`.
- Dropped non-essential/non-runnable scaffolding that referenced removed modules (`RunEventBuffer`, `observe_run_events`).
- Kept high-value coverage for the current backend SSE path:
  - `stream_agent_execution` success path (`text/status/done` + cleanup)
  - stream failure surfaces `error` event
  - `run_thread` empty-message validation (400)
  - `run_thread` returns SSE response and applies per-request model override

## Scope Guard
- Changed files: 1
- Net LOC: +151

@@@rollout-notes - PR rollout and verification evidence
- PR URL: https://github.com/OpenDCAI/leonai/pull/50
- Verification commands (exact):
  1. `cd /tmp/leonai-pr50-cleanup && uv run --with pytest --with pytest-asyncio --with fastapi --with sse-starlette pytest tests/test_sse_refactor.py -x -v`
  2. `cd /tmp/leonai-pr50-cleanup/frontend/app && npm ci`
  3. `cd /tmp/leonai-pr50-cleanup/frontend/app && npm run dev -- --host 127.0.0.1 --port 5272`
  4. `node /home/ubuntu/codex-smoke/tools/webshot.mjs http://127.0.0.1:5272/ /tmp/leonai-pr50-cleanup/artifacts/pr50-leon-frontend.png`
- Artifacts:
  - Pytest log: `/tmp/leonai-pr50-cleanup/artifacts/pr50-pytest-sse.txt`
  - Frontend screenshot: `/tmp/leonai-pr50-cleanup/artifacts/pr50-leon-frontend.png`
