### PR TITLE
chore: update branch references from dev/master to main

### DIFF
--- a/.claude/commands/wtls.md
+++ b/.claude/commands/wtls.md
@@ -20,10 +20,10 @@ git fetch origin                       # 同步远端状态
 
 # 对每个 worktree 采集：
 git -C <path> status --short           # DIRTY
-git -C <path> rev-list origin/dev..HEAD --count   # AHEAD
-git -C <path> rev-list HEAD..origin/dev --count   # BEHIND
+git -C <path> rev-list origin/main..HEAD --count   # AHEAD
+git -C <path> rev-list HEAD..origin/main --count   # BEHIND
 git -C <path> log -1 --format="%ai"               # 最近 commit 时间
-git -C <path> log --format="%ai" $(git -C <path> merge-base HEAD origin/dev) -1  # 分叉时间
+git -C <path> log --format="%ai" $(git -C <path> merge-base HEAD origin/main) -1  # 分叉时间
 gh pr view --json state,url,number -R <repo> -b <branch> 2>/dev/null  # PR 状态
 ```
 
@@ -40,7 +40,7 @@ worktrees/old-feat  old/feat        +1     -12     ✗      #8 merged ⚠
 状态标注：
 - `⚠` = PR 已 merged/closed，建议清理
 - `✓` dirty = 有未提交改动
-- behind 较多 = 落后 dev，建议 rebase
+- behind 较多 = 落后 main，建议 rebase
 
 ## Step 3：输出 Mermaid 时间轴
 
@@ -49,7 +49,7 @@ worktrees/old-feat  old/feat        +1     -12     ✗      #8 merged ⚠
 ```
 gantt 图规则：
 - 每个 worktree 一行
-- 起点 = 分叉时间（从 dev 创建分支的时间）
+- 起点 = 分叉时间（从 main 创建分支的时间）
 - 终点 = 最近 commit 时间（或今天）
 - 颜色（section）：
     active   = PR open

--- a/.claude/commands/wtnew.md
+++ b/.claude/commands/wtnew.md
@@ -1,6 +1,6 @@
 # 创建 Worktree
 
-基于最新 `origin/dev` 创建隔离的 worktree 开发环境。
+基于最新 `origin/main` 创建隔离的 worktree 开发环境。
 
 ## 参数
 
@@ -20,14 +20,14 @@ MAIN_REPO=$(git worktree list | head -1 | awk '{print $1}')
 git fetch origin
 ```
 
-确保基于最新的 `origin/dev` 创建，避免从过时的 base 分叉。
+确保基于最新的 `origin/main` 创建，避免从过时的 base 分叉。
 
 ## Step 2：创建 worktree
 
 目录名规则：分支名中的 `/` 替换为 `-`（如 `feat/eval` → `feat-eval`）
 
 ```bash
-git worktree add "$MAIN_REPO/worktrees/<目录名>" -b $ARGUMENTS origin/dev
+git worktree add "$MAIN_REPO/worktrees/<目录名>" -b $ARGUMENTS origin/main
 ```
 
 - `worktrees/` 统一放在主仓库内

--- a/.claude/commands/wtrebaseall.md
+++ b/.claude/commands/wtrebaseall.md
@@ -1,6 +1,6 @@
 # 批量 Rebase 所有 Worktree
 
-一个 PR 合并到 dev 后，批量将所有 in-progress worktree rebase 到最新 `origin/dev`。
+一个 PR 合并到 main 后，批量将所有 in-progress worktree rebase 到最新 `origin/main`。
 
 ## 使用时机
 
@@ -37,7 +37,7 @@ git worktree list --porcelain
 ```
 DIRTY 检查
 ├── 有未提交改动 → 跳过，标记为"需手动处理"
-└── 干净 → git -C <path> rebase origin/dev
+└── 干净 → git -C <path> rebase origin/main
          ├── 成功 → 标记 ✅
          └── 有冲突 → git -C <path> rebase --abort（回滚）
                       标记为"需手动处理"，继续下一个
@@ -59,7 +59,7 @@ wtrebaseall 完成
 
 ❌ 冲突（已 abort，需手动处理）：
   - worktrees/old-a (old/a)
-    提示：cd worktrees/old-a && git rebase origin/dev
+    提示：cd worktrees/old-a && git rebase origin/main
 
 🗑 建议清理（PR 已关闭）：
   - worktrees/done-b (done/b) → PR #9 merged

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -21,7 +21,7 @@
 
 **安全检查（破坏性操作前必须执行）：**
 - `reset --hard` 前 → `git log HEAD --not --remotes` 确认本地无独有 commit
-- PR 目标分支 → 默认 `dev`（master 只接受 dev 合入）
+- PR 目标分支 → 默认 `main`
 - push 前 → `git log origin/<branch>..HEAD` 确认要推送的内容符合预期
 
 ## Worktree 规范

--- a/.claude/skills/wtpr/SKILL.md
+++ b/.claude/skills/wtpr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wtpr
-description: 在 git worktree 分支上执行完整的 PR 提交流程：自动识别当前 worktree、处理未提交改动、rebase 到最新 origin/dev、force push、创建或更新 GitHub PR。当用户在 worktree 中想提交 PR、追加新 commit 到已有 PR、或执行 wtpr 命令时使用。
+description: 在 git worktree 分支上执行完整的 PR 提交流程：自动识别当前 worktree、处理未提交改动、rebase 到最新 origin/main、force push、创建或更新 GitHub PR。当用户在 worktree 中想提交 PR、追加新 commit 到已有 PR、或执行 wtpr 命令时使用。
 ---
 
 # wtpr — Worktree PR 提交流程
 
-base 分支固定为 `dev`，合并策略默认 **rebase and merge**。
+base 分支固定为 `main`，合并策略默认 **rebase and merge**。
 
 ## Phase 1：Gather（批量采集，无副作用）
 
@@ -13,7 +13,7 @@ base 分支固定为 `dev`，合并策略默认 **rebase and merge**。
 git worktree list                              # 确定 WORKTREE 上下文
 git status --short                             # DIRTY 检查
 git fetch origin                               # 同步远端（只读）
-git rev-list origin/dev..HEAD --count          # UNPUSHED 数量
+git rev-list origin/main..HEAD --count          # UNPUSHED 数量
 gh pr view --json state,url,title,number 2>/dev/null  # PR_STATE
 ```
 
@@ -25,7 +25,7 @@ gh pr view --json state,url,title,number 2>/dev/null  # PR_STATE
 |------|------|
 | `WORKTREE` | 当前目录 / 命令参数 / 对话上下文，三者任一可确定目标 |
 | `DIRTY` | git status 非空 |
-| `UNPUSHED` | HEAD 超出 origin/dev 的 commit 数 |
+| `UNPUSHED` | HEAD 超出 origin/main 的 commit 数 |
 | `PR_STATE` | none / open / merged / closed |
 
 **PR_STATE 判断优先级**：
@@ -54,7 +54,7 @@ DIRTY = true：
 ### Step 3：Rebase（无条件执行）
 
 ```bash
-git rebase origin/dev
+git rebase origin/main
 ```
 
 `git rebase` 通过 **patch-id**（diff 内容哈希）自动识别并跳过内容相同但 SHA 不同的 commit（rebase-and-merge 副产品），无需预先判断是否需要 rebase。

--- a/.claude/skills/wtpr/prototype.md
+++ b/.claude/skills/wtpr/prototype.md
@@ -16,7 +16,7 @@ flowchart TD
     DASK -- commit 不满意 --> ANALYZE
     DASK -- stash --> STASH["git stash"] --> D
 
-    FETCH["git fetch origin"] --> REBASE["git rebase origin/dev\n（patch-id 自动跳过已合并内容）"]
+    FETCH["git fetch origin"] --> REBASE["git rebase origin/main\n（patch-id 自动跳过已合并内容）"]
 
     REBASE --> RC{"有冲突？"}
     RC -- 无 --> PUSH
@@ -42,4 +42,4 @@ flowchart TD
 - **单一出口**：所有路径收敛到 `✅ 完成`，Ctrl+C 是唯一退出方式
 - **只问"怎么做"**：交互节点不问"要不要做"，只问"怎么继续"
 - **所有循环有终点**：DIRTY 循环、冲突循环、message 确认循环均在用户操作后收敛
-- **无条件 rebase**：`git rebase origin/dev` 内部通过 patch-id 处理所有情况，无需预判
+- **无条件 rebase**：`git rebase origin/main` 内部通过 patch-id 处理所有情况，无需预判

--- a/docs/memory/summary-store-persistence.md
+++ b/docs/memory/summary-store-persistence.md
@@ -57,8 +57,8 @@ CREATE TABLE summaries (
 
 ### 前置条件
 ```bash
-git checkout dev
-git pull origin dev
+git checkout main
+git pull origin main
 ```
 
 ### Phase 1: 创建 SummaryStore


### PR DESCRIPTION
## Summary
- 将项目文档和配置中所有 `origin/dev`、`master` 分支引用更新为 `origin/main`
- 涉及 worktree 命令（wtnew/wtls/wtrebaseall）、wtpr skill、git 规范等 7 个文件

## Test plan
- [ ] 确认 `/wtnew`、`/wtls`、`/wtrebaseall`、`/wtpr` 命令正常工作
- [ ] 确认 PR 默认目标分支为 main

🤖 Generated with [Claude Code](https://claude.com/claude-code)