### PR TITLE
Revive persisted evaluation operator truth (PR-D3a)

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -477,10 +477,7 @@ def _normalize_persisted_eval_status(raw_status: str | None) -> tuple[str, str, 
 
 def _build_persisted_evaluation_surface(run: dict[str, Any], metrics_rows: list[dict[str, Any]]) -> dict[str, Any]:
     status, kind, tone, headline = _normalize_persisted_eval_status(run.get("status"))
-    metrics_by_tier = {
-        str(row.get("tier") or "").strip().lower(): row.get("metrics") or {}
-        for row in metrics_rows
-    }
+    metrics_by_tier = {str(row.get("tier") or "").strip().lower(): row.get("metrics") or {} for row in metrics_rows}
     system_metrics = metrics_by_tier.get("system") or {}
     objective_metrics = metrics_by_tier.get("objective") or {}
     facts = [

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from backend.web.core.storage_factory import make_sandbox_monitor_repo
 from backend.web.services.sandbox_service import init_providers_and_managers, load_all_sessions
+from eval.storage import TrajectoryStore
 from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
@@ -25,6 +26,10 @@ def make_chat_session_repo() -> SQLiteChatSessionRepo:
 
 def make_lease_repo() -> SQLiteLeaseRepo:
     return SQLiteLeaseRepo(db_path=resolve_role_db_path(SQLiteDBRole.SANDBOX))
+
+
+def make_eval_store() -> TrajectoryStore:
+    return TrajectoryStore()
 
 
 def _format_time_ago(iso_timestamp: str | None) -> str:
@@ -422,9 +427,115 @@ def _evaluation_unavailable_surface() -> dict[str, Any]:
     }
 
 
+def _evaluation_no_runs_surface() -> dict[str, Any]:
+    return {
+        "status": "idle",
+        "kind": "no_recorded_runs",
+        "tone": "default",
+        "headline": "No persisted evaluation runs are available yet.",
+        "summary": "Evaluation storage is wired, but there are no recorded runs to report yet.",
+        "facts": [{"label": "Status", "value": "idle"}],
+        "artifacts": [],
+        "artifact_summary": {"present": 0, "missing": 0, "total": 0},
+        "next_steps": ["Run an evaluation to populate the operator surface with persisted runtime truth."],
+        "raw_notes": None,
+    }
+
+
+def _normalize_persisted_eval_status(raw_status: str | None) -> tuple[str, str, str, str]:
+    status = str(raw_status or "").strip().lower()
+    # @@@eval-status-normalization - persisted eval_runs only record coarse terminal status,
+    # so monitor must normalize them without pretending the old manifest/thread truth still exists.
+    if status == "running":
+        return (
+            "running",
+            "running_recorded",
+            "default",
+            "Latest persisted evaluation run is still marked running.",
+        )
+    if status in {"error", "failed", "cancelled"}:
+        return (
+            "completed_with_errors",
+            "run_recorded_with_errors",
+            "warning",
+            "Latest persisted evaluation run finished with errors.",
+        )
+    if status == "completed":
+        return (
+            "completed",
+            "completed_recorded",
+            "success",
+            "Latest persisted evaluation run completed successfully.",
+        )
+    return (
+        "provisional",
+        "persisted_status_unknown",
+        "warning",
+        "Latest persisted evaluation run reported an unknown status.",
+    )
+
+
+def _build_persisted_evaluation_surface(run: dict[str, Any], metrics_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    status, kind, tone, headline = _normalize_persisted_eval_status(run.get("status"))
+    metrics_by_tier = {
+        str(row.get("tier") or "").strip().lower(): row.get("metrics") or {}
+        for row in metrics_rows
+    }
+    system_metrics = metrics_by_tier.get("system") or {}
+    objective_metrics = metrics_by_tier.get("objective") or {}
+    facts = [
+        {"label": "Status", "value": status},
+        {"label": "Run ID", "value": str(run.get("id") or "-")},
+        {"label": "Thread ID", "value": str(run.get("thread_id") or "-")},
+        {"label": "Started At", "value": str(run.get("started_at") or "-")},
+        {"label": "Finished At", "value": str(run.get("finished_at") or "-")},
+        {"label": "Metric Tiers", "value": str(len(metrics_rows))},
+    ]
+    user_message = str(run.get("user_message") or "").strip()
+    if user_message:
+        facts.append({"label": "User Message", "value": user_message})
+    total_tokens = system_metrics.get("total_tokens")
+    if total_tokens is not None:
+        facts.append({"label": "Total tokens", "value": str(total_tokens)})
+    llm_call_count = system_metrics.get("llm_call_count")
+    if llm_call_count is not None:
+        facts.append({"label": "LLM calls", "value": str(llm_call_count)})
+    tool_call_count = system_metrics.get("tool_call_count")
+    if tool_call_count is not None:
+        facts.append({"label": "Tool calls", "value": str(tool_call_count)})
+    total_duration_ms = objective_metrics.get("total_duration_ms")
+    if total_duration_ms is not None:
+        duration_value = int(total_duration_ms) if float(total_duration_ms).is_integer() else total_duration_ms
+        facts.append({"label": "Duration (ms)", "value": str(duration_value)})
+
+    return {
+        "status": status,
+        "kind": kind,
+        "tone": tone,
+        "headline": headline,
+        "summary": (
+            "Monitor is reading the latest persisted eval run from eval_runs/eval_metrics. "
+            "Legacy manifest, artifact, and thread-materialization detail are not wired in this slice."
+        ),
+        "facts": facts,
+        "artifacts": [],
+        "artifact_summary": {"present": 0, "missing": 0, "total": 0},
+        "next_steps": [
+            "Use the persisted run and metric facts here as the current source of truth.",
+            "Restore richer artifact and thread drilldown in later evaluation runtime slices if still needed.",
+        ],
+        "raw_notes": None,
+    }
+
+
 def get_monitor_evaluation_truth() -> dict[str, Any]:
-    # @@@evaluation-truth-stopline - PR-D1 exposes explicit unavailable truth until a real runtime source is wired.
-    return _evaluation_unavailable_surface()
+    store = make_eval_store()
+    runs = store.list_runs(limit=1)
+    if not runs:
+        return _evaluation_no_runs_surface()
+    latest_run = runs[0]
+    metrics_rows = store.get_metrics(str(latest_run.get("id") or ""))
+    return _build_persisted_evaluation_surface(latest_run, metrics_rows)
 
 
 def build_monitor_evaluation_dashboard_summary(payload: dict[str, Any]) -> dict[str, Any]:

--- a/docs/superpowers/plans/2026-04-08-evaluation-runtime-source-truth.md
+++ b/docs/superpowers/plans/2026-04-08-evaluation-runtime-source-truth.md
@@ -1,10 +1,10 @@
-# Evaluation Runtime Source Truth Implementation Plan
+# Evaluation Persisted Source Truth Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace monitor’s hardcoded evaluation `unavailable` payload with a real file-backed runtime source that feeds the existing operator formatter.
+**Goal:** Replace monitor’s hardcoded evaluation placeholder with real repo-backed persisted truth from `eval_runs/eval_metrics`.
 
-**Architecture:** This plan is only `PR-D3a`. It introduces a narrow runtime source reader, validates the source, and wires `get_monitor_evaluation_truth()` to it. It does not implement runner writes, drilldown, or frontend work.
+**Architecture:** This plan is only `PR-D3a`. It introduces a narrow reader for the existing persisted eval source and wires `get_monitor_evaluation_truth()` to it. It does not implement runner writes, drilldown, or frontend work.
 
 **Tech Stack:** Python, FastAPI service layer, pytest
 
@@ -13,11 +13,10 @@
 ## File Structure
 
 - Modify: `backend/web/services/monitor_service.py`
-  - add runtime source reader
-  - add malformed-source failure path
+  - add persisted source reader
   - connect `get_monitor_evaluation_truth()` to real source reading
 - Modify: `tests/Unit/monitor/test_monitor_compat.py`
-  - add source-absent, malformed-source, valid-source tests
+  - add no-runs and persisted-run tests
 - Modify: `tests/Integration/test_monitor_resources_route.py`
   - prove route truth is no longer hardcoded
 
@@ -29,47 +28,44 @@
 - No product-facing evaluation work
 - No schema redesign
 
-## Task 1: Lock source-absent and malformed-source behavior
+## Task 1: Lock no-runs and persisted-run behavior
 
 **Files:**
 - Modify: `tests/Unit/monitor/test_monitor_compat.py`
 - Test: `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_truth'`
 
 - [ ] Add failing tests that prove:
-  - missing runtime source returns explicit `unavailable`
-  - malformed runtime source raises loudly instead of silently downgrading to `unavailable`
-  - valid runtime source produces a formatted operator payload
+  - wired eval storage with no runs returns explicit `idle/no_recorded_runs`
+  - latest persisted run produces a truthful operator payload
 - [ ] Run the targeted unit tests and verify the new expectations fail
 - [ ] Commit:
 
 ```bash
 git add tests/Unit/monitor/test_monitor_compat.py
-git commit -m "test: lock evaluation runtime source truth"
+git commit -m "test: lock evaluation persisted source truth"
 ```
 
-## Task 2: Implement the runtime source reader
+## Task 2: Implement the persisted source reader
 
 **Files:**
 - Modify: `backend/web/services/monitor_service.py`
 - Modify: `tests/Unit/monitor/test_monitor_compat.py`
 - Test: `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_truth'`
 
-- [ ] Add a small file-backed runtime source reader
-- [ ] Keep the source contract minimal:
-  - `status`
-  - `notes`
-  - `score`
-  - `threads`
+- [ ] Add a small repo-backed reader using the existing eval store
+- [ ] Keep the source contract minimal and truthful:
+  - latest persisted run row
+  - persisted metric rows for that run
 - [ ] Make `get_monitor_evaluation_truth()`:
-  - return explicit unavailable only when the source is absent
-  - raise loudly when the source is malformed
-  - feed valid source data into `build_evaluation_operator_surface(...)`
+  - return explicit `idle/no_recorded_runs` when the source is wired but empty
+  - fail loudly when repo reads or metric decoding break
+  - feed only the fields that actually exist today into the operator payload
 - [ ] Run targeted unit tests and verify they pass
 - [ ] Commit:
 
 ```bash
 git add backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py
-git commit -m "feat: read evaluation runtime source for monitor truth"
+git commit -m "feat: read persisted evaluation source for monitor truth"
 ```
 
 ## Task 3: Lock route-level truth upgrade
@@ -79,7 +75,7 @@ git commit -m "feat: read evaluation runtime source for monitor truth"
 - Test: `uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'`
 
 - [ ] Add integration proof that:
-  - `/api/monitor/evaluation` returns real source-backed truth when the source is present
+  - `/api/monitor/evaluation` returns real persisted-source truth when a run exists
   - `/api/monitor/dashboard` derives evaluation summary from that same truth
 - [ ] Run the targeted integration tests and verify they fail first if needed
 - [ ] Make only the minimal backend adjustments needed to pass
@@ -88,7 +84,7 @@ git commit -m "feat: read evaluation runtime source for monitor truth"
 
 ```bash
 git add tests/Integration/test_monitor_resources_route.py backend/web/services/monitor_service.py backend/web/routers/monitor.py
-git commit -m "test: lock monitor evaluation route to runtime source"
+git commit -m "test: lock monitor evaluation route to persisted source"
 ```
 
 ## Task 4: Verification and PR prep
@@ -101,13 +97,13 @@ git commit -m "test: lock monitor evaluation route to runtime source"
   - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
   - `uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
 - [ ] Record honest boundary:
-  - this PR activates reader-side runtime truth only
-  - writer-side runner activation is still `PR-D3b`
+  - this PR activates reader-side persisted truth only
+  - live/in-flight runner activation is still `PR-D3b`
 - [ ] Prepare draft PR as `PR-D3a`
 
 ## Hard Stopline
 
-- This plan does not make the runner write runtime source files
+- This plan does not make the runner write live in-flight truth
 - This plan does not add evaluation UI
 - This plan does not add drilldown/history
-- If no existing evaluation runtime source path can be identified cleanly, stop and write the missing source-path contract explicitly before coding
+- If the existing persisted eval source turns out not to be shared with web runtime, stop and write that source-gap down explicitly before coding

--- a/docs/superpowers/plans/2026-04-08-evaluation-runtime-source-truth.md
+++ b/docs/superpowers/plans/2026-04-08-evaluation-runtime-source-truth.md
@@ -1,0 +1,113 @@
+# Evaluation Runtime Source Truth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace monitor’s hardcoded evaluation `unavailable` payload with a real file-backed runtime source that feeds the existing operator formatter.
+
+**Architecture:** This plan is only `PR-D3a`. It introduces a narrow runtime source reader, validates the source, and wires `get_monitor_evaluation_truth()` to it. It does not implement runner writes, drilldown, or frontend work.
+
+**Tech Stack:** Python, FastAPI service layer, pytest
+
+---
+
+## File Structure
+
+- Modify: `backend/web/services/monitor_service.py`
+  - add runtime source reader
+  - add malformed-source failure path
+  - connect `get_monitor_evaluation_truth()` to real source reading
+- Modify: `tests/Unit/monitor/test_monitor_compat.py`
+  - add source-absent, malformed-source, valid-source tests
+- Modify: `tests/Integration/test_monitor_resources_route.py`
+  - prove route truth is no longer hardcoded
+
+## Mandatory Boundary
+
+- No frontend work
+- No runner write-path activation
+- No trace drilldown
+- No product-facing evaluation work
+- No schema redesign
+
+## Task 1: Lock source-absent and malformed-source behavior
+
+**Files:**
+- Modify: `tests/Unit/monitor/test_monitor_compat.py`
+- Test: `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_truth'`
+
+- [ ] Add failing tests that prove:
+  - missing runtime source returns explicit `unavailable`
+  - malformed runtime source raises loudly instead of silently downgrading to `unavailable`
+  - valid runtime source produces a formatted operator payload
+- [ ] Run the targeted unit tests and verify the new expectations fail
+- [ ] Commit:
+
+```bash
+git add tests/Unit/monitor/test_monitor_compat.py
+git commit -m "test: lock evaluation runtime source truth"
+```
+
+## Task 2: Implement the runtime source reader
+
+**Files:**
+- Modify: `backend/web/services/monitor_service.py`
+- Modify: `tests/Unit/monitor/test_monitor_compat.py`
+- Test: `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'evaluation_truth'`
+
+- [ ] Add a small file-backed runtime source reader
+- [ ] Keep the source contract minimal:
+  - `status`
+  - `notes`
+  - `score`
+  - `threads`
+- [ ] Make `get_monitor_evaluation_truth()`:
+  - return explicit unavailable only when the source is absent
+  - raise loudly when the source is malformed
+  - feed valid source data into `build_evaluation_operator_surface(...)`
+- [ ] Run targeted unit tests and verify they pass
+- [ ] Commit:
+
+```bash
+git add backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py
+git commit -m "feat: read evaluation runtime source for monitor truth"
+```
+
+## Task 3: Lock route-level truth upgrade
+
+**Files:**
+- Modify: `tests/Integration/test_monitor_resources_route.py`
+- Test: `uv run pytest -q tests/Integration/test_monitor_resources_route.py -k 'monitor_evaluation or monitor_dashboard_route'`
+
+- [ ] Add integration proof that:
+  - `/api/monitor/evaluation` returns real source-backed truth when the source is present
+  - `/api/monitor/dashboard` derives evaluation summary from that same truth
+- [ ] Run the targeted integration tests and verify they fail first if needed
+- [ ] Make only the minimal backend adjustments needed to pass
+- [ ] Re-run targeted integration tests and verify they pass
+- [ ] Commit:
+
+```bash
+git add tests/Integration/test_monitor_resources_route.py backend/web/services/monitor_service.py backend/web/routers/monitor.py
+git commit -m "test: lock monitor evaluation route to runtime source"
+```
+
+## Task 4: Verification and PR prep
+
+**Files:**
+- No required code files
+- Update PR description/checkpoint as needed
+
+- [ ] Run:
+  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
+  - `uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
+- [ ] Record honest boundary:
+  - this PR activates reader-side runtime truth only
+  - writer-side runner activation is still `PR-D3b`
+- [ ] Prepare draft PR as `PR-D3a`
+
+## Hard Stopline
+
+- This plan does not make the runner write runtime source files
+- This plan does not add evaluation UI
+- This plan does not add drilldown/history
+- If no existing evaluation runtime source path can be identified cleanly, stop and write the missing source-path contract explicitly before coding

--- a/docs/superpowers/specs/2026-04-08-evaluation-runtime-activation-design.md
+++ b/docs/superpowers/specs/2026-04-08-evaluation-runtime-activation-design.md
@@ -10,15 +10,19 @@ Turn monitor evaluation from a hardcoded `unavailable` placeholder into a truthf
 - `PR-D2/#265` already mounted `/evaluation` in the revived monitor shell.
 - `backend/web/services/monitor_service.py` already defines the target operator payload shape through `build_evaluation_operator_surface(...)`.
 - That same service currently hardcodes `get_monitor_evaluation_truth()` to `_evaluation_unavailable_surface()`.
-- The repo currently contains almost no runtime source reader that can supply:
-  - `status`
-  - `notes`
-  - `score_gate`
-  - `run_dir`
-  - `manifest_path`
-  - `eval_summary_path`
-  - `trace_summaries_path`
-  - thread materialization counts
+- The repo already persists completed eval runs through:
+  - `eval.storage.TrajectoryStore`
+  - `storage.container.StorageContainer.eval_repo()`
+  - `storage.providers.supabase.eval_repo.SupabaseEvalRepo`
+- `backend/web/services/streaming_service.py` already writes trajectories into that store after a run completes.
+- The persisted source currently carries:
+  - coarse run status
+  - timestamps
+  - thread id
+  - user message
+  - trajectory JSON
+  - tiered metrics rows
+- It does not currently carry the older manifest/log/thread-materialization fields that `build_evaluation_operator_surface(...)` was designed around.
 - Existing tests prove formatter behavior, not source discovery or runtime activation.
 
 ## Scope Check
@@ -68,15 +72,19 @@ Cons:
 
 Rejected.
 
-### 3. Filesystem/manifest-first activation
+### 3. Repo-backed persisted-truth activation
 
-Define a minimal runtime source contract in files, have the evaluation runner write it, and have monitor read it.
+Use the existing `TrajectoryStore -> eval_repo -> eval_runs/eval_metrics` path as the first truthful runtime source, and let monitor read the latest persisted run from there.
 
 Pros:
-- matches the existing operator payload expectations (`run_dir`, `manifest_path`, logs, summaries)
-- durable across process restarts
-- keeps monitor truth and runner writes loosely coupled
+- already exists on latest `dev`
+- stays in the same Supabase-backed storage world as the web runtime
+- avoids inventing a second source contract before proving the first one
 - allows a narrow first mergeable slice
+
+Cons:
+- current writes happen after run completion, so this does not expose live in-flight eval progress yet
+- does not carry legacy `run_dir / manifest / trace summary / thread-materialization` detail
 
 Recommended.
 
@@ -84,9 +92,9 @@ Recommended.
 
 `PR-D3` becomes a 3-step workstream:
 
-### PR-D3a: Runtime source contract + monitor truth hookup
+### PR-D3a: Persisted source truth hookup
 
-Introduce a narrow runtime source contract for “latest evaluation run” and make `get_monitor_evaluation_truth()` read it instead of hardcoding `unavailable`.
+Introduce a narrow reader for “latest persisted evaluation run” and make `get_monitor_evaluation_truth()` read it instead of hardcoding `unavailable`.
 
 This is the first mergeable slice.
 
@@ -108,70 +116,55 @@ This is explicitly later.
 
 ### Runtime source contract
 
-Use a small file-backed contract, rooted in a stable path under evaluation runtime storage.
+Use the existing persisted eval contract:
 
-Minimum fields:
+- `eval_runs`
+  - `id`
+  - `thread_id`
+  - `started_at`
+  - `finished_at`
+  - `status`
+  - `user_message`
+  - `trajectory_json`
+- `eval_metrics`
+  - tiered metric rows keyed by `run_id`
 
-- `status`
-- `notes`
-- `score`
-  - `score_gate`
-  - `publishable`
-  - `scored`
-  - `error_instances`
-  - `run_dir`
-  - `manifest_path`
-  - `eval_summary_path`
-  - `trace_summaries_path`
-- `threads`
-  - `total`
-  - `running`
-  - `done`
-- `updated_at`
-
-This contract should be sufficient to feed `build_evaluation_operator_surface(...)` without widening that formatter.
+`PR-D3a` only promises truthful consumption of what is already persisted there. It does not pretend the old manifest/log/thread-materialization fields still exist.
 
 ### Monitor hookup
 
 `get_monitor_evaluation_truth()` should:
 
-1. read the runtime source
-2. validate the minimum shape
-3. pass the extracted values into `build_evaluation_operator_surface(...)`
-4. return loud failure if the source is malformed
-5. return `unavailable` only when the runtime source is truly absent
+1. read the latest persisted run from the eval repo
+2. read that run's persisted metric rows
+3. normalize the coarse persisted status into the monitor payload shape
+4. fail loudly if repo reads or metric decoding break
+5. return an explicit idle/no-runs payload only when the source is wired but empty
 
-That keeps “no source” distinct from “broken source”.
+That keeps “no recorded runs yet” distinct from “broken source”.
 
 ### Failure semantics
 
-- source absent:
-  - explicit `unavailable`
-- source present but malformed:
+- eval source wired but no recorded runs:
+  - explicit `idle/no_recorded_runs`
+- repo or decoding failure:
   - loud error, not fake unavailable
-- source present and valid:
-  - real operator payload
+- persisted run present:
+  - real repo-backed operator payload, with legacy artifact/thread fields explicitly absent
 
 This is important because fake downgrades would hide actual activation bugs.
 
 ## PR-D3b Design
 
-Once `PR-D3a` defines the source contract, the runner side must write it.
+Once `PR-D3a` exposes repo-backed persisted truth, the runner side must evolve if we want live/in-flight operator truth.
 
-Write moments:
+Write moments for `PR-D3b`:
 
 - run bootstrapped
-- threads materialized / counts changed
-- score artifacts created
-- run completed
-- run failed early
+- in-flight progress changes
+- completion / failure
 
-The write path should stay minimal:
-
-- one canonical latest-run file or manifest
-- optional referenced artifact files
-
-Do not introduce extra UI or schema work in this slice.
+The write path should stay minimal, but it must stop waiting until terminal completion before persisting operator-relevant truth.
 
 ## PR-D3c Design
 
@@ -196,15 +189,15 @@ Monitor should not infer missing runtime semantics on its own. It should read, v
 
 ### Formatter reuse
 
-Do not redesign `build_evaluation_operator_surface(...)` unless a real source gap forces it.
+Do not redesign the whole operator surface to preserve an old artifact contract that current storage no longer writes.
 
-That formatter is already the most stable contract in this lane. Activation should feed it, not replace it.
+`PR-D3a` should surface repo-backed truth directly and honestly. Richer formatter reuse or artifact revival belongs to later slices if still justified.
 
 ## Testing
 
 ### PR-D3a
 
-- unit tests for source-absent, malformed-source, and valid-source cases
+- unit tests for no-runs and persisted-run cases
 - integration tests for `/api/monitor/evaluation` and `/api/monitor/dashboard`
 
 ### PR-D3b
@@ -220,9 +213,9 @@ That formatter is already the most stable contract in this lane. Activation shou
 
 ### In scope for PR-D3a
 
-- source contract
+- repo-backed persisted source hookup
 - monitor truth hookup
-- route-level truth upgrade from fake unavailable to real source-backed payload
+- route-level truth upgrade from fake unavailable to real persisted-source payload
 
 ### Out of scope for PR-D3a
 
@@ -235,8 +228,8 @@ That formatter is already the most stable contract in this lane. Activation shou
 
 ### PR-D3a
 
-- `get_monitor_evaluation_truth()` reads a real runtime source
-- source absent vs malformed vs valid are distinct
+- `get_monitor_evaluation_truth()` reads a real persisted source
+- no-runs vs persisted-run truth are distinct
 - route tests prove `/api/monitor/evaluation` is no longer hardcoded
 
 ### PR-D3b

--- a/docs/superpowers/specs/2026-04-08-evaluation-runtime-activation-design.md
+++ b/docs/superpowers/specs/2026-04-08-evaluation-runtime-activation-design.md
@@ -1,0 +1,249 @@
+# Evaluation Runtime Activation Design
+
+## Goal
+
+Turn monitor evaluation from a hardcoded `unavailable` placeholder into a truthful runtime-backed operator surface, without collapsing route truth, UI truth, and runner implementation into one giant PR.
+
+## Current Facts
+
+- `PR-D1/#264` already exposed `GET /api/monitor/evaluation`.
+- `PR-D2/#265` already mounted `/evaluation` in the revived monitor shell.
+- `backend/web/services/monitor_service.py` already defines the target operator payload shape through `build_evaluation_operator_surface(...)`.
+- That same service currently hardcodes `get_monitor_evaluation_truth()` to `_evaluation_unavailable_surface()`.
+- The repo currently contains almost no runtime source reader that can supply:
+  - `status`
+  - `notes`
+  - `score_gate`
+  - `run_dir`
+  - `manifest_path`
+  - `eval_summary_path`
+  - `trace_summaries_path`
+  - thread materialization counts
+- Existing tests prove formatter behavior, not source discovery or runtime activation.
+
+## Scope Check
+
+`PR-D3` is too large to be one implementation PR.
+
+If treated as one lane, it would mix:
+
+- runtime source design
+- runner write semantics
+- monitor truth hookup
+- operator page/live proof
+- possible trace drilldown
+
+That is exactly the failure mode that previously made monitor/frontend work too large to merge safely.
+
+So `PR-D3` must be a workstream, not a single code drop.
+
+## Approaches
+
+### 1. DB-first activation
+
+Add dedicated evaluation runtime tables and make monitor read from the database.
+
+Pros:
+- strong query surface
+- durable
+
+Cons:
+- schema-heavy
+- requires migration design
+- much larger blast radius than the current monitor lane needs
+
+Not recommended for the first activation slice.
+
+### 2. In-process state activation
+
+Keep evaluation runtime state only in memory and let monitor read it directly.
+
+Pros:
+- small initial implementation
+
+Cons:
+- dies on restart
+- hard to inspect after failures
+- does not fit the existing artifact/path-based operator payload shape
+
+Rejected.
+
+### 3. Filesystem/manifest-first activation
+
+Define a minimal runtime source contract in files, have the evaluation runner write it, and have monitor read it.
+
+Pros:
+- matches the existing operator payload expectations (`run_dir`, `manifest_path`, logs, summaries)
+- durable across process restarts
+- keeps monitor truth and runner writes loosely coupled
+- allows a narrow first mergeable slice
+
+Recommended.
+
+## Recommended Design
+
+`PR-D3` becomes a 3-step workstream:
+
+### PR-D3a: Runtime source contract + monitor truth hookup
+
+Introduce a narrow runtime source contract for “latest evaluation run” and make `get_monitor_evaluation_truth()` read it instead of hardcoding `unavailable`.
+
+This is the first mergeable slice.
+
+### PR-D3b: Runner write-path activation
+
+Make the actual evaluation runner write the runtime source truthfully while the run progresses and when it completes or fails.
+
+### PR-D3c: Optional drilldown and deeper operator ergonomics
+
+Only after source truth is stable:
+
+- richer drilldown
+- trace-level linking
+- maybe detail pages or deeper artifact navigation
+
+This is explicitly later.
+
+## PR-D3a Design
+
+### Runtime source contract
+
+Use a small file-backed contract, rooted in a stable path under evaluation runtime storage.
+
+Minimum fields:
+
+- `status`
+- `notes`
+- `score`
+  - `score_gate`
+  - `publishable`
+  - `scored`
+  - `error_instances`
+  - `run_dir`
+  - `manifest_path`
+  - `eval_summary_path`
+  - `trace_summaries_path`
+- `threads`
+  - `total`
+  - `running`
+  - `done`
+- `updated_at`
+
+This contract should be sufficient to feed `build_evaluation_operator_surface(...)` without widening that formatter.
+
+### Monitor hookup
+
+`get_monitor_evaluation_truth()` should:
+
+1. read the runtime source
+2. validate the minimum shape
+3. pass the extracted values into `build_evaluation_operator_surface(...)`
+4. return loud failure if the source is malformed
+5. return `unavailable` only when the runtime source is truly absent
+
+That keeps “no source” distinct from “broken source”.
+
+### Failure semantics
+
+- source absent:
+  - explicit `unavailable`
+- source present but malformed:
+  - loud error, not fake unavailable
+- source present and valid:
+  - real operator payload
+
+This is important because fake downgrades would hide actual activation bugs.
+
+## PR-D3b Design
+
+Once `PR-D3a` defines the source contract, the runner side must write it.
+
+Write moments:
+
+- run bootstrapped
+- threads materialized / counts changed
+- score artifacts created
+- run completed
+- run failed early
+
+The write path should stay minimal:
+
+- one canonical latest-run file or manifest
+- optional referenced artifact files
+
+Do not introduce extra UI or schema work in this slice.
+
+## PR-D3c Design
+
+Only after `PR-D3a` and `PR-D3b` are stable:
+
+- richer operator drilldown
+- trace drill links
+- maybe run history if a truthful source exists
+
+This must stay separate from activation itself.
+
+## Architecture
+
+### Reader/writer split
+
+Keep the boundary explicit:
+
+- writer side: evaluation runtime / runner
+- reader side: monitor service
+
+Monitor should not infer missing runtime semantics on its own. It should read, validate, and format.
+
+### Formatter reuse
+
+Do not redesign `build_evaluation_operator_surface(...)` unless a real source gap forces it.
+
+That formatter is already the most stable contract in this lane. Activation should feed it, not replace it.
+
+## Testing
+
+### PR-D3a
+
+- unit tests for source-absent, malformed-source, and valid-source cases
+- integration tests for `/api/monitor/evaluation` and `/api/monitor/dashboard`
+
+### PR-D3b
+
+- write-path tests for lifecycle transitions
+- proof that monitor sees updated truth after writes
+
+### PR-D3c
+
+- frontend tests only after drilldown exists
+
+## Boundaries
+
+### In scope for PR-D3a
+
+- source contract
+- monitor truth hookup
+- route-level truth upgrade from fake unavailable to real source-backed payload
+
+### Out of scope for PR-D3a
+
+- monitor UI redesign
+- product-facing evaluation UI
+- trace drilldown
+- schema-heavy persistence redesign
+
+## Merge Bars
+
+### PR-D3a
+
+- `get_monitor_evaluation_truth()` reads a real runtime source
+- source absent vs malformed vs valid are distinct
+- route tests prove `/api/monitor/evaluation` is no longer hardcoded
+
+### PR-D3b
+
+- real runner writes truthful source updates
+- monitor reflects live or completed evaluation state
+
+### PR-D3c
+
+- optional operator drilldown only after stable runtime truth exists

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -45,6 +45,20 @@ def _stub_monitor_leases(monkeypatch):
     return payload
 
 
+def _stub_monitor_evaluation_summary(monkeypatch):
+    payload = {
+        "evaluations_running": 0,
+        "latest_evaluation": {
+            "status": "idle",
+            "kind": "no_recorded_runs",
+            "tone": "default",
+            "headline": "No persisted evaluation runs are available yet.",
+        },
+    }
+    monkeypatch.setattr(monitor.monitor_service, "get_monitor_evaluation_dashboard_summary", lambda: payload)
+    return payload
+
+
 def _build_monitor_test_app(*, include_product_resources: bool = False) -> FastAPI:
     app = FastAPI()
     app.include_router(monitor.router)
@@ -151,6 +165,7 @@ def test_monitor_dashboard_route_smoke(monkeypatch):
     _stub_monitor_resource_snapshot(monkeypatch)
     _stub_monitor_health(monkeypatch)
     _stub_monitor_leases(monkeypatch)
+    _stub_monitor_evaluation_summary(monkeypatch)
 
     with TestClient(_build_monitor_test_app()) as client:
         response = client.get("/api/monitor/dashboard")
@@ -207,6 +222,59 @@ def test_monitor_evaluation_route_exposes_operator_truth(monkeypatch):
     assert payload["kind"] == "unavailable"
     assert payload["headline"] == "Evaluation operator truth is not wired in this runtime yet."
     assert payload["artifact_summary"] == {"present": 0, "missing": 0, "total": 0}
+
+
+def test_monitor_evaluation_route_exposes_latest_persisted_run(monkeypatch):
+    class FakeStore:
+        def list_runs(self, thread_id=None, limit=50):
+            return [
+                {
+                    "id": "run-1",
+                    "thread_id": "thread-eval",
+                    "started_at": "2026-04-08T00:00:00Z",
+                    "finished_at": "2026-04-08T00:03:00Z",
+                    "status": "completed",
+                    "user_message": "solve the eval task",
+                }
+            ]
+
+        def get_metrics(self, run_id, tier=None):
+            return [
+                {
+                    "id": "metric-1",
+                    "tier": "system",
+                    "timestamp": "2026-04-08T00:03:01Z",
+                    "metrics": {
+                        "total_tokens": 123,
+                        "llm_call_count": 3,
+                        "tool_call_count": 2,
+                    },
+                }
+            ]
+
+    monkeypatch.setattr(monitor_service, "make_eval_store", lambda: FakeStore())
+    _stub_monitor_resource_snapshot(monkeypatch)
+    _stub_monitor_health(monkeypatch)
+    _stub_monitor_leases(monkeypatch)
+
+    with TestClient(_build_monitor_test_app()) as client:
+        evaluation_response = client.get("/api/monitor/evaluation")
+        dashboard_response = client.get("/api/monitor/dashboard")
+
+    assert evaluation_response.status_code == 200
+    evaluation_payload = evaluation_response.json()
+    assert evaluation_payload["status"] == "completed"
+    assert evaluation_payload["kind"] == "completed_recorded"
+    assert evaluation_payload["headline"] == "Latest persisted evaluation run completed successfully."
+    assert dashboard_response.status_code == 200
+    dashboard_payload = dashboard_response.json()
+    assert dashboard_payload["workload"]["evaluations_running"] == 0
+    assert dashboard_payload["latest_evaluation"] == {
+        "status": "completed",
+        "kind": "completed_recorded",
+        "tone": "success",
+        "headline": "Latest persisted evaluation run completed successfully.",
+    }
 
 
 def test_monitor_dashboard_route_derives_evaluation_summary_from_service(monkeypatch):

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -273,13 +273,95 @@ def test_build_evaluation_operator_surface_marks_completed_with_errors():
     }
 
 
-def test_monitor_evaluation_truth_defaults_to_explicit_unavailable_surface():
-    payload = monitor_service.get_monitor_evaluation_truth()
+def test_evaluation_unavailable_surface_stays_explicit():
+    payload = monitor_service._evaluation_unavailable_surface()
 
     assert payload["status"] == "unavailable"
     assert payload["kind"] == "unavailable"
     assert payload["tone"] == "warning"
     assert payload["headline"] == "Evaluation operator truth is not wired in this runtime yet."
+    assert payload["artifact_summary"] == {
+        "present": 0,
+        "missing": 0,
+        "total": 0,
+    }
+    assert payload["raw_notes"] is None
+
+
+def test_monitor_evaluation_truth_reports_idle_when_repo_has_no_runs(monkeypatch):
+    class FakeStore:
+        def list_runs(self, thread_id=None, limit=50):
+            return []
+
+    monkeypatch.setattr(monitor_service, "make_eval_store", lambda: FakeStore())
+
+    payload = monitor_service.get_monitor_evaluation_truth()
+
+    assert payload["status"] == "idle"
+    assert payload["kind"] == "no_recorded_runs"
+    assert payload["tone"] == "default"
+    assert payload["headline"] == "No persisted evaluation runs are available yet."
+    assert payload["artifact_summary"] == {
+        "present": 0,
+        "missing": 0,
+        "total": 0,
+    }
+    assert payload["facts"] == [{"label": "Status", "value": "idle"}]
+    assert payload["raw_notes"] is None
+
+
+def test_monitor_evaluation_truth_uses_latest_persisted_eval_run(monkeypatch):
+    class FakeStore:
+        def list_runs(self, thread_id=None, limit=50):
+            return [
+                {
+                    "id": "run-1",
+                    "thread_id": "thread-eval",
+                    "started_at": "2026-04-08T00:00:00Z",
+                    "finished_at": "2026-04-08T00:03:00Z",
+                    "status": "completed",
+                    "user_message": "solve the eval task",
+                }
+            ]
+
+        def get_metrics(self, run_id, tier=None):
+            assert run_id == "run-1"
+            return [
+                {
+                    "id": "metric-1",
+                    "tier": "system",
+                    "timestamp": "2026-04-08T00:03:01Z",
+                    "metrics": {
+                        "total_tokens": 123,
+                        "llm_call_count": 3,
+                        "tool_call_count": 2,
+                    },
+                },
+                {
+                    "id": "metric-2",
+                    "tier": "objective",
+                    "timestamp": "2026-04-08T00:03:02Z",
+                    "metrics": {
+                        "total_duration_ms": 4567.0,
+                    },
+                },
+            ]
+
+    monkeypatch.setattr(monitor_service, "make_eval_store", lambda: FakeStore())
+
+    payload = monitor_service.get_monitor_evaluation_truth()
+
+    assert payload["status"] == "completed"
+    assert payload["kind"] == "completed_recorded"
+    assert payload["tone"] == "success"
+    assert payload["headline"] == "Latest persisted evaluation run completed successfully."
+    facts = {(item["label"], item["value"]) for item in payload["facts"]}
+    assert ("Run ID", "run-1") in facts
+    assert ("Thread ID", "thread-eval") in facts
+    assert ("Total tokens", "123") in facts
+    assert ("LLM calls", "3") in facts
+    assert ("Tool calls", "2") in facts
+    assert ("Duration (ms)", "4567") in facts
     assert payload["artifact_summary"] == {
         "present": 0,
         "missing": 0,


### PR DESCRIPTION
## Summary

This is `PR-D3a` in the evaluation activation workstream.

It replaces monitor's hardcoded evaluation placeholder with repo-backed persisted truth from the existing eval storage path:

- `eval.storage.TrajectoryStore`
- `storage.container.StorageContainer.eval_repo()`
- `storage.providers.supabase.eval_repo.SupabaseEvalRepo`
- persisted rows in `eval_runs` / `eval_metrics`

This PR is intentionally narrow:

- backend/operator-truth only
- no evaluation UI changes
- no runner write-path activation
- no product-facing behavior changes
- no live/in-flight runtime claims

## Lineage

- `#264` established the route and dashboard summary contract for evaluation truth.
- `#265` mounted the monitor evaluation surface and truthfully consumed the route payload.
- `#266` (`PR-D3a`, this PR) revives the first real runtime source behind that route.
- `PR-D3b` remains the next mandatory lane for live/in-flight runner activation.

## What Changed

- `backend/web/services/monitor_service.py`
  - adds `make_eval_store()` using the existing `TrajectoryStore`
  - reads the latest persisted run via `list_runs(limit=1)`
  - reads that run's persisted metrics via `get_metrics(run_id)`
  - replaces the hardcoded `unavailable` shim with repo-backed truth
  - returns explicit `idle / no_recorded_runs` when eval storage is wired but empty
  - normalizes coarse persisted statuses into the monitor payload shape
- `tests/Unit/monitor/test_monitor_compat.py`
  - locks no-runs and persisted-run operator truth
- `tests/Integration/test_monitor_resources_route.py`
  - locks `/api/monitor/evaluation` and `/api/monitor/dashboard` to the same persisted truth source
- docs/spec/plan updated to reflect the real architecture
  - repo-backed persisted truth first
  - live runner activation deferred to `PR-D3b`

## Honest Boundary

This PR does **not** claim live evaluation runtime truth.

Current persisted eval truth is written after run completion, so this PR can truthfully surface:

- no recorded runs yet
- latest persisted completed run
- latest persisted terminal error state

It does **not** yet surface:

- in-flight running progress before persistence
- legacy `run_dir / manifest / trace summary / thread-materialization` detail
- richer drilldown/history

Those remain follow-up work for `PR-D3b` and later slices.

## Verification

Ran:

- `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_resource_probe.py`
  - `30 passed`
- `uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
  - passed

## Roadmap

- `PR-D3a` (this PR): repo-backed persisted evaluation truth hookup
- `PR-D3b`: live/in-flight runner write-path activation
- `PR-D3c`: optional drilldown/history only after runtime truth is stable
