### PR TITLE
chore: trim invite code helper test

### DIFF
--- a/tests/Integration/test_invite_codes_router.py
+++ b/tests/Integration/test_invite_codes_router.py
@@ -53,20 +53,6 @@ def _request(repo: _FakeInviteCodeRepo):
 
 
 @pytest.mark.asyncio
-async def test_call_invite_code_repo_returns_repo_result():
-    repo = _FakeInviteCodeRepo()
-
-    result = await invite_codes_router._call_invite_code_repo(
-        _request(repo),
-        "获取邀请码列表失败：",
-        "list_all",
-    )
-
-    assert result == [{"code": "invite-1"}]
-    assert repo.list_all_calls == 1
-
-
-@pytest.mark.asyncio
 async def test_call_invite_code_repo_maps_exception_to_prefixed_500():
     repo = _FakeInviteCodeRepo()
     repo.generate_error = RuntimeError("db down")


### PR DESCRIPTION
## Summary
- remove the pure success-forwarding helper test from `test_invite_codes_router.py`
- keep the helper's `500` prefix mapping and `HTTPException` passthrough tests
- keep the route-level `revoke -> 404 \"邀请码不存在\"` contract test

## Test Plan
- `uv run ruff check tests/Integration/test_invite_codes_router.py`
- `uv run ruff format --check tests/Integration/test_invite_codes_router.py`
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py -q`
