### PR TITLE
bug fix: use member IDs in threads tabs

### DIFF
--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -34,7 +34,7 @@ export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps
 
   const handleSelect = (member: typeof memberList[0]) => {
     onOpenChange(false);
-    navigate(`/threads/${member.name}`);
+    navigate(`/threads/${member.id}`);
   };
 
   return (

--- a/frontend/app/src/components/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar.tsx
@@ -4,8 +4,15 @@ import { Link, useParams } from "react-router-dom";
 import type { ThreadSummary } from "../api";
 import MemberAvatar from "./MemberAvatar";
 import { useAppStore } from "../store/app-store";
-import { useAuthStore } from "../store/auth-store";
 import { Skeleton } from "./ui/skeleton";
+
+function requireThreadMemberId(thread: ThreadSummary): string {
+  // @@@thread-member-id-required - thread grouping/routing must use stable member IDs, never display names.
+  if (!thread.member_id) {
+    throw new Error(`Thread ${thread.thread_id} missing member_id`);
+  }
+  return thread.member_id;
+}
 
 function formatRelativeTime(dateStr?: string): string {
   if (!dateStr) return "";
@@ -165,7 +172,6 @@ export default function Sidebar({
 }: SidebarProps) {
   const { threadId } = useParams<{ threadId?: string }>();
   const activeThreadId = threadId || null;
-  const authAgent = useAuthStore(s => s.agent);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [expandedMembers, setExpandedMembers] = useState<Set<string>>(() => {
     try {
@@ -214,9 +220,10 @@ export default function Sidebar({
     const map = new Map<string, { memberName: string; avatarUrl?: string; threads: ThreadSummary[]; latestAt: number }>();
 
     for (const thread of threads) {
-      const key = thread.member_name || "Agent";
-      if (!map.has(key)) map.set(key, { memberName: key, avatarUrl: thread.avatar_url, threads: [], latestAt: 0 });
+      const key = requireThreadMemberId(thread);
+      if (!map.has(key)) map.set(key, { memberName: thread.member_name || "Agent", avatarUrl: thread.avatar_url, threads: [], latestAt: 0 });
       const g = map.get(key)!;
+      if (!g.memberName && thread.member_name) g.memberName = thread.member_name;
       if (!g.avatarUrl && thread.avatar_url) g.avatarUrl = thread.avatar_url;
       const at = thread.updated_at ? new Date(thread.updated_at).getTime() : 0;
       g.threads.push(thread);
@@ -225,8 +232,8 @@ export default function Sidebar({
 
     // Add members that have no threads yet (e.g. newly created copies)
     for (const member of memberList) {
-      if (!map.has(member.name)) {
-        map.set(member.name, { memberName: member.name, avatarUrl: member.avatar_url, threads: [], latestAt: 0 });
+      if (!map.has(member.id)) {
+        map.set(member.id, { memberName: member.name, avatarUrl: member.avatar_url, threads: [], latestAt: 0 });
       }
     }
 
@@ -241,7 +248,7 @@ export default function Sidebar({
           return tb - ta;
         }),
       }));
-  }, [threads, authAgent, memberList]);
+  }, [threads, memberList]);
 
   // Auto-expand the most recently active member on first load (only if nothing saved)
   useEffect(() => {

--- a/frontend/app/src/pages/AppLayout.tsx
+++ b/frontend/app/src/pages/AppLayout.tsx
@@ -13,6 +13,14 @@ import { useAppStore } from "../store/app-store";
 import MemberAvatar from "../components/MemberAvatar";
 import { Plus, Trash2 } from "lucide-react";
 
+function requireThreadMemberId(thread: { thread_id: string; member_id?: string }): string {
+  // @@@thread-member-id-required - mobile thread navigation must use stable member IDs, not mutable display names.
+  if (!thread.member_id) {
+    throw new Error(`Thread ${thread.thread_id} missing member_id`);
+  }
+  return thread.member_id;
+}
+
 export default function AppLayout() {
   const tm = useThreadManager();
   const {
@@ -109,7 +117,6 @@ function MobileThreadList({ threads, loading, onNewChat, onDeleteThread, newChat
   newChatOpen: boolean;
   setNewChatOpen: (v: boolean) => void;
 }) {
-  const memberList = useAppStore(s => s.memberList);
   return (
     <div className="h-full w-full bg-background flex flex-col overflow-hidden">
       <div className="h-14 flex items-center justify-between px-4 border-b border-border shrink-0">
@@ -128,11 +135,12 @@ function MobileThreadList({ threads, loading, onNewChat, onDeleteThread, newChat
           </div>
         ) : (
           threads.map(t => {
+            const memberId = requireThreadMemberId(t);
             const memberName = t.member_name || "Agent";
             const preview = t.preview || "新会话";
             return (
               <div key={t.thread_id} className="flex items-center border-b border-border">
-                <Link to={`/threads/${encodeURIComponent(memberName)}/${t.thread_id}`} className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 hover:bg-muted/50 transition-colors">
+                <Link to={`/threads/${encodeURIComponent(memberId)}/${t.thread_id}`} className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 hover:bg-muted/50 transition-colors">
                   <MemberAvatar name={memberName} avatarUrl={t.avatar_url} type="mycel_agent" size="md" />
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-medium text-foreground truncate">{memberName}</p>

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -18,7 +18,7 @@ interface OutletContext {
 
 export default function NewChatPage() {
   const navigate = useNavigate();
-  const { memberId: memberUrlId } = useParams<{ memberId: string }>();
+  const { memberId } = useParams<{ memberId: string }>();
   const { tm } = useOutletContext<OutletContext>();
   const { sandboxTypes, selectedSandbox, handleCreateThread } = tm;
   const { settings, loading, hasWorkspace, refreshSettings } = useWorkspaceSettings();
@@ -27,16 +27,15 @@ export default function NewChatPage() {
   const authAgent = useAuthStore(s => s.agent);
   const memberList = useAppStore(s => s.memberList);
 
-  // Resolve URL member name → member ID
-  const decodedName = memberUrlId ? decodeURIComponent(memberUrlId) : undefined;
-  const isOwnedAgent = !decodedName || decodedName === authAgent?.name;
-  const memberName = isOwnedAgent ? (authAgent?.name || "Agent") : decodedName;
-
-  // Get the actual member ID for thread creation
-  const resolvedMember = isOwnedAgent
-    ? memberList.find(m => m.id === authAgent?.id)
-    : memberList.find(m => m.name === decodedName);
-  const resolvedMemberId = isOwnedAgent ? authAgent?.id : resolvedMember?.id;
+  const decodedMemberId = memberId ? decodeURIComponent(memberId) : undefined;
+  const isOwnedAgent = decodedMemberId === authAgent?.id;
+  const resolvedMember = decodedMemberId
+    ? memberList.find(m => m.id === decodedMemberId)
+    : authAgent?.id
+      ? memberList.find(m => m.id === authAgent.id)
+      : undefined;
+  const resolvedMemberId = resolvedMember?.id ?? decodedMemberId ?? authAgent?.id;
+  const memberName = resolvedMember?.name ?? (isOwnedAgent ? (authAgent?.name || "Agent") : "Agent");
   const memberAvatarUrl = resolvedMember?.avatar_url;
 
   async function handleSend(message: string, sandbox: string, model: string, workspace?: string) {
@@ -54,7 +53,7 @@ export default function NewChatPage() {
     postRun(threadId, message, undefined, model ? { model } : undefined).catch(err => {
       console.error('[NewChatPage] postRun failed:', err);
     });
-    navigate(`/threads/${memberUrlId}/${threadId}`, {
+    navigate(`/threads/${encodeURIComponent(resolvedMemberId)}/${threadId}`, {
       state: { selectedModel: model, runStarted: true, message },
     });
   }

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -16,14 +16,13 @@ import LibraryPage from './pages/LibraryPage';
 import ResourcesPage from './pages/ResourcesPage';
 import ConnectionsPage from './pages/ConnectionsPage';
 
-/** Redirect /threads → /threads/{owned agent name} dynamically. */
+/** Redirect /threads → /threads/{owned agent member ID} dynamically. */
 function ThreadsIndexRedirect() {
   const agent = useAuthStore(s => s.agent);
   const navigate = useNavigate();
   useEffect(() => {
-    if (!agent?.name) return; // wait for auth to load
-    const name = agent.name;
-    navigate(`/threads/${encodeURIComponent(name)}`, { replace: true });
+    if (!agent?.id) return; // wait for auth to load
+    navigate(`/threads/${encodeURIComponent(agent.id)}`, { replace: true });
   }, [agent, navigate]);
   return null;
 }


### PR DESCRIPTION
## Summary
- switch threads routes and new-chat entrypoints from member names to stable `member_id` values
- group and persist thread sidebar state by `member_id` so duplicate names no longer collapse into one bucket
- keep member names as display-only labels while preserving ID-based navigation on desktop and mobile

## Test Plan
- launched backend locally on `:8009` and frontend locally on `:5181`
- registered a fresh user, created two different members with the same display name, created one thread from each by `member_id`, and verified `/api/threads` returned distinct `member_id` rows
- renamed one duplicate member and verified `/api/threads` updated only `member_name` while preserving the same `member_id`
- used local Playwright against the running frontend and verified the sidebar showed separate member groups and ID-based links such as `/threads/m_OHHwQvKOnkKS/m_OHHwQvKOnkKS-1`
- `npm run build` still fails due pre-existing unrelated TypeScript errors in files such as `src/api/streaming.ts`, `src/components/Header.tsx`, and `src/hooks/use-thread-data.ts`
