### PR TITLE
refactor(storage): repo-level provider parity for sqlite/supabase

### DIFF
--- a/core/storage/container.py
+++ b/core/storage/container.py
@@ -1,29 +1,36 @@
-"""StorageContainer — phase-3 composition root for hunter worktree.
-
-# @@@phase3-container - wires all 6 phase-2 repos; call sites unchanged.
-"""
+"""Storage container with repo-level provider selection."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
+import sqlite3
 
 StorageStrategy = Literal["sqlite", "supabase"]
-RepoBindingMap = Mapping[str, Any]
+RepoProviderMap = Mapping[str, str]
 
 
 class StorageContainer:
-    """Composition root: instantiates phase-2 repos from DB paths."""
+    """Composition root for storage repos."""
 
     _SUPPORTED_STRATEGIES = {"sqlite", "supabase"}
+    _REPO_NAMES = (
+        "checkpoint_repo",
+        "thread_config_repo",
+        "run_event_repo",
+        "file_operation_repo",
+        "summary_repo",
+        "eval_repo",
+    )
 
     def __init__(
         self,
         main_db_path: str | Path | None = None,
         eval_db_path: str | Path | None = None,
         strategy: StorageStrategy = "sqlite",
-        supabase_bindings: RepoBindingMap | None = None,
+        repo_providers: RepoProviderMap | None = None,
+        supabase_bindings: Mapping[str, Any] | None = None,
         supabase_client: Any | None = None,
     ) -> None:
         if strategy not in self._SUPPORTED_STRATEGIES:
@@ -36,35 +43,39 @@ class StorageContainer:
         self._eval_db = Path(eval_db_path) if eval_db_path else root / "eval.db"
         self._strategy: StorageStrategy = strategy
         self._supabase_client = supabase_client
+        self._repo_providers = self._resolve_repo_providers(
+            default_strategy=strategy,
+            repo_providers=repo_providers,
+            legacy_supabase_bindings=supabase_bindings,
+        )
 
     def checkpoint_repo(self):
-        if self._strategy == "supabase":
+        if self._provider_for("checkpoint_repo") == "supabase":
             return self._build_supabase_checkpoint_repo()
         from core.storage.providers.sqlite.checkpoint_repo import SQLiteCheckpointRepo
         return SQLiteCheckpointRepo(db_path=self._main_db)
 
     def thread_config_repo(self):
-        if self._strategy == "supabase":
+        if self._provider_for("thread_config_repo") == "supabase":
             return self._build_supabase_thread_config_repo()
         from core.storage.providers.sqlite.thread_config_repo import SQLiteThreadConfigRepo
         return SQLiteThreadConfigRepo(db_path=self._main_db)
 
     def run_event_repo(self):
-        if self._strategy == "supabase":
+        if self._provider_for("run_event_repo") == "supabase":
             return self._build_supabase_run_event_repo()
         from core.storage.providers.sqlite.run_event_repo import SQLiteRunEventRepo
         return SQLiteRunEventRepo(db_path=self._main_db)
 
     def file_operation_repo(self):
-        if self._strategy == "supabase":
+        if self._provider_for("file_operation_repo") == "supabase":
             return self._build_supabase_file_operation_repo()
         from core.storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
         return SQLiteFileOperationRepo(db_path=self._main_db)
 
     def summary_repo(self):
-        if self._strategy == "supabase":
+        if self._provider_for("summary_repo") == "supabase":
             return self._build_supabase_summary_repo()
-        import sqlite3
         from core.storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
         return SQLiteSummaryRepo(
             db_path=self._main_db,
@@ -72,10 +83,53 @@ class StorageContainer:
         )
 
     def eval_repo(self):
-        if self._strategy == "supabase":
+        if self._provider_for("eval_repo") == "supabase":
             return self._build_supabase_eval_repo()
         from core.storage.providers.sqlite.eval_repo import SQLiteEvalRepo
         return SQLiteEvalRepo(db_path=self._eval_db)
+
+    def provider_for(self, repo_name: str) -> StorageStrategy:
+        return self._provider_for(repo_name)
+
+    def _provider_for(self, repo_name: str) -> StorageStrategy:
+        if repo_name not in self._REPO_NAMES:
+            supported = ", ".join(self._REPO_NAMES)
+            raise ValueError(f"Unknown repo name: {repo_name}. Supported repo names: {supported}")
+        return self._repo_providers[repo_name]
+
+    @classmethod
+    def _resolve_repo_providers(
+        cls,
+        *,
+        default_strategy: StorageStrategy,
+        repo_providers: RepoProviderMap | None,
+        legacy_supabase_bindings: Mapping[str, Any] | None,
+    ) -> dict[str, StorageStrategy]:
+        if repo_providers is not None and legacy_supabase_bindings is not None:
+            raise ValueError("Use either repo_providers or supabase_bindings, not both.")
+
+        overrides: Mapping[str, Any] = repo_providers or legacy_supabase_bindings or {}
+        unknown_repos = sorted(set(overrides.keys()) - set(cls._REPO_NAMES))
+        if unknown_repos:
+            supported = ", ".join(cls._REPO_NAMES)
+            unknown = ", ".join(unknown_repos)
+            raise ValueError(f"Unknown repo provider bindings: {unknown}. Supported repo names: {supported}")
+
+        resolved: dict[str, StorageStrategy] = {name: default_strategy for name in cls._REPO_NAMES}
+        # @@@repo-provider-override - default strategy keeps current behavior; only explicitly listed repos diverge.
+        for repo_name, provider in overrides.items():
+            if not isinstance(provider, str):
+                raise ValueError(
+                    f"Invalid provider value for {repo_name}: {provider!r}. Expected 'sqlite' or 'supabase'."
+                )
+            normalized = provider.strip().lower()
+            if normalized not in cls._SUPPORTED_STRATEGIES:
+                supported = ", ".join(sorted(cls._SUPPORTED_STRATEGIES))
+                raise ValueError(
+                    f"Unsupported provider for {repo_name}: {provider!r}. Supported providers: {supported}"
+                )
+            resolved[repo_name] = normalized
+        return resolved
 
     def _build_supabase_checkpoint_repo(self):
         from core.storage.providers.supabase.checkpoint_repo import SupabaseCheckpointRepo


### PR DESCRIPTION
## Summary
- make StorageContainer resolve provider per repo instead of one global strategy switch
- add runtime support for LEON_STORAGE_REPO_PROVIDERS (JSON map)
- fail loud when supabase provider is requested without runtime client config

## Why
Current storage abstraction still binds all repos to a single strategy branch. This change makes sqlite/supabase parity explicit at repo granularity while preserving current defaults.

## Validation
- uv run --with pytest --with pytest-asyncio pytest -q tests/test_manager_ground_truth.py tests/test_storage_runtime_wiring.py
  - 28 passed

## Notes
- Existing broader runtime suite still has unrelated environment failures when daytona_sdk is unavailable.
