### PR TITLE
fix(sandbox): preserve pick-folder HTTP status codes

### DIFF
--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -93,8 +93,11 @@ async def pick_folder() -> dict[str, Any]:
             raise HTTPException(400, "User cancelled folder selection")
     except subprocess.TimeoutExpired:
         raise HTTPException(408, "Folder selection timed out")
+    # @@@http_passthrough - keep explicit business/status errors from selection branches intact
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(500, f"Failed to open folder picker: {str(e)}")
+        raise HTTPException(500, f"Failed to open folder picker: {str(e)}") from e
 
 
 @router.get("/sessions")

--- a/tests/test_sandbox_pick_folder_status.py
+++ b/tests/test_sandbox_pick_folder_status.py
@@ -1,0 +1,34 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import sandbox as sandbox_router
+
+
+def test_pick_folder_cancel_keeps_400(monkeypatch):
+    monkeypatch.setattr(sandbox_router.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        sandbox_router.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=""),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(sandbox_router.pick_folder())
+    assert exc_info.value.status_code == 400
+    assert "cancelled" in str(exc_info.value.detail).lower()
+
+
+def test_pick_folder_timeout_is_408(monkeypatch):
+    monkeypatch.setattr(sandbox_router.sys, "platform", "darwin")
+
+    def _raise_timeout(*args, **kwargs):
+        raise sandbox_router.subprocess.TimeoutExpired(cmd="osascript", timeout=60)
+
+    monkeypatch.setattr(sandbox_router.subprocess, "run", _raise_timeout)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(sandbox_router.pick_folder())
+    assert exc_info.value.status_code == 408


### PR DESCRIPTION
## Summary
- keep explicit HTTPException status codes in /api/sandbox/pick-folder
- avoid converting user cancel (400) into generic 500
- add focused tests for cancel(400) and timeout(408)

## Test
- . .venv/bin/activate && pytest -q tests/test_sandbox_pick_folder_status.py