### PR TITLE
fix: suppress stale default config route noise

### DIFF
--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -8,6 +8,9 @@ import { useAuthStore } from "../store/auth-store";
 import { useAppStore } from "../store/app-store";
 
 const handleGetDefaultThread = vi.fn();
+const clientMocks = vi.hoisted(() => ({
+  getDefaultThreadConfig: vi.fn(() => new Promise(() => {})),
+}));
 
 vi.mock("zustand/middleware", async () => {
   const actual = await vi.importActual<typeof import("zustand/middleware")>("zustand/middleware");
@@ -48,7 +51,7 @@ vi.mock("../api", () => ({
 }));
 
 vi.mock("../api/client", () => ({
-  getDefaultThreadConfig: vi.fn(() => new Promise(() => {})),
+  getDefaultThreadConfig: clientMocks.getDefaultThreadConfig,
   listMyLeases: vi.fn(async () => []),
   saveDefaultThreadConfig: vi.fn(async () => undefined),
 }));
@@ -86,6 +89,8 @@ describe("NewChatPage", () => {
   beforeEach(() => {
     handleGetDefaultThread.mockReset();
     handleGetDefaultThread.mockResolvedValue(null);
+    clientMocks.getDefaultThreadConfig.mockReset();
+    clientMocks.getDefaultThreadConfig.mockImplementation(() => new Promise(() => {}));
 
     useAuthStore.setState({
       token: "token",
@@ -216,6 +221,33 @@ describe("NewChatPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("thread-route:thread-42")).toBeTruthy();
+    });
+  });
+
+  it("does not log a failed default-config fetch once navigation already left the hire route", async () => {
+    clientMocks.getDefaultThreadConfig.mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+            <Route path="/chat" element={<div>chat-page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(clientMocks.getDefaultThreadConfig).toHaveBeenCalledOnce();
+    });
+
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -113,6 +113,11 @@ function enabledFeatureLabels(recipe: RecipeSnapshot | null): string[] {
     .map((item) => item.name);
 }
 
+function isActiveHireRoute(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path.startsWith("/chat/hire");
+}
+
 export default function NewChatPage({ mode = "member" }: { mode?: "member" | "new" }) {
   const navigate = useNavigate();
   const { agentId } = useParams<{ agentId: string }>();
@@ -294,6 +299,10 @@ export default function NewChatPage({ mode = "member" }: { mode?: "member" | "ne
       } catch (err) {
         if (cancelled) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
+        // @@@default-config-route-teardown - default thread config can resolve
+        // after navigation already left the hire flow. Only log while the
+        // /chat/hire route is still active; otherwise this is stale UI noise.
+        if (!isActiveHireRoute()) return;
         console.error("[NewChatPage] load default thread config failed:", err);
       } finally {
         if (!cancelled && !ac.signal.aborted) setConfigDefaultsLoading(false);


### PR DESCRIPTION
## Summary
- suppress stale default thread config load noise after navigation leaves `/chat/hire`
- extend NewChatPage regression coverage for hire-route teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/pages/NewChatPage.test.tsx
- cd frontend/app && npm run build