### PR TITLE
fix: suppress stale thread data route noise

### DIFF
--- a/frontend/app/src/hooks/use-thread-data.test.tsx
+++ b/frontend/app/src/hooks/use-thread-data.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useThreadData } from "./use-thread-data";
+
+const { getThread } = vi.hoisted(() => ({
+  getThread: vi.fn(),
+}));
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    getThread,
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+function Harness({ threadId }: { threadId?: string }) {
+  const state = useThreadData(threadId);
+  useEffect(() => {
+    void state.loading;
+  }, [state.loading]);
+  return null;
+}
+
+describe("useThreadData", () => {
+  it("does not log a failed fetch once navigation already left the thread route", async () => {
+    window.history.replaceState({}, "", "/chat/hire/thread/thread-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    getThread.mockImplementation(async () => {
+      window.history.replaceState({}, "", "/resources");
+      throw new TypeError("Failed to fetch");
+    });
+
+    render(<Harness threadId="thread-1" />);
+
+    await waitFor(() => {
+      expect(getThread).toHaveBeenCalledWith("thread-1");
+    });
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/app/src/hooks/use-thread-data.ts
+++ b/frontend/app/src/hooks/use-thread-data.ts
@@ -23,6 +23,11 @@ export interface ThreadDataActions {
 
 const threadDetailInflight = new Map<string, Promise<ThreadDetail>>();
 
+function isActiveThreadRoute(threadId: string): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path.startsWith("/chat/hire/thread/") && path.endsWith(`/${encodeURIComponent(threadId)}`);
+}
+
 function loadThreadDetail(threadId: string): Promise<ThreadDetail> {
   const existing = threadDetailInflight.get(threadId);
   if (existing) return existing;
@@ -49,6 +54,10 @@ export function useThreadData(threadId: string | undefined, skipInitialLoad = fa
       const sandbox = thread.sandbox;
       setActiveSandbox(sandbox);
     } catch (err) {
+      // @@@thread-route-teardown - browser navigation can leave an abandoned
+      // thread fetch resolving after the chat page already moved elsewhere.
+      // Only log if this thread page is still the active route.
+      if (!isActiveThreadRoute(id)) return;
       console.error("[useThreadData] Failed to load thread:", err);
     } finally {
       if (!silent) setLoading(false);


### PR DESCRIPTION
## Summary
- suppress stale useThreadData fetch noise after navigation leaves the live thread route
- lock the route-noise regression with a dedicated hook test
- keep the change frontend-only and limited to app thread data loading

## Verification
- cd frontend/app && npm test -- src/hooks/use-thread-data.test.tsx
- cd frontend/app && npm run build