### PR TITLE
docs: add Contact Us section with WeChat group

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ Agents can be extended with external tools and specialized expertise:
 - [Deployment](docs/en/deployment.md) — Production deployment guide
 - [Concepts](docs/en/product-primitives.md) — Core abstractions (Thread, Member, Task, Resource)
 
+## Contact Us
+
+- [WeChat Group (微信交流群)](https://github.com/OpenDCAI/Mycel/issues/165)
+- [GitHub Issues](https://github.com/OpenDCAI/Mycel/issues)
+
 ## Contributing
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -177,6 +177,11 @@ Agent 可通过外部工具和专业技能进行扩展：
 - [部署](docs/zh/deployment.md) — 生产部署指南
 - [核心概念](docs/zh/product-primitives.md) — 核心抽象（Thread、Member、Task、Resource）
 
+## 联系我们
+
+- [微信交流群](https://github.com/OpenDCAI/Mycel/issues/165)
+- [GitHub Issues](https://github.com/OpenDCAI/Mycel/issues)
+
 ## 贡献
 
 ```bash


### PR DESCRIPTION
Closes #165

Add "Contact Us" / "联系我们" section to both README.md and README.zh.md, linking to:
- WeChat group (#165)
- GitHub Issues