### PR TITLE
refactor: move visit chat summary ownership into messaging service

### DIFF
--- a/backend/web/routers/conversations.py
+++ b/backend/web/routers/conversations.py
@@ -22,27 +22,6 @@ def _is_internal_child_thread(thread_id: str) -> bool:
     return thread_id.startswith("subagent-")
 
 
-def _resolve_display_user(app: Any, social_user_id: str) -> Any | None:
-    user = app.state.user_repo.get_by_id(social_user_id)
-    if user is not None:
-        return user
-    thread = app.state.thread_repo.get_by_user_id(social_user_id)
-    if thread is None:
-        return None
-    agent_user_id = thread.get("agent_user_id")
-    if not agent_user_id:
-        return None
-    return app.state.user_repo.get_by_id(agent_user_id)
-
-
-def _display_name(user: Any) -> str | None:
-    return getattr(user, "display_name", None)
-
-
-def _display_avatar_url(user: Any) -> str | None:
-    return avatar_url(getattr(user, "id", None), bool(getattr(user, "avatar", None)))
-
-
 def _conversation_updated_at_key(item: dict[str, Any]) -> float:
     raw = item.get("updated_at")
     if raw is None:
@@ -98,71 +77,15 @@ async def list_conversations(
     messaging = getattr(app.state, "messaging_service", None)
     if messaging:
         chats = messaging.list_chats_for_user(user_id)
-        messages_repo = getattr(app.state, "messages_repo", None)
-
-        # Pre-fetch all member data to avoid N+1 per-member lookups
-        all_other_user_ids: set[str] = set()
-        chat_members_cache: dict[str, list[dict[str, Any]]] = {}
-        chat_obj_cache: dict[str, Any] = {}
-
-        chat_ids = [c["id"] if isinstance(c, dict) else c for c in chats]
-        for chat_id in chat_ids:
-            chat_obj = app.state.chat_repo.get_by_id(chat_id) if hasattr(app.state, "chat_repo") else None
-            if not chat_obj:
-                continue
-            chat_obj_cache[chat_id] = chat_obj
-            members_list = messaging.list_chat_members(chat_id)
-            chat_members_cache[chat_id] = members_list
-            for m in members_list:
-                uid = m.get("user_id")
-                if uid and uid != user_id:
-                    all_other_user_ids.add(uid)
-
-        # Batch resolve users so visit chats never reach back into template member shells.
-        user_cache: dict[str, Any] = {}
-        for uid in all_other_user_ids:
-            resolved_user = _resolve_display_user(app, uid)
-            if resolved_user:
-                user_cache[uid] = resolved_user
-
-        for chat_id in chat_ids:
-            chat_obj = chat_obj_cache.get(chat_id)
-            if not chat_obj:
-                continue
-            members_list = chat_members_cache[chat_id]
-
-            # Determine display name + avatar in single pass
-            title = getattr(chat_obj, "title", None) or ""
-            chat_avatar = None
-            other_names: list[str] = []
-            for m in members_list:
-                uid = m.get("user_id")
-                if not uid or uid == user_id:
-                    continue
-                resolved_user = user_cache.get(uid)
-                if not resolved_user:
-                    continue
-                display_name = _display_name(resolved_user)
-                if display_name:
-                    other_names.append(display_name)
-                if chat_avatar is None:
-                    chat_avatar = _display_avatar_url(resolved_user)
-            if not title:
-                title = ", ".join(other_names) or "Chat"
-
-            # Unread count
-            unread = 0
-            if messages_repo:
-                unread = messages_repo.count_unread(chat_id, user_id)
-
+        for chat in chats:
             items.append(
                 {
-                    "id": chat_id,
+                    "id": chat["id"],
                     "type": "visit",
-                    "title": title,
-                    "avatar_url": chat_avatar,
-                    "updated_at": getattr(chat_obj, "updated_at", None) or getattr(chat_obj, "created_at", None),
-                    "unread_count": unread,
+                    "title": chat.get("title") or "Chat",
+                    "avatar_url": chat.get("avatar_url"),
+                    "updated_at": chat.get("updated_at") or chat.get("created_at"),
+                    "unread_count": chat.get("unread_count", 0),
                     "running": False,
                 }
             )

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -294,6 +294,9 @@ class MessagingService:
                             "avatar_url": avatar_url(e.id, bool(e.avatar)),
                         }
                     )
+            other_entities = [entity for entity in entities_info if entity["id"] != user_id]
+            title = chat.title or ", ".join(entity["name"] for entity in other_entities) or "Chat"
+            chat_avatar_url = other_entities[0]["avatar_url"] if other_entities else None
             msgs = self._messages.list_by_chat(cid, limit=1)
             last_msg = None
             if msgs:
@@ -308,9 +311,11 @@ class MessagingService:
             result.append(
                 {
                     "id": cid,
-                    "title": chat.title,
+                    "title": title,
                     "status": chat.status,
                     "created_at": chat.created_at,
+                    "updated_at": getattr(chat, "updated_at", None) or getattr(chat, "created_at", None),
+                    "avatar_url": chat_avatar_url,
                     "entities": entities_info,
                     "last_message": last_msg,
                     "unread_count": unread,

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -295,7 +295,8 @@ class MessagingService:
                         }
                     )
             other_entities = [entity for entity in entities_info if entity["id"] != user_id]
-            title = chat.title or ", ".join(entity["name"] for entity in other_entities) or "Chat"
+            other_names = [entity["name"] for entity in other_entities if entity.get("name")]
+            title = chat.title or ", ".join(other_names) or "Chat"
             chat_avatar_url = other_entities[0]["avatar_url"] if other_entities else None
             msgs = self._messages.list_by_chat(cid, limit=1)
             last_msg = None

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -14,7 +14,9 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(
                 list_by_owner_user_id=lambda _user_id: [],
-                get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("visit rows should use messaging summary, not thread fallback")),
+                get_by_user_id=lambda _uid: (_ for _ in ()).throw(
+                    AssertionError("visit rows should use messaging summary, not thread fallback")
+                ),
             ),
             agent_pool={},
             thread_last_active={},
@@ -37,9 +39,15 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
                     }
                 ],
             ),
-            user_repo=SimpleNamespace(get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))),
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))),
-            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))),
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))
+            ),
+            chat_repo=SimpleNamespace(
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))
+            ),
+            messages_repo=SimpleNamespace(
+                count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))
+            ),
         )
     )
 
@@ -95,9 +103,15 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
                     }
                 ],
             ),
-            user_repo=SimpleNamespace(get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))),
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))),
-            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))),
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))
+            ),
+            chat_repo=SimpleNamespace(
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))
+            ),
+            messages_repo=SimpleNamespace(
+                count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))
+            ),
         )
     )
 
@@ -173,9 +187,15 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
                     }
                 ],
             ),
-            user_repo=SimpleNamespace(get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not resolve visit entities"))),
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))),
-            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))),
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not resolve visit entities"))
+            ),
+            chat_repo=SimpleNamespace(
+                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))
+            ),
+            messages_repo=SimpleNamespace(
+                count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))
+            ),
         )
     )
 

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -14,30 +14,32 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(
                 list_by_owner_user_id=lambda _user_id: [],
-                get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None,
+                get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("visit rows should use messaging summary, not thread fallback")),
             ),
             agent_pool={},
             thread_last_active={},
             messaging_service=SimpleNamespace(
-                list_chats_for_user=lambda _user_id: [{"id": "chat-1"}],
-                list_chat_members=lambda _chat_id: [
-                    {"user_id": "human-user-1"},
-                    {"user_id": "thread-user-1"},
+                list_chats_for_user=lambda _user_id: [
+                    {
+                        "id": "chat-1",
+                        "title": "Toad",
+                        "avatar_url": avatar_url("agent-user-1", False),
+                        "updated_at": "2026-04-07T00:00:00Z",
+                        "unread_count": 3,
+                        "entities": [
+                            {
+                                "id": "thread-user-1",
+                                "name": "Toad",
+                                "type": "agent",
+                                "avatar_url": avatar_url("agent-user-1", False),
+                            }
+                        ],
+                    }
                 ],
             ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda uid: (
-                    None
-                    if uid == "thread-user-1"
-                    else SimpleNamespace(id=uid, display_name="Toad", avatar=None)
-                    if uid == "agent-user-1"
-                    else None
-                ),
-            ),
-            chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: SimpleNamespace(id="chat-1", title=None, created_at="2026-04-07T00:00:00Z")
-            ),
-            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: 3),
+            user_repo=SimpleNamespace(get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))),
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))),
+            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))),
         )
     )
 
@@ -75,24 +77,27 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
             agent_pool={},
             thread_last_active={"thread-1": 1775540000.0},
             messaging_service=SimpleNamespace(
-                list_chats_for_user=lambda _user_id: [{"id": "chat-1"}],
-                list_chat_members=lambda _chat_id: [
-                    {"user_id": "human-user-1"},
-                    {"user_id": "member-agent-2"},
+                list_chats_for_user=lambda _user_id: [
+                    {
+                        "id": "chat-1",
+                        "title": "Toad",
+                        "avatar_url": avatar_url("member-agent-2", False),
+                        "updated_at": 1775540100.0,
+                        "unread_count": 0,
+                        "entities": [
+                            {
+                                "id": "member-agent-2",
+                                "name": "Toad",
+                                "type": "agent",
+                                "avatar_url": avatar_url("member-agent-2", False),
+                            }
+                        ],
+                    }
                 ],
             ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda uid: SimpleNamespace(id=uid, display_name="Toad", avatar=None) if uid == "member-agent-2" else None
-            ),
-            chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: SimpleNamespace(
-                    id="chat-1",
-                    title=None,
-                    created_at=1775540100.0,
-                    updated_at=1775540100.0,
-                )
-            ),
-            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: 0),
+            user_repo=SimpleNamespace(get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))),
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))),
+            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))),
         )
     )
 
@@ -145,26 +150,32 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(
                 list_by_owner_user_id=lambda _user_id: [],
-                get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None,
+                get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not bridge visit rows itself")),
             ),
             agent_pool={},
             thread_last_active={},
             messaging_service=SimpleNamespace(
-                list_chats_for_user=lambda _user_id: [{"id": "chat-1"}],
-                list_chat_members=lambda _chat_id: [
-                    {"user_id": "human-user-1"},
-                    {"user_id": "thread-user-1"},
+                list_chats_for_user=lambda _user_id: [
+                    {
+                        "id": "chat-1",
+                        "title": "Morel",
+                        "avatar_url": avatar_url("agent-user-1", True),
+                        "updated_at": "2026-04-07T00:00:00Z",
+                        "unread_count": 0,
+                        "entities": [
+                            {
+                                "id": "thread-user-1",
+                                "name": "Morel",
+                                "type": "agent",
+                                "avatar_url": avatar_url("agent-user-1", True),
+                            }
+                        ],
+                    }
                 ],
             ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda uid: (
-                    SimpleNamespace(id=uid, display_name="Morel", avatar="avatars/morel.png") if uid == "agent-user-1" else None
-                ),
-            ),
-            chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: SimpleNamespace(id="chat-1", title=None, created_at="2026-04-07T00:00:00Z")
-            ),
-            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: 0),
+            user_repo=SimpleNamespace(get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not resolve visit entities"))),
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("router should not rebuild chat summary"))),
+            messages_repo=SimpleNamespace(count_unread=lambda _chat_id, _user_id: (_ for _ in ()).throw(AssertionError("router should not recount unread"))),
         )
     )
 

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -386,6 +386,50 @@ def test_messaging_service_list_chats_exposes_thread_user_participant_id() -> No
     assert chats[0]["unread_count"] == 0
 
 
+def test_messaging_service_list_chats_ignores_blank_other_names_in_title_fallback() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            get_by_id=lambda chat_id: SimpleNamespace(id=chat_id, title=None, status="active", created_at="2026-04-07T00:00:00Z")
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members=lambda _chat_id: [
+                {"user_id": "human-user-1"},
+                {"user_id": "thread-user-blank"},
+                {"user_id": "thread-user-1"},
+            ],
+        ),
+        messages_repo=SimpleNamespace(list_by_chat=lambda _chat_id, limit=1: [], count_unread=lambda _chat_id, _user_id: 0),
+        message_read_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
+                if uid == "human-user-1"
+                else None
+                if uid in {"thread-user-blank", "thread-user-1"}
+                else SimpleNamespace(id=uid, display_name="", type="agent", avatar=None)
+                if uid == "agent-user-blank"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                if uid == "agent-user-1"
+                else None
+            )
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: (
+                {"id": "thread-blank", "agent_user_id": "agent-user-blank"}
+                if uid == "thread-user-blank"
+                else {"id": "thread-1", "agent_user_id": "agent-user-1"}
+                if uid == "thread-user-1"
+                else None
+            )
+        ),
+    )
+
+    chats = service.list_chats_for_user("human-user-1")
+
+    assert chats[0]["title"] == "Toad"
+
+
 def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_watermark() -> None:
     class _StatefulChatMemberRepo:
         def __init__(self) -> None:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -380,6 +380,10 @@ def test_messaging_service_list_chats_exposes_thread_user_participant_id() -> No
             "avatar_url": avatar_url("agent-user-1", False),
         },
     ]
+    assert chats[0]["title"] == "Toad"
+    assert chats[0]["avatar_url"] == avatar_url("agent-user-1", False)
+    assert chats[0]["updated_at"] == "2026-04-07T00:00:00Z"
+    assert chats[0]["unread_count"] == 0
 
 
 def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_watermark() -> None:


### PR DESCRIPTION
## Summary
- make MessagingService own visit-chat summary assembly for the conversations surface
- cut backend/web/routers/conversations.py over to consume the service summary instead of rebuilding it
- remove now-dead visit-chat display helper code from conversations.py

## Verification
- uv run pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_conversations_router.py -q
- python3 -m py_compile backend/web/routers/conversations.py messaging/service.py tests/Integration/test_conversations_router.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff check backend/web/routers/conversations.py messaging/service.py tests/Integration/test_conversations_router.py tests/Integration/test_messaging_social_handle_contract.py