### PR TITLE
test(helpers): add webhook instance-id extraction boundary coverage

### DIFF
--- a/tests/test_webhook_helper_instance_id.py
+++ b/tests/test_webhook_helper_instance_id.py
@@ -1,0 +1,30 @@
+from backend.web.utils.helpers import extract_webhook_instance_id
+
+
+def test_extract_webhook_instance_id_prefers_top_level_value() -> None:
+    payload = {
+        "session_id": "sess-top",
+        "data": {"session_id": "sess-nested"},
+    }
+
+    assert extract_webhook_instance_id(payload) == "sess-top"
+
+
+def test_extract_webhook_instance_id_falls_back_to_nested_data() -> None:
+    payload = {
+        "event": "sandbox.started",
+        "data": {"sandbox_id": "sbx-123"},
+    }
+
+    assert extract_webhook_instance_id(payload) == "sbx-123"
+
+
+def test_extract_webhook_instance_id_skips_empty_or_non_string_values() -> None:
+    payload = {
+        "session_id": "",
+        "sandbox_id": None,
+        "instance_id": 123,
+        "data": {"id": "inst-777"},
+    }
+
+    assert extract_webhook_instance_id(payload) == "inst-777"


### PR DESCRIPTION
## Summary
- add focused tests for `extract_webhook_instance_id` key precedence and nested fallback
- assert empty/non-string ids are ignored so webhook routing keeps strict semantics

## Scope
- single file change: `tests/test_webhook_helper_instance_id.py`
- no router/database abstraction edits
- non-overlap with #94/#95/#96 (sandbox/workspace status-code and path-boundary patches)

## Test
- `uv run --with pytest pytest -q tests/test_webhook_helper_instance_id.py`
