### PR TITLE
fix: suppress stale marketplace lineage route noise

### DIFF
--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -55,4 +55,20 @@ describe("useMarketplaceStore", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(consoleError).not.toHaveBeenCalled();
   });
+
+  it("does not log a failed lineage fetch once navigation already left the marketplace detail route", async () => {
+    window.history.replaceState({}, "", "/marketplace/item-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().fetchLineage("item-1");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -211,6 +211,10 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       const data = await hubApi<{ ancestors: LineageNode[]; children: LineageNode[] }>(`/items/${id}/lineage`);
       set({ lineage: data });
     } catch (e) {
+      // @@@marketplace-lineage-route-teardown - lineage fetches can resolve
+      // after the user already left this marketplace detail page. Only log if
+      // this item route is still active; otherwise this is stale UI noise.
+      if (!isActiveMarketplaceDetailRoute(id)) return;
       console.error("Failed to fetch lineage:", e);
       set({ error: e instanceof Error ? e.message : "Unknown error" });
     }


### PR DESCRIPTION
## Summary
- suppress stale marketplace lineage fetch noise after navigation leaves /marketplace/:id
- extend marketplace-store regression coverage for lineage route teardown
- keep the change frontend-only and limited to marketplace detail truthfulness

## Verification
- cd frontend/app && npm test -- src/store/marketplace-store.test.ts
- cd frontend/app && npm run build