### PR TITLE
fix: suppress stale default thread route noise

### DIFF
--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -250,4 +250,31 @@ describe("NewChatPage", () => {
       expect(consoleError).not.toHaveBeenCalled();
     });
   });
+
+  it("does not log a failed default-thread resolve once navigation already left the hire route", async () => {
+    handleGetDefaultThread.mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+            <Route path="/chat" element={<div>chat-page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(handleGetDefaultThread).toHaveBeenCalledOnce();
+    });
+
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -179,6 +179,10 @@ export default function NewChatPage({ mode = "member" }: { mode?: "member" | "ne
         if (cancelled) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
         const message = err instanceof Error ? err.message : "无法获取默认线程";
+        // @@@default-thread-route-teardown - default thread resolution can
+        // finish after navigation already left the hire flow. Only log while
+        // /chat/hire is still active; otherwise this is stale UI noise.
+        if (!isActiveHireRoute()) return;
         console.error("[NewChatPage] resolve default thread failed:", err);
         setError(message);
         setResolveState("error");


### PR DESCRIPTION
## Summary
- suppress stale default thread resolve noise after navigation leaves `/chat/hire`
- extend NewChatPage regression coverage for hire-route teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/pages/NewChatPage.test.tsx
- cd frontend/app && npm run build