### PR TITLE
chore: remove unused storage factory wrappers

### DIFF
--- a/backend/web/core/storage_factory.py
+++ b/backend/web/core/storage_factory.py
@@ -35,30 +35,6 @@ def make_sandbox_monitor_repo() -> Any:
     return SQLiteSandboxMonitorRepo()
 
 
-def make_agent_registry_repo() -> Any:
-    from storage.providers.supabase.agent_registry_repo import SupabaseAgentRegistryRepo
-
-    return SupabaseAgentRegistryRepo(_supabase_client())
-
-
-def make_tool_task_repo(db_path: Any = None) -> Any:
-    from storage.providers.supabase.tool_task_repo import SupabaseToolTaskRepo
-
-    return SupabaseToolTaskRepo(_supabase_client())
-
-
-def make_sync_file_repo() -> Any:
-    from storage.providers.supabase.sync_file_repo import SupabaseSyncFileRepo
-
-    return SupabaseSyncFileRepo(_supabase_client())
-
-
-def upsert_resource_snapshot(**kwargs: Any) -> None:
-    from storage.providers.supabase.resource_snapshot_repo import upsert_lease_resource_snapshot
-
-    upsert_lease_resource_snapshot(**kwargs, client=_supabase_client())
-
-
 def list_resource_snapshots(lease_ids: list[str]) -> dict[str, Any]:
     from storage.providers.supabase.resource_snapshot_repo import list_snapshots_by_lease_ids
 

--- a/tests/Integration/test_storage_repo_abstraction_unification.py
+++ b/tests/Integration/test_storage_repo_abstraction_unification.py
@@ -232,18 +232,6 @@ def test_runtime_services_default_to_storage_runtime_container(monkeypatch: pyte
 
     container = _FakeRuntimeContainer()
 
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.make_tool_task_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory tool repo")),
-    )
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.make_agent_registry_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory agent repo")),
-    )
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.make_sync_file_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory sync repo")),
-    )
     monkeypatch.setattr("storage.runtime.build_storage_container", lambda **_kwargs: container)
 
     task_service = TaskService(registry=ToolRegistry(), db_path=tmp_path / "test.db")
@@ -279,10 +267,6 @@ def test_resource_snapshot_helpers_default_to_storage_runtime_container(monkeypa
 
     container = _FakeRuntimeContainer()
 
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.upsert_resource_snapshot",
-        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory resource upsert")),
-    )
     monkeypatch.setattr(
         "backend.web.core.storage_factory.list_resource_snapshots",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory resource list")),


### PR DESCRIPTION
## Summary
- remove unused storage factory wrappers for agent registry, tool task, sync file, and resource upsert
- trim the matching integration-test sentinels that only guarded those dead wrappers
- keep list_resource_snapshots and the live monitor/resource path unchanged

## Verification
- python3 -m py_compile backend/web/core/storage_factory.py tests/Integration/test_storage_repo_abstraction_unification.py
- uv run ruff check backend/web/core/storage_factory.py tests/Integration/test_storage_repo_abstraction_unification.py
- uv run pytest tests/Integration/test_storage_repo_abstraction_unification.py -q