### PR TITLE
chore: drop unused resource session helpers

### DIFF
--- a/frontend/app/src/pages/resources/session-list-utils.ts
+++ b/frontend/app/src/pages/resources/session-list-utils.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { ResourceSession, SessionMetrics } from "./types";
 
 export interface LeaseGroup {
@@ -7,53 +6,4 @@ export interface LeaseGroup {
   sessions: ResourceSession[];
   startedAt: string;
   metrics: SessionMetrics | null;
-}
-
-const STATUS_ORDER: Record<ResourceSession["status"], number> = {
-  running: 0,
-  destroying: 1,
-  paused: 2,
-  stopped: 3,
-};
-
-export function useSessionCounts(sessions: ResourceSession[]) {
-  return useMemo(
-    () => ({
-      running: sessions.filter((s) => s.status === "running").length,
-      paused: sessions.filter((s) => s.status === "paused").length,
-      stopped: sessions.filter((s) => s.status === "stopped").length,
-    }),
-    [sessions],
-  );
-}
-
-export function groupByLease(sessions: ResourceSession[]): LeaseGroup[] {
-  const map = new Map<string, ResourceSession[]>();
-  for (const s of sessions) {
-    // Group by leaseId; local sessions with no lease each get their own group
-    const key = s.leaseId || s.id;
-    const arr = map.get(key) ?? [];
-    arr.push(s);
-    map.set(key, arr);
-  }
-
-  return Array.from(map.values())
-    .map((group) => {
-      const sorted = [...group].sort(
-        (a, b) => (STATUS_ORDER[a.status] ?? 4) - (STATUS_ORDER[b.status] ?? 4),
-      );
-      const best = sorted[0];
-      const earliest = group.reduce(
-        (min, s) => (s.startedAt < min ? s.startedAt : min),
-        group[0].startedAt,
-      );
-      return {
-        leaseId: group[0].leaseId ?? "",
-        status: best.status,
-        sessions: sorted,
-        startedAt: earliest,
-        metrics: best.metrics ?? null,
-      } satisfies LeaseGroup;
-    })
-    .sort((a, b) => (STATUS_ORDER[a.status] ?? 4) - (STATUS_ORDER[b.status] ?? 4));
 }


### PR DESCRIPTION
## Summary
- remove unused `useSessionCounts()` and `groupByLease()` exports from `frontend/app/src/pages/resources/session-list-utils.ts`
- prune the now-dead `useMemo` import and `STATUS_ORDER` constant
- keep the live `LeaseGroup` type export for `SandboxCard` and `SandboxDetailSheet`

## Residual Risk
- if something outside this repo imports those deleted page-local helpers directly, that repo-external usage would now break

## Test Plan
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py -q`
- `cd frontend/app && npm run build`
