### PR TITLE
fix: align thread file channel shell

### DIFF
--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -21,6 +21,17 @@ router = APIRouter(
 _public = APIRouter(prefix="/api/threads/{thread_id}/files", tags=["thread-files"])
 
 
+async def _call_channel_file_service(method, *args, missing_status: int | None = None, **kwargs):
+    try:
+        return await asyncio.to_thread(method, *args, **kwargs)
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+    except FileNotFoundError as e:
+        if missing_status is None:
+            raise
+        raise HTTPException(missing_status, str(e)) from e
+
+
 @router.get("/list")
 async def list_workspace_path(
     thread_id: str,
@@ -185,16 +196,12 @@ async def download_file(
     path: str = Query(...),
 ) -> FileResponse:
     """Download a file from thread-scoped files directory."""
-    try:
-        target = await asyncio.to_thread(
-            file_channel_service.resolve_channel_file,
-            thread_id=thread_id,
-            relative_path=path,
-        )
-    except ValueError as e:
-        raise HTTPException(400, str(e)) from e
-    except FileNotFoundError as e:
-        raise HTTPException(404, str(e)) from e
+    target = await _call_channel_file_service(
+        file_channel_service.resolve_channel_file,
+        thread_id=thread_id,
+        relative_path=path,
+        missing_status=404,
+    )
     return FileResponse(path=str(target), filename=target.name, media_type="application/octet-stream")
 
 
@@ -204,16 +211,12 @@ async def delete_workspace_file(
     path: str = Query(...),
 ) -> dict[str, Any]:
     """Delete a file from workspace."""
-    try:
-        await asyncio.to_thread(
-            file_channel_service.delete_channel_file,
-            thread_id=thread_id,
-            relative_path=path,
-        )
-    except ValueError as e:
-        raise HTTPException(400, str(e)) from e
-    except FileNotFoundError as e:
-        raise HTTPException(404, str(e)) from e
+    await _call_channel_file_service(
+        file_channel_service.delete_channel_file,
+        thread_id=thread_id,
+        relative_path=path,
+        missing_status=404,
+    )
     return {"ok": True, "path": path}
 
 
@@ -222,11 +225,8 @@ async def list_channel_files(
     thread_id: str,
 ) -> dict[str, Any]:
     """List files under thread-scoped files directory."""
-    try:
-        entries = await asyncio.to_thread(
-            file_channel_service.list_channel_files,
-            thread_id=thread_id,
-        )
-    except ValueError as e:
-        raise HTTPException(400, str(e)) from e
+    entries = await _call_channel_file_service(
+        file_channel_service.list_channel_files,
+        thread_id=thread_id,
+    )
     return {"thread_id": thread_id, "entries": entries}

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+
+from backend.web.routers import thread_files as thread_files_router
+
+
+@pytest.mark.asyncio
+async def test_call_channel_file_service_returns_service_result():
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_method(*args: object, **kwargs: object):
+        calls.append((args, kwargs))
+        return {"ok": True}
+
+    result = await thread_files_router._call_channel_file_service(
+        fake_method,
+        "thread-1",
+        relative_path="notes.txt",
+    )
+
+    assert result == {"ok": True}
+    assert calls == [(("thread-1",), {"relative_path": "notes.txt"})]
+
+
+@pytest.mark.asyncio
+async def test_call_channel_file_service_maps_value_error_to_400():
+    def fake_method(*_args: object, **_kwargs: object):
+        raise ValueError("bad path")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_files_router._call_channel_file_service(fake_method, "thread-1")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "bad path"
+
+
+@pytest.mark.asyncio
+async def test_call_channel_file_service_maps_missing_file_to_404():
+    def fake_method(*_args: object, **_kwargs: object):
+        raise FileNotFoundError("missing.txt")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_files_router._call_channel_file_service(
+            fake_method,
+            "thread-1",
+            missing_status=404,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "missing.txt"
+
+
+@pytest.mark.asyncio
+async def test_download_file_uses_channel_file_helper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("hello", encoding="utf-8")
+    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_call(method, *args: object, **kwargs: object):
+        calls.append((method, args, kwargs))
+        return file_path
+
+    monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
+
+    response = await thread_files_router.download_file("thread-1", path="notes.txt")
+
+    assert isinstance(response, FileResponse)
+    assert response.path == str(file_path)
+    assert response.media_type == "application/octet-stream"
+    assert calls == [
+        (
+            thread_files_router.file_channel_service.resolve_channel_file,
+            (),
+            {"thread_id": "thread-1", "relative_path": "notes.txt", "missing_status": 404},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_file_uses_channel_file_helper(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_call(method, *args: object, **kwargs: object):
+        calls.append((method, args, kwargs))
+        return None
+
+    monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
+
+    result = await thread_files_router.delete_workspace_file("thread-1", path="notes.txt")
+
+    assert result == {"ok": True, "path": "notes.txt"}
+    assert calls == [
+        (
+            thread_files_router.file_channel_service.delete_channel_file,
+            (),
+            {"thread_id": "thread-1", "relative_path": "notes.txt", "missing_status": 404},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_channel_files_uses_channel_file_helper(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_call(method, *args: object, **kwargs: object):
+        calls.append((method, args, kwargs))
+        return [{"path": "notes.txt"}]
+
+    monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
+
+    result = await thread_files_router.list_channel_files("thread-1")
+
+    assert result == {"thread_id": "thread-1", "entries": [{"path": "notes.txt"}]}
+    assert calls == [
+        (
+            thread_files_router.file_channel_service.list_channel_files,
+            (),
+            {"thread_id": "thread-1"},
+        )
+    ]


### PR DESCRIPTION
## Summary
- extract a shared local channel-file error-mapping shell for thread file routes
- keep existing success payloads and route-specific error texts intact
- add focused integration coverage for the local channel-file shell contract

## Verification
- `uv run pytest tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q`
- `python3 -m py_compile backend/web/routers/thread_files.py tests/Integration/test_thread_files_channel_shell.py`
- `uv run ruff check backend/web/routers/thread_files.py tests/Integration/test_thread_files_channel_shell.py`

## Stopline
- only touches local `file_channel_service` shell in `thread_files.py`
- helper is used only by `/download`, `/files` (delete), and `/channel-files`
- does not touch `/list`, `/read`, `/channels`, remote agent init, provider/sandbox bootstrap, or any remote workspace path
