### PR TITLE
fix: align invite codes router shell

### DIFF
--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -22,6 +22,23 @@ def _get_invite_code_repo(app: Any):
     return repo
 
 
+async def _call_invite_code_repo(
+    request: Request,
+    error_prefix: str,
+    method_name: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    repo = _get_invite_code_repo(request.app)
+    try:
+        method = getattr(repo, method_name)
+        return await asyncio.to_thread(method, *args, **kwargs)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(500, f"{error_prefix}{e}") from e
+
+
 # ── List all invite codes ────────────────────────────────────────────────────
 
 
@@ -30,14 +47,8 @@ async def list_invite_codes(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict:
-    repo = _get_invite_code_repo(request.app)
-    try:
-        codes = await asyncio.to_thread(repo.list_all)
-        return {"codes": codes}
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(500, f"获取邀请码列表失败：{e}") from e
+    codes = await _call_invite_code_repo(request, "获取邀请码列表失败：", "list_all")
+    return {"codes": codes}
 
 
 # ── Generate a new invite code ───────────────────────────────────────────────
@@ -53,18 +64,13 @@ async def generate_invite_code(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict:
-    repo = _get_invite_code_repo(request.app)
-    try:
-        code = await asyncio.to_thread(
-            repo.generate,
-            created_by=user_id,
-            expires_days=payload.expires_days,
-        )
-        return code
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(500, f"生成邀请码失败：{e}") from e
+    return await _call_invite_code_repo(
+        request,
+        "生成邀请码失败：",
+        "generate",
+        created_by=user_id,
+        expires_days=payload.expires_days,
+    )
 
 
 # ── Revoke (delete) an invite code ──────────────────────────────────────────
@@ -76,16 +82,10 @@ async def revoke_invite_code(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict:
-    repo = _get_invite_code_repo(request.app)
-    try:
-        ok = await asyncio.to_thread(repo.revoke, code)
-        if not ok:
-            raise HTTPException(404, "邀请码不存在")
-        return {"ok": True}
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(500, f"吊销邀请码失败：{e}") from e
+    ok = await _call_invite_code_repo(request, "吊销邀请码失败：", "revoke", code)
+    if not ok:
+        raise HTTPException(404, "邀请码不存在")
+    return {"ok": True}
 
 
 # ── Validate an invite code (no auth required) ───────────────────────────────
@@ -93,11 +93,5 @@ async def revoke_invite_code(
 
 @router.get("/validate/{code}")
 async def validate_invite_code(code: str, request: Request) -> dict:
-    repo = _get_invite_code_repo(request.app)
-    try:
-        valid = await asyncio.to_thread(repo.is_valid, code)
-        return {"valid": valid}
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(500, f"校验邀请码失败：{e}") from e
+    valid = await _call_invite_code_repo(request, "校验邀请码失败：", "is_valid", code)
+    return {"valid": valid}

--- a/docs/superpowers/plans/2026-04-07-invite-codes-router-shell-plan.md
+++ b/docs/superpowers/plans/2026-04-07-invite-codes-router-shell-plan.md
@@ -1,0 +1,117 @@
+# Invite Codes Router Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deduplicate the invite-codes router's repeated repo-call and error-mapping shell while preserving each route's Chinese `500` prefix and revoke's `404` contract.
+
+**Architecture:** Keep the change inside `backend/web/routers/invite_codes.py`. Introduce one router-local helper that gets the repo, runs the named repo method in `asyncio.to_thread`, preserves `HTTPException`, and maps generic errors with a route-provided prefix.
+
+**Tech Stack:** FastAPI, pytest, Python 3.12
+
+---
+
+### Task 1: Lock The Router Shell With Failing Tests
+
+**Files:**
+- Create: `tests/Integration/test_invite_codes_router.py`
+- Reference: `backend/web/routers/invite_codes.py`
+
+- [ ] **Step 1: Add focused tests for the helper and route delegation**
+
+Add tests that cover:
+
+```python
+@pytest.mark.asyncio
+async def test_call_invite_code_repo_returns_repo_result() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_call_invite_code_repo_maps_exception_to_prefixed_500() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_call_invite_code_repo_preserves_http_exception() -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_list_invite_codes_uses_router_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+
+
+@pytest.mark.asyncio
+async def test_revoke_invite_code_uses_helper_and_keeps_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    ...
+```
+
+- [ ] **Step 2: Run the focused invite-codes router test file and verify RED**
+
+Run: `uv run pytest tests/Integration/test_invite_codes_router.py -q`
+
+Expected: FAIL because the new helper contract does not exist yet.
+
+### Task 2: Implement The Minimal Router-Local Helper
+
+**Files:**
+- Modify: `backend/web/routers/invite_codes.py`
+- Test: `tests/Integration/test_invite_codes_router.py`
+
+- [ ] **Step 1: Add the minimal helper**
+
+Add:
+
+```python
+async def _call_invite_code_repo(
+    request: Request,
+    error_prefix: str,
+    method_name: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    ...
+```
+
+- [ ] **Step 2: Replace only the duplicated shell**
+
+Update only:
+
+```python
+list_invite_codes(...)
+generate_invite_code(...)
+revoke_invite_code(...)
+validate_invite_code(...)
+```
+
+Keep each route's Chinese `500` prefix explicit at the callsite, and keep revoke's `404` branch in the route.
+
+- [ ] **Step 3: Run the focused invite-codes router test file and verify GREEN**
+
+Run: `uv run pytest tests/Integration/test_invite_codes_router.py -q`
+
+Expected: PASS
+
+### Task 3: Run Regression Verification
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run the focused regression set**
+
+Run: `uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_auth_router.py tests/Integration/test_messaging_router.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run syntax verification**
+
+Run: `python3 -m py_compile backend/web/routers/invite_codes.py tests/Integration/test_invite_codes_router.py`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/web/routers/invite_codes.py tests/Integration/test_invite_codes_router.py docs/superpowers/specs/2026-04-07-invite-codes-router-shell-design.md docs/superpowers/plans/2026-04-07-invite-codes-router-shell-plan.md
+git commit -m "fix: align invite codes router shell"
+```

--- a/docs/superpowers/specs/2026-04-07-invite-codes-router-shell-design.md
+++ b/docs/superpowers/specs/2026-04-07-invite-codes-router-shell-design.md
@@ -1,0 +1,86 @@
+# Invite Codes Router Shell Design
+
+## Goal
+
+Remove the repeated router-local repo-call and error-mapping shell in `backend/web/routers/invite_codes.py` without changing any invite-code contract.
+
+## Scope
+
+In scope:
+
+- `GET /api/invite-codes`
+- `POST /api/invite-codes`
+- `DELETE /api/invite-codes/{code}`
+- `GET /api/invite-codes/validate/{code}`
+
+Out of scope:
+
+- invite-code repo implementation
+- auth requirements for each route
+- the Chinese user-facing error prefixes
+
+## Existing Problem
+
+All four routes repeat the same shell:
+
+1. `_get_invite_code_repo(request.app)`
+2. `await asyncio.to_thread(...)`
+3. `except HTTPException: raise`
+4. `except Exception as e: raise HTTPException(500, f\"<route-specific-prefix>{e}\")`
+
+That is a clean router-local seam. The routes still have their own semantics:
+
+- `list` returns `{\"codes\": ...}`
+- `generate` passes `created_by` and `expires_days`
+- `revoke` must still translate a falsey repo result into `404 \"邀请码不存在\"`
+- `validate` stays unauthenticated and returns `{\"valid\": ...}`
+
+## Design
+
+Keep the change inside `backend/web/routers/invite_codes.py`.
+
+Add one helper:
+
+```python
+async def _call_invite_code_repo(
+    request: Request,
+    error_prefix: str,
+    method_name: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    ...
+```
+
+The helper must:
+
+- fetch the repo through `_get_invite_code_repo(request.app)`
+- call the repo method with `asyncio.to_thread`
+- preserve any `HTTPException` unchanged
+- map any other exception to `HTTPException(500, f"{error_prefix}{error}")`
+
+Each route stays responsible for its own semantics:
+
+- each route passes its own Chinese `500` prefix explicitly
+- `revoke` still handles `False` with `404 "邀请码不存在"` after the helper returns
+
+## Testing
+
+Add focused tests in `tests/Integration/test_invite_codes_router.py` that pin:
+
+- helper returns the repo result on success
+- helper maps generic exceptions to the provided Chinese `500` prefix
+- helper preserves `HTTPException`
+- `list_invite_codes` delegates through the helper with the list prefix
+- `revoke_invite_code` delegates through the helper and still raises `404` when the helper returns `False`
+
+Those tests must stay on the router shell. They must not drift into repo internals.
+
+## Stopline
+
+Do not:
+
+- flatten the Chinese `500` prefixes into one shared message
+- move `404 "邀请码不存在"` into the helper
+- change auth requirements
+- move the helper out of `invite_codes.py`

--- a/tests/Integration/test_invite_codes_router.py
+++ b/tests/Integration/test_invite_codes_router.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import invite_codes as invite_codes_router
+
+
+class _FakeInviteCodeRepo:
+    def __init__(self) -> None:
+        self.list_all_calls = 0
+        self.generate_calls: list[tuple[str, int | None]] = []
+        self.revoke_calls: list[str] = []
+        self.is_valid_calls: list[str] = []
+        self.list_all_result = [{"code": "invite-1"}]
+        self.generate_result = {"code": "invite-2"}
+        self.revoke_result = True
+        self.is_valid_result = True
+        self.list_all_error: Exception | None = None
+        self.generate_error: Exception | None = None
+        self.revoke_error: Exception | None = None
+        self.is_valid_error: Exception | None = None
+
+    def list_all(self):
+        self.list_all_calls += 1
+        if self.list_all_error is not None:
+            raise self.list_all_error
+        return self.list_all_result
+
+    def generate(self, *, created_by: str, expires_days: int | None):
+        self.generate_calls.append((created_by, expires_days))
+        if self.generate_error is not None:
+            raise self.generate_error
+        return self.generate_result
+
+    def revoke(self, code: str):
+        self.revoke_calls.append(code)
+        if self.revoke_error is not None:
+            raise self.revoke_error
+        return self.revoke_result
+
+    def is_valid(self, code: str):
+        self.is_valid_calls.append(code)
+        if self.is_valid_error is not None:
+            raise self.is_valid_error
+        return self.is_valid_result
+
+
+def _request(repo: _FakeInviteCodeRepo):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(_supabase_client=object(), invite_code_repo=repo)))
+
+
+@pytest.mark.asyncio
+async def test_call_invite_code_repo_returns_repo_result():
+    repo = _FakeInviteCodeRepo()
+
+    result = await invite_codes_router._call_invite_code_repo(
+        _request(repo),
+        "获取邀请码列表失败：",
+        "list_all",
+    )
+
+    assert result == [{"code": "invite-1"}]
+    assert repo.list_all_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_call_invite_code_repo_maps_exception_to_prefixed_500():
+    repo = _FakeInviteCodeRepo()
+    repo.generate_error = RuntimeError("db down")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await invite_codes_router._call_invite_code_repo(
+            _request(repo),
+            "生成邀请码失败：",
+            "generate",
+            created_by="user-1",
+            expires_days=7,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "生成邀请码失败：db down"
+
+
+@pytest.mark.asyncio
+async def test_call_invite_code_repo_preserves_http_exception():
+    repo = _FakeInviteCodeRepo()
+    repo.is_valid_error = HTTPException(503, "邀请码仓库未初始化")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await invite_codes_router._call_invite_code_repo(
+            _request(repo),
+            "校验邀请码失败：",
+            "is_valid",
+            "invite-1",
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "邀请码仓库未初始化"
+
+
+@pytest.mark.asyncio
+async def test_list_invite_codes_uses_router_helper(monkeypatch: pytest.MonkeyPatch):
+    request = _request(_FakeInviteCodeRepo())
+    calls: list[tuple[object, str, str, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_call(request_obj, error_prefix: str, method_name: str, *args: object, **kwargs: object):
+        calls.append((request_obj, error_prefix, method_name, args, kwargs))
+        return [{"code": "invite-1"}]
+
+    monkeypatch.setattr(invite_codes_router, "_call_invite_code_repo", fake_call)
+
+    result = await invite_codes_router.list_invite_codes(request=request, user_id="user-1")
+
+    assert result == {"codes": [{"code": "invite-1"}]}
+    assert calls == [
+        (
+            request,
+            "获取邀请码列表失败：",
+            "list_all",
+            (),
+            {},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_revoke_invite_code_uses_helper_and_keeps_404(monkeypatch: pytest.MonkeyPatch):
+    request = _request(_FakeInviteCodeRepo())
+    calls: list[tuple[object, str, str, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_call(request_obj, error_prefix: str, method_name: str, *args: object, **kwargs: object):
+        calls.append((request_obj, error_prefix, method_name, args, kwargs))
+        return False
+
+    monkeypatch.setattr(invite_codes_router, "_call_invite_code_repo", fake_call)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await invite_codes_router.revoke_invite_code("invite-1", request=request, user_id="user-1")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "邀请码不存在"
+    assert calls == [
+        (
+            request,
+            "吊销邀请码失败：",
+            "revoke",
+            ("invite-1",),
+            {},
+        )
+    ]


### PR DESCRIPTION
## Summary
- add a router-local helper for invite-code repo calls and error mapping
- reuse that helper from list/generate/revoke/validate while keeping each route's Chinese 500 prefix explicit
- keep revoke's 404 branch in the route and add focused integration tests with phase-10 spec/plan docs

## Test Plan
- uv run pytest tests/Integration/test_invite_codes_router.py -q
- uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_auth_router.py tests/Integration/test_messaging_router.py -q
- python3 -m py_compile backend/web/routers/invite_codes.py tests/Integration/test_invite_codes_router.py
- uv run ruff check backend/web/routers/invite_codes.py tests/Integration/test_invite_codes_router.py