### PR TITLE
chore: remove unused auth request helper

### DIFF
--- a/frontend/app/src/store/auth-store.ts
+++ b/frontend/app/src/store/auth-store.ts
@@ -133,13 +133,3 @@ export async function authFetch(url: string, init?: RequestInit): Promise<Respon
   }
   return res;
 }
-
-export async function authRequest<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await authFetch(url, init);
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`API ${res.status}: ${body || res.statusText}`);
-  }
-  if (res.status === 204) return undefined as T;
-  return res.json();
-}


### PR DESCRIPTION
## Summary
- remove the unused `authRequest()` helper from `frontend/app/src/store/auth-store.ts`
- keep `authFetch()` as the only live auth-aware fetch helper

## Verification
- `rg -n "\bauthRequest\b" -S`
- `cd frontend/app && npm run build`
