### PR TITLE
refactor: move chat detail ownership into messaging service

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -15,7 +15,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
-from backend.web.utils.serializers import avatar_url
 from messaging.display_user import resolve_messaging_display_user
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -171,29 +170,7 @@ async def get_chat(
     app: Annotated[Any, Depends(get_app)],
 ):
     chat = _get_accessible_chat_or_404(app, chat_id, user_id)
-    members_list = _messaging(app).list_chat_members(chat_id)
-    members_info = []
-    for m in members_list:
-        uid = m.get("user_id")
-        if not uid:
-            continue
-        mem = _resolve_display_user(app, uid)
-        if mem:
-            members_info.append(
-                {
-                    "id": uid,
-                    "name": mem.display_name,
-                    "type": mem.type.value if hasattr(mem.type, "value") else str(mem.type),
-                    "avatar_url": avatar_url(mem.id, bool(mem.avatar)),
-                }
-            )
-    return {
-        "id": chat.id,
-        "title": chat.title,
-        "status": chat.status,
-        "created_at": chat.created_at,
-        "entities": members_info,
-    }
+    return _messaging(app).get_chat_detail(chat)
 
 
 # ---------------------------------------------------------------------------

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -63,6 +63,25 @@ class MessagingService:
             social_user_id=social_user_id,
         )
 
+    def _build_chat_entities(self, chat_id: str) -> list[dict[str, Any]]:
+        entities_info = []
+        for member in self._members_repo.list_members(chat_id):
+            social_user_id = member.get("user_id")
+            entity = self._resolve_display_user(social_user_id) if social_user_id else None
+            if entity is None:
+                continue
+            # @@@thread-social-entity-projection - outward chat entities must keep the
+            # social/thread user id while borrowing display/avatar fields from the resolved user row.
+            entities_info.append(
+                {
+                    "id": social_user_id,
+                    "name": entity.display_name,
+                    "type": entity.type.value if hasattr(entity.type, "value") else str(entity.type),
+                    "avatar_url": avatar_url(entity.id, bool(entity.avatar)),
+                }
+            )
+        return entities_info
+
     def set_delivery_fn(self, fn: Callable) -> None:
         self._delivery_fn = fn
 
@@ -272,6 +291,15 @@ class MessagingService:
     def update_mute(self, chat_id: str, user_id: str, muted: bool, mute_until: str | None) -> None:
         self._members_repo.update_mute(chat_id, user_id, muted, mute_until)
 
+    def get_chat_detail(self, chat: Any) -> dict[str, Any]:
+        return {
+            "id": chat.id,
+            "title": chat.title,
+            "status": chat.status,
+            "created_at": chat.created_at,
+            "entities": self._build_chat_entities(chat.id),
+        }
+
     def list_chats_for_user(self, user_id: str) -> list[dict[str, Any]]:
         """List all active chats for user with summary info."""
         chat_ids = self._members_repo.list_chats_for_user(user_id)
@@ -280,20 +308,7 @@ class MessagingService:
             chat = self._chats.get_by_id(cid)
             if not chat or chat.status != "active":
                 continue
-            members = self._members_repo.list_members(cid)
-            entities_info = []
-            for m in members:
-                uid = m.get("user_id")
-                e = self._resolve_display_user(uid) if uid else None
-                if e:
-                    entities_info.append(
-                        {
-                            "id": uid,
-                            "name": e.display_name,
-                            "type": e.type,
-                            "avatar_url": avatar_url(e.id, bool(e.avatar)),
-                        }
-                    )
+            entities_info = self._build_chat_entities(cid)
             other_entities = [entity for entity in entities_info if entity["id"] != user_id]
             other_names = [entity["name"] for entity in other_entities if entity.get("name")]
             title = chat.title or ", ".join(other_names) or "Chat"

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -111,7 +111,18 @@ async def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
             chat_repo=SimpleNamespace(
                 get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("route should use helper, not chat_repo lookup directly"))
             ),
-            messaging_service=SimpleNamespace(list_chat_members=lambda _chat_id: []),
+            messaging_service=SimpleNamespace(
+                get_chat_detail=lambda chat_obj: {
+                    "id": chat_obj.id,
+                    "title": chat_obj.title,
+                    "status": chat_obj.status,
+                    "created_at": chat_obj.created_at,
+                    "entities": [],
+                },
+                list_chat_members=lambda _chat_id: (_ for _ in ()).throw(
+                    AssertionError("route should consume service-owned chat detail, not rebuild members locally")
+                ),
+            ),
             user_repo=SimpleNamespace(get_by_id=lambda _user_id: None),
         )
     )
@@ -166,10 +177,20 @@ async def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeyp
     app = SimpleNamespace(
         state=SimpleNamespace(
             messaging_service=SimpleNamespace(
-                list_chat_members=lambda _chat_id: [
-                    {"user_id": "human-user-1"},
-                    {"user_id": "thread-user-1"},
-                ]
+                get_chat_detail=lambda _chat: {
+                    "id": "chat-1",
+                    "title": "Chat title",
+                    "status": "active",
+                    "created_at": "2026-04-07T00:00:00Z",
+                    "entities": [
+                        {
+                            "id": "thread-user-1",
+                            "name": "Toad",
+                            "type": "agent",
+                            "avatar_url": avatar_url("agent-user-1", False),
+                        }
+                    ],
+                }
             ),
             user_repo=SimpleNamespace(
                 get_by_id=lambda uid: (

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -430,6 +430,61 @@ def test_messaging_service_list_chats_ignores_blank_other_names_in_title_fallbac
     assert chats[0]["title"] == "Toad"
 
 
+def test_messaging_service_get_chat_detail_exposes_thread_user_participant_id() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [{"user_id": "human-user-1"}, {"user_id": "thread-user-1"}],
+        ),
+        messages_repo=SimpleNamespace(),
+        message_read_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
+                if uid == "human-user-1"
+                else None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                if uid == "agent-user-1"
+                else None
+            )
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+    )
+
+    detail = service.get_chat_detail(
+        SimpleNamespace(
+            id="chat-1",
+            title="Chat title",
+            status="active",
+            created_at="2026-04-07T00:00:00Z",
+        )
+    )
+
+    assert detail == {
+        "id": "chat-1",
+        "title": "Chat title",
+        "status": "active",
+        "created_at": "2026-04-07T00:00:00Z",
+        "entities": [
+            {
+                "id": "human-user-1",
+                "name": "Human",
+                "type": "human",
+                "avatar_url": avatar_url("human-user-1", False),
+            },
+            {
+                "id": "thread-user-1",
+                "name": "Toad",
+                "type": "agent",
+                "avatar_url": avatar_url("agent-user-1", False),
+            },
+        ],
+    }
+
+
 def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_watermark() -> None:
     class _StatefulChatMemberRepo:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- move `/api/chats/{chat_id}` detail projection ownership behind `MessagingService`
- keep `ChatDetail` outward keys stable while reusing service-owned entity assembly
- cover the cut with router and service integration proofs

## Verification
- `uv run pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py -q`
- `python3 -m py_compile backend/web/routers/messaging.py messaging/service.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff check backend/web/routers/messaging.py messaging/service.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff format --check backend/web/routers/messaging.py messaging/service.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`