### PR TITLE
fix: simplify review — bug fixes + cleanup

### DIFF
--- a/backend/web/core/config.py
+++ b/backend/web/core/config.py
@@ -7,9 +7,7 @@ from pathlib import Path
 DB_PATH = Path.home() / ".leon" / "leon.db"
 SANDBOXES_DIR = Path.home() / ".leon" / "sandboxes"
 FILE_CHANNEL_ROOT = Path(
-    os.environ.get("LEON_FILE_CHANNEL_ROOT",
-                   os.environ.get("LEON_SANDBOX_VOLUME_ROOT",  # backwards compat
-                                  str(Path.home() / ".leon" / "volumes")))
+    os.environ.get("LEON_FILE_CHANNEL_ROOT", str(Path.home() / ".leon" / "volumes"))
 ).expanduser().resolve()
 
 # Workspace

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -72,7 +72,6 @@ async def _prepare_attachment_message(
     # For local provider: actual host path (agent reads host FS directly)
     # For remote providers: container-side path
     if mgr and mgr.file_channel.capability.runtime_kind == "local":
-        from backend.web.services.file_channel_service import get_file_channel_source
         try:
             source = get_file_channel_source(thread_id)
             files_dir = str(source.host_path)
@@ -207,7 +206,10 @@ def _create_thread_sandbox_resources(thread_id: str, sandbox_type: str) -> None:
     source = HostVolume(channel_path)
 
     channel_repo = _get_container().file_channel_repo()
-    channel_repo.create(channel_id, json.dumps(source.serialize()), f"file-channel-{thread_id}", now_str)
+    try:
+        channel_repo.create(channel_id, json.dumps(source.serialize()), f"file-channel-{thread_id}", now_str)
+    finally:
+        channel_repo.close()
 
     lease_store = LeaseStore(db_path=DEFAULT_DB_PATH)
     lease_id = f"lease-{uuid.uuid4().hex[:12]}"
@@ -221,14 +223,9 @@ def _create_thread_sandbox_resources(thread_id: str, sandbox_type: str) -> None:
         initial_cwd = str(LOCAL_WORKSPACE_ROOT)
     else:
         from backend.web.services.sandbox_service import build_provider_from_config_name
+        from sandbox.manager import resolve_provider_cwd
         provider = build_provider_from_config_name(sandbox_type)
-        initial_cwd = "/home/user"
-        if provider:
-            for attr in ("default_cwd", "default_context_path", "mount_path"):
-                val = getattr(provider, attr, None)
-                if isinstance(val, str) and val:
-                    initial_cwd = val
-                    break
+        initial_cwd = resolve_provider_cwd(provider) if provider else "/home/user"
     terminal_store.create(
         terminal_id=terminal_id,
         thread_id=thread_id,

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -7,7 +7,6 @@ User uploads → VolumeSource (host disk) → sync/mount into sandbox → agent 
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -1027,6 +1027,7 @@ class LeaseStore:
             last_error=None,
             needs_refresh=False,
             refresh_hint_at=None,
+            file_channel_id=file_channel_id,
         )
 
     def find_by_instance(self, *, provider_name: str, instance_id: str) -> SandboxLease | None:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -23,6 +23,15 @@ from sandbox.provider import SandboxProvider
 from sandbox.terminal import TerminalState, TerminalStore
 
 
+def resolve_provider_cwd(provider) -> str:
+    """Get the default working directory for a provider."""
+    for attr in ("default_cwd", "default_context_path", "mount_path"):
+        val = getattr(provider, attr, None)
+        if isinstance(val, str) and val:
+            return val
+    return "/home/user"
+
+
 def lookup_sandbox_for_thread(thread_id: str, db_path: Path | None = None) -> str | None:
     target_db = db_path or DEFAULT_DB_PATH
     if not target_db.exists():
@@ -73,12 +82,7 @@ class SandboxManager:
         )
 
     def _default_terminal_cwd(self) -> str:
-        for attr in ("default_cwd", "default_context_path", "mount_path"):
-            if hasattr(self.provider, attr):
-                value = getattr(self.provider, attr)
-                if isinstance(value, str) and value:
-                    return value
-        return "/home/user"
+        return resolve_provider_cwd(self.provider)
 
     def _fire_session_ready(self, session_id: str, reason: str) -> None:
         if self._on_session_ready:

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -114,7 +114,7 @@ class DaytonaProvider(SandboxProvider):
             MountSpec.model_validate(m) if isinstance(m, dict) else m for m in mounts
         ]
 
-    # ==================== Member Volume ====================
+    # ==================== Managed Volume ====================
 
     def create_managed_volume(self, member_id: str, mount_path: str) -> str:
         """Create a Daytona managed volume. Returns volume name as backend_ref."""

--- a/sandbox/sync/strategy.py
+++ b/sandbox/sync/strategy.py
@@ -19,19 +19,23 @@ def _native_upload(session_id: str, provider, workspace: Path, workspace_root: s
     """
     t0 = time.time()
     total_bytes = 0
-    # @@@mkdir-once - ensure remote dir exists before uploading
-    provider.execute(session_id, f"mkdir -p {workspace_root}", timeout_ms=10000)
+    # @@@mkdir-batch - collect all needed dirs, create in one command
+    dirs_needed = {workspace_root}
+    upload_items: list[tuple[str, bytes]] = []
     for rel_path in files:
         local = workspace / rel_path
         if not local.exists() or not local.is_file():
             logger.warning("[SYNC] native_upload: skipping missing file %s", local)
             continue
-        data = local.read_bytes()
         remote = f"{workspace_root}/{rel_path}"
-        # Ensure parent directory exists for nested paths
         parent = str(Path(remote).parent)
         if parent != workspace_root:
-            provider.execute(session_id, f"mkdir -p {parent}", timeout_ms=10000)
+            dirs_needed.add(parent)
+        upload_items.append((remote, local.read_bytes()))
+    if not upload_items:
+        return
+    provider.execute(session_id, "mkdir -p " + " ".join(sorted(dirs_needed)), timeout_ms=10000)
+    for remote, data in upload_items:
         provider.upload_bytes(session_id, remote, data)
         total_bytes += len(data)
     logger.info("[SYNC-PERF] native_upload: %d files, %d bytes, %.3fs", len(files), total_bytes, time.time() - t0)


### PR DESCRIPTION
## Summary

Post-merge cleanup from simplify review on the file_channel rename.

- Fix `LeaseStore.create()` returning lease with `file_channel_id=None` (bug — in-memory object missing the field)
- Close `channel_repo` after use in `_create_thread_sandbox_resources` (SQLite connection leak)
- Remove backwards-compat `LEON_SANDBOX_VOLUME_ROOT` env var fallback (violates dev-stage no-compat rule)
- Extract `resolve_provider_cwd()` to deduplicate CWD resolution between `threads.py` and `manager.py`
- Batch `mkdir -p` calls in `_native_upload` (1 command instead of N)
- Remove unused import, redundant inner import, stale comment

## Test plan

- [x] App boots without import errors
- [x] YATU: create thread → upload → send with attachment → agent reads file
- [x] pytest: 557 passed (pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)