### PR TITLE
chore: remove unused frontend payload types

### DIFF
--- a/backend/web/core/storage_factory.py
+++ b/backend/web/core/storage_factory.py
@@ -35,30 +35,6 @@ def make_sandbox_monitor_repo() -> Any:
     return SQLiteSandboxMonitorRepo()
 
 
-def make_agent_registry_repo() -> Any:
-    from storage.providers.supabase.agent_registry_repo import SupabaseAgentRegistryRepo
-
-    return SupabaseAgentRegistryRepo(_supabase_client())
-
-
-def make_tool_task_repo(db_path: Any = None) -> Any:
-    from storage.providers.supabase.tool_task_repo import SupabaseToolTaskRepo
-
-    return SupabaseToolTaskRepo(_supabase_client())
-
-
-def make_sync_file_repo() -> Any:
-    from storage.providers.supabase.sync_file_repo import SupabaseSyncFileRepo
-
-    return SupabaseSyncFileRepo(_supabase_client())
-
-
-def upsert_resource_snapshot(**kwargs: Any) -> None:
-    from storage.providers.supabase.resource_snapshot_repo import upsert_lease_resource_snapshot
-
-    upsert_lease_resource_snapshot(**kwargs, client=_supabase_client())
-
-
 def list_resource_snapshots(lease_ids: list[str]) -> dict[str, Any]:
     from storage.providers.supabase.resource_snapshot_repo import list_snapshots_by_lease_ids
 

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -347,15 +347,6 @@ export interface ChatMember {
   branch_index?: number | null;
 }
 
-export interface ChatSummary {
-  id: string;
-  title: string | null;
-  entities: ChatMember[];
-  last_message?: { content: string; sender_name: string; created_at: number };
-  unread_count: number;
-  has_mention: boolean;
-}
-
 export interface ChatDetail {
   id: string;
   title: string | null;
@@ -374,14 +365,6 @@ export interface ChatMessage {
   created_at: number;
 }
 
-export interface TaskAgentRequest {
-  subagent_type: string;
-  prompt: string;
-  description?: string;
-  model?: string;
-  max_turns?: number;
-}
-
 // @@@channel-kind - string union used directly as a selector, not an object
 export type SandboxChannelKind = "upload" | "download";
 
@@ -389,12 +372,6 @@ export interface SandboxChannelFileEntry {
   relative_path: string;
   size_bytes: number;
   updated_at: string;
-}
-
-export interface SandboxChannelFilesResult {
-  thread_id: string;
-  channel: SandboxChannelKind;
-  entries: SandboxChannelFileEntry[];
 }
 
 export interface SandboxUploadResult {
@@ -431,15 +408,5 @@ export interface Contact {
   created_at: string;
   updated_at: string | null;
 }
-
-export interface AgentProfile {
-  id: string;
-  name: string;
-  type: "agent";
-  avatar_url?: string;
-  description?: string;
-}
-
-export type MessageStatus = "sending" | "sent" | "read";
 
 export type MessageType = "human" | "ai" | "ai_process" | "system" | "notification";

--- a/frontend/app/src/lib/supabase.ts
+++ b/frontend/app/src/lib/supabase.ts
@@ -16,31 +16,3 @@ const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
 export const supabase: SupabaseClient | null =
   url && anonKey ? createClient(url, anonKey) : null;
-
-export type ChatMessagePayload = {
-  id: string;
-  chat_id: string;
-  sender_id: string;
-  content: string;
-  content_type: string;
-  message_type: string;
-  signal: string | null;
-  mentions: string[];
-  retracted_at: string | null;
-  created_at: string;
-};
-
-export type MessageReadPayload = {
-  message_id: string;
-  user_id: string;
-  read_at: string;
-};
-
-export type RelationshipPayload = {
-  id: string;
-  principal_a: string;
-  principal_b: string;
-  state: string;
-  direction: string | null;
-  updated_at: string;
-};

--- a/tests/Integration/test_storage_repo_abstraction_unification.py
+++ b/tests/Integration/test_storage_repo_abstraction_unification.py
@@ -232,18 +232,6 @@ def test_runtime_services_default_to_storage_runtime_container(monkeypatch: pyte
 
     container = _FakeRuntimeContainer()
 
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.make_tool_task_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory tool repo")),
-    )
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.make_agent_registry_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory agent repo")),
-    )
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.make_sync_file_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory sync repo")),
-    )
     monkeypatch.setattr("storage.runtime.build_storage_container", lambda **_kwargs: container)
 
     task_service = TaskService(registry=ToolRegistry(), db_path=tmp_path / "test.db")
@@ -279,10 +267,6 @@ def test_resource_snapshot_helpers_default_to_storage_runtime_container(monkeypa
 
     container = _FakeRuntimeContainer()
 
-    monkeypatch.setattr(
-        "backend.web.core.storage_factory.upsert_resource_snapshot",
-        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory resource upsert")),
-    )
     monkeypatch.setattr(
         "backend.web.core.storage_factory.list_resource_snapshots",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web storage factory resource list")),


### PR DESCRIPTION
## Summary
- remove zero-reference frontend payload types from api/types.ts and lib/supabase.ts
- keep api client function exports and shared compatibility surfaces unchanged

## Verification
- rg -n "\b(AgentProfile|ChatSummary|MessageStatus|SandboxChannelFilesResult|TaskAgentRequest|ChatMessagePayload|MessageReadPayload|RelationshipPayload)\b" frontend/app/src -S
- cd frontend/app && npm run build