### PR TITLE
chore: remove unused tool builder helper

### DIFF
--- a/core/runtime/registry.py
+++ b/core/runtime/registry.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, NotRequired, Required, TypedDict, Unpack
+from typing import Any, NotRequired, Required, TypedDict
 
 from core.runtime.tool_result import ToolResultEnvelope
 
@@ -74,12 +74,6 @@ TOOL_DEFAULTS: _ToolEntryDefaults = {
     "context_schema": None,
     "validate_input": None,
 }
-
-
-def build_tool(**kwargs: Unpack[_ToolEntryBuildArgs]) -> ToolEntry:
-    """Factory that fills in safety defaults. Fail-closed: assumes write + non-concurrent."""
-    merged: _ToolEntryBuildArgs = {**TOOL_DEFAULTS, **kwargs}
-    return ToolEntry(**merged)
 
 
 def make_tool_schema(


### PR DESCRIPTION
## Summary
- remove the zero-call `build_tool()` helper from `core/runtime/registry.py`
- keep `ToolEntry`, `TOOL_DEFAULTS`, and the registry API unchanged
- trim dead code without adding new tests or abstractions

## Verification
- `rg -n "build_tool\(" backend core storage messaging sandbox tests -S`
- `python3 -m py_compile core/runtime/registry.py`
- `uv run ruff check core/runtime/registry.py`
- `uv run ruff format --check core/runtime/registry.py`
