### PR TITLE
feat(worktree): auto port detection + global ~/worktrees/ layout

### DIFF
--- a/.claude/commands/wtls.md
+++ b/.claude/commands/wtls.md
@@ -25,22 +25,28 @@ git -C <path> rev-list HEAD..origin/main --count   # BEHIND
 git -C <path> log -1 --format="%ai"               # 最近 commit 时间
 git -C <path> log --format="%ai" $(git -C <path> merge-base HEAD origin/main) -1  # 分叉时间
 gh pr view --json state,url,number -R <repo> -b <branch> 2>/dev/null  # PR 状态
+
+# 读取 worktree config（新创建的 worktree 才有）：
+git -C <path> config --worktree --get worktree.ports.backend 2>/dev/null
+git -C <path> config --worktree --get worktree.ports.frontend 2>/dev/null
+git -C <path> config --worktree --get worktree.description 2>/dev/null
 ```
 
 ## Step 2：输出表格
 
 ```
-worktree            branch          ahead  behind  dirty  PR
-────────────────────────────────────────────────────────────────
-worktrees/feat-x    feat/x          +3     -0      ✗      #12 open
-worktrees/fix-y     fix/y           +0     -5      ✓      none
-worktrees/old-feat  old/feat        +1     -12     ✗      #8 merged ⚠
+worktree                        branch          ports        ahead  behind  dirty  PR           description
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────
+~/worktrees/leon--feat-x        feat/x          8002:5174    +3     -0      ✗      #12 open     评估系统开发
+~/worktrees/leon--fix-y         fix/y           8003:5175    +0     -5      ✓      none         修复登录 bug
+worktrees/old-feat              old/feat        -            +1     -12     ✗      #8 merged ⚠  (旧路径)
 ```
 
 状态标注：
 - `⚠` = PR 已 merged/closed，建议清理
 - `✓` dirty = 有未提交改动
 - behind 较多 = 落后 main，建议 rebase
+- `-` ports = 旧路径 worktree，无端口配置
 
 ## Step 3：输出 Mermaid 时间轴
 

--- a/.claude/commands/wtnew.md
+++ b/.claude/commands/wtnew.md
@@ -10,6 +10,7 @@
 
 ```bash
 MAIN_REPO=$(git worktree list | head -1 | awk '{print $1}')
+PROJECT_NAME=$(basename "$MAIN_REPO")
 ```
 
 在主仓库或任意 worktree 下执行均可，自动找到主仓库根目录。
@@ -22,32 +23,101 @@ git fetch origin
 
 确保基于最新的 `origin/main` 创建，避免从过时的 base 分叉。
 
-## Step 2：创建 worktree
+## Step 2：启用 worktreeConfig
+
+```bash
+git config extensions.worktreeConfig true
+```
+
+幂等操作，已启用不报错。启用后每个 worktree 可拥有独立的 `config.worktree` 配置。
+
+## Step 3：创建 worktree
 
 目录名规则：分支名中的 `/` 替换为 `-`（如 `feat/eval` → `feat-eval`）
 
+路径规则：`~/worktrees/<项目名>--<目录名>`（如 `~/worktrees/leon--feat-eval`）
+
 ```bash
-git worktree add "$MAIN_REPO/worktrees/<目录名>" -b $ARGUMENTS origin/main
+git worktree add "$HOME/worktrees/$PROJECT_NAME--<目录名>" -b $ARGUMENTS origin/main
 ```
 
-- `worktrees/` 统一放在主仓库内
-- 必须确认 `worktrees/` 在 `.gitignore` 中，不在则自动添加
+- worktree 存放在 `~/worktrees/`，与主仓库完全隔离
+- 确保 `~/worktrees/` 目录存在（`mkdir -p ~/worktrees`）
 
-## Step 3：链接本地配置
+## Step 4：端口分配
 
-`.claude/` 已纳入 Git 管理，worktree checkout 后自动包含。  
+为 worktree 分配独立的 backend + frontend 端口对，避免多 worktree 同时开发时端口冲突。
+
+端口 8001/5173 保留给 main，worktree 从 offset=1 开始。
+
+分配逻辑（**必须严格按以下脚本执行，不要自行简化**）：
+
+```bash
+# 用 git worktree list 获取所有 worktree 路径，逐个读取已声明端口
+MAIN_REPO=$(git worktree list | head -1 | awk '{print $1}')
+declared_ports=""
+while read -r wt_path _rest; do
+  [ "$wt_path" = "$MAIN_REPO" ] && continue
+  bp=$(git -C "$wt_path" config --worktree --get worktree.ports.backend 2>/dev/null)
+  fp=$(git -C "$wt_path" config --worktree --get worktree.ports.frontend 2>/dev/null)
+  [ -n "$bp" ] && declared_ports="$declared_ports $bp"
+  [ -n "$fp" ] && declared_ports="$declared_ports $fp"
+done < <(git worktree list | tail -n +2)
+echo "已声明端口: $declared_ports"
+
+# 从 offset=1 开始找第一组未冲突的端口对
+for offset in $(seq 1 20); do
+  bp=$((8001 + offset))
+  fp=$((5173 + offset))
+  # 检查 1：是否已被其他 worktree 声明
+  if echo "$declared_ports" | grep -qw "$bp" || echo "$declared_ports" | grep -qw "$fp"; then
+    echo "跳过 $bp/$fp（已声明）"
+    continue
+  fi
+  # 检查 2：系统层是否占用
+  if lsof -i :"$bp" >/dev/null 2>&1 || lsof -i :"$fp" >/dev/null 2>&1; then
+    echo "跳过 $bp/$fp（端口占用）"
+    continue
+  fi
+  echo "分配: backend=$bp frontend=$fp"
+  break
+done
+```
+
+## Step 5：写入 worktree config
+
+```bash
+cd "$HOME/worktrees/$PROJECT_NAME--<目录名>"
+git config --worktree worktree.ports.backend <backend_port>
+git config --worktree worktree.ports.frontend <frontend_port>
+git config --worktree worktree.description "<AI 生成的描述>"
+git config --worktree worktree.created "$(date +%Y-%m-%d)"
+git config --worktree worktree.project "$PROJECT_NAME"
+```
+
+description 由 AI 根据分支名和用户提供的上下文自动推断，简短描述这个分支的目的（中文，10-20 字）。
+
+前后端代码会自动从 `git config --worktree` 读取端口，无需手动修改代码：
+- `backend/web/main.py` → `_resolve_port()` 读取 `worktree.ports.backend`
+- `frontend/app/vite.config.ts` → `getWorktreePort()` 读取 `worktree.ports.backend` 和 `worktree.ports.frontend`
+
+## Step 6：链接本地配置
+
+`.claude/` 已纳入 Git 管理，worktree checkout 后自动包含。
 只需链接不在 Git 里的本地配置文件：
 
 ```bash
-cd "$MAIN_REPO/worktrees/<目录名>"
+cd "$HOME/worktrees/$PROJECT_NAME--<目录名>"
 ln -s "$MAIN_REPO/CLAUDE.local.md" CLAUDE.local.md 2>/dev/null
 ```
 
-## Step 4：确认结果
+## Step 7：确认结果
 
 输出：
 - worktree 路径
 - 分支名
+- 分配的端口（backend / frontend）
+- 自动生成的描述
 - `CLAUDE.local.md` 符号链接状态
 
 询问用户：是否在新 worktree 中打开新的 Claude 会话？
@@ -55,7 +125,7 @@ ln -s "$MAIN_REPO/CLAUDE.local.md" CLAUDE.local.md 2>/dev/null
 如果是，用 osascript 打开新终端并启动 claude（**必须将路径替换为实际计算出的完整绝对路径，不得使用变量或占位符**）：
 
 ```bash
-osascript -e 'tell app "Terminal" to do script "cd \"/actual/absolute/path/to/worktrees/<目录名>\" && claude"'
+osascript -e 'tell app "Terminal" to do script "cd \"/Users/apple/worktrees/<项目名>--<目录名>\" && claude"'
 ```
 
 关键：`cd` 和 `claude` 必须写在 osascript 的 `do script` 字符串内部，不是写在外层 Bash 命令里。

--- a/.claude/commands/wtrebaseall.md
+++ b/.claude/commands/wtrebaseall.md
@@ -22,7 +22,7 @@ git fetch origin
 
 ## Step 2：遍历所有 worktree
 
-对每个 worktree 逐一处理（跳过主仓库本身）：
+对每个 worktree 逐一处理（跳过主仓库本身），无论在 `~/worktrees/` 还是旧路径 `$MAIN_REPO/worktrees/`：
 
 ```bash
 git worktree list --porcelain
@@ -51,11 +51,11 @@ DIRTY 检查
 wtrebaseall 完成
 ─────────────────────────────────────
 ✅ 成功 rebase：
-  - worktrees/feat-x (feat/x)  +2 新 commit
-  - worktrees/fix-y  (fix/y)   已是最新
+  - ~/worktrees/leon--feat-x (feat/x)  +2 新 commit
+  - ~/worktrees/leon--fix-y  (fix/y)   已是最新
 
 ⚠ 跳过（有未提交改动，需手动处理）：
-  - worktrees/wip-z (wip/z)
+  - ~/worktrees/leon--wip-z (wip/z)
 
 ❌ 冲突（已 abort，需手动处理）：
   - worktrees/old-a (old/a)
@@ -67,3 +67,5 @@ wtrebaseall 完成
 ─────────────────────────────────────
 成功 2 / 跳过 1 / 冲突 1 / 待清理 1
 ```
+
+报告中使用 `git worktree list` 返回的实际路径，兼容新旧两种位置。

--- a/.claude/commands/wtrm.md
+++ b/.claude/commands/wtrm.md
@@ -12,11 +12,18 @@
 
 ```bash
 MAIN_REPO=$(git worktree list | head -1 | awk '{print $1}')
+PROJECT_NAME=$(basename "$MAIN_REPO")
 ```
 
 - 当前目录是某个 worktree → 默认操作当前 worktree，确认后执行
 - 当前目录是主仓库且无参数 → 列出所有 worktree，询问移除哪个
 - 提供了参数 → 匹配分支名或目录名
+
+worktree 可能在两个位置（兼容新旧路径）：
+- 新路径：`~/worktrees/<项目名>--<目录名>`
+- 旧路径：`$MAIN_REPO/worktrees/<目录名>`
+
+用 `git worktree list` 获取实际路径，按分支名匹配即可。
 
 ## Step 1：检查未提交改动
 
@@ -31,7 +38,7 @@ git -C <worktree路径> status --short
 先移除已知的 symlink（`CLAUDE.local.md` 由 `wtnew` 创建，不在 Git 里）：
 
 ```bash
-TARGET="$MAIN_REPO/worktrees/<目录名>/CLAUDE.local.md"
+TARGET="<worktree路径>/CLAUDE.local.md"
 [ -L "$TARGET" ] && rm "$TARGET" || echo "跳过：$TARGET 不是符号链接，不删除"
 ```
 
@@ -40,15 +47,17 @@ TARGET="$MAIN_REPO/worktrees/<目录名>/CLAUDE.local.md"
 ## Step 3：移除 worktree
 
 ```bash
-git worktree remove "$MAIN_REPO/worktrees/<目录名>"
+git worktree remove "<worktree路径>"
 ```
 
 如果仍然失败（`.venv`、`__pycache__` 等其他 untracked 文件残留）：
 
 ```bash
-rm -rf "$MAIN_REPO/worktrees/<目录名>"
+rm -rf "<worktree路径>"
 git worktree prune
 ```
+
+移除后，`config.worktree` 随 `.git/worktrees/<name>/` 自动清除，无需额外处理。
 
 ## Step 4：询问是否删除本地分支
 

--- a/.claude/commands/wtsync.md
+++ b/.claude/commands/wtsync.md
@@ -16,7 +16,7 @@ CWD=$(pwd)
 ```
 
 - `CWD == MAIN_REPO` → 提示"你在主仓库，不需要 sync"，退出
-- `CWD` 在某个 worktree 下 → 继续
+- `CWD` 在某个 worktree 下 → 继续（无论是 `~/worktrees/` 还是旧路径 `$MAIN_REPO/worktrees/`）
 
 ## Step 1：链接本地配置
 

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -32,15 +32,15 @@
 
 ## Worktree 规范
 
-新功能开发使用 worktree 隔离：
+新功能开发使用 worktree 隔离，存放在全局目录，避免与主仓库混淆：
 
 ```bash
-# 在项目内的 worktrees/ 文件夹创建 worktree
-git worktree add worktrees/<feature> -b <feature>
-cd worktrees/<feature>
+# 在全局 ~/worktrees/ 目录创建
+git worktree add ~/worktrees/<项目名>--<feature> -b <feature> origin/main
+cd ~/worktrees/<项目名>--<feature>
 ```
 
 规则：
-- 统一使用项目内的 `worktrees/` 文件夹（不是同级目录 `../`）
-- 确保 `worktrees/` 已加入 `.gitignore`
+- 统一使用 `~/worktrees/`，命名 `<项目名>--<目录名>`（目录名 = 分支名 `/` → `-`）
+- 创建时自动分配端口对（写入 `git config --worktree`），避免多 worktree 端口冲突
 - 开发完成后用 `git worktree remove` 清理

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -1,7 +1,19 @@
+import { execSync } from "child_process"
 import path from "path"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 import { inspectAttr } from 'kimi-plugin-inspect-react'
+
+function getWorktreePort(key: string, fallback: string): string {
+  try {
+    return execSync(`git config --worktree --get ${key}`, { encoding: "utf-8" }).trim()
+  } catch {
+    return fallback
+  }
+}
+
+const backendPort = process.env.LEON_BACKEND_PORT || getWorktreePort("worktree.ports.backend", "8001")
+const frontendPort = parseInt(process.env.LEON_FRONTEND_PORT || getWorktreePort("worktree.ports.frontend", "5173"))
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,10 +21,10 @@ export default defineConfig({
   plugins: [inspectAttr(), react()],
   server: {
     host: "0.0.0.0",
-    port: 5173,
+    port: frontendPort,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8001",
+        target: `http://127.0.0.1:${backendPort}`,
         changeOrigin: true,
         configure: (proxy) => {
           // Disable buffering for SSE responses


### PR DESCRIPTION
## Summary
- Migrate worktree directory from project-local `worktrees/` to global `~/worktrees/<project>--<branch>` for better isolation
- Add automatic port allocation (backend/frontend) via `git config --worktree`, eliminating manual port conflicts across multiple worktrees
- Backend `_resolve_port()` and frontend `getWorktreePort()` read ports from worktree config automatically
- Update all wt commands (wtnew/wtrm/wtls/wtsync/wtrebaseall) and git rules to reflect new layout

## Test plan
- [ ] Create a worktree with `/wtnew` and verify ports are auto-assigned
- [ ] Start backend/frontend in worktree and confirm they use assigned ports
- [ ] Run `/wtrm` to clean up and verify no residual config
- [ ] Verify main repo still defaults to 8001/5173