### PR TITLE
fix: align marketplace member preflight shell

### DIFF
--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -31,14 +31,19 @@ async def _verify_member_ownership(member_id: str, user_id: str, member_repo: An
     await asyncio.to_thread(_check)
 
 
+async def _require_owned_member_repo(request: Request, member_id: str, user_id: str) -> Any:
+    member_repo = request.app.state.member_repo
+    await _verify_member_ownership(member_id, user_id, member_repo)
+    return member_repo
+
+
 @router.post("/publish")
 async def publish_to_marketplace(
     req: PublishToMarketplaceRequest,
     user_id: Annotated[str, Depends(get_current_user_id)],
     request: Request,
 ) -> dict[str, Any]:
-    member_repo = request.app.state.member_repo
-    await _verify_member_ownership(req.member_id, user_id, member_repo)
+    await _require_owned_member_repo(request, req.member_id, user_id)
 
     from backend.web.services.profile_service import get_profile
 
@@ -77,8 +82,7 @@ async def upgrade_from_marketplace(
     user_id: Annotated[str, Depends(get_current_user_id)],
     request: Request,
 ) -> dict[str, Any]:
-    member_repo = request.app.state.member_repo
-    await _verify_member_ownership(req.member_id, user_id, member_repo)
+    await _require_owned_member_repo(request, req.member_id, user_id)
 
     result = await asyncio.to_thread(
         marketplace_client.upgrade,

--- a/tests/Integration/test_marketplace_member_preflight_shell.py
+++ b/tests/Integration/test_marketplace_member_preflight_shell.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.web.models.marketplace import PublishToMarketplaceRequest, UpgradeFromMarketplaceRequest
+from backend.web.routers import marketplace as marketplace_router
+
+
+@pytest.mark.asyncio
+async def test_require_owned_member_repo_returns_repo_after_verification(monkeypatch: pytest.MonkeyPatch):
+    member_repo = object()
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(member_repo=member_repo)))
+    calls: list[tuple[str, str, object]] = []
+
+    async def fake_verify(member_id: str, user_id: str, repo: object) -> None:
+        calls.append((member_id, user_id, repo))
+
+    monkeypatch.setattr(marketplace_router, "_verify_member_ownership", fake_verify)
+
+    result = await marketplace_router._require_owned_member_repo(request, "member-1", "user-1")
+
+    assert result is member_repo
+    assert calls == [("member-1", "user-1", member_repo)]
+
+
+@pytest.mark.asyncio
+async def test_publish_to_marketplace_uses_owned_member_repo_shell(monkeypatch: pytest.MonkeyPatch):
+    member_repo = object()
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(member_repo=member_repo)))
+    req = PublishToMarketplaceRequest(member_id="member-1")
+    preflight_calls: list[tuple[object, str, str]] = []
+    publish_calls: list[dict[str, object]] = []
+
+    async def fake_require_owned_member_repo(request_obj: object, member_id: str, user_id: str):
+        preflight_calls.append((request_obj, member_id, user_id))
+        return member_repo
+
+    def fake_get_profile():
+        return {"name": "tester"}
+
+    def fake_publish(**kwargs: object):
+        publish_calls.append(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(marketplace_router, "_require_owned_member_repo", fake_require_owned_member_repo)
+    monkeypatch.setattr(marketplace_router.marketplace_client, "publish", fake_publish)
+    monkeypatch.setattr("backend.web.services.profile_service.get_profile", fake_get_profile)
+
+    result = await marketplace_router.publish_to_marketplace(req=req, user_id="user-1", request=request)
+
+    assert result == {"ok": True}
+    assert preflight_calls == [(request, "member-1", "user-1")]
+    assert publish_calls == [
+        {
+            "member_id": "member-1",
+            "type_": "member",
+            "bump_type": "patch",
+            "release_notes": "",
+            "tags": [],
+            "visibility": "public",
+            "publisher_user_id": "user-1",
+            "publisher_username": "tester",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upgrade_from_marketplace_uses_owned_member_repo_shell(monkeypatch: pytest.MonkeyPatch):
+    member_repo = object()
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(member_repo=member_repo)))
+    req = UpgradeFromMarketplaceRequest(member_id="member-1", item_id="item-1")
+    preflight_calls: list[tuple[object, str, str]] = []
+    upgrade_calls: list[dict[str, object]] = []
+
+    async def fake_require_owned_member_repo(request_obj: object, member_id: str, user_id: str):
+        preflight_calls.append((request_obj, member_id, user_id))
+        return member_repo
+
+    def fake_upgrade(**kwargs: object):
+        upgrade_calls.append(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(marketplace_router, "_require_owned_member_repo", fake_require_owned_member_repo)
+    monkeypatch.setattr(marketplace_router.marketplace_client, "upgrade", fake_upgrade)
+
+    result = await marketplace_router.upgrade_from_marketplace(req=req, user_id="user-1", request=request)
+
+    assert result == {"ok": True}
+    assert preflight_calls == [(request, "member-1", "user-1")]
+    assert upgrade_calls == [
+        {
+            "member_id": "member-1",
+            "item_id": "item-1",
+            "owner_user_id": "user-1",
+        }
+    ]


### PR DESCRIPTION
## Summary
- align the owned-member router preflight used by `/api/marketplace/publish` and `/api/marketplace/upgrade`
- keep the marketplace client contract and payloads unchanged
- add focused integration coverage for the shared preflight shell

## Verification
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_marketplace_member_preflight_shell.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_resources_overview_shell.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q`
- `python3 -m py_compile backend/web/routers/marketplace.py tests/Integration/test_marketplace_member_preflight_shell.py`
- `uv run ruff check backend/web/routers/marketplace.py tests/Integration/test_marketplace_member_preflight_shell.py`

## Stopline
- only touches the router-local owned-member preflight for `/publish` and `/upgrade`
- does not change `marketplace_client` contracts or payloads
- does not expand into `/download`, `/check-updates`, or identity/member semantics
- does not touch monitor or sandbox lines