### PR TITLE
fix: align messaging chat access shell

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -70,6 +70,15 @@ def _verify_member_ownership(app: Any, member_id: str, user_id: str) -> None:
     raise HTTPException(403, "Member does not belong to you")
 
 
+def _get_accessible_chat_or_404(app: Any, chat_id: str, user_id: str) -> Any:
+    chat = app.state.chat_repo.get_by_id(chat_id)
+    if not chat:
+        raise HTTPException(404, "Chat not found")
+    if not _messaging(app).is_chat_member(chat_id, user_id):
+        raise HTTPException(403, "Not a participant of this chat")
+    return chat
+
+
 def _msg_response(m: dict[str, Any], member_repo: Any) -> dict[str, Any]:
     sender = member_repo.get_by_id(m.get("sender_id", ""))
     return {
@@ -131,11 +140,7 @@ async def get_chat(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    chat = app.state.chat_repo.get_by_id(chat_id)
-    if not chat:
-        raise HTTPException(404, "Chat not found")
-    if not _messaging(app).is_chat_member(chat_id, user_id):
-        raise HTTPException(403, "Not a participant of this chat")
+    chat = _get_accessible_chat_or_404(app, chat_id, user_id)
     members_list = _messaging(app).list_chat_members(chat_id)
     members_info = []
     for m in members_list:
@@ -246,11 +251,7 @@ async def delete_chat(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    chat = app.state.chat_repo.get_by_id(chat_id)
-    if not chat:
-        raise HTTPException(404, "Chat not found")
-    if not _messaging(app).is_chat_member(chat_id, user_id):
-        raise HTTPException(403, "Not a participant of this chat")
+    _get_accessible_chat_or_404(app, chat_id, user_id)
     app.state.chat_repo.delete(chat_id)
     return {"status": "deleted"}
 

--- a/docs/superpowers/plans/2026-04-07-messaging-chat-access-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-messaging-chat-access-shell-plan.md
@@ -1,0 +1,106 @@
+# Messaging Chat Access Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deduplicate the repeated chat lookup and membership gate in the messaging router while preserving `404` and `403` behavior for chat detail and delete.
+
+**Architecture:** Keep the change inside `backend/web/routers/messaging.py`. Introduce one router-local helper that loads a chat, enforces membership, and returns the chat object; then use it from `get_chat` and `delete_chat` only.
+
+**Tech Stack:** FastAPI, pytest, Python 3.12
+
+---
+
+### Task 1: Lock The Chat Access Shell With Failing Tests
+
+**Files:**
+- Create: `tests/Integration/test_messaging_router.py`
+- Reference: `backend/web/routers/messaging.py`
+
+- [ ] **Step 1: Add focused tests for the router helper**
+
+Add tests that cover:
+
+```python
+def test_get_accessible_chat_or_404_returns_chat() -> None:
+    ...
+
+
+def test_get_accessible_chat_or_404_raises_404_for_missing_chat() -> None:
+    ...
+
+
+def test_get_accessible_chat_or_404_raises_403_for_non_member() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+```
+
+- [ ] **Step 2: Run the focused messaging router test file and verify RED**
+
+Run: `uv run pytest tests/Integration/test_messaging_router.py -q`
+
+Expected: FAIL because the new helper contract does not exist yet.
+
+### Task 2: Implement The Minimal Router-Local Helper
+
+**Files:**
+- Modify: `backend/web/routers/messaging.py`
+- Test: `tests/Integration/test_messaging_router.py`
+
+- [ ] **Step 1: Add the minimal helper**
+
+Add:
+
+```python
+def _get_accessible_chat_or_404(app: Any, chat_id: str, user_id: str) -> Any:
+    ...
+```
+
+- [ ] **Step 2: Replace only the duplicated route shell**
+
+Update only:
+
+```python
+get_chat(...)
+delete_chat(...)
+```
+
+Do not change `list_messages(...)`.
+
+- [ ] **Step 3: Run the focused messaging router test file and verify GREEN**
+
+Run: `uv run pytest tests/Integration/test_messaging_router.py -q`
+
+Expected: PASS
+
+### Task 3: Run Regression Verification
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run the focused regression set**
+
+Run: `uv run pytest tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py tests/Integration/test_entities_router.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run syntax verification**
+
+Run: `python3 -m py_compile backend/web/routers/messaging.py tests/Integration/test_messaging_router.py`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/web/routers/messaging.py tests/Integration/test_messaging_router.py docs/superpowers/specs/2026-04-07-messaging-chat-access-shell-design.md docs/superpowers/plans/2026-04-07-messaging-chat-access-shell-plan.md
+git commit -m "fix: align messaging chat access shell"
+```

--- a/docs/superpowers/specs/2026-04-07-messaging-chat-access-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-messaging-chat-access-shell-design.md
@@ -1,0 +1,76 @@
+# Messaging Chat Access Shell Design
+
+## Goal
+
+Remove the repeated router-local chat lookup and membership gate in `backend/web/routers/messaging.py` without changing any chat contract.
+
+## Scope
+
+In scope:
+
+- `GET /api/chats/{chat_id}`
+- `DELETE /api/chats/{chat_id}`
+
+Out of scope:
+
+- `GET /api/chats/{chat_id}/messages`
+- message send/retract/delete-for-self
+- SSE event auth
+- messaging service implementation
+
+## Existing Problem
+
+`get_chat` and `delete_chat` repeat the same opening shell:
+
+1. `chat_repo.get_by_id(chat_id)`
+2. `404 "Chat not found"` if absent
+3. `_messaging(app).is_chat_member(chat_id, user_id)`
+4. `403 "Not a participant of this chat"` if forbidden
+
+That is a clean router-local seam. The two routes diverge only after the access shell:
+
+- `get_chat` reads members and shapes a response body
+- `delete_chat` deletes the chat and returns `{"status": "deleted"}`
+
+## Design
+
+Keep the change inside `backend/web/routers/messaging.py`.
+
+Add one helper:
+
+```python
+def _get_accessible_chat_or_404(app: Any, chat_id: str, user_id: str) -> Any:
+    ...
+```
+
+The helper must:
+
+- read the chat from `chat_repo`
+- raise `HTTPException(404, "Chat not found")` when missing
+- enforce `_messaging(app).is_chat_member(chat_id, user_id)`
+- raise `HTTPException(403, "Not a participant of this chat")` when forbidden
+- return the chat object on success
+
+Only `get_chat` and `delete_chat` should delegate to this helper.
+
+## Testing
+
+Add focused tests in `tests/Integration/test_messaging_router.py` that pin:
+
+- helper returns the chat object when it exists and the user is a member
+- helper raises `404` for missing chat
+- helper raises `403` for non-member access
+- `get_chat` uses the helper instead of its own chat lookup
+- `delete_chat` uses the helper instead of its own chat lookup
+
+Those tests must stay on the router shell. They must not drift into message listing, SSE, or messaging-service internals.
+
+## Stopline
+
+Do not:
+
+- change `list_messages` to use this helper
+- change `get_chat` response shaping
+- change delete semantics
+- touch SSE auth or token verification
+- move the helper into a shared utility module

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import messaging as messaging_router
+
+
+def _chat(chat_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=chat_id,
+        title="Chat title",
+        status="active",
+        created_at="2026-04-07T00:00:00Z",
+    )
+
+
+def test_get_accessible_chat_or_404_returns_chat():
+    chat = _chat("chat-1")
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            chat_repo=SimpleNamespace(get_by_id=lambda chat_id: chat if chat_id == "chat-1" else None),
+            messaging_service=SimpleNamespace(is_chat_member=lambda chat_id, user_id: (chat_id, user_id) == ("chat-1", "user-1")),
+        )
+    )
+
+    result = messaging_router._get_accessible_chat_or_404(app, "chat-1", "user-1")
+
+    assert result is chat
+
+
+def test_get_accessible_chat_or_404_raises_404_for_missing_chat():
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: None),
+            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: True),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        messaging_router._get_accessible_chat_or_404(app, "missing", "user-1")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Chat not found"
+
+
+def test_get_accessible_chat_or_404_raises_403_for_non_member():
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: _chat("chat-1")),
+            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        messaging_router._get_accessible_chat_or_404(app, "chat-1", "user-2")
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Not a participant of this chat"
+
+
+@pytest.mark.asyncio
+async def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
+    seen: list[tuple[str, object]] = []
+    chat = _chat("chat-1")
+
+    def fake_helper(app_obj, chat_id: str, user_id: str):
+        seen.append(("helper", (app_obj, chat_id, user_id)))
+        return chat
+
+    monkeypatch.setattr(messaging_router, "_get_accessible_chat_or_404", fake_helper)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            chat_repo=SimpleNamespace(
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(
+                    AssertionError("route should use helper, not chat_repo lookup directly")
+                )
+            ),
+            messaging_service=SimpleNamespace(list_chat_members=lambda _chat_id: []),
+            member_repo=SimpleNamespace(get_by_id=lambda _member_id: None),
+        )
+    )
+
+    result = await messaging_router.get_chat("chat-1", user_id="user-1", app=app)
+
+    assert result == {
+        "id": "chat-1",
+        "title": "Chat title",
+        "status": "active",
+        "created_at": "2026-04-07T00:00:00Z",
+        "entities": [],
+    }
+    assert seen == [("helper", (app, "chat-1", "user-1"))]
+
+
+@pytest.mark.asyncio
+async def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
+    seen: list[tuple[str, object]] = []
+    chat = _chat("chat-1")
+
+    def fake_helper(app_obj, chat_id: str, user_id: str):
+        seen.append(("helper", (app_obj, chat_id, user_id)))
+        return chat
+
+    monkeypatch.setattr(messaging_router, "_get_accessible_chat_or_404", fake_helper)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            chat_repo=SimpleNamespace(
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(
+                    AssertionError("route should use helper, not chat_repo lookup directly")
+                ),
+                delete=lambda chat_id: seen.append(("delete", chat_id)),
+            ),
+        )
+    )
+
+    result = await messaging_router.delete_chat("chat-1", user_id="user-1", app=app)
+
+    assert result == {"status": "deleted"}
+    assert seen == [
+        ("helper", (app, "chat-1", "user-1")),
+        ("delete", "chat-1"),
+    ]

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -75,9 +75,7 @@ async def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
     app = SimpleNamespace(
         state=SimpleNamespace(
             chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: (_ for _ in ()).throw(
-                    AssertionError("route should use helper, not chat_repo lookup directly")
-                )
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("route should use helper, not chat_repo lookup directly"))
             ),
             messaging_service=SimpleNamespace(list_chat_members=lambda _chat_id: []),
             member_repo=SimpleNamespace(get_by_id=lambda _member_id: None),
@@ -110,9 +108,7 @@ async def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
     app = SimpleNamespace(
         state=SimpleNamespace(
             chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: (_ for _ in ()).throw(
-                    AssertionError("route should use helper, not chat_repo lookup directly")
-                ),
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("route should use helper, not chat_repo lookup directly")),
                 delete=lambda chat_id: seen.append(("delete", chat_id)),
             ),
         )


### PR DESCRIPTION
## Summary
- add a router-local helper for chat lookup + membership gating in messaging routes
- reuse that helper from get_chat and delete_chat without touching list_messages or SSE
- add focused integration tests and phase-9 spec/plan docs

## Test Plan
- uv run pytest tests/Integration/test_messaging_router.py -q
- uv run pytest tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py tests/Integration/test_entities_router.py -q
- python3 -m py_compile backend/web/routers/messaging.py tests/Integration/test_messaging_router.py
- uv run ruff check backend/web/routers/messaging.py tests/Integration/test_messaging_router.py