### PR TITLE
fix: make monitor resource refresh truthful

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -10,7 +10,7 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel, Field
 
 from backend.web.monitor import list_leases, router
-from backend.web.services import monitor_service
+from backend.web.services import monitor_service, resource_service
 from backend.web.services.resource_cache import (
     get_monitor_resource_overview_snapshot,
     refresh_monitor_resource_overview_sync,
@@ -21,6 +21,13 @@ class ResourceCleanupRequest(BaseModel):
     action: str = Field(default="cleanup_residue")
     lease_ids: list[str]
     expected_category: str
+
+
+def _refresh_monitor_resources_sync():
+    # @@@manual-resource-refresh-must-probe - the operator-facing refresh button must fetch new
+    # sandbox metrics first; recomputing the overview alone just re-labels stale snapshots.
+    resource_service.refresh_resource_snapshots()
+    return refresh_monitor_resource_overview_sync()
 
 
 @router.get("/health")
@@ -72,7 +79,7 @@ def resources_overview():
 @router.post("/resources/refresh")
 async def resources_refresh():
     # @@@refresh-off-main-loop - provider I/O stays off event loop to avoid request head-of-line blocking.
-    return await asyncio.to_thread(refresh_monitor_resource_overview_sync)
+    return await asyncio.to_thread(_refresh_monitor_resources_sync)
 
 
 @router.post("/resources/cleanup")

--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -628,6 +628,10 @@ function SandboxInspector({
   }, [group, onClose]);
 
   if (!group) return null;
+  const browserUnavailableReason =
+    providerType !== "local" && group.leaseId && !group.sessions.some((session) => Boolean(session.runtimeSessionId))
+      ? "当前 lease 没有 active runtime session，无法浏览文件。"
+      : null;
 
   return (
     <div className="sandbox-modal-backdrop" role="dialog" aria-modal="true" onClick={onClose}>
@@ -704,6 +708,7 @@ function SandboxInspector({
             leaseId={group.leaseId}
             providerType={providerType}
             disabled={group.status === "stopped" || group.status === "destroying"}
+            unavailableReason={browserUnavailableReason}
           />
         </div>
       </div>
@@ -727,10 +732,12 @@ function MonitorFileBrowser({
   leaseId,
   providerType,
   disabled,
+  unavailableReason,
 }: {
   leaseId: string;
   providerType: ProviderInfo["type"];
   disabled: boolean;
+  unavailableReason?: string | null;
 }) {
   const isLocal = providerType === "local" || !leaseId;
   const defaultPath = isLocal ? "~" : "/";
@@ -831,6 +838,10 @@ function MonitorFileBrowser({
 
   if (!leaseId && !isLocal) {
     return <p className="file-browser__empty">当前沙盒没有 lease id，无法浏览文件。</p>;
+  }
+
+  if (unavailableReason) {
+    return <p className="file-browser__empty">{unavailableReason}</p>;
   }
 
   if (disabled) {

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -489,4 +489,65 @@ describe("MonitorRoutes", () => {
 
     expect(await screen.findByText("hello from local sandbox")).toBeInTheDocument();
   });
+
+  it("does not pretend a remote lease is browsable when runtime session binding is missing", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /remote agent/i }));
+
+    expect(await screen.findByText("当前 lease 没有 active runtime session，无法浏览文件。")).toBeInTheDocument();
+  });
 });

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -93,6 +93,7 @@ def _stub_monitor_resource_snapshot(monkeypatch):
 
     monkeypatch.setattr(monitor, "get_monitor_resource_overview_snapshot", lambda: snapshot)
     monkeypatch.setattr(monitor, "refresh_monitor_resource_overview_sync", lambda: snapshot)
+    monkeypatch.setattr(resource_service, "refresh_resource_snapshots", lambda: {"probed": 0, "errors": 0})
     return snapshot
 
 
@@ -128,6 +129,49 @@ def test_monitor_resources_refresh_route_smoke(monkeypatch):
     assert "last_refreshed_at" in payload["summary"]
     assert "refresh_status" in payload["summary"]
     assert set(payload["triage"]["summary"]).issuperset({"total", "active_drift", "detached_residue", "orphan_cleanup", "healthy_capacity"})
+
+
+def test_monitor_resources_refresh_route_probes_before_refresh(monkeypatch):
+    calls: list[str] = []
+    snapshot = {
+        "summary": {
+            "snapshot_at": "2026-04-07T00:00:00Z",
+            "last_refreshed_at": "2026-04-07T00:00:00Z",
+            "refresh_status": "fresh",
+            "running_sessions": 0,
+            "active_providers": 0,
+            "unavailable_providers": 0,
+        },
+        "providers": [],
+        "triage": {
+            "summary": {
+                "total": 0,
+                "active_drift": 0,
+                "detached_residue": 0,
+                "orphan_cleanup": 0,
+                "healthy_capacity": 0,
+            },
+            "groups": [],
+        },
+    }
+
+    def _probe():
+        calls.append("probe")
+        return {"probed": 1, "errors": 0}
+
+    def _refresh():
+        calls.append("refresh")
+        return snapshot
+
+    monkeypatch.setattr(resource_service, "refresh_resource_snapshots", _probe)
+    monkeypatch.setattr(monitor, "refresh_monitor_resource_overview_sync", _refresh)
+
+    with TestClient(_build_monitor_test_app()) as client:
+        response = client.post("/api/monitor/resources/refresh")
+
+    assert response.status_code == 200
+    assert response.json() == snapshot
+    assert calls == ["probe", "refresh"]
 
 
 def test_monitor_and_product_resource_routes_coexist_intentionally(monkeypatch):


### PR DESCRIPTION
## Summary
- make `POST /api/monitor/resources/refresh` probe live sandbox metrics before recomputing the overview snapshot
- stop pretending remote leases without `runtimeSessionId` are browsable in monitor resources
- lock both behaviors with backend integration coverage and monitor route tests

## Test Plan
- uv run pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q
- uv run ruff check backend/web/routers/monitor.py tests/Integration/test_monitor_resources_route.py
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build
