### PR TITLE
fix: align entities avatar auth shell

### DIFF
--- a/backend/web/routers/entities.py
+++ b/backend/web/routers/entities.py
@@ -90,6 +90,15 @@ def _avatar_path(member_id: str) -> Path:
     return AVATARS_DIR / f"{safe_id}.png"
 
 
+def _get_owned_avatar_member_or_404(member_id: str, current_user_id: str, member_repo: Any) -> Any:
+    member = member_repo.get_by_id(member_id)
+    if not member:
+        raise HTTPException(404, "Member not found")
+    if member_id == current_user_id or member.owner_user_id == current_user_id:
+        return member
+    raise HTTPException(403, "Not authorized")
+
+
 @members_router.put("/{member_id}/avatar")
 async def upload_avatar(
     member_id: str,
@@ -99,11 +108,7 @@ async def upload_avatar(
 ) -> dict[str, str]:
     """Upload/replace avatar image. Resizes to 256x256 PNG."""
     repo = app.state.member_repo
-    member = repo.get_by_id(member_id)
-    if not member:
-        raise HTTPException(404, "Member not found")
-    if member_id != current_user_id and member.owner_user_id != current_user_id:
-        raise HTTPException(403, "Not authorized")
+    _get_owned_avatar_member_or_404(member_id, current_user_id, repo)
     ct = file.content_type or ""
     if ct not in ALLOWED_CONTENT_TYPES:
         raise HTTPException(400, f"Unsupported image type: {ct}")
@@ -138,11 +143,7 @@ async def delete_avatar(
 ) -> dict[str, str]:
     """Delete avatar."""
     repo = app.state.member_repo
-    member = repo.get_by_id(member_id)
-    if not member:
-        raise HTTPException(404, "Member not found")
-    if member_id != current_user_id and member.owner_user_id != current_user_id:
-        raise HTTPException(403, "Not authorized")
+    _get_owned_avatar_member_or_404(member_id, current_user_id, repo)
     path = _avatar_path(member_id)
     if path.exists():
         path.unlink()

--- a/docs/superpowers/plans/2026-04-07-entities-avatar-auth-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-entities-avatar-auth-shell-plan.md
@@ -1,0 +1,122 @@
+# Entities Avatar Auth Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make avatar upload/delete ownership checks a single router-owned shell while preserving existing 404, 403, and avatar file behavior.
+
+**Architecture:** Keep authorization semantics in `backend/web/routers/entities.py`, extract only the repeated avatar target lookup/owner gate, and prove unchanged behavior with focused route tests. This is a router seam, not an avatar-processing or auth-service rewrite.
+
+**Tech Stack:** FastAPI, pytest, plain router helpers
+
+---
+
+### Task 1: Write focused avatar auth regressions
+
+**Files:**
+- Create: `tests/Fix/test_entities_avatar_auth_shell.py`
+- Read: `backend/web/routers/entities.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_avatar_member_helper_allows_self_or_owner():
+    ...
+
+
+def test_avatar_member_helper_raises_404_for_missing_member():
+    ...
+
+
+def test_avatar_member_helper_raises_403_for_unrelated_user():
+    ...
+
+
+@pytest.mark.asyncio
+async def test_delete_avatar_route_uses_auth_shell():
+    ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/Fix/test_entities_avatar_auth_shell.py -q`
+Expected: FAIL because the router-local avatar auth helper does not exist yet.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/Fix/test_entities_avatar_auth_shell.py
+git commit -m "test: cover entities avatar auth shell"
+```
+
+### Task 2: Collapse repeated avatar ownership checks into one router helper
+
+**Files:**
+- Modify: `backend/web/routers/entities.py`
+- Modify: `tests/Fix/test_entities_avatar_auth_shell.py`
+
+- [ ] **Step 1: Add the minimal router helper**
+
+```python
+def _get_owned_avatar_member_or_404(member_id: str, current_user_id: str, member_repo: Any):
+    member = member_repo.get_by_id(member_id)
+    if not member:
+        raise HTTPException(404, "Member not found")
+    if member_id == current_user_id or member.owner_user_id == current_user_id:
+        return member
+    raise HTTPException(403, "Not authorized")
+```
+
+- [ ] **Step 2: Replace repeated upload/delete auth shell with the helper**
+
+```python
+member = _get_owned_avatar_member_or_404(member_id, current_user_id, repo)
+```
+
+- [ ] **Step 3: Keep avatar-specific route logic untouched**
+
+```python
+ct = file.content_type or ""
+...
+avatar_path = process_and_save_avatar(data, member_id)
+```
+
+- [ ] **Step 4: Run focused tests to verify green**
+
+Run: `uv run pytest tests/Fix/test_entities_avatar_auth_shell.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the router auth-shell alignment**
+
+```bash
+git add backend/web/routers/entities.py tests/Fix/test_entities_avatar_auth_shell.py
+git commit -m "fix: align entities avatar auth shell"
+```
+
+### Task 3: Final verification and PR prep
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-07-entities-avatar-auth-shell-design.md`
+- Modify: `docs/superpowers/plans/2026-04-07-entities-avatar-auth-shell-plan.md`
+
+- [ ] **Step 1: Run branch proof**
+
+Run: `uv run pytest tests/Fix/test_entities_avatar_auth_shell.py tests/Fix/test_panel_auth_shell_coherence.py tests/Fix/test_panel_task_owner_contract.py tests/Fix/test_thread_launch_config_contract.py -q`
+Expected: PASS
+
+Run: `python3 -m py_compile backend/web/routers/entities.py tests/Fix/test_entities_avatar_auth_shell.py`
+Expected: exit 0
+
+- [ ] **Step 2: Update docs if implementation exposed a narrower stopline**
+
+Keep the stopline explicit:
+
+- avatar auth shell only
+- no avatar processing rewrite
+- no entity/profile/thread spillover
+
+- [ ] **Step 3: Commit docs and verification-ready state**
+
+```bash
+git add docs/superpowers/specs/2026-04-07-entities-avatar-auth-shell-design.md docs/superpowers/plans/2026-04-07-entities-avatar-auth-shell-plan.md
+git commit -m "docs: capture entities avatar auth shell seam"
+```

--- a/docs/superpowers/specs/2026-04-07-entities-avatar-auth-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-entities-avatar-auth-shell-design.md
@@ -1,0 +1,131 @@
+# Entities Avatar Auth Shell Design
+
+**Date:** 2026-04-07
+**Branch:** `code-killer-phase-5`
+
+## Goal
+
+Tighten the ownership/auth shell around avatar upload/delete routes without changing avatar processing behavior.
+
+## Scope
+
+This seam is limited to:
+
+- `backend/web/routers/entities.py`
+- focused tests for avatar auth/404/403 behavior
+
+This seam explicitly does **not** cover:
+
+- avatar image processing or resizing rules
+- public avatar reads
+- entity list/profile/agent-thread behavior
+- auth service avatar bootstrap logic
+- monitor/resource or panel/task contracts
+
+## Problem
+
+`entities.py` repeats the same member authorization shell across two avatar mutation routes:
+
+1. fetch member from `member_repo.get_by_id(member_id)`
+2. raise `404` when missing
+3. allow only the member themselves or the owning user
+4. raise `403` otherwise
+
+That duplication is small but real. It creates two risks:
+
+- upload/delete auth semantics can drift because each route owns its own copy
+- future cleanup around avatar routes has to read past repeated shell logic before reaching the route-specific file behavior
+
+## Chosen Approach
+
+Keep the auth shell inside `entities.py`, but make it single-owned.
+
+Concretely:
+
+- add one narrow helper that resolves an avatar target member and enforces the existing `404` / self-or-owner / `403` contract
+- keep avatar file handling, content-type checks, size checks, and save/delete logic exactly where they are
+- change upload/delete routes to call the helper instead of open-coding the same checks
+- add focused tests that pin missing-member, wrong-user, and owner/self success behavior
+
+This keeps the seam honest:
+
+- no business logic moves into a service/repo layer
+- no new generic auth abstraction is introduced
+- route-specific avatar behavior stays explicit and local
+
+## Alternatives Considered
+
+### 1. Leave the duplication and only add tests
+
+Rejected.
+
+That adds proof but leaves the repeated shell scattered across both routes.
+
+### 2. Push avatar auth checks into a shared service
+
+Rejected.
+
+That would widen the seam and mix HTTP authorization semantics with lower-layer behavior.
+
+### 3. Recommended: one router-local helper for avatar target authorization
+
+Accepted.
+
+It is the smallest simplification that shortens the contract while preserving route-local behavior.
+
+## Intended Code Shape
+
+### Router-local avatar auth shell
+
+`entities.py` should own a helper along the lines of:
+
+- `_get_owned_avatar_member_or_404(member_id, current_user_id, member_repo)`
+
+The helper should:
+
+- fetch the member from the repo
+- raise `HTTPException(404, "Member not found")` when absent
+- allow when `member_id == current_user_id`
+- allow when `member.owner_user_id == current_user_id`
+- raise `HTTPException(403, "Not authorized")` otherwise
+- return the member row unchanged on success
+
+### Route behavior stays explicit
+
+The routes should still keep their own local behavior:
+
+- `upload_avatar()` still validates content type, emptiness, size, and image decoding
+- `delete_avatar()` still checks file existence and clears the repo avatar field
+- `get_avatar()` remains public and unchanged
+
+## Testing Strategy
+
+This seam only matters if behavior stays identical.
+
+### Focused tests
+
+Add focused tests that prove:
+
+- the helper allows self-owned and owner-owned members
+- the helper raises `404` for missing members
+- the helper raises `403` for unrelated users
+- `upload_avatar()` and `delete_avatar()` still route through the same auth shell
+
+### Verification
+
+Minimum branch proof:
+
+- focused entities avatar auth pytest file
+- existing panel/task/thread focused tests as branch sanity
+- `python3 -m py_compile` on touched router/test files
+
+## Stopline
+
+This PR stops at entities avatar auth shell simplification.
+
+It must **not** expand into:
+
+- changing avatar processing or file formats
+- changing public avatar serving
+- changing entity/profile/thread route behavior
+- moving auth checks into service/repo layers

--- a/tests/Fix/test_entities_avatar_auth_shell.py
+++ b/tests/Fix/test_entities_avatar_auth_shell.py
@@ -103,7 +103,11 @@ async def test_upload_avatar_route_uses_auth_shell(monkeypatch: pytest.MonkeyPat
         return _member(member_id, owner_user_id="user-1")
 
     monkeypatch.setattr(entities_router, "_get_owned_avatar_member_or_404", fake_helper)
-    monkeypatch.setattr(entities_router, "process_and_save_avatar", lambda data, member_id: seen.append(("save", (data, member_id))) or f"avatars/{member_id}.png")
+    monkeypatch.setattr(
+        entities_router,
+        "process_and_save_avatar",
+        lambda data, member_id: seen.append(("save", (data, member_id))) or f"avatars/{member_id}.png",
+    )
 
     fake_repo = SimpleNamespace(
         get_by_id=lambda _member_id: (_ for _ in ()).throw(AssertionError("route should use helper, not repo lookup directly")),

--- a/tests/Fix/test_entities_avatar_auth_shell.py
+++ b/tests/Fix/test_entities_avatar_auth_shell.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import entities as entities_router
+
+
+class _FakeUploadFile:
+    def __init__(self, content: bytes, *, content_type: str) -> None:
+        self._content = content
+        self.content_type = content_type
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+def _member(member_id: str, *, owner_user_id: str | None = None, avatar: str | None = None):
+    return SimpleNamespace(
+        id=member_id,
+        owner_user_id=owner_user_id,
+        avatar=avatar,
+    )
+
+
+def test_avatar_member_helper_allows_self_or_owner():
+    member_repo = SimpleNamespace(
+        get_by_id=lambda member_id: _member(member_id, owner_user_id="user-9"),
+    )
+
+    self_member = entities_router._get_owned_avatar_member_or_404("user-1", "user-1", member_repo)
+    owner_member = entities_router._get_owned_avatar_member_or_404("agent-1", "user-9", member_repo)
+
+    assert self_member.id == "user-1"
+    assert owner_member.id == "agent-1"
+
+
+def test_avatar_member_helper_raises_404_for_missing_member():
+    member_repo = SimpleNamespace(get_by_id=lambda _member_id: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        entities_router._get_owned_avatar_member_or_404("missing", "user-1", member_repo)
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == "Member not found"
+
+
+def test_avatar_member_helper_raises_403_for_unrelated_user():
+    member_repo = SimpleNamespace(
+        get_by_id=lambda _member_id: _member("agent-1", owner_user_id="user-2"),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        entities_router._get_owned_avatar_member_or_404("agent-1", "user-1", member_repo)
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Not authorized"
+
+
+@pytest.mark.asyncio
+async def test_delete_avatar_route_uses_auth_shell(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    seen: list[tuple[str, object]] = []
+    avatar_dir = tmp_path / "avatars"
+    avatar_dir.mkdir()
+    avatar_path = avatar_dir / "agent-1.png"
+    avatar_path.write_bytes(b"png")
+    monkeypatch.setattr(entities_router, "AVATARS_DIR", avatar_dir)
+
+    def fake_helper(member_id: str, current_user_id: str, member_repo):
+        seen.append(("helper", (member_id, current_user_id)))
+        return _member(member_id, owner_user_id="user-1", avatar="avatars/agent-1.png")
+
+    monkeypatch.setattr(entities_router, "_get_owned_avatar_member_or_404", fake_helper)
+
+    fake_repo = SimpleNamespace(
+        get_by_id=lambda _member_id: (_ for _ in ()).throw(AssertionError("route should use helper, not repo lookup directly")),
+        update=lambda member_id, **fields: seen.append(("update", (member_id, fields))),
+    )
+
+    result = await entities_router.delete_avatar(
+        "agent-1",
+        current_user_id="user-1",
+        app=SimpleNamespace(state=SimpleNamespace(member_repo=fake_repo)),
+    )
+
+    assert result == {"status": "ok"}
+    assert seen == [
+        ("helper", ("agent-1", "user-1")),
+        ("update", ("agent-1", {"avatar": None, "updated_at": pytest.approx(seen[1][1][1]["updated_at"], rel=0, abs=5)})),
+    ]
+    assert not avatar_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_avatar_route_uses_auth_shell(monkeypatch: pytest.MonkeyPatch):
+    seen: list[tuple[str, object]] = []
+
+    def fake_helper(member_id: str, current_user_id: str, member_repo):
+        seen.append(("helper", (member_id, current_user_id)))
+        return _member(member_id, owner_user_id="user-1")
+
+    monkeypatch.setattr(entities_router, "_get_owned_avatar_member_or_404", fake_helper)
+    monkeypatch.setattr(entities_router, "process_and_save_avatar", lambda data, member_id: seen.append(("save", (data, member_id))) or f"avatars/{member_id}.png")
+
+    fake_repo = SimpleNamespace(
+        get_by_id=lambda _member_id: (_ for _ in ()).throw(AssertionError("route should use helper, not repo lookup directly")),
+        update=lambda member_id, **fields: seen.append(("update", (member_id, fields))),
+    )
+
+    result = await entities_router.upload_avatar(
+        "agent-1",
+        _FakeUploadFile(b"png-bytes", content_type="image/png"),
+        current_user_id="user-1",
+        app=SimpleNamespace(state=SimpleNamespace(member_repo=fake_repo)),
+    )
+
+    assert result == {"status": "ok", "avatar": "avatars/agent-1.png"}
+    assert seen[0] == ("helper", ("agent-1", "user-1"))
+    assert seen[1] == ("save", (b"png-bytes", "agent-1"))
+    assert seen[2][0] == "update"
+    assert seen[2][1][0] == "agent-1"
+    assert seen[2][1][1]["avatar"] == "avatars/agent-1.png"


### PR DESCRIPTION
## Summary
- collapse repeated avatar upload/delete member authorization checks in backend/web/routers/entities.py into one router-local auth shell helper
- add focused regression coverage for helper behavior, unauthorized access, and route-level helper usage
- capture the phase-5 seam spec and plan, with an explicit stopline: no avatar processing rewrite, no public avatar read changes, and no auth-service spillover

## Test Plan
- uv run pytest tests/Fix/test_entities_avatar_auth_shell.py tests/Fix/test_panel_auth_shell_coherence.py tests/Fix/test_panel_task_owner_contract.py tests/Fix/test_thread_launch_config_contract.py -q
- python3 -m py_compile backend/web/routers/entities.py tests/Fix/test_entities_avatar_auth_shell.py

## Scope Notes
- this PR only tightens the entities avatar auth shell
- avatar processing, validation, and public avatar serving are unchanged
- the helper stays router-local and does not move checks into service or repo layers
