### PR TITLE
Fix: realign monitor evaluation surface

### DIFF
--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -386,19 +386,19 @@ describe("MonitorRoutes", () => {
   it("renders evaluation as a truthful operator surface", async () => {
     mockRoutePayloads({
       "/evaluation": {
-        status: "unavailable",
-        kind: "unavailable",
-        tone: "warning",
-        headline: "Evaluation operator truth is not wired in this runtime yet.",
-        summary: "Monitor can report that evaluation truth is unavailable without pretending nothing is happening.",
-        facts: [{ label: "Status", value: "unavailable" }],
+        status: "idle",
+        kind: "no_recorded_runs",
+        tone: "default",
+        headline: "No persisted evaluation runs are available yet.",
+        summary: "Evaluation storage is wired, but there are no recorded runs to report yet.",
+        facts: [{ label: "Status", value: "idle" }],
         artifacts: [],
         artifact_summary: {
           present: 0,
           missing: 0,
           total: 0,
         },
-        next_steps: ["Restore a truthful evaluation runtime source before reviving the monitor evaluation page."],
+        next_steps: ["Run an evaluation to populate the operator surface with persisted runtime truth."],
         raw_notes: null,
       },
     });
@@ -411,10 +411,11 @@ describe("MonitorRoutes", () => {
 
     expect(await screen.findByRole("heading", { name: "Evaluation" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /evaluation/i })).toHaveAttribute("aria-current", "page");
-    expect(screen.getByText("Evaluation operator truth is not wired in this runtime yet.")).toBeInTheDocument();
+    expect(screen.getByText("No persisted evaluation runs are available yet.")).toBeInTheDocument();
     expect(screen.getByText("Operator Facts")).toBeInTheDocument();
-    expect(screen.getByText("Artifact Coverage")).toBeInTheDocument();
     expect(screen.getByText("Next Steps")).toBeInTheDocument();
-    expect(screen.getByText("Restore a truthful evaluation runtime source before reviving the monitor evaluation page.")).toBeInTheDocument();
+    expect(screen.getByText("Run an evaluation to populate the operator surface with persisted runtime truth.")).toBeInTheDocument();
+    expect(screen.queryByText("Artifact Coverage")).not.toBeInTheDocument();
+    expect(screen.queryByText("Artifacts")).not.toBeInTheDocument();
   });
 });

--- a/frontend/monitor/src/pages/EvaluationPage.tsx
+++ b/frontend/monitor/src/pages/EvaluationPage.tsx
@@ -27,6 +27,7 @@ export default function EvaluationPage() {
   const artifacts = data.artifacts ?? [];
   const summary = data.artifact_summary ?? {};
   const nextSteps = data.next_steps ?? [];
+  const hasArtifactSignal = artifacts.length > 0 || (summary.total ?? 0) > 0;
 
   return (
     <div className="page">
@@ -49,23 +50,25 @@ export default function EvaluationPage() {
         <h2>Current Summary</h2>
         <p className="surface-card__body">{data.summary ?? "No evaluation summary available."}</p>
       </section>
-      <section className="surface-section">
-        <h2>Artifact Coverage</h2>
-        <div className="surface-grid">
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Present</p>
-            <p className="surface-card__value">{summary.present ?? 0}</p>
-          </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Missing</p>
-            <p className="surface-card__value">{summary.missing ?? 0}</p>
-          </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Total</p>
-            <p className="surface-card__value">{summary.total ?? 0}</p>
-          </article>
-        </div>
-      </section>
+      {hasArtifactSignal ? (
+        <section className="surface-section">
+          <h2>Artifact Coverage</h2>
+          <div className="surface-grid">
+            <article className="surface-card">
+              <p className="surface-card__eyebrow">Present</p>
+              <p className="surface-card__value">{summary.present ?? 0}</p>
+            </article>
+            <article className="surface-card">
+              <p className="surface-card__eyebrow">Missing</p>
+              <p className="surface-card__value">{summary.missing ?? 0}</p>
+            </article>
+            <article className="surface-card">
+              <p className="surface-card__eyebrow">Total</p>
+              <p className="surface-card__value">{summary.total ?? 0}</p>
+            </article>
+          </div>
+        </section>
+      ) : null}
       <section className="surface-section">
         <h2>Operator Facts</h2>
         <div className="info-grid">
@@ -77,33 +80,35 @@ export default function EvaluationPage() {
           ))}
         </div>
       </section>
-      <section className="surface-section">
-        <h2>Artifacts</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Label</th>
-              <th>Path</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {artifacts.length > 0 ? (
-              artifacts.map((artifact) => (
-                <tr key={`${artifact.label}-${artifact.path}`}>
-                  <td>{artifact.label ?? "-"}</td>
-                  <td className="mono">{artifact.path ?? "-"}</td>
-                  <td>{artifact.status ?? "-"}</td>
-                </tr>
-              ))
-            ) : (
+      {hasArtifactSignal ? (
+        <section className="surface-section">
+          <h2>Artifacts</h2>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={3}>No artifacts reported.</td>
+                <th>Label</th>
+                <th>Path</th>
+                <th>Status</th>
               </tr>
-            )}
-          </tbody>
-        </table>
-      </section>
+            </thead>
+            <tbody>
+              {artifacts.length > 0 ? (
+                artifacts.map((artifact) => (
+                  <tr key={`${artifact.label}-${artifact.path}`}>
+                    <td>{artifact.label ?? "-"}</td>
+                    <td className="mono">{artifact.path ?? "-"}</td>
+                    <td>{artifact.status ?? "-"}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={3}>No artifacts reported.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
       <section className="surface-section">
         <h2>Next Steps</h2>
         <ol className="surface-list">


### PR DESCRIPTION
## Summary
- realign evaluation route smoke to current persisted/no-runs monitor truth
- hide empty artifact sections when the evaluation payload carries no artifact signal
- keep the surface facts-first without backend changes

## Verification
- `cd frontend/monitor && npm test -- --run src/app/routes.test.tsx`
- `cd frontend/monitor && npm run build`

## Scope
- frontend/monitor only
- no backend, runtime, or product changes