### PR TITLE
chore: trim thread file helper test

### DIFF
--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -10,24 +10,6 @@ from backend.web.routers import thread_files as thread_files_router
 
 
 @pytest.mark.asyncio
-async def test_call_channel_file_service_returns_service_result():
-    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
-
-    def fake_method(*args: object, **kwargs: object):
-        calls.append((args, kwargs))
-        return {"ok": True}
-
-    result = await thread_files_router._call_channel_file_service(
-        fake_method,
-        "thread-1",
-        relative_path="notes.txt",
-    )
-
-    assert result == {"ok": True}
-    assert calls == [(("thread-1",), {"relative_path": "notes.txt"})]
-
-
-@pytest.mark.asyncio
 async def test_call_channel_file_service_maps_value_error_to_400():
     def fake_method(*_args: object, **_kwargs: object):
         raise ValueError("bad path")


### PR DESCRIPTION
## Summary
- remove the success-path helper forwarding test from `tests/Integration/test_thread_files_channel_shell.py`
- keep the helper error-mapping tests and route result-shape tests intact
- trim test noise without changing thread file route behavior

## Verification
- `uv run ruff check tests/Integration/test_thread_files_channel_shell.py`
- `uv run ruff format --check tests/Integration/test_thread_files_channel_shell.py`
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_invite_codes_router.py tests/Integration/test_settings_local_path_shell.py -q`
