### PR TITLE
docs: add multi-agent communication to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-Mycel is an enterprise-grade agent runtime that treats AI agents as long-running co-workers. Built on a middleware-first architecture, it provides the infrastructure layer missing from existing agent frameworks: sandbox isolation, configuration-driven governance, and multi-agent coordination.
+Mycel is an enterprise-grade agent runtime that treats AI agents as long-running co-workers. Built on a middleware-first architecture, it provides the infrastructure layer missing from existing agent frameworks: sandbox isolation, multi-agent communication, and production governance.
 
 ## Why Mycel?
 
@@ -24,7 +24,7 @@ Existing agent frameworks focus on *building* agents. Mycel focuses on *running*
 
 - **Middleware Pipeline**: Unified tool injection, validation, security, and observability
 - **Sandbox Isolation**: Run agents in Docker/E2B/cloud with automatic state management
-- **Configuration-Driven**: Control all capabilities via JSON—no code changes needed
+- **Multi-Agent Communication**: Agents discover, message, and collaborate with each other — and with humans
 - **Production Governance**: Built-in security controls, audit logging, and cost tracking
 
 ## Quick Start
@@ -171,6 +171,23 @@ leonai web
 - Token usage and cost tracking
 - Thread history and search
 
+### Multi-Agent Communication
+
+Agents are first-class social entities. They can discover each other, send messages, and collaborate autonomously:
+
+```
+Member (template)
+  └→ Entity (social identity — agents and humans both get one)
+       └→ Thread (agent brain / conversation)
+```
+
+- **`chat_send`**: Agent A messages Agent B; B responds autonomously
+- **`directory`**: Agents browse and discover other entities
+- **`tell_owner`**: Agents escalate to their human owner
+- **Real-time delivery**: SSE-based chat with typing indicators and read receipts
+
+Humans also have entities — agents can initiate conversations with humans, not just the other way around.
+
 ### File Upload & Workspace Sync
 
 Upload files to agent workspace and sync changes ([PR #130](https://github.com/OpenDCAI/leonai/pull/130)):
@@ -242,6 +259,8 @@ leonai sandbox pause <id>
 
 **Sandbox Lifecycle**: `idle → active → paused → destroyed`
 
+**Entity Model**: Member (template) → Entity (social identity) → Thread (agent brain)
+
 **Relationships**: Member (1:N) → Thread (N:1) → Sandbox
 
 ## Roadmap
@@ -251,10 +270,11 @@ leonai sandbox pause <id>
 - Multi-provider sandboxes
 - Web UI with dashboard
 - File upload/download ([PR #130](https://github.com/OpenDCAI/leonai/pull/130))
+- Multi-agent communication (Entity-Chat)
 
 **In Progress** 🚧
 - Hook system, Plugin ecosystem
-- Agent evaluation, Multi-agent coordination
+- Agent evaluation
 
 ## Contributing
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -16,7 +16,7 @@
 
 ---
 
-Mycel 是企业级 Agent 运行时，将 AI Agent 视为长期运行的协作伙伴。基于中间件优先架构，提供现有 Agent 框架缺失的基础设施层：沙箱隔离、配置驱动治理和多 Agent 协调。
+Mycel 是企业级 Agent 运行时，将 AI Agent 视为长期运行的协作伙伴。基于中间件优先架构，提供现有 Agent 框架缺失的基础设施层：沙箱隔离、多 Agent 通讯和生产治理。
 
 ## 为什么选择 Mycel？
 
@@ -24,7 +24,7 @@ Mycel 是企业级 Agent 运行时，将 AI Agent 视为长期运行的协作伙
 
 - **中间件管线**：统一的工具注入、校验、安全和可观测性
 - **沙箱隔离**：在 Docker/E2B/云端运行 Agent，自动状态管理
-- **配置驱动**：通过 JSON 控制所有能力，无需修改代码
+- **多 Agent 通讯**：Agent 之间互相发现、发送消息、自主协作——人类也参与其中
 - **生产治理**：内置安全控制、审计日志和成本追踪
 
 ## 快速开始
@@ -171,6 +171,23 @@ leonai web
 - Token 使用和成本追踪
 - 对话历史和搜索
 
+### 多 Agent 通讯
+
+Agent 是一等公民的社交实体，可以互相发现、发送消息、自主协作：
+
+```
+Member（模板）
+  └→ Entity（社交身份——Agent 和人类都有）
+       └→ Thread（Agent 大脑 / 对话）
+```
+
+- **`chat_send`**：Agent A 给 Agent B 发消息，B 自主回复
+- **`directory`**：Agent 浏览和发现其他实体
+- **`tell_owner`**：Agent 向人类 Owner 上报
+- **实时投递**：基于 SSE 的聊天，支持输入提示和已读回执
+
+人类也有 Entity——Agent 可以主动找人类对话，而不只是被动响应。
+
 ### 文件上传与工作区同步
 
 上传文件到 Agent 工作区并同步更改（[PR #130](https://github.com/OpenDCAI/leonai/pull/130)）：
@@ -242,6 +259,8 @@ leonai sandbox pause <id>
 
 **沙箱生命周期**：`闲置 → 激活 → 暂停 → 销毁`
 
+**实体模型**：Member（模板）→ Entity（社交身份）→ Thread（Agent 大脑）
+
 **关系**：Member (1:N) → Thread (N:1) → Sandbox
 
 ## 路线图
@@ -251,10 +270,11 @@ leonai sandbox pause <id>
 - 多提供商沙箱
 - Web 界面与仪表板
 - 文件上传/下载（[PR #130](https://github.com/OpenDCAI/leonai/pull/130)）
+- 多 Agent 通讯（Entity-Chat）
 
 **进行中** 🚧
 - Hook 系统、插件生态
-- Agent 评估、多 Agent 协调
+- Agent 评估
 
 ## 贡献
 


### PR DESCRIPTION
## Summary

- Replace "Configuration-Driven" selling point with "Multi-Agent Communication" — agents discover, message, and collaborate with each other and humans
- Add Entity-Chat feature section with Member → Entity → Thread model
- Update Architecture and Roadmap sections
- All changes mirrored in Chinese README

## Test plan

- [ ] Verify Entity-Chat section renders correctly
- [ ] Confirm roadmap reflects completed multi-agent coordination