### PR TITLE
chore: trim thread file helper tests

### DIFF
--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -56,13 +56,11 @@ async def test_call_channel_file_service_maps_missing_file_to_404():
 
 
 @pytest.mark.asyncio
-async def test_download_file_uses_channel_file_helper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+async def test_download_file_returns_file_response(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     file_path = tmp_path / "notes.txt"
     file_path.write_text("hello", encoding="utf-8")
-    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
 
     async def fake_call(method, *args: object, **kwargs: object):
-        calls.append((method, args, kwargs))
         return file_path
 
     monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
@@ -72,21 +70,11 @@ async def test_download_file_uses_channel_file_helper(monkeypatch: pytest.Monkey
     assert isinstance(response, FileResponse)
     assert response.path == str(file_path)
     assert response.media_type == "application/octet-stream"
-    assert calls == [
-        (
-            thread_files_router.file_channel_service.resolve_channel_file,
-            (),
-            {"thread_id": "thread-1", "relative_path": "notes.txt", "missing_status": 404},
-        )
-    ]
 
 
 @pytest.mark.asyncio
-async def test_delete_workspace_file_uses_channel_file_helper(monkeypatch: pytest.MonkeyPatch):
-    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
-
+async def test_delete_workspace_file_returns_ok_payload(monkeypatch: pytest.MonkeyPatch):
     async def fake_call(method, *args: object, **kwargs: object):
-        calls.append((method, args, kwargs))
         return None
 
     monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
@@ -94,21 +82,11 @@ async def test_delete_workspace_file_uses_channel_file_helper(monkeypatch: pytes
     result = await thread_files_router.delete_workspace_file("thread-1", path="notes.txt")
 
     assert result == {"ok": True, "path": "notes.txt"}
-    assert calls == [
-        (
-            thread_files_router.file_channel_service.delete_channel_file,
-            (),
-            {"thread_id": "thread-1", "relative_path": "notes.txt", "missing_status": 404},
-        )
-    ]
 
 
 @pytest.mark.asyncio
-async def test_list_channel_files_uses_channel_file_helper(monkeypatch: pytest.MonkeyPatch):
-    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
-
+async def test_list_channel_files_returns_entries_payload(monkeypatch: pytest.MonkeyPatch):
     async def fake_call(method, *args: object, **kwargs: object):
-        calls.append((method, args, kwargs))
         return [{"path": "notes.txt"}]
 
     monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
@@ -116,10 +94,3 @@ async def test_list_channel_files_uses_channel_file_helper(monkeypatch: pytest.M
     result = await thread_files_router.list_channel_files("thread-1")
 
     assert result == {"thread_id": "thread-1", "entries": [{"path": "notes.txt"}]}
-    assert calls == [
-        (
-            thread_files_router.file_channel_service.list_channel_files,
-            (),
-            {"thread_id": "thread-1"},
-        )
-    ]


### PR DESCRIPTION
## Summary
- remove thread file route tests that only asserted helper delegation
- keep route result-shape coverage for download, delete, and list endpoints
- make no production code changes

## Verification
- ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_settings_local_path_shell.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_auth_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q
- uv run ruff check tests/Integration/test_thread_files_channel_shell.py