### PR TITLE
refactor: align runtime chat repo truth

### DIFF
--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -151,12 +151,9 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
                 owner_id = agent_user.owner_user_id or ""
                 chat_repos = {
                     "chat_identity_id": chat_identity_id,
-                    "user_id": chat_identity_id,
                     "owner_id": owner_id,
                     "user_repo": user_repo,
                     "messaging_service": getattr(app_obj.state, "messaging_service", None),
-                    "chat_member_repo": getattr(app_obj.state, "chat_member_repo", None),
-                    "messages_repo": getattr(app_obj.state, "messages_repo", None),
                     "relationship_repo": getattr(app_obj.state, "relationship_repo", None),
                     "agent_config_repo": getattr(app_obj.state, "agent_config_repo", None),
                 }

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1254,7 +1254,7 @@ class LeonAgent:
         # @@@chat-tools - register chat tools for agents with user identity (v2 messaging)
         if self._chat_repos:
             repos = self._chat_repos
-            chat_identity_id = repos.get("chat_identity_id") or repos.get("user_id")
+            chat_identity_id = repos.get("chat_identity_id")
             owner_id = repos.get("owner_id", "")
             if chat_identity_id:
                 from messaging.tools.chat_tool_service import ChatToolService
@@ -1408,7 +1408,7 @@ class LeonAgent:
         # @@@chat-identity — inject chat identity so agent knows who it is in the social layer
         if self._chat_repos:
             repos = self._chat_repos
-            uid = repos.get("chat_identity_id") or repos.get("user_id")
+            uid = repos.get("chat_identity_id")
             owner_uid = repos.get("owner_id", "")
             if uid:
                 user_repo = repos.get("user_repo")

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -837,7 +837,7 @@ def test_leon_agent_chat_identity_prompt_uses_honest_legacy_wording():
     agent._build_system_prompt = lambda: "BASE"
     cast(Any, agent).config = SimpleNamespace(system_prompt=None)
     agent._chat_repos = {
-        "user_id": "agent-member-1",
+        "chat_identity_id": "agent-member-1",
         "owner_id": "human-user-1",
         "user_repo": SimpleNamespace(
             get_by_id=lambda uid: (
@@ -852,6 +852,24 @@ def test_leon_agent_chat_identity_prompt_uses_honest_legacy_wording():
     assert "- The chat tools still use the parameter name user_id for legacy reasons." in prompt
     assert "- Your owner: Owner (human user_id: human-user-1)" in prompt
     assert "- Your user_id:" not in prompt
+
+
+def test_leon_agent_chat_identity_prompt_does_not_fallback_to_legacy_user_id() -> None:
+    from core.runtime.agent import LeonAgent
+
+    agent = object.__new__(LeonAgent)
+    agent._build_system_prompt = lambda: "BASE"
+    cast(Any, agent).config = SimpleNamespace(system_prompt=None)
+    agent._chat_repos = {
+        "user_id": "agent-member-legacy",
+        "owner_id": "human-user-legacy",
+        "user_repo": SimpleNamespace(get_by_id=lambda uid: SimpleNamespace(id=uid, display_name=f"resolved:{uid}")),
+    }
+
+    prompt = LeonAgent._compose_system_prompt(agent)
+
+    assert "**Chat Identity:**" not in prompt
+    assert "agent-member-legacy" not in prompt
 
 
 def test_leon_agent_chat_identity_prompt_accepts_chat_identity_id_without_legacy_user_id():

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -278,8 +278,10 @@ async def test_get_or_create_agent_uses_thread_user_id_for_chat_identity(monkeyp
 
     chat_repos = cast(dict[str, object], captured["chat_repos"])
     assert chat_repos["chat_identity_id"] == "agent-user-5"
-    assert chat_repos["user_id"] == "agent-user-5"
     assert chat_repos["owner_id"] == "owner-5"
+    assert "user_id" not in chat_repos
+    assert "chat_member_repo" not in chat_repos
+    assert "messages_repo" not in chat_repos
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove stale legacy runtime chat_repos fields after #304
- make LeonAgent consume only chat_identity_id from the runtime bag
- keep messaging/tool behavior unchanged

## Scope
- backend/web/services/agent_pool.py
- core/runtime/agent.py
- tests/Unit/core/test_agent_pool.py
- tests/Integration/test_leon_agent.py

## Verification
- uv run pytest -q tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py -k 'chat_identity_prompt or chat_tool_wiring or chat_repos'
- uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py -k 'send_message_route_then_agent_terminal_notification_reenters_followthrough or run_agent_to_buffer_turns_silent_chat_notification_into_visible_followthrough'
- uv run ruff check backend/web/services/agent_pool.py core/runtime/agent.py tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py
- uv run ruff format --check backend/web/services/agent_pool.py core/runtime/agent.py tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py
- python3 -m py_compile backend/web/services/agent_pool.py core/runtime/agent.py tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py