### PR TITLE
fix: suppress stale workspace settings route noise

### DIFF
--- a/frontend/app/src/hooks/use-workspace-settings.test.tsx
+++ b/frontend/app/src/hooks/use-workspace-settings.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useWorkspaceSettings } from "./use-workspace-settings";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("useWorkspaceSettings", () => {
+  it("does not log a failed settings load once navigation already left /chat/hire", async () => {
+    window.history.replaceState({}, "", "/chat/hire/agent-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    renderHook(() => useWorkspaceSettings());
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/hooks/use-workspace-settings.ts
+++ b/frontend/app/src/hooks/use-workspace-settings.ts
@@ -7,6 +7,11 @@ interface UserSettings {
   enabled_models: string[];
 }
 
+function isActiveNewChatRoute(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path.startsWith("/chat/hire");
+}
+
 export function useWorkspaceSettings() {
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [loading, setLoading] = useState(true);
@@ -20,6 +25,10 @@ export function useWorkspaceSettings() {
       }
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
+      // @@@workspace-settings-route-teardown - this hook currently powers the
+      // new-chat hire flow. If navigation already left /chat/hire, a failed
+      // settings load is stale UI noise and should not be surfaced.
+      if (!isActiveNewChatRoute()) return;
       console.error("Failed to load settings:", err);
     } finally {
       if (!signal?.aborted) {


### PR DESCRIPTION
## Summary
- suppress stale workspace settings load noise after navigation leaves `/chat/hire`
- add a dedicated hook regression test for the new-chat hire teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/hooks/use-workspace-settings.test.tsx
- cd frontend/app && npm run build