### PR TITLE
refactor: decouple messaging ownership

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
 from backend.web.utils.serializers import avatar_url
+from messaging.display_user import resolve_messaging_display_user
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
@@ -79,19 +80,11 @@ def _get_accessible_chat_or_404(app: Any, chat_id: str, user_id: str) -> Any:
 
 
 def _resolve_display_user(app: Any, social_user_id: str) -> Any | None:
-    user = app.state.user_repo.get_by_id(social_user_id)
-    if user is not None:
-        return user
-    thread_repo = getattr(app.state, "thread_repo", None)
-    if thread_repo is None:
-        return None
-    thread = thread_repo.get_by_user_id(social_user_id)
-    if thread is None:
-        return None
-    agent_user_id = thread.get("agent_user_id")
-    if not agent_user_id:
-        return None
-    return app.state.user_repo.get_by_id(agent_user_id)
+    return resolve_messaging_display_user(
+        user_repo=app.state.user_repo,
+        thread_repo=getattr(app.state, "thread_repo", None),
+        social_user_id=social_user_id,
+    )
 
 
 def _validate_chat_participant_ids(app: Any, participant_ids: list[str], requester_user_id: str) -> list[str]:

--- a/docs/architecture/messaging-decoupling-roadmap.md
+++ b/docs/architecture/messaging-decoupling-roadmap.md
@@ -6,6 +6,8 @@ Turn `messaging/` into the single owner of messaging-domain truth instead of a t
 
 This roadmap is intentionally scoped as a long-lived implementation lane, not a one-shot refactor. The initial placeholder PR should carry this document plus follow-up implementation slices, rather than letting each slice invent its own local truth.
 
+Current campaign ruling: this branch remains a docs-only shell until the principal assigns the first bounded implementation slice. The roadmap is canonical direction for the lane, not standing permission to start Slice 1.
+
 ## Why This Exists
 
 The current codebase already treats `messaging/` as a bounded domain:
@@ -177,3 +179,13 @@ The placeholder PR for this roadmap should be allowed to carry:
 - subsequent implementation slices that stay inside the ownership plan above
 
 It should not become a grab bag for unrelated communication cleanup.
+
+## Freeze Rule
+
+Until the first bounded slice is explicitly assigned, this branch is frozen as:
+
+- one repo-shipping architecture roadmap
+- no production-code changes
+- no opportunistic tests
+- no cleanup hitchhiking
+- no parallel “helper roadmap” or scratchpad documents inside the repo

--- a/docs/architecture/messaging-decoupling-roadmap.md
+++ b/docs/architecture/messaging-decoupling-roadmap.md
@@ -1,0 +1,179 @@
+# Messaging Decoupling Roadmap
+
+## Goal
+
+Turn `messaging/` into the single owner of messaging-domain truth instead of a top-level directory that still shares live contracts with web routers and runtime tool glue.
+
+This roadmap is intentionally scoped as a long-lived implementation lane, not a one-shot refactor. The initial placeholder PR should carry this document plus follow-up implementation slices, rather than letting each slice invent its own local truth.
+
+## Why This Exists
+
+The current codebase already treats `messaging/` as a bounded domain:
+
+- web routers depend on it
+- runtime chat tools depend on it
+- realtime bridge depends on it
+- relationship and delivery policy live under it
+
+But the ownership is still split across multiple surfaces.
+
+### Current split ownership
+
+1. Canonical social/display resolution is duplicated.
+
+- `messaging/service.py` owns `_resolve_display_user()`
+- `messaging/tools/chat_tool_service.py` owns another `_resolve_display_user()`
+- `backend/web/routers/conversations.py` owns a third `_resolve_display_user()`
+
+2. Conversation read-model ownership is split.
+
+- `MessagingService.list_chats_for_user()` already assembles chat summaries
+- `backend/web/routers/conversations.py` rebuilds visit-chat title/avatar/unread data again
+
+3. Runtime chat tools bypass the messaging domain.
+
+- `ChatToolService` consumes `MessagingService`
+- but also talks directly to chat-member/message/thread repos
+
+4. The domain still depends on web presentation glue.
+
+- `messaging/service.py` imports `backend.web.utils.serializers.avatar_url`
+- so the top-level domain is still coupled to web serialization concerns
+
+These are not style issues. They are ownership failures: more than one live surface is acting like the source of truth.
+
+## Design Principles
+
+This roadmap follows the same principles recorded in [AGENTS.md](/Users/lexicalmathical/worktrees/leonai--messaging-decouple-placeholder/AGENTS.md) and mined from `Vibe-Skills`:
+
+1. Single source of truth
+2. Ownership split and boundary clarity
+3. Proof class over helper noise
+4. Fail loud instead of preserving silent compatibility shells
+
+## Target Ownership
+
+The target state is narrow:
+
+### `messaging/` owns
+
+- social/display resolution for messaging identities
+- visit-chat summary/read-model assembly
+- messaging-facing delivery and relationship policy
+- runtime-facing chat facade consumed by tools
+
+### web routers own
+
+- HTTP transport
+- auth and route-local request validation
+- response translation only where the outward contract is explicitly different
+
+### runtime tool registration owns
+
+- tool schema registration
+- tool-mode registration
+- tool argument parsing that is specific to tool UX
+
+It should not own message history storage queries, chat membership queries, or identity resolution rules directly.
+
+## Planned Slice Order
+
+### Slice 1: Canonical messaging identity resolver
+
+Create one canonical resolver inside `messaging/` for `social_user_id -> display user`.
+
+This slice should delete duplicated resolver logic from:
+
+- `messaging/service.py`
+- `messaging/tools/chat_tool_service.py`
+- `backend/web/routers/conversations.py`
+
+Stopline:
+
+- do not widen outward payloads
+- do not rewrite relationship or delivery policy
+- do not touch frontend
+
+### Slice 2: Visit-chat summary owner cutover
+
+Make `MessagingService` the sole owner of visit-chat summary assembly:
+
+- title
+- avatar
+- entities
+- unread count
+- last message
+- updated timestamp
+
+Then make `backend/web/routers/conversations.py` consume that projection instead of rebuilding it.
+
+Stopline:
+
+- keep `/api/conversations` outward contract stable
+- do not refactor hire-thread rows in the same slice
+- do not mix in frontend sidebar work
+
+### Slice 3: Tool facade cutover
+
+Narrow `ChatToolService` so it consumes a messaging facade instead of talking directly to:
+
+- chat-member repo
+- messages repo
+- thread repo
+- duplicated identity lookup
+
+Stopline:
+
+- keep tool names and tool schemas stable
+- do not redesign range syntax or tool UX
+- do not mix taskboard/runtime registry cleanup into this lane
+
+### Slice 4: Domain/web boundary cleanup
+
+After the above slices land, remove residual web-specific serialization leakage from `messaging/`, especially direct dependence on `backend.web.utils.serializers.avatar_url`.
+
+Stopline:
+
+- no broad serializer rework
+- no frontend payload rename
+- no “compat forever” fallback layer
+
+## Non-Goals
+
+This lane does not include:
+
+- relationship state machine redesign
+- delivery policy redesign
+- frontend conversation/sidebar redesign
+- taskboard contract cleanup
+- messaging schema rewrite
+- monitor/resource/provider/runtime bootstrap cleanup
+
+## Evidence Standard
+
+Each implementation slice should ship with one primary proof:
+
+- a real caller proof if the slice changes a live caller contract
+- otherwise a bounded integration proof around the new canonical owner
+
+Do not justify the refactor with helper-only tests that merely prove delegation.
+
+## Current File Hotspots
+
+- [service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/service.py#L58)
+- [service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/service.py#L170)
+- [chat_tool_service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/tools/chat_tool_service.py#L111)
+- [chat_tool_service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/tools/chat_tool_service.py#L143)
+- [chat_tool_service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/tools/chat_tool_service.py#L215)
+- [conversations.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/backend/web/routers/conversations.py#L25)
+- [conversations.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/backend/web/routers/conversations.py#L97)
+- [lifespan.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/backend/web/core/lifespan.py#L82)
+
+## Placeholder PR Contract
+
+The placeholder PR for this roadmap should be allowed to carry:
+
+- this roadmap document
+- subsequent implementation slices that stay inside the ownership plan above
+
+It should not become a grab bag for unrelated communication cleanup.

--- a/docs/architecture/messaging-decoupling-roadmap.md
+++ b/docs/architecture/messaging-decoupling-roadmap.md
@@ -185,7 +185,7 @@ It should not become a grab bag for unrelated communication cleanup.
 Until the first bounded slice is explicitly assigned, this branch is frozen as:
 
 - one repo-shipping architecture roadmap
+- do not start Slice 1 implementation yet
 - no production-code changes
-- no opportunistic tests
-- no cleanup hitchhiking
+- no opportunistic tests or cleanup hitchhiking
 - no parallel “helper roadmap” or scratchpad documents inside the repo

--- a/docs/architecture/messaging-decoupling-roadmap.md
+++ b/docs/architecture/messaging-decoupling-roadmap.md
@@ -4,15 +4,21 @@
 
 Turn `messaging/` into the single owner of messaging-domain truth instead of a top-level directory that still shares live contracts with web routers and runtime tool glue.
 
-This roadmap is intentionally scoped as a long-lived implementation lane, not a one-shot refactor. The initial placeholder PR should carry this document plus follow-up implementation slices, rather than letting each slice invent its own local truth.
+This roadmap is intentionally scoped as a long-lived implementation lane, not a one-shot refactor. PR #272 started as a placeholder carrier for this document, and now also carries bounded implementation slices that stay inside the ownership plan below instead of letting each slice invent its own local truth.
 
-Current campaign ruling: this branch remains a docs-only shell until the principal assigns the first bounded implementation slice. The roadmap is canonical direction for the lane, not standing permission to start Slice 1.
+Current campaign status:
 
-Current parking trigger: implementation may resume only after the principal's `chat-thread-runtime-closure` lane materially closes three checkpoints on mainline:
+1. Slice 1 resolver baseline is landed on this lane via `6b8afffd`, introducing `messaging.display_user.resolve_messaging_display_user(...)` and cutting `MessagingService` over to the canonical resolver.
+2. The next bounded cut is also landed on this lane via `668894eb`, cutting `backend/web/routers/messaging.py` over to that same canonical resolver for its participant/display shell.
+3. The final follow-up `1c036453` is formatting-only and keeps the live PR green without widening scope.
 
-1. group-chat turn semantics are caller-proven with real backend probes, including no duplicated first-turn replies and no noisy contention failures being treated as backend errors
-2. thread runtime/file-channel closure is caller-proven on the canonical path, including `create-thread -> files/channels -> upload -> agent reads uploaded file`, while legacy incomplete threads are converged or purged from owner-facing surfaces
-3. the brutal integration proof checkpoint on `chat-thread-runtime-closure` is materially closed with backend brutal-probe evidence recorded, not mechanism-level tests only
+Current parking rule:
+
+- `chat_tool_service.py` remains deferred
+- `backend/web/routers/conversations.py` remains deferred
+- delivery policy changes remain deferred
+- frontend/sidebar work remains deferred
+- future slices still require explicit bounded assignment rather than inertia from this roadmap
 
 ## Why This Exists
 
@@ -90,9 +96,11 @@ It should not own message history storage queries, chat membership queries, or i
 
 Create one canonical resolver inside `messaging/` for `social_user_id -> display user`.
 
+Current lane status: partially landed.
+
 This slice should delete duplicated resolver logic from:
 
-- `messaging/service.py`
+- `messaging/service.py` @ landed on this lane in `6b8afffd`
 - `messaging/tools/chat_tool_service.py`
 - `backend/web/routers/conversations.py`
 
@@ -114,6 +122,8 @@ Make `MessagingService` the sole owner of visit-chat summary assembly:
 - updated timestamp
 
 Then make `backend/web/routers/conversations.py` consume that projection instead of rebuilding it.
+
+Current lane status: not started. The smaller router participant/display shell cut in `668894eb` is intentionally earlier and narrower than this ownership surgery.
 
 Stopline:
 
@@ -179,20 +189,21 @@ Do not justify the refactor with helper-only tests that merely prove delegation.
 
 ## Placeholder PR Contract
 
-The placeholder PR for this roadmap should be allowed to carry:
+The placeholder PR for this roadmap is allowed to carry:
 
 - this roadmap document
-- subsequent implementation slices that stay inside the ownership plan above
+- bounded implementation slices that stay inside the ownership plan above
 
 It should not become a grab bag for unrelated communication cleanup.
 
-## Freeze Rule
+## Bounded Slice Rule
 
-Until the first bounded slice is explicitly assigned, this branch is frozen as:
+This branch is no longer a pure docs-only shell. It is now a bounded implementation lane, with the following hard limits:
 
-- one repo-shipping architecture roadmap
-- do not start Slice 1 implementation yet
-- no production-code changes
+- keep implementation aligned to the ownership plan above
+- do not widen from router/service identity cutover into `chat_tool_service.py`
+- do not widen into `backend/web/routers/conversations.py` ownership surgery
+- do not widen into delivery policy or frontend work
 - no opportunistic tests or cleanup hitchhiking
 - no parallel “helper roadmap” or scratchpad documents inside the repo
-- implementation resumes only when the parking trigger above is satisfied or the principal assigns a different bounded cut
+- future implementation still resumes only when the principal assigns a different bounded cut

--- a/docs/architecture/messaging-decoupling-roadmap.md
+++ b/docs/architecture/messaging-decoupling-roadmap.md
@@ -8,6 +8,12 @@ This roadmap is intentionally scoped as a long-lived implementation lane, not a 
 
 Current campaign ruling: this branch remains a docs-only shell until the principal assigns the first bounded implementation slice. The roadmap is canonical direction for the lane, not standing permission to start Slice 1.
 
+Current parking trigger: implementation may resume only after the principal's `chat-thread-runtime-closure` lane materially closes three checkpoints on mainline:
+
+1. group-chat turn semantics are caller-proven with real backend probes, including no duplicated first-turn replies and no noisy contention failures being treated as backend errors
+2. thread runtime/file-channel closure is caller-proven on the canonical path, including `create-thread -> files/channels -> upload -> agent reads uploaded file`, while legacy incomplete threads are converged or purged from owner-facing surfaces
+3. the brutal integration proof checkpoint on `chat-thread-runtime-closure` is materially closed with backend brutal-probe evidence recorded, not mechanism-level tests only
+
 ## Why This Exists
 
 The current codebase already treats `messaging/` as a bounded domain:
@@ -189,3 +195,4 @@ Until the first bounded slice is explicitly assigned, this branch is frozen as:
 - no production-code changes
 - no opportunistic tests or cleanup hitchhiking
 - no parallel “helper roadmap” or scratchpad documents inside the repo
+- implementation resumes only when the parking trigger above is satisfied or the principal assigns a different bounded cut

--- a/messaging/display_user.py
+++ b/messaging/display_user.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def resolve_messaging_display_user(*, user_repo: Any, thread_repo: Any | None, social_user_id: str) -> Any | None:
+    user = user_repo.get_by_id(social_user_id)
+    if user is not None:
+        return user
+    if thread_repo is None:
+        return None
+    thread = thread_repo.get_by_user_id(social_user_id)
+    if thread is None:
+        return None
+    agent_user_id = thread.get("agent_user_id")
+    if not agent_user_id:
+        return None
+    return user_repo.get_by_id(agent_user_id)

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from backend.web.utils.serializers import avatar_url
 from messaging.contracts import ContentType, MessageType
+from messaging.display_user import resolve_messaging_display_user
 
 logger = logging.getLogger(__name__)
 
@@ -56,18 +57,11 @@ class MessagingService:
         }
 
     def _resolve_display_user(self, social_user_id: str) -> Any | None:
-        user = self._user_repo.get_by_id(social_user_id)
-        if user is not None:
-            return user
-        if self._thread_repo is None:
-            return None
-        thread = self._thread_repo.get_by_user_id(social_user_id)
-        if thread is None:
-            return None
-        agent_user_id = thread.get("agent_user_id")
-        if not agent_user_id:
-            return None
-        return self._user_repo.get_by_id(agent_user_id)
+        return resolve_messaging_display_user(
+            user_repo=self._user_repo,
+            thread_repo=self._thread_repo,
+            social_user_id=social_user_id,
+        )
 
     def set_delivery_fn(self, fn: Callable) -> None:
         self._delivery_fn = fn

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -62,6 +62,39 @@ def test_get_accessible_chat_or_404_raises_403_for_non_member():
     assert exc_info.value.detail == "Not a participant of this chat"
 
 
+def test_resolve_display_user_delegates_to_messaging_local_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    expected = SimpleNamespace(id="agent-user-1", display_name="Toad")
+
+    def fake_resolver(*, user_repo, thread_repo, social_user_id: str):
+        seen.update(
+            {
+                "user_repo": user_repo,
+                "thread_repo": thread_repo,
+                "social_user_id": social_user_id,
+            }
+        )
+        return expected
+
+    monkeypatch.setattr(messaging_router, "resolve_messaging_display_user", fake_resolver)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            user_repo=SimpleNamespace(name="user-repo"),
+            thread_repo=SimpleNamespace(name="thread-repo"),
+        )
+    )
+
+    result = messaging_router._resolve_display_user(app, "thread-user-1")
+
+    assert result is expected
+    assert seen == {
+        "user_repo": app.state.user_repo,
+        "thread_repo": app.state.thread_repo,
+        "social_user_id": "thread-user-1",
+    }
+
+
 @pytest.mark.asyncio
 async def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
     seen: list[tuple[str, object]] = []

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -48,9 +48,7 @@ def test_messaging_display_user_resolver_prefers_direct_user_row() -> None:
     resolved = resolve_messaging_display_user(
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
-                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
-                if uid == "human-user-1"
-                else None
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None) if uid == "human-user-1" else None
             )
         ),
         thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: pytest.fail("thread bridge should not be used")),

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -10,6 +10,7 @@ from core.agents.communication import delivery as delivery_module
 from core.runtime.registry import ToolRegistry
 from messaging.delivery.actions import DeliveryAction
 from messaging.delivery.resolver import HireVisitDeliveryResolver
+from messaging.display_user import resolve_messaging_display_user
 from messaging.relationships.service import RelationshipService
 from messaging.service import MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
@@ -41,6 +42,45 @@ class _FakeRelationshipRepo:
         row["updated_at"] = "2026-04-07T00:01:00Z"
         self._existing[key] = row
         return row
+
+
+def test_messaging_display_user_resolver_prefers_direct_user_row() -> None:
+    resolved = resolve_messaging_display_user(
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
+                if uid == "human-user-1"
+                else None
+            )
+        ),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: pytest.fail("thread bridge should not be used")),
+        social_user_id="human-user-1",
+    )
+
+    assert resolved is not None
+    assert resolved.display_name == "Human"
+
+
+def test_messaging_display_user_resolver_bridges_thread_user_to_agent_row() -> None:
+    resolved = resolve_messaging_display_user(
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                if uid == "agent-user-1"
+                else None
+            )
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+        social_user_id="thread-user-1",
+    )
+
+    assert resolved is not None
+    assert resolved.id == "agent-user-1"
+    assert resolved.display_name == "Toad"
 
 
 def test_deliver_to_agents_does_not_require_main_thread_id():


### PR DESCRIPTION
## Goal
Turn `messaging/` into the canonical owner of messaging-domain truth instead of letting live ownership stay split across routers, runtime chat tools, and top-level messaging services.

## This PR currently contains
- `docs/architecture/messaging-decoupling-roadmap.md`

This PR is intentionally a placeholder branch shell.

## Current ruling
- keep this branch as a repo-shipping architecture doc, not a superpowers scratchpad
- do not start Slice 1 implementation yet
- do not widen into opportunistic cleanup or unrelated communication work

## Why now
Current `dev` already has a top-level `messaging/` module, but live truth is still split across multiple surfaces:
- duplicated `social_user_id -> display user` resolution
- duplicated visit-chat summary/read-model assembly
- `ChatToolService` still reaching directly into repos
- `messaging/` still importing web serialization glue

## Planned slice order
1. Canonical messaging identity resolver
2. Visit-chat summary owner cutover
3. Chat tool facade cutover
4. Domain/web boundary cleanup

## Stopline
- no frontend/sidebar redesign
- no relationship-state-machine redesign
- no delivery-policy redesign
- no taskboard/runtime-registry cleanup hitchhiking on this branch
- no silent compatibility fallback layer

## Non-goals
- messaging schema rewrite
- monitor/resource/provider/runtime bootstrap cleanup
- unrelated communication cleanup

## Evidence rule
Each implementation slice should ship with one primary caller proof or bounded integration proof around the new canonical owner. Helper-only delegation tests are not enough.
