### PR TITLE
fix: surface monitor telemetry truth gap

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -456,6 +456,13 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
   const isLocal = provider.type === "local";
   const showUnavailableBanner = provider.status === "unavailable";
   const hardUnavailable = provider.status === "unavailable" && provider.sessions.length === 0;
+  const showTelemetryGapBanner =
+    !isLocal &&
+    provider.status === "ready" &&
+    runningCount === 0 &&
+    provider.telemetry.cpu.freshness === "stale" &&
+    provider.telemetry.memory.freshness === "stale" &&
+    provider.telemetry.disk.freshness === "stale";
 
   return (
     <>
@@ -496,6 +503,11 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
               // surface inspectable instead of hard-disabling the whole card.
               <div className="provider-warning-banner">
                 {provider.unavailableReason || "Provider unavailable"}。但当前仍有 {provider.sessions.length} 条关联 session，可继续检查。
+              </div>
+            )}
+            {showTelemetryGapBanner && (
+              <div className="provider-warning-banner">
+                当前 provider 暂无 live telemetry，CPU / RAM / Disk 仍是未知状态。
               </div>
             )}
 

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -554,4 +554,53 @@ describe("MonitorRoutes", () => {
 
     expect(await screen.findByText("当前 lease 没有 active runtime session，无法浏览文件。")).toBeInTheDocument();
   });
+
+  it("surfaces when a ready provider still has no live telemetry", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 0,
+          unavailable_providers: 0,
+          running_sessions: 0,
+        },
+        providers: [
+          {
+            id: "agentbay",
+            name: "agentbay",
+            description: "AgentBay cloud sandbox",
+            type: "cloud",
+            status: "ready",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 0, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: null, limit: null, unit: "%", source: "unknown", freshness: "stale" },
+              memory: { used: null, limit: null, unit: "GB", source: "unknown", freshness: "stale" },
+              disk: { used: null, limit: null, unit: "GB", source: "unknown", freshness: "stale" },
+            },
+            cardCpu: { used: null, limit: null, unit: "%", source: "unknown", freshness: "stale" },
+            sessions: [],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("当前 provider 暂无 live telemetry，CPU / RAM / Disk 仍是未知状态。")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- surface a provider-level truth banner when a ready remote provider still has no live CPU/RAM/Disk telemetry
- stop making stale unknown telemetry look like a normal empty resource panel
- lock the ready-provider telemetry gap in monitor routes tests

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build