### PR TITLE
fix: align settings local path shell

### DIFF
--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -64,6 +64,23 @@ def _remember_recent_workspace(settings: "WorkspaceSettings", workspace_str: str
     settings.recent_workspaces = settings.recent_workspaces[:5]
 
 
+def _resolve_local_path_or_http(
+    path: str,
+    *,
+    missing_detail: str,
+    wrong_type_detail: str,
+    expect_dir: bool,
+) -> Path:
+    target = Path(path).expanduser().resolve()
+    if not target.exists():
+        raise HTTPException(status_code=404, detail=missing_detail)
+    if expect_dir and not target.is_dir():
+        raise HTTPException(status_code=400, detail=wrong_type_detail)
+    if not expect_dir and target.is_dir():
+        raise HTTPException(status_code=400, detail=wrong_type_detail)
+    return target
+
+
 def load_settings() -> WorkspaceSettings:
     try:
         data = _load_user_json("preferences.json")
@@ -209,11 +226,12 @@ async def get_settings(request: Request) -> UserSettings:
 async def browse_filesystem(path: str = Query(default="~"), include_files: bool = Query(default=False)) -> dict[str, Any]:
     """Browse filesystem directories (and optionally files)."""
     try:
-        target_path = Path(path).expanduser().resolve()
-        if not target_path.exists():
-            raise HTTPException(status_code=404, detail="Path does not exist")
-        if not target_path.is_dir():
-            raise HTTPException(status_code=400, detail="Path is not a directory")
+        target_path = _resolve_local_path_or_http(
+            path,
+            missing_detail="Path does not exist",
+            wrong_type_detail="Path is not a directory",
+            expect_dir=True,
+        )
 
         parent = str(target_path.parent) if target_path.parent != target_path else None
         items: list[DirectoryItem] = []
@@ -239,11 +257,12 @@ async def read_local_file(path: str = Query(...)) -> dict[str, Any]:
     """Read a local file's content (for SandboxBrowser in resources page)."""
     _read_max_bytes = 100 * 1024
     try:
-        target = Path(path).expanduser().resolve()
-        if not target.exists():
-            raise HTTPException(status_code=404, detail="File not found")
-        if target.is_dir():
-            raise HTTPException(status_code=400, detail="Path is a directory")
+        target = _resolve_local_path_or_http(
+            path,
+            missing_detail="File not found",
+            wrong_type_detail="Path is a directory",
+            expect_dir=False,
+        )
         raw = target.read_bytes()
         truncated = len(raw) > _read_max_bytes
         content = raw[:_read_max_bytes].decode(errors="replace")

--- a/tests/Integration/test_settings_local_path_shell.py
+++ b/tests/Integration/test_settings_local_path_shell.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import settings as settings_router
+
+
+def test_resolve_local_path_or_http_returns_resolved_path(tmp_path: Path):
+    result = settings_router._resolve_local_path_or_http(
+        str(tmp_path),
+        missing_detail="missing",
+        wrong_type_detail="wrong-type",
+        expect_dir=True,
+    )
+
+    assert result == tmp_path.resolve()
+
+
+def test_resolve_local_path_or_http_preserves_route_specific_errors(tmp_path: Path):
+    missing = tmp_path / "missing"
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    with pytest.raises(HTTPException) as missing_exc:
+        settings_router._resolve_local_path_or_http(
+            str(missing),
+            missing_detail="Path does not exist",
+            wrong_type_detail="Path is not a directory",
+            expect_dir=True,
+        )
+
+    with pytest.raises(HTTPException) as wrong_type_exc:
+        settings_router._resolve_local_path_or_http(
+            str(tmp_path),
+            missing_detail="File not found",
+            wrong_type_detail="Path is a directory",
+            expect_dir=False,
+        )
+
+    assert missing_exc.value.status_code == 404
+    assert missing_exc.value.detail == "Path does not exist"
+    assert wrong_type_exc.value.status_code == 400
+    assert wrong_type_exc.value.detail == "Path is a directory"
+
+
+@pytest.mark.asyncio
+async def test_browse_filesystem_uses_local_path_helper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    child = tmp_path / "child"
+    child.mkdir()
+    seen: list[tuple[str, object]] = []
+
+    def fake_resolve(path: str, *, missing_detail: str, wrong_type_detail: str, expect_dir: bool) -> Path:
+        seen.append(("resolve", (path, missing_detail, wrong_type_detail, expect_dir)))
+        return tmp_path
+
+    monkeypatch.setattr(settings_router, "_resolve_local_path_or_http", fake_resolve)
+
+    result = await settings_router.browse_filesystem(path="~/workspace", include_files=False)
+
+    assert result["current_path"] == str(tmp_path)
+    assert result["parent_path"] == str(tmp_path.parent)
+    assert result["items"] == [{"name": "child", "path": str(child), "is_dir": True}]
+    assert seen == [("resolve", ("~/workspace", "Path does not exist", "Path is not a directory", True))]
+
+
+@pytest.mark.asyncio
+async def test_read_local_file_uses_local_path_helper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello world", encoding="utf-8")
+    seen: list[tuple[str, object]] = []
+
+    def fake_resolve(path: str, *, missing_detail: str, wrong_type_detail: str, expect_dir: bool) -> Path:
+        seen.append(("resolve", (path, missing_detail, wrong_type_detail, expect_dir)))
+        return file_path
+
+    monkeypatch.setattr(settings_router, "_resolve_local_path_or_http", fake_resolve)
+
+    result = await settings_router.read_local_file(path="~/note.txt")
+
+    assert result == {"path": str(file_path), "content": "hello world", "truncated": False}
+    assert seen == [("resolve", ("~/note.txt", "File not found", "Path is a directory", False))]


### PR DESCRIPTION
## Summary
- extract a shared local-path resolution shell for settings browse/read routes
- preserve route-specific browse vs read errors instead of flattening semantics
- add focused integration coverage for the shared shell contract

## Verification
- `uv run pytest tests/Integration/test_settings_local_path_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_messaging_router.py -q`
- `python3 -m py_compile backend/web/routers/settings.py tests/Integration/test_settings_local_path_shell.py`
- `uv run ruff check backend/web/routers/settings.py tests/Integration/test_settings_local_path_shell.py`

## Stopline
- only touches `backend/web/routers/settings.py` local-path browse/read shell
- does not change browse/read user-facing semantics or error strings
- does not touch repo/local persistence rules, resources overview, or thread_files provider/runtime seams
