### PR TITLE
test(model-params): add whitespace boundary coverage for OpenAI GPT-5 normalization

### DIFF
--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -44,3 +44,10 @@ def test_openai_provider_matching_is_case_insensitive() -> None:
     out = normalize_model_kwargs("gpt-5.2", kwargs)
     assert "max_tokens" not in out
     assert out["max_completion_tokens"] == 256
+
+
+def test_openai_gpt5_normalization_trims_provider_and_model_name_whitespace() -> None:
+    kwargs = {"model_provider": "  openai  ", "max_tokens": 512}
+    out = normalize_model_kwargs("  openai/gpt-5.1  ", kwargs)
+    assert "max_tokens" not in out
+    assert out["max_completion_tokens"] == 512


### PR DESCRIPTION
## Summary
- add one boundary test for OpenAI GPT-5 kwargs normalization
- cover leading/trailing whitespace in `model_provider` and `model_name`
- keep change scope to a single test file

## Why this is separate
- does not overlap with #94/#95/#96/#102 topics (workspace path/status, sandbox picker status, webhook helper)
- does not touch #100 database abstraction files

## Test
- `uv run --with pytest pytest -q tests/test_model_params.py`
