### PR TITLE
fix: auto redirect to login when JWT user no longer exists

### DIFF
--- a/backend/web/core/dependencies.py
+++ b/backend/web/core/dependencies.py
@@ -35,8 +35,12 @@ def _extract_jwt_payload(request: Request) -> dict:
 
 
 async def get_current_user_id(request: Request) -> str:
-    """Extract user_id from JWT. Used for auth/ownership scoping."""
-    return _extract_jwt_payload(request)["user_id"]
+    """Extract user_id from JWT and verify user exists. Returns 401 if user was deleted (e.g. DB reset)."""
+    user_id = _extract_jwt_payload(request)["user_id"]
+    member_repo = getattr(request.app.state, "member_repo", None)
+    if member_repo and member_repo.get_by_id(user_id) is None:
+        raise HTTPException(401, "User no longer exists — please re-login")
+    return user_id
 
 
 async def get_current_entity_id(request: Request) -> str:


### PR DESCRIPTION
## Summary
- When DB is reset but browser keeps old JWT, requests now return 401 (not 403), triggering automatic re-login
- `get_current_user_id()` verifies user existence after JWT extraction — stale tokens get rejected early
- Frontend `authFetch` already handles 401 → `logout()` → LoginForm shown

## Problem
After DB reset, old localStorage JWT is technically valid (not expired, correct signature) but the `user_id` inside doesn't exist anymore. This cascaded to 403 "Not authorized" on downstream endpoints, showing a confusing "无法检查 Toad 的主对话" error with no way to recover except manually clearing localStorage.

## Test plan
- [ ] Reset DB (`rm ~/.leon/leon.db`), keep browser open with old session
- [ ] Refresh page → should auto-redirect to login form (not show 403 error)
- [ ] Login with new credentials → works normally
- [ ] Normal 403 cases (operating on another user's thread) still return 403, not 401