### PR TITLE
fix: align auth router shell

### DIFF
--- a/backend/web/routers/auth.py
+++ b/backend/web/routers/auth.py
@@ -11,6 +11,15 @@ from backend.web.core.dependencies import _get_auth_service, get_app
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 
+async def _call_auth_service(app: Any, status_code: int, method_name: str, *args: Any) -> Any:
+    try:
+        service = _get_auth_service(app)
+        method = getattr(service, method_name)
+        return await asyncio.to_thread(method, *args)
+    except ValueError as e:
+        raise HTTPException(status_code, str(e))
+
+
 # ── Registration step 1: send OTP ──────────────────────────────────────────
 
 
@@ -22,11 +31,8 @@ class SendOtpRequest(BaseModel):
 
 @router.post("/send-otp")
 async def send_otp(payload: SendOtpRequest, app: Annotated[Any, Depends(get_app)]) -> dict:
-    try:
-        await asyncio.to_thread(_get_auth_service(app).send_otp, payload.email, payload.password, payload.invite_code)
-        return {"ok": True}
-    except ValueError as e:
-        raise HTTPException(400, str(e))
+    await _call_auth_service(app, 400, "send_otp", payload.email, payload.password, payload.invite_code)
+    return {"ok": True}
 
 
 # ── Registration step 2: verify OTP ────────────────────────────────────────
@@ -39,10 +45,7 @@ class VerifyOtpRequest(BaseModel):
 
 @router.post("/verify-otp")
 async def verify_otp(payload: VerifyOtpRequest, app: Annotated[Any, Depends(get_app)]) -> dict:
-    try:
-        return await asyncio.to_thread(_get_auth_service(app).verify_register_otp, payload.email, payload.token)
-    except ValueError as e:
-        raise HTTPException(400, str(e))
+    return await _call_auth_service(app, 400, "verify_register_otp", payload.email, payload.token)
 
 
 # ── Registration step 3: set password + invite code ────────────────────────
@@ -55,10 +58,7 @@ class CompleteRegisterRequest(BaseModel):
 
 @router.post("/complete-register")
 async def complete_register(payload: CompleteRegisterRequest, app: Annotated[Any, Depends(get_app)]) -> dict:
-    try:
-        return await asyncio.to_thread(_get_auth_service(app).complete_register, payload.temp_token, payload.invite_code)
-    except ValueError as e:
-        raise HTTPException(400, str(e))
+    return await _call_auth_service(app, 400, "complete_register", payload.temp_token, payload.invite_code)
 
 
 # ── Login ───────────────────────────────────────────────────────────────────
@@ -71,7 +71,4 @@ class LoginRequest(BaseModel):
 
 @router.post("/login")
 async def login(payload: LoginRequest, app: Annotated[Any, Depends(get_app)]) -> dict:
-    try:
-        return await asyncio.to_thread(_get_auth_service(app).login, payload.identifier, payload.password)
-    except ValueError as e:
-        raise HTTPException(401, str(e))
+    return await _call_auth_service(app, 401, "login", payload.identifier, payload.password)

--- a/docs/superpowers/plans/2026-04-07-auth-router-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-auth-router-shell-plan.md
@@ -1,0 +1,111 @@
+# Auth Router Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deduplicate the auth router's repeated service-call and `ValueError` mapping shell while preserving the distinct `400` vs `401` route contracts.
+
+**Architecture:** Keep the change inside `backend/web/routers/auth.py`. Introduce one helper that receives a route-specific status code and auth service method name, then use it from the four auth routes without altering payloads or auth service behavior.
+
+**Tech Stack:** FastAPI, pytest, Python 3.12
+
+---
+
+### Task 1: Lock The Shell Contract With Failing Tests
+
+**Files:**
+- Modify: `tests/Integration/test_auth_router.py`
+- Reference: `backend/web/routers/auth.py`
+
+- [ ] **Step 1: Add focused tests for the router helper**
+
+Add tests that cover:
+
+```python
+@pytest.mark.asyncio
+async def test_call_auth_service_returns_service_result() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_call_auth_service_maps_value_error_to_given_status() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_send_otp_uses_auth_router_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_login_uses_auth_router_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+```
+
+- [ ] **Step 2: Run the focused auth router test file and verify RED**
+
+Run: `uv run pytest tests/Integration/test_auth_router.py -q`
+
+Expected: FAIL because the new helper contract does not exist yet.
+
+### Task 2: Implement The Minimal Router-Local Helper
+
+**Files:**
+- Modify: `backend/web/routers/auth.py`
+- Test: `tests/Integration/test_auth_router.py`
+
+- [ ] **Step 1: Add the minimal helper**
+
+Add an async helper with this shape:
+
+```python
+async def _call_auth_service(
+    app: Any,
+    status_code: int,
+    method_name: str,
+    *args: Any,
+) -> Any:
+    ...
+```
+
+- [ ] **Step 2: Replace the repeated route-local shell**
+
+Update only:
+
+```python
+send_otp(...)
+verify_otp(...)
+complete_register(...)
+login(...)
+```
+
+Keep route-specific status codes explicit at each callsite.
+
+- [ ] **Step 3: Run the focused auth router test file and verify GREEN**
+
+Run: `uv run pytest tests/Integration/test_auth_router.py -q`
+
+Expected: PASS
+
+### Task 3: Run Regression Verification
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run the focused regression set**
+
+Run: `uv run pytest tests/Integration/test_auth_router.py tests/Fix/test_thread_launch_config_contract.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run syntax verification**
+
+Run: `python3 -m py_compile backend/web/routers/auth.py tests/Integration/test_auth_router.py`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/web/routers/auth.py tests/Integration/test_auth_router.py docs/superpowers/specs/2026-04-07-auth-router-shell-design.md docs/superpowers/plans/2026-04-07-auth-router-shell-plan.md
+git commit -m "fix: align auth router shell"
+```

--- a/docs/superpowers/specs/2026-04-07-auth-router-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-auth-router-shell-design.md
@@ -1,0 +1,75 @@
+# Auth Router Shell Design
+
+## Goal
+
+Remove the repeated router-local service-call and `ValueError` to `HTTPException` mapping in `backend/web/routers/auth.py` without changing any auth contract.
+
+## Scope
+
+In scope:
+
+- `POST /api/auth/send-otp`
+- `POST /api/auth/verify-otp`
+- `POST /api/auth/complete-register`
+- `POST /api/auth/login`
+
+Out of scope:
+
+- auth service implementation
+- token generation or verification
+- frontend auth flow
+- chat event auth in `messaging.py`
+
+## Existing Problem
+
+`auth.py` repeats the same shape four times:
+
+1. call a method on `_get_auth_service(app)` through `asyncio.to_thread`
+2. map `ValueError` into `HTTPException`
+
+The seam is clean, but the routes do not all share the same HTTP contract:
+
+- the three registration steps map `ValueError` to `400`
+- `login` maps `ValueError` to `401`
+
+So the simplification must preserve the route-specific status code instead of flattening everything into one error mapping.
+
+## Design
+
+Keep the change router-local inside `backend/web/routers/auth.py`.
+
+Add one helper that:
+
+- accepts the app
+- accepts the route-specific status code
+- accepts the auth service method name and call args
+- executes the call through `asyncio.to_thread`
+- maps `ValueError` into `HTTPException(status_code, str(error))`
+
+Each route stays responsible for its own status code:
+
+- registration routes pass `400`
+- login passes `401`
+
+This keeps the contract explicit while removing the repeated shell.
+
+## Testing
+
+Extend `tests/Integration/test_auth_router.py` with focused tests that pin:
+
+- helper returns the service result when the call succeeds
+- helper maps `ValueError` to the provided status code
+- `send_otp` delegates through the helper with `400`
+- `login` delegates through the helper with `401`
+
+Those tests must not drift into auth service behavior. They only verify the router shell contract.
+
+## Stopline
+
+Do not:
+
+- move the helper into a shared utility module
+- change auth service methods
+- change route payloads or response bodies
+- change login from `401` to `400`
+- touch `messaging.py` even though the test file also covers chat auth

--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -129,6 +129,96 @@ async def test_login_maps_value_error_to_unauthorized():
     assert "Invalid username or password" in str(exc_info.value.detail)
 
 
+@pytest.mark.asyncio
+async def test_call_auth_service_returns_service_result():
+    service = _FakeAuthService()
+    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
+
+    result = await auth_router._call_auth_service(
+        app,
+        400,
+        "verify_register_otp",
+        "fresh@example.com",
+        "123456",
+    )
+
+    assert result == {"temp_token": "temp-otp"}
+    assert service.verify_otp_calls == [("fresh@example.com", "123456")]
+
+
+@pytest.mark.asyncio
+async def test_call_auth_service_maps_value_error_to_given_status():
+    service = _FakeAuthService()
+    service.complete_register_error = ValueError("邀请码无效")
+    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_router._call_auth_service(
+            app,
+            400,
+            "complete_register",
+            "temp-otp",
+            "invite-1",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "邀请码无效"
+
+
+@pytest.mark.asyncio
+async def test_send_otp_uses_auth_router_helper(monkeypatch: pytest.MonkeyPatch):
+    app = SimpleNamespace(state=SimpleNamespace(auth_service=_FakeAuthService()))
+    calls: list[tuple[object, int, str, tuple[object, ...]]] = []
+
+    async def _fake_call_auth_service(app_obj, status_code: int, method_name: str, *args: object):
+        calls.append((app_obj, status_code, method_name, args))
+        return None
+
+    monkeypatch.setattr(auth_router, "_call_auth_service", _fake_call_auth_service)
+
+    result = await auth_router.send_otp(
+        auth_router.SendOtpRequest(email="fresh@example.com", password="pass1234", invite_code="invite-1"),
+        app,
+    )
+
+    assert result == {"ok": True}
+    assert calls == [
+        (
+            app,
+            400,
+            "send_otp",
+            ("fresh@example.com", "pass1234", "invite-1"),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_login_uses_auth_router_helper(monkeypatch: pytest.MonkeyPatch):
+    app = SimpleNamespace(state=SimpleNamespace(auth_service=_FakeAuthService()))
+    calls: list[tuple[object, int, str, tuple[object, ...]]] = []
+
+    async def _fake_call_auth_service(app_obj, status_code: int, method_name: str, *args: object):
+        calls.append((app_obj, status_code, method_name, args))
+        return {"token": "tok-helper"}
+
+    monkeypatch.setattr(auth_router, "_call_auth_service", _fake_call_auth_service)
+
+    result = await auth_router.login(
+        auth_router.LoginRequest(identifier="fresh@example.com", password="pass1234"),
+        app,
+    )
+
+    assert result == {"token": "tok-helper"}
+    assert calls == [
+        (
+            app,
+            401,
+            "login",
+            ("fresh@example.com", "pass1234"),
+        )
+    ]
+
+
 class _VerifyOnlyAuthService:
     def __init__(self) -> None:
         self.tokens: list[str] = []


### PR DESCRIPTION
## Summary
- deduplicate the router-local auth service-call and error-mapping shell in auth.py
- keep registration routes on 400 while login stays on 401
- add focused auth router contract tests plus seam design/plan docs

## Test Plan
- uv run pytest tests/Integration/test_auth_router.py tests/Fix/test_thread_launch_config_contract.py -q
- python3 -m py_compile backend/web/routers/auth.py tests/Integration/test_auth_router.py
- uv run ruff format --check backend/web/routers/auth.py tests/Integration/test_auth_router.py
- uv run ruff check backend/web/routers/auth.py tests/Integration/test_auth_router.py