### PR TITLE
test(serializers): add pure coverage for web message serializers

### DIFF
--- a/tests/test_web_serializers.py
+++ b/tests/test_web_serializers.py
@@ -1,0 +1,35 @@
+from backend.web.utils.serializers import extract_text_content, serialize_message
+
+
+class _DummyMessage:
+    content = "hello"
+    tool_calls = [{"name": "calc"}]
+    tool_call_id = "call-1"
+
+
+def test_extract_text_content_joins_text_blocks_and_plain_strings() -> None:
+    raw_content = [
+        {"type": "text", "text": "alpha"},
+        {"type": "image", "url": "x"},
+        "beta",
+        {"type": "text", "text": "gamma"},
+        123,
+    ]
+
+    assert extract_text_content(raw_content) == "alphabetagamma"
+
+
+def test_extract_text_content_falls_back_to_string_conversion() -> None:
+    assert extract_text_content({"k": "v"}) == "{'k': 'v'}"
+
+
+def test_serialize_message_includes_expected_fields() -> None:
+    out = serialize_message(_DummyMessage())
+
+    assert out == {
+        "type": "_DummyMessage",
+        "id": None,
+        "content": "hello",
+        "tool_calls": [{"name": "calc"}],
+        "tool_call_id": "call-1",
+    }


### PR DESCRIPTION
## Summary\n- add focused tests for backend/web/utils/serializers.py\n- cover mixed list content extraction behavior\n- cover serialize_message output shape on a dummy message\n\n## Test\n- uv run pytest -q tests/test_web_serializers.py