### PR TITLE
fix: suppress stale background task route noise

### DIFF
--- a/frontend/app/src/hooks/use-background-tasks.test.tsx
+++ b/frontend/app/src/hooks/use-background-tasks.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useBackgroundTasks } from "./use-background-tasks";
+import type { UseThreadStreamResult } from "./use-thread-stream";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+function Harness() {
+  const subscribe: UseThreadStreamResult["subscribe"] = () => () => {};
+  useBackgroundTasks({ threadId: "thread-1", subscribe });
+  return null;
+}
+
+describe("useBackgroundTasks", () => {
+  it("does not log a failed task fetch once navigation already left the thread route", async () => {
+    window.history.replaceState({}, "", "/chat/hire/thread/thread-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/resources");
+      throw new TypeError("Failed to fetch");
+    });
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/threads/thread-1/tasks");
+    });
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/hooks/use-background-tasks.ts
+++ b/frontend/app/src/hooks/use-background-tasks.ts
@@ -19,6 +19,11 @@ interface UseBackgroundTasksProps {
 
 const threadTasksInflight = new Map<string, Promise<BackgroundTask[]>>();
 
+function isActiveThreadRoute(threadId: string): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path.startsWith("/chat/hire/thread/") && path.endsWith(`/${encodeURIComponent(threadId)}`);
+}
+
 function loadThreadTasks(threadId: string): Promise<BackgroundTask[]> {
   const existing = threadTasksInflight.get(threadId);
   if (existing) return existing;
@@ -48,6 +53,10 @@ export function useBackgroundTasks({ threadId, subscribe }: UseBackgroundTasksPr
       const data = await loadThreadTasks(threadId);
       setTasks(data);
     } catch (err) {
+      // @@@background-tasks-route-teardown - browser navigation can leave the
+      // old thread task fetch resolving after the chat page already moved to a
+      // different route. Only log if this thread page is still active.
+      if (!isActiveThreadRoute(threadId)) return;
       console.error('[BackgroundTasks] Error fetching tasks:', err);
     }
   }, [threadId]);


### PR DESCRIPTION
## Summary
- suppress stale useBackgroundTasks fetch noise after navigation leaves the live thread route
- lock the regression with a dedicated hook test
- keep the change frontend-only and limited to app background task loading

## Verification
- cd frontend/app && npm test -- src/hooks/use-background-tasks.test.tsx
- cd frontend/app && npm run build