### PR TITLE
fix: drop stale app thread route assumptions

### DIFF
--- a/frontend/app/src/hooks/use-thread-permissions.test.tsx
+++ b/frontend/app/src/hooks/use-thread-permissions.test.tsx
@@ -69,4 +69,19 @@ describe("useThreadPermissions", () => {
     expect(consoleError).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
+
+  it("does not treat removed /threads routes as active thread pages", async () => {
+    window.history.replaceState({}, "", "/threads/thread-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    getThreadPermissions.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    render(<Harness threadId="thread-1" />);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
 });

--- a/frontend/app/src/hooks/use-thread-permissions.ts
+++ b/frontend/app/src/hooks/use-thread-permissions.ts
@@ -33,7 +33,7 @@ export interface ThreadPermissionsActions {
 
 function isActiveThreadRoute(threadId: string): boolean {
   const path = window.location.pathname.replace(/\/+$/, "");
-  return (path.startsWith("/threads/") || path.startsWith("/chat/hire/")) && path.endsWith(`/${encodeURIComponent(threadId)}`);
+  return path.startsWith("/chat/hire/thread/") && path.endsWith(`/${encodeURIComponent(threadId)}`);
 }
 
 export function useThreadPermissions(threadId: string | undefined): ThreadPermissionsState & ThreadPermissionsActions {

--- a/frontend/app/src/pages/ChatPage.tsx
+++ b/frontend/app/src/pages/ChatPage.tsx
@@ -42,7 +42,7 @@ function isAskUserQuestionRequest(
 
 /** Thin wrapper: key={threadId} forces remount → all hook state resets naturally. */
 export default function ChatPage() {
-  const { threadId } = useParams<{ memberId: string; threadId: string }>();
+  const { threadId } = useParams<{ threadId: string }>();
   if (!threadId) return null;
   return <ChatPageInner key={threadId} threadId={threadId} />;
 }

--- a/frontend/app/src/pages/RootLayout.tsx
+++ b/frontend/app/src/pages/RootLayout.tsx
@@ -187,7 +187,7 @@ function AuthenticatedLayout() {
         <main className="flex-1 overflow-hidden">
           {/* @@@outlet-no-route-key - thread switches should not remount the entire
               outlet tree; RootLayout route keys were re-triggering AppLayout
-              bootstrap fetches on every /threads/:memberId/:threadId hop. */}
+              bootstrap fetches on every /chat/hire/thread/:threadId hop. */}
           <div className="h-full animate-page-in"><Outlet /></div>
         </main>
 


### PR DESCRIPTION
## Summary
- stop treating removed /threads/:threadId paths as active chat thread routes
- align the remaining app thread route references with /chat/hire/thread/:threadId
- lock the regression in use-thread-permissions tests

## Verification
- cd frontend/app && npm test -- src/hooks/use-thread-permissions.test.tsx
- cd frontend/app && npm run build