### PR TITLE
fix: fail loudly on legacy runtime chat identity

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1254,7 +1254,7 @@ class LeonAgent:
         # @@@chat-tools - register chat tools for agents with user identity (v2 messaging)
         if self._chat_repos:
             repos = self._chat_repos
-            chat_identity_id = repos.get("chat_identity_id")
+            chat_identity_id = self._runtime_chat_identity_id()
             owner_id = repos.get("owner_id", "")
             if chat_identity_id:
                 from messaging.tools.chat_tool_service import ChatToolService
@@ -1398,6 +1398,16 @@ class LeonAgent:
 
         return prompt
 
+    def _runtime_chat_identity_id(self) -> str | None:
+        if not self._chat_repos:
+            return None
+        chat_identity_id = self._chat_repos.get("chat_identity_id")
+        if chat_identity_id:
+            return str(chat_identity_id)
+        if self._chat_repos.get("user_id"):
+            raise RuntimeError("legacy chat_repos.user_id is no longer supported; use chat_identity_id")
+        return None
+
     def _compose_system_prompt(self) -> str:
         prompt = self._build_system_prompt()
 
@@ -1408,7 +1418,7 @@ class LeonAgent:
         # @@@chat-identity — inject chat identity so agent knows who it is in the social layer
         if self._chat_repos:
             repos = self._chat_repos
-            uid = repos.get("chat_identity_id")
+            uid = self._runtime_chat_identity_id()
             owner_uid = repos.get("owner_id", "")
             if uid:
                 user_repo = repos.get("user_repo")

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -854,7 +854,7 @@ def test_leon_agent_chat_identity_prompt_uses_honest_legacy_wording():
     assert "- Your user_id:" not in prompt
 
 
-def test_leon_agent_chat_identity_prompt_does_not_fallback_to_legacy_user_id() -> None:
+def test_leon_agent_chat_identity_prompt_rejects_legacy_user_id_only_runtime_shape() -> None:
     from core.runtime.agent import LeonAgent
 
     agent = object.__new__(LeonAgent)
@@ -866,10 +866,70 @@ def test_leon_agent_chat_identity_prompt_does_not_fallback_to_legacy_user_id() -
         "user_repo": SimpleNamespace(get_by_id=lambda uid: SimpleNamespace(id=uid, display_name=f"resolved:{uid}")),
     }
 
-    prompt = LeonAgent._compose_system_prompt(agent)
+    with pytest.raises(RuntimeError, match="chat_identity_id"):
+        LeonAgent._compose_system_prompt(agent)
 
-    assert "**Chat Identity:**" not in prompt
-    assert "agent-member-legacy" not in prompt
+
+def test_leon_agent_chat_tool_wiring_rejects_legacy_user_id_only_runtime_shape(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from core.runtime.agent import LeonAgent
+    from core.runtime.registry import ToolRegistry
+
+    class _NoopService:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _NoopRegistry:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeChatToolService:
+        def __init__(self, *args, **kwargs) -> None:
+            raise AssertionError("chat tool should not initialize from legacy-only runtime shape")
+
+    monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.CronToolService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.AgentRegistry", _NoopRegistry)
+    monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
+    monkeypatch.setitem(sys.modules, "backend.taskboard.service", SimpleNamespace(TaskBoardService=_NoopService))
+    monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _FakeChatToolService)
+
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(name="local", fs=lambda: None, shell=lambda: None)
+    agent._tool_registry = ToolRegistry()
+    agent.workspace_root = str(tmp_path)
+    agent.model_name = "test-model"
+    agent._thread_repo = SimpleNamespace()
+    agent._user_repo = SimpleNamespace()
+    agent.queue_manager = SimpleNamespace()
+    agent._web_app = None
+    agent.allowed_file_extensions = []
+    agent.extra_allowed_paths = []
+    agent.enable_audit_log = False
+    agent.block_dangerous_commands = False
+    agent.block_network_commands = False
+    agent.verbose = False
+    agent._get_mcp_server_configs = lambda: {}
+    agent._chat_repos = {
+        "user_id": "thread-user-legacy",
+        "owner_id": "human-user-legacy",
+        "messaging_service": SimpleNamespace(),
+        "user_repo": SimpleNamespace(),
+        "relationship_repo": SimpleNamespace(),
+    }
+    cast(Any, agent).config = SimpleNamespace(
+        tools=SimpleNamespace(
+            filesystem=SimpleNamespace(enabled=False),
+            search=SimpleNamespace(enabled=False),
+            web=SimpleNamespace(enabled=False),
+            command=SimpleNamespace(enabled=False),
+        ),
+        skills=SimpleNamespace(enabled=False, paths=[], skills={}),
+    )
+
+    with pytest.raises(RuntimeError, match="chat_identity_id"):
+        LeonAgent._init_services(agent)
 
 
 def test_leon_agent_chat_identity_prompt_accepts_chat_identity_id_without_legacy_user_id():


### PR DESCRIPTION
## Summary
- fail loudly when runtime chat_repos still carries legacy user_id without chat_identity_id
- keep the runtime chat_repos truth cleanup behavior from #306 otherwise unchanged

## Scope
- core/runtime/agent.py
- tests/Integration/test_leon_agent.py

## Verification
- uv run pytest -q tests/Integration/test_leon_agent.py -k 'chat_identity_prompt or chat_tool_wiring or legacy_user_id_only_runtime_shape'
- uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py -k 'send_message_route_then_agent_terminal_notification_reenters_followthrough or run_agent_to_buffer_turns_silent_chat_notification_into_visible_followthrough'
- uv run ruff check core/runtime/agent.py tests/Integration/test_leon_agent.py
- uv run ruff format --check core/runtime/agent.py tests/Integration/test_leon_agent.py
- python3 -m py_compile core/runtime/agent.py tests/Integration/test_leon_agent.py