### PR TITLE
refactor: decouple chat tools from messaging repos

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -279,6 +279,9 @@ class MessagingService:
     def count_unread(self, chat_id: str, user_id: str) -> int:
         return self._messages.count_unread(chat_id, user_id)
 
+    def find_direct_chat_id(self, actor_id: str, target_id: str) -> str | None:
+        return self._members_repo.find_chat_between(actor_id, target_id)
+
     def search_messages(self, query: str, *, chat_id: str | None = None) -> list[dict[str, Any]]:
         return self._messages.search(query, chat_id=chat_id)
 
@@ -287,6 +290,16 @@ class MessagingService:
 
     def is_chat_member(self, chat_id: str, user_id: str) -> bool:
         return self._members_repo.is_member(chat_id, user_id)
+
+    def list_messages_by_time_range(
+        self,
+        chat_id: str,
+        *,
+        after: str | None = None,
+        before: str | None = None,
+    ) -> list[dict[str, Any]]:
+        rows = self._messages.list_by_time_range(chat_id, after=after, before=before)
+        return [self._normalize_message_row(row) for row in rows]
 
     def update_mute(self, chat_id: str, user_id: str, muted: bool, mute_until: str | None) -> None:
         self._members_repo.update_mute(chat_id, user_id, muted, mute_until)

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -102,8 +102,6 @@ class ChatToolService:
         self._chat_identity_id: str = identity_id
         self._owner_id = owner_id
         self._messaging = messaging_service
-        self._chat_members = chat_member_repo
-        self._messages = messages_repo
         self._user_repo = user_repo
         self._thread_repo = thread_repo
         self._relationships = relationship_repo
@@ -146,14 +144,14 @@ class ChatToolService:
             limit = parsed["limit"]
             skip_last = parsed["skip_last"]
             fetch_count = limit + skip_last
-            msgs = self._messages.list_by_chat(chat_id, limit=fetch_count, viewer_id=self._chat_identity_id)
+            msgs = self._messaging.list_messages(chat_id, limit=fetch_count, viewer_id=self._chat_identity_id)
             if skip_last > 0:
                 msgs = msgs[: len(msgs) - skip_last] if len(msgs) > skip_last else []
             return msgs
         else:
             after_iso = datetime.fromtimestamp(parsed["after"], tz=UTC).isoformat() if parsed.get("after") else None
             before_iso = datetime.fromtimestamp(parsed["before"], tz=UTC).isoformat() if parsed.get("before") else None
-            return self._messages.list_by_time_range(chat_id, after=after_iso, before=before_iso)
+            return self._messaging.list_messages_by_time_range(chat_id, after=after_iso, before=before_iso)
 
     def _register_list_chats(self, registry: ToolRegistry) -> None:
         eid = self._chat_identity_id
@@ -213,7 +211,7 @@ class ChatToolService:
             if chat_id:
                 pass
             elif user_id:
-                chat_id = self._chat_members.find_chat_between(eid, user_id)
+                chat_id = self._messaging.find_direct_chat_id(eid, user_id)
                 if not chat_id:
                     target = self._resolve_display_user(user_id)
                     name = target.display_name if target else user_id
@@ -299,7 +297,7 @@ class ChatToolService:
             target_name = "chat"
 
             if chat_id:
-                if not self._chat_members.is_member(chat_id, eid):
+                if not self._messaging.is_chat_member(chat_id, eid):
                     raise RuntimeError(f"You are not a member of chat {chat_id}")
             elif user_id:
                 if user_id == eid:
@@ -398,7 +396,7 @@ class ChatToolService:
         def handle(query: str, user_id: str | None = None) -> str:
             chat_id = None
             if user_id:
-                chat_id = self._chat_members.find_chat_between(eid, user_id)
+                chat_id = self._messaging.find_direct_chat_id(eid, user_id)
                 if not chat_id:
                     target = self._resolve_display_user(user_id)
                     name = target.display_name if target else user_id

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -640,8 +640,8 @@ def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
         registry=registry,
         chat_identity_id="human-user-1",
         owner_id="owner-user-1",
-        chat_member_repo=SimpleNamespace(is_member=lambda _chat_id, _user_id: True),
         messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
             count_unread=lambda _chat_id, _user_id: 0,
             send=lambda chat_id, sender_id, content, **kwargs: sent.append(
                 {
@@ -672,6 +672,24 @@ def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
     ]
 
 
+def test_chat_tool_send_checks_group_membership_via_messaging_service_without_member_repo() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        owner_id="owner-user-1",
+        messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: False,
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    with pytest.raises(RuntimeError, match="You are not a member of chat chat-1"):
+        send_message.handler(content="hello", chat_id="chat-1")
+
+
 def test_chat_tool_send_requires_group_reply_to_consume_peer_unread() -> None:
     registry = ToolRegistry()
     sent: list[dict[str, object]] = []
@@ -679,8 +697,8 @@ def test_chat_tool_send_requires_group_reply_to_consume_peer_unread() -> None:
         registry=registry,
         chat_identity_id="thread-user-1",
         owner_id="owner-user-1",
-        chat_member_repo=SimpleNamespace(is_member=lambda _chat_id, _user_id: True),
         messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
             count_unread=lambda _chat_id, _user_id: 1,
             send=lambda chat_id, sender_id, content, **kwargs: sent.append(
                 {
@@ -715,8 +733,8 @@ def test_chat_tool_send_returns_tool_error_when_chat_advances_after_read() -> No
         registry=registry,
         chat_identity_id="thread-user-1",
         owner_id="owner-user-1",
-        chat_member_repo=SimpleNamespace(is_member=lambda _chat_id, _user_id: True),
         messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
             count_unread=lambda _chat_id, _user_id: 0,
             send=_send,
         ),
@@ -751,8 +769,7 @@ def test_read_messages_uses_thread_user_target_name_on_no_history() -> None:
         thread_repo=SimpleNamespace(
             get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
         ),
-        chat_member_repo=SimpleNamespace(find_chat_between=lambda _eid, _user_id: None),
-        messaging_service=SimpleNamespace(),
+        messaging_service=SimpleNamespace(find_direct_chat_id=lambda _eid, _user_id: None),
     )
 
     read_messages = registry.get("read_messages")
@@ -761,6 +778,74 @@ def test_read_messages_uses_thread_user_target_name_on_no_history() -> None:
     result = read_messages.handler(user_id="thread-user-1")
 
     assert result == "No chat history with Toad."
+
+
+def test_read_messages_uses_messaging_service_direct_chat_lookup_without_member_repo() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        owner_id="owner-user-1",
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", owner_user_id="owner-user-1")
+                if uid == "agent-user-1"
+                else None
+            ),
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+        messaging_service=SimpleNamespace(
+            find_direct_chat_id=lambda _eid, _user_id: None,
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    result = read_messages.handler(user_id="thread-user-1")
+
+    assert result == "No chat history with Toad."
+
+
+def test_read_messages_uses_messaging_service_time_range_history_without_messages_repo() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        owner_id="owner-user-1",
+        messaging_service=SimpleNamespace(
+            list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
+                {
+                    "sender_id": "thread-user-1",
+                    "content": f"after={after};before={before}",
+                }
+            ],
+            mark_read=lambda *_args, **_kwargs: None,
+        ),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", owner_user_id="owner-user-1")
+                if uid == "agent-user-1"
+                else None
+            ),
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    result = read_messages.handler(chat_id="chat-1", range="-1h:")
+
+    assert "[Toad]: after=" in result
 
 
 def test_chat_tool_search_does_not_fall_back_to_global_search_for_thread_user_target() -> None:
@@ -782,9 +867,9 @@ def test_chat_tool_search_does_not_fall_back_to_global_search_for_thread_user_ta
         thread_repo=SimpleNamespace(
             get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
         ),
-        chat_member_repo=SimpleNamespace(find_chat_between=lambda _eid, _user_id: None),
         messaging_service=SimpleNamespace(
-            search_messages=lambda query, *, chat_id=None: search_calls.append((query, chat_id)) or [{"content": "wrong"}]
+            find_direct_chat_id=lambda _eid, _user_id: None,
+            search_messages=lambda query, *, chat_id=None: search_calls.append((query, chat_id)) or [{"content": "wrong"}],
         ),
     )
 
@@ -795,6 +880,40 @@ def test_chat_tool_search_does_not_fall_back_to_global_search_for_thread_user_ta
 
     assert result == "No messages matching 'hello' with Toad."
     assert search_calls == []
+
+
+def test_chat_tool_search_uses_messaging_service_direct_chat_lookup_without_member_repo() -> None:
+    registry = ToolRegistry()
+    search_calls: list[tuple[str, str | None]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        owner_id="owner-user-1",
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", owner_user_id="owner-user-1")
+                if uid == "agent-user-1"
+                else None
+            ),
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+        messaging_service=SimpleNamespace(
+            find_direct_chat_id=lambda _eid, _user_id: "chat-1",
+            search_messages=lambda query, *, chat_id=None: search_calls.append((query, chat_id)) or [],
+        ),
+    )
+
+    search_messages = registry.get("search_messages")
+    assert search_messages is not None
+
+    result = search_messages.handler(query="hello", user_id="thread-user-1")
+
+    assert result == "No messages matching 'hello'."
+    assert search_calls == [("hello", "chat-1")]
 
 
 def test_deliver_to_agents_routes_delivery_by_thread_user_id() -> None:


### PR DESCRIPTION
## Summary
- move chat tool direct-chat lookup, group membership, and time-range history reads behind `MessagingService`
- add narrow `MessagingService` helpers instead of letting `ChatToolService` reach directly into chat-member/message repos
- extend messaging social-handle contract coverage for the new service-owned tool path

## Verification
- uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff check messaging/service.py messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff format --check messaging/service.py messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- python3 -m py_compile messaging/service.py messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py