### PR TITLE
Evaluation operator truth PR-D1: expose monitor truth route

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -33,6 +33,7 @@ def dashboard_snapshot():
     health = monitor_service.runtime_health_snapshot()
     resources = get_monitor_resource_overview_snapshot()
     leases = list_leases()
+    evaluation = monitor_service.get_monitor_evaluation_dashboard_summary()
 
     resource_summary = resources.get("summary") or {}
     lease_summary = leases.get("summary") or {}
@@ -52,10 +53,15 @@ def dashboard_snapshot():
             "db_sessions_total": int(((health.get("db") or {}).get("counts") or {}).get("chat_sessions") or 0),
             "provider_sessions_total": int(((health.get("sessions") or {}).get("total")) or 0),
             "running_sessions": int(resource_summary.get("running_sessions") or 0),
-            "evaluations_running": 0,
+            "evaluations_running": int(evaluation["evaluations_running"]),
         },
-        "latest_evaluation": None,
+        "latest_evaluation": evaluation["latest_evaluation"],
     }
+
+
+@router.get("/evaluation")
+def evaluation_snapshot():
+    return monitor_service.get_monitor_evaluation_truth()
 
 
 @router.get("/resources")

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -393,6 +393,7 @@ def build_evaluation_operator_surface(
         ]
 
     return {
+        "status": status,
         "kind": kind,
         "tone": tone,
         "headline": headline,

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -405,6 +405,43 @@ def build_evaluation_operator_surface(
     }
 
 
+def _evaluation_unavailable_surface() -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "kind": "unavailable",
+        "tone": "warning",
+        "headline": "Evaluation operator truth is not wired in this runtime yet.",
+        "summary": "Monitor can report that evaluation truth is unavailable without pretending nothing is happening.",
+        "facts": [{"label": "Status", "value": "unavailable"}],
+        "artifacts": [],
+        "artifact_summary": {"present": 0, "missing": 0, "total": 0},
+        "next_steps": ["Restore a truthful evaluation runtime source before reviving the monitor evaluation page."],
+        "raw_notes": None,
+    }
+
+
+def get_monitor_evaluation_truth() -> dict[str, Any]:
+    # @@@evaluation-truth-stopline - PR-D1 exposes explicit unavailable truth until a real runtime source is wired.
+    return _evaluation_unavailable_surface()
+
+
+def build_monitor_evaluation_dashboard_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    status = str(payload.get("status") or "unavailable")
+    return {
+        "evaluations_running": 1 if status == "running" else 0,
+        "latest_evaluation": {
+            "status": status,
+            "kind": payload.get("kind"),
+            "tone": payload.get("tone"),
+            "headline": payload.get("headline"),
+        },
+    }
+
+
+def get_monitor_evaluation_dashboard_summary() -> dict[str, Any]:
+    return build_monitor_evaluation_dashboard_summary(get_monitor_evaluation_truth())
+
+
 # ---------------------------------------------------------------------------
 # Mappers (private)
 # ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-04-08-evaluation-operator-truth.md
+++ b/docs/superpowers/plans/2026-04-08-evaluation-operator-truth.md
@@ -1,0 +1,374 @@
+# Evaluation Operator Truth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose a truthful monitor evaluation route and remove dashboard's hardcoded evaluation placeholders without pretending the evaluation runtime is already restored.
+
+**Architecture:** This plan keeps the first evaluation recovery slice narrow. It introduces a dedicated monitor evaluation truth surface in backend code, makes dashboard derive summary from that same truth source, and encodes the current source-absent state as an explicit `unavailable` operator payload instead of `0 / None`. It does not restore evaluation UI or runtime activation.
+
+**Tech Stack:** FastAPI, Python, pytest, monitor service/router layer
+
+---
+
+## File Structure
+
+- Modify: `backend/web/services/monitor_service.py`
+  - add the public evaluation truth helpers
+  - add the explicit unavailable operator payload
+  - add dashboard-summary derivation from operator truth
+- Modify: `backend/web/routers/monitor.py`
+  - add `GET /api/monitor/evaluation`
+  - change dashboard route to consume evaluation summary from monitor service
+- Modify: `tests/Unit/monitor/test_monitor_compat.py`
+  - keep current operator-surface truth tests
+  - add unit coverage for the new unavailable/operator-summary helpers
+- Modify: `tests/Integration/test_monitor_resources_route.py`
+  - extend monitor route smoke to cover `/api/monitor/evaluation`
+  - prove dashboard no longer hardcodes `evaluations_running = 0` and `latest_evaluation = None`
+
+## Mandatory Boundary
+
+- No monitor frontend work
+- No evaluation nav/page
+- No runtime activation claims
+- No product app changes
+- No fake “empty but healthy” fallback
+
+## Task 1: Add route-level failing tests for evaluation truth
+
+**Files:**
+- Modify: `tests/Integration/test_monitor_resources_route.py`
+- Test: `uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+```python
+def test_monitor_evaluation_route_exposes_operator_truth(monkeypatch):
+    monkeypatch.setattr(
+        monitor,
+        "get_monitor_evaluation_truth",
+        lambda: {
+            "status": "unavailable",
+            "kind": "unavailable",
+            "tone": "warning",
+            "headline": "Evaluation operator truth is not wired in this runtime yet.",
+            "summary": "Monitor can report that evaluation truth is unavailable without pretending nothing is happening.",
+            "facts": [{"label": "Status", "value": "unavailable"}],
+            "artifacts": [],
+            "artifact_summary": {"present": 0, "missing": 0, "total": 0},
+            "next_steps": ["Restore a truthful evaluation runtime source before reviving the monitor evaluation page."],
+            "raw_notes": None,
+        },
+    )
+
+    with TestClient(_build_monitor_test_app()) as client:
+        response = client.get("/api/monitor/evaluation")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "unavailable"
+    assert payload["kind"] == "unavailable"
+    assert payload["headline"] == "Evaluation operator truth is not wired in this runtime yet."
+    assert payload["artifact_summary"] == {"present": 0, "missing": 0, "total": 0}
+
+
+def test_monitor_dashboard_route_derives_evaluation_summary_from_service(monkeypatch):
+    _stub_monitor_resource_snapshot(monkeypatch)
+    monkeypatch.setattr(
+        monitor_service,
+        "get_monitor_evaluation_dashboard_summary",
+        lambda: {
+            "evaluations_running": 1,
+            "latest_evaluation": {
+                "status": "running",
+                "kind": "running_active",
+                "tone": "default",
+                "headline": "Evaluation is actively running.",
+            },
+        },
+    )
+
+    with TestClient(_build_monitor_test_app()) as client:
+        response = client.get("/api/monitor/dashboard")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["workload"]["evaluations_running"] == 1
+    assert payload["latest_evaluation"] == {
+        "status": "running",
+        "kind": "running_active",
+        "tone": "default",
+        "headline": "Evaluation is actively running.",
+    }
+```
+
+- [ ] **Step 2: Run the targeted integration tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'
+```
+
+Expected:
+- FAIL because `backend.web.routers.monitor` does not expose `/api/monitor/evaluation`
+- FAIL because dashboard still hardcodes `evaluations_running = 0` and `latest_evaluation = None`
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/Integration/test_monitor_resources_route.py
+git commit -m "test: lock monitor evaluation truth routes"
+```
+
+## Task 2: Add the unavailable operator truth helpers
+
+**Files:**
+- Modify: `backend/web/services/monitor_service.py`
+- Modify: `tests/Unit/monitor/test_monitor_compat.py`
+- Test: `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_operator_surface or unavailable_evaluation'`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+```python
+def test_monitor_evaluation_truth_defaults_to_explicit_unavailable_surface():
+    payload = monitor_service.get_monitor_evaluation_truth()
+
+    assert payload["status"] == "unavailable"
+    assert payload["kind"] == "unavailable"
+    assert payload["tone"] == "warning"
+    assert payload["headline"] == "Evaluation operator truth is not wired in this runtime yet."
+    assert payload["artifact_summary"] == {
+        "present": 0,
+        "missing": 0,
+        "total": 0,
+    }
+    assert payload["raw_notes"] is None
+
+
+def test_monitor_evaluation_dashboard_summary_reduces_operator_truth():
+    summary = monitor_service.build_monitor_evaluation_dashboard_summary(
+        {
+            "status": "running",
+            "kind": "running_active",
+            "tone": "default",
+            "headline": "Evaluation is actively running.",
+            "summary": "Long form summary that should not leak into dashboard shape.",
+            "facts": [],
+            "artifacts": [],
+            "artifact_summary": {"present": 2, "missing": 1, "total": 3},
+            "next_steps": [],
+            "raw_notes": "runner=direct rc=0",
+        }
+    )
+
+    assert summary == {
+        "evaluations_running": 1,
+        "latest_evaluation": {
+            "status": "running",
+            "kind": "running_active",
+            "tone": "default",
+            "headline": "Evaluation is actively running.",
+        },
+    }
+```
+
+- [ ] **Step 2: Run the targeted unit tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_operator_surface or unavailable_evaluation'
+```
+
+Expected:
+- FAIL because `get_monitor_evaluation_truth` and `build_monitor_evaluation_dashboard_summary` do not exist yet
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add this code to `backend/web/services/monitor_service.py` after `build_evaluation_operator_surface(...)`:
+
+```python
+def _evaluation_unavailable_surface() -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "kind": "unavailable",
+        "tone": "warning",
+        "headline": "Evaluation operator truth is not wired in this runtime yet.",
+        "summary": (
+            "Monitor can report that evaluation truth is unavailable without pretending nothing is happening."
+        ),
+        "facts": [{"label": "Status", "value": "unavailable"}],
+        "artifacts": [],
+        "artifact_summary": {"present": 0, "missing": 0, "total": 0},
+        "next_steps": [
+            "Restore a truthful evaluation runtime source before reviving the monitor evaluation page."
+        ],
+        "raw_notes": None,
+    }
+
+
+def get_monitor_evaluation_truth() -> dict[str, Any]:
+    # @@@evaluation-truth-stopline - PR-D1 exposes explicit unavailable truth until a real runtime source is wired.
+    return _evaluation_unavailable_surface()
+
+
+def build_monitor_evaluation_dashboard_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    status = str(payload.get("status") or "unavailable")
+    return {
+        "evaluations_running": 1 if status == "running" else 0,
+        "latest_evaluation": {
+            "status": status,
+            "kind": payload.get("kind"),
+            "tone": payload.get("tone"),
+            "headline": payload.get("headline"),
+        },
+    }
+
+
+def get_monitor_evaluation_dashboard_summary() -> dict[str, Any]:
+    return build_monitor_evaluation_dashboard_summary(get_monitor_evaluation_truth())
+```
+
+- [ ] **Step 4: Run the targeted unit tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_operator_surface or unavailable_evaluation'
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py
+git commit -m "feat: add monitor evaluation truth helpers"
+```
+
+## Task 3: Expose the monitor evaluation route and rewire dashboard
+
+**Files:**
+- Modify: `backend/web/routers/monitor.py`
+- Modify: `tests/Integration/test_monitor_resources_route.py`
+- Test: `uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'`
+
+- [ ] **Step 1: Write the minimal router implementation**
+
+Update `backend/web/routers/monitor.py` like this:
+
+```python
+@router.get("/evaluation")
+def evaluation_snapshot():
+    return monitor_service.get_monitor_evaluation_truth()
+
+
+@router.get("/dashboard")
+def dashboard_snapshot():
+    health = monitor_service.runtime_health_snapshot()
+    resources = get_monitor_resource_overview_snapshot()
+    leases = list_leases()
+    evaluation = monitor_service.get_monitor_evaluation_dashboard_summary()
+
+    resource_summary = resources.get("summary") or {}
+    lease_summary = leases.get("summary") or {}
+
+    return {
+        "snapshot_at": health.get("snapshot_at"),
+        "resources_summary": resource_summary,
+        "infra": {
+            "providers_active": int(resource_summary.get("active_providers") or 0),
+            "providers_unavailable": int(resource_summary.get("unavailable_providers") or 0),
+            "leases_total": int(lease_summary.get("total") or leases.get("count") or 0),
+            "leases_diverged": int(lease_summary.get("diverged") or 0) + int(lease_summary.get("orphan_diverged") or 0),
+            "leases_orphan": int(lease_summary.get("orphan") or 0) + int(lease_summary.get("orphan_diverged") or 0),
+            "leases_healthy": int(lease_summary.get("healthy") or 0),
+        },
+        "workload": {
+            "db_sessions_total": int(((health.get("db") or {}).get("counts") or {}).get("chat_sessions") or 0),
+            "provider_sessions_total": int(((health.get("sessions") or {}).get("total")) or 0),
+            "running_sessions": int(resource_summary.get("running_sessions") or 0),
+            "evaluations_running": int(evaluation["evaluations_running"]),
+        },
+        "latest_evaluation": evaluation["latest_evaluation"],
+    }
+```
+
+- [ ] **Step 2: Run the targeted integration tests**
+
+Run:
+
+```bash
+uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 3: Run the broader monitor route pack**
+
+Run:
+
+```bash
+uv run pytest -q tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_compat.py
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/web/routers/monitor.py tests/Integration/test_monitor_resources_route.py
+git commit -m "feat: expose monitor evaluation truth route"
+```
+
+## Task 4: Tighten docs and verification proof
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-08-evaluation-operator-truth-design.md` only if implementation diverged
+- Update: `/Users/lexicalmathical/Codebase/algorithm-repos/mysale-cca/rebuild-agent-core/checkpoints/architecture/cc-core-contract-alignment-2026-04-05.md`
+
+- [ ] **Step 1: Run final verification**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 2: Record the delivered truth in checkpoint**
+
+Append this kind of entry to the external checkpoint:
+
+```md
+- latest-delta-2026-04-08-pr-d1-landed:
+  - `/api/monitor/evaluation` now exposes explicit operator truth
+  - current source-absent state is encoded as `status=unavailable`, not `0 / None`
+  - dashboard evaluation summary is now derived from the same truth source
+```
+
+- [ ] **Step 3: Commit any doc/update drift**
+
+```bash
+git add -f docs/superpowers/specs/2026-04-08-evaluation-operator-truth-design.md
+git commit -m "docs: record evaluation truth delivery"
+```
+
+## Verification Standard
+
+- `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_operator_surface or unavailable_evaluation'`
+- `uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'`
+- `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
+
+## Hard Stopline
+
+- This plan does not revive an evaluation page
+- This plan does not revive evaluation nav
+- This plan does not claim the evaluation runtime is healthy or restored
+- This plan only replaces fake dashboard placeholders with explicit operator truth

--- a/docs/superpowers/specs/2026-04-08-evaluation-operator-truth-design.md
+++ b/docs/superpowers/specs/2026-04-08-evaluation-operator-truth-design.md
@@ -1,0 +1,253 @@
+# Evaluation Operator Truth Design
+
+**Goal:** Restore an honest monitor-facing evaluation truth surface before any evaluation UI comeback, so monitor can report real evaluation state instead of hardcoded placeholders.
+
+## Why This Exists
+
+- The monitor revival sequence is now split into explicit PRs instead of one oversized frontend transplant.
+- `PR-C1/#262` restored the shell and current mounted monitor routes.
+- `PR-C2/#263` rebound the mounted monitor surfaces into that shell.
+- Evaluation is different from those surfaces:
+  - service-level operator truth still exists
+  - the current monitor router does not expose a real evaluation route
+  - the current dashboard still hardcodes `evaluations_running = 0` and `latest_evaluation = None`
+- A visible evaluation page without truthful runtime backing would just recreate another shell-first fake surface.
+
+This design defines the first evaluation recovery slice as a backend/operator-truth lane, not a frontend revival lane.
+
+## Current Facts
+
+- `backend/web/services/monitor_service.py` still contains `build_evaluation_operator_surface(...)`.
+- Existing unit coverage already locks three important operator states:
+  - bootstrap failure before thread rows materialize
+  - running while waiting for threads
+  - completed with recorded errors
+- Current monitor public routes do not expose `/api/monitor/evaluation` or `/api/monitor/evaluations`.
+- Current dashboard summary still returns:
+  - `evaluations_running: 0`
+  - `latest_evaluation: None`
+- Historical evaluation/frontend anchors still exist in git history:
+  - `3a7c7984` `feat: clarify provisional evaluation operator state`
+  - `16059ddb` `feat: tighten evaluation status density`
+  - `ea096f32` `feat: tighten monitor evaluation split density`
+
+## Constraints
+
+- Do not widen into evaluation runtime activation in this PR.
+- Do not widen into monitor shell/frontend work; that belongs to the `PR-C*` line.
+- Do not reopen product-facing routes.
+- Do not invent a fake evaluation list if only one truthful operator surface exists today.
+- Fail loudly when evaluation runtime truth is unavailable; do not silently return placeholders.
+
+## Proposal Comparison
+
+### Proposal A: Dashboard-only truth patch
+
+- Keep evaluation data embedded only in `/api/monitor/dashboard`.
+- Replace hardcoded placeholders with live values.
+
+Pros:
+- Smallest possible change.
+
+Cons:
+- Dashboard becomes the only evaluation truth surface.
+- Future evaluation UI would have to reverse-extract detail from a summary endpoint.
+- Mixes dashboard summary concerns with evaluation operator detail.
+
+### Proposal B: Dedicated operator route first
+
+- Introduce a dedicated monitor evaluation truth route.
+- Let dashboard consume only a compact summary from that truth source.
+
+Pros:
+- Clean separation between summary and operator detail.
+- Gives future evaluation UI a stable source of truth.
+- Keeps dashboard lightweight.
+
+Cons:
+- Slightly more design work because route and payload need to be defined now.
+
+### Proposal C: Full evaluation comeback
+
+- Restore route, dashboard summary, monitor page, and runtime activation in one pass.
+
+Why it loses:
+- Blends backend truth, frontend revival, and runtime recovery into one PR.
+- Makes review and blame isolation poor.
+- Repeats the same overscope pattern that already hurt earlier lanes.
+
+## Chosen Direction
+
+Use Proposal B.
+
+`PR-D1` should introduce a dedicated monitor evaluation truth route first, then let dashboard consume a compact summary from that source.
+
+This keeps the work mergeable and creates a stable base for:
+
+1. `PR-D1` evaluation operator truth
+2. `PR-D2` evaluation monitor surface
+3. `PR-D3` evaluation runtime activation
+
+## Sequence Of PRs
+
+### `PR-D1` evaluation operator truth
+
+**Goal**
+- Expose a truthful monitor evaluation route and remove dashboard's hardcoded evaluation placeholders.
+
+**Includes**
+- dedicated monitor evaluation route
+- payload contract for operator truth
+- dashboard summary fields derived from the same truth source
+- integration and unit coverage for route behavior
+
+**Does not include**
+- monitor evaluation page/nav
+- runtime runner repair or activation
+- trace UI
+
+### `PR-D2` evaluation monitor surface
+
+**Goal**
+- Mount evaluation inside the revived monitor shell using the truth route from `PR-D1`.
+
+**Includes**
+- monitor evaluation page
+- shell navigation entry if route support is real
+- operator-facing rendering of facts, artifacts, and next steps
+
+### `PR-D3` evaluation runtime activation
+
+**Goal**
+- Make evaluation truly runnable again.
+
+**Includes**
+- runtime execution truth
+- runner / summary / traces / thread materialization recovery
+- coordination with the upstream owner where the runtime seam crosses identity/core changes
+
+## `PR-D1` Route Design
+
+### Primary route
+
+- `GET /api/monitor/evaluation`
+
+This route should return the current operator truth surface for the latest relevant evaluation run. It is intentionally singular unless the runtime source already supports a truthful list.
+
+### Dashboard summary
+
+`GET /api/monitor/dashboard` should keep only summary-level evaluation fields:
+
+- `workload.evaluations_running`
+- `latest_evaluation`
+
+`latest_evaluation` should be a reduced summary derived from the operator truth route, not a second handcrafted logic branch.
+
+## `PR-D1` Payload Shape
+
+### Operator truth payload
+
+Recommended shape:
+
+```json
+{
+  "status": "running",
+  "kind": "running_active",
+  "tone": "default",
+  "headline": "Evaluation is actively running.",
+  "summary": "Thread rows and traces may lag behind the runner. Use live progress and logs before declaring drift.",
+  "facts": [],
+  "artifacts": [],
+  "artifact_summary": {
+    "present": 0,
+    "missing": 0,
+    "total": 0
+  },
+  "next_steps": [],
+  "raw_notes": "runner=direct rc=0 ..."
+}
+```
+
+`build_evaluation_operator_surface(...)` already defines most of this contract. `PR-D1` should formalize it as route output, not reinvent it.
+
+### Dashboard summary payload
+
+Recommended `latest_evaluation` summary shape:
+
+```json
+{
+  "status": "running",
+  "kind": "running_active",
+  "tone": "default",
+  "headline": "Evaluation is actively running."
+}
+```
+
+The dashboard summary should stay intentionally small.
+
+## Data Sources
+
+`PR-D1` must identify one truthful source for:
+
+- current evaluation status
+- notes / runner facts
+- score gate
+- artifact paths
+- thread counts
+
+If the source does not exist or cannot be resolved, the route must fail honestly instead of returning `None` placeholders.
+
+The first PR in this lane should prefer existing monitor/runtime truth over inventing a new store.
+
+## Error Handling
+
+- If no evaluation source exists yet, return an explicit `unavailable` operator payload, not fake emptiness.
+- If evaluation notes exist but the operator surface cannot be derived, fail loudly.
+- Dashboard must not silently swallow evaluation lookup failures and regress to `0 / None`.
+
+`PR-D1` should choose this exact split:
+
+- source absent or runtime intentionally unavailable:
+  - `GET /api/monitor/evaluation` returns a truthful `unavailable` operator payload
+  - dashboard derives summary from that explicit unavailable truth
+- source present but operator payload derivation fails:
+  - fail the route loudly
+  - do not replace the failure with `None` or a fake empty payload
+
+## Testing
+
+### Existing unit truth that must stay green
+
+- bootstrap failure before threads materialize
+- running while waiting for threads
+- completed with recorded errors
+
+### New `PR-D1` coverage
+
+- integration smoke for `GET /api/monitor/evaluation`
+- integration proof that dashboard no longer hardcodes:
+  - `evaluations_running = 0`
+  - `latest_evaluation = None`
+- negative-path proof for missing/unavailable evaluation truth
+
+## Non-goals
+
+- No shell/navigation work
+- No evaluation density polish
+- No evaluation route list view unless truthful source already exists
+- No runtime activation claims
+- No product app work
+
+## Verification
+
+Minimum bar for `PR-D1`:
+
+- targeted unit tests around operator truth remain green
+- new route integration tests green
+- dashboard integration test proves evaluation fields come from real truth, not placeholders
+
+## Risk Notes
+
+- The main risk is inventing a route before confirming a truthful runtime source.
+- The second risk is letting dashboard continue to own evaluation semantics directly.
+- `PR-D1` should therefore keep the operator route authoritative and the dashboard derivative.

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 
 from backend.web.core.dependencies import get_current_user_id
 from backend.web.routers import monitor, resources
-from backend.web.services import resource_service
+from backend.web.services import monitor_service, resource_service
 
 
 def _build_monitor_test_app(*, include_product_resources: bool = False) -> FastAPI:
@@ -119,6 +119,65 @@ def test_monitor_dashboard_route_smoke(monkeypatch):
     assert "infra" in payload
     assert "workload" in payload
     assert "latest_evaluation" in payload
+
+
+def test_monitor_evaluation_route_exposes_operator_truth(monkeypatch):
+    monkeypatch.setattr(
+        monitor_service,
+        "get_monitor_evaluation_truth",
+        lambda: {
+            "status": "unavailable",
+            "kind": "unavailable",
+            "tone": "warning",
+            "headline": "Evaluation operator truth is not wired in this runtime yet.",
+            "summary": "Monitor can report that evaluation truth is unavailable without pretending nothing is happening.",
+            "facts": [{"label": "Status", "value": "unavailable"}],
+            "artifacts": [],
+            "artifact_summary": {"present": 0, "missing": 0, "total": 0},
+            "next_steps": ["Restore a truthful evaluation runtime source before reviving the monitor evaluation page."],
+            "raw_notes": None,
+        },
+    )
+
+    with TestClient(_build_monitor_test_app()) as client:
+        response = client.get("/api/monitor/evaluation")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "unavailable"
+    assert payload["kind"] == "unavailable"
+    assert payload["headline"] == "Evaluation operator truth is not wired in this runtime yet."
+    assert payload["artifact_summary"] == {"present": 0, "missing": 0, "total": 0}
+
+
+def test_monitor_dashboard_route_derives_evaluation_summary_from_service(monkeypatch):
+    _stub_monitor_resource_snapshot(monkeypatch)
+    monkeypatch.setattr(
+        monitor_service,
+        "get_monitor_evaluation_dashboard_summary",
+        lambda: {
+            "evaluations_running": 1,
+            "latest_evaluation": {
+                "status": "running",
+                "kind": "running_active",
+                "tone": "default",
+                "headline": "Evaluation is actively running.",
+            },
+        },
+    )
+
+    with TestClient(_build_monitor_test_app()) as client:
+        response = client.get("/api/monitor/dashboard")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["workload"]["evaluations_running"] == 1
+    assert payload["latest_evaluation"] == {
+        "status": "running",
+        "kind": "running_active",
+        "tone": "default",
+        "headline": "Evaluation is actively running.",
+    }
 
 
 def test_monitor_leases_route_exposes_summary_and_groups():

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -191,6 +191,7 @@ def test_build_evaluation_operator_surface_flags_runner_exit_before_threads_mate
         threads_done=0,
     )
 
+    assert payload["status"] == "provisional"
     assert payload["kind"] == "bootstrap_failure"
     assert payload["tone"] == "danger"
     assert payload["headline"] == "Runner exited before evaluation threads materialized."
@@ -235,6 +236,7 @@ def test_build_evaluation_operator_surface_marks_running_waiting_for_threads():
         threads_done=0,
     )
 
+    assert payload["status"] == "running"
     assert payload["kind"] == "running_waiting_for_threads"
     assert payload["tone"] == "default"
     assert "actively running" in payload["headline"]
@@ -260,6 +262,7 @@ def test_build_evaluation_operator_surface_marks_completed_with_errors():
         threads_done=10,
     )
 
+    assert payload["status"] == "completed_with_errors"
     assert payload["kind"] == "completed_with_errors"
     assert payload["tone"] == "warning"
     assert "completed with recorded errors" in payload["headline"]

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -270,6 +270,48 @@ def test_build_evaluation_operator_surface_marks_completed_with_errors():
     }
 
 
+def test_monitor_evaluation_truth_defaults_to_explicit_unavailable_surface():
+    payload = monitor_service.get_monitor_evaluation_truth()
+
+    assert payload["status"] == "unavailable"
+    assert payload["kind"] == "unavailable"
+    assert payload["tone"] == "warning"
+    assert payload["headline"] == "Evaluation operator truth is not wired in this runtime yet."
+    assert payload["artifact_summary"] == {
+        "present": 0,
+        "missing": 0,
+        "total": 0,
+    }
+    assert payload["raw_notes"] is None
+
+
+def test_monitor_evaluation_dashboard_summary_reduces_operator_truth():
+    summary = monitor_service.build_monitor_evaluation_dashboard_summary(
+        {
+            "status": "running",
+            "kind": "running_active",
+            "tone": "default",
+            "headline": "Evaluation is actively running.",
+            "summary": "Long form summary that should not leak into dashboard shape.",
+            "facts": [],
+            "artifacts": [],
+            "artifact_summary": {"present": 2, "missing": 1, "total": 3},
+            "next_steps": [],
+            "raw_notes": "runner=direct rc=0",
+        }
+    )
+
+    assert summary == {
+        "evaluations_running": 1,
+        "latest_evaluation": {
+            "status": "running",
+            "kind": "running_active",
+            "tone": "default",
+            "headline": "Evaluation is actively running.",
+        },
+    }
+
+
 def test_cleanup_resource_leases_deletes_allowed_detached_residue(monkeypatch):
     rows = [
         {


### PR DESCRIPTION
## Summary
- start the mandatory evaluation companion lane as a dedicated `PR-D1` backend/operator-truth slice
- expose a real monitor evaluation truth route before any evaluation UI comeback
- remove dashboard's hardcoded evaluation placeholders without pretending the evaluation runtime is already restored

## This PR
- adds `GET /api/monitor/evaluation`
- encodes the current source-absent state as explicit operator truth:
  - `status=unavailable`
  - `kind=unavailable`
  - `tone=warning`
- makes `/api/monitor/dashboard` derive `workload.evaluations_running` and `latest_evaluation` from the same truth helper
- keeps scope backend-only: no evaluation page, no nav, no runtime activation work

## Lineage
- issue: `#205`
- `#260` rebuilt resource observability contracts and monitor resource surface
- `#261` locked backend/user-scoped actor-first resource proof
- `#262` revived the monitor shell (`PR-C1`)
- `#263` rebounded the mounted monitor surfaces (`PR-C2`)
- this PR starts `PR-D1`: evaluation operator truth

## Out Of Scope
- evaluation monitor UI
- evaluation sidebar/nav
- runtime activation / runner repair
- product app work
- fake empty fallback when evaluation truth is unavailable

## Verification
- `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
- `uv run ruff check backend/web/services/monitor_service.py backend/web/routers/monitor.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
