### PR TITLE
Realign monitor leases to current backend contract

### DIFF
--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -152,11 +152,25 @@ describe("MonitorRoutes", () => {
   it("renders leases with a triage summary before the raw table", async () => {
     mockRoutePayloads({
       "/leases": {
-        title: "Leases",
+        title: "All Leases",
         count: 1,
+        summary: {
+          healthy: 1,
+          diverged: 0,
+          orphan: 0,
+          orphan_diverged: 0,
+          total: 1,
+        },
+        groups: [],
         triage: {
-          active: 1,
-          residue: 0,
+          summary: {
+            active_drift: 1,
+            detached_residue: 0,
+            orphan_cleanup: 0,
+            healthy_capacity: 0,
+            total: 1,
+          },
+          groups: [],
         },
         items: [
           {
@@ -188,6 +202,9 @@ describe("MonitorRoutes", () => {
     );
 
     expect(await screen.findByText("Lease Triage")).toBeInTheDocument();
+    expect(screen.getByText("Active Drift")).toBeInTheDocument();
+    expect(screen.getByText("Detached Residue")).toBeInTheDocument();
+    expect(screen.getByText("Tracked Leases")).toBeInTheDocument();
     expect(screen.getByText("Raw Lease Table")).toBeInTheDocument();
   });
 

--- a/frontend/monitor/src/pages/LeasesPage.tsx
+++ b/frontend/monitor/src/pages/LeasesPage.tsx
@@ -4,17 +4,44 @@ import ErrorState from "../components/ErrorState";
 import StateBadge from "../components/StateBadge";
 import { useMonitorData } from "../app/fetch";
 
+type LeasesPayload = {
+  title: string;
+  count: number;
+  triage?: {
+    summary?: {
+      active_drift?: number;
+      detached_residue?: number;
+      orphan_cleanup?: number;
+      healthy_capacity?: number;
+      total?: number;
+    };
+  };
+  items: Array<{
+    lease_id: string;
+    lease_url: string;
+    provider: string;
+    instance_id?: string | null;
+    thread: {
+      thread_id?: string | null;
+      thread_url?: string | null;
+    };
+    state_badge: Record<string, unknown>;
+    updated_ago?: string | null;
+    error?: string | null;
+  }>;
+};
+
 export default function LeasesPage() {
-  const { data, error } = useMonitorData<any>("/leases");
+  const { data, error } = useMonitorData<LeasesPayload>("/leases");
 
   if (error) return <ErrorState title="Leases" error={error} />;
   if (!data) return <div>Loading...</div>;
 
-  const triage = data.triage ?? {};
+  const triage = data.triage?.summary ?? {};
   const triageCards = [
-    { label: "Active", value: triage.active ?? 0 },
-    { label: "Residue", value: triage.residue ?? 0 },
-    { label: "Total", value: data.count ?? 0 },
+    { label: "Active Drift", value: triage.active_drift ?? 0 },
+    { label: "Detached Residue", value: triage.detached_residue ?? 0 },
+    { label: "Tracked Leases", value: triage.total ?? data.count ?? 0 },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- realign `frontend/monitor` leases consumption to the current `/api/monitor/leases` triage payload
- update the monitor route smoke test to assert `triage.summary` instead of dead top-level triage keys
- keep scope frontend-only: no backend, runtime, or product changes

## Verification
- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
- `cd frontend/monitor && npm run build`

## Boundary
- this PR does not change `/api/monitor/leases`
- this PR does not resurrect dead `triage.active` / `triage.residue` keys
- this PR is one bounded truthful-contract slice only