### PR TITLE
chore: inline invite code repo lookup

### DIFF
--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -11,17 +11,6 @@ from backend.web.core.dependencies import get_current_user_id
 router = APIRouter(prefix="/api/invite-codes", tags=["invite-codes"])
 
 
-def _get_invite_code_repo(app: Any):
-    """Get SupabaseInviteCodeRepo from app state, or raise 503 if unavailable."""
-    sb_client = getattr(app.state, "_supabase_client", None)
-    if sb_client is None:
-        raise HTTPException(503, "邀请码服务不可用（当前为 SQLite 模式）")
-    repo = getattr(app.state, "invite_code_repo", None)
-    if repo is None:
-        raise HTTPException(503, "邀请码仓库未初始化")
-    return repo
-
-
 async def _call_invite_code_repo(
     request: Request,
     error_prefix: str,
@@ -29,7 +18,12 @@ async def _call_invite_code_repo(
     *args: Any,
     **kwargs: Any,
 ) -> Any:
-    repo = _get_invite_code_repo(request.app)
+    sb_client = getattr(request.app.state, "_supabase_client", None)
+    if sb_client is None:
+        raise HTTPException(503, "邀请码服务不可用（当前为 SQLite 模式）")
+    repo = getattr(request.app.state, "invite_code_repo", None)
+    if repo is None:
+        raise HTTPException(503, "邀请码仓库未初始化")
     try:
         method = getattr(repo, method_name)
         return await asyncio.to_thread(method, *args, **kwargs)


### PR DESCRIPTION
## Summary
- inline the single-use invite-code repo lookup into `_call_invite_code_repo`
- keep route behavior and Chinese error messages unchanged

## Verification
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_settings_local_path_shell.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q`
- `python3 -m py_compile backend/web/routers/invite_codes.py tests/Integration/test_invite_codes_router.py`
- `uv run ruff check backend/web/routers/invite_codes.py tests/Integration/test_invite_codes_router.py`
- Harvey review: `No findings`

## Diff shape
- net negative only: `+6 / -12`
- no new tests
- no contract rewrite
