### PR TITLE
fix: align entities member lookup shell

### DIFF
--- a/backend/web/routers/entities.py
+++ b/backend/web/routers/entities.py
@@ -212,9 +212,7 @@ async def get_entity_profile(
     app: Annotated[Any, Depends(get_app)],
 ):
     """Public agent profile. No auth required (frontend uses plain fetch)."""
-    member = app.state.member_repo.get_by_id(user_id)
-    if not member:
-        raise HTTPException(404, "Member not found")
+    member = _get_member_or_404(app, user_id)
     member_type = member.type.value if hasattr(member.type, "value") else str(member.type)
     if "agent" not in member_type:
         raise HTTPException(404, "Profile not available for this member type")
@@ -234,10 +232,15 @@ async def get_agent_thread(
     app: Annotated[Any, Depends(get_app)],
 ):
     """Get the thread_id for an agent's main thread. user_id here is the agent's member_id."""
-    member = app.state.member_repo.get_by_id(user_id)
-    if not member:
-        raise HTTPException(404, "Member not found")
+    member = _get_member_or_404(app, user_id)
     thread = app.state.thread_repo.get_main_thread(user_id)
     if member.type != MemberType.HUMAN and thread is not None:
         return {"user_id": user_id, "thread_id": thread["id"]}
     raise HTTPException(404, "No agent thread found")
+
+
+def _get_member_or_404(app: Any, user_id: str) -> Any:
+    member = app.state.member_repo.get_by_id(user_id)
+    if not member:
+        raise HTTPException(404, "Member not found")
+    return member

--- a/docs/superpowers/plans/2026-04-07-entities-member-lookup-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-entities-member-lookup-shell-plan.md
@@ -1,0 +1,102 @@
+# Entities Member Lookup Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deduplicate the repeated public member lookup shell in `entities.py` while preserving the route-specific behavior after the lookup.
+
+**Architecture:** Keep the change inside `backend/web/routers/entities.py`. Introduce one router-local helper that returns the member or raises `404 "Member not found"`, then reuse it from `get_entity_profile` and `get_agent_thread` without touching profile shaping or thread lookup semantics.
+
+**Tech Stack:** FastAPI, pytest, Python 3.12
+
+---
+
+### Task 1: Lock The Lookup Contract With Failing Tests
+
+**Files:**
+- Modify: `tests/Integration/test_entities_router.py`
+- Reference: `backend/web/routers/entities.py`
+
+- [ ] **Step 1: Add focused tests for the lookup helper**
+
+Add tests that cover:
+
+```python
+def test_get_member_or_404_returns_member() -> None:
+    ...
+
+
+def test_get_member_or_404_raises_for_missing_member() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_get_entity_profile_uses_member_lookup_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_get_agent_thread_uses_member_lookup_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+```
+
+- [ ] **Step 2: Run the focused entities router test file and verify RED**
+
+Run: `uv run pytest tests/Integration/test_entities_router.py -q`
+
+Expected: FAIL because the new helper contract does not exist yet.
+
+### Task 2: Implement The Minimal Router-Local Helper
+
+**Files:**
+- Modify: `backend/web/routers/entities.py`
+- Test: `tests/Integration/test_entities_router.py`
+
+- [ ] **Step 1: Add the minimal helper**
+
+Add a helper with this shape:
+
+```python
+def _get_member_or_404(app: Any, user_id: str) -> Any:
+    ...
+```
+
+- [ ] **Step 2: Replace the repeated route-local lookup**
+
+Update only:
+
+```python
+get_entity_profile(...)
+get_agent_thread(...)
+```
+
+Do not touch any later route-specific branches.
+
+- [ ] **Step 3: Run the focused entities router test file and verify GREEN**
+
+Run: `uv run pytest tests/Integration/test_entities_router.py -q`
+
+Expected: PASS
+
+### Task 3: Run Regression Verification
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run the focused regression set**
+
+Run: `uv run pytest tests/Integration/test_entities_router.py tests/Fix/test_entities_avatar_auth_shell.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run syntax verification**
+
+Run: `python3 -m py_compile backend/web/routers/entities.py tests/Integration/test_entities_router.py`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/web/routers/entities.py tests/Integration/test_entities_router.py docs/superpowers/specs/2026-04-07-entities-member-lookup-shell-design.md docs/superpowers/plans/2026-04-07-entities-member-lookup-shell-plan.md
+git commit -m "fix: align entities member lookup shell"
+```

--- a/docs/superpowers/specs/2026-04-07-entities-member-lookup-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-entities-member-lookup-shell-design.md
@@ -1,0 +1,69 @@
+# Entities Member Lookup Shell Design
+
+## Goal
+
+Remove the repeated public member lookup and `404 "Member not found"` shell in `backend/web/routers/entities.py` without changing any route-specific behavior.
+
+## Scope
+
+In scope:
+
+- `GET /api/entities/{user_id}/profile`
+- `GET /api/entities/{user_id}/agent-thread`
+
+Out of scope:
+
+- profile response shaping
+- avatar routes
+- auth or ownership checks
+- the `No agent thread found` branch in `get_agent_thread`
+
+## Existing Problem
+
+Two nearby routes repeat the same opening shell:
+
+1. `member = app.state.member_repo.get_by_id(user_id)`
+2. if missing, raise `HTTPException(404, "Member not found")`
+
+The duplication is mechanical, but the routes diverge immediately after that:
+
+- `get_entity_profile` validates the member type and shapes a public profile response
+- `get_agent_thread` asks `thread_repo` for the main thread and may still raise `404 "No agent thread found"`
+
+So the simplification must stop after the shared member lookup and not flatten the later route-specific branches.
+
+## Design
+
+Keep the change router-local inside `backend/web/routers/entities.py`.
+
+Add one helper:
+
+- `_get_member_or_404(app, user_id)`
+
+That helper does exactly two things:
+
+- call `member_repo.get_by_id(user_id)`
+- raise `404 "Member not found"` when absent
+
+Both routes reuse the helper and keep their existing downstream logic unchanged.
+
+## Testing
+
+Extend `tests/Integration/test_entities_router.py` with focused tests that pin:
+
+- helper returns the member when found
+- helper raises `404` when missing
+- `get_entity_profile` delegates through the helper
+- `get_agent_thread` delegates through the helper
+
+The route tests should only prove delegation and preserve the existing route-specific branches. They must not rewrite the later `Profile not available for this member type` or `No agent thread found` behavior.
+
+## Stopline
+
+Do not:
+
+- move the helper into another module
+- touch profile shaping
+- touch `get_agent_thread` thread lookup semantics
+- touch avatar routes
+- add auth or ownership logic

--- a/tests/Integration/test_entities_router.py
+++ b/tests/Integration/test_entities_router.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from backend.web.routers import entities as entities_router
 from storage.contracts import MemberRow, MemberType
@@ -97,3 +98,95 @@ async def test_get_agent_thread_reads_main_thread_from_thread_repo():
     result = await entities_router.get_agent_thread("a-main", current_user_id="u2", app=app)
 
     assert result == {"user_id": "a-main", "thread_id": "thread-main"}
+
+
+def test_get_member_or_404_returns_member():
+    now = 1_775_223_756.0
+    agent = MemberRow(
+        id="a-main",
+        name="Toad",
+        type=MemberType.MYCEL_AGENT,
+        owner_user_id="u2",
+        created_at=now,
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            member_repo=SimpleNamespace(get_by_id=lambda member_id: agent if member_id == "a-main" else None),
+        )
+    )
+
+    result = entities_router._get_member_or_404(app, "a-main")
+
+    assert result is agent
+
+
+def test_get_member_or_404_raises_for_missing_member():
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            member_repo=SimpleNamespace(get_by_id=lambda _member_id: None),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        entities_router._get_member_or_404(app, "missing")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Member not found"
+
+
+@pytest.mark.asyncio
+async def test_get_entity_profile_uses_member_lookup_helper(monkeypatch: pytest.MonkeyPatch):
+    now = 1_775_223_756.0
+    agent = MemberRow(
+        id="a-main",
+        name="Toad",
+        type=MemberType.MYCEL_AGENT,
+        owner_user_id="u2",
+        created_at=now,
+    )
+    app = SimpleNamespace(state=SimpleNamespace())
+    calls: list[tuple[object, str]] = []
+
+    def _fake_get_member_or_404(app_obj, user_id: str):
+        calls.append((app_obj, user_id))
+        return agent
+
+    monkeypatch.setattr(entities_router, "_get_member_or_404", _fake_get_member_or_404)
+
+    result = await entities_router.get_entity_profile("a-main", app)
+
+    assert result["id"] == "a-main"
+    assert calls == [(app, "a-main")]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_thread_uses_member_lookup_helper(monkeypatch: pytest.MonkeyPatch):
+    now = 1_775_223_756.0
+    agent = MemberRow(
+        id="a-main",
+        name="Toad",
+        type=MemberType.MYCEL_AGENT,
+        owner_user_id="u2",
+        created_at=now,
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                get_main_thread=lambda member_id: (
+                    {"id": "thread-main", "is_main": True, "branch_index": 0} if member_id == "a-main" else None
+                )
+            ),
+        )
+    )
+    calls: list[tuple[object, str]] = []
+
+    def _fake_get_member_or_404(app_obj, user_id: str):
+        calls.append((app_obj, user_id))
+        return agent
+
+    monkeypatch.setattr(entities_router, "_get_member_or_404", _fake_get_member_or_404)
+
+    result = await entities_router.get_agent_thread("a-main", current_user_id="u2", app=app)
+
+    assert result == {"user_id": "a-main", "thread_id": "thread-main"}
+    assert calls == [(app, "a-main")]


### PR DESCRIPTION
## Summary
- deduplicate the shared public member lookup shell in entities.py
- keep profile shaping and agent-thread semantics unchanged after the lookup
- add focused entities router contract tests plus seam design/plan docs

## Test Plan
- uv run pytest tests/Integration/test_entities_router.py tests/Fix/test_entities_avatar_auth_shell.py -q
- python3 -m py_compile backend/web/routers/entities.py tests/Integration/test_entities_router.py
- uv run ruff format --check backend/web/routers/entities.py tests/Integration/test_entities_router.py
- uv run ruff check backend/web/routers/entities.py tests/Integration/test_entities_router.py