### PR TITLE
fix: suppress stale marketplace updates route noise

### DIFF
--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -87,4 +87,22 @@ describe("useMarketplaceStore", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(consoleError).not.toHaveBeenCalled();
   });
+
+  it("does not log a failed update check once navigation already left the marketplace route", async () => {
+    window.history.replaceState({}, "", "/marketplace?tab=installed");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().checkUpdates([
+      { marketplace_item_id: "item-1", installed_version: "1.0.0" },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -235,6 +235,10 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       });
       set({ updates: data.updates || [] });
     } catch (e) {
+      // @@@marketplace-updates-route-teardown - installed update checks can
+      // resolve after the user already left /marketplace. Only log if the
+      // marketplace route is still active; otherwise this is stale UI noise.
+      if (!isActiveMarketplaceRoute()) return;
       console.error("Failed to check updates:", e);
       set({ error: e instanceof Error ? e.message : "Unknown error" });
     }


### PR DESCRIPTION
## Summary
- suppress stale marketplace update-check noise after navigation leaves `/marketplace`
- extend marketplace-store regression coverage for installed-surface teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/store/marketplace-store.test.ts
- cd frontend/app && npm run build