### PR TITLE
feat: enable eval trajectories on public thread path

### DIFF
--- a/backend/web/models/requests.py
+++ b/backend/web/models/requests.py
@@ -52,6 +52,7 @@ class RunRequest(BaseModel):
 
 class SendMessageRequest(BaseModel):
     message: str
+    enable_trajectory: bool = False
     attachments: list[str] = Field(default_factory=list)
 
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -912,7 +912,14 @@ async def send_message(
             agent=agent,
         )
 
-    return await route_message_to_brain(app, thread_id, message, source="owner", attachments=payload.attachments or None)
+    return await route_message_to_brain(
+        app,
+        thread_id,
+        message,
+        source="owner",
+        enable_trajectory=payload.enable_trajectory,
+        attachments=payload.attachments or None,
+    )
 
 
 @router.post("/{thread_id}/queue")

--- a/backend/web/services/message_routing.py
+++ b/backend/web/services/message_routing.py
@@ -16,6 +16,7 @@ async def route_message_to_brain(
     thread_id: str,
     content: str,
     source: str = "owner",
+    enable_trajectory: bool = False,
     sender_name: str | None = None,
     sender_avatar_url: str | None = None,
     attachments: list[str] | None = None,
@@ -77,7 +78,14 @@ async def route_message_to_brain(
             meta.update(message_metadata)
         if attachments:
             meta["attachments"] = attachments
-        run_id = start_agent_run(agent, thread_id, run_content, app, message_metadata=meta)
+        run_id = start_agent_run(
+            agent,
+            thread_id,
+            run_content,
+            app,
+            enable_trajectory=enable_trajectory,
+            message_metadata=meta,
+        )
         # @@@monitor-resource-cache-run-start - a fresh run can create or resume a lease immediately.
         # Drop the cached monitor snapshot so the next /api/monitor/resources read reflects the live topology.
         clear_monitor_resource_overview_cache()

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -1259,17 +1259,24 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         # Persist trajectory
         if tracer is not None and store is not None:
             try:
+                from eval.collector import MetricsCollector
+
                 trajectory = tracer.to_trajectory()
+                runtime_status = agent.runtime.get_status_dict() if hasattr(agent, "runtime") else None
                 if hasattr(agent, "runtime"):
                     tracer.enrich_from_runtime(trajectory, agent.runtime)
+                finalized = trajectory.model_copy(update={"status": trajectory_status})
+                system_metrics, objective_metrics = MetricsCollector().compute_all(finalized, runtime_status)
                 store.finalize_run(
                     run_id=run_id,
                     finished_at=trajectory.finished_at,
                     final_response=trajectory.final_response,
                     status=trajectory_status,
                     run_tree_json=trajectory.run_tree_json,
-                    trajectory_json=trajectory.model_copy(update={"status": trajectory_status}).model_dump_json(),
+                    trajectory_json=finalized.model_dump_json(),
                 )
+                store.save_metrics(run_id, "system", system_metrics)
+                store.save_metrics(run_id, "objective", objective_metrics)
             except Exception:
                 logger.error("Failed to persist trajectory for thread %s", thread_id, exc_info=True)
 

--- a/eval/harness/client.py
+++ b/eval/harness/client.py
@@ -1,12 +1,9 @@
-"""SSE client for Leon backend API.
-
-Consumes SSE streams from /api/threads/{id}/runs endpoint,
-collecting text chunks, tool calls, tool results, and status snapshots.
-"""
+"""Eval harness client for the current public thread API."""
 
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import httpx
@@ -17,16 +14,31 @@ from eval.models import TrajectoryCapture
 class EvalClient:
     """HTTP + SSE client for driving Leon agent evaluation."""
 
-    def __init__(self, base_url: str = "http://localhost:8001"):
+    def __init__(self, base_url: str = "http://localhost:8001", token: str | None = None):
         self.base_url = base_url.rstrip("/")
-        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=300.0, proxy=None)
+        self.token = token or None
+        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=300.0, trust_env=False)
+        self._thread_event_cursors: dict[str, int] = {}
 
-    async def create_thread(self, sandbox: str = "local", cwd: str | None = None) -> str:
+    def _auth_headers(self) -> dict[str, str]:
+        if not self.token:
+            return {}
+        return {"Authorization": f"Bearer {self.token}"}
+
+    async def create_thread(
+        self,
+        agent_user_id: str | None = None,
+        sandbox: str = "local",
+        cwd: str | None = None,
+    ) -> str:
         """Create a new thread. Returns thread_id."""
-        payload: dict[str, Any] = {"sandbox": sandbox}
+        resolved_agent_user_id = agent_user_id or os.getenv("LEON_EVAL_AGENT_USER_ID")
+        if not resolved_agent_user_id:
+            raise RuntimeError("EvalClient.create_thread requires agent_user_id or LEON_EVAL_AGENT_USER_ID")
+        payload: dict[str, Any] = {"agent_user_id": resolved_agent_user_id, "sandbox": sandbox}
         if cwd:
             payload["cwd"] = cwd
-        resp = await self._client.post("/api/threads", json=payload)
+        resp = await self._client.post("/api/threads", json=payload, headers=self._auth_headers())
         resp.raise_for_status()
         return resp.json()["thread_id"]
 
@@ -36,33 +48,57 @@ class EvalClient:
         message: str,
         enable_trajectory: bool = True,
     ) -> TrajectoryCapture:
-        """Send a message and consume the SSE stream. Returns TrajectoryCapture."""
+        """Start a public thread run, then consume its thread event stream."""
         capture = TrajectoryCapture()
         payload = {"message": message, "enable_trajectory": enable_trajectory}
-
-        async with self._client.stream(
-            "POST",
-            f"/api/threads/{thread_id}/runs",
+        headers = self._auth_headers()
+        start_resp = await self._client.post(
+            f"/api/threads/{thread_id}/messages",
             json=payload,
+            headers=headers,
+        )
+        start_resp.raise_for_status()
+
+        after = self._thread_event_cursors.get(thread_id, 0)
+        stream_path = f"/api/threads/{thread_id}/events?after={after}"
+        if self.token:
+            stream_path = f"{stream_path}&token={self.token}"
+
+        # @@@public-thread-sse-handoff - the current public contract starts a run
+        # with POST /messages, then delivers lifecycle/text over persistent
+        # thread events. The harness must mirror that path exactly or it will
+        # prove a dead API instead of real runtime truth.
+        async with self._client.stream(
+            "GET",
+            stream_path,
             headers={"Accept": "text/event-stream"},
         ) as resp:
             resp.raise_for_status()
             event_type = ""
             data_buf = ""
+            event_id: int | None = None
 
             async for line in resp.aiter_lines():
                 if line.startswith("event:"):
                     event_type = line[6:].strip()
                     data_buf = ""
+                elif line.startswith("id:"):
+                    try:
+                        event_id = int(line[3:].strip())
+                    except ValueError:
+                        event_id = None
                 elif line.startswith("data:"):
                     data_buf = line[5:].strip()
                 elif line == "" and event_type and data_buf:
                     # End of SSE event
                     self._process_event(capture, event_type, data_buf)
-                    if event_type in ("done", "cancelled", "error"):
+                    if event_id is not None:
+                        self._thread_event_cursors[thread_id] = event_id
+                    if event_type in ("run_done", "cancelled", "error"):
                         break
                     event_type = ""
                     data_buf = ""
+                    event_id = None
 
         return capture
 
@@ -84,7 +120,9 @@ class EvalClient:
         elif event_type == "status":
             capture.status_snapshots.append(parsed)
             capture.final_status = parsed
-        elif event_type in ("done", "cancelled", "error"):
+        elif event_type == "run_done":
+            capture.terminal_event = "done"
+        elif event_type in ("cancelled", "error"):
             capture.terminal_event = event_type
             if event_type == "error":
                 capture.final_status = parsed

--- a/eval/harness/runner.py
+++ b/eval/harness/runner.py
@@ -21,16 +21,18 @@ class EvalRunner:
     def __init__(
         self,
         client: EvalClient,
+        agent_user_id: str,
         store: TrajectoryStore | None = None,
         collector: MetricsCollector | None = None,
     ):
         self.client = client
+        self.agent_user_id = agent_user_id
         self.store = store
         self.collector = collector or MetricsCollector()
 
     async def run_scenario(self, scenario: EvalScenario) -> EvalResult:
         """Execute a single scenario end-to-end."""
-        thread_id = await self.client.create_thread(sandbox=scenario.sandbox)
+        thread_id = await self.client.create_thread(agent_user_id=self.agent_user_id, sandbox=scenario.sandbox)
         captures: list[TrajectoryCapture] = []
         started_at = datetime.now(UTC)
 
@@ -201,6 +203,8 @@ async def _main() -> None:
     parser.add_argument("--scenario", type=str, help="Path to a single scenario YAML")
     parser.add_argument("--scenario-dir", type=str, help="Path to scenario directory")
     parser.add_argument("--base-url", type=str, default="http://localhost:8001")
+    parser.add_argument("--token", type=str, default=None)
+    parser.add_argument("--agent-user-id", type=str, required=True)
     parser.add_argument("--max-concurrent", type=int, default=3)
     args = parser.parse_args()
 
@@ -221,9 +225,9 @@ async def _main() -> None:
 
     print(f"Running {len(scenarios)} scenario(s) against {args.base_url}")
 
-    client = EvalClient(base_url=args.base_url)
+    client = EvalClient(base_url=args.base_url, token=args.token)
     store = TrajectoryStore()
-    runner = EvalRunner(client=client, store=store)
+    runner = EvalRunner(client=client, agent_user_id=args.agent_user_id, store=store)
 
     try:
         results = await runner.run_all(scenarios, max_concurrent=args.max_concurrent)

--- a/tests/Integration/test_eval_public_message_trajectory.py
+++ b/tests/Integration/test_eval_public_message_trajectory.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from backend.web.core.dependencies import get_current_user_id, verify_thread_owner
+from backend.web.routers import monitor
+from backend.web.routers import threads as threads_router
+from core.runtime.middleware.monitor import AgentState
+from eval.models import LLMCallRecord, RunTrajectory, ToolCallRecord
+from eval.repo import SQLiteEvalRepo
+from eval.storage import TrajectoryStore
+from storage.contracts import UserRow, UserType
+
+
+class _FakeUserRepo:
+    def __init__(self) -> None:
+        self._users = {
+            "member-1": UserRow(
+                id="member-1",
+                type=UserType.AGENT,
+                display_name="Toad",
+                owner_user_id="owner-1",
+                agent_config_id="cfg-1",
+                avatar="avatars/member-1.png",
+                created_at=1.0,
+            ),
+            "owner-1": UserRow(
+                id="owner-1",
+                type=UserType.HUMAN,
+                display_name="Owner",
+                owner_user_id=None,
+                created_at=1.0,
+            ),
+        }
+        self._seq = {"member-1": 0}
+
+    def get_by_id(self, user_id: str):
+        return self._users.get(user_id)
+
+    def increment_thread_seq(self, user_id: str) -> int:
+        self._seq[user_id] += 1
+        return self._seq[user_id]
+
+
+class _FakeThreadRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict] = {}
+
+    def get_by_id(self, thread_id: str):
+        row = self.rows.get(thread_id)
+        if row is None:
+            return None
+        return {"id": thread_id, **row}
+
+    def get_default_thread(self, agent_user_id: str):
+        for thread_id, row in self.rows.items():
+            if row["agent_user_id"] == agent_user_id and row["is_main"]:
+                return {"id": thread_id, **row}
+        return None
+
+    def get_next_branch_index(self, agent_user_id: str) -> int:
+        indices = [row["branch_index"] for row in self.rows.values() if row["agent_user_id"] == agent_user_id]
+        return max(indices, default=0) + 1
+
+    def create(self, **kwargs):
+        self.rows[kwargs["thread_id"]] = dict(kwargs)
+
+
+class _FakeDisplayBuilder:
+    def apply_event(self, thread_id: str, event_type: str, data: dict) -> None:
+        return None
+
+
+class _FakeQueueManager:
+    def peek(self, _thread_id: str) -> bool:
+        return False
+
+    def drain_all(self, _thread_id: str) -> list[object]:
+        return []
+
+    def enqueue(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.current_state = AgentState.IDLE
+        self.current_run_source = None
+        self.state = SimpleNamespace(flags=SimpleNamespace(is_compacting=False))
+        self._event_callback = None
+
+    def set_event_callback(self, cb) -> None:
+        self._event_callback = cb
+
+    def get_status_dict(self) -> dict[str, object]:
+        return {"state": {"state": "idle", "flags": {}}, "calls": 1, "context": {"usage_percent": 0.0}}
+
+    def transition(self, new_state) -> bool:
+        self.current_state = new_state
+        return True
+
+
+class _FakeGraphAgent:
+    async def aget_state(self, _config):
+        return SimpleNamespace(values={"messages": []})
+
+    async def astream(self, *_args, **_kwargs):
+        if False:
+            yield None
+
+
+class _FakeTrajectoryTracer:
+    def __init__(self, *, thread_id: str, user_message: str, run_id: str | None = None, cost_calculator=None, **_kwargs):
+        self.thread_id = thread_id
+        self.user_message = user_message
+        self.run_id = run_id
+        self._start_time = datetime.fromisoformat("2026-04-08T12:00:00+00:00").astimezone(UTC)
+
+    def to_trajectory(self) -> RunTrajectory:
+        return RunTrajectory(
+            id=self.run_id or "missing-run-id",
+            thread_id=self.thread_id,
+            user_message=self.user_message,
+            final_response="done",
+            llm_calls=[
+                LLMCallRecord(
+                    run_id=self.run_id or "missing-run-id",
+                    model_name="gpt-5.4-mini",
+                    input_tokens=7,
+                    output_tokens=4,
+                    total_tokens=11,
+                    cost_usd=0.01,
+                )
+            ],
+            tool_calls=[
+                ToolCallRecord(
+                    run_id=self.run_id or "missing-run-id",
+                    tool_name="Read",
+                    tool_call_id="tool-1",
+                    duration_ms=12.0,
+                    success=True,
+                    args_summary="{}",
+                    result_summary="ok",
+                )
+            ],
+            run_tree_json="{}",
+            started_at="2026-04-08T12:00:00+00:00",
+            finished_at="2026-04-08T12:01:00+00:00",
+            status="completed",
+        )
+
+    def enrich_from_runtime(self, trajectory: RunTrajectory, runtime) -> None:
+        return None
+
+
+async def _noop_async(*_args, **_kwargs) -> None:
+    return None
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(threads_router.router)
+    app.include_router(monitor.router)
+    app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
+    app.dependency_overrides[verify_thread_owner] = lambda: "owner-1"
+    app.state.user_repo = _FakeUserRepo()
+    app.state.thread_repo = _FakeThreadRepo()
+    app.state.thread_sandbox = {}
+    app.state.thread_cwd = {}
+    app.state.display_builder = _FakeDisplayBuilder()
+    app.state.thread_event_buffers = {}
+    app.state.thread_tasks = {}
+    app.state.thread_last_active = {}
+    app.state.thread_locks = {}
+    app.state.thread_locks_guard = asyncio.Lock()
+    app.state.queue_manager = _FakeQueueManager()
+    app.state.typing_tracker = None
+    app.state.agent_pool = {}
+    return app
+
+
+@pytest.mark.asyncio
+async def test_public_thread_messages_enable_trajectory_persists_eval_truth_for_monitor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    app = _build_app()
+    agent = SimpleNamespace(agent=_FakeGraphAgent(), runtime=_FakeRuntime(), storage_container=None)
+    repo = SQLiteEvalRepo(tmp_path / "eval.db")
+    repo.ensure_schema()
+    store = TrajectoryStore(eval_repo=repo)
+    seq = 0
+
+    async def fake_append_event(thread_id, run_id, event, message_id=None, run_event_repo=None):
+        nonlocal seq
+        seq += 1
+        return seq
+
+    monkeypatch.setattr(threads_router, "_validate_sandbox_provider_gate", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(threads_router, "_invalidate_resource_overview_cache", lambda: None)
+    monkeypatch.setattr(threads_router, "save_last_successful_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(threads_router, "_create_thread_sandbox_resources", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(threads_router, "_validate_mount_capability_gate", _noop_async)
+    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", AsyncMock(return_value=agent))
+    monkeypatch.setattr("backend.web.services.event_store.append_event", fake_append_event)
+    monkeypatch.setattr("backend.web.services.streaming_service.cleanup_old_runs", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *args, **kwargs: None)
+    monkeypatch.setattr("backend.web.services.streaming_service._consume_followup_queue", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service.write_cancellation_markers", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._persist_cancelled_run_input_if_missing", _noop_async)
+    monkeypatch.setattr("backend.web.services.streaming_service._flush_cancelled_owner_steers", _noop_async)
+    monkeypatch.setattr("eval.storage.TrajectoryStore", lambda: store)
+    monkeypatch.setattr("backend.web.services.monitor_service.make_eval_store", lambda: store)
+    monkeypatch.setattr("eval.tracer.TrajectoryTracer", _FakeTrajectoryTracer)
+    monkeypatch.setattr(
+        "backend.web.routers.monitor.get_monitor_resource_overview_snapshot",
+        lambda: {
+            "summary": {
+                "snapshot_at": "2026-04-07T00:00:00Z",
+                "last_refreshed_at": "2026-04-07T00:00:00Z",
+                "refresh_status": "fresh",
+                "running_sessions": 0,
+                "active_providers": 0,
+                "unavailable_providers": 0,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "backend.web.services.monitor_service.runtime_health_snapshot",
+        lambda: {
+            "snapshot_at": "2026-04-07T00:00:00Z",
+            "db": {"counts": {"chat_sessions": 0}},
+            "sessions": {"total": 0},
+        },
+    )
+    monkeypatch.setattr(
+        "backend.web.services.monitor_service.list_leases",
+        lambda: {"summary": {"total": 0, "diverged": 0, "orphan_diverged": 0, "orphan": 0, "healthy": 0}},
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        create_response = await client.post("/api/threads", json={"agent_user_id": "member-1", "sandbox": "local"})
+        assert create_response.status_code == 200
+        thread_id = create_response.json()["thread_id"]
+
+        send_response = await client.post(
+            f"/api/threads/{thread_id}/messages",
+            json={"message": "hello", "enable_trajectory": True},
+        )
+        assert send_response.status_code == 200
+        assert send_response.json()["status"] == "started"
+
+        run_id = ""
+        for _ in range(100):
+            runs = store.list_runs(limit=1)
+            if runs:
+                run_id = str(runs[0]["id"])
+                if len(store.get_metrics(run_id)) == 2 and thread_id not in app.state.thread_tasks:
+                    break
+            await asyncio.sleep(0)
+
+        assert run_id
+        assert len(store.get_metrics(run_id)) == 2
+
+        evaluation_response = await client.get("/api/monitor/evaluation")
+        dashboard_response = await client.get("/api/monitor/dashboard")
+
+    assert evaluation_response.status_code == 200
+    evaluation_payload = evaluation_response.json()
+    assert evaluation_payload["status"] == "completed"
+    assert evaluation_payload["kind"] == "completed_recorded"
+    facts = {(item["label"], item["value"]) for item in evaluation_payload["facts"]}
+    assert ("Thread ID", thread_id) in facts
+    assert ("Metric Tiers", "2") in facts
+    assert ("Total tokens", "11") in facts
+
+    assert dashboard_response.status_code == 200
+    dashboard_payload = dashboard_response.json()
+    assert dashboard_payload["workload"]["evaluations_running"] == 0
+    assert dashboard_payload["latest_evaluation"] == {
+        "status": "completed",
+        "kind": "completed_recorded",
+        "tone": "success",
+        "headline": "Latest persisted evaluation run completed successfully.",
+    }

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi import Request
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 
-from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, ThreadPermissionRuleRequest
+from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
 from backend.web.routers import threads as threads_router
 from core.runtime.loop import QueryLoop
 from core.runtime.middleware.monitor import AgentState
@@ -74,6 +74,22 @@ class _FakeAuthService:
     def verify_token(self, token: str) -> dict:
         self.tokens.append(token)
         return {"user_id": "owner-1"}
+
+
+@pytest.mark.asyncio
+async def test_send_message_passes_enable_trajectory_to_message_routing() -> None:
+    route_message = AsyncMock(return_value={"status": "started", "thread_id": "thread-1"})
+
+    with patch("backend.web.services.message_routing.route_message_to_brain", route_message):
+        result = await threads_router.send_message(
+            "thread-1",
+            SendMessageRequest(message="hello", enable_trajectory=True),
+            user_id="owner-1",
+            app=SimpleNamespace(),
+        )
+
+    assert result == {"status": "started", "thread_id": "thread-1"}
+    assert route_message.await_args.kwargs["enable_trajectory"] is True
 
 
 def _make_request(headers: dict[str, str] | None = None) -> Request:

--- a/tests/Unit/backend/test_message_routing.py
+++ b/tests/Unit/backend/test_message_routing.py
@@ -50,3 +50,25 @@ async def test_route_message_to_brain_clears_resource_overview_cache_when_starti
 
     assert result == {"status": "started", "routing": "direct", "run_id": "run-123", "thread_id": "thread-1"}
     clear_cache.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_route_message_to_brain_passes_enable_trajectory_to_start_agent_run() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            queue_manager=_FakeQueueManager(),
+            thread_locks={},
+            thread_locks_guard=asyncio.Lock(),
+        )
+    )
+    agent = _FakeAgent()
+
+    with (
+        patch("backend.web.services.agent_pool.resolve_thread_sandbox", return_value="local"),
+        patch("backend.web.services.agent_pool.get_or_create_agent", AsyncMock(return_value=agent)),
+        patch("backend.web.services.streaming_service.start_agent_run", return_value="run-123") as start_run,
+        patch("backend.web.services.resource_cache.clear_monitor_resource_overview_cache"),
+    ):
+        await route_message_to_brain(app, "thread-1", "hello", enable_trajectory=True)
+
+    assert start_run.call_args.kwargs["enable_trajectory"] is True

--- a/tests/Unit/backend/test_thread_request_model.py
+++ b/tests/Unit/backend/test_thread_request_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.web.models.requests import CreateThreadRequest
+from backend.web.models.requests import CreateThreadRequest, SendMessageRequest
 
 
 def test_create_thread_request_accepts_legacy_sandbox_type_key() -> None:
@@ -35,3 +35,15 @@ def test_create_thread_request_rejects_legacy_member_id_field() -> None:
                 "sandbox": "local",
             }
         )
+
+
+def test_send_message_request_defaults_enable_trajectory_to_false() -> None:
+    payload = SendMessageRequest.model_validate({"message": "hello"})
+
+    assert payload.enable_trajectory is False
+
+
+def test_send_message_request_accepts_enable_trajectory_flag() -> None:
+    payload = SendMessageRequest.model_validate({"message": "hello", "enable_trajectory": True})
+
+    assert payload.enable_trajectory is True

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -65,6 +65,7 @@ class _FakeGraphAgent:
 class _FakeTrajectoryStore:
     header_calls: list[dict] = []
     finalize_calls: list[dict] = []
+    metric_calls: list[dict] = []
 
     def __init__(self) -> None:
         return None
@@ -73,12 +74,16 @@ class _FakeTrajectoryStore:
     def reset(cls) -> None:
         cls.header_calls = []
         cls.finalize_calls = []
+        cls.metric_calls = []
 
     def upsert_run_header(self, **payload) -> None:
         _FakeTrajectoryStore.header_calls.append(payload)
 
     def finalize_run(self, **payload) -> None:
         _FakeTrajectoryStore.finalize_calls.append(payload)
+
+    def save_metrics(self, run_id: str, tier: str, metrics) -> None:
+        _FakeTrajectoryStore.metric_calls.append({"run_id": run_id, "tier": tier, "metrics": metrics.model_dump()})
 
 
 class _FakeTrajectoryTracer:
@@ -171,6 +176,7 @@ async def test_run_agent_to_buffer_persists_running_then_completed_eval_row(monk
             "trajectory_json": '{"id":"run-123","thread_id":"thread-1","user_message":"hello","final_response":"done","llm_calls":[],"tool_calls":[],"run_tree_json":"{}","started_at":"2026-04-08T12:00:00+00:00","finished_at":"2026-04-08T12:01:00+00:00","status":"completed"}',
         }
     ]
+    assert [call["tier"] for call in _FakeTrajectoryStore.metric_calls] == ["system", "objective"]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/eval/test_harness_client.py
+++ b/tests/Unit/eval/test_harness_client.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from eval.harness.client import EvalClient
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict | None = None) -> None:
+        self._payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_create_thread_sends_agent_user_id() -> None:
+    calls: list[tuple[str, dict, dict]] = []
+
+    async def fake_post(path: str, *, json: dict, headers: dict) -> _FakeResponse:
+        calls.append((path, json, headers))
+        return _FakeResponse({"thread_id": "thread-1"})
+
+    with patch("eval.harness.client.httpx.AsyncClient", return_value=SimpleNamespace(post=fake_post)):
+        client = EvalClient(base_url="http://example.test", token="tok-1")
+        thread_id = await client.create_thread(agent_user_id="agent-1", sandbox="local")
+
+    assert thread_id == "thread-1"
+    assert calls == [
+        (
+            "/api/threads",
+            {
+                "agent_user_id": "agent-1",
+                "sandbox": "local",
+            },
+            {"Authorization": "Bearer tok-1"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_message_uses_public_messages_path_then_thread_events_stream() -> None:
+    post_calls: list[tuple[str, dict, dict]] = []
+    stream_calls: list[tuple[str, dict]] = []
+
+    async def fake_post(path: str, *, json: dict, headers: dict) -> _FakeResponse:
+        post_calls.append((path, json, headers))
+        return _FakeResponse({"status": "started", "run_id": "run-1", "thread_id": "thread-1"})
+
+    @asynccontextmanager
+    async def fake_stream(method: str, path: str, *, headers: dict):
+        stream_calls.append((path, headers))
+
+        class _StreamResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+            async def aiter_lines(self):
+                for line in (
+                    "event: run_start",
+                    'data: {"thread_id":"thread-1","run_id":"run-1"}',
+                    "",
+                    "event: text",
+                    'data: {"content":"done"}',
+                    "",
+                    "event: run_done",
+                    'data: {"thread_id":"thread-1","run_id":"run-1"}',
+                    "",
+                ):
+                    yield line
+
+        yield _StreamResponse()
+
+    client_transport = SimpleNamespace(post=fake_post, stream=fake_stream)
+    with patch("eval.harness.client.httpx.AsyncClient", return_value=client_transport):
+        client = EvalClient(base_url="http://example.test", token="tok-1")
+        capture = await client.run_message("thread-1", "hello", enable_trajectory=True)
+
+    assert capture.text_chunks == ["done"]
+    assert capture.terminal_event == "done"
+    assert post_calls == [
+        (
+            "/api/threads/thread-1/messages",
+            {
+                "message": "hello",
+                "enable_trajectory": True,
+            },
+            {"Authorization": "Bearer tok-1"},
+        )
+    ]
+    assert stream_calls == [
+        (
+            "/api/threads/thread-1/events?after=0&token=tok-1",
+            {"Accept": "text/event-stream"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_thread_falls_back_to_env_agent_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict, dict]] = []
+
+    async def fake_post(path: str, *, json: dict, headers: dict) -> _FakeResponse:
+        calls.append((path, json, headers))
+        return _FakeResponse({"thread_id": "thread-1"})
+
+    monkeypatch.setenv("LEON_EVAL_AGENT_USER_ID", "agent-from-env")
+    with patch("eval.harness.client.httpx.AsyncClient", return_value=SimpleNamespace(post=fake_post)):
+        client = EvalClient(base_url="http://example.test", token="tok-1")
+        thread_id = await client.create_thread(sandbox="local")
+
+    assert thread_id == "thread-1"
+    assert calls[0][1]["agent_user_id"] == "agent-from-env"


### PR DESCRIPTION
## Summary
- add `enable_trajectory` to the real public `POST /api/threads/{thread_id}/messages` path and thread it into `start_agent_run`
- update the eval harness to use the current thread contract (`agent_user_id`, `/messages`, then `/events`)
- persist both `eval_runs` and `eval_metrics` for trajectory-enabled public runs, with monitor-facing integration coverage

## Verification
- `env -u all_proxy -u http_proxy -u https_proxy -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY /Users/lexicalmathical/worktrees/leonai--dev-feature/.venv/bin/pytest -q tests/Unit/backend/test_thread_request_model.py tests/Unit/backend/test_message_routing.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/eval/test_harness_client.py tests/Integration/test_eval_public_message_trajectory.py`
- `/Users/lexicalmathical/worktrees/leonai--dev-feature/.venv/bin/python -m py_compile backend/web/models/requests.py backend/web/routers/threads.py backend/web/services/message_routing.py backend/web/services/streaming_service.py eval/harness/client.py eval/harness/runner.py tests/Unit/backend/test_thread_request_model.py tests/Unit/backend/test_message_routing.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/eval/test_harness_client.py tests/Integration/test_eval_public_message_trajectory.py`
- `uv run ruff check backend/web/models/requests.py backend/web/routers/threads.py backend/web/services/message_routing.py backend/web/services/streaming_service.py eval/harness/client.py eval/harness/runner.py tests/Unit/backend/test_thread_request_model.py tests/Unit/backend/test_message_routing.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/eval/test_harness_client.py tests/Integration/test_eval_public_message_trajectory.py`
- `uv run ruff format --check backend/web/models/requests.py backend/web/routers/threads.py backend/web/services/message_routing.py backend/web/services/streaming_service.py eval/harness/client.py eval/harness/runner.py tests/Unit/backend/test_thread_request_model.py tests/Unit/backend/test_message_routing.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/eval/test_harness_client.py tests/Integration/test_eval_public_message_trajectory.py`

## Boundary
- no new eval-only startup API
- no `/runs` revival
- no chat semantics changes

## Live Proof Status
- the code path and integration proof are in place
- fresh local backend startup is still blocked by local postgres/checkpointer connectivity (`LEON_POSTGRES_URL` target currently not accepting new connections), so the live monitor proof remains queued behind env recovery
