### PR TITLE
fix: surface telemetry gap on monitor cards

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -380,6 +380,13 @@ function ProviderCard({
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const capabilityList = capabilityTags(provider.capabilities);
   const showCpuMetric = provider.cardCpu.used != null || provider.cardCpu.limit != null;
+  const showTelemetryGapTruth =
+    provider.type !== "local" &&
+    provider.status === "ready" &&
+    runningCount === 0 &&
+    provider.telemetry.cpu.freshness === "stale" &&
+    provider.telemetry.memory.freshness === "stale" &&
+    provider.telemetry.disk.freshness === "stale";
   const unavailableHint =
     provider.unavailableReason ||
     (provider.type === "container" ? "需要容器运行时" : "当前进程未安装对应 SDK");
@@ -422,6 +429,10 @@ function ProviderCard({
         {pausedCount > 0 && <span>{pausedCount} 暂停</span>}
         {stoppedCount > 0 && <span>{stoppedCount} 已结束</span>}
       </div>
+
+      {showTelemetryGapTruth && (
+        <div className="provider-card__truth">暂无 live telemetry</div>
+      )}
 
       {capabilityList.length > 0 && (
         <div className="provider-card__capabilities">

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -602,6 +602,9 @@ describe("MonitorRoutes", () => {
       </MemoryRouter>,
     );
 
+    const providerCard = await screen.findByRole("button", { name: /agentbay/i });
+    expect(within(providerCard).getByText("暂无 live telemetry")).toBeInTheDocument();
+    fireEvent.click(providerCard);
     expect(await screen.findByText("当前 provider 暂无 live telemetry，CPU / RAM / Disk 仍是未知状态。")).toBeInTheDocument();
   });
 });

--- a/frontend/monitor/src/styles.css
+++ b/frontend/monitor/src/styles.css
@@ -651,6 +651,12 @@ div:has(> :only-child:is(div:contains("Loading"))) {
   margin-top: 0.8rem;
 }
 
+.provider-card__truth {
+  margin-top: 0.8rem;
+  font-size: 0.76rem;
+  color: #f4cf83;
+}
+
 .provider-capability-chip {
   padding: 0.28rem 0.55rem;
   font-size: 0.68rem;


### PR DESCRIPTION
## Summary
- surface a card-level truth label when a ready remote provider still has no live telemetry
- keep the existing detail banner, but stop making the top-level card look normal
- lock the provider-card telemetry gap in monitor routes tests

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build