### PR TITLE
feat: mobile responsive, NewChatDialog, member card actions

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import uuid
 from typing import Annotated, Any
 
@@ -32,6 +33,8 @@ from backend.web.services.thread_state_service import (
 )
 from backend.web.utils.helpers import delete_thread_in_db
 from backend.web.utils.serializers import serialize_message
+
+logger = logging.getLogger(__name__)
 from core.monitor import AgentState
 from core.queue import QueueMode, get_queue_manager
 from sandbox.thread_context import set_current_thread_id
@@ -123,7 +126,7 @@ async def delete_thread(
         try:
             await asyncio.to_thread(destroy_thread_resources_sync, thread_id, sandbox_type, app.state.agent_pool)
         except Exception as exc:
-            raise HTTPException(status_code=409, detail=f"Failed to destroy sandbox resources: {exc}") from exc
+            logger.warning("Failed to destroy sandbox resources for thread %s: %s", thread_id, exc)
         await asyncio.to_thread(delete_thread_in_db, thread_id)
 
     # Clean up thread-specific state

--- a/core/task/middleware.py
+++ b/core/task/middleware.py
@@ -75,7 +75,7 @@ class TaskMiddleware(AgentMiddleware):
 
         # Load agents from all sources
         self.loader = AgentLoader(self.workspace_root)
-        self.agents = self.loader.load_all()
+        self.agents = self.loader.load_all_agents()
 
         # Initialize runner
         self.runner = SubagentRunner(

--- a/frontend/app/src/components/CenteredInputBox.tsx
+++ b/frontend/app/src/components/CenteredInputBox.tsx
@@ -127,7 +127,7 @@ export default function CenteredInputBox({
   // This component must return complete JSX with proper closing tags.
   // ====================================================
   return (
-    <div className="w-[600px]">
+    <div className="w-full max-w-[600px]">
       <div className="bg-card rounded-[24px] border border-border shadow-lg p-6">
         <textarea
           value={message}
@@ -146,7 +146,7 @@ export default function CenteredInputBox({
         />
         <p className="text-[11px] text-[#a3a3a3] mb-4">Enter 发送，Shift + Enter 换行</p>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <Select value={sandbox} onValueChange={setSandbox}>
             <SelectTrigger className="w-[140px] h-9 text-sm">
               <SelectValue />

--- a/frontend/app/src/components/Header.tsx
+++ b/frontend/app/src/components/Header.tsx
@@ -1,5 +1,7 @@
-import { Monitor, PanelLeft, Pause, Play } from "lucide-react";
+import { ChevronLeft, Monitor, PanelLeft, Pause, Play } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import type { SandboxInfo } from "../api";
+import { useIsMobile } from "../hooks/use-mobile";
 import ModelSelector from "./ModelSelector";
 import QueueModeToggle from "./QueueModeToggle";
 
@@ -40,6 +42,8 @@ export default function Header({
   onModelChange,
   onToggleQueue,
 }: HeaderProps) {
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
   const hasRemote = sandboxInfo && sandboxInfo.type !== "local";
   const sandboxLabelText = sandboxLabel(sandboxInfo?.type ?? "local");
   const hasKnownStatus = sandboxInfo?.status === "running" || sandboxInfo?.status === "paused";
@@ -52,43 +56,58 @@ export default function Header({
 
   return (
     <header className="h-12 flex items-center justify-between px-4 flex-shrink-0 bg-white border-b border-[#e5e5e5]">
-      <div className="flex items-center gap-3">
-        <button
-          onClick={onToggleSidebar}
-          className="w-8 h-8 rounded-lg flex items-center justify-center text-[#737373] hover:bg-[#f5f5f5] hover:text-[#171717]"
-        >
-          <PanelLeft className="w-4 h-4" />
-        </button>
+      <div className="flex items-center gap-3 min-w-0">
+        {isMobile ? (
+          <button
+            onClick={() => navigate("/chat")}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-[#737373] hover:bg-[#f5f5f5] hover:text-[#171717]"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+        ) : (
+          <button
+            onClick={onToggleSidebar}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-[#737373] hover:bg-[#f5f5f5] hover:text-[#171717]"
+          >
+            <PanelLeft className="w-4 h-4" />
+          </button>
+        )}
 
-        {/* Context indicator */}
-        <div className="flex items-center rounded-lg border border-[#e5e5e5] overflow-hidden">
-          <div className="flex items-center gap-2 px-3 py-1.5 bg-[#fafafa]">
-            <Monitor className="w-3.5 h-3.5 text-[#a3a3a3]" />
-            <span className="text-sm text-[#171717] truncate max-w-[160px]">
-              {threadPreview || (activeThreadId ? "新对话" : "无对话")}
-            </span>
+        {/* Context indicator — hide sandbox details on mobile */}
+        {isMobile ? (
+          <span className="text-sm font-medium text-[#171717] truncate">
+            {threadPreview || "新对话"}
+          </span>
+        ) : (
+          <div className="flex items-center rounded-lg border border-[#e5e5e5] overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-1.5 bg-[#fafafa]">
+              <Monitor className="w-3.5 h-3.5 text-[#a3a3a3]" />
+              <span className="text-sm text-[#171717] truncate max-w-[160px]">
+                {threadPreview || (activeThreadId ? "新对话" : "无对话")}
+              </span>
+            </div>
+            {hasKnownStatus && (
+              <>
+                <div className="w-px h-6 bg-[#e5e5e5]" />
+                <div className="flex items-center gap-2 px-3 py-1.5 bg-[#fafafa]">
+                  <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: statusDotColor }} />
+                  <span className="text-sm text-[#525252]">{sandboxLabelText}</span>
+                  {hasRemote && statusText && (
+                    <span
+                      className="text-[10px] px-1.5 py-0.5 rounded font-medium"
+                      style={{
+                        background: sandboxInfo?.status === "running" ? "rgba(34,197,94,0.1)" : "rgba(234,179,8,0.1)",
+                        color: sandboxInfo?.status === "running" ? "#16a34a" : "#ca8a04",
+                      }}
+                    >
+                      {statusText}
+                    </span>
+                  )}
+                </div>
+              </>
+            )}
           </div>
-          {hasKnownStatus && (
-            <>
-              <div className="w-px h-6 bg-[#e5e5e5]" />
-              <div className="flex items-center gap-2 px-3 py-1.5 bg-[#fafafa]">
-                <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: statusDotColor }} />
-                <span className="text-sm text-[#525252]">{sandboxLabelText}</span>
-                {hasRemote && statusText && (
-                  <span
-                    className="text-[10px] px-1.5 py-0.5 rounded font-medium"
-                    style={{
-                      background: sandboxInfo?.status === "running" ? "rgba(34,197,94,0.1)" : "rgba(234,179,8,0.1)",
-                      color: sandboxInfo?.status === "running" ? "#16a34a" : "#ca8a04",
-                    }}
-                  >
-                    {statusText}
-                  </span>
-                )}
-              </div>
-            </>
-          )}
-        </div>
+        )}
       </div>
 
       <div className="flex items-center gap-1.5">

--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Search, MessageSquare } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+import { Input } from "./ui/input";
+import { useAppStore } from "@/store/app-store";
+
+interface NewChatDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps) {
+  const navigate = useNavigate();
+  const memberList = useAppStore(s => s.memberList);
+  const loadAll = useAppStore(s => s.loadAll);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      loadAll();
+      setFilter("");
+    }
+  }, [open, loadAll]);
+
+  const filtered = useMemo(() => {
+    if (!filter) return memberList;
+    const q = filter.toLowerCase();
+    return memberList.filter(m =>
+      m.name.toLowerCase().includes(q) || m.description?.toLowerCase().includes(q)
+    );
+  }, [memberList, filter]);
+
+  const handleSelect = (member: typeof memberList[0]) => {
+    onOpenChange(false);
+    navigate("/chat", {
+      state: { startWith: member.id, memberName: member.name },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md p-0 gap-0">
+        <DialogHeader className="px-4 pt-4 pb-3">
+          <DialogTitle className="text-base">发起会话</DialogTitle>
+        </DialogHeader>
+        <div className="px-4 pb-3">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              className="pl-9 h-9 text-sm"
+              placeholder="搜索成员..."
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+              autoFocus
+            />
+          </div>
+        </div>
+        <div className="border-t max-h-80 overflow-y-auto">
+          {filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              {memberList.length === 0 ? "暂无成员" : "无匹配结果"}
+            </p>
+          ) : (
+            filtered.map(member => (
+              <button
+                key={member.id}
+                onClick={() => handleSelect(member)}
+                className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted transition-colors"
+              >
+                <div className="w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-medium shrink-0">
+                  {member.name.slice(0, 2).toUpperCase()}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium truncate">{member.name}</span>
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${
+                      member.status === "active" ? "bg-green-100 text-green-700" : "bg-muted text-muted-foreground"
+                    }`}>
+                      {member.status === "active" ? "在线" : member.status === "draft" ? "草稿" : "离线"}
+                    </span>
+                  </div>
+                  {member.description && (
+                    <p className="text-xs text-muted-foreground truncate mt-0.5">{member.description}</p>
+                  )}
+                </div>
+                <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
+              </button>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/app/src/index.css
+++ b/frontend/app/src/index.css
@@ -21,9 +21,9 @@
     --accent-foreground: 0 0% 9%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
-    --border: 0 0% 90%;
-    --input: 0 0% 90%;
-    --ring: 0 0% 9%;
+    --border: 0 0% 91%;
+    --input: 0 0% 91%;
+    --ring: 0 0% 91%;
     --radius: 0.5rem;
     --success: 142 71% 45%;
     --success-foreground: 0 0% 100%;
@@ -64,9 +64,18 @@
 }
 
 *:focus-visible {
-  outline: 2px solid hsl(var(--primary) / 0.4);
+  outline: 2px solid hsl(var(--ring) / 0.35);
   outline-offset: 2px;
   border-radius: 4px;
+}
+
+/* Form elements have their own focus ring via shadcn — skip global outline */
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+button:focus-visible,
+[data-slot]:focus-visible {
+  outline: none;
 }
 
 /* Scrollbar — auto-hide, show on hover */

--- a/frontend/app/src/pages/AppLayout.tsx
+++ b/frontend/app/src/pages/AppLayout.tsx
@@ -1,12 +1,16 @@
-import { useState } from "react";
-import { Outlet } from "react-router-dom";
+import { useState, useRef } from "react";
+import { Link, Outlet, useParams } from "react-router-dom";
 import { DragHandle } from "../components/DragHandle";
+import NewChatDialog from "../components/NewChatDialog";
 import NewThreadModal from "../components/NewThreadModal";
 import SandboxSessionsModal from "../components/SandboxSessionsModal";
 import SearchModal from "../components/SearchModal";
 import Sidebar from "../components/Sidebar";
+import { useIsMobile } from "../hooks/use-mobile";
 import { useResizableX } from "../hooks/use-resizable-x";
 import { useThreadManager } from "../hooks/use-thread-manager";
+import { useAppStore } from "../store/app-store";
+import { Plus, Search, Trash2 } from "lucide-react";
 
 export default function AppLayout() {
   const tm = useThreadManager();
@@ -15,13 +19,38 @@ export default function AppLayout() {
     refreshThreads, handleCreateThread, handleDeleteThread,
   } = tm;
 
+  const isMobile = useIsMobile();
+  const { threadId } = useParams<{ threadId?: string }>();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [newThreadOpen, setNewThreadOpen] = useState(false);
   const [sessionsOpen, setSessionsOpen] = useState(false);
+  const [newChatOpen, setNewChatOpen] = useState(false);
 
   const sidebarResize = useResizableX(272, 200, 420);
 
+  if (isMobile) {
+    if (!threadId) {
+      return (
+        <MobileThreadList
+          threads={threads}
+          loading={loading}
+          onNewChat={() => setNewChatOpen(true)}
+          onDeleteThread={(id) => void handleDeleteThread(id)}
+          newChatOpen={newChatOpen}
+          setNewChatOpen={setNewChatOpen}
+        />
+      );
+    }
+    return (
+      <div className="h-full w-full bg-background flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col min-w-0">
+          <Outlet context={{ tm, sidebarCollapsed, setSidebarCollapsed, setSessionsOpen }} />
+        </div>
+        <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
+      </div>
+    );
+  }
   return (
     <div className="h-full w-full bg-background flex overflow-hidden">
       <Sidebar
@@ -31,6 +60,7 @@ export default function AppLayout() {
         width={sidebarResize.width}
         onDeleteThread={(id) => void handleDeleteThread(id)}
         onSearchClick={() => setSearchOpen(true)}
+        onNewChat={() => setNewChatOpen(true)}
       />
       {!sidebarCollapsed && <DragHandle onMouseDown={sidebarResize.onMouseDown} />}
 
@@ -62,6 +92,65 @@ export default function AppLayout() {
           void refreshThreads();
         }}
       />
+
+      <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
+    </div>
+  );
+}
+
+function MobileThreadList({ threads, loading, onNewChat, onDeleteThread, newChatOpen, setNewChatOpen }: {
+  threads: any[];
+  loading: boolean;
+  onNewChat: () => void;
+  onDeleteThread: (id: string) => void;
+  newChatOpen: boolean;
+  setNewChatOpen: (v: boolean) => void;
+}) {
+  const memberList = useAppStore(s => s.memberList);
+  return (
+    <div className="h-full w-full bg-background flex flex-col overflow-hidden">
+      <div className="h-14 flex items-center justify-between px-4 border-b border-border shrink-0">
+        <h2 className="text-sm font-semibold text-foreground">消息</h2>
+        <button onClick={onNewChat} className="w-8 h-8 rounded-lg flex items-center justify-center text-muted-foreground hover:bg-muted">
+          <Plus className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <p className="text-sm text-muted-foreground text-center py-8">加载中...</p>
+        ) : threads.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 px-4">
+            <p className="text-sm text-muted-foreground mb-3">暂无会话</p>
+            <button onClick={onNewChat} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm">发起会话</button>
+          </div>
+        ) : (
+          threads.map(t => {
+            const member = memberList.find((m: any) => m.id === t.agent);
+            const memberName = member?.name || t.agent || "Leon";
+            const preview = t.preview || "新会话";
+            return (
+              <div key={t.thread_id} className="flex items-center border-b border-border">
+                <Link to={`/chat/${t.thread_id}`} className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 hover:bg-muted/50 transition-colors">
+                  <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                    <span className="text-xs font-bold text-primary">{memberName.slice(0, 1)}</span>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground truncate">{memberName}</p>
+                    <p className="text-xs text-muted-foreground truncate">{preview}</p>
+                  </div>
+                </Link>
+                <button
+                  onClick={() => onDeleteThread(t.thread_id)}
+                  className="w-8 h-8 flex items-center justify-center text-muted-foreground/40 hover:text-destructive transition-colors shrink-0 mr-1"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
     </div>
   );
 }

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -23,7 +23,7 @@ export default function NewChatPage() {
 
   const startWith = (location.state as any)?.startWith as string | undefined;
   const memberName = (location.state as any)?.memberName as string | undefined;
-  const agentForThread = startWith === "__leon__" ? undefined : startWith;
+  const agentForThread = startWith === "__leon__" ? undefined : memberName;
 
   async function handleSend(message: string, sandbox: string, model: string, workspace?: string) {
     // For local sandbox, check if workspace is set
@@ -56,7 +56,7 @@ export default function NewChatPage() {
 
   return (
     <div className="flex-1 flex items-center justify-center relative">
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px]">
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[600px] px-4">
         {/* Welcome Section */}
         <div className="text-center mb-8">
           <h1 className="text-2xl font-medium text-foreground mb-2">

--- a/frontend/app/src/pages/RootLayout.tsx
+++ b/frontend/app/src/pages/RootLayout.tsx
@@ -3,6 +3,7 @@ import { MessageSquare, Users, ListTodo, Library, Settings, Plus, ChevronLeft, C
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import CreateMemberDialog from "@/components/CreateMemberDialog";
+import NewChatDialog from "@/components/NewChatDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAppStore } from "@/store/app-store";
 import { toast } from "sonner";
@@ -14,12 +15,18 @@ const navItems = [
   { to: "/library", icon: Library, label: "能力库" },
 ];
 
+const mobileNavItems = [
+  ...navItems,
+  { to: "/settings", icon: Settings, label: "设置" },
+];
+
 export default function RootLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const [showCreate, setShowCreate] = useState(false);
   const [createMemberOpen, setCreateMemberOpen] = useState(false);
+  const [newChatOpen, setNewChatOpen] = useState(false);
 
   const userProfile = useAppStore((s) => s.userProfile);
   const loadAll = useAppStore((s) => s.loadAll);
@@ -54,7 +61,7 @@ export default function RootLayout() {
     setShowCreate(false);
     switch (action) {
       case "staff": setCreateMemberOpen(true); break;
-      case "chat": navigate("/members"); break;
+      case "chat": setNewChatOpen(true); break;
       case "task":
         try {
           await storeAddTask();
@@ -151,7 +158,7 @@ export default function RootLayout() {
 
         {/* Bottom tab bar */}
         <nav className="shrink-0 border-t border-border bg-card flex items-stretch" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
-          {navItems.map((item) => {
+          {mobileNavItems.map((item) => {
             const isActive = location.pathname.startsWith(item.to);
             return (
               <NavLink
@@ -170,6 +177,7 @@ export default function RootLayout() {
         </nav>
 
         <CreateMemberDialog open={createMemberOpen} onOpenChange={setCreateMemberOpen} />
+        <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
       </div>
     );
   }
@@ -250,6 +258,7 @@ export default function RootLayout() {
 
       <main className="flex-1 overflow-hidden"><Outlet /></main>
       <CreateMemberDialog open={createMemberOpen} onOpenChange={setCreateMemberOpen} />
+      <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
     </div>
   );
 }

--- a/frontend/app/src/pages/SettingsPage.tsx
+++ b/frontend/app/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
-import { Box, Cpu, Activity, AlertCircle, RefreshCw } from "lucide-react";
+import { Box, Cpu, Activity, AlertCircle, RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { useIsMobile } from "../hooks/use-mobile";
 import ModelMappingSection from "../components/ModelMappingSection";
 import ModelPoolSection from "../components/ModelPoolSection";
 import ObservationSection from "../components/ObservationSection";
@@ -39,7 +40,8 @@ const TABS: { id: Tab; label: string; icon: typeof Cpu; desc: string }[] = [
 ];
 
 export default function SettingsPage() {
-  const [tab, setTab] = useState<Tab>("model");
+  const isMobile = useIsMobile();
+  const [tab, setTab] = useState<Tab | null>(isMobile ? null : "model");
   const [availableModels, setAvailableModels] = useState<AvailableModelsData | null>(null);
   const [settings, setSettings] = useState<Settings | null>(null);
   const [sandboxes, setSandboxes] = useState<Record<string, Record<string, unknown>>>({});
@@ -126,146 +128,187 @@ export default function SettingsPage() {
     );
   }
 
+  const activeTab = tab ?? "model";
+
+  const renderContent = () => (
+    <div className="max-w-2xl mx-auto py-6 px-6 space-y-6">
+      {activeTab === "model" && (
+        <>
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">默认模型</h3>
+            <p className="text-xs text-muted-foreground">新对话的默认虚拟模型</p>
+            <div className="flex gap-2 flex-wrap">
+              {(["leon:mini", "leon:medium", "leon:large", "leon:max"] as const).map((id) => {
+                const label = id.split(":")[1].charAt(0).toUpperCase() + id.split(":")[1].slice(1);
+                const active = settings.default_model === id;
+                return (
+                  <button
+                    key={id}
+                    onClick={async () => {
+                      setSettings({ ...settings, default_model: id });
+                      await fetch("/api/settings/default-model", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ model: id }),
+                      });
+                    }}
+                    className={`px-4 py-2 text-sm rounded-lg border transition-colors ${
+                      active
+                        ? "bg-primary/10 border-primary/40 text-primary font-medium"
+                        : "border-border text-muted-foreground hover:border-primary/20 hover:text-foreground"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <ModelMappingSection
+            virtualModels={availableModels.virtual_models}
+            availableModels={availableModels.models}
+            modelMapping={settings.model_mapping}
+            enabledModels={settings.enabled_models}
+            onUpdate={(mapping) => setSettings({ ...settings, model_mapping: mapping })}
+          />
+          <ModelPoolSection
+            models={availableModels.models}
+            enabledModels={settings.enabled_models}
+            customConfig={settings.custom_config || {}}
+            providers={settings.providers}
+            onToggle={(modelId, enabled) => {
+              const newEnabled = enabled
+                ? [...settings.enabled_models, modelId]
+                : settings.enabled_models.filter((id) => id !== modelId);
+              setSettings({ ...settings, enabled_models: newEnabled });
+            }}
+            onAddCustomModel={handleAddCustomModel}
+            onRemoveCustomModel={async (modelId) => {
+              const res = await fetch(`/api/settings/models/custom?model_id=${encodeURIComponent(modelId)}`, {
+                method: "DELETE",
+              });
+              const data = await res.json();
+              if (data.success) {
+                const [modelsRes, settingsRes] = await Promise.all([
+                  fetch("/api/settings/available-models"),
+                  fetch("/api/settings"),
+                ]);
+                setAvailableModels(await modelsRes.json());
+                setSettings(await settingsRes.json());
+              }
+            }}
+          />
+          <ProvidersSection
+            providers={settings.providers}
+            onUpdate={(provider, config) => {
+              setSettings({
+                ...settings,
+                providers: { ...settings.providers, [provider]: config },
+              });
+            }}
+          />
+        </>
+      )}
+
+      {activeTab === "sandbox" && (
+        <>
+          <WorkspaceSection
+            defaultWorkspace={settings.default_workspace}
+            onUpdate={(ws) => setSettings({ ...settings, default_workspace: ws })}
+          />
+          <SandboxSection
+            sandboxes={sandboxes}
+            onUpdate={(name, config) => {
+              setSandboxes({ ...sandboxes, [name]: config });
+            }}
+          />
+        </>
+      )}
+
+      {activeTab === "observation" && (
+        <ObservationSection
+          config={observationConfig}
+          onUpdate={(cfg) => setObservationConfig(cfg)}
+        />
+      )}
+    </div>
+  );
+
+  const renderTabList = () => (
+    <div className="space-y-1">
+      {TABS.map((t) => {
+        const Icon = t.icon;
+        const active = tab === t.id;
+        return (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors group ${
+              active
+                ? "bg-primary/5 border border-primary/15"
+                : "hover:bg-muted border border-transparent"
+            }`}
+          >
+            <div className="flex items-center gap-2.5">
+              <Icon className={`w-4 h-4 ${active ? "text-primary" : "text-muted-foreground group-hover:text-foreground"}`} />
+              <span className={`text-sm font-medium ${active ? "text-foreground" : "text-muted-foreground group-hover:text-foreground"}`}>
+                {t.label}
+              </span>
+              {isMobile && <ChevronRight className="w-4 h-4 text-muted-foreground ml-auto" />}
+            </div>
+            <p className={`text-xs mt-0.5 ml-[26px] ${active ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
+              {t.desc}
+            </p>
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  if (isMobile) {
+    if (tab === null) {
+      return (
+        <div className="h-full flex flex-col bg-background">
+          <div className="px-4 pt-4 pb-2">
+            <h1 className="text-lg font-semibold">设置</h1>
+          </div>
+          <div className="flex-1 overflow-y-auto px-3 py-2">
+            {renderTabList()}
+          </div>
+        </div>
+      );
+    }
+    const currentTab = TABS.find(t => t.id === tab);
+    return (
+      <div className="h-full flex flex-col bg-background">
+        <div className="px-4 pt-4 pb-2 flex items-center gap-3">
+          <button
+            onClick={() => setTab(null)}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-muted-foreground hover:bg-muted"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+          <h1 className="text-lg font-semibold">{currentTab?.label}</h1>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {renderContent()}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="h-full flex">
-      {/* Left tab nav */}
       <div className="w-[200px] shrink-0 border-r border-border bg-card flex flex-col">
         <div className="px-4 py-5 border-b border-border">
           <span className="text-sm font-semibold text-foreground">设置</span>
         </div>
-
-        <div className="flex-1 px-3 py-4 space-y-1">
-          {TABS.map((t) => {
-            const Icon = t.icon;
-            const active = tab === t.id;
-            return (
-              <button
-                key={t.id}
-                onClick={() => setTab(t.id)}
-                className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors group ${
-                  active
-                    ? "bg-primary/5 border border-primary/15"
-                    : "hover:bg-muted border border-transparent"
-                }`}
-              >
-                <div className="flex items-center gap-2.5">
-                  <Icon className={`w-4 h-4 ${active ? "text-primary" : "text-muted-foreground group-hover:text-foreground"}`} />
-                  <span className={`text-sm font-medium ${active ? "text-foreground" : "text-muted-foreground group-hover:text-foreground"}`}>
-                    {t.label}
-                  </span>
-                </div>
-                <p className={`text-xs mt-0.5 ml-[26px] ${active ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
-                  {t.desc}
-                </p>
-              </button>
-            );
-          })}
+        <div className="flex-1 px-3 py-4">
+          {renderTabList()}
         </div>
       </div>
-
-      {/* Right content */}
       <div className="flex-1 overflow-y-auto bg-background">
-        <div className="max-w-2xl mx-auto py-6 px-6 space-y-6">
-          {tab === "model" && (
-            <>
-              <div className="space-y-2">
-                <h3 className="text-sm font-semibold text-foreground">默认模型</h3>
-                <p className="text-xs text-muted-foreground">新对话的默认虚拟模型</p>
-                <div className="flex gap-2">
-                  {(["leon:mini", "leon:medium", "leon:large", "leon:max"] as const).map((id) => {
-                    const label = id.split(":")[1].charAt(0).toUpperCase() + id.split(":")[1].slice(1);
-                    const active = settings.default_model === id;
-                    return (
-                      <button
-                        key={id}
-                        onClick={async () => {
-                          setSettings({ ...settings, default_model: id });
-                          await fetch("/api/settings/default-model", {
-                            method: "POST",
-                            headers: { "Content-Type": "application/json" },
-                            body: JSON.stringify({ model: id }),
-                          });
-                        }}
-                        className={`px-4 py-2 text-sm rounded-lg border transition-colors ${
-                          active
-                            ? "bg-primary/10 border-primary/40 text-primary font-medium"
-                            : "border-border text-muted-foreground hover:border-primary/20 hover:text-foreground"
-                        }`}
-                      >
-                        {label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <ModelMappingSection
-                virtualModels={availableModels.virtual_models}
-                availableModels={availableModels.models}
-                modelMapping={settings.model_mapping}
-                enabledModels={settings.enabled_models}
-                onUpdate={(mapping) => setSettings({ ...settings, model_mapping: mapping })}
-              />
-              <ModelPoolSection
-                models={availableModels.models}
-                enabledModels={settings.enabled_models}
-                customConfig={settings.custom_config || {}}
-                providers={settings.providers}
-                onToggle={(modelId, enabled) => {
-                  const newEnabled = enabled
-                    ? [...settings.enabled_models, modelId]
-                    : settings.enabled_models.filter((id) => id !== modelId);
-                  setSettings({ ...settings, enabled_models: newEnabled });
-                }}
-                onAddCustomModel={handleAddCustomModel}
-                onRemoveCustomModel={async (modelId) => {
-                  const res = await fetch(`/api/settings/models/custom?model_id=${encodeURIComponent(modelId)}`, {
-                    method: "DELETE",
-                  });
-                  const data = await res.json();
-                  if (data.success) {
-                    const [modelsRes, settingsRes] = await Promise.all([
-                      fetch("/api/settings/available-models"),
-                      fetch("/api/settings"),
-                    ]);
-                    setAvailableModels(await modelsRes.json());
-                    setSettings(await settingsRes.json());
-                  }
-                }}
-              />
-              <ProvidersSection
-                providers={settings.providers}
-                onUpdate={(provider, config) => {
-                  setSettings({
-                    ...settings,
-                    providers: { ...settings.providers, [provider]: config },
-                  });
-                }}
-              />
-            </>
-          )}
-
-          {tab === "sandbox" && (
-            <>
-              <WorkspaceSection
-                defaultWorkspace={settings.default_workspace}
-                onUpdate={(ws) => setSettings({ ...settings, default_workspace: ws })}
-              />
-              <SandboxSection
-                sandboxes={sandboxes}
-                onUpdate={(name, config) => {
-                  setSandboxes({ ...sandboxes, [name]: config });
-                }}
-              />
-            </>
-          )}
-
-          {tab === "observation" && (
-            <ObservationSection
-              config={observationConfig}
-              onUpdate={(cfg) => setObservationConfig(cfg)}
-            />
-          )}
-        </div>
+        {renderContent()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Mobile responsive: thread list view, back navigation, drill-down settings, bottom nav with settings tab
- NewChatDialog: select member to start chat (sidebar + mobile)
- MembersPage: copy/delete hover actions on member cards
- Fix: thread deletion logs warning instead of 409 on sandbox cleanup failure
- Fix: TaskMiddleware uses correct `load_all_agents()` method name
- UI: softer focus rings, responsive input width

## Test
- [x] Mobile: thread list, chat detail back button, settings drill-down
- [x] Desktop: NewChatDialog from sidebar, member card copy/delete
- [x] Delete thread with failed sandbox — no longer 409