### PR TITLE
chore: remove unused frontend internal types

### DIFF
--- a/frontend/app/src/components/computer-panel/types.ts
+++ b/frontend/app/src/components/computer-panel/types.ts
@@ -1,5 +1,4 @@
-import type { ChatEntry, LeaseStatus, SessionStatus, TerminalStatus } from "../../api";
-import type { SandboxChannelFileEntry, SandboxChannelKind } from "../../api";
+import type { ChatEntry } from "../../api";
 
 export type TabType = "terminal" | "files" | "agents";
 
@@ -24,36 +23,4 @@ export interface TreeNode {
   children?: TreeNode[];
   expanded?: boolean;
   loading?: boolean;
-}
-
-export interface SandboxStatus {
-  session: SessionStatus | null;
-  terminal: TerminalStatus | null;
-  lease: LeaseStatus | null;
-  error: string | null;
-  refresh: () => Promise<void>;
-}
-
-export interface FileExplorerState {
-  currentPath: string;
-  workspaceRoot: string;
-  treeNodes: TreeNode[];
-  selectedFilePath: string | null;
-  selectedFileContent: string;
-  loadingWorkspace: boolean;
-  workspaceError: string | null;
-  channel: SandboxChannelKind;
-  channelRootPath: string;
-  sandboxFilesId: string | null;
-  channelEntries: SandboxChannelFileEntry[];
-  loadingChannelFiles: boolean;
-  uploadingChannelFile: boolean;
-  channelError: string | null;
-  setChannel: (channel: SandboxChannelKind) => void;
-  refreshChannelFiles: () => Promise<void>;
-  uploadChannelFile: (file: File) => Promise<void>;
-  downloadChannelFile: (relativePath: string) => void;
-  handleToggleFolder: (fullPath: string) => Promise<void>;
-  handleSelectFile: (fullPath: string) => Promise<void>;
-  refreshWorkspace: (pathOverride?: string) => Promise<void>;
 }

--- a/frontend/app/src/pages/resources/types.ts
+++ b/frontend/app/src/pages/resources/types.ts
@@ -85,17 +85,3 @@ export interface ProviderInfo {
   latencyMs?: number;
   sessions: ResourceSession[];
 }
-
-/** An atomic resource allocated to an agent via a provider session */
-export type ResourceType = keyof ProviderCapabilities;
-
-export interface AllocatedResource {
-  resourceType: ResourceType;
-  providerId: string;
-  providerName: string;
-  threadId: string;
-  memberId: string;
-  memberName: string;
-  sessionId: string;
-  sessionStatus: ResourceSession["status"];
-}


### PR DESCRIPTION
## Summary
- remove zero-reference internal types from the frontend resources and computer-panel type files
- keep the remaining shared types unchanged

## Verification
- `rg -n "\b(AllocatedResource|ResourceType|SandboxStatus|FileExplorerState)\b" frontend/app/src -S`
- `cd frontend/app && npm run build`
