### PR TITLE
chore: unexport internal workspace settings type

### DIFF
--- a/frontend/app/src/hooks/use-workspace-settings.ts
+++ b/frontend/app/src/hooks/use-workspace-settings.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export interface UserSettings {
+interface UserSettings {
   default_workspace: string | null;
   recent_workspaces: string[];
   default_model: string;


### PR DESCRIPTION
## Summary
- stop exporting the internal `UserSettings` interface from `use-workspace-settings`
- keep the type file-local because it has no external in-repo consumers

## Verification
- `rg -n "\bUserSettings\b" frontend/app/src -S`
- `cd frontend/app && npm run build`
