### PR TITLE
refactor(task): code simplification after task system review

### DIFF
--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -6,6 +6,21 @@ from croniter import croniter
 from pydantic import BaseModel, field_validator
 
 
+def _check_cron_expr(v: str | None) -> str | None:
+    if v is not None and not croniter.is_valid(v):
+        raise ValueError(f"Invalid cron expression: {v!r}")
+    return v
+
+
+def _check_json_template(v: str | None) -> str | None:
+    if v is not None:
+        try:
+            json.loads(v)
+        except (json.JSONDecodeError, TypeError):
+            raise ValueError("task_template must be valid JSON")
+    return v
+
+
 # ── Members ──
 
 class MemberConfigPayload(BaseModel):
@@ -96,18 +111,12 @@ class CreateCronJobRequest(BaseModel):
     @field_validator("cron_expression")
     @classmethod
     def validate_cron_expression(cls, v: str) -> str:
-        if not croniter.is_valid(v):
-            raise ValueError(f"Invalid cron expression: {v!r}")
-        return v
+        return _check_cron_expr(v)  # type: ignore[return-value]
 
     @field_validator("task_template")
     @classmethod
     def validate_task_template(cls, v: str) -> str:
-        try:
-            json.loads(v)
-        except (json.JSONDecodeError, TypeError):
-            raise ValueError("task_template must be valid JSON")
-        return v
+        return _check_json_template(v)  # type: ignore[return-value]
 
 
 class UpdateCronJobRequest(BaseModel):
@@ -120,19 +129,12 @@ class UpdateCronJobRequest(BaseModel):
     @field_validator("cron_expression")
     @classmethod
     def validate_cron_expression(cls, v: str | None) -> str | None:
-        if v is not None and not croniter.is_valid(v):
-            raise ValueError(f"Invalid cron expression: {v!r}")
-        return v
+        return _check_cron_expr(v)
 
     @field_validator("task_template")
     @classmethod
     def validate_task_template(cls, v: str | None) -> str | None:
-        if v is not None:
-            try:
-                json.loads(v)
-            except (json.JSONDecodeError, TypeError):
-                raise ValueError("task_template must be valid JSON")
-        return v
+        return _check_json_template(v)
 
 
 # ── Backward compatibility aliases ──

--- a/backend/web/services/cron_job_service.py
+++ b/backend/web/services/cron_job_service.py
@@ -1,6 +1,7 @@
 """Cron Jobs CRUD — SQLite based (cron_jobs table)."""
 
 import sqlite3
+import time
 import uuid
 from typing import Any
 
@@ -48,7 +49,6 @@ def create_cron_job(*, name: str, cron_expression: str, **fields: Any) -> dict[s
     if not cron_expression or not cron_expression.strip():
         raise ValueError("cron_expression must not be empty")
 
-    import time
     now = int(time.time() * 1000)
     job_id = uuid.uuid4().hex
     with _conn() as c:

--- a/backend/web/services/cron_service.py
+++ b/backend/web/services/cron_service.py
@@ -20,6 +20,7 @@ from backend.web.services import cron_job_service, task_service
 logger = logging.getLogger(__name__)
 
 _CHECK_INTERVAL_SEC = 60
+_ALLOWED_TEMPLATE_KEYS = {"title", "description", "priority", "assignee_id", "deadline", "tags"}
 
 
 class CronService:
@@ -72,7 +73,6 @@ class CronService:
             return None
 
         # Build task fields from template — only allow known safe keys
-        _ALLOWED_TEMPLATE_KEYS = {"title", "description", "priority", "assignee_id", "deadline", "tags"}
         task_fields: dict[str, Any] = {k: v for k, v in template.items() if k in _ALLOWED_TEMPLATE_KEYS}
         task_fields["source"] = "cron"
         task_fields["cron_job_id"] = job_id

--- a/backend/web/services/task_service.py
+++ b/backend/web/services/task_service.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import time
 import uuid
 from typing import Any
 
@@ -68,8 +69,24 @@ def list_tasks() -> list[dict[str, Any]]:
         return [_deserialize_row(r) for r in rows]
 
 
+def get_task(task_id: str) -> dict[str, Any] | None:
+    with _tasks_conn() as conn:
+        row = conn.execute("SELECT * FROM panel_tasks WHERE id = ?", (task_id,)).fetchone()
+        return _deserialize_row(row) if row else None
+
+
+def get_highest_priority_pending_task() -> dict[str, Any] | None:
+    """Return the highest-priority pending task (high > medium > low, oldest first)."""
+    with _tasks_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM panel_tasks WHERE status = 'pending'"
+            " ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,"
+            " created_at ASC LIMIT 1"
+        ).fetchone()
+        return _deserialize_row(row) if row else None
+
+
 def create_task(**fields: Any) -> dict[str, Any]:
-    import time
     now = int(time.time() * 1000)
     tid = uuid.uuid4().hex
     with _tasks_conn() as conn:

--- a/core/taskboard/middleware.py
+++ b/core/taskboard/middleware.py
@@ -332,8 +332,7 @@ class TaskBoardMiddleware(AgentMiddleware):
 
         note = args.get("Note")
         if note:
-            # Fetch current description to append
-            current = task_service.update_task(task_id)  # no-op read
+            current = task_service.get_task(task_id)
             if current is None:
                 return {"error": f"Task not found: {task_id}"}
             existing = current.get("description", "")
@@ -382,15 +381,7 @@ class TaskBoardMiddleware(AgentMiddleware):
 
     async def on_idle(self) -> dict[str, Any] | None:
         """Called when agent enters IDLE state. Returns highest-priority pending task, or None."""
-        tasks = await asyncio.to_thread(task_service.list_tasks)
-        pending = [t for t in tasks if t["status"] == "pending"]
-        if not pending:
-            return None
-
-        # Sort: high > medium > low, then oldest first
-        priority_order = {"high": 0, "medium": 1, "low": 2}
-        pending.sort(key=lambda t: (priority_order.get(t.get("priority", "medium"), 9), t["created_at"]))
-        return pending[0]
+        return await asyncio.to_thread(task_service.get_highest_priority_pending_task)
 
     # ------------------------------------------------------------------
     # Handlers

--- a/frontend/app/src/pages/TasksPage.tsx
+++ b/frontend/app/src/pages/TasksPage.tsx
@@ -210,10 +210,18 @@ export default function Tasks() {
     }
   };
 
+  const THREAD_CACHE_MAX = 50;
+
   const fetchThreadDetail = useCallback(async (threadId: string) => {
     setThreadCache((prev) => {
       if (prev[threadId]?.loading || (prev[threadId] && !prev[threadId].loading && (prev[threadId].text !== null || prev[threadId].error !== null))) return prev;
-      return { ...prev, [threadId]: { text: null, loading: true, error: null } };
+      const next = { ...prev, [threadId]: { text: null, loading: true, error: null } };
+      // Evict oldest entries when over limit
+      const keys = Object.keys(next);
+      if (keys.length > THREAD_CACHE_MAX) {
+        delete next[keys[0]];
+      }
+      return next;
     });
     try {
       const res = await fetch(`/api/threads/${threadId}`);


### PR DESCRIPTION
## Summary

Post-review cleanup of the task system V1 (follows #137):

- Extract `_check_cron_expr` / `_check_json_template` helpers in `panel.py` to eliminate duplicated validators across `CreateCronJobRequest` and `UpdateCronJobRequest`
- Promote `_ALLOWED_TEMPLATE_KEYS` from function-local to module-level constant in `cron_service.py`
- Move `import time` from function scope to module top in `task_service.py` and `cron_job_service.py`
- Add `get_task(task_id)` to `task_service.py` — replaces misuse of `update_task()` as a no-op read in `middleware._handle_progress`
- Add `get_highest_priority_pending_task()` to `task_service.py` — replaces full-table load + in-memory sort in `on_idle()` with a single SQL query (`ORDER BY ... LIMIT 1`)
- Cap `threadCache` at 50 entries in `TasksPage.tsx` to prevent unbounded memory growth

## Test plan

- [x] All 71 tests pass: `uv run pytest tests/test_task_service.py tests/test_taskboard_middleware.py tests/test_cron_job_service.py tests/test_cron_service.py`
- [x] `on_idle()` returns highest-priority pending task via SQL (no full-table scan)
- [x] `_handle_progress` with a note uses `get_task()` (single read, then single write)