### PR TITLE
chore: inline settings local path checks

### DIFF
--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -64,23 +64,6 @@ def _remember_recent_workspace(settings: "WorkspaceSettings", workspace_str: str
     settings.recent_workspaces = settings.recent_workspaces[:5]
 
 
-def _resolve_local_path_or_http(
-    path: str,
-    *,
-    missing_detail: str,
-    wrong_type_detail: str,
-    expect_dir: bool,
-) -> Path:
-    target = Path(path).expanduser().resolve()
-    if not target.exists():
-        raise HTTPException(status_code=404, detail=missing_detail)
-    if expect_dir and not target.is_dir():
-        raise HTTPException(status_code=400, detail=wrong_type_detail)
-    if not expect_dir and target.is_dir():
-        raise HTTPException(status_code=400, detail=wrong_type_detail)
-    return target
-
-
 def load_settings() -> WorkspaceSettings:
     try:
         data = _load_user_json("preferences.json")
@@ -226,12 +209,11 @@ async def get_settings(request: Request) -> UserSettings:
 async def browse_filesystem(path: str = Query(default="~"), include_files: bool = Query(default=False)) -> dict[str, Any]:
     """Browse filesystem directories (and optionally files)."""
     try:
-        target_path = _resolve_local_path_or_http(
-            path,
-            missing_detail="Path does not exist",
-            wrong_type_detail="Path is not a directory",
-            expect_dir=True,
-        )
+        target_path = Path(path).expanduser().resolve()
+        if not target_path.exists():
+            raise HTTPException(status_code=404, detail="Path does not exist")
+        if not target_path.is_dir():
+            raise HTTPException(status_code=400, detail="Path is not a directory")
 
         parent = str(target_path.parent) if target_path.parent != target_path else None
         items: list[DirectoryItem] = []
@@ -257,12 +239,11 @@ async def read_local_file(path: str = Query(...)) -> dict[str, Any]:
     """Read a local file's content (for SandboxBrowser in resources page)."""
     _read_max_bytes = 100 * 1024
     try:
-        target = _resolve_local_path_or_http(
-            path,
-            missing_detail="File not found",
-            wrong_type_detail="Path is a directory",
-            expect_dir=False,
-        )
+        target = Path(path).expanduser().resolve()
+        if not target.exists():
+            raise HTTPException(status_code=404, detail="File not found")
+        if target.is_dir():
+            raise HTTPException(status_code=400, detail="Path is a directory")
         raw = target.read_bytes()
         truncated = len(raw) > _read_max_bytes
         content = raw[:_read_max_bytes].decode(errors="replace")

--- a/tests/Integration/test_settings_local_path_shell.py
+++ b/tests/Integration/test_settings_local_path_shell.py
@@ -8,77 +8,53 @@ from fastapi import HTTPException
 from backend.web.routers import settings as settings_router
 
 
-def test_resolve_local_path_or_http_returns_resolved_path(tmp_path: Path):
-    result = settings_router._resolve_local_path_or_http(
-        str(tmp_path),
-        missing_detail="missing",
-        wrong_type_detail="wrong-type",
-        expect_dir=True,
-    )
+@pytest.mark.asyncio
+async def test_browse_filesystem_lists_directory_entries(tmp_path: Path):
+    child = tmp_path / "child"
+    child.mkdir()
 
-    assert result == tmp_path.resolve()
+    result = await settings_router.browse_filesystem(path=str(tmp_path), include_files=False)
+
+    assert result == {
+        "current_path": str(tmp_path.resolve()),
+        "parent_path": str(tmp_path.resolve().parent),
+        "items": [{"name": "child", "path": str(child.resolve()), "is_dir": True}],
+    }
 
 
-def test_resolve_local_path_or_http_preserves_route_specific_errors(tmp_path: Path):
+@pytest.mark.asyncio
+async def test_read_local_file_reads_content(tmp_path: Path):
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello world", encoding="utf-8")
+
+    result = await settings_router.read_local_file(path=str(file_path))
+
+    assert result == {"path": str(file_path.resolve()), "content": "hello world", "truncated": False}
+
+
+@pytest.mark.asyncio
+async def test_browse_and_read_keep_route_specific_path_errors(tmp_path: Path):
     missing = tmp_path / "missing"
     file_path = tmp_path / "note.txt"
     file_path.write_text("hello", encoding="utf-8")
 
-    with pytest.raises(HTTPException) as missing_exc:
-        settings_router._resolve_local_path_or_http(
-            str(missing),
-            missing_detail="Path does not exist",
-            wrong_type_detail="Path is not a directory",
-            expect_dir=True,
-        )
+    with pytest.raises(HTTPException) as browse_missing_exc:
+        await settings_router.browse_filesystem(path=str(missing), include_files=False)
 
-    with pytest.raises(HTTPException) as wrong_type_exc:
-        settings_router._resolve_local_path_or_http(
-            str(tmp_path),
-            missing_detail="File not found",
-            wrong_type_detail="Path is a directory",
-            expect_dir=False,
-        )
+    with pytest.raises(HTTPException) as browse_wrong_type_exc:
+        await settings_router.browse_filesystem(path=str(file_path), include_files=False)
 
-    assert missing_exc.value.status_code == 404
-    assert missing_exc.value.detail == "Path does not exist"
-    assert wrong_type_exc.value.status_code == 400
-    assert wrong_type_exc.value.detail == "Path is a directory"
+    with pytest.raises(HTTPException) as read_missing_exc:
+        await settings_router.read_local_file(path=str(missing))
 
+    with pytest.raises(HTTPException) as read_wrong_type_exc:
+        await settings_router.read_local_file(path=str(tmp_path))
 
-@pytest.mark.asyncio
-async def test_browse_filesystem_uses_local_path_helper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    child = tmp_path / "child"
-    child.mkdir()
-    seen: list[tuple[str, object]] = []
-
-    def fake_resolve(path: str, *, missing_detail: str, wrong_type_detail: str, expect_dir: bool) -> Path:
-        seen.append(("resolve", (path, missing_detail, wrong_type_detail, expect_dir)))
-        return tmp_path
-
-    monkeypatch.setattr(settings_router, "_resolve_local_path_or_http", fake_resolve)
-
-    result = await settings_router.browse_filesystem(path="~/workspace", include_files=False)
-
-    assert result["current_path"] == str(tmp_path)
-    assert result["parent_path"] == str(tmp_path.parent)
-    assert result["items"] == [{"name": "child", "path": str(child), "is_dir": True}]
-    assert seen == [("resolve", ("~/workspace", "Path does not exist", "Path is not a directory", True))]
-
-
-@pytest.mark.asyncio
-async def test_read_local_file_uses_local_path_helper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    file_path = tmp_path / "note.txt"
-    file_path.write_text("hello world", encoding="utf-8")
-    seen: list[tuple[str, object]] = []
-
-    def fake_resolve(path: str, *, missing_detail: str, wrong_type_detail: str, expect_dir: bool) -> Path:
-        seen.append(("resolve", (path, missing_detail, wrong_type_detail, expect_dir)))
-        return file_path
-
-    monkeypatch.setattr(settings_router, "_resolve_local_path_or_http", fake_resolve)
-
-    result = await settings_router.read_local_file(path="~/note.txt")
-
-    assert result == {"path": str(file_path), "content": "hello world", "truncated": False}
-    assert seen == [("resolve", ("~/note.txt", "File not found", "Path is a directory", False))]
+    assert browse_missing_exc.value.status_code == 404
+    assert browse_missing_exc.value.detail == "Path does not exist"
+    assert browse_wrong_type_exc.value.status_code == 400
+    assert browse_wrong_type_exc.value.detail == "Path is not a directory"
+    assert read_missing_exc.value.status_code == 404
+    assert read_missing_exc.value.detail == "File not found"
+    assert read_wrong_type_exc.value.status_code == 400
+    assert read_wrong_type_exc.value.detail == "Path is a directory"


### PR DESCRIPTION
## Summary
- inline the thin local-path validation back into `browse_filesystem` and `read_local_file`
- rewrite `test_settings_local_path_shell.py` to assert route behavior instead of helper wiring
- keep the four route-specific path error messages covered

## Why
This is a net-negative cleanup. The previous shape carried a single-use helper plus helper-focused tests. This version keeps the user-visible contract while reducing total code.

## Verification
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_settings_local_path_shell.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_invite_codes_router.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q`
- `python3 -m py_compile backend/web/routers/settings.py tests/Integration/test_settings_local_path_shell.py`
- `uv run ruff check backend/web/routers/settings.py tests/Integration/test_settings_local_path_shell.py`
- Harvey review: `No findings`

## Diff shape
- current diff is net negative: `+45 / -88`
- no new test file added
- browse/read keep distinct error messages
