### PR TITLE
fix: workspace popup stale state + API key not propagating to agents

### DIFF
--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -527,8 +527,8 @@ class ProviderRequest(BaseModel):
 
 
 @router.post("/providers")
-async def update_provider(request: ProviderRequest) -> dict[str, Any]:
-    """Update provider config → models.json providers."""
+async def update_provider(request: ProviderRequest, req: Request) -> dict[str, Any]:
+    """Update provider config → models.json providers, then reload all agents."""
     data = load_models()
     providers = data.setdefault("providers", {})
     provider_data: dict[str, Any] = {}
@@ -538,7 +538,18 @@ async def update_provider(request: ProviderRequest) -> dict[str, Any]:
         provider_data["base_url"] = request.base_url
     providers[request.provider] = provider_data
     save_models(data)
-    return {"success": True, "provider": request.provider}
+
+    # @@@reload-agents-on-key-change — hot-reload all cached agents so they pick up new API keys
+    pool = getattr(req.app.state, "agent_pool", {})
+    reloaded = 0
+    for agent in pool.values():
+        try:
+            agent.update_config()
+            reloaded += 1
+        except Exception:
+            pass
+
+    return {"success": True, "provider": request.provider, "agents_reloaded": reloaded}
 
 
 # ============================================================================

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -640,13 +640,24 @@ class LeonAgent:
             loader = AgentLoader(workspace_root=self.workspace_root)
             self.config = loader.load(cli_overrides=cli_overrides)
 
-        if model is None:
-            return
-
-        # Reload models config with new model
-        models_cli = {"active": {"model": model}}
+        # Reload models config (picks up new API keys + model changes from disk)
+        models_cli = {"active": {"model": model}} if model else None
         models_loader = ModelsLoader(workspace_root=self.workspace_root)
         self.models_config = models_loader.load(cli_overrides=models_cli)
+
+        if model is None:
+            # @@@api-key-reload — no model change, just refresh credentials from disk
+            provider_name = self._resolve_provider_name(self.model_name, self._model_overrides)
+            p = self.models_config.get_provider(provider_name) if provider_name else None
+            self.api_key = (p.api_key if p else None) or self.models_config.get_api_key()
+            base_url = (p.base_url if p else None) or self.models_config.get_base_url()
+            if base_url:
+                base_url = self._normalize_base_url(base_url, provider_name)
+            self._current_model_config.update({
+                "api_key": self.api_key,
+                "base_url": base_url,
+            })
+            return
 
         # Resolve virtual model
         active_model = self.models_config.active.model if self.models_config.active else model

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -21,7 +21,7 @@ export default function NewChatPage() {
   const { memberId: memberUrlId } = useParams<{ memberId: string }>();
   const { tm } = useOutletContext<OutletContext>();
   const { sandboxTypes, selectedSandbox, handleCreateThread } = tm;
-  const { settings, loading, hasWorkspace } = useWorkspaceSettings();
+  const { settings, loading, hasWorkspace, refreshSettings } = useWorkspaceSettings();
   const [showWorkspaceSetup, setShowWorkspaceSetup] = useState(false);
 
   const authAgent = useAuthStore(s => s.agent);
@@ -59,7 +59,8 @@ export default function NewChatPage() {
     });
   }
 
-  function handleWorkspaceSet(_workspace: string) {
+  async function handleWorkspaceSet(_workspace: string) {
+    await refreshSettings();
     setShowWorkspaceSetup(false);
   }
 


### PR DESCRIPTION
## Bug 1: Workspace popup blocks first message

**Symptom**: Click send → workspace selection popup appears → save → nothing happens → need frontend restart

**Root cause**: `handleWorkspaceSet()` in NewChatPage.tsx closed the modal but never called `refreshSettings()`. Workspace was saved to backend but frontend state remained stale (null).

**Fix**: Call `refreshSettings()` before closing the modal.

## Bug 2: API key 401 after setting in Web UI

**Symptom**: Set API key in Settings → send message → `Error: 401 invalid x-api-key`

**Root cause**: Two breaks in the chain:
1. `settings.py` `update_provider()` saved to `models.json` but never told running agents to reload
2. `agent.update_config()` returned early when `model=None`, so even if called, it wouldn't reload API keys

**Fix**:
1. `update_provider()` now iterates `agent_pool` and calls `agent.update_config()` on each cached agent
2. `update_config()` now reloads `models.json` from disk and refreshes credentials even when `model` is None

## Files changed

| File | Change |
|------|--------|
| `frontend/app/src/pages/NewChatPage.tsx` | Call `refreshSettings()` in workspace callback |
| `backend/web/routers/settings.py` | Reload all agents after provider update |
| `core/runtime/agent.py` | Support API-key-only reload path in `update_config()` |

## Test plan

- [ ] Set API key in Settings → send message → no 401
- [ ] Change API key → existing thread continues working (hot reload)
- [ ] First message with local sandbox → workspace popup → save → sends without restart