### PR TITLE
chore: remove unused visibility helpers

### DIFF
--- a/core/runtime/visibility.py
+++ b/core/runtime/visibility.py
@@ -12,21 +12,6 @@ from typing import Any
 _ALWAYS_SHOWING = {"showing": True}
 
 
-def compute_visibility(source: str, is_steer: bool, context: str) -> tuple[bool, str]:
-    """Always visible. Kept for call-site compatibility during transition."""
-    return True, "owner"
-
-
-def message_visibility(context: str, tool_names: list[str] | None = None) -> dict[str, Any]:
-    """Always visible."""
-    return _ALWAYS_SHOWING
-
-
-def tool_event_visibility(context: str, tool_name: str) -> dict[str, Any]:
-    """Always visible."""
-    return _ALWAYS_SHOWING
-
-
 def annotate_owner_visibility(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str]:
     """Annotate messages as visible unless they already carry display metadata."""
     for msg in messages:


### PR DESCRIPTION
## Summary
- remove the zero-call compatibility helpers from `core/runtime/visibility.py`
- keep `annotate_owner_visibility()` unchanged
- trim dead transitional code without adding new tests or abstractions

## Verification
- `rg -n "compute_visibility\(|message_visibility\(|tool_event_visibility\(" backend core storage messaging sandbox tests -S`
- `python3 -m py_compile core/runtime/visibility.py`
- `uv run ruff check core/runtime/visibility.py`
- `uv run ruff format --check core/runtime/visibility.py`
