### PR TITLE
chore: remove dead invite code fallback

### DIFF
--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -308,9 +308,8 @@ export interface InviteCode {
 }
 
 export async function fetchInviteCodes(): Promise<InviteCode[]> {
-  const payload = await request<{ codes: InviteCode[] } | InviteCode[]>("/api/invite-codes");
-  if (Array.isArray(payload)) return payload;
-  return (payload as { codes: InviteCode[] }).codes;
+  const payload = await request<{ codes: InviteCode[] }>("/api/invite-codes");
+  return payload.codes;
 }
 
 export async function generateInviteCode(expiresDays = 7): Promise<InviteCode> {

--- a/tests/Integration/test_invite_codes_router.py
+++ b/tests/Integration/test_invite_codes_router.py
@@ -10,24 +10,15 @@ from backend.web.routers import invite_codes as invite_codes_router
 
 class _FakeInviteCodeRepo:
     def __init__(self) -> None:
-        self.list_all_calls = 0
         self.generate_calls: list[tuple[str, int | None]] = []
         self.revoke_calls: list[str] = []
         self.is_valid_calls: list[str] = []
-        self.list_all_result = [{"code": "invite-1"}]
         self.generate_result = {"code": "invite-2"}
         self.revoke_result = True
         self.is_valid_result = True
-        self.list_all_error: Exception | None = None
         self.generate_error: Exception | None = None
         self.revoke_error: Exception | None = None
         self.is_valid_error: Exception | None = None
-
-    def list_all(self):
-        self.list_all_calls += 1
-        if self.list_all_error is not None:
-            raise self.list_all_error
-        return self.list_all_result
 
     def generate(self, *, created_by: str, expires_days: int | None):
         self.generate_calls.append((created_by, expires_days))


### PR DESCRIPTION
## Summary
- remove the dead `Array.isArray` compatibility branch from `fetchInviteCodes()`
- prune the now-unused `list_all*` fake-repo surface from `test_invite_codes_router.py`
- keep the invite-code helper's real error-contract tests (`500` prefix mapping, `HTTPException` passthrough, `revoke -> 404`)

## Residual Risk
- if some stale backend outside this repo still returns a bare invite-code array instead of `{ "codes": [...] }`, that unsupported version skew would now fail on the frontend

## Test Plan
- `uv run ruff check tests/Integration/test_invite_codes_router.py`
- `uv run ruff format --check tests/Integration/test_invite_codes_router.py`
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py -q`
- `cd frontend/app && npm run build`
