### PR TITLE
chore: remove unused router loggers

### DIFF
--- a/backend/web/routers/contacts.py
+++ b/backend/web/routers/contacts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import time
 from typing import Annotated, Any, Literal
 
@@ -11,8 +10,6 @@ from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
 from storage.contracts import ContactRow
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/contacts", tags=["contacts"])
 

--- a/backend/web/routers/conversations.py
+++ b/backend/web/routers/conversations.py
@@ -6,7 +6,6 @@ ConversationList can render a unified sidebar.
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
@@ -15,8 +14,6 @@ from fastapi import APIRouter, Depends
 from backend.web.core.dependencies import get_app, get_current_user_id
 from backend.web.utils.serializers import avatar_url
 from core.runtime.middleware.monitor import AgentState
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/conversations", tags=["conversations"])
 

--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
@@ -17,8 +16,6 @@ from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
 from backend.web.utils.serializers import avatar_url
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 


### PR DESCRIPTION
## Summary
- remove unused module-level logger setup from `messaging.py`, `contacts.py`, and `conversations.py`
- keep router behavior unchanged

## Verification
- `python3 -m py_compile backend/web/routers/messaging.py backend/web/routers/contacts.py backend/web/routers/conversations.py`
- `uv run ruff check backend/web/routers/messaging.py backend/web/routers/contacts.py backend/web/routers/conversations.py`
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_panel_task_owner_contract.py -q`
- Harvey review: `No findings`

## Diff shape
- net negative only: `-9` lines
- no new tests
- no behavior change
