### PR TITLE
Fix background task indicator stale running state after cancel

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -611,6 +611,6 @@ async def cancel_task(
     elif task.task_type == "agent" and task._async_task:
         task._async_task.cancel()
 
-    await registry.update(task_id, status="error", error="Cancelled by user")
+    await registry.update(task_id, status="cancelled", error="Cancelled by user")
 
-    return {"success": True}
+    return {"success": True, "status": "cancelled"}

--- a/core/task/registry.py
+++ b/core/task/registry.py
@@ -12,7 +12,7 @@ class TaskEntry:
     task_id: str
     task_type: Literal["bash", "agent"]
     thread_id: str
-    status: Literal["running", "completed", "error"]
+    status: Literal["running", "completed", "error", "cancelled"]
 
     # Bash 专属
     command_line: str | None = None

--- a/frontend/app/src/components/chat-area/BackgroundSessionsIndicator.tsx
+++ b/frontend/app/src/components/chat-area/BackgroundSessionsIndicator.tsx
@@ -14,6 +14,7 @@ function StatusIcon({ status }: { status: string }) {
     case "completed":
       return <CheckCircle2 className="w-3 h-3 text-green-500 flex-shrink-0" />;
     case "error":
+    case "cancelled":
       return <XCircle className="w-3 h-3 text-red-500 flex-shrink-0" />;
     default:
       return <Loader2 className="w-3 h-3 text-gray-400 flex-shrink-0" />;
@@ -22,12 +23,13 @@ function StatusIcon({ status }: { status: string }) {
 
 export function BackgroundSessionsIndicator({ tasks, onCancelTask }: BackgroundSessionsIndicatorProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const runningTasks = tasks.filter((t) => t.status === "running");
 
-  if (tasks.length === 0) return null;
+  if (runningTasks.length === 0) return null;
 
-  const runningCount = tasks.filter((t) => t.status === "running").length;
-  const agents = tasks.filter((t) => t.task_type === "agent");
-  const terminals = tasks.filter((t) => t.task_type === "bash");
+  const runningCount = runningTasks.length;
+  const agents = runningTasks.filter((t) => t.task_type === "agent");
+  const terminals = runningTasks.filter((t) => t.task_type === "bash");
 
   return (
     <div

--- a/frontend/app/src/hooks/use-background-tasks.ts
+++ b/frontend/app/src/hooks/use-background-tasks.ts
@@ -5,7 +5,7 @@ import type { StreamEvent } from '../api/types';
 export interface BackgroundTask {
   task_id: string;
   task_type: 'bash' | 'agent';
-  status: 'running' | 'completed' | 'error';
+  status: 'running' | 'completed' | 'error' | 'cancelled';
   command_line?: string;
   description?: string;
   exit_code?: number;
@@ -47,15 +47,28 @@ export function useBackgroundTasks({ threadId, loading, refreshThreads }: UseBac
       if (!isBackgroundTask) return;
 
       if (event.type === 'task_start') {
-        // Optimistic update
-        setTasks(prev => [...prev, {
-          task_id: data.task_id,
-          task_type: data.task_type || 'agent',
-          status: 'running',
-          command_line: data.command_line,
-          description: data.description
-        }]);
-      } else if (event.type === 'task_done' || event.type === 'task_error') {
+        // Optimistic update, but avoid duplicate entries for the same task_id
+        setTasks(prev => {
+          if (prev.some(task => task.task_id === data.task_id)) {
+            return prev.map(task => task.task_id === data.task_id
+              ? {
+                  ...task,
+                  task_type: data.task_type || task.task_type,
+                  status: 'running',
+                  command_line: data.command_line ?? task.command_line,
+                  description: data.description ?? task.description,
+                }
+              : task);
+          }
+          return [...prev, {
+            task_id: data.task_id,
+            task_type: data.task_type || 'agent',
+            status: 'running',
+            command_line: data.command_line,
+            description: data.description
+          }];
+        });
+      } else if (event.type === 'task_done' || event.type === 'task_error' || event.type === 'cancelled') {
         // Re-fetch 获取最新状态
         fetchTasks();
       }


### PR DESCRIPTION
## Summary
- add explicit `cancelled` status for background tasks
- persist cancelled state from the cancel endpoint instead of overloading `error`
- refresh background task state on cancellation-related lifecycle updates
- dedupe optimistic task inserts in the frontend hook
- only show actively running background tasks in the indicator

## Root cause
Cancelling a background run updated backend state in a way that the indicator UI did not model cleanly:
- backend task state had no dedicated `cancelled` status
- cancel requests marked tasks as `error` with "Cancelled by user"
- the indicator rendered all fetched tasks instead of only active/running ones
- optimistic task insertion could leave duplicate/stale entries around

That combination made the UI appear out of sync: users could cancel a task successfully, but the indicator could still show it as if it were actively running.

## Validation
- verified backend Python files compile
- attempted frontend build; existing unrelated TypeScript errors remain in the repo and are not part of this change
