### PR TITLE
fix: suppress stale model mapping route noise

### DIFF
--- a/frontend/app/src/components/ModelMappingSection.test.tsx
+++ b/frontend/app/src/components/ModelMappingSection.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ModelMappingSection from "./ModelMappingSection";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("ModelMappingSection", () => {
+  it("does not log a failed mapping save once navigation already left /settings", async () => {
+    window.history.replaceState({}, "", "/settings");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      window.history.replaceState({}, "", "/chat");
+      throw new TypeError("Failed to fetch");
+    });
+
+    render(
+      <ModelMappingSection
+        virtualModels={[{ id: "vm-1", name: "VM 1", description: "virtual", icon: "V" }]}
+        availableModels={[{ id: "gpt-5.4", name: "GPT-5.4" }]}
+        modelMapping={{}}
+        enabledModels={["gpt-5.4"]}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "gpt-5.4" },
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/components/ModelMappingSection.tsx
+++ b/frontend/app/src/components/ModelMappingSection.tsx
@@ -21,6 +21,11 @@ interface ModelMappingSectionProps {
   onUpdate: (mapping: Record<string, string>) => void;
 }
 
+function isActiveSettingsRoute(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path === "/settings";
+}
+
 export default function ModelMappingSection({
   virtualModels,
   availableModels,
@@ -45,6 +50,10 @@ export default function ModelMappingSection({
       setSuccessMessage(true);
       setTimeout(() => setSuccessMessage(false), FEEDBACK_NORMAL);
     } catch (error) {
+      // @@@mapping-route-teardown - mapping saves can resolve after navigation
+      // already left /settings. Only log while the settings route is still
+      // active; otherwise this is stale UI noise.
+      if (!isActiveSettingsRoute()) return;
       console.error("Failed to save mapping:", error);
     } finally {
       setSaving(false);


### PR DESCRIPTION
## Summary
- suppress stale model mapping save noise after navigation leaves /settings
- add a dedicated ModelMappingSection regression test
- keep the slice frontend/app only with no contract widening

## Verification
- cd frontend/app && npm test -- src/components/ModelMappingSection.test.tsx
- cd frontend/app && npm run build