### PR TITLE
fix: suppress stale marketplace snapshot route noise

### DIFF
--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -71,4 +71,20 @@ describe("useMarketplaceStore", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(consoleError).not.toHaveBeenCalled();
   });
+
+  it("does not log a failed snapshot fetch once navigation already left the marketplace detail route", async () => {
+    window.history.replaceState({}, "", "/marketplace/item-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().fetchVersionSnapshot("item-1", "1.0.0");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -195,6 +195,10 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       const data = await hubApi<{ snapshot: any }>(`/items/${itemId}/versions/${version}`);
       set({ versionSnapshot: data.snapshot ?? null });
     } catch (e) {
+      // @@@marketplace-snapshot-route-teardown - snapshot fetches can resolve
+      // after the user already left this marketplace detail page. Only log if
+      // this item route is still active; otherwise this is stale UI noise.
+      if (!isActiveMarketplaceDetailRoute(itemId)) return;
       console.error("Failed to fetch snapshot:", e);
     } finally {
       set({ snapshotLoading: false });


### PR DESCRIPTION
## Summary
- suppress stale marketplace snapshot fetch noise after navigation leaves `/marketplace/:id`
- extend marketplace-store regression coverage for snapshot route teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/store/marketplace-store.test.ts
- cd frontend/app && npm run build