### PR TITLE
Persist live evaluation run lifecycle (PR-D3b)

### DIFF
--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -6,6 +6,7 @@ import logging
 import random
 import uuid as _uuid
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
 from typing import Any
 
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
@@ -693,6 +694,8 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     stream_gen = None
     pending_tool_calls: dict[str, dict] = {}
     output_parts: list[str] = []
+    store = None
+    trajectory_status = "completed"
     try:
         config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
         if hasattr(agent, "_current_model_config"):
@@ -705,6 +708,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         tracer = None
         if enable_trajectory:
             try:
+                from eval.storage import TrajectoryStore
                 from eval.tracer import TrajectoryTracer
 
                 cost_calc = getattr(
@@ -715,7 +719,16 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
                 tracer = TrajectoryTracer(
                     thread_id=thread_id,
                     user_message=message,
+                    run_id=run_id,
                     cost_calculator=cost_calc,
+                )
+                store = TrajectoryStore()
+                store.upsert_run_header(
+                    run_id=run_id,
+                    thread_id=thread_id,
+                    started_at=tracer._start_time.isoformat(),
+                    user_message=message,
+                    status="running",
                 )
                 config["callbacks"] = [tracer]
             except ImportError:
@@ -1226,6 +1239,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
                 await stream_gen.aclose()
                 await asyncio.sleep(wait)
             else:
+                trajectory_status = "error"
                 _log_captured_exception(
                     f"[streaming] stream failed for thread {thread_id}",
                     stream_err,
@@ -1243,15 +1257,19 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
             )
 
         # Persist trajectory
-        if tracer is not None:
+        if tracer is not None and store is not None:
             try:
-                from eval.storage import TrajectoryStore
-
                 trajectory = tracer.to_trajectory()
                 if hasattr(agent, "runtime"):
                     tracer.enrich_from_runtime(trajectory, agent.runtime)
-                store = TrajectoryStore()
-                store.save_trajectory(trajectory)
+                store.finalize_run(
+                    run_id=run_id,
+                    finished_at=trajectory.finished_at,
+                    final_response=trajectory.final_response,
+                    status=trajectory_status,
+                    run_tree_json=trajectory.run_tree_json,
+                    trajectory_json=trajectory.model_copy(update={"status": trajectory_status}).model_dump_json(),
+                )
             except Exception:
                 logger.error("Failed to persist trajectory for thread %s", thread_id, exc_info=True)
 
@@ -1265,6 +1283,19 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
         return "".join(output_parts).strip()
     except asyncio.CancelledError:
+        if tracer is not None and store is not None:
+            try:
+                trajectory = tracer.to_trajectory()
+                store.finalize_run(
+                    run_id=run_id,
+                    finished_at=datetime.now(UTC).isoformat(),
+                    final_response=trajectory.final_response,
+                    status="cancelled",
+                    run_tree_json=trajectory.run_tree_json,
+                    trajectory_json=trajectory.model_copy(update={"status": "cancelled"}).model_dump_json(),
+                )
+            except Exception:
+                logger.error("Failed to finalize cancelled trajectory for thread %s", thread_id, exc_info=True)
         cancelled_tool_call_ids = await write_cancellation_markers(agent, config, pending_tool_calls)
         await _persist_cancelled_run_input_if_missing(
             agent=agent,
@@ -1293,6 +1324,19 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
         return ""
     except Exception as e:
+        if tracer is not None and store is not None:
+            try:
+                trajectory = tracer.to_trajectory()
+                store.finalize_run(
+                    run_id=run_id,
+                    finished_at=datetime.now(UTC).isoformat(),
+                    final_response=trajectory.final_response,
+                    status="error",
+                    run_tree_json=trajectory.run_tree_json,
+                    trajectory_json=trajectory.model_copy(update={"status": "error"}).model_dump_json(),
+                )
+            except Exception:
+                logger.error("Failed to finalize errored trajectory for thread %s", thread_id, exc_info=True)
         _log_captured_exception(
             f"[streaming] run failed for thread {thread_id}",
             e,

--- a/docs/superpowers/plans/2026-04-08-evaluation-runtime-writer-activation.md
+++ b/docs/superpowers/plans/2026-04-08-evaluation-runtime-writer-activation.md
@@ -1,0 +1,168 @@
+# Evaluation Runtime Writer Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make evaluation runs persist live `running` truth at start and finalize the same row at completion/cancellation/error.
+
+**Architecture:** This plan keeps `PR-D3b` on the existing persisted source path introduced by `PR-D3a`. It adds minimal writer lifecycle methods for `eval_runs`, reuses the existing web `run_id` as the stable eval id, and keeps monitor/UI/product work out of scope.
+
+**Tech Stack:** Python, FastAPI service layer, pytest, Supabase repo parity, SQLite repo parity
+
+---
+
+## File Structure
+
+- Modify: `eval/tracer.py`
+  - reuse caller-supplied `run_id`
+- Modify: `storage/contracts.py`
+  - extend `EvalRepo` protocol with minimal lifecycle writer methods
+- Modify: `eval/repo.py`
+  - SQLite lifecycle write parity
+- Modify: `storage/providers/supabase/eval_repo.py`
+  - Supabase lifecycle write parity
+- Modify: `eval/storage.py`
+  - expose lifecycle writer helpers through `TrajectoryStore`
+- Modify: `backend/web/services/streaming_service.py`
+  - write live `running` truth at start
+  - finalize same row on completion/cancellation/error
+- Modify: tests covering repo parity and streaming writer behavior
+
+## Mandatory Boundary
+
+- No frontend changes
+- No monitor route changes
+- No product behavior changes
+- No new storage world
+- No richer artifact/log/thread drilldown
+- No fake live metrics beyond what already exists
+
+## Task 1: Lock stable run-id reuse
+
+**Files:**
+- Modify: `tests/Unit/eval/test_tracer.py` or create it if absent
+- Test: `uv run pytest -q tests/Unit/eval/test_tracer.py -k 'run_id'`
+
+- [ ] Add a failing test that proves `TrajectoryTracer` preserves a caller-supplied `run_id`.
+- [ ] Run the targeted test and verify it fails for the right reason.
+- [ ] Implement the minimal tracer change to accept `run_id` and emit it in `RunTrajectory`.
+- [ ] Re-run the targeted test and verify it passes.
+- [ ] Commit:
+
+```bash
+git add eval/tracer.py tests/Unit/eval/test_tracer.py
+git commit -m "test: lock evaluation tracer run id reuse"
+```
+
+## Task 2: Lock repo lifecycle writer parity
+
+**Files:**
+- Modify: `storage/contracts.py`
+- Modify: `eval/repo.py`
+- Modify: `storage/providers/supabase/eval_repo.py`
+- Modify: parity tests near existing eval repo coverage
+- Test:
+  - `uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py -k 'eval'`
+
+- [ ] Add failing tests that prove both SQLite and Supabase eval repos support:
+  - `upsert_run_header(...)`
+  - `finalize_run(...)`
+  - same-row lifecycle by shared `run_id`
+- [ ] Run the targeted tests and verify they fail.
+- [ ] Add the minimal protocol methods and provider implementations.
+- [ ] Keep write semantics narrow:
+  - run start upserts coarse row fields
+  - terminal finalize updates row fields
+  - no live incremental tool/llm row writes
+- [ ] Re-run the targeted tests and verify they pass.
+- [ ] Commit:
+
+```bash
+git add storage/contracts.py eval/repo.py storage/providers/supabase/eval_repo.py tests/Integration/test_storage_repo_abstraction_unification.py
+git commit -m "feat: add evaluation lifecycle writer parity"
+```
+
+## Task 3: Expose lifecycle helpers through `TrajectoryStore`
+
+**Files:**
+- Modify: `eval/storage.py`
+- Modify or create: `tests/Unit/eval/test_storage.py`
+- Test: `uv run pytest -q tests/Unit/eval/test_storage.py`
+
+- [ ] Add failing tests that prove `TrajectoryStore` exposes:
+  - `upsert_run_header(...)`
+  - `finalize_run(...)`
+- [ ] Run the targeted test and verify it fails.
+- [ ] Implement the smallest store helpers on top of the repo methods.
+- [ ] Re-run the targeted test and verify it passes.
+- [ ] Commit:
+
+```bash
+git add eval/storage.py tests/Unit/eval/test_storage.py
+git commit -m "feat: expose evaluation lifecycle store helpers"
+```
+
+## Task 4: Activate writer-side live run persistence in streaming
+
+**Files:**
+- Modify: `backend/web/services/streaming_service.py`
+- Modify or create targeted tests for streaming writer behavior
+- Test:
+  - `uv run pytest -q tests/Unit/backend/web/services/test_streaming_service.py -k 'evaluation or trajectory'`
+
+- [ ] Add failing tests that prove:
+  - a live `running` row is written when trajectory is enabled and the run starts
+  - normal completion finalizes the same row id
+  - cancellation/error finalizes the same row id with terminal status
+- [ ] Run the targeted tests and verify they fail first.
+- [ ] Implement the minimal streaming changes:
+  - instantiate tracer with stable `run_id`
+  - write `running` header before streaming begins
+  - finalize same row on terminal completion
+  - finalize same row on cancellation/error paths
+- [ ] Re-run the targeted tests and verify they pass.
+- [ ] Commit:
+
+```bash
+git add backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_streaming_service.py
+git commit -m "feat: persist live evaluation run lifecycle"
+```
+
+## Task 5: Lock monitor-visible live truth
+
+**Files:**
+- Modify: monitor integration tests
+- Test:
+  - `uv run pytest -q tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_compat.py -k 'evaluation'`
+
+- [ ] Add failing proof that a persisted `running` row now surfaces through the existing monitor evaluation truth path.
+- [ ] Keep the assertion narrow:
+  - same persisted source path
+  - `status=running`
+  - no fake artifact revival
+- [ ] Re-run the targeted tests and verify they pass.
+- [ ] Commit:
+
+```bash
+git add tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_compat.py
+git commit -m "test: lock live evaluation writer truth"
+```
+
+## Task 6: Verification and PR prep
+
+**Files:**
+- No required code files
+
+- [ ] Run:
+  - `uv run pytest -q tests/Unit/eval/test_tracer.py tests/Unit/eval/test_storage.py tests/Integration/test_storage_repo_abstraction_unification.py tests/Unit/backend/web/services/test_streaming_service.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
+  - `uv run ruff check eval/tracer.py eval/storage.py eval/repo.py storage/contracts.py storage/providers/supabase/eval_repo.py backend/web/services/streaming_service.py tests/Unit/eval/test_tracer.py tests/Unit/eval/test_storage.py tests/Integration/test_storage_repo_abstraction_unification.py tests/Unit/backend/web/services/test_streaming_service.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
+- [ ] Record honest boundary:
+  - this PR activates writer-side live status only
+  - richer artifacts/drilldown remain later work
+- [ ] Prepare draft PR as `PR-D3b`
+
+## Hard Stopline
+
+- Do not add evaluation UI
+- Do not add product-facing behavior
+- Do not add a second live source contract
+- Do not revive legacy manifest/log/thread-materialization fields unless a real writer exists for them

--- a/docs/superpowers/specs/2026-04-08-evaluation-runtime-writer-activation-design.md
+++ b/docs/superpowers/specs/2026-04-08-evaluation-runtime-writer-activation-design.md
@@ -1,0 +1,203 @@
+# Evaluation Runtime Writer Activation Design
+
+## Goal
+
+Turn evaluation truth from terminal-only persisted history into live writer-backed runtime truth, without widening into UI, product behavior, or a schema-heavy redesign.
+
+## Current Facts
+
+- `PR-D3a/#266` already makes monitor read persisted eval truth from:
+  - `eval.storage.TrajectoryStore`
+  - `storage.container.StorageContainer.eval_repo()`
+  - `storage.providers.supabase.eval_repo.SupabaseEvalRepo`
+  - `eval_runs / eval_metrics`
+- `backend/web/services/streaming_service.py` currently writes eval truth only once, after run completion:
+  - `TrajectoryStore().save_trajectory(trajectory)`
+- current persisted rows are truthful for:
+  - no runs
+  - latest completed run
+  - latest terminal error/cancelled run, if written
+- current persisted rows are not truthful for:
+  - live in-flight runs before completion
+  - progress during retries / cancellation / error transitions
+- `TrajectoryTracer` currently generates its own trajectory id late and `streaming_service` already has an earlier `run_id`.
+- current repo contracts only support terminal inserts:
+  - `save_trajectory(...)`
+  - `save_metrics(...)`
+  - no run-start write
+  - no row update/finalize API
+
+## Scope Check
+
+`PR-D3b` must stay narrow. If it grows into one lane, it will mix:
+
+- writer-side live activation
+- monitor truth semantics
+- richer artifact/model/thread drilldown
+- frontend claims
+
+That is the same failure mode that previously made monitor/evaluation work too large to merge safely.
+
+So `PR-D3b` must only do writer-side live activation for the existing persisted source.
+
+## Approaches
+
+### 1. In-place `eval_runs` lifecycle writes
+
+Use the existing `eval_runs` row as the single source of truth for both live and terminal state:
+
+- create or upsert a `running` row at run start
+- update the same row on cancellation / error / completion
+- continue writing metrics separately
+
+Pros:
+- no second source contract
+- no new table
+- monitor continues reading the same path as `PR-D3a`
+- smallest blast radius
+
+Cons:
+- only coarse live truth unless more fields are added later
+- requires careful upsert/finalize semantics across SQLite and Supabase
+
+Recommended.
+
+### 2. Separate live snapshot table
+
+Introduce a second table for live status and let monitor merge it with terminal history.
+
+Pros:
+- clean separation between live and historical data
+
+Cons:
+- new schema surface
+- monitor now has to reconcile two sources
+- much larger than this lane needs
+
+Not recommended.
+
+### 3. Revive old manifest/artifact contract now
+
+Reintroduce `run_dir`, `manifest_path`, `trace_summaries_path`, and thread-materialization counters as part of live activation.
+
+Pros:
+- closer to the older operator formatter shape
+
+Cons:
+- current runtime does not already produce those fields truthfully
+- forces `PR-D3b` to invent new writer semantics and larger storage shape
+- too much scope for one lane
+
+Rejected for this slice.
+
+## Recommended Design
+
+`PR-D3b` should activate live truth by making the existing persisted row appear earlier and advance in place.
+
+The concrete shape is:
+
+- run start:
+  - persist a `running` row immediately using the known `run_id`
+  - include:
+    - `id`
+    - `thread_id`
+    - `started_at`
+    - `status=running`
+    - `user_message`
+- run completion:
+  - finalize the same row with:
+    - `finished_at`
+    - `final_response`
+    - `status`
+    - `run_tree_json`
+    - `trajectory_json`
+- terminal error / cancellation:
+  - finalize the same row with terminal status even if the normal completion path is skipped
+- metrics:
+  - continue writing through existing `save_metrics(...)`
+  - do not invent new metric tiers in this slice
+
+## Data Model Decisions
+
+### Stable run identity
+
+`PR-D3b` should stop relying on “trajectory id appears only at terminal serialization time”.
+
+Use one stable id across the full run lifecycle:
+
+- `streaming_service` already has `run_id`
+- `TrajectoryTracer` should accept and preserve that same `run_id`
+- persisted `eval_runs.id` should therefore line up with the web runtime run id
+
+This avoids “start row id” and “completed row id” drifting apart.
+
+### Writer semantics
+
+Add minimal repo operations for lifecycle truth:
+
+- `upsert_run_header(...)`
+  - for run start / coarse live status
+- `finalize_run(...)`
+  - for terminal state on the same row
+
+Terminal call/tool rows remain terminal-only in this slice. Do not attempt incremental live persistence for them yet.
+
+### Failure semantics
+
+Live writer activation must fail loudly:
+
+- if run-start persistence fails:
+  - log loudly
+  - do not silently fake that live truth exists
+- if terminal finalize fails:
+  - log loudly
+  - the row may remain stale as `running`, which is preferable to fake cleanup
+
+This lane is about making source truth real, not making it cosmetically pleasant.
+
+## Implementation Boundaries
+
+### In scope for `PR-D3b`
+
+- stable run id reuse between `streaming_service` and `TrajectoryTracer`
+- repo methods for run-start upsert and terminal finalize
+- SQLite + Supabase parity for those methods
+- write-path activation in `streaming_service`
+- tests proving:
+  - live `running` row is written before terminal completion
+  - terminal completion reuses the same row
+  - cancellation/error finalize the same row truthfully
+
+### Out of scope for `PR-D3b`
+
+- frontend changes
+- monitor route changes
+- product-facing evaluation behavior
+- new tables or migrations beyond the smallest repo contract change
+- richer artifact/log/thread drilldown
+- trace-level detail persistence during live execution
+
+## Testing
+
+### Unit
+
+- repo parity tests for new lifecycle methods
+- `TrajectoryTracer` tests proving stable id reuse
+- streaming writer tests for:
+  - run-start write
+  - terminal finalize
+  - cancellation/error finalize
+
+### Integration
+
+- route-level proof that monitor can observe a `running` eval row before terminal completion
+- route-level proof that terminal completion updates the same row id
+
+## Merge Bar
+
+`PR-D3b` is done when:
+
+- a run writes `running` truth before completion
+- completion/cancellation/error update the same persisted row id
+- `PR-D3a` monitor reader can now observe live-vs-terminal truth through the same source path
+- no UI/product/schema sprawl was mixed in

--- a/eval/repo.py
+++ b/eval/repo.py
@@ -81,6 +81,46 @@ class SQLiteEvalRepo:
     def ensure_schema(self) -> None:
         self._conn.executescript(_SCHEMA_SQL)
 
+    def upsert_run_header(
+        self,
+        *,
+        run_id: str,
+        thread_id: str,
+        started_at: str,
+        user_message: str,
+        status: str,
+    ) -> None:
+        self._conn.execute(
+            "INSERT INTO eval_runs (id, thread_id, started_at, user_message, status) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "thread_id = excluded.thread_id, "
+            "started_at = excluded.started_at, "
+            "user_message = excluded.user_message, "
+            "status = excluded.status",
+            (run_id, thread_id, started_at, user_message, status),
+        )
+        self._conn.commit()
+
+    def finalize_run(
+        self,
+        *,
+        run_id: str,
+        finished_at: str,
+        final_response: str,
+        status: str,
+        run_tree_json: str,
+        trajectory_json: str,
+    ) -> None:
+        result = self._conn.execute(
+            "UPDATE eval_runs SET finished_at = ?, final_response = ?, status = ?, "
+            "run_tree_json = ?, trajectory_json = ? WHERE id = ?",
+            (finished_at, final_response, status, run_tree_json, trajectory_json, run_id),
+        )
+        if result.rowcount != 1:
+            raise RuntimeError(f"SQLite eval repo expected existing run for finalize_run: {run_id}")
+        self._conn.commit()
+
     def save_trajectory(self, trajectory: RunTrajectory, trajectory_json: str) -> str:
         run_id = trajectory.id
         self._conn.execute(

--- a/eval/storage.py
+++ b/eval/storage.py
@@ -34,6 +34,42 @@ class TrajectoryStore:
         trajectory_json = trajectory.model_dump_json()
         return self._repo.save_trajectory(trajectory, trajectory_json)
 
+    def upsert_run_header(
+        self,
+        *,
+        run_id: str,
+        thread_id: str,
+        started_at: str,
+        user_message: str,
+        status: str,
+    ) -> None:
+        self._repo.upsert_run_header(
+            run_id=run_id,
+            thread_id=thread_id,
+            started_at=started_at,
+            user_message=user_message,
+            status=status,
+        )
+
+    def finalize_run(
+        self,
+        *,
+        run_id: str,
+        finished_at: str,
+        final_response: str,
+        status: str,
+        run_tree_json: str,
+        trajectory_json: str,
+    ) -> None:
+        self._repo.finalize_run(
+            run_id=run_id,
+            finished_at=finished_at,
+            final_response=final_response,
+            status=status,
+            run_tree_json=run_tree_json,
+            trajectory_json=trajectory_json,
+        )
+
     def save_metrics(
         self,
         run_id: str,

--- a/eval/tracer.py
+++ b/eval/tracer.py
@@ -32,12 +32,14 @@ class TrajectoryTracer(BaseTracer):
         thread_id: str,
         user_message: str,
         cost_calculator: Any | None = None,
+        run_id: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.thread_id = thread_id
         self.user_message = user_message
         self.cost_calculator = cost_calculator
+        self.run_id = run_id
         self.traced_runs: list[Run] = []
         self._start_time = datetime.now(UTC)
 
@@ -65,17 +67,21 @@ class TrajectoryTracer(BaseTracer):
 
         finished_at = datetime.now(UTC)
 
-        return RunTrajectory(
-            thread_id=self.thread_id,
-            user_message=self.user_message,
-            final_response=final_response,
-            llm_calls=llm_calls,
-            tool_calls=tool_calls,
-            run_tree_json=json.dumps(run_tree_data, default=str, ensure_ascii=False),
-            started_at=self._start_time.isoformat(),
-            finished_at=finished_at.isoformat(),
-            status="completed",
-        )
+        trajectory_kwargs = {
+            "thread_id": self.thread_id,
+            "user_message": self.user_message,
+            "final_response": final_response,
+            "llm_calls": llm_calls,
+            "tool_calls": tool_calls,
+            "run_tree_json": json.dumps(run_tree_data, default=str, ensure_ascii=False),
+            "started_at": self._start_time.isoformat(),
+            "finished_at": finished_at.isoformat(),
+            "status": "completed",
+        }
+        if self.run_id is not None:
+            trajectory_kwargs["id"] = self.run_id
+
+        return RunTrajectory(**trajectory_kwargs)
 
     def enrich_from_runtime(self, trajectory: RunTrajectory, runtime: Any) -> None:
         """Enrich trajectory with token data from MonitorMiddleware runtime.

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -673,6 +673,25 @@ class SandboxVolumeRepo(Protocol):
 
 class EvalRepo(Protocol):
     def ensure_schema(self) -> None: ...
+    def upsert_run_header(
+        self,
+        *,
+        run_id: str,
+        thread_id: str,
+        started_at: str,
+        user_message: str,
+        status: str,
+    ) -> None: ...
+    def finalize_run(
+        self,
+        *,
+        run_id: str,
+        finished_at: str,
+        final_response: str,
+        status: str,
+        run_tree_json: str,
+        trajectory_json: str,
+    ) -> None: ...
     def save_trajectory(self, trajectory: Any, trajectory_json: str) -> str: ...
     def save_metrics(self, run_id: str, tier: str, timestamp: str, metrics_json: str) -> None: ...
     def get_trajectory_json(self, run_id: str) -> str | None: ...

--- a/storage/providers/supabase/eval_repo.py
+++ b/storage/providers/supabase/eval_repo.py
@@ -21,6 +21,63 @@ class SupabaseEvalRepo:
         """Supabase schema is managed via migrations, not runtime DDL."""
         return None
 
+    def upsert_run_header(
+        self,
+        *,
+        run_id: str,
+        thread_id: str,
+        started_at: str,
+        user_message: str,
+        status: str,
+    ) -> None:
+        rows = q.rows(
+            self._t("eval_runs")
+            .upsert(
+                {
+                    "id": run_id,
+                    "thread_id": thread_id,
+                    "started_at": started_at,
+                    "user_message": user_message,
+                    "status": status,
+                },
+                on_conflict="id",
+            )
+            .execute(),
+            _REPO,
+            "upsert_run_header",
+        )
+        if not rows:
+            raise RuntimeError("Supabase eval repo expected row for upsert_run_header. Check table permissions.")
+
+    def finalize_run(
+        self,
+        *,
+        run_id: str,
+        finished_at: str,
+        final_response: str,
+        status: str,
+        run_tree_json: str,
+        trajectory_json: str,
+    ) -> None:
+        rows = q.rows(
+            self._t("eval_runs")
+            .update(
+                {
+                    "finished_at": finished_at,
+                    "final_response": final_response,
+                    "status": status,
+                    "run_tree_json": run_tree_json,
+                    "trajectory_json": trajectory_json,
+                }
+            )
+            .eq("id", run_id)
+            .execute(),
+            _REPO,
+            "finalize_run",
+        )
+        if not rows:
+            raise RuntimeError(f"Supabase eval repo expected existing row for finalize_run: {run_id}")
+
     def save_trajectory(self, trajectory: RunTrajectory, trajectory_json: str) -> str:
         run_id = trajectory.id
         run_rows = q.rows(

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from backend.web.services.event_buffer import ThreadEventBuffer
+from backend.web.services.streaming_service import _run_agent_to_buffer
+from core.runtime.middleware.monitor import AgentState
+from eval.models import RunTrajectory
+
+
+class _FakeDisplayBuilder:
+    def apply_event(self, thread_id: str, event_type: str, data: dict) -> None:
+        return None
+
+
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.current_state = AgentState.ACTIVE
+        self.current_run_source = None
+        self.state = SimpleNamespace(flags=SimpleNamespace(is_compacting=False))
+        self._event_callback = None
+
+    def set_event_callback(self, cb) -> None:
+        self._event_callback = cb
+
+    def get_status_dict(self) -> dict[str, object]:
+        return {"state": {"state": "idle", "flags": {}}, "calls": 0}
+
+    def transition(self, new_state) -> bool:
+        self.current_state = new_state
+        return True
+
+
+class _FakeGraphAgent:
+    def __init__(self, *, expected_run_id: str, error: Exception | None = None, wait_forever: bool = False) -> None:
+        self.expected_run_id = expected_run_id
+        self.error = error
+        self.wait_forever = wait_forever
+
+    async def aget_state(self, _config):
+        return SimpleNamespace(values={"messages": []})
+
+    async def astream(self, *_args, **_kwargs):
+        assert _FakeTrajectoryStore.header_calls == [
+            {
+                "run_id": self.expected_run_id,
+                "thread_id": "thread-1",
+                "started_at": "2026-04-08T12:00:00+00:00",
+                "user_message": "hello",
+                "status": "running",
+            }
+        ]
+        if self.error is not None:
+            raise self.error
+        if self.wait_forever:
+            await asyncio.Event().wait()
+        if False:
+            yield None
+
+
+class _FakeTrajectoryStore:
+    header_calls: list[dict] = []
+    finalize_calls: list[dict] = []
+
+    def __init__(self) -> None:
+        return None
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.header_calls = []
+        cls.finalize_calls = []
+
+    def upsert_run_header(self, **payload) -> None:
+        _FakeTrajectoryStore.header_calls.append(payload)
+
+    def finalize_run(self, **payload) -> None:
+        _FakeTrajectoryStore.finalize_calls.append(payload)
+
+
+class _FakeTrajectoryTracer:
+    def __init__(self, *, thread_id: str, user_message: str, run_id: str | None = None, cost_calculator=None, **_kwargs):
+        self.thread_id = thread_id
+        self.user_message = user_message
+        self.run_id = run_id
+        self._start_time = datetime.fromisoformat("2026-04-08T12:00:00+00:00").astimezone(UTC)
+
+    def to_trajectory(self) -> RunTrajectory:
+        return RunTrajectory(
+            id=self.run_id or "missing-run-id",
+            thread_id=self.thread_id,
+            user_message=self.user_message,
+            final_response="done",
+            run_tree_json="{}",
+            started_at="2026-04-08T12:00:00+00:00",
+            finished_at="2026-04-08T12:01:00+00:00",
+            status="completed",
+        )
+
+    def enrich_from_runtime(self, trajectory: RunTrajectory, runtime) -> None:
+        return None
+
+
+async def _noop_async(*_args, **_kwargs) -> None:
+    return None
+
+
+def _make_app() -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            display_builder=_FakeDisplayBuilder(),
+            thread_tasks={},
+            thread_last_active={},
+            typing_tracker=None,
+            queue_manager=SimpleNamespace(peek=lambda _thread_id: False),
+        )
+    )
+
+
+def _install_runtime_writer_test_doubles(monkeypatch: pytest.MonkeyPatch) -> None:
+    seq = 0
+
+    async def fake_append_event(thread_id, run_id, event, message_id=None, run_event_repo=None):
+        nonlocal seq
+        seq += 1
+        return seq
+
+    monkeypatch.setattr("backend.web.services.event_store.append_event", fake_append_event)
+    monkeypatch.setattr("backend.web.services.streaming_service.cleanup_old_runs", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *args, **kwargs: None)
+    monkeypatch.setattr("backend.web.services.streaming_service._consume_followup_queue", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service.write_cancellation_markers", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._persist_cancelled_run_input_if_missing", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._flush_cancelled_owner_steers", _noop_async)
+    monkeypatch.setattr("eval.storage.TrajectoryStore", _FakeTrajectoryStore)
+    monkeypatch.setattr("eval.tracer.TrajectoryTracer", _FakeTrajectoryTracer)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_to_buffer_persists_running_then_completed_eval_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeTrajectoryStore.reset()
+    _install_runtime_writer_test_doubles(monkeypatch)
+
+    agent = SimpleNamespace(
+        agent=_FakeGraphAgent(expected_run_id="run-123"),
+        runtime=_FakeRuntime(),
+        storage_container=None,
+    )
+
+    result = await _run_agent_to_buffer(
+        agent,
+        "thread-1",
+        "hello",
+        _make_app(),
+        True,
+        ThreadEventBuffer(),
+        "run-123",
+    )
+
+    assert result == ""
+    assert _FakeTrajectoryStore.finalize_calls == [
+        {
+            "run_id": "run-123",
+            "finished_at": "2026-04-08T12:01:00+00:00",
+            "final_response": "done",
+            "status": "completed",
+            "run_tree_json": "{}",
+            "trajectory_json": '{"id":"run-123","thread_id":"thread-1","user_message":"hello","final_response":"done","llm_calls":[],"tool_calls":[],"run_tree_json":"{}","started_at":"2026-04-08T12:00:00+00:00","finished_at":"2026-04-08T12:01:00+00:00","status":"completed"}',
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_to_buffer_finalizes_same_eval_row_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeTrajectoryStore.reset()
+    _install_runtime_writer_test_doubles(monkeypatch)
+
+    agent = SimpleNamespace(
+        agent=_FakeGraphAgent(expected_run_id="run-123", error=RuntimeError("boom")),
+        runtime=_FakeRuntime(),
+        storage_container=None,
+    )
+
+    result = await _run_agent_to_buffer(
+        agent,
+        "thread-1",
+        "hello",
+        _make_app(),
+        True,
+        ThreadEventBuffer(),
+        "run-123",
+    )
+
+    assert result == ""
+    assert _FakeTrajectoryStore.finalize_calls[0]["run_id"] == "run-123"
+    assert _FakeTrajectoryStore.finalize_calls[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_to_buffer_finalizes_same_eval_row_on_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeTrajectoryStore.reset()
+    _install_runtime_writer_test_doubles(monkeypatch)
+
+    agent = SimpleNamespace(
+        agent=_FakeGraphAgent(expected_run_id="run-123", wait_forever=True),
+        runtime=_FakeRuntime(),
+        storage_container=None,
+    )
+
+    task = asyncio.create_task(
+        _run_agent_to_buffer(
+            agent,
+            "thread-1",
+            "hello",
+            _make_app(),
+            True,
+            ThreadEventBuffer(),
+            "run-123",
+        )
+    )
+    for _ in range(50):
+        if _FakeTrajectoryStore.header_calls:
+            break
+        await asyncio.sleep(0)
+
+    task.cancel()
+    result = await task
+
+    assert result == ""
+    assert _FakeTrajectoryStore.finalize_calls[0]["run_id"] == "run-123"
+    assert _FakeTrajectoryStore.finalize_calls[0]["status"] == "cancelled"

--- a/tests/Unit/eval/test_repo_lifecycle.py
+++ b/tests/Unit/eval/test_repo_lifecycle.py
@@ -1,0 +1,83 @@
+from eval.repo import SQLiteEvalRepo
+from storage.providers.supabase.eval_repo import SupabaseEvalRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_sqlite_eval_repo_updates_same_row_across_run_lifecycle(tmp_path) -> None:
+    repo = SQLiteEvalRepo(tmp_path / "eval.db")
+    repo.ensure_schema()
+
+    repo.upsert_run_header(
+        run_id="run-1",
+        thread_id="thread-1",
+        started_at="2026-04-08T12:00:00Z",
+        user_message="hello",
+        status="running",
+    )
+
+    runs = repo.list_runs(thread_id="thread-1")
+    assert runs == [
+        {
+            "id": "run-1",
+            "thread_id": "thread-1",
+            "started_at": "2026-04-08T12:00:00Z",
+            "finished_at": None,
+            "status": "running",
+            "user_message": "hello",
+        }
+    ]
+
+    repo.finalize_run(
+        run_id="run-1",
+        finished_at="2026-04-08T12:01:00Z",
+        final_response="done",
+        status="completed",
+        run_tree_json="{}",
+        trajectory_json='{"id":"run-1"}',
+    )
+
+    runs = repo.list_runs(thread_id="thread-1")
+    assert runs[0]["id"] == "run-1"
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["finished_at"] == "2026-04-08T12:01:00Z"
+    assert repo.get_trajectory_json("run-1") == '{"id":"run-1"}'
+
+
+def test_supabase_eval_repo_updates_same_row_across_run_lifecycle() -> None:
+    client = FakeSupabaseClient(tables={})
+    repo = SupabaseEvalRepo(client)
+
+    repo.upsert_run_header(
+        run_id="run-1",
+        thread_id="thread-1",
+        started_at="2026-04-08T12:00:00Z",
+        user_message="hello",
+        status="running",
+    )
+
+    runs = repo.list_runs(thread_id="thread-1")
+    assert runs == [
+        {
+            "id": "run-1",
+            "thread_id": "thread-1",
+            "started_at": "2026-04-08T12:00:00Z",
+            "finished_at": None,
+            "status": "running",
+            "user_message": "hello",
+        }
+    ]
+
+    repo.finalize_run(
+        run_id="run-1",
+        finished_at="2026-04-08T12:01:00Z",
+        final_response="done",
+        status="completed",
+        run_tree_json="{}",
+        trajectory_json='{"id":"run-1"}',
+    )
+
+    runs = repo.list_runs(thread_id="thread-1")
+    assert runs[0]["id"] == "run-1"
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["finished_at"] == "2026-04-08T12:01:00Z"
+    assert repo.get_trajectory_json("run-1") == '{"id":"run-1"}'

--- a/tests/Unit/eval/test_storage.py
+++ b/tests/Unit/eval/test_storage.py
@@ -1,0 +1,61 @@
+from eval.storage import TrajectoryStore
+
+
+class _FakeEvalRepo:
+    def __init__(self) -> None:
+        self.header_calls: list[dict] = []
+        self.finalize_calls: list[dict] = []
+
+    def upsert_run_header(self, **payload):
+        self.header_calls.append(payload)
+
+    def finalize_run(self, **payload):
+        self.finalize_calls.append(payload)
+
+
+def test_trajectory_store_exposes_upsert_run_header() -> None:
+    repo = _FakeEvalRepo()
+    store = TrajectoryStore(eval_repo=repo)
+
+    store.upsert_run_header(
+        run_id="run-1",
+        thread_id="thread-1",
+        started_at="2026-04-08T12:00:00Z",
+        user_message="hello",
+        status="running",
+    )
+
+    assert repo.header_calls == [
+        {
+            "run_id": "run-1",
+            "thread_id": "thread-1",
+            "started_at": "2026-04-08T12:00:00Z",
+            "user_message": "hello",
+            "status": "running",
+        }
+    ]
+
+
+def test_trajectory_store_exposes_finalize_run() -> None:
+    repo = _FakeEvalRepo()
+    store = TrajectoryStore(eval_repo=repo)
+
+    store.finalize_run(
+        run_id="run-1",
+        finished_at="2026-04-08T12:01:00Z",
+        final_response="done",
+        status="completed",
+        run_tree_json="{}",
+        trajectory_json='{"id":"run-1"}',
+    )
+
+    assert repo.finalize_calls == [
+        {
+            "run_id": "run-1",
+            "finished_at": "2026-04-08T12:01:00Z",
+            "final_response": "done",
+            "status": "completed",
+            "run_tree_json": "{}",
+            "trajectory_json": '{"id":"run-1"}',
+        }
+    ]

--- a/tests/Unit/eval/test_tracer.py
+++ b/tests/Unit/eval/test_tracer.py
@@ -1,0 +1,13 @@
+from eval.tracer import TrajectoryTracer
+
+
+def test_trajectory_tracer_reuses_supplied_run_id() -> None:
+    tracer = TrajectoryTracer(
+        thread_id="thread-1",
+        user_message="hello",
+        run_id="run-123",
+    )
+
+    trajectory = tracer.to_trajectory()
+
+    assert trajectory.id == "run-123"

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -1,3 +1,5 @@
+import pytest
+
 from backend.web.services import monitor_service
 
 
@@ -395,6 +397,142 @@ def test_monitor_evaluation_dashboard_summary_reduces_operator_truth():
             "headline": "Evaluation is actively running.",
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_monitor_evaluation_truth_reads_live_running_row_from_same_persisted_source(monkeypatch, tmp_path):
+    import asyncio
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from backend.web.services.event_buffer import ThreadEventBuffer
+    from backend.web.services.streaming_service import _run_agent_to_buffer
+    from core.runtime.middleware.monitor import AgentState
+    from eval.repo import SQLiteEvalRepo
+    from eval.storage import TrajectoryStore
+
+    class FakeDisplayBuilder:
+        def apply_event(self, thread_id: str, event_type: str, data: dict) -> None:
+            return None
+
+    class FakeRuntime:
+        def __init__(self) -> None:
+            self.current_state = AgentState.ACTIVE
+            self.current_run_source = None
+            self.state = SimpleNamespace(flags=SimpleNamespace(is_compacting=False))
+
+        def set_event_callback(self, cb) -> None:
+            self._event_callback = cb
+
+        def get_status_dict(self) -> dict[str, object]:
+            return {"state": {"state": "idle", "flags": {}}, "calls": 0}
+
+        def transition(self, new_state) -> bool:
+            self.current_state = new_state
+            return True
+
+    class FakeGraphAgent:
+        async def aget_state(self, _config):
+            return SimpleNamespace(values={"messages": []})
+
+        async def astream(self, *_args, **_kwargs):
+            await asyncio.Event().wait()
+            if False:
+                yield None
+
+    class FakeTrajectoryTracer:
+        def __init__(self, *, thread_id: str, user_message: str, run_id: str | None = None, cost_calculator=None, **_kwargs):
+            self.thread_id = thread_id
+            self.user_message = user_message
+            self.run_id = run_id
+            self._start_time = datetime.fromisoformat("2026-04-08T12:00:00+00:00").astimezone(UTC)
+
+        def to_trajectory(self):
+            from eval.models import RunTrajectory
+
+            return RunTrajectory(
+                id=self.run_id or "missing-run-id",
+                thread_id=self.thread_id,
+                user_message=self.user_message,
+                final_response="",
+                run_tree_json="{}",
+                started_at="2026-04-08T12:00:00+00:00",
+                finished_at="2026-04-08T12:01:00+00:00",
+                status="completed",
+            )
+
+        def enrich_from_runtime(self, trajectory, runtime) -> None:
+            return None
+
+    async def noop_async(*_args, **_kwargs) -> None:
+        return None
+
+    seq = 0
+
+    async def fake_append_event(thread_id, run_id, event, message_id=None, run_event_repo=None):
+        nonlocal seq
+        seq += 1
+        return seq
+
+    repo = SQLiteEvalRepo(tmp_path / "eval.db")
+    repo.ensure_schema()
+    store = TrajectoryStore(eval_repo=repo)
+
+    monkeypatch.setattr(monitor_service, "make_eval_store", lambda: store)
+    monkeypatch.setattr("backend.web.services.event_store.append_event", fake_append_event)
+    monkeypatch.setattr("backend.web.services.streaming_service.cleanup_old_runs", noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *args, **kwargs: None)
+    monkeypatch.setattr("backend.web.services.streaming_service._consume_followup_queue", noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service.write_cancellation_markers", noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._persist_cancelled_run_input_if_missing", noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._flush_cancelled_owner_steers", noop_async)
+    monkeypatch.setattr("eval.storage.TrajectoryStore", lambda: store)
+    monkeypatch.setattr("eval.tracer.TrajectoryTracer", FakeTrajectoryTracer)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            display_builder=FakeDisplayBuilder(),
+            thread_tasks={},
+            thread_last_active={},
+            typing_tracker=None,
+            queue_manager=SimpleNamespace(peek=lambda _thread_id: False),
+        )
+    )
+    agent = SimpleNamespace(
+        agent=FakeGraphAgent(),
+        runtime=FakeRuntime(),
+        storage_container=None,
+    )
+
+    task = asyncio.create_task(
+        _run_agent_to_buffer(
+            agent,
+            "thread-eval",
+            "hello",
+            app,
+            True,
+            ThreadEventBuffer(),
+            "run-live",
+        )
+    )
+
+    payload = None
+    for _ in range(100):
+        payload = monitor_service.get_monitor_evaluation_truth()
+        if payload["status"] == "running":
+            break
+        await asyncio.sleep(0)
+
+    assert payload is not None
+    assert payload["status"] == "running"
+    assert payload["kind"] == "running_recorded"
+    facts = {(item["label"], item["value"]) for item in payload["facts"]}
+    assert ("Run ID", "run-live") in facts
+    assert ("Thread ID", "thread-eval") in facts
+
+    task.cancel()
+    result = await task
+    assert result == ""
 
 
 def test_cleanup_resource_leases_deletes_allowed_detached_residue(monkeypatch):


### PR DESCRIPTION
## Summary
- activate writer-side evaluation lifecycle persistence on top of `#266`'s persisted operator truth reader
- reuse the web runtime `run_id` end-to-end so the same `eval_runs.id` survives start, completion, cancellation, and error
- keep monitor truth on the same persisted source path instead of inventing a second live contract

## What Changed
- `TrajectoryTracer` now preserves a caller-supplied `run_id`
- `EvalRepo` now exposes narrow lifecycle methods:
  - `upsert_run_header(...)`
  - `finalize_run(...)`
- SQLite and Supabase eval repos now support same-row lifecycle writes keyed by shared `run_id`
- `TrajectoryStore` now exposes matching lifecycle helpers
- `streaming_service` now:
  - writes a persisted `status=running` row before stream execution
  - finalizes the same row on completion / error / cancellation
  - keeps using the existing persisted eval source instead of introducing a second live source
- monitor-side proof now shows the reader can observe a live `running_recorded` row from that same persisted source

## Boundaries
- stacked on top of `#266`
- no evaluation UI work
- no product-facing behavior
- no legacy manifest / artifact / thread-materialization revival
- no separate live snapshot table

## Why This PR Exists
`#266` made monitor evaluation truth read the latest persisted run truthfully, but it was still terminal-only. This PR makes the writer surface `running` truth early enough that the same persisted source can describe in-flight runs without widening into a new storage world.

## Verification
- `uv run pytest -q tests/Unit/eval/test_tracer.py tests/Unit/eval/test_repo_lifecycle.py tests/Unit/eval/test_storage.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
  - `36 passed`
- `uv run ruff check eval/tracer.py eval/storage.py eval/repo.py storage/contracts.py storage/providers/supabase/eval_repo.py backend/web/services/streaming_service.py tests/Unit/eval/test_tracer.py tests/Unit/eval/test_repo_lifecycle.py tests/Unit/eval/test_storage.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/monitor/test_monitor_compat.py tests/Integration/test_monitor_resources_route.py`
  - passed

## Honest Boundary
This PR activates persisted live-vs-terminal status only. Richer artifact drilldown, trace drilldown, and any claim about broader evaluation runtime UX remain later work.
