### PR TITLE
chore: remove dead resource type re-export

### DIFF
--- a/frontend/app/src/pages/resources/SandboxDetailSheet.tsx
+++ b/frontend/app/src/pages/resources/SandboxDetailSheet.tsx
@@ -9,7 +9,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { SandboxFileBrowser } from "@/components/SandboxFileBrowser";
 import type { LeaseGroup } from "./session-list-utils";
-import type { ResourceSession, SessionMetrics } from "./types";
+import type { ResourceSession } from "./types";
 import { calculateDuration, formatDuration } from "./utils/duration";
 import { formatMetric } from "./utils/format";
 
@@ -181,6 +181,3 @@ function MetricBlock({
     </div>
   );
 }
-
-// Re-export for consumers that only need the type
-export type { SessionMetrics };


### PR DESCRIPTION
## Summary
- remove the dead `SessionMetrics` type re-export from `frontend/app/src/pages/resources/SandboxDetailSheet.tsx`
- drop the now-unused `SessionMetrics` import from the same file
- keep the live type source in `frontend/app/src/pages/resources/types.ts`

## Residual Risk
- if something outside this repo imports `SessionMetrics` from `SandboxDetailSheet.tsx` directly, that repo-external usage would now break

## Test Plan
- `ALL_PROXY= HTTPS_PROXY= HTTP_PROXY= all_proxy= https_proxy= http_proxy= uv run pytest tests/Integration/test_invite_codes_router.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_settings_local_path_shell.py -q`
- `cd frontend/app && npm run build`
