### PR TITLE
fix(workspace): preserve agent-init HTTP status codes

### DIFF
--- a/backend/web/routers/workspace.py
+++ b/backend/web/routers/workspace.py
@@ -48,6 +48,9 @@ async def list_workspace_path(
     try:
         set_current_thread_id(thread_id)
         agent = await get_or_create_agent(app, sandbox_type, thread_id=thread_id)
+    # @@@http_passthrough - preserve policy/validation errors from agent creation
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(503, f"Sandbox agent init failed for {sandbox_type}: {e}") from e
 
@@ -107,6 +110,9 @@ async def read_workspace_file(
     try:
         set_current_thread_id(thread_id)
         agent = await get_or_create_agent(app, sandbox_type, thread_id=thread_id)
+    # @@@http_passthrough - preserve policy/validation errors from agent creation
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(503, f"Sandbox agent init failed for {sandbox_type}: {e}") from e
 

--- a/tests/test_workspace_agent_init_status.py
+++ b/tests/test_workspace_agent_init_status.py
@@ -1,0 +1,34 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import workspace as workspace_router
+from backend.web.services import agent_pool
+
+
+def _make_app():
+    return SimpleNamespace(state=SimpleNamespace(thread_cwd={}, thread_sandbox={}, agent_pool={}))
+
+
+async def _raise_disabled(*_args, **_kwargs):
+    raise HTTPException(status_code=403, detail="Sandbox is disabled")
+
+
+def test_list_workspace_path_keeps_http_status(monkeypatch):
+    monkeypatch.setattr(workspace_router, "resolve_thread_sandbox", lambda *_args, **_kwargs: "e2b")
+    monkeypatch.setattr(agent_pool, "get_or_create_agent", _raise_disabled)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(workspace_router.list_workspace_path("thread-1", app=_make_app()))
+    assert exc_info.value.status_code == 403
+
+
+def test_read_workspace_file_keeps_http_status(monkeypatch):
+    monkeypatch.setattr(workspace_router, "resolve_thread_sandbox", lambda *_args, **_kwargs: "e2b")
+    monkeypatch.setattr(agent_pool, "get_or_create_agent", _raise_disabled)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(workspace_router.read_workspace_file("thread-2", path="/tmp/x", app=_make_app()))
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
- preserve HTTPException status codes raised during remote agent initialization
- avoid converting policy/validation errors into generic 503 in workspace list/read routes
- add focused tests for list/read status passthrough

## Test
- . .venv/bin/activate && pytest -q tests/test_workspace_agent_init_status.py