### PR TITLE
chore: remove dead thread list fallback

### DIFF
--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -34,21 +34,11 @@ export async function request<T>(url: string, init?: RequestInit): Promise<T> {
   return (await response.json()) as T;
 }
 
-function toThreads(payload: unknown): ThreadSummary[] {
-  if (payload && typeof payload === "object" && Array.isArray((payload as { threads?: unknown }).threads)) {
-    return (payload as { threads: ThreadSummary[] }).threads;
-  }
-  if (Array.isArray(payload)) {
-    return payload as ThreadSummary[];
-  }
-  throw new Error("Unexpected /api/threads response shape");
-}
-
 // --- Thread API ---
 
 export async function listThreads(): Promise<ThreadSummary[]> {
-  const payload = await request<unknown>("/api/threads");
-  return toThreads(payload);
+  const payload = await request<{ threads: ThreadSummary[] }>("/api/threads");
+  return payload.threads;
 }
 
 export interface CreateThreadOptions {


### PR DESCRIPTION
## Summary
- remove the dead `toThreads()` compatibility parser from `frontend/app/src/api/client.ts`
- have `listThreads()` read the current `/api/threads` contract directly as `{ "threads": ThreadSummary[] }`
- keep the change net-negative and frontend-only

## Residual Risk
- if some stale backend outside this repo still returns a bare array instead of `{ "threads": [...] }`, that unsupported version skew would now fail on the frontend

## Test Plan
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py -q`
- `cd frontend/app && npm run build`
