### PR TITLE
fix: suppress stale provider route noise

### DIFF
--- a/frontend/app/src/components/ProvidersSection.test.tsx
+++ b/frontend/app/src/components/ProvidersSection.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ProvidersSection from "./ProvidersSection";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("ProvidersSection", () => {
+  it("does not log a failed provider save once navigation already left /settings", async () => {
+    window.history.replaceState({}, "", "/settings");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    render(
+      <ProvidersSection
+        providers={{ anthropic: { api_key: null, base_url: null } }}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("输入 Anthropic API 密钥"), {
+      target: { value: "sk-test" },
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/components/ProvidersSection.tsx
+++ b/frontend/app/src/components/ProvidersSection.tsx
@@ -27,6 +27,11 @@ const PROVIDER_CONFIGS = [
   },
 ];
 
+function isActiveSettingsRoute(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path === "/settings";
+}
+
 export default function ProvidersSection({ providers, onUpdate }: ProvidersSectionProps) {
   const [saving, setSaving] = useState<string | null>(null);
   const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
@@ -51,6 +56,10 @@ export default function ProvidersSection({ providers, onUpdate }: ProvidersSecti
       setSuccessMessage(providerId);
       setTimeout(() => setSuccessMessage(null), FEEDBACK_NORMAL);
     } catch (error) {
+      // @@@provider-route-teardown - provider saves can resolve after
+      // navigation already left /settings. Only log while the settings route
+      // is still active; otherwise this is stale UI noise.
+      if (!isActiveSettingsRoute()) return;
       console.error("Failed to save provider:", error);
     } finally {
       setSaving(null);


### PR DESCRIPTION
## Summary
- suppress stale provider save noise after navigation leaves `/settings`
- add a dedicated ProvidersSection regression test for settings-route teardown
- keep the slice frontend-only without backend/runtime/product changes

## Verification
- cd frontend/app && npm test -- src/components/ProvidersSection.test.tsx
- cd frontend/app && npm run build