### PR TITLE
fix(webhook): normalize instance IDs from payload

### DIFF
--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -49,17 +49,25 @@ def get_lease_timestamps(lease_id: str) -> tuple[str | None, str | None]:
 def extract_webhook_instance_id(payload: dict[str, Any]) -> str | None:
     """Extract provider instance/session id from webhook payload."""
     direct_keys = ("session_id", "sandbox_id", "instance_id", "id")
+
+    # @@@webhook-id-normalize - providers occasionally pad ids; trim whitespace before lease matching.
+    def _normalized_id(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None
+
     for key in direct_keys:
-        value = payload.get(key)
-        if isinstance(value, str) and value:
-            return value
+        normalized = _normalized_id(payload.get(key))
+        if normalized:
+            return normalized
 
     nested = payload.get("data")
     if isinstance(nested, dict):
         for key in direct_keys:
-            value = nested.get(key)
-            if isinstance(value, str) and value:
-                return value
+            normalized = _normalized_id(nested.get(key))
+            if normalized:
+                return normalized
 
     return None
 

--- a/tests/test_settings_browse.py
+++ b/tests/test_settings_browse.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 
 from backend.web.routers import sandbox as sandbox_router
 from backend.web.routers.settings import browse_filesystem
-from backend.web.utils.helpers import resolve_local_workspace_path
+from backend.web.utils.helpers import extract_webhook_instance_id, resolve_local_workspace_path
 from backend.web.routers import workspace as workspace_router
 from backend.web.services import agent_pool
 
@@ -42,6 +42,14 @@ def test_resolve_local_workspace_path_accepts_relative_workspace_root(tmp_path, 
     resolved = resolve_local_workspace_path("src/main.py", local_workspace_root=Path("workspace"))
 
     assert resolved == (workspace_root / "src/main.py").resolve()
+
+
+def test_extract_webhook_instance_id_trims_whitespace() -> None:
+    assert extract_webhook_instance_id({"session_id": "  sess-123  "}) == "sess-123"
+    assert extract_webhook_instance_id({"data": {"instance_id": "\n inst-9\t"}}) == "inst-9"
+    assert extract_webhook_instance_id({"sandbox_id": "   "}) is None
+
+
 @pytest.mark.asyncio
 async def test_pick_folder_cancel_keeps_400(monkeypatch):
     monkeypatch.setattr(sandbox_router.sys, "platform", "darwin")


### PR DESCRIPTION
## Summary
- Trim leading/trailing whitespace when extracting webhook instance/session IDs.
- Keep behavior strict: blank-after-trim IDs are treated as missing.
- Add focused regression test in existing `tests/test_settings_browse.py`.

## User Impact
Webhook payloads with padded IDs (for example `"  sess-123  "`) previously failed lease matching, causing events to be recorded as unmatched. This patch makes matching reliable for those payloads.

## Changes
- `backend/web/utils/helpers.py`
  - normalize ID candidates with `strip()` before returning.
- `tests/test_settings_browse.py`
  - add `test_extract_webhook_instance_id_trims_whitespace`.

## Focused Validation
- `uv run pytest -q tests/test_settings_browse.py -k "extract_webhook_instance_id_trims_whitespace or resolve_local_workspace_path_accepts_relative_workspace_root"`
- Result: `2 passed, 6 deselected`
