### PR TITLE
chore: remove unused directory ensure helpers

### DIFF
--- a/backend/web/services/library_service.py
+++ b/backend/web/services/library_service.py
@@ -14,6 +14,7 @@ from storage.contracts import RecipeRepo
 
 LIBRARY_DIR = library_dir()
 
+
 def _read_json(path: Path, default: Any = None) -> Any:
     if not path.exists():
         return default if default is not None else {}

--- a/backend/web/services/library_service.py
+++ b/backend/web/services/library_service.py
@@ -14,20 +14,6 @@ from storage.contracts import RecipeRepo
 
 LIBRARY_DIR = library_dir()
 
-
-def ensure_library_dir() -> None:
-    LIBRARY_DIR.mkdir(parents=True, exist_ok=True)
-    (LIBRARY_DIR / "skills").mkdir(exist_ok=True)
-    (LIBRARY_DIR / "agents").mkdir(exist_ok=True)
-    legacy_recipe_dir = LIBRARY_DIR / "recipes"
-    # @@@recipe-storage-cutover - recipes now live in SQLite only; delete the dead file tree so it cannot masquerade as live state.
-    if legacy_recipe_dir.exists():
-        if legacy_recipe_dir.is_dir():
-            shutil.rmtree(legacy_recipe_dir)
-        else:
-            legacy_recipe_dir.unlink()
-
-
 def _read_json(path: Path, default: Any = None) -> Any:
     if not path.exists():
         return default if default is not None else {}

--- a/backend/web/services/member_service.py
+++ b/backend/web/services/member_service.py
@@ -37,10 +37,6 @@ def _load_tools_catalog() -> dict[str, ToolDef]:
     return TOOLS_BY_NAME
 
 
-def ensure_members_dir() -> None:
-    MEMBERS_DIR.mkdir(parents=True, exist_ok=True)
-
-
 # ── Low-level I/O helpers ──
 
 


### PR DESCRIPTION
## Summary
- remove zero-call ensure_library_dir() and ensure_members_dir() wrappers
- keep all live directory creation behavior where it already exists
- make no behavior changes

## Verification
- rg -n "ensure_library_dir|ensure_members_dir" . -S
- python3 -m py_compile backend/web/services/library_service.py backend/web/services/member_service.py
- uv run ruff check backend/web/services/library_service.py backend/web/services/member_service.py
- ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_entities_router.py tests/Integration/test_settings_local_path_shell.py tests/Integration/test_auth_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_messaging_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_panel_task_owner_contract.py -q