### PR TITLE
Draft: remote resource proof and payload realignment

### DIFF
--- a/frontend/app/src/pages/resources/ProviderCard.test.tsx
+++ b/frontend/app/src/pages/resources/ProviderCard.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+const sourceModules = import.meta.glob("./ProviderCard.tsx", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+describe("ProviderCard source", () => {
+  it("renders provider unavailableReason instead of hardcoded SDK copy", () => {
+    const source = sourceModules["./ProviderCard.tsx"];
+
+    expect(source).toContain("provider.unavailableReason");
+    expect(source).not.toContain("需要安装 SDK");
+    expect(source).not.toContain("需要 Docker");
+  });
+});

--- a/frontend/app/src/pages/resources/ProviderCard.tsx
+++ b/frontend/app/src/pages/resources/ProviderCard.tsx
@@ -28,6 +28,7 @@ export default function ProviderCard({ provider, selected, onSelect }: ProviderC
   const isActive = status === "active";
   const TypeIcon = typeIcon[type];
   const cardCpu = provider.cardCpu;
+  const unavailableReason = provider.unavailableReason || "未提供原因";
 
   const runningSessions = sessions.filter((s) => s.status === "running");
   const pausedSessions = sessions.filter((s) => s.status === "paused");
@@ -76,7 +77,7 @@ export default function ProviderCard({ provider, selected, onSelect }: ProviderC
           <div className="text-center">
             <p className="text-xs text-muted-foreground">未就绪</p>
             <p className="text-2xs text-muted-foreground/60 mt-0.5">
-              {type === "container" ? "需要 Docker" : "需要安装 SDK"}
+              {unavailableReason}
             </p>
           </div>
         ) : (

--- a/frontend/app/src/pages/resources/SandboxCard.test.tsx
+++ b/frontend/app/src/pages/resources/SandboxCard.test.tsx
@@ -13,4 +13,10 @@ describe("SandboxCard source", () => {
     expect(source).toContain("s.agentName");
     expect(source).not.toContain("s.memberName");
   });
+
+  it("renders resource agent avatars from avatarUrl", () => {
+    const source = sourceModules["./SandboxCard.tsx"];
+
+    expect(source).toContain("s.avatarUrl");
+  });
 });

--- a/frontend/app/src/pages/resources/SandboxDetailSheet.test.tsx
+++ b/frontend/app/src/pages/resources/SandboxDetailSheet.test.tsx
@@ -25,4 +25,10 @@ describe("SandboxDetailSheet source", () => {
 
     expect(source).toContain("session.runtimeSessionId");
   });
+
+  it("renders resource agent avatars from avatarUrl", () => {
+    const source = sourceModules["./SandboxDetailSheet.tsx"];
+
+    expect(source).toContain("session.avatarUrl");
+  });
 });

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -122,8 +122,11 @@ def test_user_resource_projection_groups_visible_leases_into_provider_cards(monk
     assert payload["providers"][0]["sessions"][0]["threadId"] == "thread-1"
     assert payload["providers"][0]["sessions"][0]["agentUserId"] == "agent-1"
     assert payload["providers"][0]["sessions"][0]["agentName"] == "Morel"
+    assert payload["providers"][0]["sessions"][0]["avatarUrl"] == "/api/users/agent-1/avatar"
     assert payload["providers"][0]["sessions"][0]["runtimeSessionId"] == "provider-session-1"
     assert payload["providers"][0]["sessions"][0]["startedAt"] == "2026-04-07T10:00:00Z"
+    assert "memberId" not in payload["providers"][0]["sessions"][0]
+    assert "memberName" not in payload["providers"][0]["sessions"][0]
 
 
 def test_user_resource_projection_marks_provider_unavailable_when_capability_probe_fails(monkeypatch) -> None:

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -188,6 +188,76 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
     assert "memberName" not in payload["providers"][0]["sessions"][0]
 
 
+def test_resources_overview_route_surfaces_actor_first_user_payload(monkeypatch) -> None:
+    class _State:
+        thread_repo = object()
+        member_repo = object()
+
+    test_app = FastAPI()
+    test_app.state = _State()
+    test_app.include_router(resources_router.router)
+    test_app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
+
+    monkeypatch.setattr(
+        resource_projection_service.sandbox_service,
+        "list_user_leases",
+        lambda owner_user_id, **_kwargs: [
+            {
+                "lease_id": "lease-1",
+                "provider_name": "daytona_selfhost",
+                "thread_ids": ["thread-1"],
+                "agents": [
+                    {
+                        "agent_user_id": "agent-1",
+                        "agent_name": "Morel",
+                        "avatar_url": "/api/users/agent-1/avatar",
+                    }
+                ],
+                "observed_state": "running",
+                "desired_state": "running",
+                "created_at": "2026-04-07T10:00:00Z",
+                "runtime_session_id": "provider-session-1",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        resource_projection_service.resource_service,
+        "get_provider_display_contract",
+        lambda *_args, **_kwargs: {
+            "provider_name": "daytona",
+            "description": "Daytona",
+            "vendor": "Daytona",
+            "type": "cloud",
+            "console_url": "https://example.com/daytona",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        resource_projection_service.resource_service,
+        "get_provider_capability_contract",
+        lambda *_args, **_kwargs: (resource_projection_service._empty_capabilities(), None),
+        raising=False,
+    )
+
+    try:
+        with TestClient(test_app) as client:
+            response = client.get("/api/resources/overview")
+    finally:
+        test_app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    session = payload["providers"][0]["sessions"][0]
+    assert payload["summary"]["scope"] == "user"
+    assert payload["providers"][0]["id"] == "daytona_selfhost"
+    assert session["runtimeSessionId"] == "provider-session-1"
+    assert session["agentUserId"] == "agent-1"
+    assert session["agentName"] == "Morel"
+    assert session["avatarUrl"] == "/api/users/agent-1/avatar"
+    assert "memberId" not in session
+    assert "memberName" not in session
+
+
 def test_provider_display_contract_exposes_public_metadata(monkeypatch) -> None:
     monkeypatch.setattr(resource_service, "resolve_provider_name", lambda *_args, **_kwargs: "daytona")
     monkeypatch.setattr(

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -145,10 +145,11 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
                 "lease_id": "lease-1",
                 "provider_name": "daytona_selfhost",
                 "thread_ids": ["thread-1"],
-                "agents": [{"agent_user_id": "agent-1", "agent_name": "Morel", "avatar_url": None}],
+                "agents": [{"agent_user_id": "agent-1", "agent_name": "Morel", "avatar_url": "/api/users/agent-1/avatar"}],
                 "observed_state": "paused",
                 "desired_state": "paused",
                 "created_at": "2026-04-07T10:00:00Z",
+                "runtime_session_id": "provider-session-1",
             }
         ],
     )
@@ -179,6 +180,12 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
         "code": "PROVIDER_UNAVAILABLE",
         "message": "provider unavailable",
     }
+    assert payload["providers"][0]["sessions"][0]["runtimeSessionId"] == "provider-session-1"
+    assert payload["providers"][0]["sessions"][0]["agentUserId"] == "agent-1"
+    assert payload["providers"][0]["sessions"][0]["agentName"] == "Morel"
+    assert payload["providers"][0]["sessions"][0]["avatarUrl"] == "/api/users/agent-1/avatar"
+    assert "memberId" not in payload["providers"][0]["sessions"][0]
+    assert "memberName" not in payload["providers"][0]["sessions"][0]
 
 
 def test_provider_display_contract_exposes_public_metadata(monkeypatch) -> None:

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -2,15 +2,19 @@ from backend.web.services import resource_common, resource_projection_service
 
 
 class _FakeRepo:
-    def __init__(self, rows, lease_threads=None):
+    def __init__(self, rows, lease_threads=None, instance_ids=None):
         self._rows = rows
         self._lease_threads = lease_threads or {}
+        self._instance_ids = instance_ids or {}
 
     def list_sessions_with_leases(self):
         return list(self._rows)
 
     def query_lease_threads(self, lease_id: str):
         return [{"thread_id": tid} for tid in self._lease_threads.get(lease_id, [])]
+
+    def query_lease_instance_id(self, lease_id: str):
+        return self._instance_ids.get(lease_id)
 
     def close(self):
         pass
@@ -321,3 +325,52 @@ def test_list_resource_providers_deduplicates_same_lease_thread_even_with_distin
             "metrics": None,
         }
     ]
+
+
+def test_list_resource_providers_keeps_remote_runtime_session_id_actor_first(monkeypatch):
+    rows = [
+        {
+            "provider": "daytona_selfhost",
+            "session_id": "provider-session-1",
+            "thread_id": "thread-remote",
+            "lease_id": "lease-remote",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-08T00:00:00",
+        },
+    ]
+
+    monkeypatch.setattr(
+        resource_projection_service,
+        "make_sandbox_monitor_repo",
+        lambda: _FakeRepo(rows, instance_ids={"lease-remote": "provider-session-1"}),
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "available_sandbox_types",
+        lambda: [{"name": "daytona_selfhost", "available": True}],
+    )
+    monkeypatch.setattr(resource_projection_service, "resolve_provider_name", lambda *_args, **_kwargs: "daytona")
+    monkeypatch.setattr(resource_projection_service, "_resolve_console_url", lambda *_args, **_kwargs: "https://example.com/daytona")
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_resolve_instance_capabilities",
+        lambda _config_name: (resource_projection_service._empty_capabilities(), None),
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_thread_owners",
+        lambda thread_ids: {tid: {"agent_user_id": "agent-remote", "agent_name": "Remote Agent", "avatar_url": None} for tid in thread_ids},
+    )
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+
+    payload = resource_projection_service.list_resource_providers()
+    provider = payload["providers"][0]
+    session = provider["sessions"][0]
+
+    assert provider["consoleUrl"] == "https://example.com/daytona"
+    assert session["runtimeSessionId"] == "provider-session-1"
+    assert session["agentUserId"] == "agent-remote"
+    assert session["agentName"] == "Remote Agent"
+    assert "memberId" not in session
+    assert "memberName" not in session

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -360,7 +360,14 @@ def test_list_resource_providers_keeps_remote_runtime_session_id_actor_first(mon
     monkeypatch.setattr(
         resource_projection_service,
         "_thread_owners",
-        lambda thread_ids: {tid: {"agent_user_id": "agent-remote", "agent_name": "Remote Agent", "avatar_url": None} for tid in thread_ids},
+        lambda thread_ids: {
+            tid: {
+                "agent_user_id": "agent-remote",
+                "agent_name": "Remote Agent",
+                "avatar_url": "/api/users/agent-remote/avatar",
+            }
+            for tid in thread_ids
+        },
     )
     monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
 
@@ -372,5 +379,6 @@ def test_list_resource_providers_keeps_remote_runtime_session_id_actor_first(mon
     assert session["runtimeSessionId"] == "provider-session-1"
     assert session["agentUserId"] == "agent-remote"
     assert session["agentName"] == "Remote Agent"
+    assert session["avatarUrl"] == "/api/users/agent-remote/avatar"
     assert "memberId" not in session
     assert "memberName" not in session


### PR DESCRIPTION
## Summary

This is the next follow-up lane after `#260`, focused on the narrow `PR-B` scope from the resource-observability sequence:
- synthesize remote-shaped resource/session proof locally instead of blocking on staging
- lock actor-first outward payload contracts for product + monitor resource surfaces
- realign any remaining resource payload drift without widening into identity/runtime rewrites

Current slices already landed on this draft:
- adds monitor-side synthetic remote proof for `runtimeSessionId`
- locks that monitor resource sessions stay actor-first (`agentUserId` / `agentName`)
- locks monitor-side remote `avatarUrl` to the users-avatar public contract (`/api/users/{user_id}/avatar`)
- shifts the next proof slices to the user-scoped/app-facing path:
  - user-scoped resource projection now has explicit proof for `runtimeSessionId`, `agentUserId`, `agentName`, and `avatarUrl`
  - user-scoped resource sessions are explicitly proven not to regress to `memberId` / `memberName`
  - both active and unavailable user-scoped provider sessions are now locked to that same actor-first outward shape
  - app-facing resource detail and card source are now test-locked to render `session.avatarUrl`
  - the actual `/api/resources/overview` HTTP route is now integration-locked to surface `summary.scope=user` and actor-first session fields (`runtimeSessionId`, `agentUserId`, `agentName`, `avatarUrl`) without regressing to `memberId` / `memberName`
- adds one narrow product-surface honesty fix on top of that proof:
  - app `ProviderCard` now surfaces `provider.unavailableReason` instead of hardcoded fake SDK / Docker copy

Important latest-dev truth:
- current app router redirects `/resources` to `/marketplace`
- so the app-side slices in this PR are preserving truthful resource component contracts on the existing preserved UI pieces, not reviving a mounted product route
- route revival remains a later-lane decision, not part of this PR
- while that redirect remains in place, this PR stops at backend/user-scoped proof plus truthful payload consumption; it does not keep polishing dead-surface app route behavior

## Lineage

This PR sits in the same workstream as:
- Issue `#205` Split user-visible Resources from global monitor overview
  - https://github.com/OpenDCAI/Mycel/issues/205
- PR `#210` Tighten monitor-only resource observability compatibility
  - https://github.com/OpenDCAI/Mycel/pull/210
- PR `#259` Draft: user/thread/agent_config schema redesign
  - https://github.com/OpenDCAI/Mycel/pull/259
- PR `#260` Resource observability follow-up: transplant monitor resources and harden contracts
  - https://github.com/OpenDCAI/Mycel/pull/260

Why this exists after `#260`:
- `#260` stabilized the resource/monitor lane and moved outward resource payloads to actor-first shapes
- `#259` is still the active identity/social/core redesign and changes the canonical ownership/identity joins (`users`, `thread.agent_user_id`, `agent_config_id`)
- staging currently has no usable remote lease/session sample, so this lane uses local synthetic proof instead of blocking on unavailable live data

## Current contract assumptions

Aligned with `#259` direction:
- root identity is `users`, not `members`
- runtime ownership in this lane is actor-first
- outward resource payloads should use `agent*` / user-facing ids, not `member*`
- resource avatar URLs in this lane should follow the users-avatar route, not the old members-avatar route
- unavailable provider copy should stay grounded in backend truth (`unavailableReason`), not generic fallback prose
- this lane should not reopen runtime/lifespan repo surgery while `#259` is still active

## Scope in this PR

Keep:
- synthetic remote-shaped proof for product/monitor resource payloads
- actor-first outward resource fields
- narrow payload-contract realignment when a real outward drift is proven
- small product-surface honesty fixes that directly consume already-existing truthful payload fields on preserved resource components only

Do not add here:
- identity/runtime repo rewrites that belong in `#259`
- large monitor shell/frontend revival work
- product-surface resurrection outside the current resource-observability lane
- dead-surface app polishing while `/resources` still redirects to `/marketplace`

## Verification

Current draft verification for the landed slices:
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run pytest -q tests/Integration/test_resource_overview_contract_split.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py` -> `18 passed`
- `cd frontend/app && npm test -- src/pages/resources/SandboxDetailSheet.test.tsx src/pages/resources/SandboxCard.test.tsx src/pages/resources/ProviderCard.test.tsx` -> `7 passed`
- `cd frontend/app && npm run build` -> passed

## Sequence Of PRs

- `PR-A`: `#260` merged
  - resource observability foundation + monitor resources transplant
- `PR-B`: this PR
  - remote proof + payload realignment
- `PR-C`: legacy monitor shell/frontend revival
  - separate large frontend PR; not folded into this resource-contract lane
