### PR TITLE
fix: suppress stale marketplace detail route noise

### DIFF
--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -39,4 +39,20 @@ describe("useMarketplaceStore", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(consoleError).not.toHaveBeenCalled();
   });
+
+  it("does not log a failed detail fetch once navigation already left the marketplace detail route", async () => {
+    window.history.replaceState({}, "", "/marketplace/item-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().fetchDetail("item-1");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -97,6 +97,11 @@ function isActiveMarketplaceRoute(): boolean {
   return path === "/marketplace" || path.startsWith("/marketplace/");
 }
 
+function isActiveMarketplaceDetailRoute(itemId: string): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path === `/marketplace/${encodeURIComponent(itemId)}`;
+}
+
 async function hubApi<T = any>(path: string): Promise<T> {
   try {
     const res = await fetch(`${HUB_URL}/api/v1${path}`);
@@ -168,6 +173,10 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       const data = await hubApi<MarketplaceItemDetail>(`/items/${id}`);
       set({ detail: data });
     } catch (e) {
+      // @@@marketplace-detail-route-teardown - detail fetches can resolve after
+      // the user already left this marketplace detail page. Only log if this
+      // item route is still active; otherwise this is stale UI noise.
+      if (!isActiveMarketplaceDetailRoute(id)) return;
       console.error("Failed to fetch detail:", e);
       set({ error: e instanceof Error ? e.message : "Unknown error" });
     } finally {


### PR DESCRIPTION
## Summary
- suppress stale marketplace detail fetch noise after navigation leaves /marketplace/:id
- extend marketplace-store regression coverage for detail route teardown
- keep the change frontend-only and limited to marketplace detail truthfulness

## Verification
- cd frontend/app && npm test -- src/store/marketplace-store.test.ts
- cd frontend/app && npm run build