### PR TITLE
fix: surface monitor runtime binding drift

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -526,6 +526,7 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
                     <SandboxCard
                       key={group.leaseId || group.sessions.map((session) => session.id).join("|")}
                       group={group}
+                      providerType={provider.type}
                       onOpen={() => setSelectedGroup(group)}
                     />
                   ))}
@@ -554,7 +555,15 @@ function InlineMetric({ label, value }: { label: string; value: string }) {
   );
 }
 
-function SandboxCard({ group, onOpen }: { group: LeaseGroup; onOpen: () => void }) {
+function SandboxCard({
+  group,
+  providerType,
+  onOpen,
+}: {
+  group: LeaseGroup;
+  providerType: ProviderInfo["type"];
+  onOpen: () => void;
+}) {
   const duration = formatStartedAtDuration(group.startedAt);
   const names = group.sessions.map((session) => session.agentName || "未绑定").join(", ");
   const metrics = group.metrics;
@@ -565,6 +574,11 @@ function SandboxCard({ group, onOpen }: { group: LeaseGroup; onOpen: () => void 
       metrics.memoryLimit != null ||
       metrics.disk != null ||
       metrics.diskLimit != null);
+  const showRuntimeBindingWarning =
+    providerType !== "local" &&
+    group.status === "running" &&
+    Boolean(group.leaseId) &&
+    !group.sessions.some((session) => Boolean(session.runtimeSessionId));
 
   return (
     <button type="button" className={`sandbox-card sandbox-card--${group.status}`} onClick={onOpen}>
@@ -587,6 +601,12 @@ function SandboxCard({ group, onOpen }: { group: LeaseGroup; onOpen: () => void 
           </div>
           <div className="sandbox-card__names">{names}</div>
         </div>
+        {showRuntimeBindingWarning && (
+          // @@@running-card-without-runtime - a persisted lease row can still say `running`
+          // after the live runtime session disappears; the card has to surface that drift
+          // before the operator drills into a guaranteed-failing file browser.
+          <div className="sandbox-card__warning">无 active runtime</div>
+        )}
         <div className="sandbox-card__thread-list">
           {group.sessions.slice(0, 2).map((session) => (
             <div key={session.id} className="sandbox-card__thread">

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -546,6 +546,7 @@ describe("MonitorRoutes", () => {
       </MemoryRouter>,
     );
 
+    expect(await screen.findByText("无 active runtime")).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: /remote agent/i }));
 
     expect(await screen.findByText("当前 lease 没有 active runtime session，无法浏览文件。")).toBeInTheDocument();

--- a/frontend/monitor/src/styles.css
+++ b/frontend/monitor/src/styles.css
@@ -812,6 +812,18 @@ div:has(> :only-child:is(div:contains("Loading"))) {
   margin: 0.75rem 0;
 }
 
+.sandbox-card__warning {
+  display: inline-flex;
+  margin: 0.7rem 0 0.15rem;
+  padding: 0.18rem 0.55rem;
+  border: 1px solid rgba(245, 185, 66, 0.32);
+  border-radius: 999px;
+  background: rgba(245, 185, 66, 0.08);
+  color: #f4cf83;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+}
+
 .sandbox-card__agent-row,
 .sandbox-session-row__identity,
 .sandbox-session-row__status {


### PR DESCRIPTION
## Summary
- surface a truth chip on running remote sandbox cards when the lease has no active runtime binding
- keep the existing modal-level file-browser block, but tell the operator the drift earlier at card level
- lock the regression in monitor routes tests

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build