### PR TITLE
fix: surface full monitor lease triage

### DIFF
--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -204,6 +204,8 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("Lease Triage")).toBeInTheDocument();
     expect(screen.getByText("Active Drift")).toBeInTheDocument();
     expect(screen.getByText("Detached Residue")).toBeInTheDocument();
+    expect(screen.getByText("Orphan Cleanup")).toBeInTheDocument();
+    expect(screen.getByText("Healthy Capacity")).toBeInTheDocument();
     expect(screen.getByText("Tracked Leases")).toBeInTheDocument();
     expect(screen.getByText("Raw Lease Table")).toBeInTheDocument();
   });

--- a/frontend/monitor/src/pages/LeasesPage.tsx
+++ b/frontend/monitor/src/pages/LeasesPage.tsx
@@ -41,6 +41,8 @@ export default function LeasesPage() {
   const triageCards = [
     { label: "Active Drift", value: triage.active_drift ?? 0 },
     { label: "Detached Residue", value: triage.detached_residue ?? 0 },
+    { label: "Orphan Cleanup", value: triage.orphan_cleanup ?? 0 },
+    { label: "Healthy Capacity", value: triage.healthy_capacity ?? 0 },
     { label: "Tracked Leases", value: triage.total ?? data.count ?? 0 },
   ];
 


### PR DESCRIPTION
## Summary
- surface the full monitor lease triage summary on the leases page
- add orphan cleanup and healthy capacity cards to match the current backend payload
- lock the truthful surface in monitor route smoke

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build