### PR TITLE
refactor: align chat tool constructor dependencies

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1264,8 +1264,6 @@ class LeonAgent:
                     chat_identity_id=chat_identity_id,
                     owner_id=owner_id,
                     messaging_service=repos.get("messaging_service"),
-                    chat_member_repo=repos.get("chat_member_repo"),
-                    messages_repo=repos.get("messages_repo"),
                     user_repo=repos.get("user_repo"),
                     thread_repo=self._thread_repo,
                     relationship_repo=repos.get("relationship_repo"),

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -90,8 +90,6 @@ class ChatToolService:
         chat_identity_id: str | None = None,
         user_id: str | None = None,
         messaging_service: Any = None,  # MessagingService (new)
-        chat_member_repo: Any = None,  # SupabaseChatMemberRepo
-        messages_repo: Any = None,  # SupabaseMessagesRepo
         user_repo: Any = None,
         thread_repo: Any = None,
         relationship_repo: Any = None,

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -5,6 +5,7 @@ Uses mock model to verify the full astream pipeline without real API calls.
 
 import json
 import os
+import sys
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -905,6 +906,76 @@ def test_leon_agent_chat_identity_prompt_resolves_thread_user_name_via_member() 
     assert "- Your name: Truffle" in prompt
     assert "- Your chat identity id: thread-user-3" in prompt
     assert "- Your owner: Owner 3 (human user_id: human-user-3)" in prompt
+
+
+def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from core.runtime.agent import LeonAgent
+    from core.runtime.registry import ToolRegistry
+
+    captured: dict[str, Any] = {}
+
+    class _NoopService:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _NoopRegistry:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeChatToolService:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.CronToolService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.AgentRegistry", _NoopRegistry)
+    monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
+    monkeypatch.setitem(sys.modules, "backend.taskboard.service", SimpleNamespace(TaskBoardService=_NoopService))
+    monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _FakeChatToolService)
+
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(name="local", fs=lambda: None, shell=lambda: None)
+    agent._tool_registry = ToolRegistry()
+    agent.workspace_root = str(tmp_path)
+    agent.model_name = "test-model"
+    agent._thread_repo = SimpleNamespace()
+    agent._user_repo = SimpleNamespace()
+    agent.queue_manager = SimpleNamespace()
+    agent._web_app = None
+    agent.allowed_file_extensions = []
+    agent.extra_allowed_paths = []
+    agent.enable_audit_log = False
+    agent.block_dangerous_commands = False
+    agent.block_network_commands = False
+    agent.verbose = False
+    agent._get_mcp_server_configs = lambda: {}
+    agent._chat_repos = {
+        "chat_identity_id": "thread-user-9",
+        "owner_id": "human-user-9",
+        "messaging_service": SimpleNamespace(),
+        "chat_member_repo": object(),
+        "messages_repo": object(),
+        "user_repo": SimpleNamespace(),
+        "relationship_repo": SimpleNamespace(),
+    }
+    cast(Any, agent).config = SimpleNamespace(
+        tools=SimpleNamespace(
+            filesystem=SimpleNamespace(enabled=False),
+            search=SimpleNamespace(enabled=False),
+            web=SimpleNamespace(enabled=False),
+            command=SimpleNamespace(enabled=False),
+        ),
+        skills=SimpleNamespace(enabled=False, paths=[], skills={}),
+    )
+
+    LeonAgent._init_services(agent)
+
+    assert captured["chat_identity_id"] == "thread-user-9"
+    assert captured["owner_id"] == "human-user-9"
+    assert "chat_member_repo" not in captured
+    assert "messages_repo" not in captured
 
 
 def test_build_rules_section_includes_function_result_clearing_guidance_when_spill_buffer_enabled():

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -262,6 +262,19 @@ def test_chat_tool_service_accepts_chat_identity_id_without_legacy_user_id() -> 
     assert registry.get("list_chats") is not None
 
 
+def test_chat_tool_service_rejects_dead_repo_constructor_kwargs() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(TypeError, match="chat_member_repo|messages_repo"):
+        ChatToolService(
+            registry=registry,
+            chat_identity_id="agent-user-1",
+            owner_id="owner-user-1",
+            messaging_service=SimpleNamespace(),
+            chat_member_repo=SimpleNamespace(),
+        )
+
+
 def test_messaging_service_resolves_sender_name_from_thread_user_id() -> None:
     published: list[dict[str, object]] = []
     service = MessagingService(
@@ -616,7 +629,6 @@ def test_chat_tool_send_accepts_thread_user_target_id() -> None:
         thread_repo=SimpleNamespace(
             get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
         ),
-        chat_member_repo=SimpleNamespace(is_member=lambda _chat_id, _user_id: True),
         messaging_service=SimpleNamespace(
             find_or_create_chat=lambda user_ids: {"id": "chat-1", "user_ids": user_ids},
             count_unread=lambda _chat_id, _user_id: 0,


### PR DESCRIPTION
## Summary
- remove dead `chat_member_repo` and `messages_repo` constructor inputs from `ChatToolService`
- stop passing those dead dependencies from LeonAgent runtime wiring
- add focused integration coverage for constructor truth alignment and runtime wiring

## Verification
- uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py -k "chat_tool or chat_identity_prompt"
- uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py -k "send_message_route_then_agent_terminal_notification_reenters_followthrough or run_agent_to_buffer_turns_silent_chat_notification_into_visible_followthrough"
- uv run ruff check messaging/tools/chat_tool_service.py core/runtime/agent.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py
- uv run ruff format --check messaging/tools/chat_tool_service.py core/runtime/agent.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py
- python3 -m py_compile messaging/tools/chat_tool_service.py core/runtime/agent.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py