### PR TITLE
fix: hub download 404, installed skills UI, and navigation

### DIFF
--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -15,7 +15,7 @@ from config.loader import AgentLoader
 
 logger = logging.getLogger(__name__)
 
-HUB_URL = os.environ.get("MYCEL_HUB_URL", "http://localhost:8080")
+HUB_URL = os.environ.get("MYCEL_HUB_URL", "http://localhost:8090")
 
 _hub_client = httpx.Client(timeout=30.0)
 

--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -196,7 +196,7 @@ export default function AgentDetail() {
     <div className="h-full flex flex-col">
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b shrink-0">
-        <Button variant="ghost" size="icon" onClick={() => navigate("/members")}>
+        <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <Bot className="h-5 w-5 text-primary" />

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ArrowLeft, Zap, Users, RefreshCw } from "lucide-react";
+import { useAppStore } from "@/store/app-store";
+import type { ResourceItem } from "@/store/types";
+
+export default function LibraryItemDetailPage() {
+  const { type, id } = useParams<{ type: string; id: string }>();
+  const navigate = useNavigate();
+  const librarySkills = useAppStore((s) => s.librarySkills);
+  const libraryAgents = useAppStore((s) => s.libraryAgents);
+  const fetchLibrary = useAppStore((s) => s.fetchLibrary);
+  const fetchResourceContent = useAppStore((s) => s.fetchResourceContent);
+
+  const [item, setItem] = useState<ResourceItem | null>(null);
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!type || !id) return;
+    fetchLibrary(type === "skill" ? "skill" : "agent");
+  }, [type, id, fetchLibrary]);
+
+  useEffect(() => {
+    if (!type || !id) return;
+    const list = type === "skill" ? librarySkills : libraryAgents;
+    const found = list.find((i) => i.id === id);
+    if (found) setItem(found);
+  }, [librarySkills, libraryAgents, type, id]);
+
+  useEffect(() => {
+    if (!type || !id) return;
+    setLoading(true);
+    fetchResourceContent(type, id)
+      .then(setContent)
+      .finally(() => setLoading(false));
+  }, [type, id, fetchResourceContent]);
+
+  const isSkill = type === "skill";
+  const filename = isSkill ? "SKILL.md" : "agent.md";
+
+  if (!item && !loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <span className="text-sm text-muted-foreground">未找到该内容</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-3xl mx-auto py-6 px-4 md:px-6">
+        {/* Back */}
+        <button
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors duration-fast mb-6"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          返回
+        </button>
+
+        {/* Header */}
+        <div className="flex items-start gap-4 mb-6">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 bg-warning/10">
+                {isSkill
+                  ? <Zap className="w-4 h-4 text-warning" />
+                  : <Users className="w-4 h-4 text-info" />}
+              </div>
+              <h1 className="text-xl font-semibold text-foreground">{item?.name ?? id}</h1>
+              <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
+                {type}
+              </span>
+            </div>
+            {item?.desc && (
+              <p className="text-sm text-muted-foreground mt-2">{item.desc}</p>
+            )}
+          </div>
+        </div>
+
+        {/* File content */}
+        <div className="surface-card p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-xs font-mono text-muted-foreground px-2 py-0.5 rounded bg-muted">
+              {filename}
+            </span>
+          </div>
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <RefreshCw className="w-4 h-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : content ? (
+            <pre className="text-xs text-foreground whitespace-pre-wrap font-mono leading-relaxed max-h-[600px] overflow-y-auto">
+              {content}
+            </pre>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center py-6">暂无内容</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/src/pages/MarketplaceDetailPage.tsx
+++ b/frontend/app/src/pages/MarketplaceDetailPage.tsx
@@ -22,8 +22,6 @@ export default function MarketplaceDetailPage() {
   const fetchVersionSnapshot = useMarketplaceStore((s) => s.fetchVersionSnapshot);
   const clearSnapshot = useMarketplaceStore((s) => s.clearSnapshot);
   const [installOpen, setInstallOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<"overview" | "versions" | "files">("overview");
-  const tabLabels: Record<string, string> = { overview: "概览", versions: "版本", files: "文件" };
 
   useEffect(() => {
     if (id) {
@@ -34,11 +32,11 @@ export default function MarketplaceDetailPage() {
   }, [id, fetchDetail, fetchLineage, clearDetail]);
 
   useEffect(() => {
-    if (activeTab === "files" && detail && detail.versions.length > 0) {
+    if (detail && detail.versions.length > 0 && (detail.type === "skill" || detail.type === "agent")) {
       fetchVersionSnapshot(detail.id, detail.versions[0].version);
     }
     return () => clearSnapshot();
-  }, [activeTab, detail?.id, fetchVersionSnapshot, clearSnapshot]);
+  }, [detail?.id, detail?.type, fetchVersionSnapshot, clearSnapshot]);
 
   if (detailLoading) {
     return (
@@ -68,11 +66,11 @@ export default function MarketplaceDetailPage() {
       <div className="max-w-3xl mx-auto py-6 px-4 md:px-6">
         {/* Back button */}
         <button
-          onClick={() => navigate("/marketplace")}
+          onClick={() => navigate(-1)}
           className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors duration-fast mb-6"
         >
           <ArrowLeft className="w-3.5 h-3.5" />
-          返回 Marketplace
+          返回
         </button>
 
         {/* Header */}
@@ -108,89 +106,40 @@ export default function MarketplaceDetailPage() {
           </div>
         )}
 
-        {/* Tabs */}
-        <div className="flex gap-4 border-b border-border mb-6">
-          {(["overview", "versions", ...(detail.type === "skill" || detail.type === "agent" ? ["files" as const] : [])] as const).map((tab) => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`pb-2 text-sm font-medium transition-colors duration-fast border-b-2 ${
-                activeTab === tab ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              {tabLabels[tab] ?? tab}
-            </button>
-          ))}
-        </div>
+        <div className="space-y-6">
+          {/* Lineage */}
+          <LineageTree
+            ancestors={lineage.ancestors}
+            children={lineage.children}
+            currentName={detail.name}
+            onNodeClick={(nodeId) => navigate(`/marketplace/${nodeId}`)}
+          />
 
-        {/* Tab content */}
-        {activeTab === "overview" && (
-          <div className="space-y-6">
-            {/* Lineage */}
-            <LineageTree
-              ancestors={lineage.ancestors}
-              children={lineage.children}
-              currentName={detail.name}
-              onNodeClick={(nodeId) => navigate(`/marketplace/${nodeId}`)}
-            />
-
-            {/* Latest version info */}
-            {detail.versions.length > 0 && (
-              <div className="surface-card p-4 space-y-2">
-                <h3 className="text-sm font-medium text-foreground">最新版本</h3>
-                <p className="text-xs font-mono text-primary">v{detail.versions[0].version}</p>
-                {detail.versions[0].release_notes && (
-                  <p className="text-sm text-muted-foreground whitespace-pre-wrap">{detail.versions[0].release_notes}</p>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-
-        {activeTab === "versions" && (
-          <div className="space-y-3">
-            {detail.versions.map((v) => (
-              <div key={v.id} className="surface-card p-4">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-mono font-medium text-foreground">v{v.version}</span>
-                  <span className="text-2xs text-muted-foreground">{new Date(v.created_at).toLocaleDateString()}</span>
+          {/* Version history */}
+          {detail.versions.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-foreground">版本历史</h3>
+              {detail.versions.map((v) => (
+                <div key={v.id} className="surface-card p-4">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm font-mono font-medium text-primary">v{v.version}</span>
+                    <span className="text-2xs text-muted-foreground">{new Date(v.created_at).toLocaleDateString()}</span>
+                  </div>
+                  {v.release_notes && (
+                    <p className="text-xs text-muted-foreground whitespace-pre-wrap">{v.release_notes}</p>
+                  )}
                 </div>
-                {v.release_notes && (
-                  <p className="text-xs text-muted-foreground whitespace-pre-wrap">{v.release_notes}</p>
-                )}
-              </div>
-            ))}
-            {detail.versions.length === 0 && (
-              <p className="text-sm text-muted-foreground text-center py-8">暂无已发布的版本</p>
-            )}
-          </div>
-        )}
-
-        {activeTab === "files" && (
-          <div className="space-y-4">
-            {/* File tree */}
-            <div className="surface-card p-4">
-              <h3 className="text-sm font-medium text-foreground mb-3">文件结构</h3>
-              <div className="font-mono text-xs text-muted-foreground space-y-1">
-                <div className="flex items-center gap-2 text-foreground font-medium">
-                  <span>📁</span>
-                  <span>{detail.slug}/</span>
-                </div>
-                <div className="flex items-center gap-2 ml-5">
-                  <span>📄</span>
-                  <span className="text-primary">SKILL.md</span>
-                </div>
-                <div className="flex items-center gap-2 ml-5">
-                  <span>📄</span>
-                  <span>meta.json</span>
-                </div>
-              </div>
+              ))}
             </div>
+          )}
 
-            {/* SKILL.md preview */}
+          {/* File content for skill / agent */}
+          {(detail.type === "skill" || detail.type === "agent") && (
             <div className="surface-card p-4">
               <div className="flex items-center gap-2 mb-3">
-                <span className="text-xs font-mono text-muted-foreground px-2 py-0.5 rounded bg-muted">SKILL.md</span>
+                <span className="text-xs font-mono text-muted-foreground px-2 py-0.5 rounded bg-muted">
+                  {detail.type === "skill" ? "SKILL.md" : "agent.md"}
+                </span>
               </div>
               {snapshotLoading ? (
                 <div className="flex items-center justify-center py-8">
@@ -204,8 +153,8 @@ export default function MarketplaceDetailPage() {
                 <p className="text-sm text-muted-foreground text-center py-6">暂无内容</p>
               )}
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {/* Install dialog */}

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
-import { Search, Store, Package, TrendingUp, Clock, Star, RefreshCw } from "lucide-react";
+import React, { useState, useEffect, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Search, Store, Package, TrendingUp, Clock, Star, RefreshCw, Zap, Users, Trash2 } from "lucide-react";
 import { useMarketplaceStore } from "@/store/marketplace-store";
 import { useAppStore } from "@/store/app-store";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -9,6 +9,7 @@ import UpdateDialog from "@/components/marketplace/UpdateDialog";
 import type { Member } from "@/store/types";
 
 type Tab = "explore" | "installed";
+type InstalledSubTab = "member" | "skill" | "agent";
 type TypeFilter = "all" | "member" | "agent" | "skill" | "env";
 
 const typeFilters: { id: TypeFilter; label: string }[] = [
@@ -28,7 +29,13 @@ const sortOptions = [
 export default function MarketplacePage() {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
-  const [tab, setTab] = useState<Tab>("explore");
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const tab = (searchParams.get("tab") as Tab) || "explore";
+  const installedSubTab = (searchParams.get("sub") as InstalledSubTab) || "member";
+
+  const setTab = (t: Tab) => setSearchParams((p) => { p.set("tab", t); p.delete("sub"); return p; }, { replace: true });
+  const setInstalledSubTab = (s: InstalledSubTab) => setSearchParams((p) => { p.set("sub", s); return p; }, { replace: true });
 
   // Explore state
   const items = useMarketplaceStore((s) => s.items);
@@ -41,6 +48,10 @@ export default function MarketplacePage() {
 
   // Installed state
   const memberList = useAppStore((s) => s.memberList);
+  const librarySkills = useAppStore((s) => s.librarySkills);
+  const libraryAgents = useAppStore((s) => s.libraryAgents);
+  const fetchLibrary = useAppStore((s) => s.fetchLibrary);
+  const deleteResource = useAppStore((s) => s.deleteResource);
   const updates = useMarketplaceStore((s) => s.updates);
   const checkUpdates = useMarketplaceStore((s) => s.checkUpdates);
 
@@ -51,6 +62,7 @@ export default function MarketplacePage() {
   // Update dialog
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
   const [updateTarget, setUpdateTarget] = useState<{ member: Member; update: any } | null>(null);
+
 
   // Fetch explore items when filters change
   useEffect(() => {
@@ -69,12 +81,31 @@ export default function MarketplacePage() {
     setFilter("type", type === "all" ? null : type);
   };
 
+  // Load library on installed tab open
+  useEffect(() => {
+    if (tab === "installed") {
+      fetchLibrary("skill");
+      fetchLibrary("agent");
+    }
+  }, [tab, fetchLibrary]);
+
   // Installed members with marketplace source info
   const installedMembers = memberList.filter((m) => !m.builtin);
-  const filteredInstalled = installedMembers.filter((m) => {
-    if (installedSearch && !m.name.toLowerCase().includes(installedSearch.toLowerCase())) return false;
-    return true;
-  });
+  const filteredMembers = installedMembers.filter((m) =>
+    !installedSearch || m.name.toLowerCase().includes(installedSearch.toLowerCase())
+  );
+  const filteredSkills = librarySkills.filter((s) =>
+    !installedSearch || s.name.toLowerCase().includes(installedSearch.toLowerCase())
+  );
+  const filteredAgents = libraryAgents.filter((a) =>
+    !installedSearch || a.name.toLowerCase().includes(installedSearch.toLowerCase())
+  );
+
+  const installedSubTabs: { id: InstalledSubTab; label: string; icon: React.ElementType; count: number }[] = [
+    { id: "member", label: "成员", icon: Package, count: installedMembers.length },
+    { id: "skill", label: "Skill", icon: Zap, count: librarySkills.length },
+    { id: "agent", label: "Agent", icon: Users, count: libraryAgents.length },
+  ];
 
   const handleCheckUpdates = useCallback(async () => {
     // source field comes from meta.json; members without it cannot be checked
@@ -286,40 +317,139 @@ export default function MarketplacePage() {
                   />
                 </div>
 
-                {/* Grid */}
-                <div className={`grid ${isMobile ? "grid-cols-1" : "grid-cols-2"} gap-3`}>
-                  {filteredInstalled.map((member) => {
-                    const update = updates.find((u) => u.marketplace_item_id === member.id);
-                    return (
-                      <div key={member.id} className="surface-interactive p-4 cursor-pointer group relative" onClick={() => navigate(`/members/${member.id}`)}>
-                        <div className="flex items-start gap-3">
-                          <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-                            <Package className="w-4 h-4 text-primary" />
-                          </div>
-                          <div className="min-w-0 flex-1">
-                            <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{member.name}</h4>
-                            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{member.description}</p>
-                            <p className="text-2xs text-muted-foreground mt-2 font-mono">v{member.version}</p>
-                          </div>
-                        </div>
-                        {update && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setUpdateTarget({ member, update });
-                              setUpdateDialogOpen(true);
-                            }}
-                            className="absolute top-2 right-2 text-2xs px-2 py-0.5 rounded-full bg-primary/10 text-primary font-medium hover:bg-primary/20 transition-colors duration-fast"
-                          >
-                            更新到 v{update.latest_version}
-                          </button>
-                        )}
-                      </div>
-                    );
-                  })}
+                {/* Sub-tabs */}
+                <div className="flex gap-1 mb-4">
+                  {installedSubTabs.map((t) => (
+                    <button
+                      key={t.id}
+                      onClick={() => setInstalledSubTab(t.id)}
+                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors duration-fast ${
+                        installedSubTab === t.id
+                          ? "bg-primary/10 text-primary"
+                          : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      }`}
+                    >
+                      <t.icon className="w-3 h-3" />
+                      {t.label}
+                      {t.count > 0 && (
+                        <span className={`px-1.5 py-0.5 rounded-full text-2xs font-medium ${
+                          installedSubTab === t.id ? "bg-primary/20 text-primary" : "bg-muted text-muted-foreground"
+                        }`}>
+                          {t.count}
+                        </span>
+                      )}
+                    </button>
+                  ))}
                 </div>
-                {filteredInstalled.length === 0 && (
-                  <div className="text-center py-12 text-sm text-muted-foreground">暂无已安装的成员</div>
+
+                {/* Member list */}
+                {installedSubTab === "member" && (
+                  <>
+                    <div className={`grid ${isMobile ? "grid-cols-1" : "grid-cols-2"} gap-3`}>
+                      {filteredMembers.map((member) => {
+                        const update = updates.find((u) => u.marketplace_item_id === member.id);
+                        return (
+                          <div key={member.id} className="surface-interactive p-4 cursor-pointer group relative" onClick={() => navigate(`/members/${member.id}`)}>
+                            <div className="flex items-start gap-3">
+                              <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+                                <Package className="w-4 h-4 text-primary" />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{member.name}</h4>
+                                <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{member.description}</p>
+                                <p className="text-2xs text-muted-foreground mt-2 font-mono">v{member.version}</p>
+                              </div>
+                            </div>
+                            {update && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setUpdateTarget({ member, update });
+                                  setUpdateDialogOpen(true);
+                                }}
+                                className="absolute top-2 right-2 text-2xs px-2 py-0.5 rounded-full bg-primary/10 text-primary font-medium hover:bg-primary/20 transition-colors duration-fast"
+                              >
+                                更新到 v{update.latest_version}
+                              </button>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {filteredMembers.length === 0 && (
+                      <div className="text-center py-12 text-sm text-muted-foreground">暂无已安装的成员</div>
+                    )}
+                  </>
+                )}
+
+                {/* Skill list */}
+                {installedSubTab === "skill" && (
+                  <>
+                    <div className={`grid ${isMobile ? "grid-cols-1" : "grid-cols-2"} gap-3`}>
+                      {filteredSkills.map((skill) => (
+                        <div
+                          key={skill.id}
+                          onClick={() => navigate(`/library/skill/${skill.id}`)}
+                          className="surface-interactive p-4 cursor-pointer group relative"
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="w-9 h-9 rounded-lg bg-warning/10 flex items-center justify-center shrink-0">
+                              <Zap className="w-4 h-4 text-warning" />
+                            </div>
+                            <div className="min-w-0 flex-1 pr-8">
+                              <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{skill.name}</h4>
+                              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{skill.desc || "暂无描述"}</p>
+                            </div>
+                          </div>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); deleteResource("skill", skill.id); }}
+                            className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
+                            title="删除"
+                          >
+                            <Trash2 className="w-3.5 h-3.5 text-muted-foreground hover:text-destructive" />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                    {filteredSkills.length === 0 && (
+                      <div className="text-center py-12 text-sm text-muted-foreground">暂无已安装的 Skill</div>
+                    )}
+                  </>
+                )}
+
+                {/* Agent list */}
+                {installedSubTab === "agent" && (
+                  <>
+                    <div className={`grid ${isMobile ? "grid-cols-1" : "grid-cols-2"} gap-3`}>
+                      {filteredAgents.map((agent) => (
+                        <div
+                          key={agent.id}
+                          onClick={() => navigate(`/library/agent/${agent.id}`)}
+                          className="surface-interactive p-4 cursor-pointer group relative"
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="w-9 h-9 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
+                              <Users className="w-4 h-4 text-info" />
+                            </div>
+                            <div className="min-w-0 flex-1 pr-8">
+                              <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{agent.name}</h4>
+                              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{agent.desc || "暂无描述"}</p>
+                            </div>
+                          </div>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); deleteResource("agent", agent.id); }}
+                            className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
+                            title="删除"
+                          >
+                            <Trash2 className="w-3.5 h-3.5 text-muted-foreground hover:text-destructive" />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                    {filteredAgents.length === 0 && (
+                      <div className="text-center py-12 text-sm text-muted-foreground">暂无已安装的 Agent</div>
+                    )}
+                  </>
                 )}
               </>
             )}
@@ -337,6 +467,7 @@ export default function MarketplacePage() {
           memberName={updateTarget.member.name}
         />
       )}
+
     </div>
   );
 }

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -13,6 +13,7 @@ import AgentDetailPage from './pages/AgentDetailPage';
 import TasksPage from './pages/TasksPage';
 import MarketplacePage from './pages/MarketplacePage';
 import MarketplaceDetailPage from './pages/MarketplaceDetailPage';
+import LibraryItemDetailPage from './pages/LibraryItemDetailPage';
 import ResourcesPage from './pages/ResourcesPage';
 import ConnectionsPage from './pages/ConnectionsPage';
 
@@ -89,6 +90,10 @@ export const router = createBrowserRouter([
       {
         path: 'marketplace/:id',
         element: <MarketplaceDetailPage />,
+      },
+      {
+        path: 'library/:type/:id',
+        element: <LibraryItemDetailPage />,
       },
       {
         path: 'library',


### PR DESCRIPTION
## Summary

- Fix Hub skill download 404: `marketplace_client.py` default `MYCEL_HUB_URL` was `localhost:8080` (wrong port), changed to `localhost:8090`
- Add Installed tab to Marketplace page with sub-tabs (成员/Skill/Agent) showing downloaded skills and agents
- Add `/library/:type/:id` full-page detail route for installed skill/agent, mirroring MarketplaceDetailPage UI
- Remove 概览/版本/文件 tabs from MarketplaceDetailPage — all content shown flat
- Fix back navigation: hardcoded routes → `navigate(-1)` across AgentDetailPage, MarketplaceDetailPage, LibraryItemDetailPage
- Move tab state to URL search params (`?tab=installed&sub=skill`) so back navigation preserves tab position

## Test plan

- [ ] Download a skill from Hub — should succeed (no 404)
- [ ] Navigate to Marketplace > Installed tab — should show downloaded skills/agents in sub-tabs
- [ ] Click an installed skill/agent — should open full-page detail at `/library/skill/:id`
- [ ] Press back from detail page — should return to `/marketplace?tab=installed&sub=skill`
- [ ] Marketplace detail page shows lineage, version history, and file content without tabs