### PR TITLE
fix: align threads member ownership shell

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -81,6 +81,20 @@ def _invalidate_resource_overview_cache() -> None:
     clear_resource_overview_cache()
 
 
+def _find_owned_member(app: Any, member_id: str, owner_user_id: str) -> Any | None:
+    member = app.state.member_repo.get_by_id(member_id)
+    if not member or member.owner_user_id != owner_user_id:
+        return None
+    return member
+
+
+def _require_owned_member(app: Any, member_id: str, owner_user_id: str) -> Any:
+    member = _find_owned_member(app, member_id, owner_user_id)
+    if member is None:
+        raise HTTPException(403, "Not authorized")
+    return member
+
+
 async def _prepare_attachment_message(
     thread_id: str,
     sandbox_type: str,
@@ -655,8 +669,8 @@ async def resolve_main_thread(
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any]:
     """Return the main thread for a member, or null when none exists."""
-    agent_member = app.state.member_repo.get_by_id(payload.member_id)
-    if not agent_member or agent_member.owner_user_id != user_id:
+    agent_member = _find_owned_member(app, payload.member_id, user_id)
+    if agent_member is None:
         # Return null instead of 403 — member may not exist yet (stale client state)
         # or belong to another user (harmless to reveal "no thread")
         return {"thread": None}
@@ -681,9 +695,7 @@ async def get_default_thread_config(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any]:
-    agent_member = app.state.member_repo.get_by_id(member_id)
-    if not agent_member or agent_member.owner_user_id != user_id:
-        raise HTTPException(403, "Not authorized")
+    _require_owned_member(app, member_id, user_id)
     return resolve_default_config(app, user_id, member_id)
 
 
@@ -693,9 +705,7 @@ async def save_default_thread_config(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any]:
-    agent_member = app.state.member_repo.get_by_id(payload.member_id)
-    if not agent_member or agent_member.owner_user_id != user_id:
-        raise HTTPException(403, "Not authorized")
+    _require_owned_member(app, payload.member_id, user_id)
     save_last_confirmed_config(app, user_id, payload.member_id, payload.model_dump())
     return {"ok": True}
 

--- a/docs/superpowers/plans/2026-04-07-threads-member-ownership-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-threads-member-ownership-shell-plan.md
@@ -1,0 +1,108 @@
+# Threads Member Ownership Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deduplicate the router-local member lookup and ownership shell in `threads.py` for `resolve_main_thread` and `GET/POST /default-config` without changing route semantics.
+
+**Architecture:** Keep the change inside `backend/web/routers/threads.py`. Introduce one soft lookup helper and one strict wrapper helper so `/main` can keep returning `{"thread": None}` while `/default-config` keeps returning `403 "Not authorized"`.
+
+**Tech Stack:** FastAPI, pytest, Python 3.12
+
+---
+
+### Task 1: Lock The Contract With Failing Tests
+
+**Files:**
+- Modify: `tests/Fix/test_thread_launch_config_contract.py`
+- Reference: `backend/web/routers/threads.py`
+
+- [ ] **Step 1: Add focused tests for the ownership shell**
+
+Add tests that cover:
+
+```python
+def test_find_owned_member_returns_none_for_foreign_member() -> None:
+    ...
+
+def test_require_owned_member_raises_for_foreign_member() -> None:
+    ...
+
+@pytest.mark.asyncio
+async def test_resolve_main_thread_returns_null_when_member_is_not_owned() -> None:
+    ...
+
+@pytest.mark.asyncio
+async def test_get_default_thread_config_raises_when_member_is_not_owned() -> None:
+    ...
+
+@pytest.mark.asyncio
+async def test_save_default_thread_config_raises_when_member_is_not_owned() -> None:
+    ...
+```
+
+- [ ] **Step 2: Run the focused test file and verify RED**
+
+Run: `uv run pytest tests/Fix/test_thread_launch_config_contract.py -q`
+
+Expected: FAIL because the new helper contract does not exist yet.
+
+### Task 2: Implement The Minimal Router-Local Helpers
+
+**Files:**
+- Modify: `backend/web/routers/threads.py`
+- Test: `tests/Fix/test_thread_launch_config_contract.py`
+
+- [ ] **Step 1: Add the minimal helpers**
+
+Add a soft helper and a strict wrapper in `threads.py`:
+
+```python
+def _find_owned_member(app: Any, member_id: str, owner_user_id: str) -> Any | None:
+    ...
+
+
+def _require_owned_member(app: Any, member_id: str, owner_user_id: str) -> Any:
+    ...
+```
+
+- [ ] **Step 2: Replace the repeated route-local lookup/check**
+
+Update only:
+
+```python
+resolve_main_thread(...)
+get_default_thread_config(...)
+save_default_thread_config(...)
+```
+
+Do not change `create_thread(...)` or any other route.
+
+- [ ] **Step 3: Run the focused test file and verify GREEN**
+
+Run: `uv run pytest tests/Fix/test_thread_launch_config_contract.py -q`
+
+Expected: PASS
+
+### Task 3: Run Regression Verification
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run the focused regression set**
+
+Run: `uv run pytest tests/Fix/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run syntax verification**
+
+Run: `python3 -m py_compile backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py docs/superpowers/specs/2026-04-07-threads-member-ownership-shell-design.md docs/superpowers/plans/2026-04-07-threads-member-ownership-shell-plan.md
+git commit -m "fix: align threads member ownership shell"
+```

--- a/docs/superpowers/specs/2026-04-07-threads-member-ownership-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-threads-member-ownership-shell-design.md
@@ -1,0 +1,67 @@
+# Threads Member Ownership Shell Design
+
+## Goal
+
+Remove the repeated member lookup and ownership gate in `backend/web/routers/threads.py` for the small launch-config surface without changing any business rule.
+
+## Scope
+
+In scope:
+
+- `POST /api/threads/main`
+- `GET /api/threads/default-config`
+- `POST /api/threads/default-config`
+
+Out of scope:
+
+- `create_thread`
+- launch-config persistence or precedence logic
+- provider gate and mount gate behavior
+- any thread runtime, streaming, or sandbox contract
+
+## Existing Problem
+
+`threads.py` currently repeats the same `member_repo.get_by_id(...)` plus owner check in three nearby routes. The duplication is small, but the file is sensitive enough that leaving repeated auth shell code invites drift.
+
+The catch is that the three routes do not share the same failure contract:
+
+- `resolve_main_thread` returns `{"thread": None}` when the member is missing or foreign
+- `get_default_thread_config` and `save_default_thread_config` raise `403 "Not authorized"` when the member is missing or foreign
+
+So the simplification must not flatten those two behaviors into one helper result.
+
+## Design
+
+Keep the seam router-local inside `backend/web/routers/threads.py`.
+
+Add two tiny helpers:
+
+1. A lookup helper that returns the owned member or `None`
+2. A strict helper that reuses the lookup helper and raises `403 "Not authorized"` when the owned member is absent
+
+This keeps the repeated repo lookup and owner check in one place while preserving the two route contracts:
+
+- `/main` keeps the soft-null behavior
+- `/default-config` keeps the strict 403 behavior
+
+## Testing
+
+Add focused tests in `tests/Fix/test_thread_launch_config_contract.py` that pin:
+
+- the soft helper returns `None` for a foreign member
+- the strict helper raises `403`
+- `resolve_main_thread` uses the soft helper contract
+- `GET /default-config` uses the strict helper contract
+- `POST /default-config` uses the strict helper contract
+
+The tests must not assert or rewrite launch-config precedence, existing/new thread creation, or provider-gate behavior.
+
+## Stopline
+
+Do not:
+
+- move this logic into a service or repo
+- touch `thread_launch_config_service.py`
+- change `resolve_main_thread` null semantics
+- change `default-config` 403 semantics
+- touch `create_thread` or any provider gate code

--- a/tests/Fix/test_thread_launch_config_contract.py
+++ b/tests/Fix/test_thread_launch_config_contract.py
@@ -21,7 +21,14 @@ class _FakeMemberRepo:
                 type=MemberType.MYCEL_AGENT,
                 owner_user_id="owner-1",
                 created_at=1.0,
-            )
+            ),
+            "member-2": MemberRow(
+                id="member-2",
+                name="Dryad",
+                type=MemberType.MYCEL_AGENT,
+                owner_user_id="owner-2",
+                created_at=2.0,
+            ),
         }
         self._seq = {"member-1": 0}
 
@@ -309,6 +316,24 @@ def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() ->
     }
 
 
+def test_find_owned_member_returns_none_for_foreign_member() -> None:
+    app = _make_threads_app()
+
+    result = threads_router._find_owned_member(app, "member-2", "owner-1")
+
+    assert result is None
+
+
+def test_require_owned_member_raises_for_foreign_member() -> None:
+    app = _make_threads_app()
+
+    with pytest.raises(threads_router.HTTPException) as excinfo:
+        threads_router._require_owned_member(app, "member-2", "owner-1")
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Not authorized"
+
+
 @pytest.mark.asyncio
 async def test_create_thread_persists_existing_lease_successful_config() -> None:
     app = _make_threads_app()
@@ -354,6 +379,71 @@ async def test_create_thread_persists_existing_lease_successful_config() -> None
             "workspace": "/workspace/reused",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_resolve_main_thread_uses_owned_member_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_threads_app()
+    payload = threads_router.ResolveMainThreadRequest(member_id="member-2")
+    calls: list[tuple[object, str, str]] = []
+
+    def _fake_find_owned_member(app_obj, member_id: str, owner_user_id: str):
+        calls.append((app_obj, member_id, owner_user_id))
+        return None
+
+    monkeypatch.setattr(threads_router, "_find_owned_member", _fake_find_owned_member)
+
+    result = await threads_router.resolve_main_thread(payload, "owner-1", app)
+
+    assert result == {"thread": None}
+    assert calls == [(app, "member-2", "owner-1")]
+
+
+@pytest.mark.asyncio
+async def test_get_default_thread_config_uses_strict_member_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_threads_app()
+    calls: list[tuple[object, str, str]] = []
+
+    def _fake_require_owned_member(app_obj, member_id: str, owner_user_id: str):
+        calls.append((app_obj, member_id, owner_user_id))
+        raise threads_router.HTTPException(403, "Not authorized")
+
+    monkeypatch.setattr(threads_router, "_require_owned_member", _fake_require_owned_member)
+
+    with pytest.raises(threads_router.HTTPException) as excinfo:
+        await threads_router.get_default_thread_config("member-2", "owner-1", app)
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Not authorized"
+    assert calls == [(app, "member-2", "owner-1")]
+
+
+@pytest.mark.asyncio
+async def test_save_default_thread_config_uses_strict_member_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_threads_app()
+    payload = threads_router.SaveThreadLaunchConfigRequest(
+        member_id="member-2",
+        create_mode="new",
+        provider_config="local",
+        recipe=None,
+        lease_id=None,
+        model="gpt-5.4-mini",
+        workspace="/tmp/demo",
+    )
+    calls: list[tuple[object, str, str]] = []
+
+    def _fake_require_owned_member(app_obj, member_id: str, owner_user_id: str):
+        calls.append((app_obj, member_id, owner_user_id))
+        raise threads_router.HTTPException(403, "Not authorized")
+
+    monkeypatch.setattr(threads_router, "_require_owned_member", _fake_require_owned_member)
+
+    with pytest.raises(threads_router.HTTPException) as excinfo:
+        await threads_router.save_default_thread_config(payload, "owner-1", app)
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Not authorized"
+    assert calls == [(app, "member-2", "owner-1")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- deduplicate the router-local member ownership shell in threads.py for resolve_main_thread and GET/POST default-config
- keep /main on the soft null contract while default-config stays on the strict 403 contract
- add focused contract tests plus seam design/plan docs

## Test Plan
- uv run pytest tests/Fix/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q
- python3 -m py_compile backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py
- uv run ruff format --check backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py
- uv run ruff check backend/web/routers/threads.py tests/Fix/test_thread_launch_config_contract.py