### PR TITLE
fix: surface runtime gap on monitor cards

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -373,6 +373,9 @@ function ProviderCard({
   onSelect: () => void;
 }) {
   const runningCount = provider.sessions.filter((session) => session.status === "running").length;
+  const runtimeUnboundRunningCount = provider.sessions.filter(
+    (session) => session.status === "running" && !session.runtimeSessionId,
+  ).length;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const capabilityList = capabilityTags(provider.capabilities);
@@ -415,6 +418,7 @@ function ProviderCard({
 
       <div className="provider-card__footer">
         <span>{runningCount} 占用中</span>
+        {runtimeUnboundRunningCount > 0 && <span>{runtimeUnboundRunningCount} 无 runtime</span>}
         {pausedCount > 0 && <span>{pausedCount} 暂停</span>}
         {stoppedCount > 0 && <span>{stoppedCount} 已结束</span>}
       </div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -546,6 +546,7 @@ describe("MonitorRoutes", () => {
       </MemoryRouter>,
     );
 
+    expect(await screen.findByRole("button", { name: /daytona_selfhost/i })).toHaveTextContent("1 无 runtime");
     expect(await screen.findByText("无 active runtime")).toBeInTheDocument();
     const runtimeGapLabel = screen.getByText("无 runtime");
     expect(runtimeGapLabel).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- surface the runtime-binding gap directly on provider cards in the monitor resources grid
- stop making remote providers with many runtime-unbound running rows look fully healthy at the top level
- extend the stale remote lease regression proof to the provider-card surface

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build