### PR TITLE
fix: restrict uvicorn reload_dirs to prevent 50-80% CPU usage

### DIFF
--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -58,4 +58,12 @@ if __name__ == "__main__":
     # @@@port-precedence - git worktree config > LEON_BACKEND_PORT > PORT > 8001
     port = _resolve_port()
     # @@@module-launch-target - Package-qualified target keeps module launch (`python -m backend.web.main`) import-safe.
-    uvicorn.run("backend.web.main:app", host="0.0.0.0", port=port, reload=True)
+    # @@@reload-dirs - restrict file watching to backend + core + config + storage only.
+    # Without this, StatReload scans .venv/, node_modules/, .git/ etc. and burns 50-80% CPU.
+    uvicorn.run(
+        "backend.web.main:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+        reload_dirs=["backend", "core", "config", "storage", "sandbox"],
+    )


### PR DESCRIPTION
## Problem

`uvicorn.run(reload=True)` without `reload_dirs` scans the entire project directory for file changes, including `.venv/` (thousands of files), `node_modules/` (tens of thousands), and `.git/`. This causes the backend process to consume **50-80% CPU** continuously.

## Fix

Add `reload_dirs` to limit file watching to only the Python source directories:

```python
reload_dirs=["backend", "core", "config", "storage", "sandbox"]
```

## Result

CPU usage drops from **76.6% → ~1%** idle.

## Test plan

- [x] Verified: `Will watch for changes in` log shows only 5 directories
- [x] Verified: CPU dropped from 76.6% to 7.6% immediately after restart (settles to ~1%)
- [ ] Verify hot reload still works when editing backend Python files