### PR TITLE
chore: remove unused settings save helper

### DIFF
--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -122,13 +122,6 @@ def load_models() -> dict[str, Any]:
     return _load_user_json("models.json")
 
 
-def save_models(data: dict[str, Any]) -> None:
-    """Save models.json to disk (user-level)."""
-    MODELS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(MODELS_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-
-
 def load_merged_models() -> ModelsConfig:
     """Load fully merged ModelsConfig (system + user)."""
     return ModelsLoader().load()


### PR DESCRIPTION
## Summary
- remove the zero-call settings save_models() wrapper
- keep all live models writes on the existing _save_models_for_user(...) path
- make no behavior changes

## Verification
- ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_settings_local_path_shell.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_invite_codes_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_auth_router.py tests/Integration/test_messaging_router.py tests/Integration/test_entities_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q
- python3 -m py_compile backend/web/routers/settings.py
- uv run ruff check backend/web/routers/settings.py