### PR TITLE
fix: align panel member auth shell

### DIFF
--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -27,6 +27,15 @@ from backend.web.services import cron_job_service, library_service, member_servi
 router = APIRouter(prefix="/api/panel", tags=["panel"])
 
 
+def _get_owned_member_or_404(member_id: str, user_id: str) -> dict[str, Any]:
+    item = member_service.get_member(member_id)
+    if not item:
+        raise HTTPException(404, "Member not found")
+    if item.get("owner_user_id") != user_id:
+        raise HTTPException(403, "Forbidden")
+    return item
+
+
 # ── Members ──
 
 
@@ -45,12 +54,7 @@ async def get_member(
     member_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    item = await asyncio.to_thread(member_service.get_member, member_id)
-    if not item:
-        raise HTTPException(404, "Member not found")
-    if item.get("owner_user_id") != user_id:
-        raise HTTPException(403, "Forbidden")
-    return item
+    return await asyncio.to_thread(_get_owned_member_or_404, member_id, user_id)
 
 
 @router.post("/members")
@@ -79,11 +83,7 @@ async def update_member(
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
     member_repo = getattr(request.app.state, "member_repo", None)
-    existing = await asyncio.to_thread(member_service.get_member, member_id)
-    if not existing:
-        raise HTTPException(404, "Member not found")
-    if existing.get("owner_user_id") != user_id:
-        raise HTTPException(403, "Forbidden")
+    await asyncio.to_thread(_get_owned_member_or_404, member_id, user_id)
     item = await asyncio.to_thread(
         member_service.update_member,
         member_id,
@@ -102,11 +102,7 @@ async def update_member_config(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    existing = await asyncio.to_thread(member_service.get_member, member_id)
-    if not existing:
-        raise HTTPException(404, "Member not found")
-    if existing.get("owner_user_id") != user_id:
-        raise HTTPException(403, "Forbidden")
+    await asyncio.to_thread(_get_owned_member_or_404, member_id, user_id)
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     item = await asyncio.to_thread(
         member_service.update_member_config,
@@ -128,11 +124,7 @@ async def publish_member(
 ) -> dict[str, Any]:
     if member_id == "__leon__":
         raise HTTPException(403, "Cannot publish builtin member")
-    existing = await asyncio.to_thread(member_service.get_member, member_id)
-    if not existing:
-        raise HTTPException(404, "Member not found")
-    if existing.get("owner_user_id") != user_id:
-        raise HTTPException(403, "Forbidden")
+    await asyncio.to_thread(_get_owned_member_or_404, member_id, user_id)
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     item = await asyncio.to_thread(
         member_service.publish_member,
@@ -153,11 +145,7 @@ async def delete_member(
 ) -> dict[str, Any]:
     if member_id == "__leon__":
         raise HTTPException(403, "Cannot delete builtin member")
-    existing = await asyncio.to_thread(member_service.get_member, member_id)
-    if not existing:
-        raise HTTPException(404, "Member not found")
-    if existing.get("owner_user_id") != user_id:
-        raise HTTPException(403, "Forbidden")
+    await asyncio.to_thread(_get_owned_member_or_404, member_id, user_id)
     member_repo = getattr(request.app.state, "member_repo", None)
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     ok = await asyncio.to_thread(

--- a/docs/superpowers/plans/2026-04-07-panel-member-auth-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-panel-member-auth-shell-plan.md
@@ -1,0 +1,119 @@
+# Panel Member Auth Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make panel member ownership checks a single router-owned shell while preserving existing 404, 403, and builtin guard behavior.
+
+**Architecture:** Keep auth semantics in `backend/web/routers/panel.py`, extract only the repeated member lookup/owner gate, and prove unchanged behavior with focused route tests. This is a router seam, not a service or storage rewrite.
+
+**Tech Stack:** FastAPI, pytest, plain router helpers
+
+---
+
+### Task 1: Write focused panel member auth regressions
+
+**Files:**
+- Modify: `tests/Fix/test_panel_auth_shell_coherence.py`
+- Read: `backend/web/routers/panel.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_get_member_route_rejects_wrong_owner():
+    ...
+
+
+@pytest.mark.asyncio
+async def test_update_member_route_returns_404_for_missing_member():
+    ...
+
+
+@pytest.mark.asyncio
+async def test_delete_member_route_keeps_builtin_guard_before_owner_lookup():
+    ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/Fix/test_panel_auth_shell_coherence.py -q`
+Expected: FAIL because the helper-backed member shell does not exist yet, so the new focused expectations are not anchored.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/Fix/test_panel_auth_shell_coherence.py
+git commit -m "test: cover panel member auth shell"
+```
+
+### Task 2: Collapse repeated member ownership checks into one router helper
+
+**Files:**
+- Modify: `backend/web/routers/panel.py`
+- Modify: `tests/Fix/test_panel_auth_shell_coherence.py`
+
+- [ ] **Step 1: Add the minimal router helper**
+
+```python
+def _get_owned_member_or_404(member_id: str, user_id: str) -> dict[str, Any]:
+    item = member_service.get_member(member_id)
+    if not item:
+        raise HTTPException(404, "Member not found")
+    if item.get("owner_user_id") != user_id:
+        raise HTTPException(403, "Forbidden")
+    return item
+```
+
+- [ ] **Step 2: Replace repeated member lookup / owner checks in member routes**
+
+```python
+existing = await asyncio.to_thread(_get_owned_member_or_404, member_id, user_id)
+```
+
+- [ ] **Step 3: Keep builtin route guards explicit**
+
+```python
+if member_id == "__leon__":
+    raise HTTPException(403, "Cannot publish builtin member")
+```
+
+- [ ] **Step 4: Run focused tests to verify green**
+
+Run: `uv run pytest tests/Fix/test_panel_auth_shell_coherence.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the router auth-shell alignment**
+
+```bash
+git add backend/web/routers/panel.py tests/Fix/test_panel_auth_shell_coherence.py
+git commit -m "fix: align panel member auth shell"
+```
+
+### Task 3: Final verification and PR prep
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-07-panel-member-auth-shell-design.md`
+- Modify: `docs/superpowers/plans/2026-04-07-panel-member-auth-shell-plan.md`
+
+- [ ] **Step 1: Run branch proof**
+
+Run: `uv run pytest tests/Fix/test_panel_auth_shell_coherence.py tests/Fix/test_panel_task_owner_contract.py -q`
+Expected: PASS
+
+Run: `python3 -m py_compile backend/web/routers/panel.py tests/Fix/test_panel_auth_shell_coherence.py`
+Expected: exit 0
+
+- [ ] **Step 2: Update docs if implementation exposed a narrower stopline**
+
+Keep the stopline explicit:
+
+- panel member auth shell only
+- no member service rewrite
+- no task / cron / monitor spillover
+
+- [ ] **Step 3: Commit docs and verification-ready state**
+
+```bash
+git add docs/superpowers/specs/2026-04-07-panel-member-auth-shell-design.md docs/superpowers/plans/2026-04-07-panel-member-auth-shell-plan.md
+git commit -m "docs: capture panel member auth shell seam"
+```

--- a/docs/superpowers/specs/2026-04-07-panel-member-auth-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-panel-member-auth-shell-design.md
@@ -1,0 +1,129 @@
+# Panel Member Auth Shell Design
+
+**Date:** 2026-04-07
+**Branch:** `code-killer-phase-4`
+
+## Goal
+
+Tighten the ownership/auth shell around panel member routes without changing member CRUD behavior.
+
+## Scope
+
+This seam is limited to:
+
+- `backend/web/routers/panel.py`
+- focused tests for panel member auth/404/403 behavior
+
+This seam explicitly does **not** cover:
+
+- task / cron owner contracts
+- `member_service.py` storage semantics
+- provider / runtime / monitor / resource contracts
+- builtin Leon behavior beyond preserving existing guards
+- frontend product changes
+
+## Problem
+
+`panel.py` repeats the same member ownership shell across multiple routes:
+
+1. fetch member via `member_service.get_member(member_id)`
+2. raise `404` when missing
+3. raise `403` when `owner_user_id` mismatches
+4. continue with route-specific service call
+
+That duplication is small but real. It creates two risks:
+
+- panel member routes can drift on auth/404 semantics because each one owns its own shell
+- future panel cleanup gets noisier because the router mixes route intent with repeated ownership gates
+
+## Chosen Approach
+
+Keep the shell inside `panel.py`, but make it single-owned.
+
+Concretely:
+
+- add one narrow helper that resolves a panel member and enforces the existing `404` / `403` contract
+- keep builtin guard clauses (`__leon__` publish/delete restrictions) at the route level
+- change member routes to call the helper instead of open-coding the same checks
+- add focused tests that pin missing-member, wrong-owner, and injected-repo behavior
+
+This keeps the seam honest:
+
+- no business rules move into `member_service.py`
+- no new router abstraction beyond the existing repeated shell
+- route-specific behavior stays local and visible
+
+## Alternatives Considered
+
+### 1. Leave the duplication and only add tests
+
+Rejected.
+
+That improves proof but keeps the repeated auth shell scattered across each route.
+
+### 2. Push owner checks into `member_service.py`
+
+Rejected.
+
+That would mix HTTP auth semantics with service/storage logic and widen the seam unnecessarily.
+
+### 3. Recommended: one router-local helper for member ownership checks
+
+Accepted.
+
+It is the smallest simplification that shortens the contract without hiding route-specific behavior.
+
+## Intended Code Shape
+
+### Router-local auth shell
+
+`panel.py` should own a helper along the lines of:
+
+- `_get_owned_member_or_404(member_id, user_id)`
+
+The helper should:
+
+- call `member_service.get_member(member_id)`
+- raise `HTTPException(404, "Member not found")` when absent
+- raise `HTTPException(403, "Forbidden")` when owner mismatches
+- return the member dict unchanged otherwise
+
+### Route behavior stays explicit
+
+Routes should still keep their own special cases:
+
+- `publish_member()` continues to reject `__leon__` before touching the helper
+- `delete_member()` continues to reject `__leon__` before touching the helper
+- update/config/publish/delete still perform their own service calls after the helper returns
+
+## Testing Strategy
+
+This seam only matters if behavior stays identical.
+
+### Focused tests
+
+Add focused tests that prove:
+
+- `list_members()` still uses the injected repo for owner-scoped listing
+- helper-backed member routes still raise `404` for missing members
+- helper-backed member routes still raise `403` for wrong-owner members
+- builtin publish/delete guards still fire before any ownership helper path
+
+### Verification
+
+Minimum branch proof:
+
+- focused panel auth pytest file
+- existing panel task owner pytest file
+- `python3 -m py_compile` on touched router/test files
+
+## Stopline
+
+This PR stops at panel member auth shell simplification.
+
+It must **not** expand into:
+
+- changing member CRUD storage behavior
+- changing builtin Leon policy
+- mixing in panel task / cron cleanup
+- moving HTTP ownership logic into service/repo layers

--- a/tests/Fix/test_panel_auth_shell_coherence.py
+++ b/tests/Fix/test_panel_auth_shell_coherence.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from backend.web.routers import panel as panel_router
 from backend.web.models.panel import PublishMemberRequest, UpdateMemberRequest
+from backend.web.routers import panel as panel_router
 from backend.web.services import member_service, profile_service
 from storage.contracts import MemberRow, MemberType
 

--- a/tests/Fix/test_panel_auth_shell_coherence.py
+++ b/tests/Fix/test_panel_auth_shell_coherence.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from backend.web.routers import panel as panel_router
+from backend.web.models.panel import PublishMemberRequest, UpdateMemberRequest
 from backend.web.services import member_service, profile_service
 from storage.contracts import MemberRow, MemberType
 
@@ -47,6 +49,92 @@ async def test_panel_members_uses_injected_member_repo_for_owner_scope(monkeypat
 
     assert seen == ["user-1"]
     assert result["items"] == [{"id": "agent-1", "name": "Toad", "avatar_url": "avatars/agent-1.png", "config": {}}]
+
+
+def test_owned_member_helper_returns_member_for_owner(monkeypatch: pytest.MonkeyPatch):
+    member = {"id": "agent-1", "owner_user_id": "user-1", "name": "Toad"}
+    monkeypatch.setattr(member_service, "get_member", lambda member_id: member if member_id == "agent-1" else None)
+
+    result = panel_router._get_owned_member_or_404("agent-1", "user-1")
+
+    assert result == member
+
+
+def test_owned_member_helper_raises_404_for_missing_member(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(member_service, "get_member", lambda _member_id: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        panel_router._get_owned_member_or_404("missing", "user-1")
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == "Member not found"
+
+
+def test_owned_member_helper_raises_403_for_wrong_owner(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        member_service,
+        "get_member",
+        lambda _member_id: {"id": "agent-1", "owner_user_id": "user-2"},
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        panel_router._get_owned_member_or_404("agent-1", "user-1")
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Forbidden"
+
+
+@pytest.mark.asyncio
+async def test_update_member_route_returns_404_for_missing_member(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(member_service, "get_member", lambda _member_id: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await panel_router.update_member(
+            "missing",
+            UpdateMemberRequest(name="new-name"),
+            request=SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(member_repo=SimpleNamespace()))),
+            user_id="user-1",
+        )
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == "Member not found"
+
+
+@pytest.mark.asyncio
+async def test_delete_member_route_keeps_builtin_guard_before_owner_lookup(monkeypatch: pytest.MonkeyPatch):
+    def explode(_member_id: str):
+        raise AssertionError("member lookup should not run for builtin guard")
+
+    monkeypatch.setattr(member_service, "get_member", explode)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await panel_router.delete_member(
+            "__leon__",
+            request=SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace())),
+            user_id="user-1",
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Cannot delete builtin member"
+
+
+@pytest.mark.asyncio
+async def test_publish_member_route_keeps_builtin_guard_before_owner_lookup(monkeypatch: pytest.MonkeyPatch):
+    def explode(_member_id: str):
+        raise AssertionError("member lookup should not run for builtin guard")
+
+    monkeypatch.setattr(member_service, "get_member", explode)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await panel_router.publish_member(
+            "__leon__",
+            PublishMemberRequest(),
+            request=SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace())),
+            user_id="user-1",
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Cannot publish builtin member"
 
 
 def test_profile_service_prefers_authenticated_member_over_config_defaults():


### PR DESCRIPTION
## Summary
- collapse repeated member lookup and owner checks in backend/web/routers/panel.py into one router-local auth shell helper
- add focused regression coverage for helper behavior, missing-member and wrong-owner handling, and builtin publish/delete guard ordering
- capture the phase-4 seam spec and plan, with an explicit stopline: no member service rewrite and no task, cron, or monitor spillover

## Test Plan
- uv run pytest tests/Fix/test_panel_auth_shell_coherence.py tests/Fix/test_panel_task_owner_contract.py -q
- python3 -m py_compile backend/web/routers/panel.py tests/Fix/test_panel_auth_shell_coherence.py

## Scope Notes
- this PR only tightens the panel member auth shell
- builtin Leon publish/delete guards stay route-local
- member_service and repo contracts are unchanged
