### PR TITLE
fix: align panel task owner contract

### DIFF
--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -195,7 +195,7 @@ async def bulk_update_status(
     req: BulkTaskStatusRequest,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    count = await asyncio.to_thread(task_service.bulk_update_task_status, req.ids, req.status)
+    count = await asyncio.to_thread(task_service.bulk_update_task_status, req.ids, req.status, owner_user_id=user_id)
     return {"updated": count}
 
 
@@ -204,7 +204,7 @@ async def bulk_delete_tasks(
     req: BulkDeleteTasksRequest,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    count = await asyncio.to_thread(task_service.bulk_delete_tasks, req.ids)
+    count = await asyncio.to_thread(task_service.bulk_delete_tasks, req.ids, owner_user_id=user_id)
     return {"deleted": count}
 
 
@@ -214,7 +214,7 @@ async def update_task(
     req: UpdateTaskRequest,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    item = await asyncio.to_thread(task_service.update_task, task_id, **req.model_dump())
+    item = await asyncio.to_thread(task_service.update_task, task_id, owner_user_id=user_id, **req.model_dump())
     if not item:
         raise HTTPException(404, "Task not found")
     return item
@@ -225,7 +225,7 @@ async def delete_task(
     task_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    ok = await asyncio.to_thread(task_service.delete_task, task_id)
+    ok = await asyncio.to_thread(task_service.delete_task, task_id, owner_user_id=user_id)
     if not ok:
         raise HTTPException(404, "Task not found")
     return {"success": True}
@@ -268,7 +268,7 @@ async def update_cron_job(
     fields = req.model_dump(exclude_none=True)
     if "enabled" in fields:
         fields["enabled"] = int(fields["enabled"])
-    job = await asyncio.to_thread(cron_job_service.update_cron_job, job_id, **fields)
+    job = await asyncio.to_thread(cron_job_service.update_cron_job, job_id, owner_user_id=user_id, **fields)
     if not job:
         raise HTTPException(404, "Cron job not found")
     return {"item": job}
@@ -279,7 +279,7 @@ async def delete_cron_job(
     job_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    ok = await asyncio.to_thread(cron_job_service.delete_cron_job, job_id)
+    ok = await asyncio.to_thread(cron_job_service.delete_cron_job, job_id, owner_user_id=user_id)
     if not ok:
         raise HTTPException(404, "Cron job not found")
     return {"ok": True}
@@ -294,7 +294,7 @@ async def trigger_cron_job(
     cron_service = getattr(request.app.state, "cron_service", None)
     if not cron_service:
         raise HTTPException(503, "Cron service not available")
-    task = await cron_service.trigger_job(job_id)
+    task = await cron_service.trigger_job(job_id, owner_user_id=user_id)
     if not task:
         raise HTTPException(404, "Cron job not found or disabled")
     return {"item": task}

--- a/backend/web/services/cron_job_service.py
+++ b/backend/web/services/cron_job_service.py
@@ -17,10 +17,10 @@ def list_cron_jobs(owner_user_id: str | None = None) -> list[dict[str, Any]]:
         repo.close()
 
 
-def get_cron_job(job_id: str) -> dict[str, Any] | None:
+def get_cron_job(job_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
     repo = _repo()
     try:
-        return repo.get(job_id)
+        return repo.get(job_id, owner_user_id=owner_user_id)
     finally:
         repo.close()
 
@@ -37,17 +37,17 @@ def create_cron_job(*, name: str, cron_expression: str, **fields: Any) -> dict[s
         repo.close()
 
 
-def update_cron_job(job_id: str, **fields: Any) -> dict[str, Any] | None:
+def update_cron_job(job_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any] | None:
     repo = _repo()
     try:
-        return repo.update(job_id, **fields)
+        return repo.update(job_id, owner_user_id=owner_user_id, **fields)
     finally:
         repo.close()
 
 
-def delete_cron_job(job_id: str) -> bool:
+def delete_cron_job(job_id: str, owner_user_id: str | None = None) -> bool:
     repo = _repo()
     try:
-        return repo.delete(job_id)
+        return repo.delete(job_id, owner_user_id=owner_user_id)
     finally:
         repo.close()

--- a/backend/web/services/cron_service.py
+++ b/backend/web/services/cron_service.py
@@ -52,13 +52,13 @@ class CronService:
             self._task = None
         logger.info("[cron-service] stopped")
 
-    async def trigger_job(self, job_id: str) -> dict[str, Any] | None:
+    async def trigger_job(self, job_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
         """Manually trigger a cron job. Creates a task from template.
 
         Returns the created task dict, or None if the job doesn't exist,
         is disabled, or has an invalid template.
         """
-        job = await asyncio.to_thread(cron_job_service.get_cron_job, job_id)
+        job = await asyncio.to_thread(cron_job_service.get_cron_job, job_id, owner_user_id=owner_user_id)
         if job is None:
             return None
         if not job.get("enabled"):
@@ -76,12 +76,18 @@ class CronService:
         task_fields: dict[str, Any] = {k: v for k, v in template.items() if k in _ALLOWED_TEMPLATE_KEYS}
         task_fields["source"] = "cron"
         task_fields["cron_job_id"] = job_id
+        task_fields["owner_user_id"] = job.get("owner_user_id")
 
         task = await asyncio.to_thread(task_service.create_task, **task_fields)
 
         # Update last_run_at on the cron job
         now_ms = int(time.time() * 1000)
-        await asyncio.to_thread(cron_job_service.update_cron_job, job_id, last_run_at=now_ms)
+        await asyncio.to_thread(
+            cron_job_service.update_cron_job,
+            job_id,
+            owner_user_id=job.get("owner_user_id"),
+            last_run_at=now_ms,
+        )
 
         logger.info("[cron-service] triggered job %s → task %s", job_id, task.get("id"))
         return task

--- a/backend/web/services/task_service.py
+++ b/backend/web/services/task_service.py
@@ -42,10 +42,10 @@ def _enrich_task_thread_members(tasks: list[dict[str, Any]]) -> list[dict[str, A
     return enriched
 
 
-def get_task(task_id: str) -> dict[str, Any] | None:
+def get_task(task_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
     repo = _repo()
     try:
-        return repo.get(task_id)
+        return repo.get(task_id, owner_user_id=owner_user_id)
     finally:
         repo.close()
 
@@ -66,33 +66,33 @@ def create_task(**fields: Any) -> dict[str, Any]:
         repo.close()
 
 
-def update_task(task_id: str, **fields: Any) -> dict[str, Any] | None:
+def update_task(task_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any] | None:
     repo = _repo()
     try:
-        return repo.update(task_id, **fields)
+        return repo.update(task_id, owner_user_id=owner_user_id, **fields)
     finally:
         repo.close()
 
 
-def delete_task(task_id: str) -> bool:
+def delete_task(task_id: str, owner_user_id: str | None = None) -> bool:
     repo = _repo()
     try:
-        return repo.delete(task_id)
+        return repo.delete(task_id, owner_user_id=owner_user_id)
     finally:
         repo.close()
 
 
-def bulk_delete_tasks(ids: list[str]) -> int:
+def bulk_delete_tasks(ids: list[str], owner_user_id: str | None = None) -> int:
     repo = _repo()
     try:
-        return repo.bulk_delete(ids)
+        return repo.bulk_delete(ids, owner_user_id=owner_user_id)
     finally:
         repo.close()
 
 
-def bulk_update_task_status(ids: list[str], status: str) -> int:
+def bulk_update_task_status(ids: list[str], status: str, owner_user_id: str | None = None) -> int:
     repo = _repo()
     try:
-        return repo.bulk_update_status(ids, status)
+        return repo.bulk_update_status(ids, status, owner_user_id=owner_user_id)
     finally:
         repo.close()

--- a/docs/superpowers/plans/2026-04-06-panel-task-owner-contract-alignment.md
+++ b/docs/superpowers/plans/2026-04-06-panel-task-owner-contract-alignment.md
@@ -1,0 +1,277 @@
+# Panel Task Owner Contract Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make panel task and cron-job routes owner-honest end to end, while keeping the change limited to router/service/repo wiring.
+
+**Architecture:** Pass `owner_user_id` through every panel task/cron mutation path, teach the service layer to require and forward that contract, and let the Supabase repos enforce the scope in query space. Keep the router thin and avoid introducing generic CRUD helpers.
+
+**Tech Stack:** FastAPI, asyncio `to_thread`, Supabase repos, pytest
+
+---
+
+### Task 1: Write focused owner-contract regressions
+
+**Files:**
+- Create: `tests/Fix/test_panel_task_owner_contract.py`
+- Read: `backend/web/routers/panel.py`
+- Read: `backend/web/services/cron_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.web.models.panel import BulkDeleteTasksRequest, BulkTaskStatusRequest, UpdateCronJobRequest, UpdateTaskRequest
+from backend.web.routers import panel as panel_router
+from backend.web.services.cron_service import CronService
+
+
+@pytest.mark.asyncio
+async def test_panel_task_mutations_forward_owner_scope(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, tuple] = {}
+
+    monkeypatch.setattr(
+        panel_router.task_service,
+        "bulk_update_task_status",
+        lambda ids, status, owner_user_id=None: seen.setdefault("bulk_status", (ids, status, owner_user_id)) or len(ids),
+    )
+    monkeypatch.setattr(
+        panel_router.task_service,
+        "bulk_delete_tasks",
+        lambda ids, owner_user_id=None: seen.setdefault("bulk_delete", (ids, owner_user_id)) or len(ids),
+    )
+    monkeypatch.setattr(
+        panel_router.task_service,
+        "update_task",
+        lambda task_id, owner_user_id=None, **fields: seen.setdefault("update", (task_id, owner_user_id, fields)) or {"id": task_id},
+    )
+    monkeypatch.setattr(
+        panel_router.task_service,
+        "delete_task",
+        lambda task_id, owner_user_id=None: seen.setdefault("delete", (task_id, owner_user_id)) or True,
+    )
+
+    await panel_router.bulk_update_status(BulkTaskStatusRequest(ids=["t-1"], status="completed"), user_id="user-1")
+    await panel_router.bulk_delete_tasks(BulkDeleteTasksRequest(ids=["t-2"]), user_id="user-1")
+    await panel_router.update_task("t-3", UpdateTaskRequest(title="new"), user_id="user-1")
+    await panel_router.delete_task("t-4", user_id="user-1")
+
+    assert seen["bulk_status"] == (["t-1"], "completed", "user-1")
+    assert seen["bulk_delete"] == (["t-2"], "user-1")
+    assert seen["update"][0:2] == ("t-3", "user-1")
+    assert seen["delete"] == ("t-4", "user-1")
+
+
+@pytest.mark.asyncio
+async def test_panel_cron_mutations_forward_owner_scope(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, tuple] = {}
+
+    monkeypatch.setattr(
+        panel_router.cron_job_service,
+        "update_cron_job",
+        lambda job_id, owner_user_id=None, **fields: seen.setdefault("update", (job_id, owner_user_id, fields)) or {"id": job_id},
+    )
+    monkeypatch.setattr(
+        panel_router.cron_job_service,
+        "delete_cron_job",
+        lambda job_id, owner_user_id=None: seen.setdefault("delete", (job_id, owner_user_id)) or True,
+    )
+
+    cron_service = SimpleNamespace(trigger_job=lambda job_id, owner_user_id=None: {"id": "task-1", "job_id": job_id, "owner_user_id": owner_user_id})
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(cron_service=cron_service)))
+
+    await panel_router.update_cron_job("job-1", UpdateCronJobRequest(description="desc"), user_id="user-1")
+    await panel_router.delete_cron_job("job-2", user_id="user-1")
+    result = await panel_router.trigger_cron_job("job-3", request=request, user_id="user-1")
+
+    assert seen["update"][0:2] == ("job-1", "user-1")
+    assert seen["delete"] == ("job-2", "user-1")
+    assert result["item"]["owner_user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_copies_job_owner_to_created_task(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "backend.web.services.cron_service.cron_job_service.get_cron_job",
+        lambda job_id, owner_user_id=None: {
+            "id": job_id,
+            "enabled": 1,
+            "owner_user_id": "owner-7",
+            "task_template": "{\"title\":\"From cron\"}",
+        },
+    )
+
+    created: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "backend.web.services.cron_service.task_service.create_task",
+        lambda **fields: created.update(fields) or {"id": "task-1", **fields},
+    )
+    monkeypatch.setattr(
+        "backend.web.services.cron_service.cron_job_service.update_cron_job",
+        lambda *_args, **_kwargs: {"id": "job-1"},
+    )
+
+    task = await CronService().trigger_job("job-1")
+
+    assert task is not None
+    assert created["owner_user_id"] == "owner-7"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/Fix/test_panel_task_owner_contract.py -q`
+Expected: FAIL because current panel task/cron mutation paths do not consistently pass `owner_user_id`.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/Fix/test_panel_task_owner_contract.py
+git commit -m "test: cover panel owner contract drift"
+```
+
+### Task 2: Align router and service contracts
+
+**Files:**
+- Modify: `backend/web/routers/panel.py`
+- Modify: `backend/web/services/task_service.py`
+- Modify: `backend/web/services/cron_job_service.py`
+
+- [ ] **Step 1: Make the task router pass owner scope everywhere**
+
+```python
+count = await asyncio.to_thread(task_service.bulk_update_task_status, req.ids, req.status, owner_user_id=user_id)
+count = await asyncio.to_thread(task_service.bulk_delete_tasks, req.ids, owner_user_id=user_id)
+item = await asyncio.to_thread(task_service.update_task, task_id, owner_user_id=user_id, **req.model_dump())
+ok = await asyncio.to_thread(task_service.delete_task, task_id, owner_user_id=user_id)
+```
+
+- [ ] **Step 2: Make the cron router pass owner scope everywhere**
+
+```python
+job = await asyncio.to_thread(cron_job_service.update_cron_job, job_id, owner_user_id=user_id, **fields)
+ok = await asyncio.to_thread(cron_job_service.delete_cron_job, job_id, owner_user_id=user_id)
+task = await cron_service.trigger_job(job_id, owner_user_id=user_id)
+```
+
+- [ ] **Step 3: Make service signatures owner-honest**
+
+```python
+def get_task(task_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
+    ...
+    return repo.get(task_id, owner_user_id=owner_user_id)
+
+def update_task(task_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any] | None:
+    ...
+
+def delete_task(task_id: str, owner_user_id: str | None = None) -> bool:
+    ...
+
+def bulk_delete_tasks(ids: list[str], owner_user_id: str | None = None) -> int:
+    ...
+
+def bulk_update_task_status(ids: list[str], status: str, owner_user_id: str | None = None) -> int:
+    ...
+```
+
+Apply the same pattern in `cron_job_service.py` for `get/update/delete`.
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `uv run pytest tests/Fix/test_panel_task_owner_contract.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit router/service alignment**
+
+```bash
+git add backend/web/routers/panel.py backend/web/services/task_service.py backend/web/services/cron_job_service.py tests/Fix/test_panel_task_owner_contract.py
+git commit -m "fix: align panel owner scope through services"
+```
+
+### Task 3: Align repo filtering and cron-trigger ownership
+
+**Files:**
+- Modify: `storage/providers/supabase/panel_task_repo.py`
+- Modify: `storage/providers/supabase/cron_job_repo.py`
+- Modify: `backend/web/services/cron_service.py`
+
+- [ ] **Step 1: Add owner-aware repo methods**
+
+```python
+def get(self, task_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
+    query = self._table().select("*").eq("id", task_id)
+    if owner_user_id is not None:
+        query = query.eq("owner_user_id", owner_user_id)
+```
+
+Apply the same filter shape to:
+
+- task repo `update/delete/bulk_delete/bulk_update_status`
+- cron repo `get/update/delete`
+
+- [ ] **Step 2: Preserve owner on cron-triggered tasks**
+
+```python
+async def trigger_job(self, job_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
+    job = await asyncio.to_thread(cron_job_service.get_cron_job, job_id, owner_user_id=owner_user_id)
+    ...
+    task_fields["owner_user_id"] = job.get("owner_user_id")
+    task = await asyncio.to_thread(task_service.create_task, **task_fields)
+```
+
+- [ ] **Step 3: Run focused verification**
+
+Run: `uv run pytest tests/Fix/test_panel_task_owner_contract.py tests/Fix/test_panel_auth_shell_coherence.py -q`
+Expected: PASS
+
+- [ ] **Step 4: Run seam-level sanity checks**
+
+Run: `python3 -m py_compile backend/web/routers/panel.py backend/web/services/task_service.py backend/web/services/cron_job_service.py backend/web/services/cron_service.py storage/providers/supabase/panel_task_repo.py storage/providers/supabase/cron_job_repo.py`
+Expected: exit 0
+
+Run: `cd frontend/app && npm run build`
+Expected: PASS
+
+- [ ] **Step 5: Commit repo + cron alignment**
+
+```bash
+git add backend/web/services/cron_service.py storage/providers/supabase/panel_task_repo.py storage/providers/supabase/cron_job_repo.py
+git commit -m "fix: enforce owner scope in panel task repos"
+```
+
+### Task 4: Final verification and PR prep
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-06-panel-task-owner-contract-design.md`
+- Modify: `docs/superpowers/plans/2026-04-06-panel-task-owner-contract-alignment.md`
+
+- [ ] **Step 1: Run the final branch proof**
+
+Run: `uv run pytest tests/Fix/test_panel_task_owner_contract.py tests/Fix/test_panel_auth_shell_coherence.py -q`
+Expected: PASS
+
+Run: `cd frontend/app && npm run build`
+Expected: PASS
+
+Run: `python3 -m py_compile backend/web/routers/panel.py backend/web/services/task_service.py backend/web/services/cron_job_service.py backend/web/services/cron_service.py storage/providers/supabase/panel_task_repo.py storage/providers/supabase/cron_job_repo.py`
+Expected: exit 0
+
+- [ ] **Step 2: Update docs with any scope adjustments discovered during implementation**
+
+Keep the stopline explicit:
+
+- panel/task owner contract only
+- no generic panel abstraction
+- no runtime/display/provider spillover
+
+- [ ] **Step 3: Commit final docs and verification-ready state**
+
+```bash
+git add docs/superpowers/specs/2026-04-06-panel-task-owner-contract-design.md docs/superpowers/plans/2026-04-06-panel-task-owner-contract-alignment.md
+git commit -m "docs: capture panel owner-contract phase-2 seam"
+```

--- a/docs/superpowers/specs/2026-04-06-panel-task-owner-contract-design.md
+++ b/docs/superpowers/specs/2026-04-06-panel-task-owner-contract-design.md
@@ -1,0 +1,154 @@
+# Panel Task Owner Contract Design
+
+**Date:** 2026-04-06
+**Branch:** `code-killer-phase-2`
+
+## Goal
+
+Tighten the owner-scoping contract for panel task and cron-job APIs without widening into runtime, display/streaming, or Supabase factory work.
+
+## Scope
+
+This design only covers:
+
+- `backend/web/routers/panel.py`
+- `backend/web/services/task_service.py`
+- `backend/web/services/cron_job_service.py`
+- `backend/web/services/cron_service.py`
+- `storage/providers/supabase/panel_task_repo.py`
+- `storage/providers/supabase/cron_job_repo.py`
+- focused tests for these paths
+
+This design explicitly does **not** cover:
+
+- runtime/message routing/checkpointer
+- display/history/SSE surfaces
+- provider/sandbox contracts
+- Supabase client factory or lifespan wiring
+- monitor/resource issue-205 work
+
+## Problem
+
+The panel owner contract is currently inconsistent.
+
+Facts from the current tree:
+
+- task `list/create` paths pass `owner_user_id=user_id`
+- task `bulk-status / bulk-delete / update / delete` do not pass owner scope
+- cron `list/create` paths pass `owner_user_id=user_id`
+- cron `update / delete / run` do not carry owner scope
+- `CronService.trigger_job()` fetches a job without owner scope and creates a task without preserving the job's `owner_user_id`
+- task/cron repos only expose owner filtering on `list_all()`, so write paths cannot be owner-honest even if routers want to be
+
+This is not only duplicate wiring noise. It is a real contract drift: some panel paths are tenant-aware and some are effectively global-by-id.
+
+## Chosen Approach
+
+Use a narrow contract-alignment pass:
+
+1. Make owner scope explicit on all panel task/cron write paths.
+2. Push that scope through service functions instead of duplicating ad-hoc checks in routers.
+3. Teach the Supabase task/cron repos to perform owner-scoped get/update/delete/bulk operations.
+4. Preserve cron-trigger semantics by copying `owner_user_id` from the cron job into the created task.
+
+This keeps the simplification honest:
+
+- less repeated “sometimes owner-aware, sometimes not” wiring
+- clearer service/repo contracts
+- no fake generic CRUD abstraction
+
+## Alternatives Considered
+
+### 1. Router-only owner checks
+
+Rejected.
+
+This would keep service/repo contracts dishonest and leave `CronService.trigger_job()` outside the safety boundary.
+
+### 2. Generic shared panel CRUD owner helper
+
+Rejected.
+
+This compresses task and cron semantics into one helper layer just to save lines. It would trade visible duplication for a less honest abstraction.
+
+### 3. Recommended: explicit owner contract alignment
+
+Accepted.
+
+It is small enough for one PR and actually reduces semantic drift instead of just moving code around.
+
+## Intended Code Shape
+
+### Router layer
+
+`panel.py` remains thin:
+
+- read `user_id`
+- pass `owner_user_id=user_id` to every task/cron mutation and lookup path
+- keep HTTP mapping local (`404`, `403` only if returned shape demands it)
+
+### Service layer
+
+`task_service.py` and `cron_job_service.py` become owner-honest:
+
+- `get_*`, `update_*`, `delete_*`, and task bulk mutations accept `owner_user_id`
+- service signatures make the owner requirement visible to callers
+- existing list/create behavior stays intact
+
+### Repo layer
+
+Supabase repos get the minimum new surface needed:
+
+- task repo:
+  - `get(task_id, owner_user_id=None)`
+  - `update(task_id, owner_user_id=None, **fields)`
+  - `delete(task_id, owner_user_id=None)`
+  - `bulk_delete(ids, owner_user_id=None)`
+  - `bulk_update_status(ids, status, owner_user_id=None)`
+- cron repo:
+  - `get(job_id, owner_user_id=None)`
+  - `update(job_id, owner_user_id=None, **fields)`
+  - `delete(job_id, owner_user_id=None)`
+
+Filtering stays at the data layer with `eq("owner_user_id", owner_user_id)` when provided.
+
+### Cron trigger path
+
+`CronService.trigger_job()` should:
+
+- fetch the job with owner scope when a caller provides one
+- preserve job ownership by passing `owner_user_id=job.get("owner_user_id")` into `task_service.create_task()`
+
+## Testing Strategy
+
+Use TDD and keep tests focused.
+
+### Focused regressions
+
+Add a new targeted test file for owner-contract behavior:
+
+- panel task mutation routes pass `owner_user_id` through
+- panel cron mutation routes pass `owner_user_id` through
+- cron trigger creates a task under the cron job's owner
+
+### Verification
+
+Minimum proof for this seam:
+
+- focused pytest file for the new owner-contract tests
+- existing `tests/Fix/test_panel_auth_shell_coherence.py`
+- `frontend/app npm run build`
+- `python3 -m py_compile` on touched backend modules
+
+If broader tests become necessary, add them only when a real regression demands them.
+
+## Stopline
+
+This PR stops at owner-contract alignment plus the small simplification that falls out of it.
+
+It must **not** expand into:
+
+- generic panel infrastructure
+- display/streaming cleanup
+- monitor/resource refactors
+- runtime or provider seams

--- a/storage/providers/supabase/cron_job_repo.py
+++ b/storage/providers/supabase/cron_job_repo.py
@@ -44,9 +44,12 @@ class SupabaseCronJobRepo:
         )
         return [self._deserialize(r) for r in rows]
 
-    def get(self, job_id: str) -> dict[str, Any] | None:
+    def get(self, job_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
+        query = self._table().select("*").eq("id", job_id)
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
         rows = q.rows(
-            self._table().select("*").eq("id", job_id).execute(),
+            query.execute(),
             _REPO,
             "get",
         )
@@ -79,7 +82,7 @@ class SupabaseCronJobRepo:
         ).execute()
         return self.get(job_id) or {}
 
-    def update(self, job_id: str, **fields: Any) -> dict[str, Any] | None:
+    def update(self, job_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any] | None:
         allowed = {"name", "description", "cron_expression", "task_template", "enabled", "last_run_at", "next_run_at"}
         updates = {k: v for k, v in fields.items() if k in allowed and v is not None}
         if "task_template" in updates and isinstance(updates["task_template"], str):
@@ -90,13 +93,19 @@ class SupabaseCronJobRepo:
             except Exception:
                 updates["task_template"] = {}
         if not updates:
-            return self.get(job_id)
-        self._table().update(updates).eq("id", job_id).execute()
-        return self.get(job_id)
+            return self.get(job_id, owner_user_id=owner_user_id)
+        query = self._table().update(updates).eq("id", job_id)
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
+        query.execute()
+        return self.get(job_id, owner_user_id=owner_user_id)
 
-    def delete(self, job_id: str) -> bool:
+    def delete(self, job_id: str, owner_user_id: str | None = None) -> bool:
+        query = self._table().delete().eq("id", job_id)
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
         rows = q.rows(
-            self._table().delete().eq("id", job_id).execute(),
+            query.execute(),
             _REPO,
             "delete",
         )

--- a/storage/providers/supabase/panel_task_repo.py
+++ b/storage/providers/supabase/panel_task_repo.py
@@ -49,9 +49,12 @@ class SupabasePanelTaskRepo:
         )
         return [self._deserialize(r) for r in rows]
 
-    def get(self, task_id: str) -> dict[str, Any] | None:
+    def get(self, task_id: str, owner_user_id: str | None = None) -> dict[str, Any] | None:
+        query = self._table().select("*").eq("id", task_id)
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
         rows = q.rows(
-            self._table().select("*").eq("id", task_id).execute(),
+            query.execute(),
             _REPO,
             "get",
         )
@@ -99,7 +102,7 @@ class SupabasePanelTaskRepo:
         ).execute()
         return self.get(task_id) or {}
 
-    def update(self, task_id: str, **fields: Any) -> dict[str, Any] | None:
+    def update(self, task_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any] | None:
         allowed = {
             "title",
             "description",
@@ -119,29 +122,38 @@ class SupabasePanelTaskRepo:
         }
         updates = {k: v for k, v in fields.items() if k in allowed and v is not None}
         if not updates:
-            return self.get(task_id)
-        self._table().update(updates).eq("id", task_id).execute()
-        return self.get(task_id)
+            return self.get(task_id, owner_user_id=owner_user_id)
+        query = self._table().update(updates).eq("id", task_id)
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
+        query.execute()
+        return self.get(task_id, owner_user_id=owner_user_id)
 
-    def delete(self, task_id: str) -> bool:
+    def delete(self, task_id: str, owner_user_id: str | None = None) -> bool:
+        query = self._table().delete().eq("id", task_id)
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
         rows = q.rows(
-            self._table().delete().eq("id", task_id).execute(),
+            query.execute(),
             _REPO,
             "delete",
         )
         return len(rows) > 0
 
-    def bulk_delete(self, ids: list[str]) -> int:
+    def bulk_delete(self, ids: list[str], owner_user_id: str | None = None) -> int:
         if not ids:
             return 0
+        query = q.in_(self._table().delete(), "id", ids, _REPO, "bulk_delete")
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
         rows = q.rows(
-            q.in_(self._table().delete(), "id", ids, _REPO, "bulk_delete").execute(),
+            query.execute(),
             _REPO,
             "bulk_delete",
         )
         return len(rows)
 
-    def bulk_update_status(self, ids: list[str], status: str) -> int:
+    def bulk_update_status(self, ids: list[str], status: str, owner_user_id: str | None = None) -> int:
         if not ids:
             return 0
         updates: dict[str, Any] = {"status": status}
@@ -149,8 +161,11 @@ class SupabasePanelTaskRepo:
             updates["progress"] = 100
         elif status == "pending":
             updates["progress"] = 0
+        query = q.in_(self._table().update(updates), "id", ids, _REPO, "bulk_update_status")
+        if owner_user_id is not None:
+            query = query.eq("owner_user_id", owner_user_id)
         rows = q.rows(
-            q.in_(self._table().update(updates), "id", ids, _REPO, "bulk_update_status").execute(),
+            query.execute(),
             _REPO,
             "bulk_update_status",
         )

--- a/tests/Fix/test_panel_task_owner_contract.py
+++ b/tests/Fix/test_panel_task_owner_contract.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from backend.web.models.panel import BulkDeleteTasksRequest, BulkTaskStatusRequest, UpdateCronJobRequest, UpdateTaskRequest
+from backend.web.routers import panel as panel_router
+from backend.web.services import cron_job_service, task_service
+from backend.web.services.cron_service import CronService
+
+
+@pytest.mark.asyncio
+async def test_panel_task_mutations_forward_owner_scope(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, Any] = {}
+
+    def fake_bulk_update(ids: list[str], status: str, owner_user_id: str | None = None) -> int:
+        seen["bulk_status"] = (ids, status, owner_user_id)
+        return len(ids)
+
+    def fake_bulk_delete(ids: list[str], owner_user_id: str | None = None) -> int:
+        seen["bulk_delete"] = (ids, owner_user_id)
+        return len(ids)
+
+    def fake_update(task_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any]:
+        seen["update"] = (task_id, owner_user_id, fields)
+        return {"id": task_id, **fields}
+
+    def fake_delete(task_id: str, owner_user_id: str | None = None) -> bool:
+        seen["delete"] = (task_id, owner_user_id)
+        return True
+
+    monkeypatch.setattr(panel_router.task_service, "bulk_update_task_status", fake_bulk_update)
+    monkeypatch.setattr(panel_router.task_service, "bulk_delete_tasks", fake_bulk_delete)
+    monkeypatch.setattr(panel_router.task_service, "update_task", fake_update)
+    monkeypatch.setattr(panel_router.task_service, "delete_task", fake_delete)
+
+    await panel_router.bulk_update_status(BulkTaskStatusRequest(ids=["t-1"], status="completed"), user_id="user-1")
+    await panel_router.bulk_delete_tasks(BulkDeleteTasksRequest(ids=["t-2"]), user_id="user-1")
+    await panel_router.update_task("t-3", UpdateTaskRequest(title="new"), user_id="user-1")
+    await panel_router.delete_task("t-4", user_id="user-1")
+
+    assert seen["bulk_status"] == (["t-1"], "completed", "user-1")
+    assert seen["bulk_delete"] == (["t-2"], "user-1")
+    assert seen["update"][0:2] == ("t-3", "user-1")
+    assert seen["update"][2]["title"] == "new"
+    assert seen["delete"] == ("t-4", "user-1")
+
+
+@pytest.mark.asyncio
+async def test_panel_cron_mutations_forward_owner_scope(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, Any] = {}
+
+    def fake_update(job_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any]:
+        seen["update"] = (job_id, owner_user_id, fields)
+        return {"id": job_id, **fields}
+
+    def fake_delete(job_id: str, owner_user_id: str | None = None) -> bool:
+        seen["delete"] = (job_id, owner_user_id)
+        return True
+
+    class _FakeCronService:
+        async def trigger_job(self, job_id: str, owner_user_id: str | None = None) -> dict[str, Any]:
+            seen["trigger"] = (job_id, owner_user_id)
+            return {"id": "task-1", "job_id": job_id, "owner_user_id": owner_user_id}
+
+    monkeypatch.setattr(panel_router.cron_job_service, "update_cron_job", fake_update)
+    monkeypatch.setattr(panel_router.cron_job_service, "delete_cron_job", fake_delete)
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(cron_service=_FakeCronService())))
+
+    await panel_router.update_cron_job("job-1", UpdateCronJobRequest(description="desc"), user_id="user-1")
+    await panel_router.delete_cron_job("job-2", user_id="user-1")
+    result = await panel_router.trigger_cron_job("job-3", request=request, user_id="user-1")
+
+    assert seen["update"] == ("job-1", "user-1", {"description": "desc"})
+    assert seen["delete"] == ("job-2", "user-1")
+    assert seen["trigger"] == ("job-3", "user-1")
+    assert result["item"]["owner_user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_copies_job_owner_to_created_task(monkeypatch: pytest.MonkeyPatch):
+    def fake_get(job_id: str, owner_user_id: str | None = None) -> dict[str, Any]:
+        return {
+            "id": job_id,
+            "enabled": 1,
+            "owner_user_id": "owner-7",
+            "task_template": "{\"title\": \"From cron\"}",
+        }
+
+    created: dict[str, Any] = {}
+
+    def fake_create_task(**fields: Any) -> dict[str, Any]:
+        created.update(fields)
+        return {"id": "task-1", **fields}
+
+    def fake_update_job(job_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any]:
+        return {"id": job_id, "owner_user_id": owner_user_id, **fields}
+
+    monkeypatch.setattr("backend.web.services.cron_service.cron_job_service.get_cron_job", fake_get)
+    monkeypatch.setattr("backend.web.services.cron_service.task_service.create_task", fake_create_task)
+    monkeypatch.setattr("backend.web.services.cron_service.cron_job_service.update_cron_job", fake_update_job)
+
+    task = await CronService().trigger_job("job-1")
+
+    assert task is not None
+    assert created["owner_user_id"] == "owner-7"
+    assert created["source"] == "cron"
+    assert created["cron_job_id"] == "job-1"
+
+
+def test_task_service_forwards_owner_scope_to_repo(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, Any] = {}
+
+    class _FakeRepo:
+        def close(self) -> None:
+            return None
+
+        def get(self, task_id: str, owner_user_id: str | None = None) -> dict[str, Any]:
+            seen["get"] = (task_id, owner_user_id)
+            return {"id": task_id}
+
+        def update(self, task_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any]:
+            seen["update"] = (task_id, owner_user_id, fields)
+            return {"id": task_id, **fields}
+
+        def delete(self, task_id: str, owner_user_id: str | None = None) -> bool:
+            seen["delete"] = (task_id, owner_user_id)
+            return True
+
+        def bulk_delete(self, ids: list[str], owner_user_id: str | None = None) -> int:
+            seen["bulk_delete"] = (ids, owner_user_id)
+            return len(ids)
+
+        def bulk_update_status(self, ids: list[str], status: str, owner_user_id: str | None = None) -> int:
+            seen["bulk_status"] = (ids, status, owner_user_id)
+            return len(ids)
+
+    monkeypatch.setattr(task_service, "_repo", lambda: _FakeRepo())
+
+    task_service.get_task("t-1", owner_user_id="user-1")
+    task_service.update_task("t-2", owner_user_id="user-1", title="new")
+    task_service.delete_task("t-3", owner_user_id="user-1")
+    task_service.bulk_delete_tasks(["t-4"], owner_user_id="user-1")
+    task_service.bulk_update_task_status(["t-5"], "completed", owner_user_id="user-1")
+
+    assert seen["get"] == ("t-1", "user-1")
+    assert seen["update"] == ("t-2", "user-1", {"title": "new"})
+    assert seen["delete"] == ("t-3", "user-1")
+    assert seen["bulk_delete"] == (["t-4"], "user-1")
+    assert seen["bulk_status"] == (["t-5"], "completed", "user-1")
+
+
+def test_cron_job_service_forwards_owner_scope_to_repo(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, Any] = {}
+
+    class _FakeRepo:
+        def close(self) -> None:
+            return None
+
+        def get(self, job_id: str, owner_user_id: str | None = None) -> dict[str, Any]:
+            seen["get"] = (job_id, owner_user_id)
+            return {"id": job_id}
+
+        def update(self, job_id: str, owner_user_id: str | None = None, **fields: Any) -> dict[str, Any]:
+            seen["update"] = (job_id, owner_user_id, fields)
+            return {"id": job_id, **fields}
+
+        def delete(self, job_id: str, owner_user_id: str | None = None) -> bool:
+            seen["delete"] = (job_id, owner_user_id)
+            return True
+
+    monkeypatch.setattr(cron_job_service, "_repo", lambda: _FakeRepo())
+
+    cron_job_service.get_cron_job("job-1", owner_user_id="user-1")
+    cron_job_service.update_cron_job("job-2", owner_user_id="user-1", description="desc")
+    cron_job_service.delete_cron_job("job-3", owner_user_id="user-1")
+
+    assert seen["get"] == ("job-1", "user-1")
+    assert seen["update"] == ("job-2", "user-1", {"description": "desc"})
+    assert seen["delete"] == ("job-3", "user-1")

--- a/tests/Fix/test_panel_task_owner_contract.py
+++ b/tests/Fix/test_panel_task_owner_contract.py
@@ -87,7 +87,7 @@ async def test_cron_trigger_copies_job_owner_to_created_task(monkeypatch: pytest
             "id": job_id,
             "enabled": 1,
             "owner_user_id": "owner-7",
-            "task_template": "{\"title\": \"From cron\"}",
+            "task_template": '{"title": "From cron"}',
         }
 
     created: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- align panel task and cron mutation paths so every panel write path carries `owner_user_id`
- make task/cron services and Supabase repos owner-honest for get/update/delete/bulk operations
- preserve ownership when manual cron triggers create panel tasks

## Proof
- `uv run pytest tests/Fix/test_panel_task_owner_contract.py tests/Fix/test_panel_auth_shell_coherence.py -q`
- `cd frontend/app && npm run build`
- `python3 -m py_compile backend/web/routers/panel.py backend/web/services/task_service.py backend/web/services/cron_job_service.py backend/web/services/cron_service.py storage/providers/supabase/panel_task_repo.py storage/providers/supabase/cron_job_repo.py tests/Fix/test_panel_task_owner_contract.py`

## Scope
- panel/task wiring only
- no display/streaming changes
- no runtime/provider/checkpointer/supabase_factory/lifespan changes

## Residual Risk
- bulk Supabase owner filtering currently has forwarding/unit-style proof plus code review, not a real Supabase integration test
- this PR should be reviewed as owner-contract alignment, not as end-to-end tenancy proof across every storage path
