### PR TITLE
fix(chat): find_chat_between must only return 1:1 chats

### DIFF
--- a/storage/providers/sqlite/chat_repo.py
+++ b/storage/providers/sqlite/chat_repo.py
@@ -142,13 +142,16 @@ class SQLiteChatEntityRepo:
                 self._conn.commit()
         _retry_on_locked(_do)
 
-    # @@@find-chat-between - core uniqueness query: two entities share at most one chat
+    # @@@find-chat-between — find the 1:1 chat (exactly 2 members) between two entities.
+    # Must NOT return group chats that happen to contain both entities.
     def find_chat_between(self, entity_a: str, entity_b: str) -> str | None:
         with self._lock:
             row = self._conn.execute(
                 "SELECT ce1.chat_id FROM chat_entities ce1"
                 " JOIN chat_entities ce2 ON ce1.chat_id = ce2.chat_id"
-                " WHERE ce1.entity_id = ? AND ce2.entity_id = ?",
+                " WHERE ce1.entity_id = ? AND ce2.entity_id = ?"
+                " AND (SELECT COUNT(*) FROM chat_entities ce3"
+                "      WHERE ce3.chat_id = ce1.chat_id) = 2",
                 (entity_a, entity_b),
             ).fetchone()
             return row[0] if row else None


### PR DESCRIPTION
## Problem

`chat_send(entity_id=...)` is supposed to send a private 1:1 message, but `find_chat_between` returned **any chat containing both entities** — including group chats. When Julia tried to privately deal cards to Alice, the message went straight into the group chat because both were members of it.

## Root cause

```sql
-- OLD: matches group chats too
SELECT ce1.chat_id FROM chat_entities ce1
JOIN chat_entities ce2 ON ce1.chat_id = ce2.chat_id
WHERE ce1.entity_id = ? AND ce2.entity_id = ?
```

## Fix

```sql
-- NEW: only 1:1 chats (exactly 2 members)
... AND (SELECT COUNT(*) FROM chat_entities ce3
         WHERE ce3.chat_id = ce1.chat_id) = 2
```

If no 1:1 chat exists, `find_or_create_chat` creates a new one — same as WeChat/Telegram DM behavior.

## Reproduction

In the group chat `d0036d9d`, Julia was asked to privately deal cards:
1. Julia correctly used `chat_send(entity_id=alice_id)` 
2. `find_chat_between(julia, alice)` returned the **group chat ID** (both are members)
3. Cards appeared in the group chat instead of a private 1:1 chat

## Test plan

- [ ] `chat_send(entity_id=X)` in a group creates/uses a separate 1:1 chat
- [ ] Group chat messages are unaffected
- [ ] Existing 1:1 chats still found correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)