### PR TITLE
fix: align resources overview shell

### DIFF
--- a/backend/web/routers/resources.py
+++ b/backend/web/routers/resources.py
@@ -13,16 +13,20 @@ from backend.web.services import resource_projection_service
 router = APIRouter(prefix="/api/resources", tags=["resources"])
 
 
+async def _list_user_resource_providers_or_500(method, *args, **kwargs) -> dict[str, Any]:
+    try:
+        return await asyncio.to_thread(method, *args, **kwargs)
+    except RuntimeError as exc:
+        raise HTTPException(500, str(exc)) from exc
+
+
 @router.get("/overview")
 async def resources_overview(
     user_id: Annotated[str, Depends(get_current_user_id)],
     request: Request,
 ) -> dict[str, Any]:
-    try:
-        return await asyncio.to_thread(
-            resource_projection_service.list_user_resource_providers,
-            request.app,
-            user_id,
-        )
-    except RuntimeError as exc:
-        raise HTTPException(500, str(exc)) from exc
+    return await _list_user_resource_providers_or_500(
+        resource_projection_service.list_user_resource_providers,
+        request.app,
+        user_id,
+    )

--- a/tests/Integration/test_resources_overview_shell.py
+++ b/tests/Integration/test_resources_overview_shell.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.web.routers import resources as resources_router
+
+
+@pytest.mark.asyncio
+async def test_list_user_resource_providers_or_500_returns_projection_result():
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    app = object()
+
+    def fake_list_user_resource_providers(*args: object, **kwargs: object):
+        calls.append((args, kwargs))
+        return {"summary": {"total_providers": 1}, "providers": []}
+
+    result = await resources_router._list_user_resource_providers_or_500(
+        fake_list_user_resource_providers,
+        app,
+        "user-1",
+    )
+
+    assert result == {"summary": {"total_providers": 1}, "providers": []}
+    assert calls == [((app, "user-1"), {})]
+
+
+@pytest.mark.asyncio
+async def test_list_user_resource_providers_or_500_maps_runtime_error_to_500():
+    def fake_list_user_resource_providers(*_args: object, **_kwargs: object):
+        raise RuntimeError("provider unavailable")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resources_router._list_user_resource_providers_or_500(
+            fake_list_user_resource_providers,
+            object(),
+            "user-1",
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "provider unavailable"
+
+
+@pytest.mark.asyncio
+async def test_resources_overview_uses_router_shell(monkeypatch: pytest.MonkeyPatch):
+    request = SimpleNamespace(app=object())
+    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_list_or_500(method, *args: object, **kwargs: object):
+        calls.append((method, args, kwargs))
+        return {"summary": {"total_providers": 2}, "providers": [{"id": "daytona"}]}
+
+    monkeypatch.setattr(resources_router, "_list_user_resource_providers_or_500", fake_list_or_500)
+
+    result = await resources_router.resources_overview(user_id="user-1", request=request)
+
+    assert result == {"summary": {"total_providers": 2}, "providers": [{"id": "daytona"}]}
+    assert calls == [
+        (
+            resources_router.resource_projection_service.list_user_resource_providers,
+            (request.app, "user-1"),
+            {},
+        )
+    ]


### PR DESCRIPTION
## Summary
- extract the router-local resources overview shell into a shared helper
- preserve the existing user-resource projection contract and 500 mapping
- add focused integration coverage for the overview shell contract

## Verification
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_resources_overview_shell.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q`
- `python3 -m py_compile backend/web/routers/resources.py tests/Integration/test_resources_overview_shell.py`
- `uv run ruff check backend/web/routers/resources.py tests/Integration/test_resources_overview_shell.py`

## Stopline
- only touches `backend/web/routers/resources.py` overview shell
- does not change `resource_projection_service` contract or `/api/monitor/resources`
- does not touch issue-205 monitor/resource split, cache/refresh/panel monitor, or frontend
