### PR TITLE
[proposer:chloe] feat(storage): consolidate database abstraction phase-2+3

### DIFF
--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import HTTPException
 
 from backend.web.core.config import DB_PATH
+from core.memory.thread_config_repo import SQLiteThreadConfigRepo
 from sandbox.db import DEFAULT_DB_PATH as SANDBOX_DB_PATH
 
 
@@ -139,6 +140,15 @@ def init_thread_config(thread_id: str, sandbox_type: str, cwd: str | None) -> No
         conn.commit()
 
 
+def save_thread_metadata(thread_id: str, sandbox_type: str, cwd: str | None) -> None:
+    """Persist thread sandbox_type and cwd to SQLite."""
+    repo = SQLiteThreadConfigRepo(DB_PATH)
+    try:
+        repo.save_metadata(thread_id, sandbox_type, cwd)
+    finally:
+        repo.close()
+
+
 def get_active_observation_provider() -> str | None:
     """Read global observation config and return the active provider name."""
     from config.observation_loader import ObservationLoader
@@ -156,6 +166,20 @@ def lookup_thread_model(thread_id: str) -> str | None:
     """Look up persisted model for a thread."""
     config = load_thread_config(thread_id)
     return config.model if config else None
+
+
+def lookup_thread_metadata(thread_id: str) -> tuple[str, str | None] | None:
+    """Look up persisted (sandbox_type, cwd) for a thread. Returns None if not found."""
+    if not DB_PATH.exists():
+        return None
+    try:
+        repo = SQLiteThreadConfigRepo(DB_PATH)
+        try:
+            return repo.lookup_metadata(thread_id)
+        finally:
+            repo.close()
+    except sqlite3.OperationalError:
+        return None
 
 
 def resolve_local_workspace_path(

--- a/core/memory/checkpoint_repo.py
+++ b/core/memory/checkpoint_repo.py
@@ -1,0 +1,94 @@
+"""SQLite repository for checkpoint/writes persistence operations."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+class SQLiteCheckpointRepo:
+    """Minimal checkpoint repository for thread-level read/write cleanup."""
+
+    _ALLOWED_TABLES = {"checkpoints", "writes", "checkpoint_writes", "checkpoint_blobs"}
+
+    def __init__(self, db_path: str | Path | None = None, conn: sqlite3.Connection | None = None) -> None:
+        self._own_conn = conn is None
+        if conn is not None:
+            self._conn = conn
+            return
+
+        if db_path is None:
+            db_path = Path.home() / ".leon" / "leon.db"
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+
+    def close(self) -> None:
+        if self._own_conn:
+            self._conn.close()
+
+    def list_thread_ids(self) -> list[str]:
+        cursor = self._conn.execute(
+            """
+            SELECT DISTINCT thread_id
+            FROM checkpoints
+            WHERE thread_id IS NOT NULL
+            ORDER BY thread_id
+            """
+        )
+        return [row[0] for row in cursor.fetchall() if row[0]]
+
+    def delete_thread_data(self, thread_id: str) -> None:
+        self._delete_by_thread("checkpoints", thread_id)
+        self._delete_by_thread("writes", thread_id)
+        self._delete_by_thread("checkpoint_writes", thread_id)
+        self._delete_by_thread("checkpoint_blobs", thread_id)
+        self._conn.commit()
+
+    def delete_checkpoints_by_ids(self, thread_id: str, checkpoint_ids: list[str]) -> None:
+        if not checkpoint_ids:
+            return
+
+        self._delete_by_thread_and_checkpoint_ids("checkpoints", thread_id, checkpoint_ids)
+        self._delete_by_thread_and_checkpoint_ids("writes", thread_id, checkpoint_ids)
+        self._delete_by_thread_and_checkpoint_ids("checkpoint_writes", thread_id, checkpoint_ids)
+        self._delete_by_thread_and_checkpoint_ids("checkpoint_blobs", thread_id, checkpoint_ids)
+        self._conn.commit()
+
+    def _table_exists(self, table: str) -> bool:
+        self._validate_table(table)
+        cursor = self._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        )
+        return cursor.fetchone() is not None
+
+    def _column_exists(self, table: str, column: str) -> bool:
+        if not self._table_exists(table):
+            return False
+        cursor = self._conn.execute(f"PRAGMA table_info({table})")
+        return any(row[1] == column for row in cursor.fetchall())
+
+    def _validate_table(self, table: str) -> None:
+        # @@@table_whitelist - table names cannot use query parameters; enforce strict internal whitelist.
+        if table not in self._ALLOWED_TABLES:
+            raise ValueError(f"Unsupported table name: {table}")
+
+    def _delete_by_thread(self, table: str, thread_id: str) -> None:
+        if not self._column_exists(table, "thread_id"):
+            return
+        self._conn.execute(
+            f"DELETE FROM {table} WHERE thread_id = ?",
+            (thread_id,),
+        )
+
+    def _delete_by_thread_and_checkpoint_ids(self, table: str, thread_id: str, checkpoint_ids: list[str]) -> None:
+        if not self._column_exists(table, "thread_id"):
+            return
+        if not self._column_exists(table, "checkpoint_id"):
+            return
+
+        placeholders = ",".join("?" for _ in checkpoint_ids)
+        # @@@param_sql - checkpoint ids are user-derived; keep parameterized placeholders for safe deletion.
+        self._conn.execute(
+            f"DELETE FROM {table} WHERE thread_id = ? AND checkpoint_id IN ({placeholders})",
+            [thread_id] + checkpoint_ids,
+        )

--- a/core/memory/file_operation_repo.py
+++ b/core/memory/file_operation_repo.py
@@ -1,0 +1,243 @@
+"""SQLite repository for file_operations persistence."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class FileOperationRow:
+    id: str
+    thread_id: str
+    checkpoint_id: str
+    timestamp: float
+    operation_type: str
+    file_path: str
+    before_content: str | None
+    after_content: str
+    changes: list[dict] | None
+    status: str = "applied"
+
+
+class SQLiteFileOperationRepo:
+    """Repository boundary for file_operations table."""
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        if db_path is None:
+            db_path = Path.home() / ".leon" / "leon.db"
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_table()
+
+    def record(
+        self,
+        thread_id: str,
+        checkpoint_id: str,
+        operation_type: str,
+        file_path: str,
+        before_content: str | None,
+        after_content: str,
+        changes: list[dict] | None = None,
+    ) -> str:
+        op_id = str(uuid.uuid4())
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO file_operations
+                (id, thread_id, checkpoint_id, timestamp, operation_type,
+                 file_path, before_content, after_content, changes, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    op_id,
+                    thread_id,
+                    checkpoint_id,
+                    time.time(),
+                    operation_type,
+                    file_path,
+                    before_content,
+                    after_content,
+                    json.dumps(changes) if changes else None,
+                    "applied",
+                ),
+            )
+            conn.commit()
+        return op_id
+
+    def get_operations_for_thread(self, thread_id: str, status: str = "applied") -> list[FileOperationRow]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT * FROM file_operations
+                WHERE thread_id = ? AND status = ?
+                ORDER BY timestamp ASC
+                """,
+                (thread_id, status),
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_operation(row) for row in rows]
+
+    def get_operations_after_checkpoint(self, thread_id: str, checkpoint_id: str) -> list[FileOperationRow]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT MIN(timestamp) as ts FROM file_operations
+                WHERE thread_id = ? AND checkpoint_id = ?
+                """,
+                (thread_id, checkpoint_id),
+            )
+            row = cursor.fetchone()
+            if not row or row["ts"] is None:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM file_operations
+                    WHERE thread_id = ? AND status = 'applied'
+                    ORDER BY timestamp DESC
+                    """,
+                    (thread_id,),
+                )
+            else:
+                target_ts = row["ts"]
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM file_operations
+                    WHERE thread_id = ? AND timestamp >= ? AND status = 'applied'
+                    ORDER BY timestamp DESC
+                    """,
+                    (thread_id, target_ts),
+                )
+            rows = cursor.fetchall()
+        return [self._row_to_operation(row) for row in rows]
+
+    def get_operations_between_checkpoints(
+        self,
+        thread_id: str,
+        from_checkpoint_id: str,
+        to_checkpoint_id: str,
+    ) -> list[FileOperationRow]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT * FROM file_operations
+                WHERE thread_id = ?
+                AND checkpoint_id != ?
+                AND status = 'applied'
+                ORDER BY timestamp DESC
+                """,
+                (thread_id, from_checkpoint_id),
+            )
+            rows = cursor.fetchall()
+
+        result: list[FileOperationRow] = []
+        found_target = False
+        for row in rows:
+            if row["checkpoint_id"] == to_checkpoint_id:
+                found_target = True
+            if found_target:
+                break
+            result.append(self._row_to_operation(row))
+        return result
+
+    def get_operations_for_checkpoint(self, thread_id: str, checkpoint_id: str) -> list[FileOperationRow]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT * FROM file_operations
+                WHERE thread_id = ? AND checkpoint_id = ? AND status = 'applied'
+                ORDER BY timestamp ASC
+                """,
+                (thread_id, checkpoint_id),
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_operation(row) for row in rows]
+
+    def count_operations_for_checkpoint(self, thread_id: str, checkpoint_id: str) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT COUNT(*) FROM file_operations
+                WHERE thread_id = ? AND checkpoint_id = ? AND status = 'applied'
+                """,
+                (thread_id, checkpoint_id),
+            )
+            return int(cursor.fetchone()[0])
+
+    def mark_reverted(self, operation_ids: list[str]) -> None:
+        if not operation_ids:
+            return
+        placeholders = ",".join("?" * len(operation_ids))
+        with sqlite3.connect(self.db_path) as conn:
+            # @@@param_sql - operation ids can originate from runtime state; keep IN-clause parameterized.
+            conn.execute(
+                f"""
+                UPDATE file_operations
+                SET status = 'reverted'
+                WHERE id IN ({placeholders})
+                """,
+                operation_ids,
+            )
+            conn.commit()
+
+    def delete_thread_operations(self, thread_id: str) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "DELETE FROM file_operations WHERE thread_id = ?",
+                (thread_id,),
+            )
+            conn.commit()
+            return int(cursor.rowcount)
+
+    def _ensure_table(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS file_operations (
+                    id TEXT PRIMARY KEY,
+                    thread_id TEXT NOT NULL,
+                    checkpoint_id TEXT NOT NULL,
+                    timestamp REAL NOT NULL,
+                    operation_type TEXT NOT NULL,
+                    file_path TEXT NOT NULL,
+                    before_content TEXT,
+                    after_content TEXT NOT NULL,
+                    changes TEXT,
+                    status TEXT DEFAULT 'applied'
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_file_ops_thread
+                ON file_operations(thread_id, timestamp)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_file_ops_checkpoint
+                ON file_operations(checkpoint_id)
+                """
+            )
+            conn.commit()
+
+    def _row_to_operation(self, row: sqlite3.Row) -> FileOperationRow:
+        return FileOperationRow(
+            id=row["id"],
+            thread_id=row["thread_id"],
+            checkpoint_id=row["checkpoint_id"],
+            timestamp=row["timestamp"],
+            operation_type=row["operation_type"],
+            file_path=row["file_path"],
+            before_content=row["before_content"],
+            after_content=row["after_content"],
+            changes=json.loads(row["changes"]) if row["changes"] else None,
+            status=row["status"],
+        )

--- a/core/memory/run_event_repo.py
+++ b/core/memory/run_event_repo.py
@@ -1,0 +1,149 @@
+"""SQLite repository for run event persistence operations."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+class SQLiteRunEventRepo:
+    """Minimal run event repository with parameterized SQL operations."""
+
+    def __init__(self, db_path: str | Path | None = None, conn: sqlite3.Connection | None = None) -> None:
+        self._own_conn = conn is None
+        if conn is not None:
+            self._conn = conn
+        else:
+            if db_path is None:
+                db_path = Path.home() / ".leon" / "leon.db"
+            self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._ensure_table()
+
+    def close(self) -> None:
+        if self._own_conn:
+            self._conn.close()
+
+    def append_event(
+        self,
+        thread_id: str,
+        run_id: str,
+        event_type: str,
+        data: dict[str, Any],
+        message_id: str | None = None,
+    ) -> int:
+        payload = json.dumps(data, ensure_ascii=False)
+        cursor = self._conn.execute(
+            """
+            INSERT INTO run_events (thread_id, run_id, event_type, data, message_id)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (thread_id, run_id, event_type, payload, message_id),
+        )
+        self._conn.commit()
+        return int(cursor.lastrowid)
+
+    def list_events(
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        after: int = 0,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT seq, event_type, data, message_id
+            FROM run_events
+            WHERE thread_id = ? AND run_id = ? AND seq > ?
+            ORDER BY seq ASC
+            LIMIT ?
+            """,
+            (thread_id, run_id, after, limit),
+        ).fetchall()
+        return [
+            {
+                "seq": row[0],
+                "event_type": row[1],
+                "data": json.loads(row[2]) if row[2] else {},
+                "message_id": row[3],
+            }
+            for row in rows
+        ]
+
+    def latest_seq(self, thread_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT MAX(seq) FROM run_events WHERE thread_id = ?",
+            (thread_id,),
+        ).fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    def latest_run_id(self, thread_id: str) -> str | None:
+        row = self._conn.execute(
+            """
+            SELECT run_id
+            FROM run_events
+            WHERE thread_id = ?
+            ORDER BY seq DESC
+            LIMIT 1
+            """,
+            (thread_id,),
+        ).fetchone()
+        return row[0] if row else None
+
+    def list_run_ids(self, thread_id: str) -> list[str]:
+        rows = self._conn.execute(
+            """
+            SELECT run_id
+            FROM run_events
+            WHERE thread_id = ?
+            GROUP BY run_id
+            ORDER BY MAX(seq) DESC
+            """,
+            (thread_id,),
+        ).fetchall()
+        return [row[0] for row in rows if row[0]]
+
+    def delete_runs(self, thread_id: str, run_ids: list[str]) -> int:
+        if not run_ids:
+            return 0
+
+        placeholders = ",".join("?" for _ in run_ids)
+        # @@@param_sql - run ids can be external input; keep IN-clause values fully parameterized.
+        cursor = self._conn.execute(
+            f"DELETE FROM run_events WHERE thread_id = ? AND run_id IN ({placeholders})",
+            [thread_id] + run_ids,
+        )
+        self._conn.commit()
+        return int(cursor.rowcount)
+
+    def delete_thread_events(self, thread_id: str) -> int:
+        cursor = self._conn.execute(
+            "DELETE FROM run_events WHERE thread_id = ?",
+            (thread_id,),
+        )
+        self._conn.commit()
+        return int(cursor.rowcount)
+
+    def _ensure_table(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS run_events (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                thread_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                data TEXT NOT NULL,
+                message_id TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_run_events_thread_run
+            ON run_events (thread_id, run_id, seq)
+            """
+        )
+        self._conn.commit()

--- a/core/memory/summary_repo.py
+++ b/core/memory/summary_repo.py
@@ -1,0 +1,126 @@
+"""SQLite repository for summaries persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+
+class SQLiteSummaryRepo:
+    """Repository boundary for summaries table operations."""
+
+    def __init__(self, db_path: Path, connect_fn: Callable[[Path], sqlite3.Connection]) -> None:
+        self.db_path = db_path
+        self._connect = connect_fn
+
+    def ensure_tables(self) -> None:
+        with self._connect(self.db_path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS summaries (
+                    summary_id TEXT PRIMARY KEY,
+                    thread_id TEXT NOT NULL,
+                    summary_text TEXT NOT NULL,
+                    compact_up_to_index INTEGER NOT NULL,
+                    compacted_at INTEGER NOT NULL,
+                    is_split_turn BOOLEAN DEFAULT FALSE,
+                    split_turn_prefix TEXT,
+                    is_active BOOLEAN DEFAULT TRUE,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_summaries_thread_id
+                ON summaries(thread_id, is_active, created_at DESC)
+                """
+            )
+            conn.commit()
+
+    def save_summary(
+        self,
+        summary_id: str,
+        thread_id: str,
+        summary_text: str,
+        compact_up_to_index: int,
+        compacted_at: int,
+        is_split_turn: bool,
+        split_turn_prefix: str | None,
+        created_at: str,
+    ) -> None:
+        with self._connect(self.db_path) as conn:
+            conn.execute(
+                """
+                UPDATE summaries
+                SET is_active = FALSE
+                WHERE thread_id = ? AND is_active = TRUE
+                """,
+                (thread_id,),
+            )
+            conn.execute(
+                """
+                INSERT INTO summaries (
+                    summary_id, thread_id, summary_text,
+                    compact_up_to_index, compacted_at,
+                    is_split_turn, split_turn_prefix,
+                    is_active, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    summary_id,
+                    thread_id,
+                    summary_text,
+                    compact_up_to_index,
+                    compacted_at,
+                    is_split_turn,
+                    split_turn_prefix,
+                    True,
+                    created_at,
+                ),
+            )
+            conn.commit()
+
+    def get_latest_summary_row(self, thread_id: str) -> sqlite3.Row | None:
+        with self._connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            return conn.execute(
+                """
+                SELECT summary_id, thread_id, summary_text,
+                       compact_up_to_index, compacted_at,
+                       is_split_turn, split_turn_prefix,
+                       is_active, created_at
+                FROM summaries
+                WHERE thread_id = ? AND is_active = TRUE
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (thread_id,),
+            ).fetchone()
+
+    def list_summaries(self, thread_id: str) -> list[dict[str, object]]:
+        with self._connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT summary_id, thread_id,
+                       compact_up_to_index, compacted_at,
+                       is_split_turn, is_active, created_at
+                FROM summaries
+                WHERE thread_id = ?
+                ORDER BY created_at DESC
+                """,
+                (thread_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def delete_thread_summaries(self, thread_id: str) -> None:
+        with self._connect(self.db_path) as conn:
+            conn.execute(
+                "DELETE FROM summaries WHERE thread_id = ?",
+                (thread_id,),
+            )
+            conn.commit()

--- a/core/memory/summary_store.py
+++ b/core/memory/summary_store.py
@@ -23,6 +23,8 @@ from typing import Any
 
 from sandbox.db import DEFAULT_DB_PATH
 
+from .summary_repo import SQLiteSummaryRepo
+
 logger = logging.getLogger(__name__)
 
 
@@ -60,35 +62,13 @@ class SummaryStore:
 
     def __init__(self, db_path: Path = DEFAULT_DB_PATH):
         self.db_path = db_path
+        # @@@connect_injection - keep _connect as an indirection point so existing retry/rollback tests can patch it.
+        self._repo = SQLiteSummaryRepo(db_path, connect_fn=lambda p: _connect(p))
         self._ensure_tables()
 
     def _ensure_tables(self) -> None:
         """Ensure summaries table exists."""
-        with _connect(self.db_path) as conn:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS summaries (
-                    summary_id TEXT PRIMARY KEY,
-                    thread_id TEXT NOT NULL,
-                    summary_text TEXT NOT NULL,
-                    compact_up_to_index INTEGER NOT NULL,
-                    compacted_at INTEGER NOT NULL,
-                    is_split_turn BOOLEAN DEFAULT FALSE,
-                    split_turn_prefix TEXT,
-                    is_active BOOLEAN DEFAULT TRUE,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
-                """
-            )
-            # Index for fast lookup by thread_id
-            conn.execute(
-                """
-                CREATE INDEX IF NOT EXISTS idx_summaries_thread_id
-                ON summaries(thread_id, is_active, created_at DESC)
-                """
-            )
-            conn.commit()
+        self._repo.ensure_tables()
 
     def save_summary(
         self,
@@ -122,41 +102,16 @@ class SummaryStore:
 
         for attempt in range(max_retries):
             try:
-                with _connect(self.db_path) as conn:
-                    # Mark all existing summaries for this thread as inactive
-                    conn.execute(
-                        """
-                        UPDATE summaries
-                        SET is_active = FALSE
-                        WHERE thread_id = ? AND is_active = TRUE
-                        """,
-                        (thread_id,),
-                    )
-
-                    # Insert new summary
-                    conn.execute(
-                        """
-                        INSERT INTO summaries (
-                            summary_id, thread_id, summary_text,
-                            compact_up_to_index, compacted_at,
-                            is_split_turn, split_turn_prefix,
-                            is_active, created_at
-                        )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            summary_id,
-                            thread_id,
-                            summary_text,
-                            compact_up_to_index,
-                            compacted_at,
-                            is_split_turn,
-                            split_turn_prefix,
-                            True,
-                            now,
-                        ),
-                    )
-                    conn.commit()
+                self._repo.save_summary(
+                    summary_id=summary_id,
+                    thread_id=thread_id,
+                    summary_text=summary_text,
+                    compact_up_to_index=compact_up_to_index,
+                    compacted_at=compacted_at,
+                    is_split_turn=is_split_turn,
+                    split_turn_prefix=split_turn_prefix,
+                    created_at=now,
+                )
 
                 logger.info(f"[SummaryStore] Saved summary {summary_id} for thread {thread_id}")
                 return summary_id
@@ -185,41 +140,27 @@ class SummaryStore:
         """
         for attempt in range(max_retries):
             try:
-                with _connect(self.db_path) as conn:
-                    conn.row_factory = sqlite3.Row
-                    row = conn.execute(
-                        """
-                        SELECT summary_id, thread_id, summary_text,
-                               compact_up_to_index, compacted_at,
-                               is_split_turn, split_turn_prefix,
-                               is_active, created_at
-                        FROM summaries
-                        WHERE thread_id = ? AND is_active = TRUE
-                        ORDER BY created_at DESC
-                        LIMIT 1
-                        """,
-                        (thread_id,),
-                    ).fetchone()
+                row = self._repo.get_latest_summary_row(thread_id)
 
-                    if not row:
-                        return None
+                if not row:
+                    return None
 
-                    # Validate data integrity
-                    try:
-                        return SummaryData(
-                            summary_id=row["summary_id"],
-                            thread_id=row["thread_id"],
-                            summary_text=row["summary_text"],
-                            compact_up_to_index=row["compact_up_to_index"],
-                            compacted_at=row["compacted_at"],
-                            is_split_turn=bool(row["is_split_turn"]),
-                            split_turn_prefix=row["split_turn_prefix"],
-                            is_active=bool(row["is_active"]),
-                            created_at=row["created_at"],
-                        )
-                    except (KeyError, TypeError, ValueError) as e:
-                        logger.error(f"[SummaryStore] Data corruption detected: {e}")
-                        return None  # Signal data corruption
+                # Validate data integrity
+                try:
+                    return SummaryData(
+                        summary_id=row["summary_id"],
+                        thread_id=row["thread_id"],
+                        summary_text=row["summary_text"],
+                        compact_up_to_index=row["compact_up_to_index"],
+                        compacted_at=row["compacted_at"],
+                        is_split_turn=bool(row["is_split_turn"]),
+                        split_turn_prefix=row["split_turn_prefix"],
+                        is_active=bool(row["is_active"]),
+                        created_at=row["created_at"],
+                    )
+                except (KeyError, TypeError, ValueError) as e:
+                    logger.error(f"[SummaryStore] Data corruption detected: {e}")
+                    return None  # Signal data corruption
 
             except sqlite3.Error as e:
                 if attempt < max_retries - 1:
@@ -240,21 +181,7 @@ class SummaryStore:
         Returns:
             List of summary records as dictionaries
         """
-        with _connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                """
-                SELECT summary_id, thread_id,
-                       compact_up_to_index, compacted_at,
-                       is_split_turn, is_active, created_at
-                FROM summaries
-                WHERE thread_id = ?
-                ORDER BY created_at DESC
-                """,
-                (thread_id,),
-            ).fetchall()
-
-            return [dict(row) for row in rows]
+        return self._repo.list_summaries(thread_id)
 
     def delete_thread_summaries(self, thread_id: str) -> None:
         """Delete all summaries for a thread.
@@ -262,11 +189,6 @@ class SummaryStore:
         Args:
             thread_id: Thread identifier
         """
-        with _connect(self.db_path) as conn:
-            conn.execute(
-                "DELETE FROM summaries WHERE thread_id = ?",
-                (thread_id,),
-            )
-            conn.commit()
+        self._repo.delete_thread_summaries(thread_id)
 
         logger.info(f"[SummaryStore] Deleted all summaries for thread {thread_id}")

--- a/core/memory/thread_config_repo.py
+++ b/core/memory/thread_config_repo.py
@@ -1,0 +1,92 @@
+"""SQLite repository for thread-level config persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+class SQLiteThreadConfigRepo:
+    """Thread config repository with minimal read/write API."""
+
+    def __init__(self, db_path: str | Path, conn: sqlite3.Connection | None = None) -> None:
+        self._own_conn = conn is None
+        if conn is not None:
+            self._conn = conn
+        else:
+            self._conn = sqlite3.connect(str(db_path))
+        self._ensure_table()
+
+    def close(self) -> None:
+        if self._own_conn:
+            self._conn.close()
+
+    def save_metadata(self, thread_id: str, sandbox_type: str, cwd: str | None) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO thread_config (thread_id, sandbox_type, cwd)
+            VALUES (?, ?, ?)
+            ON CONFLICT(thread_id) DO UPDATE SET
+                sandbox_type = excluded.sandbox_type,
+                cwd = excluded.cwd
+            """,
+            (thread_id, sandbox_type, cwd),
+        )
+        self._conn.commit()
+
+    def save_model(self, thread_id: str, model: str) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO thread_config (thread_id, sandbox_type, model)
+            VALUES (?, 'local', ?)
+            ON CONFLICT(thread_id) DO UPDATE SET
+                model = excluded.model
+            """,
+            (thread_id, model),
+        )
+        self._conn.commit()
+
+    def lookup_model(self, thread_id: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT model FROM thread_config WHERE thread_id = ?",
+            (thread_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return row[0] if row[0] else None
+
+    def lookup_metadata(self, thread_id: str) -> tuple[str, str | None] | None:
+        row = self._conn.execute(
+            "SELECT sandbox_type, cwd FROM thread_config WHERE thread_id = ?",
+            (thread_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return row[0], row[1]
+
+    def _ensure_table(self) -> None:
+        tables = {r[0] for r in self._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        # @@@table_migration - keep backward compatibility by renaming old thread_metadata table once.
+        if "thread_metadata" in tables and "thread_config" not in tables:
+            self._conn.execute("ALTER TABLE thread_metadata RENAME TO thread_config")
+
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS thread_config (
+                thread_id TEXT PRIMARY KEY,
+                sandbox_type TEXT NOT NULL DEFAULT 'local',
+                cwd TEXT,
+                model TEXT
+            )
+            """
+        )
+
+        existing_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(thread_config)")}
+        if "model" not in existing_cols:
+            self._conn.execute("ALTER TABLE thread_config ADD COLUMN model TEXT")
+        if "cwd" not in existing_cols:
+            self._conn.execute("ALTER TABLE thread_config ADD COLUMN cwd TEXT")
+        if "sandbox_type" not in existing_cols:
+            self._conn.execute("ALTER TABLE thread_config ADD COLUMN sandbox_type TEXT")
+
+        self._conn.commit()

--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -1,0 +1,3 @@
+from .container import StorageContainer
+
+__all__ = ["StorageContainer"]

--- a/core/storage/container.py
+++ b/core/storage/container.py
@@ -1,0 +1,49 @@
+"""StorageContainer — phase-3 composition root for hunter worktree.
+
+# @@@phase3-container - wires all 6 phase-2 repos; call sites unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class StorageContainer:
+    """Composition root: instantiates phase-2 repos from DB paths."""
+
+    def __init__(
+        self,
+        main_db_path: str | Path | None = None,
+        eval_db_path: str | Path | None = None,
+    ) -> None:
+        root = Path.home() / ".leon"
+        self._main_db = Path(main_db_path) if main_db_path else root / "leon.db"
+        self._eval_db = Path(eval_db_path) if eval_db_path else root / "eval.db"
+
+    def checkpoint_repo(self):
+        from core.memory.checkpoint_repo import SQLiteCheckpointRepo
+        return SQLiteCheckpointRepo(db_path=self._main_db)
+
+    def thread_config_repo(self):
+        from core.memory.thread_config_repo import SQLiteThreadConfigRepo
+        return SQLiteThreadConfigRepo(db_path=self._main_db)
+
+    def run_event_repo(self):
+        from core.memory.run_event_repo import SQLiteRunEventRepo
+        return SQLiteRunEventRepo(db_path=self._main_db)
+
+    def file_operation_repo(self):
+        from core.memory.file_operation_repo import SQLiteFileOperationRepo
+        return SQLiteFileOperationRepo(db_path=self._main_db)
+
+    def summary_repo(self):
+        import sqlite3
+        from core.memory.summary_repo import SQLiteSummaryRepo
+        return SQLiteSummaryRepo(
+            db_path=self._main_db,
+            connect_fn=lambda p: sqlite3.connect(str(p)),
+        )
+
+    def eval_repo(self):
+        from eval.repo import SQLiteEvalRepo
+        return SQLiteEvalRepo(db_path=self._eval_db)

--- a/eval/repo.py
+++ b/eval/repo.py
@@ -1,0 +1,194 @@
+"""SQLite repository for eval trajectory persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+from eval.models import RunTrajectory
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS eval_runs (
+    id TEXT PRIMARY KEY,
+    thread_id TEXT NOT NULL,
+    started_at TEXT,
+    finished_at TEXT,
+    user_message TEXT,
+    final_response TEXT,
+    status TEXT DEFAULT 'completed',
+    run_tree_json TEXT,
+    trajectory_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS eval_llm_calls (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    parent_run_id TEXT,
+    duration_ms REAL DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    total_tokens INTEGER DEFAULT 0,
+    cost_usd REAL DEFAULT 0,
+    model_name TEXT DEFAULT '',
+    FOREIGN KEY (run_id) REFERENCES eval_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS eval_tool_calls (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    parent_run_id TEXT,
+    tool_name TEXT NOT NULL,
+    tool_call_id TEXT DEFAULT '',
+    duration_ms REAL DEFAULT 0,
+    success INTEGER DEFAULT 1,
+    error TEXT,
+    args_summary TEXT DEFAULT '',
+    result_summary TEXT DEFAULT '',
+    FOREIGN KEY (run_id) REFERENCES eval_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS eval_metrics (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    tier TEXT NOT NULL,
+    timestamp TEXT,
+    metrics_json TEXT,
+    FOREIGN KEY (run_id) REFERENCES eval_runs(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eval_runs_thread ON eval_runs(thread_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_eval_tool_name ON eval_tool_calls(tool_name);
+CREATE INDEX IF NOT EXISTS idx_eval_metrics_run ON eval_metrics(run_id, tier);
+"""
+
+
+class SQLiteEvalRepo:
+    """Repository boundary for eval DB SQL operations."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(str(self.db_path))
+
+    def ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA_SQL)
+
+    def save_trajectory(self, trajectory: RunTrajectory, trajectory_json: str) -> str:
+        run_id = trajectory.id
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO eval_runs (id, thread_id, started_at, finished_at, "
+                "user_message, final_response, status, run_tree_json, trajectory_json) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    trajectory.thread_id,
+                    trajectory.started_at,
+                    trajectory.finished_at,
+                    trajectory.user_message,
+                    trajectory.final_response,
+                    trajectory.status,
+                    trajectory.run_tree_json,
+                    trajectory_json,
+                ),
+            )
+
+            for call in trajectory.llm_calls:
+                conn.execute(
+                    "INSERT INTO eval_llm_calls (id, run_id, parent_run_id, "
+                    "duration_ms, input_tokens, output_tokens, total_tokens, "
+                    "cost_usd, model_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        str(uuid4()),
+                        run_id,
+                        call.parent_run_id,
+                        call.duration_ms,
+                        call.input_tokens,
+                        call.output_tokens,
+                        call.total_tokens,
+                        call.cost_usd,
+                        call.model_name,
+                    ),
+                )
+
+            for call in trajectory.tool_calls:
+                conn.execute(
+                    "INSERT INTO eval_tool_calls (id, run_id, parent_run_id, "
+                    "tool_name, tool_call_id, duration_ms, success, error, "
+                    "args_summary, result_summary) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        str(uuid4()),
+                        run_id,
+                        call.parent_run_id,
+                        call.tool_name,
+                        call.tool_call_id,
+                        call.duration_ms,
+                        int(call.success),
+                        call.error,
+                        call.args_summary,
+                        call.result_summary,
+                    ),
+                )
+        return run_id
+
+    def save_metrics(self, run_id: str, tier: str, timestamp: str, metrics_json: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO eval_metrics (id, run_id, tier, timestamp, metrics_json) VALUES (?, ?, ?, ?, ?)",
+                (
+                    str(uuid4()),
+                    run_id,
+                    tier,
+                    timestamp,
+                    metrics_json,
+                ),
+            )
+
+    def get_trajectory_json(self, run_id: str) -> str | None:
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT trajectory_json FROM eval_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+            if not row:
+                return None
+            return row["trajectory_json"]
+
+    def list_runs(self, thread_id: str | None = None, limit: int = 50) -> list[dict]:
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            if thread_id:
+                rows = conn.execute(
+                    "SELECT id, thread_id, started_at, finished_at, status, "
+                    "user_message FROM eval_runs "
+                    "WHERE thread_id = ? ORDER BY started_at DESC LIMIT ?",
+                    (thread_id, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT id, thread_id, started_at, finished_at, status, "
+                    "user_message FROM eval_runs "
+                    "ORDER BY started_at DESC LIMIT ?",
+                    (limit,),
+                ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_metrics(self, run_id: str, tier: str | None = None) -> list[dict]:
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            if tier:
+                rows = conn.execute(
+                    "SELECT id, tier, timestamp, metrics_json FROM eval_metrics WHERE run_id = ? AND tier = ?",
+                    (run_id, tier),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT id, tier, timestamp, metrics_json FROM eval_metrics WHERE run_id = ?",
+                    (run_id,),
+                ).fetchall()
+        return [dict(r) for r in rows]

--- a/eval/storage.py
+++ b/eval/storage.py
@@ -6,11 +6,10 @@ Database: ~/.leon/eval.db (separate from main leon.db)
 from __future__ import annotations
 
 import json
-import sqlite3
 from datetime import UTC
 from pathlib import Path
-from uuid import uuid4
 
+from eval.repo import SQLiteEvalRepo
 from eval.models import (
     ObjectiveMetrics,
     RunTrajectory,
@@ -19,138 +18,22 @@ from eval.models import (
 
 _DEFAULT_DB_PATH = Path.home() / ".leon" / "eval.db"
 
-_SCHEMA_SQL = """
-CREATE TABLE IF NOT EXISTS eval_runs (
-    id TEXT PRIMARY KEY,
-    thread_id TEXT NOT NULL,
-    started_at TEXT,
-    finished_at TEXT,
-    user_message TEXT,
-    final_response TEXT,
-    status TEXT DEFAULT 'completed',
-    run_tree_json TEXT,
-    trajectory_json TEXT
-);
-
-CREATE TABLE IF NOT EXISTS eval_llm_calls (
-    id TEXT PRIMARY KEY,
-    run_id TEXT NOT NULL,
-    parent_run_id TEXT,
-    duration_ms REAL DEFAULT 0,
-    input_tokens INTEGER DEFAULT 0,
-    output_tokens INTEGER DEFAULT 0,
-    total_tokens INTEGER DEFAULT 0,
-    cost_usd REAL DEFAULT 0,
-    model_name TEXT DEFAULT '',
-    FOREIGN KEY (run_id) REFERENCES eval_runs(id)
-);
-
-CREATE TABLE IF NOT EXISTS eval_tool_calls (
-    id TEXT PRIMARY KEY,
-    run_id TEXT NOT NULL,
-    parent_run_id TEXT,
-    tool_name TEXT NOT NULL,
-    tool_call_id TEXT DEFAULT '',
-    duration_ms REAL DEFAULT 0,
-    success INTEGER DEFAULT 1,
-    error TEXT,
-    args_summary TEXT DEFAULT '',
-    result_summary TEXT DEFAULT '',
-    FOREIGN KEY (run_id) REFERENCES eval_runs(id)
-);
-
-CREATE TABLE IF NOT EXISTS eval_metrics (
-    id TEXT PRIMARY KEY,
-    run_id TEXT NOT NULL,
-    tier TEXT NOT NULL,
-    timestamp TEXT,
-    metrics_json TEXT,
-    FOREIGN KEY (run_id) REFERENCES eval_runs(id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_eval_runs_thread ON eval_runs(thread_id, started_at);
-CREATE INDEX IF NOT EXISTS idx_eval_tool_name ON eval_tool_calls(tool_name);
-CREATE INDEX IF NOT EXISTS idx_eval_metrics_run ON eval_metrics(run_id, tier);
-"""
-
-
 class TrajectoryStore:
     """SQLite-backed storage for eval trajectories and metrics."""
 
     def __init__(self, db_path: str | Path | None = None):
         self.db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._repo = SQLiteEvalRepo(self.db_path)
         self._init_db()
 
     def _init_db(self) -> None:
-        with self._connect() as conn:
-            conn.executescript(_SCHEMA_SQL)
-
-    def _connect(self) -> sqlite3.Connection:
-        return sqlite3.connect(str(self.db_path))
+        self._repo.ensure_schema()
 
     def save_trajectory(self, trajectory: RunTrajectory) -> str:
         """Save a trajectory and its LLM/tool call records. Returns run_id."""
-        run_id = trajectory.id
         trajectory_json = trajectory.model_dump_json()
-
-        with self._connect() as conn:
-            conn.execute(
-                "INSERT INTO eval_runs (id, thread_id, started_at, finished_at, "
-                "user_message, final_response, status, run_tree_json, trajectory_json) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    run_id,
-                    trajectory.thread_id,
-                    trajectory.started_at,
-                    trajectory.finished_at,
-                    trajectory.user_message,
-                    trajectory.final_response,
-                    trajectory.status,
-                    trajectory.run_tree_json,
-                    trajectory_json,
-                ),
-            )
-
-            for call in trajectory.llm_calls:
-                conn.execute(
-                    "INSERT INTO eval_llm_calls (id, run_id, parent_run_id, "
-                    "duration_ms, input_tokens, output_tokens, total_tokens, "
-                    "cost_usd, model_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        str(uuid4()),
-                        run_id,
-                        call.parent_run_id,
-                        call.duration_ms,
-                        call.input_tokens,
-                        call.output_tokens,
-                        call.total_tokens,
-                        call.cost_usd,
-                        call.model_name,
-                    ),
-                )
-
-            for call in trajectory.tool_calls:
-                conn.execute(
-                    "INSERT INTO eval_tool_calls (id, run_id, parent_run_id, "
-                    "tool_name, tool_call_id, duration_ms, success, error, "
-                    "args_summary, result_summary) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        str(uuid4()),
-                        run_id,
-                        call.parent_run_id,
-                        call.tool_name,
-                        call.tool_call_id,
-                        call.duration_ms,
-                        int(call.success),
-                        call.error,
-                        call.args_summary,
-                        call.result_summary,
-                    ),
-                )
-
-        return run_id
+        return self._repo.save_trajectory(trajectory, trajectory_json)
 
     def save_metrics(
         self,
@@ -161,69 +44,31 @@ class TrajectoryStore:
         """Save computed metrics for a run."""
         from datetime import datetime
 
-        with self._connect() as conn:
-            conn.execute(
-                "INSERT INTO eval_metrics (id, run_id, tier, timestamp, metrics_json) VALUES (?, ?, ?, ?, ?)",
-                (
-                    str(uuid4()),
-                    run_id,
-                    tier,
-                    datetime.now(UTC).isoformat(),
-                    metrics.model_dump_json(),
-                ),
-            )
+        self._repo.save_metrics(
+            run_id=run_id,
+            tier=tier,
+            timestamp=datetime.now(UTC).isoformat(),
+            metrics_json=metrics.model_dump_json(),
+        )
 
     def get_trajectory(self, run_id: str) -> RunTrajectory | None:
         """Load a trajectory by run_id."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT trajectory_json FROM eval_runs WHERE id = ?",
-                (run_id,),
-            ).fetchone()
-            if not row or not row["trajectory_json"]:
-                return None
-            return RunTrajectory.model_validate_json(row["trajectory_json"])
+        trajectory_json = self._repo.get_trajectory_json(run_id)
+        if not trajectory_json:
+            return None
+        return RunTrajectory.model_validate_json(trajectory_json)
 
     def list_runs(self, thread_id: str | None = None, limit: int = 50) -> list[dict]:
         """List eval runs, optionally filtered by thread_id."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
-            if thread_id:
-                rows = conn.execute(
-                    "SELECT id, thread_id, started_at, finished_at, status, "
-                    "user_message FROM eval_runs "
-                    "WHERE thread_id = ? ORDER BY started_at DESC LIMIT ?",
-                    (thread_id, limit),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT id, thread_id, started_at, finished_at, status, "
-                    "user_message FROM eval_runs "
-                    "ORDER BY started_at DESC LIMIT ?",
-                    (limit,),
-                ).fetchall()
-            return [dict(r) for r in rows]
+        return self._repo.list_runs(thread_id=thread_id, limit=limit)
 
     def get_metrics(self, run_id: str, tier: str | None = None) -> list[dict]:
         """Get metrics for a run, optionally filtered by tier."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
-            if tier:
-                rows = conn.execute(
-                    "SELECT id, tier, timestamp, metrics_json FROM eval_metrics WHERE run_id = ? AND tier = ?",
-                    (run_id, tier),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT id, tier, timestamp, metrics_json FROM eval_metrics WHERE run_id = ?",
-                    (run_id,),
-                ).fetchall()
-            result = []
-            for r in rows:
-                d = dict(r)
-                if d.get("metrics_json"):
-                    d["metrics"] = json.loads(d["metrics_json"])
-                    del d["metrics_json"]
-                result.append(d)
-            return result
+        rows = self._repo.get_metrics(run_id=run_id, tier=tier)
+        result = []
+        for d in rows:
+            if d.get("metrics_json"):
+                d["metrics"] = json.loads(d["metrics_json"])
+                del d["metrics_json"]
+            result.append(d)
+        return result

--- a/tests/test_checkpoint_repo.py
+++ b/tests/test_checkpoint_repo.py
@@ -1,0 +1,115 @@
+import sqlite3
+from pathlib import Path
+
+from core.memory.checkpoint_repo import SQLiteCheckpointRepo
+
+
+def _setup_tables(db_path: Path) -> None:
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("CREATE TABLE checkpoints (thread_id TEXT, checkpoint_id TEXT)")
+        conn.execute("CREATE TABLE writes (thread_id TEXT, checkpoint_id TEXT)")
+        conn.execute("CREATE TABLE checkpoint_writes (thread_id TEXT, checkpoint_id TEXT)")
+        conn.execute("CREATE TABLE checkpoint_blobs (thread_id TEXT, checkpoint_id TEXT)")
+        conn.commit()
+
+
+def test_list_thread_ids(tmp_path):
+    db_path = tmp_path / "leon.db"
+    _setup_tables(db_path)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("INSERT INTO checkpoints (thread_id, checkpoint_id) VALUES (?, ?)", ("t-2", "c1"))
+        conn.execute("INSERT INTO checkpoints (thread_id, checkpoint_id) VALUES (?, ?)", ("t-1", "c2"))
+        conn.execute("INSERT INTO checkpoints (thread_id, checkpoint_id) VALUES (?, ?)", ("t-1", "c3"))
+        conn.commit()
+
+    repo = SQLiteCheckpointRepo(db_path=db_path)
+    try:
+        assert repo.list_thread_ids() == ["t-1", "t-2"]
+    finally:
+        repo.close()
+
+
+def test_delete_checkpoints_by_ids(tmp_path):
+    db_path = tmp_path / "leon.db"
+    _setup_tables(db_path)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executemany(
+            "INSERT INTO checkpoints (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c1"), ("t-1", "c2"), ("t-1", "c3"), ("t-2", "c2")],
+        )
+        conn.executemany(
+            "INSERT INTO writes (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c2"), ("t-1", "c3"), ("t-2", "c2")],
+        )
+        conn.executemany(
+            "INSERT INTO checkpoint_writes (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c2"), ("t-1", "c3"), ("t-2", "c2")],
+        )
+        conn.executemany(
+            "INSERT INTO checkpoint_blobs (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c2"), ("t-1", "c3"), ("t-2", "c2")],
+        )
+        conn.commit()
+
+    repo = SQLiteCheckpointRepo(db_path=db_path)
+    try:
+        repo.delete_checkpoints_by_ids("t-1", ["c2", "c3"])
+    finally:
+        repo.close()
+
+    with sqlite3.connect(str(db_path)) as conn:
+        left_checkpoints = conn.execute(
+            "SELECT thread_id, checkpoint_id FROM checkpoints ORDER BY thread_id, checkpoint_id"
+        ).fetchall()
+        left_writes = conn.execute("SELECT thread_id, checkpoint_id FROM writes ORDER BY thread_id, checkpoint_id").fetchall()
+        left_cp_writes = conn.execute(
+            "SELECT thread_id, checkpoint_id FROM checkpoint_writes ORDER BY thread_id, checkpoint_id"
+        ).fetchall()
+        left_cp_blobs = conn.execute(
+            "SELECT thread_id, checkpoint_id FROM checkpoint_blobs ORDER BY thread_id, checkpoint_id"
+        ).fetchall()
+
+    assert left_checkpoints == [("t-1", "c1"), ("t-2", "c2")]
+    assert left_writes == [("t-2", "c2")]
+    assert left_cp_writes == [("t-2", "c2")]
+    assert left_cp_blobs == [("t-2", "c2")]
+
+
+def test_delete_thread_data(tmp_path):
+    db_path = tmp_path / "leon.db"
+    _setup_tables(db_path)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executemany(
+            "INSERT INTO checkpoints (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c1"), ("t-2", "c2")],
+        )
+        conn.executemany(
+            "INSERT INTO writes (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c1"), ("t-2", "c2")],
+        )
+        conn.executemany(
+            "INSERT INTO checkpoint_writes (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c1"), ("t-2", "c2")],
+        )
+        conn.executemany(
+            "INSERT INTO checkpoint_blobs (thread_id, checkpoint_id) VALUES (?, ?)",
+            [("t-1", "c1"), ("t-2", "c2")],
+        )
+        conn.commit()
+
+    repo = SQLiteCheckpointRepo(db_path=db_path)
+    try:
+        repo.delete_thread_data("t-1")
+    finally:
+        repo.close()
+
+    with sqlite3.connect(str(db_path)) as conn:
+        left_checkpoints = conn.execute("SELECT thread_id FROM checkpoints ORDER BY thread_id").fetchall()
+        left_writes = conn.execute("SELECT thread_id FROM writes ORDER BY thread_id").fetchall()
+        left_cp_writes = conn.execute("SELECT thread_id FROM checkpoint_writes ORDER BY thread_id").fetchall()
+        left_cp_blobs = conn.execute("SELECT thread_id FROM checkpoint_blobs ORDER BY thread_id").fetchall()
+
+    assert left_checkpoints == [("t-2",)]
+    assert left_writes == [("t-2",)]
+    assert left_cp_writes == [("t-2",)]
+    assert left_cp_blobs == [("t-2",)]

--- a/tests/test_eval_repo.py
+++ b/tests/test_eval_repo.py
@@ -1,0 +1,53 @@
+from eval.models import LLMCallRecord, RunTrajectory, SystemMetrics, ToolCallRecord
+from eval.storage import TrajectoryStore
+
+
+def test_save_and_load_trajectory(tmp_path):
+    db_path = tmp_path / "eval.db"
+    store = TrajectoryStore(db_path)
+
+    trajectory = RunTrajectory(
+        id="run-1",
+        thread_id="thread-1",
+        user_message="hello",
+        final_response="world",
+        started_at="2026-02-24T20:00:00Z",
+        finished_at="2026-02-24T20:00:01Z",
+        llm_calls=[LLMCallRecord(run_id="run-1", model_name="m1", input_tokens=10, output_tokens=3, total_tokens=13)],
+        tool_calls=[ToolCallRecord(run_id="run-1", tool_name="bash", success=True)],
+    )
+
+    run_id = store.save_trajectory(trajectory)
+    assert run_id == "run-1"
+
+    loaded = store.get_trajectory("run-1")
+    assert loaded is not None
+    assert loaded.thread_id == "thread-1"
+    assert loaded.final_response == "world"
+    assert len(loaded.llm_calls) == 1
+    assert len(loaded.tool_calls) == 1
+
+
+def test_list_runs_and_metrics(tmp_path):
+    db_path = tmp_path / "eval.db"
+    store = TrajectoryStore(db_path)
+
+    t1 = RunTrajectory(id="run-a", thread_id="thread-a", user_message="a")
+    t2 = RunTrajectory(id="run-b", thread_id="thread-b", user_message="b")
+    store.save_trajectory(t1)
+    store.save_trajectory(t2)
+
+    all_runs = store.list_runs(limit=10)
+    assert len(all_runs) == 2
+
+    thread_a_runs = store.list_runs(thread_id="thread-a", limit=10)
+    assert len(thread_a_runs) == 1
+    assert thread_a_runs[0]["id"] == "run-a"
+
+    metrics = SystemMetrics(total_tokens=42, llm_call_count=1)
+    store.save_metrics("run-a", "system", metrics)
+
+    rows = store.get_metrics("run-a")
+    assert len(rows) == 1
+    assert rows[0]["tier"] == "system"
+    assert rows[0]["metrics"]["total_tokens"] == 42

--- a/tests/test_file_operation_repo.py
+++ b/tests/test_file_operation_repo.py
@@ -1,0 +1,47 @@
+from core.memory.file_operation_repo import SQLiteFileOperationRepo
+
+
+def test_record_and_query_file_operations(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteFileOperationRepo(db_path)
+
+    op1 = repo.record("t-1", "cp-1", "write", "/tmp/a.txt", None, "hello")
+    op2 = repo.record("t-1", "cp-2", "edit", "/tmp/a.txt", "hello", "world", [{"old": "hello", "new": "world"}])
+
+    assert op1 != op2
+
+    rows = repo.get_operations_for_thread("t-1")
+    assert len(rows) == 2
+    assert rows[0].checkpoint_id == "cp-1"
+    assert rows[1].changes == [{"old": "hello", "new": "world"}]
+
+
+def test_mark_reverted_and_status_filter(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteFileOperationRepo(db_path)
+
+    op1 = repo.record("t-2", "cp-1", "write", "/tmp/a.txt", None, "a")
+    repo.record("t-2", "cp-1", "write", "/tmp/b.txt", None, "b")
+
+    repo.mark_reverted([op1])
+
+    applied = repo.get_operations_for_thread("t-2", status="applied")
+    reverted = repo.get_operations_for_thread("t-2", status="reverted")
+
+    assert len(applied) == 1
+    assert len(reverted) == 1
+    assert reverted[0].id == op1
+
+
+def test_delete_thread_operations(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteFileOperationRepo(db_path)
+
+    repo.record("t-3", "cp-1", "write", "/tmp/a.txt", None, "a")
+    repo.record("t-3", "cp-2", "write", "/tmp/b.txt", None, "b")
+    repo.record("t-x", "cp-x", "write", "/tmp/c.txt", None, "c")
+
+    deleted = repo.delete_thread_operations("t-3")
+    assert deleted == 2
+    assert repo.get_operations_for_thread("t-3") == []
+    assert len(repo.get_operations_for_thread("t-x")) == 1

--- a/tests/test_run_event_repo.py
+++ b/tests/test_run_event_repo.py
@@ -1,0 +1,62 @@
+import sqlite3
+
+from core.memory.run_event_repo import SQLiteRunEventRepo
+
+
+def test_append_and_list_events_with_cursor(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteRunEventRepo(db_path)
+    try:
+        seq1 = repo.append_event("t-1", "r-1", "tool_call", {"name": "ls"}, "m-1")
+        seq2 = repo.append_event("t-1", "r-1", "tool_result", {"ok": True}, "m-2")
+
+        assert seq1 == 1
+        assert seq2 == 2
+
+        events = repo.list_events("t-1", "r-1", after=0)
+        assert [event["event_type"] for event in events] == ["tool_call", "tool_result"]
+
+        cursor_events = repo.list_events("t-1", "r-1", after=1)
+        assert len(cursor_events) == 1
+        assert cursor_events[0]["seq"] == 2
+        assert cursor_events[0]["data"] == {"ok": True}
+    finally:
+        repo.close()
+
+
+def test_latest_and_list_run_ids(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteRunEventRepo(db_path)
+    try:
+        repo.append_event("t-2", "r-1", "status", {"s": 1})
+        repo.append_event("t-2", "r-2", "status", {"s": 2})
+        repo.append_event("t-2", "r-1", "status", {"s": 3})
+
+        assert repo.latest_seq("t-2") == 3
+        assert repo.latest_run_id("t-2") == "r-1"
+        assert repo.list_run_ids("t-2") == ["r-1", "r-2"]
+    finally:
+        repo.close()
+
+
+def test_delete_runs_and_thread_events(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteRunEventRepo(db_path)
+    try:
+        repo.append_event("t-3", "r-1", "status", {"v": 1})
+        repo.append_event("t-3", "r-2", "status", {"v": 2})
+        repo.append_event("t-3", "r-2", "status", {"v": 3})
+
+        deleted = repo.delete_runs("t-3", ["r-2"])
+        assert deleted == 2
+        assert repo.list_run_ids("t-3") == ["r-1"]
+
+        deleted_all = repo.delete_thread_events("t-3")
+        assert deleted_all == 1
+        assert repo.latest_seq("t-3") == 0
+
+        with sqlite3.connect(str(db_path)) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM run_events WHERE thread_id = ?", ("t-3",)).fetchone()[0]
+            assert remaining == 0
+    finally:
+        repo.close()

--- a/tests/test_session_file_operations_cleanup.py
+++ b/tests/test_session_file_operations_cleanup.py
@@ -1,0 +1,33 @@
+import sqlite3
+
+from core.memory.file_operation_repo import SQLiteFileOperationRepo
+from tui.session import SessionManager
+
+
+def test_session_delete_thread_cleans_file_operations(tmp_path):
+    session_dir = tmp_path / ".leon"
+    session_dir.mkdir(parents=True)
+    db_path = session_dir / "leon.db"
+
+    repo = SQLiteFileOperationRepo(db_path)
+    repo.record("t-clean", "cp-1", "write", "/tmp/a.txt", None, "x")
+    repo.record("t-other", "cp-2", "write", "/tmp/b.txt", None, "y")
+
+    manager = SessionManager(session_dir=session_dir)
+    manager.save_session("t-clean")
+
+    ok = manager.delete_thread("t-clean")
+    assert ok is True
+
+    with sqlite3.connect(str(db_path)) as conn:
+        n_clean = conn.execute(
+            "SELECT COUNT(*) FROM file_operations WHERE thread_id = ?",
+            ("t-clean",),
+        ).fetchone()[0]
+        n_other = conn.execute(
+            "SELECT COUNT(*) FROM file_operations WHERE thread_id = ?",
+            ("t-other",),
+        ).fetchone()[0]
+
+    assert n_clean == 0
+    assert n_other == 1

--- a/tests/test_thread_config_repo.py
+++ b/tests/test_thread_config_repo.py
@@ -1,0 +1,53 @@
+import sqlite3
+from pathlib import Path
+
+from backend.web.utils import helpers
+from core.memory.thread_config_repo import SQLiteThreadConfigRepo
+
+
+def test_migrate_thread_metadata_table(tmp_path):
+    db_path = tmp_path / "leon.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "CREATE TABLE thread_metadata (thread_id TEXT PRIMARY KEY, sandbox_type TEXT NOT NULL, cwd TEXT, model TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO thread_metadata (thread_id, sandbox_type, cwd, model) VALUES (?, ?, ?, ?)",
+            ("t-1", "local", "/tmp/ws", "m-1"),
+        )
+        conn.commit()
+
+    repo = SQLiteThreadConfigRepo(db_path)
+    try:
+        assert repo.lookup_metadata("t-1") == ("local", "/tmp/ws")
+        assert repo.lookup_model("t-1") == "m-1"
+    finally:
+        repo.close()
+
+    with sqlite3.connect(str(db_path)) as conn:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "thread_config" in tables
+        assert "thread_metadata" not in tables
+
+
+def test_save_and_lookup_thread_config(tmp_path):
+    db_path = tmp_path / "leon.db"
+    repo = SQLiteThreadConfigRepo(db_path)
+    try:
+        repo.save_metadata("t-2", "docker", "/workspace")
+        repo.save_model("t-2", "anthropic/claude-sonnet-4.6")
+        assert repo.lookup_metadata("t-2") == ("docker", "/workspace")
+        assert repo.lookup_model("t-2") == "anthropic/claude-sonnet-4.6"
+    finally:
+        repo.close()
+
+
+def test_helpers_compatibility_api(tmp_path, monkeypatch):
+    db_path = tmp_path / "leon.db"
+    monkeypatch.setattr(helpers, "DB_PATH", Path(db_path))
+
+    helpers.save_thread_metadata("t-3", "local", "/tmp/p")
+    helpers.save_thread_model("t-3", "m-3")
+
+    assert helpers.lookup_thread_metadata("t-3") == ("local", "/tmp/p")
+    assert helpers.lookup_thread_model("t-3") == "m-3"

--- a/tui/operations.py
+++ b/tui/operations.py
@@ -1,12 +1,10 @@
 """File operation recorder for time travel functionality"""
 
-import json
-import sqlite3
-import time
-import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
+
+from core.memory.file_operation_repo import FileOperationRow, SQLiteFileOperationRepo
 
 # Context variables for tracking current thread and checkpoint
 current_thread_id: ContextVar[str] = ContextVar("current_thread_id", default="")
@@ -37,34 +35,11 @@ class FileOperationRecorder:
             db_path = Path.home() / ".leon" / "leon.db"
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._init_db()
+        self._repo = SQLiteFileOperationRepo(self.db_path)
 
     def _init_db(self) -> None:
-        """Initialize the file_operations table"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS file_operations (
-                    id TEXT PRIMARY KEY,
-                    thread_id TEXT NOT NULL,
-                    checkpoint_id TEXT NOT NULL,
-                    timestamp REAL NOT NULL,
-                    operation_type TEXT NOT NULL,
-                    file_path TEXT NOT NULL,
-                    before_content TEXT,
-                    after_content TEXT NOT NULL,
-                    changes TEXT,
-                    status TEXT DEFAULT 'applied'
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_file_ops_thread
-                ON file_operations(thread_id, timestamp)
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_file_ops_checkpoint
-                ON file_operations(checkpoint_id)
-            """)
-            conn.commit()
+        """Initialize file operation schema via repository boundary."""
+        self._repo = SQLiteFileOperationRepo(self.db_path)
 
     def record(
         self,
@@ -77,177 +52,62 @@ class FileOperationRecorder:
         changes: list[dict] | None = None,
     ) -> str:
         """Record a file operation"""
-        op_id = str(uuid.uuid4())
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute(
-                """
-                INSERT INTO file_operations
-                (id, thread_id, checkpoint_id, timestamp, operation_type,
-                 file_path, before_content, after_content, changes, status)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    op_id,
-                    thread_id,
-                    checkpoint_id,
-                    time.time(),
-                    operation_type,
-                    file_path,
-                    before_content,
-                    after_content,
-                    json.dumps(changes) if changes else None,
-                    "applied",
-                ),
-            )
-            conn.commit()
-        return op_id
+        return self._repo.record(
+            thread_id=thread_id,
+            checkpoint_id=checkpoint_id,
+            operation_type=operation_type,
+            file_path=file_path,
+            before_content=before_content,
+            after_content=after_content,
+            changes=changes,
+        )
 
     def get_operations_for_thread(self, thread_id: str, status: str = "applied") -> list[FileOperation]:
         """Get all operations for a thread"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                """
-                SELECT * FROM file_operations
-                WHERE thread_id = ? AND status = ?
-                ORDER BY timestamp ASC
-                """,
-                (thread_id, status),
-            )
-            rows = cursor.fetchall()
-            return [self._row_to_operation(row) for row in rows]
+        rows = self._repo.get_operations_for_thread(thread_id, status=status)
+        return [self._to_file_operation(row) for row in rows]
 
     def get_operations_after_checkpoint(self, thread_id: str, checkpoint_id: str) -> list[FileOperation]:
         """Get operations after a specific checkpoint (for rollback)"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            # First get the timestamp of the target checkpoint
-            cursor = conn.execute(
-                """
-                SELECT MIN(timestamp) as ts FROM file_operations
-                WHERE thread_id = ? AND checkpoint_id = ?
-                """,
-                (thread_id, checkpoint_id),
-            )
-            row = cursor.fetchone()
-            if not row or row["ts"] is None:
-                # No operations for this checkpoint, get all after it
-                # We need to find operations with checkpoint_id > target
-                cursor = conn.execute(
-                    """
-                    SELECT * FROM file_operations
-                    WHERE thread_id = ? AND status = 'applied'
-                    ORDER BY timestamp DESC
-                    """,
-                    (thread_id,),
-                )
-            else:
-                target_ts = row["ts"]
-                cursor = conn.execute(
-                    """
-                    SELECT * FROM file_operations
-                    WHERE thread_id = ? AND timestamp >= ? AND status = 'applied'
-                    ORDER BY timestamp DESC
-                    """,
-                    (thread_id, target_ts),
-                )
-            rows = cursor.fetchall()
-            return [self._row_to_operation(row) for row in rows]
+        rows = self._repo.get_operations_after_checkpoint(thread_id, checkpoint_id)
+        return [self._to_file_operation(row) for row in rows]
 
     def get_operations_between_checkpoints(
         self, thread_id: str, from_checkpoint_id: str, to_checkpoint_id: str
     ) -> list[FileOperation]:
         """Get operations between two checkpoints (exclusive of from, inclusive of to)"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                """
-                SELECT * FROM file_operations
-                WHERE thread_id = ?
-                AND checkpoint_id != ?
-                AND status = 'applied'
-                ORDER BY timestamp DESC
-                """,
-                (thread_id, from_checkpoint_id),
-            )
-            rows = cursor.fetchall()
-            # Filter to only include operations after from_checkpoint
-            result = []
-            found_target = False
-            for row in rows:
-                if row["checkpoint_id"] == to_checkpoint_id:
-                    found_target = True
-                if found_target:
-                    break
-                result.append(self._row_to_operation(row))
-            return result
+        rows = self._repo.get_operations_between_checkpoints(thread_id, from_checkpoint_id, to_checkpoint_id)
+        return [self._to_file_operation(row) for row in rows]
 
     def get_operations_for_checkpoint(self, thread_id: str, checkpoint_id: str) -> list[FileOperation]:
         """Get all operations for a specific checkpoint"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                """
-                SELECT * FROM file_operations
-                WHERE thread_id = ? AND checkpoint_id = ? AND status = 'applied'
-                ORDER BY timestamp ASC
-                """,
-                (thread_id, checkpoint_id),
-            )
-            rows = cursor.fetchall()
-            return [self._row_to_operation(row) for row in rows]
+        rows = self._repo.get_operations_for_checkpoint(thread_id, checkpoint_id)
+        return [self._to_file_operation(row) for row in rows]
 
     def count_operations_for_checkpoint(self, thread_id: str, checkpoint_id: str) -> int:
         """Count operations for a specific checkpoint"""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(
-                """
-                SELECT COUNT(*) FROM file_operations
-                WHERE thread_id = ? AND checkpoint_id = ? AND status = 'applied'
-                """,
-                (thread_id, checkpoint_id),
-            )
-            return cursor.fetchone()[0]
+        return self._repo.count_operations_for_checkpoint(thread_id, checkpoint_id)
 
     def mark_reverted(self, operation_ids: list[str]) -> None:
         """Mark operations as reverted"""
-        if not operation_ids:
-            return
-        with sqlite3.connect(self.db_path) as conn:
-            placeholders = ",".join("?" * len(operation_ids))
-            conn.execute(
-                f"""
-                UPDATE file_operations
-                SET status = 'reverted'
-                WHERE id IN ({placeholders})
-                """,
-                operation_ids,
-            )
-            conn.commit()
+        self._repo.mark_reverted(operation_ids)
 
     def delete_thread_operations(self, thread_id: str) -> int:
         """Delete all operations for a thread"""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(
-                "DELETE FROM file_operations WHERE thread_id = ?",
-                (thread_id,),
-            )
-            conn.commit()
-            return cursor.rowcount
+        return self._repo.delete_thread_operations(thread_id)
 
-    def _row_to_operation(self, row: sqlite3.Row) -> FileOperation:
-        """Convert a database row to FileOperation"""
+    def _to_file_operation(self, row: FileOperationRow) -> FileOperation:
         return FileOperation(
-            id=row["id"],
-            thread_id=row["thread_id"],
-            checkpoint_id=row["checkpoint_id"],
-            timestamp=row["timestamp"],
-            operation_type=row["operation_type"],
-            file_path=row["file_path"],
-            before_content=row["before_content"],
-            after_content=row["after_content"],
-            changes=json.loads(row["changes"]) if row["changes"] else None,
-            status=row["status"],
+            id=row.id,
+            thread_id=row.thread_id,
+            checkpoint_id=row.checkpoint_id,
+            timestamp=row.timestamp,
+            operation_type=row.operation_type,
+            file_path=row.file_path,
+            before_content=row.before_content,
+            after_content=row.after_content,
+            changes=row.changes,
+            status=row.status,
         )
 
 


### PR DESCRIPTION
## Why
Consolidate previously split database-abstraction increments (phase-2 repos + phase-3 StorageContainer wiring) into one reviewable PR with a single commit, and exclude all rollout/artifact files from code diff.

## Scope
- Add phase-2 repositories:
  - `CheckpointRepo`
  - `ThreadConfigRepo`
  - `RunEventRepo`
  - `FileOperationRepo`
  - `SummaryRepo`
  - `EvalRepo`
- Delegate existing SQL call sites to repos (no artifact docs/images in code changes)
- Add phase-3 composition root wiring:
  - `core/storage/container.py`
  - `core/storage/__init__.py`

## Explicit non-scope
- No `artifacts/` files
- No rollout markdown evidence files in repository diff
- No runtime behavior outside storage abstraction line

## Validation
- `uv run pytest -q tests/test_checkpoint_repo.py tests/test_thread_config_repo.py tests/test_run_event_repo.py tests/test_file_operation_repo.py tests/test_session_file_operations_cleanup.py tests/test_eval_repo.py`
  - result: `15 passed`
- `uv run pytest -q tests/test_integration_new_arch.py`
  - result: `22 passed`

## Image proof via blob links (not committed in this PR)
- https://github.com/OpenDCAI/leonai/blob/0349839837b8595016b7daa50ad17e6e6670badc/artifacts/leon-fe-pty-boundary-mode.png
- https://github.com/OpenDCAI/leonai/blob/ba32434caf95c6a3d3cd28d48768ad896a2f1ffc/artifacts/pr/hunter-pr-minife-home.png
