### PR TITLE
fix: suppress stale settings route noise

### DIFF
--- a/frontend/app/src/pages/SettingsPage.test.tsx
+++ b/frontend/app/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import SettingsPage from "./SettingsPage";
+
+vi.mock("../hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("../components/ModelMappingSection", () => ({ default: () => null }));
+vi.mock("../components/ModelPoolSection", () => ({ default: () => null }));
+vi.mock("../components/ObservationSection", () => ({ default: () => null }));
+vi.mock("../components/ProvidersSection", () => ({ default: () => null }));
+vi.mock("../components/SandboxSection", () => ({ default: () => null }));
+vi.mock("../components/WorkspaceSection", () => ({ default: () => null }));
+
+vi.mock("@/api/client", () => ({
+  fetchInviteCodes: vi.fn(),
+  generateInviteCode: vi.fn(),
+  revokeInviteCode: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("SettingsPage", () => {
+  it("does not log a failed settings load once navigation already left /settings", async () => {
+    window.history.replaceState({}, "", "/settings");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.pushState({}, "", "/chat");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      throw new TypeError("Failed to fetch");
+    });
+
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/chat" element={<div>chat-page</div>} />
+        </Routes>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/pages/SettingsPage.tsx
+++ b/frontend/app/src/pages/SettingsPage.tsx
@@ -46,6 +46,11 @@ const TABS: { id: Tab; label: string; icon: typeof Cpu; desc: string }[] = [
   { id: "invite", label: "邀请码", icon: Ticket, desc: "管理注册邀请码" },
 ];
 
+function isActiveSettingsRoute(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path === "/settings";
+}
+
 function formatInviteDate(dateStr?: string | null): string {
   if (!dateStr) return "—";
   const d = new Date(dateStr);
@@ -306,6 +311,10 @@ export default function SettingsPage() {
       setSandboxes(sandboxesData.sandboxes || {});
       setObservationConfig(observationData);
     } catch (err) {
+      // @@@settings-route-teardown - settings bootstrap requests can finish
+      // after navigation already left /settings. Only surface failures while
+      // this route is still active; otherwise this is stale UI noise.
+      if (!isActiveSettingsRoute()) return;
       console.error("Failed to load settings:", err);
       setError(err instanceof Error ? err.message : "加载设置失败");
     } finally {


### PR DESCRIPTION
## Summary
- suppress stale SettingsPage load noise after navigation leaves `/settings`
- add a dedicated page-level regression test for the settings route teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/pages/SettingsPage.test.tsx
- cd frontend/app && npm run build