### PR TITLE
fix: keep daytona runtime state in canonical storage

### DIFF
--- a/backend/web/services/activity_tracker.py
+++ b/backend/web/services/activity_tracker.py
@@ -4,7 +4,8 @@ Decouples activity sources (file uploads, API calls) from session management.
 """
 
 import logging
-from datetime import datetime
+
+from sandbox.clock import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def track_thread_activity(thread_id: str, activity_type: str = "activity") -> No
     """
     from backend.web.core.storage_factory import make_chat_session_repo
 
-    now = datetime.now().isoformat()
+    now = utc_now_iso()
     repo = make_chat_session_repo()
     try:
         repo.touch_thread_activity(thread_id, now)

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -145,7 +145,7 @@ class _CommandWrapper(BaseExecutor):
             raise RuntimeError(f"Terminal {terminal_id} not found")
         from sandbox.terminal import terminal_from_row
 
-        terminal = terminal_from_row(terminal_row, self._manager.terminal_store.db_path)
+        terminal = terminal_from_row(terminal_row, self._manager.db_path)
         if terminal.thread_id != self._session.thread_id:
             raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal.thread_id}, not {self._session.thread_id}")
         lease = self._manager.get_lease(terminal.lease_id)

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
 from sandbox.lifecycle import (
     ChatSessionState,
     assert_chat_session_transition,
@@ -105,13 +106,13 @@ class ChatSession:
         self._session_repo = session_repo
 
     def is_expired(self) -> bool:
-        now = datetime.now()
+        now = utc_now()
         idle_seconds = (now - self.last_active_at).total_seconds()
         total_seconds = (now - self.started_at).total_seconds()
         return idle_seconds > self.policy.idle_ttl_sec or total_seconds > self.policy.max_duration_sec
 
     def touch(self) -> None:
-        now = datetime.now()
+        now = utc_now()
         self.last_active_at = now
         if self.status != "paused":
             assert_chat_session_transition(
@@ -142,7 +143,7 @@ class ChatSession:
             reason=reason,
         )
         self.status = "closed"
-        self.ended_at = datetime.now()
+        self.ended_at = utc_now()
         self.close_reason = reason
         if self._session_repo is not None:
             self._session_repo.delete_session(self.session_id, reason=self.close_reason)
@@ -290,13 +291,13 @@ class ChatSessionManager:
                 idle_ttl_sec=row["idle_ttl_sec"],
                 max_duration_sec=row["max_duration_sec"],
             ),
-            started_at=datetime.fromisoformat(row["started_at"]),
-            last_active_at=datetime.fromisoformat(row["last_active_at"]),
+            started_at=parse_runtime_datetime(row["started_at"]),
+            last_active_at=parse_runtime_datetime(row["last_active_at"]),
             db_path=self.db_path,
             runtime_id=row["runtime_id"],
             status=row["status"],
             budget_json=row["budget_json"],
-            ended_at=datetime.fromisoformat(row["ended_at"]) if row["ended_at"] else None,
+            ended_at=parse_runtime_datetime(row["ended_at"]) if row["ended_at"] else None,
             close_reason=row["close_reason"],
             session_repo=self._repo,
         )
@@ -316,7 +317,7 @@ class ChatSessionManager:
         policy: ChatSessionPolicy | None = None,
     ) -> ChatSession:
         policy = policy or self.default_policy
-        now = datetime.now()
+        now = utc_now()
 
         existing = self._live_sessions.get(terminal.terminal_id)
         if existing and existing.session_id != session_id:
@@ -364,11 +365,11 @@ class ChatSessionManager:
         current = parse_chat_session_state(current_raw)
         target = ChatSessionState.PAUSED if current == ChatSessionState.PAUSED else ChatSessionState.ACTIVE
         assert_chat_session_transition(current, target, reason="touch_manager")
-        now = datetime.now().isoformat()
+        now = utc_now_iso()
         self._repo.touch(session_id, last_active_at=now, status=target.value)
         for session in self._live_sessions.values():
             if session.session_id == session_id:
-                session.last_active_at = datetime.fromisoformat(now)
+                session.last_active_at = parse_runtime_datetime(now)
                 session.status = target.value
                 break
 
@@ -439,15 +440,15 @@ class ChatSessionManager:
     def cleanup_expired(self) -> int:
         count = 0
         for session in self._repo.list_active():
-            started_at = datetime.fromisoformat(session["started_at"])
-            last_active_at = datetime.fromisoformat(session["last_active_at"])
+            started_at = parse_runtime_datetime(session["started_at"])
+            last_active_at = parse_runtime_datetime(session["last_active_at"])
             idle_ttl_sec = self.default_policy.idle_ttl_sec
             max_duration_sec = self.default_policy.max_duration_sec
             policy = self._repo.get_session_policy(session["session_id"])
             if policy:
                 idle_ttl_sec = policy["idle_ttl_sec"]
                 max_duration_sec = policy["max_duration_sec"]
-            now = datetime.now()
+            now = utc_now()
             idle_elapsed = (now - last_active_at).total_seconds()
             total_elapsed = (now - started_at).total_seconds()
             if idle_elapsed > idle_ttl_sec or total_elapsed > max_duration_sec:

--- a/sandbox/clock.py
+++ b/sandbox/clock.py
@@ -1,0 +1,27 @@
+"""Sandbox runtime time helpers.
+
+Current mainline runtime storage is Supabase-backed and returns timestamptz.
+Keep sandbox/session math in one UTC-aware domain instead of mixing naive and aware datetimes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def utc_now_iso() -> str:
+    return utc_now().isoformat()
+
+
+def parse_runtime_datetime(raw: str | datetime) -> datetime:
+    if isinstance(raw, datetime):
+        parsed = raw
+    else:
+        parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -11,6 +11,7 @@ State machine contract:
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 import uuid
@@ -20,6 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
 from sandbox.lifecycle import (
     LeaseInstanceState,
     assert_lease_instance_transition,
@@ -73,6 +75,16 @@ REQUIRED_EVENT_COLUMNS = {
 
 def _connect(db_path: Path) -> sqlite3.Connection:
     return connect_sqlite(db_path)
+
+
+def _use_supabase_storage() -> bool:
+    return os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase"
+
+
+def _make_lease_repo(db_path: Path | None = None):
+    from backend.web.core.storage_factory import make_lease_repo
+
+    return make_lease_repo(db_path=db_path)
 
 
 @dataclass
@@ -229,7 +241,7 @@ class SQLiteLease(SandboxLease):
     def _is_fresh(self, max_age_sec: float = LEASE_FRESHNESS_TTL_SEC) -> bool:
         if not self.observed_at:
             return False
-        return (datetime.now() - self.observed_at).total_seconds() <= max_age_sec
+        return (utc_now() - self.observed_at).total_seconds() <= max_age_sec
 
     def _instance_state(self) -> LeaseInstanceState:
         if not self._current_instance:
@@ -325,7 +337,7 @@ class SQLiteLease(SandboxLease):
                     source,
                     json.dumps(payload),
                     error,
-                    datetime.now().isoformat(),
+                    utc_now_iso(),
                 ),
             )
             if should_commit:
@@ -372,7 +384,7 @@ class SQLiteLease(SandboxLease):
                     1 if self.needs_refresh else 0,
                     self.refresh_hint_at.isoformat() if self.refresh_hint_at else None,
                     self.status,
-                    datetime.now().isoformat(),
+                    utc_now_iso(),
                     self.lease_id,
                 ),
             )
@@ -393,7 +405,7 @@ class SQLiteLease(SandboxLease):
                         self._current_instance.instance_id,
                         self._current_instance.status,
                         self._current_instance.created_at.isoformat(),
-                        datetime.now().isoformat(),
+                        utc_now_iso(),
                     ),
                 )
 
@@ -406,7 +418,7 @@ class SQLiteLease(SandboxLease):
                     """,
                     (
                         "stopped",
-                        datetime.now().isoformat(),
+                        utc_now_iso(),
                         detached_instance.instance_id,
                     ),
                 )
@@ -452,7 +464,7 @@ class SQLiteLease(SandboxLease):
                     1 if self.needs_refresh else 0,
                     self.refresh_hint_at.isoformat() if self.refresh_hint_at else None,
                     self.status,
-                    datetime.now().isoformat(),
+                    utc_now_iso(),
                     self.lease_id,
                 ),
             )
@@ -465,9 +477,25 @@ class SQLiteLease(SandboxLease):
     def _record_provider_error(self, message: str) -> None:
         self.last_error = message[:500]
         self.needs_refresh = True
-        self.refresh_hint_at = datetime.now()
+        self.refresh_hint_at = utc_now()
         self.version += 1
+        if _use_supabase_storage():
+            repo = _make_lease_repo(self.db_path)
+            try:
+                repo.mark_needs_refresh(self.lease_id, hint_at=self.refresh_hint_at)
+            finally:
+                repo.close()
+            return
         self._persist_lease_metadata()
+
+    def _reload_from_storage(self) -> None:
+        repo = _make_lease_repo(self.db_path)
+        try:
+            row = repo.get(self.lease_id)
+        finally:
+            repo.close()
+        if row:
+            self._sync_from(lease_from_row(row, self.db_path))
 
     def _sync_from(self, other: SQLiteLease) -> None:
         self._current_instance = other._current_instance
@@ -498,16 +526,8 @@ class SQLiteLease(SandboxLease):
 
         with self._instance_lock():
             if event_type != "intent.ensure_running":
-                from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
-
-                _repo = SQLiteLeaseRepo(db_path=self.db_path)
-                try:
-                    _row = _repo.get(self.lease_id)
-                finally:
-                    _repo.close()
-                if _row:
-                    self._sync_from(lease_from_row(_row, self.db_path))
-            now = datetime.now()
+                self._reload_from_storage()
+            now = utc_now()
 
             try:
                 if event_type == "intent.pause":
@@ -613,8 +633,8 @@ class SQLiteLease(SandboxLease):
                 error = str(exc)
                 self.last_error = error[:500]
                 self.needs_refresh = True
-                self.refresh_hint_at = datetime.now()
-                self.observed_at = datetime.now()
+                self.refresh_hint_at = utc_now()
+                self.observed_at = utc_now()
                 self.version += 1
                 with _connect(self.db_path) as conn:
                     self._persist_lease_metadata(conn=conn)
@@ -653,12 +673,25 @@ class SQLiteLease(SandboxLease):
                     return resolved
             try:
                 status = provider.get_session_status(self._current_instance.instance_id)
-                self.apply(
-                    provider,
-                    event_type="observe.status",
-                    source="run.refresh",
-                    payload={"status": status},
-                )
+                if _use_supabase_storage():
+                    repo = _make_lease_repo(self.db_path)
+                    try:
+                        row = repo.adopt_instance(
+                            lease_id=self.lease_id,
+                            provider_name=self.provider_name,
+                            instance_id=self._current_instance.instance_id,
+                            status=self._normalize_provider_state(status),
+                        )
+                    finally:
+                        repo.close()
+                    self._sync_from(lease_from_row(row, self.db_path))
+                else:
+                    self.apply(
+                        provider,
+                        event_type="observe.status",
+                        source="run.refresh",
+                        payload={"status": status},
+                    )
                 if self.observed_state == "running" and self._current_instance:
                     return self._current_instance
                 if self.observed_state == "paused":
@@ -669,15 +702,7 @@ class SQLiteLease(SandboxLease):
                 self._record_provider_error(str(exc))
 
         with self._instance_lock():
-            from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
-
-            _repo = SQLiteLeaseRepo(db_path=self.db_path)
-            try:
-                _row = _repo.get(self.lease_id)
-            finally:
-                _repo.close()
-            if _row:
-                self._sync_from(lease_from_row(_row, self.db_path))
+            self._reload_from_storage()
 
             if self._current_instance:
                 if not capability.supports_status_probe:
@@ -686,12 +711,25 @@ class SQLiteLease(SandboxLease):
                         return resolved
                 try:
                     status = provider.get_session_status(self._current_instance.instance_id)
-                    self.apply(
-                        provider,
-                        event_type="observe.status",
-                        source="run.refresh_locked",
-                        payload={"status": status},
-                    )
+                    if _use_supabase_storage():
+                        repo = _make_lease_repo(self.db_path)
+                        try:
+                            row = repo.adopt_instance(
+                                lease_id=self.lease_id,
+                                provider_name=self.provider_name,
+                                instance_id=self._current_instance.instance_id,
+                                status=self._normalize_provider_state(status),
+                            )
+                        finally:
+                            repo.close()
+                        self._sync_from(lease_from_row(row, self.db_path))
+                    else:
+                        self.apply(
+                            provider,
+                            event_type="observe.status",
+                            source="run.refresh_locked",
+                            payload={"status": status},
+                        )
                     if self.observed_state == "running" and self._current_instance:
                         return self._current_instance
                     if self.observed_state == "paused":
@@ -702,7 +740,8 @@ class SQLiteLease(SandboxLease):
                     self._record_provider_error(str(exc))
 
             self.status = "recovering"
-            self._persist_lease_metadata()
+            if not _use_supabase_storage():
+                self._persist_lease_metadata()
             from sandbox.thread_context import get_current_thread_id
 
             thread_id = get_current_thread_id()
@@ -711,14 +750,27 @@ class SQLiteLease(SandboxLease):
                 instance_id=session_info.session_id,
                 provider_name=self.provider_name,
                 status="running",
-                created_at=datetime.now(),
+                created_at=utc_now(),
             )
-            self.apply(
-                provider,
-                event_type="intent.ensure_running",
-                source="run.create",
-                payload={"created": True, "instance_id": session_info.session_id},
-            )
+            if _use_supabase_storage():
+                repo = _make_lease_repo(self.db_path)
+                try:
+                    row = repo.adopt_instance(
+                        lease_id=self.lease_id,
+                        provider_name=self.provider_name,
+                        instance_id=session_info.session_id,
+                        status="running",
+                    )
+                finally:
+                    repo.close()
+                self._sync_from(lease_from_row(row, self.db_path))
+            else:
+                self.apply(
+                    provider,
+                    event_type="intent.ensure_running",
+                    source="run.create",
+                    payload={"created": True, "instance_id": session_info.session_id},
+                )
             from sandbox.resource_snapshot import probe_and_upsert_for_instance
 
             probe_result = probe_and_upsert_for_instance(
@@ -731,7 +783,6 @@ class SQLiteLease(SandboxLease):
                 db_path=self.db_path,
             )
             if not probe_result["ok"]:
-                # @@@create-probe-fail-loud - lease creation succeeds, but resource probe failure stays explicit.
                 print(f"[lease:{self.lease_id}] create probe error: {probe_result['error']}")
             if not self._current_instance:
                 raise RuntimeError(f"Lease {self.lease_id}: failed to bind created instance")
@@ -787,8 +838,15 @@ class SQLiteLease(SandboxLease):
 
     def mark_needs_refresh(self, hint_at: datetime | None = None) -> None:
         self.needs_refresh = True
-        self.refresh_hint_at = hint_at or datetime.now()
+        self.refresh_hint_at = hint_at or utc_now()
         self.version += 1
+        if _use_supabase_storage():
+            repo = _make_lease_repo(self.db_path)
+            try:
+                repo.mark_needs_refresh(self.lease_id, hint_at=self.refresh_hint_at)
+            finally:
+                repo.close()
+            return
         self._persist_lease_metadata()
 
 
@@ -801,23 +859,23 @@ def lease_from_row(row: dict, db_path: Path) -> SQLiteLease:
             instance_id=inst_data["instance_id"],
             provider_name=row["provider_name"],
             status=inst_data.get("status", "unknown"),
-            created_at=datetime.fromisoformat(str(inst_data["created_at"])),
+            created_at=parse_runtime_datetime(str(inst_data["created_at"])),
         )
     elif row.get("current_instance_id"):
         instance = SandboxInstance(
             instance_id=row["current_instance_id"],
             provider_name=row["provider_name"],
             status=row.get("instance_status") or row.get("observed_state") or "unknown",
-            created_at=datetime.fromisoformat(str(row["instance_created_at"])) if row.get("instance_created_at") else datetime.now(),
+            created_at=parse_runtime_datetime(str(row["instance_created_at"])) if row.get("instance_created_at") else utc_now(),
         )
 
     observed_at = None
     if row.get("observed_at"):
-        observed_at = datetime.fromisoformat(str(row["observed_at"]))
+        observed_at = parse_runtime_datetime(str(row["observed_at"]))
 
     refresh_hint_at = None
     if row.get("refresh_hint_at"):
-        refresh_hint_at = datetime.fromisoformat(str(row["refresh_hint_at"]))
+        refresh_hint_at = parse_runtime_datetime(str(row["refresh_hint_at"]))
 
     return SQLiteLease(
         lease_id=row["lease_id"],

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -10,18 +10,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from backend.web.core.storage_factory import make_lease_repo, make_terminal_repo
+from backend.web.core.storage_factory import make_chat_session_repo, make_lease_repo, make_terminal_repo
 from config.user_paths import user_home_path
 from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
+from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
 from sandbox.lease import lease_from_row
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
-from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
-from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 from storage.runtime import build_storage_container
 
 logger = logging.getLogger(__name__)
@@ -168,14 +166,14 @@ class SandboxManager:
         self._on_session_ready = on_session_ready
 
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-        self.terminal_store = SQLiteTerminalRepo(db_path=self.db_path)
-        self.lease_store = SQLiteLeaseRepo(db_path=self.db_path)
+        self.terminal_store = make_terminal_repo(db_path=self.db_path)
+        self.lease_store = make_lease_repo(db_path=self.db_path)
 
         self.session_manager = ChatSessionManager(
             provider=provider,
             db_path=self.db_path,
             default_policy=ChatSessionPolicy(),
-            chat_session_repo=SQLiteChatSessionRepo(db_path=self.db_path),
+            chat_session_repo=make_chat_session_repo(db_path=self.db_path),
             terminal_repo=self.terminal_store,
             lease_repo=self.lease_store,
         )
@@ -192,12 +190,12 @@ class SandboxManager:
         row = self.lease_store.get(lease_id)
         if row is None:
             return None
-        return lease_from_row(row, self.lease_store.db_path)
+        return lease_from_row(row, self.db_path)
 
     def _create_lease(self, lease_id: str, provider_name: str, volume_id: str | None = None):
         """Create lease and return as domain object."""
         row = self.lease_store.create(lease_id, provider_name, volume_id=volume_id)
-        return lease_from_row(row, self.lease_store.db_path)
+        return lease_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
         """Public API: get active terminal as domain object."""
@@ -241,7 +239,7 @@ class SandboxManager:
 
         from sandbox.volume_source import HostVolume
 
-        now_str = datetime.now().isoformat()
+        now_str = utc_now_iso()
         volume_root = Path(os.environ.get("LEON_SANDBOX_VOLUME_ROOT", str(user_home_path("volumes")))).expanduser().resolve()
         volume_root.mkdir(parents=True, exist_ok=True)
         source = HostVolume(volume_root / volume_id)
@@ -355,7 +353,7 @@ class SandboxManager:
     def _get_active_terminal(self, thread_id: str):
         row = self.terminal_store.get_active(thread_id)
         if row:
-            return terminal_from_row(row, self.terminal_store.db_path)
+            return terminal_from_row(row, self.db_path)
         thread_terminals = self.terminal_store.list_by_thread(thread_id)
         # @@@thread-pointer-consistency - If terminals exist but no active pointer, DB is inconsistent and must fail loudly.
         if thread_terminals:
@@ -370,7 +368,7 @@ class SandboxManager:
 
     def _get_thread_terminals(self, thread_id: str):
         rows = self.terminal_store.list_by_thread(thread_id)
-        return [terminal_from_row(row, self.terminal_store.db_path) for row in rows]
+        return [terminal_from_row(row, self.db_path) for row in rows]
 
     def _get_thread_lease(self, thread_id: str):
         terminals = self._get_thread_terminals(thread_id)
@@ -485,7 +483,7 @@ class SandboxManager:
                     lease_id=lease_id,
                     initial_cwd=initial_cwd,
                 ),
-                self.terminal_store.db_path,
+                self.db_path,
             )
         else:
             lease = self._get_lease(terminal.lease_id)
@@ -558,7 +556,7 @@ class SandboxManager:
             default_row = self.terminal_store.get_active(thread_id)
         if default_row is None:
             raise RuntimeError(f"Thread {thread_id} has no default terminal")
-        default_terminal = terminal_from_row(default_row, self.terminal_store.db_path)
+        default_terminal = terminal_from_row(default_row, self.db_path)
         lease = self._get_lease(default_terminal.lease_id)
         if lease is None:
             raise RuntimeError(f"Missing lease {default_terminal.lease_id} for thread {thread_id}")
@@ -573,7 +571,7 @@ class SandboxManager:
                 lease_id=lease.lease_id,
                 initial_cwd=initial_cwd,
             ),
-            self.terminal_store.db_path,
+            self.db_path,
         )
         # @@@async-terminal-inherit-state - non-blocking commands fork from default terminal cwd/env snapshot.
         terminal.update_state(
@@ -612,8 +610,8 @@ class SandboxManager:
         last_active_raw = session_row.get("last_active_at")
         if not started_at_raw or not last_active_raw:
             return False
-        started_at = datetime.fromisoformat(str(started_at_raw))
-        last_active_at = datetime.fromisoformat(str(last_active_raw))
+        started_at = parse_runtime_datetime(str(started_at_raw))
+        last_active_at = parse_runtime_datetime(str(last_active_raw))
         idle_ttl_sec = int(session_row.get("idle_ttl_sec") or 0)
         max_duration_sec = int(session_row.get("max_duration_sec") or 0)
         idle_elapsed = (now - last_active_at).total_seconds()
@@ -633,7 +631,7 @@ class SandboxManager:
         if self.provider.name == "local":
             return 0
 
-        now = datetime.now()
+        now = utc_now()
         count = 0
 
         active_rows = self.session_manager.list_active()
@@ -646,8 +644,8 @@ class SandboxManager:
             if not session_id or not thread_id or not started_at_raw or not last_active_raw:
                 continue
 
-            started_at = datetime.fromisoformat(str(started_at_raw))
-            last_active_at = datetime.fromisoformat(str(last_active_raw))
+            started_at = parse_runtime_datetime(str(started_at_raw))
+            last_active_at = parse_runtime_datetime(str(last_active_raw))
             idle_ttl_sec = int(row.get("idle_ttl_sec") or 0)
             max_duration_sec = int(row.get("max_duration_sec") or 0)
 
@@ -658,7 +656,7 @@ class SandboxManager:
 
             terminal_id = row.get("terminal_id")
             terminal_row = self.terminal_store.get_by_id(str(terminal_id)) if terminal_id else None
-            terminal = terminal_from_row(terminal_row, self.terminal_store.db_path) if terminal_row else None
+            terminal = terminal_from_row(terminal_row, self.db_path) if terminal_row else None
             lease = self._get_lease(terminal.lease_id) if terminal else None
             if lease and lease.provider_name != self.provider.name:
                 continue
@@ -820,7 +818,7 @@ class SandboxManager:
     def destroy_thread_resources(self, thread_id: str) -> bool:
         """Destroy physical resources and detach thread from terminal/lease records."""
         terminal_rows = self.terminal_store.list_by_thread(thread_id)
-        terminals = [terminal_from_row(r, self.terminal_store.db_path) for r in terminal_rows]
+        terminals = [terminal_from_row(r, self.db_path) for r in terminal_rows]
         if not terminals:
             return False
 

--- a/storage/providers/supabase/chat_session_repo.py
+++ b/storage/providers/supabase/chat_session_repo.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from storage.providers.supabase import _query as q
@@ -11,6 +11,10 @@ _REPO = "chat session repo"
 _SESSIONS_TABLE = "chat_sessions"
 _COMMANDS_TABLE = "terminal_commands"
 _CHUNKS_TABLE = "terminal_command_chunks"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
 
 
 class SupabaseChatSessionRepo:
@@ -162,7 +166,7 @@ class SupabaseChatSessionRepo:
         started_at: str | None = None,
         last_active_at: str | None = None,
     ) -> dict[str, Any]:
-        now_iso = started_at or datetime.now().isoformat()
+        now_iso = started_at or _utc_now_iso()
         last_active = last_active_at or now_iso
 
         # Supersede any existing active sessions for this terminal
@@ -205,14 +209,14 @@ class SupabaseChatSessionRepo:
         }
 
     def touch(self, session_id: str, last_active_at: str | None = None, status: str | None = None) -> None:
-        now = last_active_at or datetime.now().isoformat()
+        now = last_active_at or _utc_now_iso()
         update: dict[str, Any] = {"last_active_at": now}
         if status is not None:
             update["status"] = status
         self._sessions().update(update).eq("chat_session_id", session_id).execute()
 
     def touch_thread_activity(self, thread_id: str, last_active_at: str | None = None) -> None:
-        now = last_active_at or datetime.now().isoformat()
+        now = last_active_at or _utc_now_iso()
         self._sessions().update({"last_active_at": now}).eq("thread_id", thread_id).neq("status", "closed").execute()
 
     def pause(self, session_id: str) -> None:
@@ -226,7 +230,7 @@ class SupabaseChatSessionRepo:
         ).execute()
 
     def delete_session(self, session_id: str, *, reason: str = "closed") -> None:
-        self._sessions().update({"status": "closed", "ended_at": datetime.now().isoformat(), "close_reason": reason}).eq(
+        self._sessions().update({"status": "closed", "ended_at": _utc_now_iso(), "close_reason": reason}).eq(
             "chat_session_id", session_id
         ).in_("status", ["active", "idle", "paused"]).execute()
 

--- a/storage/providers/supabase/lease_repo.py
+++ b/storage/providers/supabase/lease_repo.py
@@ -157,7 +157,7 @@ class SupabaseLeaseRepo:
                 "version": (existing.get("version") or 0) + 1,
                 "observed_at": now,
                 "last_error": None,
-                "needs_refresh": True,
+                "needs_refresh": 1,
                 "refresh_hint_at": now,
                 "status": "active",
                 "updated_at": now,
@@ -187,7 +187,7 @@ class SupabaseLeaseRepo:
             self._leases()
             .update(
                 {
-                    "needs_refresh": True,
+                    "needs_refresh": 1,
                     "refresh_hint_at": hinted_at,
                     "updated_at": now,
                 }

--- a/storage/providers/supabase/terminal_repo.py
+++ b/storage/providers/supabase/terminal_repo.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from storage.providers.supabase import _query as q
@@ -10,6 +10,10 @@ from storage.providers.supabase import _query as q
 _REPO = "terminal repo"
 _TERMINALS_TABLE = "abstract_terminals"
 _POINTERS_TABLE = "thread_terminal_pointers"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
 
 
 class SupabaseTerminalRepo:
@@ -130,7 +134,7 @@ class SupabaseTerminalRepo:
         existing = self._get_pointer_row(thread_id)
         if existing:
             return
-        now = datetime.now().isoformat()
+        now = _utc_now_iso()
         self._pointers().insert(
             {
                 "thread_id": thread_id,
@@ -147,7 +151,7 @@ class SupabaseTerminalRepo:
         lease_id: str,
         initial_cwd: str = "/root",
     ) -> dict[str, Any]:
-        now = datetime.now().isoformat()
+        now = _utc_now_iso()
         env_delta_json = "{}"
         state_version = 0
         self._terminals().insert(
@@ -182,7 +186,7 @@ class SupabaseTerminalRepo:
         if terminal["thread_id"] != thread_id:
             raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal['thread_id']}, not thread {thread_id}")
 
-        now = datetime.now().isoformat()
+        now = _utc_now_iso()
         pointer = self._get_pointer_row(thread_id)
         if pointer is None:
             self._pointers().insert(
@@ -226,7 +230,7 @@ class SupabaseTerminalRepo:
                     {
                         "active_terminal_id": next_terminal_id if active_terminal_id == terminal_id else active_terminal_id,
                         "default_terminal_id": next_terminal_id if default_terminal_id == terminal_id else default_terminal_id,
-                        "updated_at": datetime.now().isoformat(),
+                        "updated_at": _utc_now_iso(),
                     }
                 ).eq("thread_id", thread_id).execute()
 

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sandbox.lease import lease_from_row
+
+
+class _FakeProvider:
+    name = "daytona_selfhost"
+
+    def get_capability(self):
+        return SimpleNamespace(supports_status_probe=True)
+
+    def create_session(self, context_id=None, thread_id=None):
+        return SimpleNamespace(session_id="instance-created")
+
+
+class _FakeLeaseRepo:
+    def __init__(self) -> None:
+        self.adopt_calls: list[tuple[str, str, str, str]] = []
+        self._row = {
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "recipe_id": None,
+            "recipe_json": None,
+            "workspace_key": None,
+            "current_instance_id": None,
+            "instance_created_at": None,
+            "desired_state": "running",
+            "observed_state": "detached",
+            "version": 0,
+            "observed_at": "2026-04-08T00:00:00+00:00",
+            "last_error": None,
+            "needs_refresh": 0,
+            "refresh_hint_at": None,
+            "status": "active",
+            "volume_id": None,
+            "created_at": "2026-04-08T00:00:00+00:00",
+            "updated_at": "2026-04-08T00:00:00+00:00",
+            "_instance": None,
+        }
+
+    def get(self, lease_id: str):
+        if lease_id != "lease-1":
+            return None
+        return dict(self._row)
+
+    def adopt_instance(self, *, lease_id: str, provider_name: str, instance_id: str, status: str = "unknown"):
+        self.adopt_calls.append((lease_id, provider_name, instance_id, status))
+        self._row = {
+            **self._row,
+            "current_instance_id": instance_id,
+            "instance_created_at": "2026-04-08T00:00:01+00:00",
+            "desired_state": "running",
+            "observed_state": status,
+            "version": 1,
+            "observed_at": "2026-04-08T00:00:01+00:00",
+            "needs_refresh": 1,
+            "refresh_hint_at": "2026-04-08T00:00:01+00:00",
+            "_instance": {
+                "instance_id": instance_id,
+                "lease_id": lease_id,
+                "provider_session_id": instance_id,
+                "status": status,
+                "created_at": "2026-04-08T00:00:01+00:00",
+                "last_seen_at": "2026-04-08T00:00:01+00:00",
+            },
+        }
+        return dict(self._row)
+
+    def close(self) -> None:
+        return None
+
+
+def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(monkeypatch):
+    repo = _FakeLeaseRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+
+    def _explode_probe(**_kwargs):
+        raise RuntimeError("snapshot fk boom")
+
+    monkeypatch.setattr("sandbox.resource_snapshot.probe_and_upsert_for_instance", _explode_probe)
+
+    with pytest.raises(RuntimeError, match="snapshot fk boom"):
+        lease.ensure_active_instance(_FakeProvider())
+
+    assert repo.adopt_calls == [("lease-1", "daytona_selfhost", "instance-created", "running")]
+    assert lease.get_instance() is not None
+    assert lease.get_instance().instance_id == "instance-created"

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from types import SimpleNamespace
+
 from sandbox.chat_session import ChatSession, ChatSessionPolicy
 from sandbox.lease import SandboxLease
 from sandbox.manager import (
@@ -63,6 +66,24 @@ class _FakeSessionRepo:
 
     def delete_session(self, session_id: str, *, reason: str = "closed") -> None:
         self.deletes.append((session_id, reason))
+
+
+class _RepoStub:
+    def close(self):
+        return None
+
+
+class _ActiveTerminalRepoStub(_RepoStub):
+    def get_active(self, _thread_id: str):
+        return {"terminal_id": "term-1", "lease_id": "lease-1", "cwd": "/workspace"}
+
+    def list_by_thread(self, _thread_id: str):
+        return [{"terminal_id": "term-1", "lease_id": "lease-1", "cwd": "/workspace"}]
+
+
+class _LeaseRowRepoStub(_RepoStub):
+    def get(self, _lease_id: str):
+        return {"lease_id": "lease-1", "provider_name": "daytona_selfhost"}
 
 
 class _FakeTerminal(AbstractTerminal):
@@ -195,3 +216,66 @@ def test_chat_session_close_uses_injected_repo():
 
     assert runtime.closed is True
     assert repo.deletes == [("sess-1", "closed")]
+
+
+def test_chat_session_is_expired_accepts_aware_supabase_timestamps():
+    aware = datetime.fromisoformat("2099-04-08T00:00:00+00:00")
+    session = ChatSession(
+        session_id="sess-1",
+        thread_id="thread-1",
+        terminal=_FakeTerminal(),
+        lease=_FakeLease(),
+        runtime=object(),
+        policy=ChatSessionPolicy(),
+        started_at=aware,
+        last_active_at=aware,
+        session_repo=_FakeSessionRepo(),
+    )
+
+    assert session.is_expired() is False
+
+
+def test_sandbox_manager_uses_strategy_aware_repos_under_supabase(monkeypatch):
+    import sandbox.manager as sandbox_manager_module
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr(sandbox_manager_module, "make_terminal_repo", lambda db_path=None: _RepoStub())
+    monkeypatch.setattr(sandbox_manager_module, "make_lease_repo", lambda db_path=None: _RepoStub())
+    monkeypatch.setattr(sandbox_manager_module, "make_chat_session_repo", lambda db_path=None: _RepoStub(), raising=False)
+
+    provider = SimpleNamespace(get_capability=lambda: SimpleNamespace(runtime_kind="local"))
+
+    manager = sandbox_manager_module.SandboxManager(provider=provider)
+
+    assert isinstance(manager.terminal_store, _RepoStub)
+    assert isinstance(manager.lease_store, _RepoStub)
+
+
+def test_sandbox_manager_uses_own_db_path_when_repo_has_no_db_path(monkeypatch, tmp_path):
+    import sandbox.manager as sandbox_manager_module
+
+    manager = object.__new__(sandbox_manager_module.SandboxManager)
+    manager.db_path = tmp_path / "sandbox.db"
+    manager.terminal_store = _ActiveTerminalRepoStub()
+    manager.lease_store = _LeaseRowRepoStub()
+
+    seen_terminal_db_paths = []
+    seen_lease_db_paths = []
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "terminal_from_row",
+        lambda row, db_path: seen_terminal_db_paths.append(db_path) or row,
+    )
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "lease_from_row",
+        lambda row, db_path: seen_lease_db_paths.append(db_path) or row,
+    )
+
+    terminal = manager._get_active_terminal("thread-1")
+    lease = manager._get_lease("lease-1")
+
+    assert terminal["terminal_id"] == "term-1"
+    assert lease["lease_id"] == "lease-1"
+    assert seen_terminal_db_paths == [manager.db_path]
+    assert seen_lease_db_paths == [manager.db_path]

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -117,7 +117,9 @@ def _new_test_manager() -> Any:
     # @@@nu59-sandbox-manager-harness - these tests intentionally bypass
     # SandboxManager.__init__ and monkey-build partial instances. Treat that
     # object as a test harness, not a fully typed production manager.
-    return cast(Any, object.__new__(SandboxManager))
+    manager = cast(Any, object.__new__(SandboxManager))
+    manager.db_path = Path("/tmp/fake-sandbox.db")
+    return manager
 
 
 def test_setup_mounts_reads_volume_from_active_storage_repo(tmp_path):
@@ -257,6 +259,26 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
 
     assert destroy_calls == [True]
     assert manager.session_manager.deleted == [("sess-1", "idle_timeout")]
+
+
+def test_enforce_idle_timeouts_accepts_aware_supabase_timestamps():
+    manager = _new_test_manager()
+    manager.provider = SimpleNamespace(name="daytona_selfhost", get_capability=lambda: SimpleNamespace(can_pause=True, can_destroy=True))
+    manager.session_manager = SimpleNamespace(
+        list_active=lambda: [
+            {
+                "session_id": "sess-1",
+                "thread_id": "thread-1",
+                "started_at": "2099-04-04T00:00:00+00:00",
+                "last_active_at": "2099-04-04T00:00:00+00:00",
+                "idle_ttl_sec": 3600,
+                "max_duration_sec": 7200,
+                "status": "active",
+            }
+        ]
+    )
+
+    assert manager.enforce_idle_timeouts() == 0
 
 
 def test_destroy_thread_resources_skips_local_sync_when_lease_has_no_volume_id():

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -96,3 +96,43 @@ def test_supabase_lease_repo_create_persists_utc_timestamps():
     assert payload["created_at"].endswith("+00:00")
     assert payload["updated_at"].endswith("+00:00")
     assert payload["observed_at"].endswith("+00:00")
+
+
+def test_supabase_lease_repo_adopt_instance_persists_integer_refresh_flag():
+    tables = {
+        "sandbox_leases": [
+            {
+                "lease_id": "lease-1",
+                "provider_name": "local",
+                "recipe_id": None,
+                "workspace_key": None,
+                "recipe_json": None,
+                "current_instance_id": None,
+                "instance_created_at": None,
+                "desired_state": "running",
+                "observed_state": "detached",
+                "version": 0,
+                "observed_at": "2026-04-07T00:00:00+00:00",
+                "last_error": None,
+                "needs_refresh": 0,
+                "refresh_hint_at": None,
+                "status": "active",
+                "volume_id": None,
+                "created_at": "2026-04-07T00:00:00+00:00",
+                "updated_at": "2026-04-07T00:00:00+00:00",
+            }
+        ],
+        "sandbox_instances": [],
+    }
+    repo = SupabaseLeaseRepo(client=FakeSupabaseClient(tables=tables))
+
+    repo.adopt_instance(
+        lease_id="lease-1",
+        provider_name="local",
+        instance_id="inst-1",
+        status="running",
+    )
+
+    lease_row = tables["sandbox_leases"][0]
+    assert lease_row["needs_refresh"] == 1
+    assert type(lease_row["needs_refresh"]) is int


### PR DESCRIPTION
## Summary
- keep sandbox lease/chat-session persistence on the configured canonical storage strategy instead of falling back through SQLite lease paths in Supabase runtime
- normalize runtime timestamps to UTC-aware values across chat session, lease, terminal, and activity tracking writes
- preserve fail-loudly behavior while making self-host Daytona upload -> remote file visibility stable again under the Supabase/staging mainline contract

## Verification
- `uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_supabase_terminal_repo.py`
  - `32 passed in 0.44s`
- `uv run ruff check sandbox/clock.py sandbox/chat_session.py sandbox/lease.py sandbox/manager.py sandbox/capability.py backend/web/services/activity_tracker.py storage/providers/supabase/chat_session_repo.py storage/providers/supabase/lease_repo.py storage/providers/supabase/terminal_repo.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/storage/test_supabase_lease_repo.py`
  - `All checks passed!`

## Brutal Proof
- live `8017` direct chat recovered after shared gateway repair:
  - thread `m_dKjuBBLbR1bw-23`
  - assistant replied `LIVE8017_DIRECT_RECOVERED_1775647320`
- self-host Daytona upload/read/reply proved on isolated `18012`:
  - thread `m_dKjuBBLbR1bw-24`
  - remote `/home/daytona/files/upload_probe_DAYTONA_FINAL_1775647358.txt` listed and read successfully
  - assistant replied `FIRST_LINE DAYTONA_FINAL_1775647358`
- subagent tool call proved on isolated `18012`:
  - thread `m_dKjuBBLbR1bw-25`
  - `Agent` tool result `SUBAGENT_BRUTAL_1775647412`
  - assistant replied `SUBAGENT_BRUTAL_1775647412`

## Notes
- remaining shared-runtime outage during probing was external, not repo code: Sub2API upstream traffic was failing through `mihomo` on a dead ChatGPT node. I repaired the runtime proxy selection on `101.201.227.31` and then reran the brutal probes above.
