### PR TITLE
feat(bench): add Anthropic native API benchmark script

### DIFF
--- a/.claude/skills/bench/SKILL.md
+++ b/.claude/skills/bench/SKILL.md
@@ -3,13 +3,27 @@ name: bench
 description: 测试 API 模型性能 - TTFB 和吐字速度
 ---
 
-快速测试第三方中转 API 的模型性能。
+快速测试第三方 API 的模型性能。两个脚本，按 API 格式选择。
 
 ## 用法
 
-用户提供：
-- API Key
-- Base URL
+用户提供：API Key + Base URL
+
+**默认 → OpenAI 格式**（`/v1/chat/completions`）：
+```bash
+cd .claude/skills/bench && uv run python test_models.py "<API_KEY>" "<BASE_URL>"
+```
+
+**用户说"Anthropic 格式"→ Anthropic 原生**（`/v1/messages`）：
+```bash
+cd .claude/skills/bench && uv run python test_anthropic.py "<API_KEY>" "<BASE_URL>"
+```
+
+## 判断规则
+
+- 默认走 `test_models.py`（OpenAI 格式）
+- 仅当用户明确说"Anthropic 格式/原生 API"时，走 `test_anthropic.py`
+- 不要自动猜测，由用户指定
 
 ## 测试指标
 
@@ -17,62 +31,21 @@ description: 测试 API 模型性能 - TTFB 和吐字速度
 - **Tok/s**: 吐字速度
 - 总超时：30秒
 
-## 实现
+## OpenAI 脚本特性（test_models.py）
 
-**必须使用 `uv run`** 运行脚本以自动处理依赖（aiohttp）：
+- 自动从 `/models` 端点获取可用模型并智能筛选
+- 筛选最新主流文本模型（Claude 4.x, GPT 5.x, Gemini 3.x, Qwen 3.x, GLM 4.7+, Kimi k2.5+）
+- 排除 DeepSeek、多模态模型、过时版本
+- Base URL 必须带 `/v1` 后缀
 
-```bash
-cd .claude/skills/bench && uv run python test_models.py "<API_KEY>" "<BASE_URL>"
-```
+## Anthropic 脚本特性（test_anthropic.py）
 
-## 智能模型过滤
-
-自动从 `/models` 端点获取可用模型，并智能筛选：
-
-**包含的模型版本：**
-- Claude: 4.6, 4.5（排除 3.x）
-- GPT: 5.x（排除 4.x, 4o, 4.1, o1, o3）
-- Gemini: 3.x（排除 2.x）
-- Qwen: 3.x（排除 2.x）
-- GLM: 4.7+（排除 4.6 及以下）
-- Kimi: k2.5+（排除 k2 及以下）
-
-**排除的模型：**
-- DeepSeek 全系列
-- 多模态模型（embed, vision, image, audio, realtime, tts, vl, lite）
-- 过时版本
+- 使用 `x-api-key` + `anthropic-version` 认证
+- 默认测试：opus-4-6, sonnet-4-6, sonnet-4-5, haiku-4-5
+- Base URL 带不带 `/v1` 都行（自动处理）
 
 ## 常见问题
 
-### 1. Base URL 格式
-- ✅ 正确：`http://example.com:3000/v1`
-- ❌ 错误：`http://example.com:3000`（缺少 `/v1` 后缀会导致 `/models` 返回 HTML）
-
-### 2. 依赖问题
-- ❌ 错误：`python test_models.py` → `ModuleNotFoundError: No module named 'aiohttp'`
-- ✅ 正确：`uv run python test_models.py` → 自动处理依赖
-
-### 3. 模型数量
-- API 可能有 300+ 模型，脚本会自动筛选出最新主流文本模型（通常 10-20 个）
-- 如果 `/models` 端点失败，会回退到默认模型列表
-
-## 输出示例
-
-```
-Fetching available models...
-Testing 9 models with streaming...
-Task: 请写一篇300字的短文，主题是春天的早晨。
-
-==========================================================================================
-Model                                    TTFB         Tok/s        Status
-==========================================================================================
-gpt-5-chat-latest                        1.81s         81.0       ✓
-gpt-5-2025-08-07                         8.52s        411.1       ✓
-gemini-3-flash-preview                   8.69s          7.1       ✓
-gpt-5                                    --           --           ✗ TTFB timeout (>10s)
-...
-==========================================================================================
-🏆 最快首次响应: gpt-5-chat-latest (1.81s)
-⚡ 最快吐字速度: gpt-5-2025-08-07 (411.1 tok/s)
-✓ 3/9 模型可用
-```
+- **依赖**：必须用 `uv run`，不能直接 `python`
+- **OpenAI Base URL**：必须带 `/v1`，否则 `/models` 返回 HTML
+- **Anthropic `/models` 被拦截**：正常，Cloudflare 保护，脚本用默认模型列表

--- a/.claude/skills/bench/test_anthropic.py
+++ b/.claude/skills/bench/test_anthropic.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Test Anthropic native API (/v1/messages) performance: TTFB and token speed.
+"""
+
+import asyncio
+import json
+import sys
+import time
+
+import aiohttp
+
+if len(sys.argv) < 3:
+    print("Usage: python test_anthropic.py <API_KEY> <BASE_URL>")
+    print("Example: python test_anthropic.py sk-ant-xxx https://api.example.com/claude/droid")
+    sys.exit(1)
+
+API_KEY = sys.argv[1]
+BASE_URL = sys.argv[2].rstrip("/")
+
+# Strip /v1 suffix if present — we'll add it ourselves
+if BASE_URL.endswith("/v1"):
+    BASE_URL = BASE_URL[:-3]
+
+TEST_PROMPT = "请写一篇300字的短文，主题是春天的早晨。"
+
+DEFAULT_MODELS = [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5-20251001",
+]
+
+
+async def test_model(session, model):
+    """Test a single model with Anthropic streaming."""
+    start_time = time.time()
+    first_token_time = None
+    chunks_received = 0
+    content_length = 0
+    output_tokens = 0
+
+    try:
+        async with session.post(
+            f"{BASE_URL}/v1/messages",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": TEST_PROMPT}],
+                "max_tokens": 4096,
+                "stream": True,
+            },
+            timeout=aiohttp.ClientTimeout(total=90),
+        ) as resp:
+            if resp.status != 200:
+                try:
+                    text = await resp.text()
+                    # Try to parse error JSON
+                    err = json.loads(text).get("error", {}).get("message", text[:60])
+                except Exception:
+                    err = text[:60]
+                return {"model": model, "status": "✗", "error": err[:60]}
+
+            async for raw_line in resp.content:
+                if first_token_time is None and (time.time() - start_time) > 10:
+                    return {"model": model, "status": "✗", "error": "TTFB timeout (>10s)"}
+                if (time.time() - start_time) > 90:
+                    return {"model": model, "status": "✗", "error": "Total timeout (>30s)"}
+
+                line = raw_line.decode("utf-8").strip()
+                if not line.startswith("data: "):
+                    continue
+
+                data_str = line[6:]
+                try:
+                    data = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+
+                event_type = data.get("type", "")
+
+                if event_type == "content_block_delta":
+                    text = data.get("delta", {}).get("text", "")
+                    if text:
+                        if first_token_time is None:
+                            first_token_time = time.time()
+                        chunks_received += 1
+                        content_length += len(text)
+
+                elif event_type == "message_delta":
+                    usage = data.get("usage", {})
+                    output_tokens = usage.get("output_tokens", 0)
+
+                elif event_type == "message_stop":
+                    break
+
+        total_time = time.time() - start_time
+        ttfb = first_token_time - start_time if first_token_time else None
+
+        if ttfb is None:
+            return {"model": model, "status": "✗", "error": "No tokens received"}
+
+        gen_time = total_time - ttfb
+        tok_s = output_tokens / gen_time if gen_time > 0 else 0
+
+        return {
+            "model": model, "status": "✓",
+            "ttfb": ttfb, "total_time": total_time,
+            "tokens": output_tokens, "chars": content_length,
+            "tokens_per_sec": tok_s,
+        }
+
+    except TimeoutError:
+        return {"model": model, "status": "✗", "error": "Timeout (>30s)"}
+    except Exception as e:
+        return {"model": model, "status": "✗", "error": str(e)[:60]}
+
+
+async def main():
+    headers = {
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    }
+
+    print(f"Endpoint: {BASE_URL}/v1/messages")
+    print(f"Testing {len(DEFAULT_MODELS)} models with streaming...")
+    print(f"Task: {TEST_PROMPT}\n")
+
+    async with aiohttp.ClientSession(headers=headers) as session:
+        tasks = [test_model(session, m) for m in DEFAULT_MODELS]
+        results = await asyncio.gather(*tasks)
+
+    ok = [r for r in results if r["status"] in ("✓", "⚠")]
+    fail = [r for r in results if r["status"] == "✗"]
+    ok.sort(key=lambda x: (x.get("ttfb", 999), -x.get("tokens_per_sec", 0)))
+
+    print("=" * 90)
+    print(f"{'Model':<40} {'TTFB':<12} {'Tok/s':<12} {'Status'}")
+    print("=" * 90)
+
+    for r in ok:
+        print(f"{r['model']:<40} {r['ttfb']:.2f}s       {r['tokens_per_sec']:>6.1f}       {r['status']}")
+    for r in fail:
+        print(f"{r['model']:<40} {'--':<12} {'--':<12} ✗ {r.get('error', '')[:40]}")
+
+    if ok:
+        best_ttfb = min(ok, key=lambda x: x["ttfb"])
+        best_tok = max(ok, key=lambda x: x["tokens_per_sec"])
+        print("=" * 90)
+        print(f"🏆 最快首次响应: {best_ttfb['model']} ({best_ttfb['ttfb']:.2f}s)")
+        print(f"⚡ 最快吐字速度: {best_tok['model']} ({best_tok['tokens_per_sec']:.1f} tok/s)")
+        print(f"✓ {len(ok)}/{len(results)} 模型可用")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What

Add a dedicated benchmark script for Anthropic native API (`/v1/messages`) endpoints, alongside the existing OpenAI-format script.

## Changes

- **New `test_anthropic.py`**: Streams via Anthropic SSE protocol (`content_block_delta` / `message_delta` / `message_stop`), uses `x-api-key` + `anthropic-version` auth, defaults to opus-4-6, sonnet-4-6, sonnet-4-5, haiku-4-5
- **Fix tok/s calculation**: Use real `output_tokens` from API `message_delta` usage instead of counting SSE chunks (which underestimated by ~5-6x)
- **Update SKILL.md**: Document both scripts with clear selection rules — default OpenAI, Anthropic only when user explicitly says so

## Testing

Verified against a live Anthropic-native endpoint. Sample output:

```
Model                                    TTFB         Tok/s        Status
claude-opus-4-6                          2.86s         63.3       ✓
claude-haiku-4-5-20251001                3.00s        122.1       ✓
claude-sonnet-4-5-20250929               3.58s         92.9       ✓
```