### PR TITLE
fix: align thread launch config contract

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -37,6 +37,8 @@ from backend.web.services.streaming_service import (
     observe_thread_events,
 )
 from backend.web.services.thread_launch_config_service import (
+    build_existing_launch_config,
+    build_new_launch_config,
     resolve_default_config,
     save_last_confirmed_config,
     save_last_successful_config,
@@ -597,26 +599,18 @@ def _create_owned_thread(
         )
 
     if selected_lease_id and owned_lease is not None:
-        successful_config = {
-            "create_mode": "existing",
-            "provider_config": sandbox_type,
-            "recipe": owned_lease.get("recipe"),
-            "lease_id": owned_lease["lease_id"],
-            "model": payload.model,
-            "workspace": app.state.thread_cwd.get(new_thread_id),
-        }
+        successful_config = build_existing_launch_config(
+            lease=owned_lease,
+            model=payload.model,
+            workspace=app.state.thread_cwd.get(new_thread_id),
+        )
     else:
-        successful_config = {
-            "create_mode": "new",
-            "provider_config": sandbox_type,
-            "recipe": normalize_recipe_snapshot(
-                provider_type_from_name(sandbox_type),
-                payload.recipe.model_dump() if payload.recipe else None,
-            ),
-            "lease_id": None,
-            "model": payload.model,
-            "workspace": app.state.thread_cwd.get(new_thread_id) or payload.cwd,
-        }
+        successful_config = build_new_launch_config(
+            provider_config=sandbox_type,
+            recipe=payload.recipe.model_dump() if payload.recipe else None,
+            model=payload.model,
+            workspace=app.state.thread_cwd.get(new_thread_id) or payload.cwd,
+        )
     save_last_successful_config(app, owner_user_id, agent_member_id, successful_config)
 
     return {

--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from backend.web.services import sandbox_service
 from backend.web.services.library_service import list_library
-from sandbox.recipes import provider_type_from_name
+from sandbox.recipes import normalize_recipe_snapshot, provider_type_from_name
 
 
 def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -20,20 +20,49 @@ def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def save_last_confirmed_config(app: Any, owner_user_id: str, member_id: str, payload: dict[str, Any]) -> None:
-    app.state.thread_launch_pref_repo.save_confirmed(
-        owner_user_id,
-        member_id,
-        normalize_launch_config_payload(payload),
+def build_existing_launch_config(
+    *,
+    lease: dict[str, Any],
+    model: str | None,
+    workspace: str | None,
+) -> dict[str, Any]:
+    return normalize_launch_config_payload(
+        {
+            "create_mode": "existing",
+            "provider_config": lease.get("provider_name"),
+            "recipe": lease.get("recipe"),
+            "lease_id": lease.get("lease_id"),
+            "model": model,
+            "workspace": workspace,
+        }
     )
+
+
+def build_new_launch_config(
+    *,
+    provider_config: str,
+    recipe: dict[str, Any] | None,
+    model: str | None,
+    workspace: str | None,
+) -> dict[str, Any]:
+    return normalize_launch_config_payload(
+        {
+            "create_mode": "new",
+            "provider_config": provider_config,
+            "recipe": normalize_recipe_snapshot(provider_type_from_name(provider_config), recipe),
+            "lease_id": None,
+            "model": model,
+            "workspace": workspace,
+        }
+    )
+
+
+def save_last_confirmed_config(app: Any, owner_user_id: str, member_id: str, payload: dict[str, Any]) -> None:
+    _save_launch_config(app.state.thread_launch_pref_repo.save_confirmed, owner_user_id, member_id, payload)
 
 
 def save_last_successful_config(app: Any, owner_user_id: str, member_id: str, payload: dict[str, Any]) -> None:
-    app.state.thread_launch_pref_repo.save_successful(
-        owner_user_id,
-        member_id,
-        normalize_launch_config_payload(payload),
-    )
+    _save_launch_config(app.state.thread_launch_pref_repo.save_successful, owner_user_id, member_id, payload)
 
 
 def resolve_default_config(app: Any, owner_user_id: str, member_id: str) -> dict[str, Any]:
@@ -117,6 +146,14 @@ def _validate_saved_config(
         "model": config.get("model"),
         "workspace": config.get("workspace"),
     }
+
+
+def _save_launch_config(save_fn: Any, owner_user_id: str, member_id: str, payload: dict[str, Any]) -> None:
+    save_fn(
+        owner_user_id,
+        member_id,
+        normalize_launch_config_payload(payload),
+    )
 
 
 def _derive_default_config(

--- a/docs/superpowers/plans/2026-04-06-thread-launch-config-contract-alignment.md
+++ b/docs/superpowers/plans/2026-04-06-thread-launch-config-contract-alignment.md
@@ -1,0 +1,125 @@
+# Thread Launch Config Contract Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make thread launch config a single owned contract in `thread_launch_config_service.py`, and prove it with focused tests.
+
+**Architecture:** Extract the successful launch-config payload shape behind explicit service helpers, keep router branch selection local, and verify that persisted confirmed/successful configs still normalize to the same contract.
+
+**Tech Stack:** FastAPI, pytest, plain service helpers
+
+---
+
+### Task 1: Write focused launch-config regressions
+
+**Files:**
+- Create: `tests/Fix/test_thread_launch_config_contract.py`
+- Read: `backend/web/services/thread_launch_config_service.py`
+- Read: `backend/web/routers/threads.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_save_last_confirmed_config_normalizes_payload():
+    ...
+
+def test_build_existing_launch_config_uses_canonical_shape():
+    ...
+
+def test_build_new_launch_config_normalizes_recipe_snapshot():
+    ...
+
+@pytest.mark.asyncio
+async def test_create_thread_persists_existing_lease_successful_config():
+    ...
+
+@pytest.mark.asyncio
+async def test_create_thread_persists_new_launch_successful_config():
+    ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/Fix/test_thread_launch_config_contract.py -q`
+Expected: FAIL because the helper builders do not exist yet and the router still owns the successful-config dict shape.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/Fix/test_thread_launch_config_contract.py
+git commit -m "test: cover thread launch config contract"
+```
+
+### Task 2: Move successful payload construction into the service
+
+**Files:**
+- Modify: `backend/web/services/thread_launch_config_service.py`
+- Modify: `backend/web/routers/threads.py`
+
+- [ ] **Step 1: Add explicit builder helpers in the service**
+
+```python
+def build_existing_launch_config(*, provider_config: str, lease: dict[str, Any], model: str | None, workspace: str | None) -> dict[str, Any]:
+    ...
+
+def build_new_launch_config(*, provider_config: str, recipe: dict[str, Any] | None, model: str | None, workspace: str | None) -> dict[str, Any]:
+    ...
+```
+
+- [ ] **Step 2: Deduplicate the two save functions behind one tiny internal helper**
+
+```python
+def _save_launch_config(...):
+    ...
+```
+
+- [ ] **Step 3: Replace router hand-built `successful_config` dicts with service helper calls**
+
+```python
+successful_config = build_existing_launch_config(...)
+successful_config = build_new_launch_config(...)
+```
+
+- [ ] **Step 4: Run focused tests to verify green**
+
+Run: `uv run pytest tests/Fix/test_thread_launch_config_contract.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the service/router alignment**
+
+```bash
+git add backend/web/services/thread_launch_config_service.py backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py
+git commit -m "fix: align thread launch config contract"
+```
+
+### Task 3: Final verification and PR prep
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-06-thread-launch-config-contract-design.md`
+- Modify: `docs/superpowers/plans/2026-04-06-thread-launch-config-contract-alignment.md`
+
+- [ ] **Step 1: Run branch proof**
+
+Run: `uv run pytest tests/Fix/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q`
+Expected: PASS
+
+Run: `python3 -m py_compile backend/web/services/thread_launch_config_service.py backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py`
+Expected: exit 0
+
+Run: `cd frontend/app && npm run build`
+Expected: PASS
+
+- [ ] **Step 2: Update docs if implementation exposed any narrower stopline**
+
+Keep the stopline explicit:
+
+- launch-config contract only
+- no thread-create policy rewrite
+- no monitor/resource spillover
+
+- [ ] **Step 3: Commit docs and verification-ready state**
+
+```bash
+git add docs/superpowers/specs/2026-04-06-thread-launch-config-contract-design.md docs/superpowers/plans/2026-04-06-thread-launch-config-contract-alignment.md
+git commit -m "docs: capture thread launch config seam"
+```

--- a/docs/superpowers/specs/2026-04-06-thread-launch-config-contract-design.md
+++ b/docs/superpowers/specs/2026-04-06-thread-launch-config-contract-design.md
@@ -1,0 +1,134 @@
+# Thread Launch Config Contract Design
+
+**Date:** 2026-04-06
+**Branch:** `code-killer-phase-3`
+
+## Goal
+
+Tighten and simplify the launch-config contract that drives thread defaults and persisted "last confirmed / last successful" state.
+
+## Scope
+
+This seam is limited to:
+
+- `backend/web/services/thread_launch_config_service.py`
+- `backend/web/routers/threads.py`
+- focused tests that cover launch-config save/build behavior
+
+This seam explicitly does **not** cover:
+
+- display/history/SSE
+- monitor/resource contracts
+- runtime/provider/checkpointer/lifespan
+- panel/task wiring
+- broader thread-create behavior changes
+
+## Problem
+
+The launch-config contract is semantically one thing, but it currently lives in three loosely coupled shapes:
+
+1. `save_default_thread_config()` posts a payload and persists it through `save_last_confirmed_config()`
+2. `create_thread()` hand-builds a `successful_config` dict in two branches
+3. `resolve_default_config()` later validates and derives defaults against the same shape
+
+That creates two risks:
+
+- launch-config shape is easy to drift because the router still hand-builds the "successful" dict
+- the service that owns normalization/validation has almost no direct tests, so the product path depends on shape conventions more than explicit proof
+
+## Chosen Approach
+
+Use `thread_launch_config_service.py` as the single contract owner for persisted launch-config payloads.
+
+Concretely:
+
+- keep `normalize_launch_config_payload()` as the canonical persisted shape
+- add narrow builder helpers for:
+  - successful config from an existing lease
+  - successful config from a new sandbox launch
+- deduplicate the two save functions behind one tiny internal save helper
+- change `threads.py` to ask the service for the successful-config payload instead of hand-building it inline
+
+This keeps the seam honest:
+
+- the router stops owning launch-config shape
+- the service owns both normalization and successful-payload construction
+- no generic abstraction is introduced
+
+## Alternatives Considered
+
+### 1. Leave router dicts as-is and only add tests
+
+Rejected.
+
+That improves proof but leaves the contract duplicated across router and service.
+
+### 2. Introduce a generic launch-config object/class
+
+Rejected.
+
+This is too much machinery for a narrow shape-normalization seam.
+
+### 3. Recommended: explicit builder helpers inside the service
+
+Accepted.
+
+It is the smallest change that shortens the contract boundary without hiding semantics.
+
+## Intended Code Shape
+
+### Service layer owns the launch-config shape
+
+`thread_launch_config_service.py` should expose:
+
+- `normalize_launch_config_payload(payload)`
+- `build_existing_launch_config(...)`
+- `build_new_launch_config(...)`
+- `save_last_confirmed_config(...)`
+- `save_last_successful_config(...)`
+- `resolve_default_config(...)`
+
+The save functions remain thin, but no longer duplicate the repo write shape internally.
+
+### Router stops hand-building successful payloads
+
+`threads.py` should call the service helpers:
+
+- existing lease branch → `build_existing_launch_config(...)`
+- new thread branch → `build_new_launch_config(...)`
+
+The router still chooses which branch applies. The service owns the resulting payload shape.
+
+## Testing Strategy
+
+This seam needs direct proof because the current repo barely tests it.
+
+### Focused tests
+
+Add a new focused test file that proves:
+
+- `save_last_confirmed_config()` persists normalized shape
+- `build_existing_launch_config()` and `build_new_launch_config()` produce canonical payloads
+- `create_thread()` persists the same canonical successful payload shape for:
+  - reused existing lease
+  - new sandbox launch
+
+### Verification
+
+Minimum branch proof:
+
+- focused launch-config pytest file
+- existing `tests/Integration/test_threads_router.py`
+- `frontend/app npm run build`
+- `python3 -m py_compile` on touched backend files
+
+## Stopline
+
+This PR stops at launch-config contract ownership and proof.
+
+It must **not** expand into:
+
+- changing thread-create business rules
+- redesigning default-config product behavior
+- threading new settings/workspace semantics through the whole app
+- resource/monitor cleanup

--- a/tests/Fix/test_thread_launch_config_contract.py
+++ b/tests/Fix/test_thread_launch_config_contract.py
@@ -50,6 +50,13 @@ class _FakeThreadRepo:
     def create(self, **kwargs):
         self.rows[kwargs["thread_id"]] = dict(kwargs)
 
+    def list_by_member(self, member_id: str):
+        return [
+            {"id": thread_id, **row}
+            for thread_id, row in self.rows.items()
+            if row["member_id"] == member_id
+        ]
+
 
 class _FakeThreadLaunchPrefRepo:
     def __init__(self) -> None:
@@ -78,6 +85,17 @@ def _make_threads_app():
 def _require_thread_result(result: dict[str, object] | threads_router.JSONResponse) -> dict[str, object]:
     assert not isinstance(result, threads_router.JSONResponse)
     return result
+
+
+def _recipe_library_entry(provider_type: str) -> dict[str, object]:
+    recipe = default_recipe_snapshot(provider_type)
+    return {
+        **recipe,
+        "type": "recipe",
+        "available": True,
+        "created_at": 0,
+        "updated_at": 0,
+    }
 
 
 def test_save_last_confirmed_config_normalizes_payload() -> None:
@@ -162,6 +180,136 @@ def test_build_new_launch_config_normalizes_recipe_snapshot() -> None:
         "lease_id": None,
         "model": "gpt-5.4-mini",
         "workspace": "/tmp/custom",
+    }
+
+
+def test_resolve_default_config_prefers_last_successful_over_last_confirmed() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_launch_pref_repo=SimpleNamespace(
+                get=lambda _owner_user_id, _member_id: {
+                    "last_successful": {
+                        "create_mode": "existing",
+                        "provider_config": "local",
+                        "recipe": {"id": "stale"},
+                        "lease_id": "lease-1",
+                        "model": "gpt-5.4",
+                        "workspace": "/workspace/stale",
+                    },
+                    "last_confirmed": {
+                        "create_mode": "new",
+                        "provider_config": "local",
+                        "recipe": default_recipe_snapshot("local"),
+                        "lease_id": None,
+                        "model": "gpt-4.1",
+                        "workspace": "/tmp/draft",
+                    },
+                }
+            ),
+            thread_repo=_FakeThreadRepo(),
+            member_repo=_FakeMemberRepo(),
+            recipe_repo=object(),
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "list_user_leases",
+            return_value=[
+                {
+                    "lease_id": "lease-1",
+                    "provider_name": "local",
+                    "recipe": default_recipe_snapshot("local"),
+                    "cwd": "/workspace/reused",
+                    "thread_ids": [],
+                }
+            ],
+        ),
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "available_sandbox_types",
+            return_value=[{"name": "local", "available": True}],
+        ),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
+    ):
+        result = thread_launch_config_service.resolve_default_config(app, "owner-1", "member-1")
+
+    assert result == {
+        "source": "last_successful",
+        "config": {
+            "create_mode": "existing",
+            "provider_config": "local",
+            "recipe": default_recipe_snapshot("local"),
+            "lease_id": "lease-1",
+            "model": "gpt-5.4",
+            "workspace": "/workspace/reused",
+        },
+    }
+
+
+def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_launch_pref_repo=SimpleNamespace(
+                get=lambda _owner_user_id, _member_id: {
+                    "last_successful": {
+                        "create_mode": "existing",
+                        "provider_config": "local",
+                        "recipe": None,
+                        "lease_id": "missing-lease",
+                        "model": "gpt-5.4",
+                        "workspace": "/workspace/missing",
+                    },
+                    "last_confirmed": {
+                        "create_mode": "new",
+                        "provider_config": "local",
+                        "recipe": default_recipe_snapshot("local"),
+                        "lease_id": None,
+                        "model": "gpt-4.1",
+                        "workspace": "/tmp/draft",
+                    },
+                }
+            ),
+            thread_repo=_FakeThreadRepo(),
+            member_repo=_FakeMemberRepo(),
+            recipe_repo=object(),
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "list_user_leases",
+            return_value=[],
+        ),
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "available_sandbox_types",
+            return_value=[{"name": "local", "available": True}],
+        ),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
+    ):
+        result = thread_launch_config_service.resolve_default_config(app, "owner-1", "member-1")
+
+    assert result == {
+        "source": "last_confirmed",
+        "config": {
+            "create_mode": "new",
+            "provider_config": "local",
+            "recipe": default_recipe_snapshot("local"),
+            "lease_id": None,
+            "model": "gpt-4.1",
+            "workspace": "/tmp/draft",
+        },
     }
 
 

--- a/tests/Fix/test_thread_launch_config_contract.py
+++ b/tests/Fix/test_thread_launch_config_contract.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.web.models.requests import CreateThreadRequest
+from backend.web.routers import threads as threads_router
+from backend.web.services import thread_launch_config_service
+from sandbox.recipes import default_recipe_snapshot, normalize_recipe_snapshot
+from storage.contracts import MemberRow, MemberType
+
+
+class _FakeMemberRepo:
+    def __init__(self) -> None:
+        self._members = {
+            "member-1": MemberRow(
+                id="member-1",
+                name="Toad",
+                type=MemberType.MYCEL_AGENT,
+                owner_user_id="owner-1",
+                created_at=1.0,
+            )
+        }
+        self._seq = {"member-1": 0}
+
+    def get_by_id(self, member_id: str):
+        return self._members.get(member_id)
+
+    def increment_entity_seq(self, member_id: str) -> int:
+        self._seq[member_id] += 1
+        return self._seq[member_id]
+
+
+class _FakeThreadRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict] = {}
+
+    def get_main_thread(self, member_id: str):
+        for row in self.rows.values():
+            if row["member_id"] == member_id and row["is_main"]:
+                return {"id": row["thread_id"], **row}
+        return None
+
+    def get_next_branch_index(self, member_id: str) -> int:
+        indices = [row["branch_index"] for row in self.rows.values() if row["member_id"] == member_id]
+        return max(indices, default=0) + 1
+
+    def create(self, **kwargs):
+        self.rows[kwargs["thread_id"]] = dict(kwargs)
+
+
+class _FakeThreadLaunchPrefRepo:
+    def __init__(self) -> None:
+        self.confirmed: list[tuple[str, str, dict[str, object]]] = []
+        self.successful: list[tuple[str, str, dict[str, object]]] = []
+
+    def save_confirmed(self, owner_user_id: str, member_id: str, config: dict[str, object]) -> None:
+        self.confirmed.append((owner_user_id, member_id, config))
+
+    def save_successful(self, owner_user_id: str, member_id: str, config: dict[str, object]) -> None:
+        self.successful.append((owner_user_id, member_id, config))
+
+
+def _make_threads_app():
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            member_repo=_FakeMemberRepo(),
+            thread_repo=_FakeThreadRepo(),
+            thread_launch_pref_repo=_FakeThreadLaunchPrefRepo(),
+            thread_sandbox={},
+            thread_cwd={},
+        )
+    )
+
+
+def _require_thread_result(result: dict[str, object] | threads_router.JSONResponse) -> dict[str, object]:
+    assert not isinstance(result, threads_router.JSONResponse)
+    return result
+
+
+def test_save_last_confirmed_config_normalizes_payload() -> None:
+    app = _make_threads_app()
+
+    thread_launch_config_service.save_last_confirmed_config(
+        app,
+        "owner-1",
+        "member-1",
+        {
+            "create_mode": "wat",
+            "provider_config": "  local  ",
+            "recipe": "nope",
+            "lease_id": "  ",
+            "model": "  gpt-5.4-mini  ",
+            "workspace": "  /tmp/demo  ",
+        },
+    )
+
+    assert app.state.thread_launch_pref_repo.confirmed == [
+        (
+            "owner-1",
+            "member-1",
+            {
+                "create_mode": "new",
+                "provider_config": "local",
+                "recipe": None,
+                "lease_id": None,
+                "model": "gpt-5.4-mini",
+                "workspace": "/tmp/demo",
+            },
+        )
+    ]
+
+
+def test_build_existing_launch_config_uses_canonical_shape() -> None:
+    config = thread_launch_config_service.build_existing_launch_config(
+        lease={
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "recipe": {"id": "daytona:recipe-1"},
+        },
+        model="gpt-5.4",
+        workspace="/workspace/reused",
+    )
+
+    assert config == {
+        "create_mode": "existing",
+        "provider_config": "daytona_selfhost",
+        "recipe": {"id": "daytona:recipe-1"},
+        "lease_id": "lease-1",
+        "model": "gpt-5.4",
+        "workspace": "/workspace/reused",
+    }
+
+
+def test_build_new_launch_config_normalizes_recipe_snapshot() -> None:
+    config = thread_launch_config_service.build_new_launch_config(
+        provider_config="local",
+        recipe={
+            "id": "local:custom",
+            "name": "Custom Local",
+            "provider_type": "local",
+            "features": {"lark_cli": True},
+        },
+        model="gpt-5.4-mini",
+        workspace="/tmp/custom",
+    )
+
+    assert config == {
+        "create_mode": "new",
+        "provider_config": "local",
+        "recipe": normalize_recipe_snapshot(
+            "local",
+            {
+                "id": "local:custom",
+                "name": "Custom Local",
+                "provider_type": "local",
+                "features": {"lark_cli": True},
+            },
+        ),
+        "lease_id": None,
+        "model": "gpt-5.4-mini",
+        "workspace": "/tmp/custom",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_thread_persists_existing_lease_successful_config() -> None:
+    app = _make_threads_app()
+    payload = CreateThreadRequest.model_validate(
+        {
+            "member_id": "member-1",
+            "lease_id": "lease-1",
+            "model": "gpt-5.4",
+            "cwd": "/workspace/requested",
+        }
+    )
+
+    with (
+        patch.object(threads_router, "_validate_sandbox_provider_gate", return_value=None),
+        patch.object(threads_router, "_validate_mount_capability_gate", AsyncMock(return_value=None)),
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(
+            threads_router.sandbox_service,
+            "list_user_leases",
+            return_value=[
+                {
+                    "lease_id": "lease-1",
+                    "provider_name": "daytona_selfhost",
+                    "recipe": {"id": "daytona:recipe-1"},
+                }
+            ],
+        ),
+        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
+        patch.object(threads_router, "save_last_successful_config", return_value=None) as save_successful,
+    ):
+        _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    save_successful.assert_called_once_with(
+        app,
+        "owner-1",
+        "member-1",
+        {
+            "create_mode": "existing",
+            "provider_config": "daytona_selfhost",
+            "recipe": {"id": "daytona:recipe-1"},
+            "lease_id": "lease-1",
+            "model": "gpt-5.4",
+            "workspace": "/workspace/reused",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_thread_persists_new_launch_successful_config() -> None:
+    app = _make_threads_app()
+    payload = CreateThreadRequest.model_validate(
+        {
+            "member_id": "member-1",
+            "model": "gpt-5.4-mini",
+            "cwd": "/tmp/fresh-local-thread",
+        }
+    )
+
+    with (
+        patch.object(threads_router, "_validate_sandbox_provider_gate", return_value=None),
+        patch.object(threads_router, "_validate_mount_capability_gate", AsyncMock(return_value=None)),
+        patch.object(threads_router, "_create_thread_sandbox_resources", return_value=None),
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", return_value=None) as save_successful,
+    ):
+        result = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    save_successful.assert_called_once_with(
+        app,
+        "owner-1",
+        "member-1",
+        {
+            "create_mode": "new",
+            "provider_config": "local",
+            "recipe": default_recipe_snapshot("local"),
+            "lease_id": None,
+            "model": "gpt-5.4-mini",
+            "workspace": "/tmp/fresh-local-thread",
+        },
+    )
+    assert app.state.thread_cwd[result["thread_id"]] == "/tmp/fresh-local-thread"

--- a/tests/Fix/test_thread_launch_config_contract.py
+++ b/tests/Fix/test_thread_launch_config_contract.py
@@ -51,11 +51,7 @@ class _FakeThreadRepo:
         self.rows[kwargs["thread_id"]] = dict(kwargs)
 
     def list_by_member(self, member_id: str):
-        return [
-            {"id": thread_id, **row}
-            for thread_id, row in self.rows.items()
-            if row["member_id"] == member_id
-        ]
+        return [{"id": thread_id, **row} for thread_id, row in self.rows.items() if row["member_id"] == member_id]
 
 
 class _FakeThreadLaunchPrefRepo:


### PR DESCRIPTION
## Summary
- move successful launch-config payload construction out of threads.py and into backend/web/services/thread_launch_config_service.py
- add focused regression coverage for confirmed and successful launch-config shape, plus default-config precedence and validation on the read side
- capture the phase-3 seam spec and plan, and keep the stopline explicit: no provider gate, recipe normalization, or thread-create rule rewrite

## Test Plan
- uv run pytest tests/Fix/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q
- python3 -m py_compile backend/web/services/thread_launch_config_service.py backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py
- cd frontend/app && npm run build

## Scope Notes
- this PR only tightens the launch-config contract for last_confirmed and last_successful
- router branch selection for existing vs new thread creation is unchanged
- request-time provider gating and recipe normalization behavior are unchanged
