### PR TITLE
Monitor local proxy honesty: align vite ports with worktree config

### DIFF
--- a/docs/superpowers/plans/2026-04-08-monitor-local-proxy-honesty.md
+++ b/docs/superpowers/plans/2026-04-08-monitor-local-proxy-honesty.md
@@ -1,0 +1,106 @@
+# Monitor Local Proxy Honesty Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the standalone monitor frontend resolve local backend/dev/preview ports from env and worktree config instead of hardcoded values.
+
+**Architecture:** Keep this lane frontend-local. Reuse the app’s existing worktree-aware backend-port pattern, introduce monitor-specific optional port keys for the standalone frontend, and update local-dev docs to match the real behavior.
+
+**Tech Stack:** Vite, React frontend config, Vitest, npm
+
+---
+
+## File Structure
+
+- Modify: `frontend/monitor/vite.config.ts`
+  - add worktree-aware port resolution
+- Modify: `frontend/monitor/package.json`
+  - stop overriding config ports with hardcoded CLI flags
+- Modify: `frontend/monitor/README.md`
+  - document real local-dev port contract
+- Create: `frontend/monitor/vite.config.test.ts`
+  - lock env/worktree port resolution behavior
+
+## Mandatory Boundary
+
+- No backend changes
+- No monitor UI changes
+- No product app changes
+- No auto-detection or probing
+- No config fallback hiding
+
+## Task 1: Lock monitor Vite resolution behavior
+
+**Files:**
+- Create: `frontend/monitor/vite.config.test.ts`
+- Modify: `frontend/monitor/vite.config.ts`
+- Modify: `frontend/monitor/package.json`
+- Test:
+  - `cd frontend/monitor && npm test -- --run vite.config.test.ts`
+
+- [ ] Add a failing test that proves monitor resolves:
+  - backend target from `LEON_BACKEND_PORT` before worktree config
+  - monitor dev port from `LEON_MONITOR_PORT` before worktree config
+  - monitor preview port from `LEON_MONITOR_PREVIEW_PORT` before worktree config
+  - fallback values when no env/worktree config exists
+- [ ] Run the targeted test and verify it fails.
+- [ ] Implement the smallest config change:
+  - add `getWorktreePort(...)`
+  - export a small helper for resolved config values so the test can read them
+  - remove hardcoded `--port` flags from `package.json` so Vite config actually owns the ports
+- [ ] Re-run the targeted test and verify it passes.
+- [ ] Re-run monitor build and verify it still passes:
+  - `cd frontend/monitor && npm run build`
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/vite.config.ts frontend/monitor/vite.config.test.ts frontend/monitor/package.json
+git commit -m "feat: align monitor local vite ports with worktree config"
+```
+
+## Task 2: Lock README honesty
+
+**Files:**
+- Modify: `frontend/monitor/README.md`
+- Test:
+  - `cd frontend/monitor && npm run build`
+
+- [ ] Update README so it no longer claims backend is always `127.0.0.1:8001`.
+- [ ] Document the real local-dev contract:
+  - `LEON_BACKEND_PORT`
+  - `LEON_MONITOR_PORT`
+  - `LEON_MONITOR_PREVIEW_PORT`
+  - `worktree.ports.backend`
+  - `worktree.ports.monitor_frontend`
+  - `worktree.ports.monitor_preview`
+- [ ] Keep the wording narrow:
+  - local-dev honesty only
+  - no claim that monitor auto-discovers or heals wrong ports
+- [ ] Re-run monitor build as a quick guard:
+  - `cd frontend/monitor && npm run build`
+- [ ] Commit:
+
+```bash
+git add frontend/monitor/README.md
+git commit -m "docs: document monitor local port contract"
+```
+
+## Task 3: Verification and PR prep
+
+**Files:**
+- No required code files
+
+- [ ] Run:
+  - `cd frontend/monitor && npm test -- --run vite.config.test.ts`
+  - `cd frontend/monitor && npm run build`
+- [ ] Record the honest boundary:
+  - this PR only fixes local-dev proxy/port honesty
+  - wrong configured ports still fail loudly
+- [ ] Prepare a narrow draft PR
+
+## Hard Stopline
+
+- Do not touch backend routes
+- Do not touch app Vite config
+- Do not add dynamic port probing
+- Do not expand this into monitor runtime or product behavior work

--- a/docs/superpowers/plans/2026-04-08-monitor-local-proxy-honesty.md
+++ b/docs/superpowers/plans/2026-04-08-monitor-local-proxy-honesty.md
@@ -14,11 +14,15 @@
 
 - Modify: `frontend/monitor/vite.config.ts`
   - add worktree-aware port resolution
+- Create: `frontend/monitor/dev-ports.ts`
+  - read env/worktree config for Vite
 - Modify: `frontend/monitor/package.json`
   - stop overriding config ports with hardcoded CLI flags
 - Modify: `frontend/monitor/README.md`
   - document real local-dev port contract
-- Create: `frontend/monitor/vite.config.test.ts`
+- Create: `frontend/monitor/src/monitor-ports.ts`
+  - pure port-resolution helper
+- Create: `frontend/monitor/src/test/vite-port-config.test.ts`
   - lock env/worktree port resolution behavior
 
 ## Mandatory Boundary
@@ -32,11 +36,13 @@
 ## Task 1: Lock monitor Vite resolution behavior
 
 **Files:**
-- Create: `frontend/monitor/vite.config.test.ts`
+- Create: `frontend/monitor/dev-ports.ts`
+- Create: `frontend/monitor/src/monitor-ports.ts`
+- Create: `frontend/monitor/src/test/vite-port-config.test.ts`
 - Modify: `frontend/monitor/vite.config.ts`
 - Modify: `frontend/monitor/package.json`
 - Test:
-  - `cd frontend/monitor && npm test -- --run vite.config.test.ts`
+  - `cd frontend/monitor && npm test -- --run src/test/vite-port-config.test.ts`
 
 - [ ] Add a failing test that proves monitor resolves:
   - backend target from `LEON_BACKEND_PORT` before worktree config
@@ -45,8 +51,8 @@
   - fallback values when no env/worktree config exists
 - [ ] Run the targeted test and verify it fails.
 - [ ] Implement the smallest config change:
-  - add `getWorktreePort(...)`
-  - export a small helper for resolved config values so the test can read them
+  - keep the pure resolution logic in `src/monitor-ports.ts`
+  - keep `git config` and `process.env` reads in `dev-ports.ts`
   - remove hardcoded `--port` flags from `package.json` so Vite config actually owns the ports
 - [ ] Re-run the targeted test and verify it passes.
 - [ ] Re-run monitor build and verify it still passes:
@@ -54,7 +60,7 @@
 - [ ] Commit:
 
 ```bash
-git add frontend/monitor/vite.config.ts frontend/monitor/vite.config.test.ts frontend/monitor/package.json
+git add frontend/monitor/dev-ports.ts frontend/monitor/src/monitor-ports.ts frontend/monitor/src/test/vite-port-config.test.ts frontend/monitor/vite.config.ts frontend/monitor/package.json
 git commit -m "feat: align monitor local vite ports with worktree config"
 ```
 
@@ -71,8 +77,8 @@ git commit -m "feat: align monitor local vite ports with worktree config"
   - `LEON_MONITOR_PORT`
   - `LEON_MONITOR_PREVIEW_PORT`
   - `worktree.ports.backend`
-  - `worktree.ports.monitor_frontend`
-  - `worktree.ports.monitor_preview`
+  - `worktree.ports.monitor-frontend`
+  - `worktree.ports.monitor-preview`
 - [ ] Keep the wording narrow:
   - local-dev honesty only
   - no claim that monitor auto-discovers or heals wrong ports
@@ -91,7 +97,7 @@ git commit -m "docs: document monitor local port contract"
 - No required code files
 
 - [ ] Run:
-  - `cd frontend/monitor && npm test -- --run vite.config.test.ts`
+  - `cd frontend/monitor && npm test -- --run src/test/vite-port-config.test.ts`
   - `cd frontend/monitor && npm run build`
 - [ ] Record the honest boundary:
   - this PR only fixes local-dev proxy/port honesty

--- a/docs/superpowers/specs/2026-04-08-monitor-local-proxy-honesty-design.md
+++ b/docs/superpowers/specs/2026-04-08-monitor-local-proxy-honesty-design.md
@@ -75,11 +75,11 @@ Use the same local-dev truth sources the app already uses:
   - fallback `8001`
 - monitor dev port from:
   - `LEON_MONITOR_PORT`
-  - `worktree.ports.monitor_frontend`
+  - `worktree.ports.monitor-frontend`
   - fallback `5174`
 - monitor preview port from:
   - `LEON_MONITOR_PREVIEW_PORT`
-  - `worktree.ports.monitor_preview`
+  - `worktree.ports.monitor-preview`
   - fallback `4174`
 
 Pros:
@@ -129,8 +129,8 @@ Monitor should not reuse `worktree.ports.frontend`, because that key already bel
 
 So monitor gets its own optional keys:
 
-- `worktree.ports.monitor_frontend`
-- `worktree.ports.monitor_preview`
+- `worktree.ports.monitor-frontend`
+- `worktree.ports.monitor-preview`
 
 And matching env overrides:
 

--- a/docs/superpowers/specs/2026-04-08-monitor-local-proxy-honesty-design.md
+++ b/docs/superpowers/specs/2026-04-08-monitor-local-proxy-honesty-design.md
@@ -1,0 +1,172 @@
+# Monitor Local Proxy Honesty Design
+
+## Goal
+
+Make the standalone monitor frontend use the same local-dev backend port truth as the current worktree, instead of hardcoding `127.0.0.1:8001`.
+
+## Current Facts
+
+- `frontend/monitor/vite.config.ts` still hardcodes:
+  - dev server proxy target: `http://127.0.0.1:8001`
+  - dev server port: `5174`
+  - preview port: `4174`
+- `frontend/monitor/package.json` also hardcodes:
+  - `vite --port 5174`
+  - `vite preview --port 4174`
+- `frontend/monitor/README.md` still tells the user:
+  - backend is expected at `127.0.0.1:8001`
+- `frontend/app/vite.config.ts` already has the honest local-dev pattern:
+  - `LEON_BACKEND_PORT`
+  - `git config --worktree --get worktree.ports.backend`
+- the current worktree already has:
+  - `worktree.ports.backend=8012`
+  - `worktree.ports.frontend=5184`
+
+So monitor can still open a truthful shell against a false backend target.
+
+## Scope Check
+
+This lane must stay narrow. It is about local-dev honesty only.
+
+If it grows, it will start mixing:
+
+- backend/runtime changes
+- monitor UI behavior changes
+- product app behavior
+- automatic environment discovery logic
+
+That would turn a simple local-dev seam into another broad frontend/backend PR. This lane should not do that.
+
+## Approaches
+
+### 1. Keep hardcoded monitor defaults
+
+Leave monitor on `8001 / 5174 / 4174`.
+
+Pros:
+- zero code churn
+
+Cons:
+- keeps the current local-dev lie
+- diverges from app’s already-established worktree-aware pattern
+
+Rejected.
+
+### 2. Replace hardcoded values with different hardcoded values
+
+Point monitor at the currently observed backend port.
+
+Pros:
+- very small diff
+
+Cons:
+- still dishonest as soon as another worktree uses a different port
+- just moves the hardcoding
+
+Rejected.
+
+### 3. Align monitor with the app’s worktree-aware port resolution
+
+Use the same local-dev truth sources the app already uses:
+
+- backend target from:
+  - `LEON_BACKEND_PORT`
+  - `worktree.ports.backend`
+  - fallback `8001`
+- monitor dev port from:
+  - `LEON_MONITOR_PORT`
+  - `worktree.ports.monitor_frontend`
+  - fallback `5174`
+- monitor preview port from:
+  - `LEON_MONITOR_PREVIEW_PORT`
+  - `worktree.ports.monitor_preview`
+  - fallback `4174`
+
+Pros:
+- truthful local-dev behavior
+- matches an existing pattern already in the repo
+- keeps scope entirely frontend-local
+
+Cons:
+- slightly more code than a hardcoded replacement
+- introduces two new optional worktree keys for monitor-specific ports
+
+Recommended.
+
+## Recommended Design
+
+Apply the app’s local-dev port resolution pattern to the standalone monitor frontend, but keep it monitor-specific where needed.
+
+The concrete shape is:
+
+- `frontend/monitor/vite.config.ts`
+  - add `getWorktreePort(...)`
+  - resolve backend target through env/worktree config/fallback
+  - resolve monitor dev port through env/worktree config/fallback
+  - resolve monitor preview port through env/worktree config/fallback
+- `frontend/monitor/package.json`
+  - stop forcing `--port 5174` and `--port 4174`
+  - let Vite config own the resolved ports
+- `frontend/monitor/README.md`
+  - stop claiming backend is always `127.0.0.1:8001`
+  - document the env vars and worktree config keys that now control local ports
+
+## Configuration Decisions
+
+### Backend target
+
+Monitor should read backend target in this order:
+
+1. `process.env.LEON_BACKEND_PORT`
+2. `git config --worktree --get worktree.ports.backend`
+3. fallback `8001`
+
+This keeps monitor aligned with the app and avoids inventing a second backend-port convention.
+
+### Monitor-specific frontend ports
+
+Monitor should not reuse `worktree.ports.frontend`, because that key already belongs to the product app frontend in this worktree.
+
+So monitor gets its own optional keys:
+
+- `worktree.ports.monitor_frontend`
+- `worktree.ports.monitor_preview`
+
+And matching env overrides:
+
+- `LEON_MONITOR_PORT`
+- `LEON_MONITOR_PREVIEW_PORT`
+
+If they are absent, monitor keeps today’s defaults:
+
+- dev `5174`
+- preview `4174`
+
+## Error Handling
+
+Do not add port auto-detection or fallback probing.
+
+If the resolved backend port is wrong:
+
+- the proxy should fail loudly
+- the frontend should surface the real request failure
+
+This lane is about making local configuration honest, not hiding configuration mistakes.
+
+## Testing
+
+This lane only needs narrow verification:
+
+- frontend monitor build still passes
+- Vite config resolves backend target from env/worktree config correctly
+- Vite config resolves monitor dev/preview ports correctly
+- README examples match actual resolution behavior
+
+## Merge Bar
+
+This PR is done when:
+
+- monitor no longer hardcodes `/api -> 127.0.0.1:8001`
+- monitor no longer hardcodes `5174 / 4174` in package scripts
+- monitor local-dev docs describe the real env/worktree config contract
+- no backend/product/UI scope was mixed in

--- a/eval/repo.py
+++ b/eval/repo.py
@@ -113,8 +113,7 @@ class SQLiteEvalRepo:
         trajectory_json: str,
     ) -> None:
         result = self._conn.execute(
-            "UPDATE eval_runs SET finished_at = ?, final_response = ?, status = ?, "
-            "run_tree_json = ?, trajectory_json = ? WHERE id = ?",
+            "UPDATE eval_runs SET finished_at = ?, final_response = ?, status = ?, run_tree_json = ?, trajectory_json = ? WHERE id = ?",
             (finished_at, final_response, status, run_tree_json, trajectory_json, run_id),
         )
         if result.rowcount != 1:

--- a/frontend/monitor/README.md
+++ b/frontend/monitor/README.md
@@ -10,7 +10,22 @@ npm install
 npm run dev
 ```
 
-Backend is expected at `http://127.0.0.1:8001`, proxied via Vite `/api`.
+Local ports resolve in this order:
+
+- backend proxy target:
+  - `LEON_BACKEND_PORT`
+  - `git config --worktree --get worktree.ports.backend`
+  - fallback `8001`
+- monitor dev server:
+  - `LEON_MONITOR_PORT`
+  - `git config --worktree --get worktree.ports.monitor-frontend`
+  - fallback `5174`
+- monitor preview server:
+  - `LEON_MONITOR_PREVIEW_PORT`
+  - `git config --worktree --get worktree.ports.monitor-preview`
+  - fallback `4174`
+
+The Vite `/api` proxy still fails loudly if these ports are wrong. This only fixes local-dev honesty; it does not auto-detect or heal bad config.
 
 Open: `http://localhost:5174`
 

--- a/frontend/monitor/dev-ports.ts
+++ b/frontend/monitor/dev-ports.ts
@@ -1,0 +1,18 @@
+import { execSync } from "child_process";
+
+import { resolveMonitorPorts } from "./src/monitor-ports";
+
+export function getWorktreePort(key: string, fallback: string): string {
+  try {
+    return execSync(`git config --worktree --get ${key}`, { encoding: "utf-8" }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+export function loadMonitorPorts() {
+  return resolveMonitorPorts({
+    env: process.env,
+    getWorktreePort,
+  });
+}

--- a/frontend/monitor/package.json
+++ b/frontend/monitor/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0 --port 5174",
+    "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "preview": "vite preview --host 127.0.0.1 --port 4174",
+    "preview": "vite preview",
     "test": "vitest"
   },
   "dependencies": {

--- a/frontend/monitor/src/monitor-ports.ts
+++ b/frontend/monitor/src/monitor-ports.ts
@@ -1,0 +1,22 @@
+type PortEnv = Partial<Record<"LEON_BACKEND_PORT" | "LEON_MONITOR_PORT" | "LEON_MONITOR_PREVIEW_PORT", string>>;
+
+type WorktreePortReader = (key: string, fallback: string) => string;
+
+type ResolveMonitorPortsOptions = {
+  env: PortEnv;
+  getWorktreePort: WorktreePortReader;
+};
+
+export function resolveMonitorPorts(options: ResolveMonitorPortsOptions) {
+  return {
+    backendPort: options.env.LEON_BACKEND_PORT || options.getWorktreePort("worktree.ports.backend", "8001"),
+    devPort: parseInt(
+      options.env.LEON_MONITOR_PORT || options.getWorktreePort("worktree.ports.monitor-frontend", "5174"),
+      10,
+    ),
+    previewPort: parseInt(
+      options.env.LEON_MONITOR_PREVIEW_PORT || options.getWorktreePort("worktree.ports.monitor-preview", "4174"),
+      10,
+    ),
+  };
+}

--- a/frontend/monitor/src/test/vite-port-config.test.ts
+++ b/frontend/monitor/src/test/vite-port-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMonitorPorts } from "../monitor-ports";
+
+describe("resolveMonitorPorts", () => {
+  it("prefers env vars over worktree config", () => {
+    const ports = resolveMonitorPorts({
+      env: {
+        LEON_BACKEND_PORT: "9012",
+        LEON_MONITOR_PORT: "5274",
+        LEON_MONITOR_PREVIEW_PORT: "4274",
+      },
+      getWorktreePort: (key, fallback) =>
+        (
+          {
+            "worktree.ports.backend": "8012",
+            "worktree.ports.monitor-frontend": "5178",
+            "worktree.ports.monitor-preview": "4178",
+          } as Record<string, string>
+        )[key] ?? fallback,
+    });
+
+    expect(ports).toEqual({
+      backendPort: "9012",
+      devPort: 5274,
+      previewPort: 4274,
+    });
+  });
+
+  it("uses worktree config when env vars are absent", () => {
+    const ports = resolveMonitorPorts({
+      env: {},
+      getWorktreePort: (key, fallback) =>
+        (
+          {
+            "worktree.ports.backend": "8012",
+            "worktree.ports.monitor-frontend": "5178",
+            "worktree.ports.monitor-preview": "4178",
+          } as Record<string, string>
+        )[key] ?? fallback,
+    });
+
+    expect(ports).toEqual({
+      backendPort: "8012",
+      devPort: 5178,
+      previewPort: 4178,
+    });
+  });
+
+  it("falls back to current monitor defaults", () => {
+    const ports = resolveMonitorPorts({
+      env: {},
+      getWorktreePort: (_key, fallback) => fallback,
+    });
+
+    expect(ports).toEqual({
+      backendPort: "8001",
+      devPort: 5174,
+      previewPort: 4174,
+    });
+  });
+});

--- a/frontend/monitor/vite.config.ts
+++ b/frontend/monitor/vite.config.ts
@@ -1,21 +1,26 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+import { loadMonitorPorts } from "./dev-ports";
+
+const { backendPort, devPort, previewPort } = loadMonitorPorts();
 
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5174,
+    host: "0.0.0.0",
+    port: devPort,
     strictPort: true,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8001",
+        target: `http://127.0.0.1:${backendPort}`,
         changeOrigin: true,
       },
     },
   },
   preview: {
-    port: 4174,
+    host: "127.0.0.1",
+    port: previewPort,
     strictPort: true,
   },
 });
-


### PR DESCRIPTION
## Summary
- align `frontend/monitor` Vite proxy/backend/dev/preview ports with env + worktree config instead of hardcoded `8001/5174/4174`
- add a narrow pure port-resolution test and remove package script port overrides so Vite config owns the contract
- update monitor local-dev docs/spec/plan to reflect the real keys and the loud-failure boundary

## Scope
- frontend/monitor only
- local-dev honesty only
- no backend/runtime/product behavior changes

## Test Plan
- [x] `cd frontend/monitor && npm test -- --run src/test/vite-port-config.test.ts`
- [x] `cd frontend/monitor && npm run build`

## Notes
- `git config` rejects underscore key names here, so the monitor-specific worktree keys are `worktree.ports.monitor-frontend` and `worktree.ports.monitor-preview`
- wrong configured ports still fail loudly; this PR does not auto-detect or heal bad config
