### PR TITLE
fix: keep agent registry on public schema

### DIFF
--- a/storage/container.py
+++ b/storage/container.py
@@ -120,7 +120,9 @@ class StorageContainer:
         return self._build("cron_job_repo")
 
     def agent_registry_repo(self) -> AgentRegistryRepo:
-        return self._build("agent_registry_repo")
+        # @@@agent-registry-public-schema - agent_registry is still a public-schema
+        # island, so subagent persistence must not silently inherit staging.
+        return self._build("agent_registry_repo", client=self._public_supabase_client)
 
     def tool_task_repo(self) -> ToolTaskRepo:
         return self._build("tool_task_repo")

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -76,6 +76,7 @@ def build_agent_registry_repo(
     return build_storage_container(
         supabase_client=supabase_client,
         supabase_client_factory=supabase_client_factory,
+        public_supabase_client_factory="backend.web.core.supabase_factory:create_public_supabase_client",
         **kwargs,
     ).agent_registry_repo()
 

--- a/tests/Integration/test_storage_repo_abstraction_unification.py
+++ b/tests/Integration/test_storage_repo_abstraction_unification.py
@@ -349,6 +349,34 @@ def test_make_panel_task_repo_uses_public_supabase_factory(monkeypatch: pytest.M
         repo.close()
 
 
+def test_storage_container_routes_agent_registry_repo_through_public_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeAgentRegistryRepo:
+        def __init__(self, client: object) -> None:
+            captured["client"] = client
+
+        def close(self) -> None:
+            return None
+
+    public_client = object()
+    private_client = object()
+    monkeypatch.setattr(
+        "storage.providers.supabase.agent_registry_repo.SupabaseAgentRegistryRepo",
+        _FakeAgentRegistryRepo,
+    )
+
+    repo = StorageContainer(
+        supabase_client=private_client,
+        public_supabase_client=public_client,
+    ).agent_registry_repo()
+    try:
+        assert isinstance(repo, _FakeAgentRegistryRepo)
+        assert captured["client"] is public_client
+    finally:
+        repo.close()
+
+
 @pytest.mark.asyncio
 async def test_lifespan_wires_user_and_thread_repos_from_storage_container(
     monkeypatch: pytest.MonkeyPatch,
@@ -481,5 +509,24 @@ def test_build_sync_file_repo_defaults_to_public_supabase_factory(monkeypatch: p
     monkeypatch.setattr("storage.runtime.build_storage_container", _fake_build_storage_container)
 
     storage_runtime.build_sync_file_repo()
+
+    assert recorded["public_supabase_client_factory"] == "backend.web.core.supabase_factory:create_public_supabase_client"
+
+
+def test_build_agent_registry_repo_defaults_to_public_supabase_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, object] = {}
+
+    class _FakeRuntimeContainer:
+        def agent_registry_repo(self) -> object:
+            return object()
+
+    def _fake_build_storage_container(**kwargs: object) -> _FakeRuntimeContainer:
+        recorded.update(kwargs)
+        return _FakeRuntimeContainer()
+
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setattr("storage.runtime.build_storage_container", _fake_build_storage_container)
+
+    storage_runtime.build_agent_registry_repo()
 
     assert recorded["public_supabase_client_factory"] == "backend.web.core.supabase_factory:create_public_supabase_client"


### PR DESCRIPTION
## Summary
- route `agent_registry_repo` through the public Supabase client instead of inheriting runtime `staging`
- lock the residual-island contract with storage/runtime + storage/container tests
- keep this cut backend-only and separate from the Daytona host-to-remote sync seam

## Test Plan
- `uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py -k "agent_registry_repo_through_public_client or build_agent_registry_repo_defaults_to_public_supabase_factory"`
- `uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py tests/Integration/test_leon_agent.py -k "agent_registry or runtime_services_default_to_storage_runtime_container or storage_container_exposes_bypass_repo_builders"`
- live backend proof on `18011`: local thread `m_dKjuBBLbR1bw-10` now shows `tool_result Agent` returning `SUBAGENT_TOOL_PROBE_FIX_1775643722` instead of `staging.agent_registry` schema-cache failure
