### PR TITLE
fix(frontend): clean up existing TypeScript build blockers

### DIFF
--- a/frontend/app/src/components/ChatArea.tsx
+++ b/frontend/app/src/components/ChatArea.tsx
@@ -12,7 +12,7 @@ interface ChatAreaProps {
   onFocusAgent?: (stepId: string) => void;
 }
 
-export default function ChatArea({ entries, isStreaming, runtimeStatus, loading, onFocusAgent }: ChatAreaProps) {
+export default function ChatArea({ entries, isStreaming: _isStreaming, runtimeStatus, loading, onFocusAgent }: ChatAreaProps) {
   const containerRef = useStickyScroll<HTMLDivElement>();
 
   return (

--- a/frontend/app/src/components/SettingsPanel.tsx
+++ b/frontend/app/src/components/SettingsPanel.tsx
@@ -29,7 +29,7 @@ export default function SettingsPanel({
     return () => document.removeEventListener("mousedown", handler);
   }, [settingsOpen]);
 
-  async function handleWorkspaceSet(workspace: string) {
+  async function handleWorkspaceSet(_workspace: string) {
     await refreshSettings();
     setWorkspaceModalOpen(false);
     setSettingsOpen(false);

--- a/frontend/app/src/components/WorkspaceSetupModal.tsx
+++ b/frontend/app/src/components/WorkspaceSetupModal.tsx
@@ -1,4 +1,3 @@
-import { Folder } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "./ui/button";
 import {

--- a/frontend/app/src/hooks/subagent-event-handler.ts
+++ b/frontend/app/src/hooks/subagent-event-handler.ts
@@ -1,8 +1,8 @@
-import type { AssistantTurn } from "../api";
+import type { AssistantTurn, ToolStep } from "../api";
 import type { UpdateEntries, StreamEvent } from "./stream-event-handlers";
 
 type EventPayload = Record<string, unknown>;
-type SubagentStream = NonNullable<AssistantTurn["segments"][0] extends { step: infer S } ? S extends { subagent_stream?: infer R } ? R : never : never>;
+type SubagentStream = NonNullable<ToolStep["subagent_stream"]>;
 type Mutator = (stream: SubagentStream, data: EventPayload) => void;
 
 const MUTATORS: Record<string, Mutator> = {

--- a/frontend/app/src/hooks/use-thread-data.ts
+++ b/frontend/app/src/hooks/use-thread-data.ts
@@ -29,7 +29,8 @@ export function useThreadData(threadId: string | undefined, skipInitialLoad = fa
     try {
       const thread = await getThread(id);
       setEntries(mapBackendEntries(thread.messages));
-      setActiveSandbox(thread.sandbox);
+      const sandbox = thread.sandbox;
+      setActiveSandbox(sandbox && typeof sandbox === "object" ? (sandbox as SandboxInfo) : null);
     } finally {
       setLoading(false);
     }

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -17,7 +17,7 @@ export default function NewChatPage() {
   const navigate = useNavigate();
   const { tm } = useOutletContext<OutletContext>();
   const { sandboxTypes, selectedSandbox, handleCreateThread } = tm;
-  const { settings, loading, setDefaultWorkspace, hasWorkspace } = useWorkspaceSettings();
+  const { settings, loading, hasWorkspace } = useWorkspaceSettings();
   const [showWorkspaceSetup, setShowWorkspaceSetup] = useState(false);
 
   async function handleSend(message: string, sandbox: string, model: string, workspace?: string) {
@@ -41,7 +41,7 @@ export default function NewChatPage() {
     });
   }
 
-  function handleWorkspaceSet(workspace: string) {
+  function handleWorkspaceSet(_workspace: string) {
     setShowWorkspaceSetup(false);
     // Workspace is now set, user can try sending again
   }


### PR DESCRIPTION
## Summary\n- remove/rename unused variables that fail TS noUnused checks\n- fix subagent stream typing that resolved to `never`\n- narrow unknown sandbox payload before storing into `SandboxInfo` state\n\n## Validation\n- `cd frontend/app && npm run -s build`