### PR TITLE
fix(memory): fix thread isolation in memory compaction

### DIFF
--- a/core/runtime/middleware/memory/middleware.py
+++ b/core/runtime/middleware/memory/middleware.py
@@ -80,10 +80,8 @@ class MemoryMiddleware(AgentMiddleware):
         self._model: Any = None
         self._runtime: Any = None
 
-        # Compaction cache
-        self._cached_summary: str | None = None
-        self._compact_up_to_index: int = 0
-        self._summary_restored: bool = False
+        # Compaction cache (per-thread)
+        self._thread_cache: dict[str, dict[str, Any]] = {}  # thread_id -> {summary, compact_up_to_index}
 
         if verbose:
             print("[MemoryMiddleware] Initialized")
@@ -112,12 +110,10 @@ class MemoryMiddleware(AgentMiddleware):
         messages = list(request.messages)
         original_count = len(messages)
 
-        # Restore summary from store if not already done
-        if not self._summary_restored and self.summary_store:
-            thread_id = self._extract_thread_id(request)
-            if thread_id:
-                await self._restore_summary_from_store(thread_id)
-                self._summary_restored = True
+        # Restore summary from store if not already done for this thread
+        thread_id = self._extract_thread_id(request)
+        if thread_id and self.summary_store and thread_id not in self._thread_cache:
+            await self._restore_summary_from_store(thread_id)
 
         sys_tokens = self._estimate_system_tokens(request)
 
@@ -150,16 +146,16 @@ class MemoryMiddleware(AgentMiddleware):
             )
 
         if self.compactor.should_compact(estimated, self._context_limit, self._compaction_threshold) and self._model:
-            thread_id = self._extract_thread_id(request)
             messages = await self._do_compact(messages, thread_id)
-        elif self._cached_summary and self._compact_up_to_index > 0:
-            if self._compact_up_to_index <= len(messages):
-                summary_msg = SystemMessage(content=f"[Conversation Summary]\n{self._cached_summary}")
-                messages = [summary_msg] + messages[self._compact_up_to_index :]
+        elif thread_id and thread_id in self._thread_cache:
+            cache = self._thread_cache[thread_id]
+            if cache["compact_up_to_index"] > 0 and cache["compact_up_to_index"] <= len(messages):
+                summary_msg = SystemMessage(content=f"[Conversation Summary]\n{cache['summary']}")
+                messages = [summary_msg] + messages[cache["compact_up_to_index"] :]
                 if self.verbose:
                     print(
                         f"[Memory] Using cached summary: "
-                        f"{self._compact_up_to_index} old msgs replaced, "
+                        f"{cache['compact_up_to_index']} old msgs replaced, "
                         f"{len(messages) - 1} msgs sent to LLM"
                     )
 
@@ -199,15 +195,21 @@ class MemoryMiddleware(AgentMiddleware):
                 if self.verbose:
                     print(f"[Memory] Compacted: {len(to_summarize)} msgs → summary + {len(to_keep)} recent")
 
-            self._cached_summary = summary_text
-            self._compact_up_to_index = len(messages) - len(to_keep)
+            compact_up_to_index = len(messages) - len(to_keep)
+
+            # Cache per thread
+            if thread_id:
+                self._thread_cache[thread_id] = {
+                    "summary": summary_text,
+                    "compact_up_to_index": compact_up_to_index,
+                }
 
             if self.summary_store and thread_id:
                 try:
                     summary_id = self.summary_store.save_summary(
                         thread_id=thread_id,
                         summary_text=summary_text,
-                        compact_up_to_index=self._compact_up_to_index,
+                        compact_up_to_index=compact_up_to_index,
                         compacted_at=len(messages),
                         is_split_turn=is_split_turn,
                         split_turn_prefix=prefix_summary,
@@ -223,7 +225,7 @@ class MemoryMiddleware(AgentMiddleware):
             if self._runtime:
                 self._runtime.set_flag("isCompacting", False)
 
-    async def force_compact(self, messages: list[Any]) -> dict[str, Any] | None:
+    async def force_compact(self, messages: list[Any], thread_id: str | None = None) -> dict[str, Any] | None:
         """Manual compaction trigger (/compact command). Ignores threshold."""
         if not self._model:
             return None
@@ -237,8 +239,15 @@ class MemoryMiddleware(AgentMiddleware):
             self._runtime.set_flag("isCompacting", True)
         try:
             summary_text = await self.compactor.compact(to_summarize, self._model)
-            self._cached_summary = summary_text
-            self._compact_up_to_index = len(messages) - len(to_keep)
+            compact_up_to_index = len(messages) - len(to_keep)
+
+            # Cache per thread
+            if thread_id:
+                self._thread_cache[thread_id] = {
+                    "summary": summary_text,
+                    "compact_up_to_index": compact_up_to_index,
+                }
+
             return {
                 "stats": {
                     "summarized": len(to_summarize),
@@ -306,8 +315,10 @@ class MemoryMiddleware(AgentMiddleware):
                     await self._rebuild_summary_from_checkpointer(thread_id)
                 return
 
-            self._cached_summary = summary_data.summary_text
-            self._compact_up_to_index = summary_data.compact_up_to_index
+            self._thread_cache[thread_id] = {
+                "summary": summary_data.summary_text,
+                "compact_up_to_index": summary_data.compact_up_to_index,
+            }
 
             if self.verbose:
                 print(
@@ -364,13 +375,18 @@ class MemoryMiddleware(AgentMiddleware):
                 summary_text = await self.compactor.compact(to_summarize, self._model)
                 prefix_summary = None
 
-            self._cached_summary = summary_text
-            self._compact_up_to_index = len(messages) - len(to_keep)
+            compact_up_to_index = len(messages) - len(to_keep)
+
+            # Cache per thread
+            self._thread_cache[thread_id] = {
+                "summary": summary_text,
+                "compact_up_to_index": compact_up_to_index,
+            }
 
             summary_id = self.summary_store.save_summary(
                 thread_id=thread_id,
                 summary_text=summary_text,
-                compact_up_to_index=self._compact_up_to_index,
+                compact_up_to_index=compact_up_to_index,
                 compacted_at=len(messages),
                 is_split_turn=is_split_turn,
                 split_turn_prefix=prefix_summary,

--- a/tests/middleware/memory/test_memory_middleware_integration.py
+++ b/tests/middleware/memory/test_memory_middleware_integration.py
@@ -156,9 +156,10 @@ class TestSummaryRestoreOnStartup:
         await middleware1.awrap_model_call(mock_request, mock_handler)
 
         # Verify summary was saved
-        assert middleware1._cached_summary is not None
-        original_summary = middleware1._cached_summary
-        original_index = middleware1._compact_up_to_index
+        thread_id = "test-thread-1"
+        assert thread_id in middleware1._thread_cache
+        original_summary = middleware1._thread_cache[thread_id]["summary"]
+        original_index = middleware1._thread_cache[thread_id]["compact_up_to_index"]
 
         # Step 2: Create new middleware instance (simulating restart)
         middleware2 = MemoryMiddleware(
@@ -177,9 +178,9 @@ class TestSummaryRestoreOnStartup:
         await middleware2.awrap_model_call(mock_request, mock_handler)
 
         # Verify summary was restored
-        assert middleware2._cached_summary == original_summary
-        assert middleware2._compact_up_to_index == original_index
-        assert middleware2._summary_restored is True
+        assert thread_id in middleware2._thread_cache
+        assert middleware2._thread_cache[thread_id]["summary"] == original_summary
+        assert middleware2._thread_cache[thread_id]["compact_up_to_index"] == original_index
 
 
 class TestSplitTurnSaveAndRestore:
@@ -323,10 +324,6 @@ class TestMultipleThreadsIsolated:
 
         # Execute for both threads
         await middleware.awrap_model_call(request1, mock_handler)
-
-        # Reset restoration flag for second thread
-        middleware._summary_restored = False
-
         await middleware.awrap_model_call(request2, mock_handler)
 
         # Verify both threads have separate summaries
@@ -381,8 +378,7 @@ class TestMissingThreadIdRaisesError:
         # Verify execution succeeded
         assert result is not None
         # Verify summary was not restored (since thread_id was missing)
-        assert middleware._cached_summary is None
-        assert middleware._summary_restored is False
+        assert len(middleware._thread_cache) == 0
 
 
 class TestCheckpointerUnavailableGracefulDegradation:
@@ -423,8 +419,9 @@ class TestCheckpointerUnavailableGracefulDegradation:
 
         # Verify middleware continues to work (no crash)
         # Fresh compaction should have created a new summary
-        assert middleware._cached_summary is not None
-        assert "This is a test summary of the conversation." in middleware._cached_summary
+        thread_id = "test-thread-1"
+        assert thread_id in middleware._thread_cache
+        assert "This is a test summary of the conversation." in middleware._thread_cache[thread_id]["summary"]
 
 
 class TestSummaryUpdateOnSecondCompaction:


### PR DESCRIPTION
## Problem

The memory middleware had a critical thread isolation bug. A global `_summary_restored` flag prevented multiple threads from restoring their summaries from storage.

**Root cause:**
```python
# OLD CODE (BUGGY)
self._summary_restored: bool = False  # Global flag

if not self._summary_restored and self.summary_store:
    await self._restore_summary_from_store(thread_id)
    self._summary_restored = True  # Blocks all future threads!
```

Once set to `True` after the first thread, subsequent threads would skip restoration entirely.

## Discovery

Found by analyzing the test suite - line 328 had a manual workaround:
```python
middleware._summary_restored = False  # Manual reset between threads
```

This workaround was **hiding the bug** by manually resetting the flag. Without it, thread isolation was completely broken.

## Solution

Replace global cache with per-thread dictionary:
```python
# NEW CODE (FIXED)
self._thread_cache: dict[str, dict[str, Any]] = {}

if thread_id and thread_id not in self._thread_cache:
    await self._restore_summary_from_store(thread_id)
```

Each thread now maintains independent cache: `_thread_cache[thread_id] = {summary, compact_up_to_index}`

## Testing

✅ All 25 memory middleware tests pass
✅ Removed manual flag reset workaround from tests
✅ Verified thread isolation with multi-thread test showing independent cache entries

**Before:** Thread-2 skips restoration (flag already True)
**After:** Each thread restores independently

## Changes

- `core/runtime/middleware/memory/middleware.py` - Per-thread cache implementation
- `tests/middleware/memory/test_memory_middleware_integration.py` - Updated assertions, removed workaround