### PR TITLE
fix: quantify monitor runtime binding gap

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -448,6 +448,9 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
   const [selectedGroup, setSelectedGroup] = React.useState<LeaseGroup | null>(null);
   const groups = React.useMemo(() => groupByLease(provider.sessions), [provider.sessions]);
   const runningCount = provider.sessions.filter((session) => session.status === "running").length;
+  const runtimeUnboundRunningCount = provider.sessions.filter(
+    (session) => session.status === "running" && !session.runtimeSessionId,
+  ).length;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const isLocal = provider.type === "local";
@@ -507,6 +510,7 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
               ) : (
                 <div className="provider-inline-metrics">
                   <InlineMetric label="运行中" value={String(runningCount)} />
+                  {runtimeUnboundRunningCount > 0 && <InlineMetric label="无 runtime" value={String(runtimeUnboundRunningCount)} />}
                   <InlineMetric label="已暂停" value={String(pausedCount)} />
                   <InlineMetric label="已结束" value={String(stoppedCount)} />
                 </div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MonitorRoutes } from "./routes";
@@ -547,6 +547,9 @@ describe("MonitorRoutes", () => {
     );
 
     expect(await screen.findByText("无 active runtime")).toBeInTheDocument();
+    const runtimeGapLabel = screen.getByText("无 runtime");
+    expect(runtimeGapLabel).toBeInTheDocument();
+    expect(within(runtimeGapLabel.parentElement as HTMLElement).getByText("1")).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: /remote agent/i }));
 
     expect(await screen.findByText("当前 lease 没有 active runtime session，无法浏览文件。")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- quantify runtime-binding drift in the provider detail overview for remote monitor resources
- surface a `无 runtime` count when running sessions exist without an active runtime binding
- extend the monitor routes regression proof for the stale remote lease case

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build