### PR TITLE
chore: remove unused hook discovery helper

### DIFF
--- a/core/tools/command/hooks/loader.py
+++ b/core/tools/command/hooks/loader.py
@@ -39,13 +39,3 @@ def load_hooks(
     hooks.sort(key=lambda h: h.priority)
     print(f"[BashHooks] Total {len(hooks)} hooks loaded")
     return hooks
-
-
-def discover_hooks() -> list[str]:
-    """Discover all available hook plugins without loading them."""
-    hooks_dir = Path(__file__).parent
-    return [
-        py_file.stem
-        for py_file in hooks_dir.glob("*.py")
-        if not py_file.name.startswith("_") and py_file.name not in ["base.py", "loader.py"]
-    ]


### PR DESCRIPTION
## Summary
- remove the zero-call `discover_hooks()` helper from `core/tools/command/hooks/loader.py`
- keep the exported `load_hooks()` API unchanged
- trim dead code without adding new tests or abstractions

## Verification
- `rg -n "\bdiscover_hooks\b" backend core storage messaging sandbox tests -S`
- `python3 -m py_compile core/tools/command/hooks/loader.py`
- `uv run ruff check core/tools/command/hooks/loader.py`
- `uv run ruff format --check core/tools/command/hooks/loader.py`
