### PR TITLE
Revive monitor evaluation surface (PR-D2)

### DIFF
--- a/docs/superpowers/plans/2026-04-08-evaluation-monitor-surface.md
+++ b/docs/superpowers/plans/2026-04-08-evaluation-monitor-surface.md
@@ -1,0 +1,118 @@
+# Evaluation Monitor Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mount a dedicated monitor evaluation page that truthfully renders the existing `/api/monitor/evaluation` operator payload.
+
+**Architecture:** This plan keeps `PR-D2` frontend-only. It adds one mounted route, one sidebar entry, and one page component that consumes the already-shipped operator truth from `PR-D1/#264`. It does not widen into runtime activation, trace drilldown, or backend contract changes.
+
+**Tech Stack:** React 19, React Router 7, TypeScript, Vitest, Vite, CSS
+
+---
+
+## File Structure
+
+- Create: `frontend/monitor/src/pages/EvaluationPage.tsx`
+  - mounted operator surface for `/evaluation`
+- Modify: `frontend/monitor/src/app/routes.tsx`
+  - register `/evaluation`
+- Modify: `frontend/monitor/src/app/monitor-nav.ts`
+  - add nav entry
+- Modify: `frontend/monitor/src/app/routes.test.tsx`
+  - lock route mounting, nav highlight, unavailable copy
+- Modify: `frontend/monitor/src/styles.css`
+  - add only the minimal styles needed for the evaluation surface
+
+## Mandatory Boundary
+
+- No backend route or payload changes
+- No evaluation runtime activation claims
+- No traces drilldown
+- No product-facing evaluation UI
+- No dashboard rewrite beyond existing summary consumption
+
+## Task 1: Lock route smoke for the evaluation surface
+
+**Files:**
+- Modify: `frontend/monitor/src/app/routes.test.tsx`
+- Test: `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+
+- [ ] Add failing route smoke for the new monitor evaluation surface:
+  - sidebar renders `Evaluation`
+  - `/evaluation` mounts inside `MonitorShell`
+  - evaluation nav item becomes current
+  - unavailable operator truth is visible on the page
+- [ ] Run route smoke and verify the new assertions fail
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/app/routes.test.tsx
+git commit -m "test: lock monitor evaluation surface smoke"
+```
+
+## Task 2: Mount the evaluation route and nav entry
+
+**Files:**
+- Modify: `frontend/monitor/src/app/routes.tsx`
+- Modify: `frontend/monitor/src/app/monitor-nav.ts`
+- Create: `frontend/monitor/src/pages/EvaluationPage.tsx`
+- Test: `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+
+- [ ] Add `/evaluation` to `MonitorRoutes`
+- [ ] Add `Evaluation` to the sidebar nav using the existing monitor nav grammar
+- [ ] Create `EvaluationPage` with the same fetch/error/loading pattern used by other monitor pages
+- [ ] Render the truthful operator headline/summary for the current unavailable payload
+- [ ] Run route smoke and verify it passes
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/app/routes.tsx frontend/monitor/src/app/monitor-nav.ts frontend/monitor/src/pages/EvaluationPage.tsx frontend/monitor/src/app/routes.test.tsx
+git commit -m "feat: mount monitor evaluation surface"
+```
+
+## Task 3: Add minimal operator-surface sections
+
+**Files:**
+- Modify: `frontend/monitor/src/pages/EvaluationPage.tsx`
+- Modify: `frontend/monitor/src/styles.css`
+- Test:
+  - `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+  - `cd frontend/monitor && npm run build`
+
+- [ ] Add a compact status/summary header
+- [ ] Add artifact-summary cards driven by `artifact_summary`
+- [ ] Add facts grid driven by `facts`
+- [ ] Add artifacts table driven by `artifacts`
+- [ ] Add ordered `next_steps`
+- [ ] Add raw-notes block only when `raw_notes` is present
+- [ ] Keep unavailable state honest; do not invent zero-state success copy
+- [ ] Run route smoke and build
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/src/pages/EvaluationPage.tsx frontend/monitor/src/styles.css frontend/monitor/src/app/routes.test.tsx
+git commit -m "feat: flesh out monitor evaluation operator surface"
+```
+
+## Task 4: Proof and PR prep
+
+**Files:**
+- No required code files
+- Update PR description/checkpoint as needed
+
+- [ ] Run fresh browser proof for `/evaluation`
+- [ ] Record the honest boundary if the payload is still `status=unavailable`
+- [ ] Prepare draft PR as `PR-D2`
+
+## Verification Standard
+
+- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
+- `cd frontend/monitor && npm run build`
+- browser proof for `/evaluation` inside the revived shell
+
+## Hard Stopline
+
+- This plan does not activate evaluation runtime
+- This plan does not add trace drilldown
+- This plan does not change `/api/monitor/evaluation`
+- If the operator payload proves insufficient, stop and open a bounded backend follow-up instead of silently expanding `PR-D2`

--- a/docs/superpowers/specs/2026-04-08-evaluation-monitor-surface-design.md
+++ b/docs/superpowers/specs/2026-04-08-evaluation-monitor-surface-design.md
@@ -1,0 +1,190 @@
+# Evaluation Monitor Surface Design
+
+## Goal
+
+Restore a real monitor-facing evaluation page that consumes the truthful backend surface added in `PR-D1/#264`, without pretending that evaluation runtime activation is already finished.
+
+## Current Facts
+
+- `GET /api/monitor/evaluation` now exists and returns operator truth.
+- Current truth is still explicitly `status=unavailable` until a real runtime source is wired.
+- The revived monitor shell already exists and mounts these routes:
+  - `/dashboard`
+  - `/threads`
+  - `/resources`
+  - `/leases`
+  - `/diverged`
+  - `/events`
+- There is no mounted monitor evaluation page yet.
+- Dashboard currently derives evaluation summary, but it is still only a summary, not a real operator surface.
+
+## Approaches
+
+### 1. Dashboard-only evaluation exposure
+
+Keep evaluation visible only as a dashboard summary card.
+
+- Smallest diff
+- Keeps dashboard overloaded
+- Does not give operators a dedicated place to inspect evaluation facts, artifacts, and next steps
+
+Not recommended.
+
+### 2. Dedicated evaluation page
+
+Add a real `/evaluation` route and sidebar entry that consumes `/api/monitor/evaluation`.
+
+- Matches the shell revival direction
+- Uses the truth route that already exists
+- Keeps `PR-D2` narrow: mounted monitor surface only
+- Cleanly separates `PR-D2` from `PR-D3`
+
+Recommended.
+
+### 3. Full evaluation comeback
+
+Add page, nav, traces, drilldown, and runtime activation all at once.
+
+- Recreates the old “one giant PR” failure mode
+- Mixes frontend surface work with runtime/operator semantics
+
+Rejected.
+
+## Recommended Design
+
+`PR-D2` will add a dedicated monitor evaluation surface:
+
+- new route: `/evaluation`
+- new sidebar entry: `Evaluation`
+- new page component that fetches `/api/monitor/evaluation`
+- page sections that map directly to the current operator payload:
+  - headline/status section
+  - fact list
+  - artifact summary + artifact table
+  - next steps
+  - raw notes block when present
+
+This page must remain honest when the runtime source is not yet wired. If the payload says `status=unavailable`, the page should render that operator truth directly instead of inventing zero-state metrics or fake healthy copy.
+
+## Architecture
+
+### Route and navigation
+
+- Extend `frontend/monitor/src/app/routes.tsx` with `/evaluation`
+- Extend `frontend/monitor/src/app/monitor-nav.ts` with an `Evaluation` entry
+- Do not change existing mounted routes
+
+### Page component
+
+Add `frontend/monitor/src/pages/EvaluationPage.tsx`.
+
+Responsibilities:
+
+- fetch `/evaluation` using existing `useMonitorData`
+- render `ErrorState` on request failure
+- render loading state while fetch is pending
+- render truthful operator sections once payload exists
+
+The page should follow the same shell/page grammar already used by `DashboardPage`, `LeasesPage`, and `EventsPage`.
+
+### Data mapping
+
+No backend payload changes are part of `PR-D2`.
+
+The page should consume these existing fields directly:
+
+- `status`
+- `kind`
+- `tone`
+- `headline`
+- `summary`
+- `facts`
+- `artifacts`
+- `artifact_summary`
+- `next_steps`
+- `raw_notes`
+
+If a field is absent, the page may render a minimal fallback label like `-`, but it must not invent a different semantic state.
+
+## UI Structure
+
+### Hero section
+
+- page title: `Evaluation`
+- subtitle/description taken from `headline` and `summary`
+- compact status chip showing `status` and `kind`
+
+### Operator surface cards
+
+Small cards derived from `artifact_summary`:
+
+- present artifacts
+- missing artifacts
+- total artifacts
+
+If `status=running`, the page may visually emphasize operator activity, but this should come from existing payload truth, not client-side inference beyond the status field.
+
+### Facts section
+
+Render the `facts` array as a simple key/value grid.
+
+### Artifacts section
+
+Render the `artifacts` array as a table:
+
+- label
+- path
+- status
+
+### Next steps section
+
+Render `next_steps` as a flat ordered list. These are already operator-oriented instructions; no additional UI inference is needed.
+
+### Raw notes section
+
+Render only when `raw_notes` is non-null. Use a monospace block and keep it visually secondary.
+
+## Error Handling
+
+- Request failure: use existing `ErrorState`
+- `status=unavailable`: render as valid page content, not as an error
+- Empty arrays: render honest empty sections, not placeholder business claims
+
+## Testing
+
+`PR-D2` should be locked with frontend route smoke only.
+
+Minimum verification:
+
+- `src/app/routes.test.tsx`
+  - sidebar contains `Evaluation`
+  - `/evaluation` route mounts and highlights nav correctly
+  - unavailable payload renders truthful operator copy
+- `npm run build`
+
+No backend contract tests belong in this PR unless the frontend reveals a real contract gap.
+
+## Boundaries
+
+### In scope
+
+- monitor sidebar entry
+- monitor evaluation page
+- truthful rendering of the existing `/api/monitor/evaluation` payload
+
+### Out of scope
+
+- evaluation runtime activation
+- traces drilldown
+- dashboard semantic rewrite
+- product-facing evaluation UI
+- backend payload expansion
+
+## Merge Bar
+
+- `/evaluation` exists inside the revived monitor shell
+- sidebar navigation reaches it
+- page truthfully renders the current unavailable payload
+- route smoke passes
+- monitor frontend build passes
+- no backend contract changes are required for this slice

--- a/frontend/monitor/src/app/monitor-nav.ts
+++ b/frontend/monitor/src/app/monitor-nav.ts
@@ -10,6 +10,7 @@ export const monitorNav: readonly MonitorNavItem[] = [
   { to: "/threads", label: "Threads", matchPrefix: "/thread/", eyebrow: "Runtime" },
   { to: "/resources", label: "Resources", eyebrow: "Runtime" },
   { to: "/leases", label: "Leases", matchPrefix: "/lease/", eyebrow: "Runtime" },
+  { to: "/evaluation", label: "Evaluation", eyebrow: "Operators" },
   { to: "/diverged", label: "Diverged", eyebrow: "Signals" },
   { to: "/events", label: "Events", matchPrefix: "/event/", eyebrow: "Signals" },
 ];

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -291,5 +291,9 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByRole("heading", { name: "Evaluation" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /evaluation/i })).toHaveAttribute("aria-current", "page");
     expect(screen.getByText("Evaluation operator truth is not wired in this runtime yet.")).toBeInTheDocument();
+    expect(screen.getByText("Operator Facts")).toBeInTheDocument();
+    expect(screen.getByText("Artifact Coverage")).toBeInTheDocument();
+    expect(screen.getByText("Next Steps")).toBeInTheDocument();
+    expect(screen.getByText("Restore a truthful evaluation runtime source before reviving the monitor evaluation page.")).toBeInTheDocument();
   });
 });

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -50,6 +50,7 @@ describe("MonitorRoutes", () => {
     expect(screen.getByRole("link", { name: /threads/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /resources/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /leases/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /evaluation/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /diverged/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /events/i })).toBeInTheDocument();
   });
@@ -259,5 +260,36 @@ describe("MonitorRoutes", () => {
 
     expect(await screen.findByText("Signal Feed")).toBeInTheDocument();
     expect(screen.getByText("Raw Event Table")).toBeInTheDocument();
+  });
+
+  it("renders evaluation as a truthful operator surface", async () => {
+    mockRoutePayloads({
+      "/evaluation": {
+        status: "unavailable",
+        kind: "unavailable",
+        tone: "warning",
+        headline: "Evaluation operator truth is not wired in this runtime yet.",
+        summary: "Monitor can report that evaluation truth is unavailable without pretending nothing is happening.",
+        facts: [{ label: "Status", value: "unavailable" }],
+        artifacts: [],
+        artifact_summary: {
+          present: 0,
+          missing: 0,
+          total: 0,
+        },
+        next_steps: ["Restore a truthful evaluation runtime source before reviving the monitor evaluation page."],
+        raw_notes: null,
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/evaluation"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Evaluation" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /evaluation/i })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("Evaluation operator truth is not wired in this runtime yet.")).toBeInTheDocument();
   });
 });

--- a/frontend/monitor/src/app/routes.tsx
+++ b/frontend/monitor/src/app/routes.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from "react-router-dom";
 import ResourcesPage from "../ResourcesPage";
 import DashboardPage from "../pages/DashboardPage";
 import DivergedPage from "../pages/DivergedPage";
+import EvaluationPage from "../pages/EvaluationPage";
 import EventDetailPage from "../pages/EventDetailPage";
 import EventsPage from "../pages/EventsPage";
 import LeaseDetailPage from "../pages/LeaseDetailPage";
@@ -22,6 +23,7 @@ export function MonitorRoutes() {
         <Route path="/thread/:threadId" element={<ThreadDetailPage />} />
         <Route path="/leases" element={<LeasesPage />} />
         <Route path="/lease/:leaseId" element={<LeaseDetailPage />} />
+        <Route path="/evaluation" element={<EvaluationPage />} />
         <Route path="/diverged" element={<DivergedPage />} />
         <Route path="/events" element={<EventsPage />} />
         <Route path="/event/:eventId" element={<EventDetailPage />} />

--- a/frontend/monitor/src/pages/EvaluationPage.tsx
+++ b/frontend/monitor/src/pages/EvaluationPage.tsx
@@ -1,0 +1,40 @@
+import ErrorState from "../components/ErrorState";
+import { useMonitorData } from "../app/fetch";
+
+type EvaluationPayload = {
+  status?: string | null;
+  kind?: string | null;
+  headline?: string | null;
+  summary?: string | null;
+};
+
+export default function EvaluationPage() {
+  const { data, error } = useMonitorData<EvaluationPayload>("/evaluation");
+
+  if (error) return <ErrorState title="Evaluation" error={error} />;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div className="page">
+      <h1>Evaluation</h1>
+      <p className="description">{data.headline ?? "No evaluation operator headline."}</p>
+      <section className="surface-section">
+        <h2>Operator Truth</h2>
+        <div className="surface-grid">
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Status</p>
+            <p className="surface-card__value">{data.status ?? "-"}</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Kind</p>
+            <p className="surface-card__value">{data.kind ?? "-"}</p>
+          </article>
+        </div>
+      </section>
+      <section className="surface-section">
+        <h2>Current Summary</h2>
+        <p className="surface-card__body">{data.summary ?? "No evaluation summary available."}</p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/monitor/src/pages/EvaluationPage.tsx
+++ b/frontend/monitor/src/pages/EvaluationPage.tsx
@@ -6,6 +6,15 @@ type EvaluationPayload = {
   kind?: string | null;
   headline?: string | null;
   summary?: string | null;
+  facts?: Array<{ label?: string | null; value?: string | null }>;
+  artifacts?: Array<{ label?: string | null; path?: string | null; status?: string | null }>;
+  artifact_summary?: {
+    present?: number | null;
+    missing?: number | null;
+    total?: number | null;
+  } | null;
+  next_steps?: string[] | null;
+  raw_notes?: string | null;
 };
 
 export default function EvaluationPage() {
@@ -13,6 +22,11 @@ export default function EvaluationPage() {
 
   if (error) return <ErrorState title="Evaluation" error={error} />;
   if (!data) return <div>Loading...</div>;
+
+  const facts = data.facts ?? [];
+  const artifacts = data.artifacts ?? [];
+  const summary = data.artifact_summary ?? {};
+  const nextSteps = data.next_steps ?? [];
 
   return (
     <div className="page">
@@ -35,6 +49,75 @@ export default function EvaluationPage() {
         <h2>Current Summary</h2>
         <p className="surface-card__body">{data.summary ?? "No evaluation summary available."}</p>
       </section>
+      <section className="surface-section">
+        <h2>Artifact Coverage</h2>
+        <div className="surface-grid">
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Present</p>
+            <p className="surface-card__value">{summary.present ?? 0}</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Missing</p>
+            <p className="surface-card__value">{summary.missing ?? 0}</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Total</p>
+            <p className="surface-card__value">{summary.total ?? 0}</p>
+          </article>
+        </div>
+      </section>
+      <section className="surface-section">
+        <h2>Operator Facts</h2>
+        <div className="info-grid">
+          {facts.map((fact) => (
+            <div key={`${fact.label}-${fact.value}`}>
+              <strong>{fact.label ?? "-"}</strong>
+              <span>{fact.value ?? "-"}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="surface-section">
+        <h2>Artifacts</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>Path</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {artifacts.length > 0 ? (
+              artifacts.map((artifact) => (
+                <tr key={`${artifact.label}-${artifact.path}`}>
+                  <td>{artifact.label ?? "-"}</td>
+                  <td className="mono">{artifact.path ?? "-"}</td>
+                  <td>{artifact.status ?? "-"}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={3}>No artifacts reported.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+      <section className="surface-section">
+        <h2>Next Steps</h2>
+        <ol className="surface-list">
+          {nextSteps.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+      </section>
+      {data.raw_notes ? (
+        <section className="surface-section">
+          <h2>Raw Notes</h2>
+          <pre className="json-payload">{data.raw_notes}</pre>
+        </section>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- mount a dedicated `/evaluation` surface inside the revived monitor shell
- consume the existing `/api/monitor/evaluation` operator payload without widening backend/runtime scope
- lock route smoke for evaluation nav, route mounting, and truthful unavailable rendering

## Lineage
- follows `PR-D1/#264`, which exposed `GET /api/monitor/evaluation`
- continues the evaluation companion lane after `PR-C1/#262` and `PR-C2/#263` restored the monitor shell and mounted surfaces
- stays explicitly separate from `PR-D3` evaluation runtime activation

## Scope
In scope:
- monitor sidebar entry
- mounted monitor `/evaluation` page
- truthful rendering of current operator fields (`status`, `kind`, `headline`, `summary`, `facts`, `artifacts`, `artifact_summary`, `next_steps`, `raw_notes`)

Out of scope:
- backend payload expansion
- evaluation runtime activation
- traces drilldown
- product-facing evaluation UI

## Verification
- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
- `cd frontend/monitor && npm run build`

## Honest Boundary
- local preview browser proof confirms the shell/nav/route are mounted
- local preview does not yet prove live operator truth because `/api/monitor/evaluation` returns `500` behind preview in this setup
- this PR therefore proves the mounted monitor surface and truthful frontend consumption, not runtime activation
