### PR TITLE
Legacy monitor revival PR-C2: rebind mounted monitor surfaces

### DIFF
--- a/docs/superpowers/plans/2026-04-08-legacy-monitor-surfaces-pr-c2.md
+++ b/docs/superpowers/plans/2026-04-08-legacy-monitor-surfaces-pr-c2.md
@@ -1,0 +1,125 @@
+# Legacy Monitor Surfaces PR-C2 Implementation Plan
+
+**Goal:** Rebind the current monitor pages into the revived sidebar shell so the dashboard, resources, leases, threads, and events surfaces read as one console.
+
+**Architecture:** This plan keeps backend contracts fixed. It works in three bounded frontend-only slices: first establish shared page framing and a real dashboard switchboard, then rebind leases/resources into shell-native structure, then align threads/events detail surfaces with the same console grammar. Evaluation runtime activation stays outside this plan.
+
+**Tech Stack:** React 19, React Router 7, TypeScript, Vite, Vitest, CSS
+
+---
+
+## Mandatory Boundary
+
+- No backend route changes
+- No product `/resources`
+- No identity/runtime rewrites
+- No fake evaluation comeback
+- No PR-C3 density sweep in this PR
+
+## Task 1: Add PR-C2 surface smoke tests
+
+**Files:**
+- Modify: `frontend/monitor/src/app/routes.test.tsx`
+- Test: `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+
+- [ ] Add failing smoke expectations for:
+  - dashboard switchboard framing
+  - shell-native leases/resources headings
+  - page-level consistency markers
+- [ ] Run route smoke to verify the new expectations fail
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/app/routes.test.tsx
+git commit -m "test: lock monitor surface rebind smoke"
+```
+
+## Task 2: Rebind dashboard as a real switchboard
+
+**Files:**
+- Modify: `frontend/monitor/src/pages/DashboardPage.tsx`
+- Create or modify shared shell-page primitives if needed
+- Modify: `frontend/monitor/src/styles.css`
+- Test:
+  - `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+  - `cd frontend/monitor && npm run build`
+
+- [ ] Replace the thin dashboard body with switchboard structure that uses current backend truth only
+- [ ] Keep dashboard honest if backend data is thin or unavailable
+- [ ] Verify tests/build
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/pages/DashboardPage.tsx frontend/monitor/src/styles.css frontend/monitor/src/app
+git commit -m "feat: rebind monitor dashboard into console switchboard"
+```
+
+## Task 3: Rebind leases and resources into shell-native sections
+
+**Files:**
+- Modify: `frontend/monitor/src/pages/LeasesPage.tsx`
+- Modify: `frontend/monitor/src/pages/LeaseDetailPage.tsx`
+- Modify: `frontend/monitor/src/ResourcesPage.tsx`
+- Modify: `frontend/monitor/src/styles.css`
+- Test:
+  - `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+  - `cd frontend/monitor && npm run build`
+
+- [ ] Move leases away from flat-table-first framing
+- [ ] Tighten resources section hierarchy without changing resource data contracts
+- [ ] Keep current browse/detail/resource wiring intact
+- [ ] Verify tests/build
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/pages/LeasesPage.tsx frontend/monitor/src/pages/LeaseDetailPage.tsx frontend/monitor/src/ResourcesPage.tsx frontend/monitor/src/styles.css
+git commit -m "feat: rebind monitor runtime surfaces"
+```
+
+## Task 4: Align threads and events with console drilldown grammar
+
+**Files:**
+- Modify: `frontend/monitor/src/pages/ThreadsPage.tsx`
+- Modify: `frontend/monitor/src/pages/ThreadDetailPage.tsx`
+- Modify: `frontend/monitor/src/pages/EventsPage.tsx`
+- Modify: `frontend/monitor/src/pages/EventDetailPage.tsx`
+- Modify: `frontend/monitor/src/styles.css`
+- Test:
+  - `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+  - `cd frontend/monitor && npm run build`
+
+- [ ] Align list/detail framing with the shell-native page structure
+- [ ] Do not widen into backend/event semantics work
+- [ ] Verify tests/build
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/pages/ThreadsPage.tsx frontend/monitor/src/pages/ThreadDetailPage.tsx frontend/monitor/src/pages/EventsPage.tsx frontend/monitor/src/pages/EventDetailPage.tsx frontend/monitor/src/styles.css
+git commit -m "feat: align monitor drilldown surfaces"
+```
+
+## Task 5: Browser proof and PR prep
+
+**Files:**
+- No required code files
+- Update PR description/checkpoint as needed
+
+- [ ] Run fresh browser proof on the rebuilt pages
+- [ ] Record honest boundary if data routes are unavailable in local proof
+- [ ] Prepare draft PR as `PR-C2`
+
+## Verification Standard
+
+- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+- `cd frontend/monitor && npm run build`
+- browser proof for:
+  - `/dashboard`
+  - `/resources`
+  - `/leases`
+  - at least one list/detail pair from threads/events
+
+## Hard Stopline
+
+- This plan does not restore evaluation runtime
+- This plan does not add evaluation nav unless real route support exists
+- If evaluation needs to come back, open or continue the separate mandatory companion lane instead of expanding `PR-C2`

--- a/docs/superpowers/specs/2026-04-08-legacy-monitor-surfaces-pr-c2-design.md
+++ b/docs/superpowers/specs/2026-04-08-legacy-monitor-surfaces-pr-c2-design.md
@@ -1,0 +1,146 @@
+# Legacy Monitor Surfaces PR-C2 Design
+
+**Goal:** Rebind the main monitor pages into the revived sidebar shell so the monitor reads as one operator console instead of a shell wrapped around unrelated documents.
+
+## Position In Sequence
+
+- `PR-C1` is merged at `#262`
+  - shell revival
+  - route extraction
+  - sidebar navigation
+- `PR-C2` is the next narrow lane
+  - key surfaces rebind
+  - no backend contract rewrite
+- `PR-C3` remains later
+  - density/detail polish
+- mandatory companion lane remains separate
+  - evaluation runtime activation
+
+## Current Facts
+
+- `dev` now has a real sidebar shell in `frontend/monitor`
+- current route set is:
+  - `/dashboard`
+  - `/threads`
+  - `/thread/:threadId`
+  - `/resources`
+  - `/leases`
+  - `/lease/:leaseId`
+  - `/diverged`
+  - `/events`
+  - `/event/:eventId`
+- current pages still mostly read like standalone documents mounted inside the shell
+- current `ResourcesPage` already has the richest operator structure
+- `evaluation` and `traces` are not current mounted monitor routes on `dev`
+
+## Why PR-C2 Exists
+
+`PR-C1` fixed information architecture, not page fit.
+
+That was the right first move, but it leaves an obvious gap:
+- the shell looks modern
+- the pages still mostly look like legacy standalone views
+
+`PR-C2` closes that gap by making the key surfaces feel native to the shell without changing backend ownership.
+
+## In Scope
+
+- dashboard as a real switchboard surface
+- leases page rebind toward drilldown-first operator flow
+- resources page alignment with the shell header, sectioning, and lease-first scanning
+- threads and events placement cleanup so they match the shell hierarchy
+- small shared monitor-page framing components if needed
+
+## Out Of Scope
+
+- backend route changes
+- product `/resources`
+- identity/runtime rewrites
+- full density sweep
+- evaluation runtime activation
+- reintroducing eval/traces pages without real backend support
+
+## Historical Anchors
+
+These commits matter as source material, not as blind cherry-picks:
+
+- `6adf7f0e` `feat: add monitor dashboard and resources surface`
+- `c23dfb2e` `feat: tighten monitor resources surface`
+- `d476818d` `feat: split monitor resources into rail and detail`
+- `d7cbe8c7` `feat: add monitor lease drilldown panel`
+
+## Design Direction
+
+### Dashboard
+
+Current dashboard is too thin.
+
+`PR-C2` should turn it into a real switchboard:
+- one summary band for current monitor truth
+- one section for runtime navigation
+- one section for operator attention
+
+It does not need new backend data if current `/api/monitor/dashboard` is enough for a first honest pass.
+
+### Resources
+
+Resources is already the strongest surface.
+
+`PR-C2` should not rewrite its data logic.
+It should only make it feel structurally native to the shell:
+- stronger section boundaries
+- clearer relation between provider cards, provider detail, and lease/session drilldown
+- consistent page framing with other monitor pages
+
+### Leases
+
+Leases should move away from “flat table first”.
+
+The target is:
+- top summary / triage framing first
+- then the table
+- then drilldown entry that feels consistent with the resources lease detail layer
+
+No backend contract changes are required for that first pass.
+
+### Threads And Events
+
+These can stay simpler in this PR.
+
+The main need is structural consistency:
+- page titles and summaries should match shell framing
+- detail pages should read like drilldown surfaces, not raw dumps
+
+## Proposed Execution Split
+
+### Slice 1: dashboard + page-frame adapters
+
+- introduce shared page-frame primitives if needed
+- rebind dashboard to use them
+- align shell-page spacing and summary bands
+
+### Slice 2: leases + resources shell-native structure
+
+- rework leases page composition
+- tighten resources section hierarchy without rewriting resource data contracts
+
+### Slice 3: threads/events consistency pass
+
+- make thread/event list/detail pages fit the same console grammar
+
+## Merge Bar
+
+- key monitor pages no longer feel like shell-wrapped leftovers
+- no backend contracts change
+- no eval-runtime claim sneaks into this PR
+- build passes
+- targeted frontend route/browser proof passes
+
+## Explicit Evaluation Boundary
+
+Evaluation is still part of the overall monitor recovery story.
+
+But for this PR:
+- do not fake an evaluation comeback with dead nav
+- do not reintroduce eval pages unless real routes are deliberately added
+- keep evaluation runtime activation as a separate mandatory lane coordinated with the upstream owner

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -139,4 +139,78 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("Lease Triage")).toBeInTheDocument();
     expect(screen.getByText("Raw Lease Table")).toBeInTheDocument();
   });
+
+  it("renders threads with pressure summary before the raw table", async () => {
+    mockRoutePayloads({
+      "/threads": {
+        title: "Threads",
+        count: 1,
+        items: [
+          {
+            thread_id: "thread-1",
+            thread_url: "/thread/thread-1",
+            session_count: 2,
+            last_active_ago: "2m",
+            lease: {
+              lease_id: "lease-1",
+              lease_url: "/lease/lease-1",
+              provider: "local",
+            },
+            state_badge: {
+              color: "yellow",
+              observed: "paused",
+              desired: "running",
+              text: "paused",
+            },
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/threads"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Thread Pressure")).toBeInTheDocument();
+    expect(screen.getByText("Raw Thread Table")).toBeInTheDocument();
+  });
+
+  it("renders diverged leases with triage before the raw table", async () => {
+    mockRoutePayloads({
+      "/diverged": {
+        title: "Diverged leases",
+        description: "Leases whose observed state diverges from desired state.",
+        count: 1,
+        items: [
+          {
+            lease_id: "lease-1",
+            lease_url: "/lease/lease-1",
+            provider: "daytona_selfhost",
+            thread: {
+              thread_id: "thread-1",
+              thread_url: "/thread/thread-1",
+            },
+            state_badge: {
+              color: "red",
+              desired: "running",
+              observed: "stopped",
+              hours_diverged: 5,
+            },
+            error: "provider unavailable",
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/diverged"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Drift Triage")).toBeInTheDocument();
+    expect(screen.getByText("Raw Divergence Table")).toBeInTheDocument();
+  });
 });

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -213,4 +213,51 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("Drift Triage")).toBeInTheDocument();
     expect(screen.getByText("Raw Divergence Table")).toBeInTheDocument();
   });
+
+  it("renders events with signal summary before the raw table", async () => {
+    mockRoutePayloads({
+      "/events?limit=100": {
+        title: "Events",
+        description: "Recent monitor events.",
+        count: 2,
+        items: [
+          {
+            event_id: "event-1",
+            event_url: "/event/event-1",
+            event_type: "lease.state.changed",
+            source: "monitor",
+            provider: "local",
+            lease: {
+              lease_id: "lease-1",
+              lease_url: "/lease/lease-1",
+            },
+            error: null,
+            created_ago: "1m",
+          },
+          {
+            event_id: "event-2",
+            event_url: "/event/event-2",
+            event_type: "probe.failed",
+            source: "probe",
+            provider: "daytona_selfhost",
+            lease: {
+              lease_id: null,
+              lease_url: null,
+            },
+            error: "provider unavailable",
+            created_ago: "3m",
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/events"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Signal Feed")).toBeInTheDocument();
+    expect(screen.getByText("Raw Event Table")).toBeInTheDocument();
+  });
 });

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -23,6 +23,20 @@ beforeEach(() => {
   );
 });
 
+function mockRoutePayloads(routes: Record<string, unknown>) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.pathname : String(input.url);
+    const match = Object.entries(routes).find(([path]) => url.endsWith(path));
+    if (!match) {
+      throw new Error(`Unexpected fetch: ${url}`);
+    }
+    return new Response(JSON.stringify(match[1]), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
 describe("MonitorRoutes", () => {
   it("renders the current monitor route set under the app router", () => {
     render(
@@ -60,5 +74,69 @@ describe("MonitorRoutes", () => {
 
     expect(screen.getByRole("navigation", { name: "Monitor sections" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /leases/i })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("renders dashboard as a switchboard surface", async () => {
+    mockRoutePayloads({
+      "/dashboard": {
+        snapshot_at: "2026-04-08T00:00:00Z",
+        summary: {
+          active_threads: 7,
+          active_leases: 3,
+          resources_ready: 4,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Runtime Surfaces")).toBeInTheDocument();
+    expect(screen.getByText("Operator Attention")).toBeInTheDocument();
+  });
+
+  it("renders leases with a triage summary before the raw table", async () => {
+    mockRoutePayloads({
+      "/leases": {
+        title: "Leases",
+        count: 1,
+        triage: {
+          active: 1,
+          residue: 0,
+        },
+        items: [
+          {
+            lease_id: "lease-1",
+            lease_url: "/lease/lease-1",
+            provider: "local",
+            instance_id: "instance-1",
+            thread: {
+              thread_id: "thread-1",
+              thread_url: "/thread/thread-1",
+            },
+            state_badge: {
+              color: "green",
+              observed: "running",
+              desired: "running",
+              text: "running",
+            },
+            updated_ago: "1m",
+            error: null,
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Lease Triage")).toBeInTheDocument();
+    expect(screen.getByText("Raw Lease Table")).toBeInTheDocument();
   });
 });

--- a/frontend/monitor/src/pages/DashboardPage.tsx
+++ b/frontend/monitor/src/pages/DashboardPage.tsx
@@ -7,10 +7,46 @@ export default function DashboardPage() {
   if (error) return <ErrorState title="Dashboard" error={error} />;
   if (!data) return <div>Loading...</div>;
 
+  const summary = data.summary ?? {};
+  const surfaces = [
+    { label: "Active Threads", value: summary.active_threads ?? 0 },
+    { label: "Active Leases", value: summary.active_leases ?? 0 },
+    { label: "Resources Ready", value: summary.resources_ready ?? 0 },
+  ];
+
   return (
     <div className="page">
       <h1>Dashboard</h1>
       <p className="count">Snapshot: {data.snapshot_at}</p>
+      <section className="surface-section">
+        <h2>Runtime Surfaces</h2>
+        <div className="surface-grid">
+          {surfaces.map((surface) => (
+            <article className="surface-card" key={surface.label}>
+              <p className="surface-card__eyebrow">{surface.label}</p>
+              <p className="surface-card__value">{surface.value}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+      <section className="surface-section">
+        <h2>Operator Attention</h2>
+        <div className="surface-grid">
+          <article className="surface-card" key="coverage">
+            <p className="surface-card__eyebrow">Coverage</p>
+            <p className="surface-card__body">
+              {summary.resources_ready ?? 0} resource surfaces reporting against {summary.active_leases ?? 0} active
+              leases.
+            </p>
+          </article>
+          <article className="surface-card" key="focus">
+            <p className="surface-card__eyebrow">Immediate Focus</p>
+            <p className="surface-card__body">
+              Check leases that drift away from running state before moving deeper into thread or resource drilldown.
+            </p>
+          </article>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/monitor/src/pages/DivergedPage.tsx
+++ b/frontend/monitor/src/pages/DivergedPage.tsx
@@ -9,11 +9,36 @@ export default function DivergedPage() {
   if (error) return <ErrorState title="Diverged leases" error={error} />;
   if (!data) return <div>Loading...</div>;
 
+  const items = data.items ?? [];
+  const triageCards = [
+    { label: "Total Diverged", value: data.count ?? items.length },
+    {
+      label: "Critical",
+      value: items.filter((item: any) => item.state_badge?.color === "red").length,
+    },
+    {
+      label: "Orphans",
+      value: items.filter((item: any) => !item.thread?.thread_id).length,
+    },
+  ];
+
   return (
     <div className="page">
       <h1>{data.title}</h1>
       <p className="description">{data.description}</p>
       <p className="count">Total: {data.count}</p>
+      <section className="surface-section">
+        <h2>Drift Triage</h2>
+        <div className="surface-grid">
+          {triageCards.map((card) => (
+            <article className="surface-card" key={card.label}>
+              <p className="surface-card__eyebrow">{card.label}</p>
+              <p className="surface-card__value">{card.value}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+      <h2>Raw Divergence Table</h2>
       <table>
         <thead>
           <tr>

--- a/frontend/monitor/src/pages/EventsPage.tsx
+++ b/frontend/monitor/src/pages/EventsPage.tsx
@@ -9,11 +9,36 @@ export default function EventsPage() {
   if (error) return <ErrorState title="Events" error={error} />;
   if (!data) return <div>Loading...</div>;
 
+  const items = data.items ?? [];
+  const signalCards = [
+    { label: "Recent Events", value: data.count ?? items.length },
+    {
+      label: "Errors",
+      value: items.filter((item: any) => item.error).length,
+    },
+    {
+      label: "Lease-linked",
+      value: items.filter((item: any) => item.lease?.lease_id).length,
+    },
+  ];
+
   return (
     <div className="page">
       <h1>{data.title}</h1>
       <p className="description">{data.description}</p>
       <p className="count">Total: {data.count}</p>
+      <section className="surface-section">
+        <h2>Signal Feed</h2>
+        <div className="surface-grid">
+          {signalCards.map((card) => (
+            <article className="surface-card" key={card.label}>
+              <p className="surface-card__eyebrow">{card.label}</p>
+              <p className="surface-card__value">{card.value}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+      <h2>Raw Event Table</h2>
       <table>
         <thead>
           <tr>

--- a/frontend/monitor/src/pages/LeasesPage.tsx
+++ b/frontend/monitor/src/pages/LeasesPage.tsx
@@ -10,10 +10,29 @@ export default function LeasesPage() {
   if (error) return <ErrorState title="Leases" error={error} />;
   if (!data) return <div>Loading...</div>;
 
+  const triage = data.triage ?? {};
+  const triageCards = [
+    { label: "Active", value: triage.active ?? 0 },
+    { label: "Residue", value: triage.residue ?? 0 },
+    { label: "Total", value: data.count ?? 0 },
+  ];
+
   return (
     <div className="page">
       <h1>{data.title}</h1>
       <p className="count">Total: {data.count}</p>
+      <section className="surface-section">
+        <h2>Lease Triage</h2>
+        <div className="surface-grid">
+          {triageCards.map((card) => (
+            <article className="surface-card" key={card.label}>
+              <p className="surface-card__eyebrow">{card.label}</p>
+              <p className="surface-card__value">{card.value}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+      <h2>Raw Lease Table</h2>
       <table>
         <thead>
           <tr>

--- a/frontend/monitor/src/pages/ThreadsPage.tsx
+++ b/frontend/monitor/src/pages/ThreadsPage.tsx
@@ -10,10 +10,35 @@ export default function ThreadsPage() {
   if (error) return <ErrorState title="Threads" error={error} />;
   if (!data) return <div>Loading...</div>;
 
+  const items = data.items ?? [];
+  const threadCards = [
+    { label: "Active Threads", value: data.count ?? items.length },
+    {
+      label: "Attached Leases",
+      value: items.filter((item: any) => item.lease?.lease_id).length,
+    },
+    {
+      label: "Pressure Sessions",
+      value: items.reduce((total: number, item: any) => total + (item.session_count ?? 0), 0),
+    },
+  ];
+
   return (
     <div className="page">
       <h1>{data.title}</h1>
       <p className="count">Total: {data.count}</p>
+      <section className="surface-section">
+        <h2>Thread Pressure</h2>
+        <div className="surface-grid">
+          {threadCards.map((card) => (
+            <article className="surface-card" key={card.label}>
+              <p className="surface-card__eyebrow">{card.label}</p>
+              <p className="surface-card__value">{card.value}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+      <h2>Raw Thread Table</h2>
       <table>
         <thead>
           <tr>

--- a/frontend/monitor/src/styles.css
+++ b/frontend/monitor/src/styles.css
@@ -169,6 +169,44 @@ h2 {
   margin-bottom: 1rem;
 }
 
+.surface-section {
+  margin-bottom: 1.75rem;
+}
+
+.surface-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.surface-card {
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(81, 59, 29, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 252, 245, 0.82);
+  box-shadow: 0 12px 30px rgba(82, 59, 27, 0.06);
+}
+
+.surface-card__eyebrow {
+  color: #8f5d2f;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.surface-card__value {
+  margin-top: 0.5rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #241d14;
+}
+
+.surface-card__body {
+  margin-top: 0.5rem;
+  color: #5c5145;
+}
+
 .description {
   color: #5c5145;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- continue the legacy monitor revival sequence after `#262` (`PR-C1`)
- rebind the mounted monitor surfaces inside the revived shell so they read as one console instead of a set of bare tables
- keep scope frontend-only: no backend contract changes, no product `/resources`, no evaluation runtime activation

## This PR
- adds red/green route smoke coverage for shell-native monitor surface framing
- turns `Dashboard` into a runtime switchboard
- turns `Leases` into a triage-first runtime surface
- turns `Threads`, `Diverged`, and `Events` into summary-first console pages instead of raw-table-first pages
- keeps every existing `/api/monitor/*` fetch path intact

## Lineage
- issue: `#205` split user-visible resources from global monitor overview
- `#210` tightened the earlier monitor-only compatibility slice
- `#259` is the active identity/social/core refactor that this frontend lane must not outrun
- `#260` rebuilt resource observability contracts and monitor resources surface
- `#261` locked backend/user-scoped actor-first resource proof
- `#262` (`PR-C1`) revived the monitor shell, sidebar, and route/page extraction
- this PR is `PR-C2`: key surfaces rebind inside that revived shell

## Out of Scope
- backend contract work
- product app `/resources`
- dead-surface polishing outside mounted monitor routes
- evaluation runtime activation; that remains a separate mandatory companion lane
- `PR-C3` density/detail polish

## Verification
- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
- `cd frontend/monitor && npm run build`
- local `vite preview` + Playwright screenshot proof for the revived shell/navigation

## Honest Boundary
- local preview proves shell and route framing only
- page bodies still depend on `/api/monitor/*`; without a live backend proxy, preview screenshots show shell/navigation plus `Loading...`
