### PR TITLE
Realign monitor dashboard to current backend contract

### DIFF
--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -14,6 +14,31 @@ beforeEach(() => {
     new Response(
       JSON.stringify({
         snapshot_at: "2026-04-08T00:00:00Z",
+        resources_summary: {
+          running_sessions: 0,
+          active_providers: 0,
+          unavailable_providers: 0,
+        },
+        infra: {
+          providers_active: 0,
+          providers_unavailable: 0,
+          leases_total: 0,
+          leases_diverged: 0,
+          leases_orphan: 0,
+          leases_healthy: 0,
+        },
+        workload: {
+          db_sessions_total: 0,
+          provider_sessions_total: 0,
+          running_sessions: 0,
+          evaluations_running: 0,
+        },
+        latest_evaluation: {
+          status: "idle",
+          kind: "no_recorded_runs",
+          tone: "default",
+          headline: "No persisted evaluation runs are available yet.",
+        },
       }),
       {
         status: 200,
@@ -81,10 +106,30 @@ describe("MonitorRoutes", () => {
     mockRoutePayloads({
       "/dashboard": {
         snapshot_at: "2026-04-08T00:00:00Z",
-        summary: {
-          active_threads: 7,
-          active_leases: 3,
-          resources_ready: 4,
+        resources_summary: {
+          running_sessions: 4,
+          active_providers: 2,
+          unavailable_providers: 1,
+        },
+        infra: {
+          providers_active: 2,
+          providers_unavailable: 1,
+          leases_total: 3,
+          leases_diverged: 1,
+          leases_orphan: 0,
+          leases_healthy: 2,
+        },
+        workload: {
+          db_sessions_total: 7,
+          provider_sessions_total: 4,
+          running_sessions: 4,
+          evaluations_running: 1,
+        },
+        latest_evaluation: {
+          status: "running",
+          kind: "running_recorded",
+          tone: "warning",
+          headline: "Evaluation run is actively recording new metrics.",
         },
       },
     });
@@ -97,6 +142,11 @@ describe("MonitorRoutes", () => {
 
     expect(await screen.findByText("Runtime Surfaces")).toBeInTheDocument();
     expect(screen.getByText("Operator Attention")).toBeInTheDocument();
+    expect(screen.getByText("Running Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Evaluations Running")).toBeInTheDocument();
+    expect(screen.getByText("Tracked Leases")).toBeInTheDocument();
+    expect(screen.getByText("Latest Evaluation")).toBeInTheDocument();
+    expect(screen.getByText("Evaluation run is actively recording new metrics.")).toBeInTheDocument();
   });
 
   it("renders leases with a triage summary before the raw table", async () => {

--- a/frontend/monitor/src/pages/DashboardPage.tsx
+++ b/frontend/monitor/src/pages/DashboardPage.tsx
@@ -1,17 +1,34 @@
 import ErrorState from "../components/ErrorState";
 import { useMonitorData } from "../app/fetch";
 
+type DashboardPayload = {
+  snapshot_at: string;
+  infra: {
+    providers_active: number;
+    providers_unavailable: number;
+    leases_total: number;
+    leases_diverged: number;
+    leases_orphan: number;
+  };
+  workload: {
+    running_sessions: number;
+    evaluations_running: number;
+  };
+  latest_evaluation: {
+    headline: string;
+  };
+};
+
 export default function DashboardPage() {
-  const { data, error } = useMonitorData<any>("/dashboard");
+  const { data, error } = useMonitorData<DashboardPayload>("/dashboard");
 
   if (error) return <ErrorState title="Dashboard" error={error} />;
   if (!data) return <div>Loading...</div>;
 
-  const summary = data.summary ?? {};
   const surfaces = [
-    { label: "Active Threads", value: summary.active_threads ?? 0 },
-    { label: "Active Leases", value: summary.active_leases ?? 0 },
-    { label: "Resources Ready", value: summary.resources_ready ?? 0 },
+    { label: "Running Sessions", value: data.workload.running_sessions },
+    { label: "Evaluations Running", value: data.workload.evaluations_running },
+    { label: "Tracked Leases", value: data.infra.leases_total },
   ];
 
   return (
@@ -32,17 +49,22 @@ export default function DashboardPage() {
       <section className="surface-section">
         <h2>Operator Attention</h2>
         <div className="surface-grid">
-          <article className="surface-card" key="coverage">
-            <p className="surface-card__eyebrow">Coverage</p>
+          <article className="surface-card" key="providers">
+            <p className="surface-card__eyebrow">Provider Coverage</p>
             <p className="surface-card__body">
-              {summary.resources_ready ?? 0} resource surfaces reporting against {summary.active_leases ?? 0} active
-              leases.
+              {data.infra.providers_active} active providers, {data.infra.providers_unavailable} unavailable.
             </p>
           </article>
-          <article className="surface-card" key="focus">
-            <p className="surface-card__eyebrow">Immediate Focus</p>
+          <article className="surface-card" key="leases">
+            <p className="surface-card__eyebrow">Lease Drift</p>
             <p className="surface-card__body">
-              Check leases that drift away from running state before moving deeper into thread or resource drilldown.
+              {data.infra.leases_diverged} diverged leases, {data.infra.leases_orphan} orphan leases.
+            </p>
+          </article>
+          <article className="surface-card" key="evaluation">
+            <p className="surface-card__eyebrow">Latest Evaluation</p>
+            <p className="surface-card__body">
+              {data.latest_evaluation.headline}
             </p>
           </article>
         </div>


### PR DESCRIPTION
## Summary
- realign `frontend/monitor` dashboard consumption to the current `/api/monitor/dashboard` payload
- update the monitor route smoke test to assert the truthful backend shape instead of dead `summary.active_*` keys
- keep scope frontend-only: no backend, runtime, or product changes

## Verification
- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
- `cd frontend/monitor && npm run build`

## Boundary
- this PR does not try to resurrect old dashboard keys on the backend
- this PR does not address the stale local `8012` process mismatch; that remains a local runtime setup issue, not a code seam