### PR TITLE
fix: suppress stale conversation route noise

### DIFF
--- a/frontend/app/src/store/conversation-store.test.ts
+++ b/frontend/app/src/store/conversation-store.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { authFetch } = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("./auth-store", () => ({
+  authFetch,
+}));
+
+afterEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  window.history.replaceState({}, "", "/");
+  const { useConversationStore } = await import("./conversation-store");
+  useConversationStore.setState({ conversations: [], loading: false });
+});
+
+describe("useConversationStore", () => {
+  it("does not log a failed fetch once navigation already left the chat route", async () => {
+    window.history.replaceState({}, "", "/chat");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    authFetch.mockImplementation(async () => {
+      window.history.replaceState({}, "", "/settings");
+      throw new TypeError("Failed to fetch");
+    });
+
+    const { useConversationStore } = await import("./conversation-store");
+
+    await useConversationStore.getState().fetchConversations();
+
+    expect(authFetch).toHaveBeenCalledWith("/api/conversations");
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/store/conversation-store.ts
+++ b/frontend/app/src/store/conversation-store.ts
@@ -10,6 +10,11 @@ interface ConversationState {
 
 let inflight: Promise<void> | null = null;
 
+function isActiveChatRoute(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path === "/chat" || path.startsWith("/chat/");
+}
+
 export const useConversationStore = create<ConversationState>((set, get) => ({
   conversations: [],
   loading: false,
@@ -28,6 +33,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
           set({ conversations: data });
         }
       } catch (err) {
+        // @@@conversation-route-teardown - chat sidebar polling can resolve
+        // after the user has already left /chat. Only log if chat is still the
+        // active route, otherwise this is stale noise.
+        if (!isActiveChatRoute()) return;
         console.error("[ConversationStore] fetch failed:", err);
       } finally {
         inflight = null;


### PR DESCRIPTION
## Summary
- suppress stale conversation sidebar fetch noise after navigation leaves /chat
- lock the regression with a dedicated conversation-store test
- keep the change frontend-only and limited to chat sidebar polling truthfulness

## Verification
- cd frontend/app && npm test -- src/store/conversation-store.test.ts
- cd frontend/app && npm run build