### PR TITLE
chore(wt): update worktree symlink handling after .claude added to git

### DIFF
--- a/.claude/commands/wtnew.md
+++ b/.claude/commands/wtnew.md
@@ -33,13 +33,13 @@ git worktree add "$MAIN_REPO/worktrees/<目录名>" -b $ARGUMENTS origin/dev
 - `worktrees/` 统一放在主仓库内
 - 必须确认 `worktrees/` 在 `.gitignore` 中，不在则自动添加
 
-## Step 3：链接 Claude 配置
+## Step 3：链接本地配置
 
-worktree 不包含 gitignored 文件，必须手动链接：
+`.claude/` 已纳入 Git 管理，worktree checkout 后自动包含。  
+只需链接不在 Git 里的本地配置文件：
 
 ```bash
 cd "$MAIN_REPO/worktrees/<目录名>"
-ln -s "$MAIN_REPO/.claude" .claude
 ln -s "$MAIN_REPO/CLAUDE.local.md" CLAUDE.local.md 2>/dev/null
 ```
 
@@ -48,7 +48,7 @@ ln -s "$MAIN_REPO/CLAUDE.local.md" CLAUDE.local.md 2>/dev/null
 输出：
 - worktree 路径
 - 分支名
-- `.claude` 符号链接状态
+- `CLAUDE.local.md` 符号链接状态
 
 询问用户：是否在新 worktree 中打开新的 Claude 会话？
 

--- a/.claude/commands/wtrm.md
+++ b/.claude/commands/wtrm.md
@@ -26,20 +26,31 @@ git -C <worktree路径> status --short
 
 有未提交改动 → 列出改动内容，询问用户：**继续移除（改动会丢失）？还是先处理？**
 
-## Step 2：移除 worktree
+## Step 2：清理 untracked 文件
+
+先移除已知的 symlink（`CLAUDE.local.md` 由 `wtnew` 创建，不在 Git 里）：
+
+```bash
+TARGET="$MAIN_REPO/worktrees/<目录名>/CLAUDE.local.md"
+[ -L "$TARGET" ] && rm "$TARGET" || echo "跳过：$TARGET 不是符号链接，不删除"
+```
+
+**必须用 `[ -L ]` 确认是 symlink 再删**，绝不对普通文件执行 `rm`，防止误删原始文件。
+
+## Step 3：移除 worktree
 
 ```bash
 git worktree remove "$MAIN_REPO/worktrees/<目录名>"
 ```
 
-如果失败（`.venv`、`__pycache__` 等 untracked 文件残留）：
+如果仍然失败（`.venv`、`__pycache__` 等其他 untracked 文件残留）：
 
 ```bash
 rm -rf "$MAIN_REPO/worktrees/<目录名>"
 git worktree prune
 ```
 
-## Step 3：询问是否删除本地分支
+## Step 4：询问是否删除本地分支
 
 ```bash
 git branch -d <分支名>   # 已合并分支

--- a/.claude/commands/wtsync.md
+++ b/.claude/commands/wtsync.md
@@ -1,11 +1,12 @@
-# 同步 Worktree 配置
+# 同步 Worktree 本地配置
 
-将主仓库的 `.claude` 配置链接到当前 worktree。
+将主仓库的 `CLAUDE.local.md` 链接到当前 worktree。
+
+> `.claude/` 已纳入 Git 管理，worktree checkout 后自动包含，无需手动处理。
 
 ## 使用场景
 
-- worktree 中新开的 Claude 会话发现没有加载项目规则
-- worktree 创建时忘了链接配置
+- worktree 中找不到 `CLAUDE.local.md`（本地配置不在 Git 里，不会随 checkout 复制）
 
 ## Step 0：确定位置
 
@@ -17,12 +18,18 @@ CWD=$(pwd)
 - `CWD == MAIN_REPO` → 提示"你在主仓库，不需要 sync"，退出
 - `CWD` 在某个 worktree 下 → 继续
 
-## Step 1：链接配置
+## Step 1：链接本地配置
 
 ```bash
-ln -sf "$MAIN_REPO/.claude" .claude
-ln -sf "$MAIN_REPO/CLAUDE.local.md" CLAUDE.local.md 2>/dev/null
+TARGET="CLAUDE.local.md"
+if [ -e "$TARGET" ] && [ ! -L "$TARGET" ]; then
+  echo "错误：$TARGET 是普通文件，不覆盖，请手动确认后再操作"
+  exit 1
+fi
+ln -sf "$MAIN_REPO/CLAUDE.local.md" "$TARGET"
 ```
+
+**若目标已存在且不是 symlink（即普通文件），直接报错退出**，绝不强制覆盖。
 
 ## Step 2：验证
 
@@ -30,7 +37,6 @@ ln -sf "$MAIN_REPO/CLAUDE.local.md" CLAUDE.local.md 2>/dev/null
 
 ```
 ✅ 已同步：
-  .claude → /path/to/main/.claude
   CLAUDE.local.md → /path/to/main/CLAUDE.local.md
 ```
 


### PR DESCRIPTION
## Background

`.claude/` has been added to version control. Worktree checkouts now automatically include `.claude/`, so manual symlinking is no longer needed.

## Changes

**wtsync.md**
- Renamed to "Sync Worktree Local Config" — only syncs `CLAUDE.local.md` now
- Removed the `.claude` symlink step
- Added safety guard: if the target exists as a regular file (not a symlink), exit with an error instead of force-overwriting

**wtnew.md**
- Step 3: removed `ln -s "$MAIN_REPO/.claude" .claude`
- Added note explaining `.claude/` is now git-managed and included automatically on checkout

**wtrm.md**
- Added Step 2: explicitly remove `CLAUDE.local.md` symlink before `git worktree remove` using `[ -L ]` check — never `rm` a regular file
- Primary path no longer relies on the `rm -rf` fallback