### PR TITLE
test(model-params): trim provider whitespace for OpenAI GPT-5 normalization

### DIFF
--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -44,3 +44,10 @@ def test_openai_provider_matching_is_case_insensitive() -> None:
     out = normalize_model_kwargs("gpt-5.2", kwargs)
     assert "max_tokens" not in out
     assert out["max_completion_tokens"] == 256
+
+
+def test_openai_provider_matching_trims_whitespace() -> None:
+    kwargs = {"model_provider": "  openai  ", "max_tokens": 256}
+    out = normalize_model_kwargs("gpt-5.2", kwargs)
+    assert "max_tokens" not in out
+    assert out["max_completion_tokens"] == 256


### PR DESCRIPTION
## Summary
- add one minimal boundary test for `normalize_model_kwargs`
- verify `model_provider` whitespace is trimmed before OpenAI GPT-5 token param normalization

## Scope
- test-only housekeeping patch
- no runtime logic changes

## Validation
- `uv run --with pytest pytest -q tests/test_model_params.py`
- result: `7 passed`
