### PR TITLE
fix: make background task cancellation runtime-authoritative

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -53,6 +53,7 @@ from backend.web.services.thread_state_service import (
 )
 from backend.web.utils.helpers import delete_thread_in_db
 from backend.web.utils.serializers import avatar_url, serialize_message
+from core.agents.service import _background_run_cancelled, request_background_run_stop
 from core.runtime.middleware.monitor import AgentState
 from sandbox.config import MountSpec
 from sandbox.manager import bind_thread_to_existing_lease
@@ -1406,10 +1407,14 @@ def _background_run_type(run: Any) -> str:
 def _serialize_background_run(task_id: str, run: Any, *, include_result: bool) -> dict[str, Any]:
     run_type = _background_run_type(run)
     result_text = run.get_result() if include_result and run.is_done else None
+    if _background_run_cancelled(run):
+        status = "cancelled"
+    else:
+        status = "completed" if run.is_done else "running"
     payload = {
         "task_id": task_id,
         "task_type": run_type,
-        "status": "completed" if run.is_done else "running",
+        "status": status,
         "command_line": getattr(run, "command", None) if run_type == "bash" else None,
     }
     if include_result:
@@ -1500,15 +1505,7 @@ async def cancel_task(
     if run.is_done:
         raise HTTPException(status_code=400, detail="Task is not running")
 
-    if run.__class__.__name__ == "_RunningTask":
-        run.task.cancel()
-    elif run.__class__.__name__ == "_BashBackgroundRun":
-        process = getattr(run._cmd, "process", None)
-        if process:
-            try:
-                process.terminate()
-            except ProcessLookupError:
-                pass
+    await request_background_run_stop(run)
 
     # Emit task_done SSE and notify main agent once cancellation completes
     asyncio.create_task(_notify_task_cancelled(request.app, thread_id, task_id, run))
@@ -1523,6 +1520,10 @@ async def _notify_task_cancelled(app: Any, thread_id: str, task_id: str, run: An
         if run.is_done:
             break
         await asyncio.sleep(0.1)
+
+    if not run.is_done:
+        logger.warning("Cancelled task %s never reached a terminal state; skipping cancellation surface", task_id)
+        return
 
     # Emit task_done so the frontend indicator updates
     try:

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -366,6 +366,43 @@ class _BashBackgroundRun:
 BackgroundRun = _RunningTask | _BashBackgroundRun
 
 
+def _background_run_cancelled(running: BackgroundRun) -> bool:
+    return isinstance(running, _BashBackgroundRun) and bool(getattr(running._cmd, "cancelled", False))
+
+
+async def request_background_run_stop(running: BackgroundRun) -> None:
+    """Stop a background run and mark bash runs with authoritative cancellation state."""
+    if isinstance(running, _RunningTask):
+        running.task.cancel()
+        return
+
+    cmd = running._cmd
+    if getattr(cmd, "done", False):
+        cmd.cancelled = True
+        return
+
+    cmd.cancelled = True
+    process = getattr(cmd, "process", None)
+    wait = getattr(process, "wait", None) if process is not None else None
+    terminate = getattr(process, "terminate", None) if process is not None else None
+    kill = getattr(process, "kill", None) if process is not None else None
+
+    if callable(terminate):
+        terminate()
+    if callable(wait):
+        wait_fn = cast(Callable[[], Awaitable[Any]], wait)
+        try:
+            await asyncio.wait_for(wait_fn(), timeout=1.0)
+        except TimeoutError:
+            if callable(kill):
+                kill()
+            await wait_fn()
+
+    if getattr(cmd, "exit_code", None) is None and process is not None:
+        cmd.exit_code = getattr(process, "returncode", None)
+    cmd.done = True
+
+
 def _background_run_running_message(running: BackgroundRun) -> str:
     return "Command is still running." if isinstance(running, _BashBackgroundRun) else "Agent is still running."
 
@@ -1213,21 +1250,7 @@ class AgentService:
             return
 
         if not running.is_done:
-            process = getattr(running._cmd, "process", None)
-            wait = getattr(process, "wait", None) if process is not None else None
-            terminate = getattr(process, "terminate", None) if process is not None else None
-            kill = getattr(process, "kill", None) if process is not None else None
-
-            if callable(terminate):
-                terminate()
-            if callable(wait):
-                wait_fn = cast(Callable[[], Awaitable[Any]], wait)
-                try:
-                    await asyncio.wait_for(wait_fn(), timeout=1.0)
-                except TimeoutError:
-                    if callable(kill):
-                        kill()
-                    await wait_fn()
+            await request_background_run_stop(running)
 
         self._tasks.pop(task_id, None)
 

--- a/core/runtime/middleware/queue/formatters.py
+++ b/core/runtime/middleware/queue/formatters.py
@@ -90,7 +90,7 @@ def format_background_notification(
 
 def format_command_notification(
     command_id: str,
-    status: Literal["completed", "failed"],
+    status: Literal["completed", "failed", "cancelled"],
     exit_code: int,
     command_line: str,
     output: str,

--- a/core/tools/command/middleware.py
+++ b/core/tools/command/middleware.py
@@ -275,7 +275,10 @@ class CommandMiddleware(AgentMiddleware[CommandState]):
                 # Get final output
                 output = self._merge_running_output(status)
                 exit_code = status.exit_code or 0
-                task_status = "completed" if exit_code == 0 else "failed"
+                if getattr(status, "cancelled", False):
+                    task_status = "cancelled"
+                else:
+                    task_status = "completed" if exit_code == 0 else "failed"
 
                 # Update registry first
                 if self._registry:
@@ -300,7 +303,10 @@ class CommandMiddleware(AgentMiddleware[CommandState]):
                     )
 
                 # Emit task completion event
-                event_type = "task_done" if exit_code == 0 else "task_error"
+                if getattr(status, "cancelled", False):
+                    event_type = "task_done"
+                else:
+                    event_type = "task_done" if exit_code == 0 else "task_error"
                 runtime.emit_activity_event(
                     {
                         "event": event_type,
@@ -309,6 +315,7 @@ class CommandMiddleware(AgentMiddleware[CommandState]):
                                 "task_id": command_id,
                                 "exit_code": exit_code,
                                 "background": True,
+                                "cancelled": bool(getattr(status, "cancelled", False)),
                             },
                             ensure_ascii=False,
                         ),
@@ -380,7 +387,8 @@ class CommandMiddleware(AgentMiddleware[CommandState]):
                     cleaned_output = self._clean_running_output(combined_output, status.command_line)
                     return f"Status: running\nCommand: {status.command_line}\nOutput so far:\n{cleaned_output}"
                 output = result.to_tool_result()
-                return f"Status: done\nExit code: {result.exit_code}\n{output}"
+                terminal = "cancelled" if getattr(result, "cancelled", False) else "done"
+                return f"Status: {terminal}\nExit code: {result.exit_code}\n{output}"
 
         status = await self._executor.get_status(command_id)
         if status is None:
@@ -390,7 +398,8 @@ class CommandMiddleware(AgentMiddleware[CommandState]):
             result = await self._executor.wait_for(command_id)
             if result:
                 output = result.to_tool_result()
-                return f"Status: done\nExit code: {result.exit_code}\n{output}"
+                terminal = "cancelled" if getattr(status, "cancelled", False) else "done"
+                return f"Status: {terminal}\nExit code: {result.exit_code}\n{output}"
 
         combined_output = self._merge_running_output(status)
         cleaned_output = self._clean_running_output(combined_output, status.command_line)

--- a/core/tools/command/service.py
+++ b/core/tools/command/service.py
@@ -224,6 +224,10 @@ class CommandService:
         """Poll until async command finishes, then enqueue CommandNotification."""
         while not async_cmd.done:
             await asyncio.sleep(1)
+
+        if getattr(async_cmd, "cancelled", False):
+            return
+
         from core.agents.service import _BashBackgroundRun
 
         result = _BashBackgroundRun(async_cmd, command).get_result() or ""

--- a/sandbox/interfaces/executor.py
+++ b/sandbox/interfaces/executor.py
@@ -47,6 +47,7 @@ class AsyncCommand:
     stderr_buffer: list[str] = field(default_factory=list)
     exit_code: int | None = None
     done: bool = False
+    cancelled: bool = False
 
 
 class BaseExecutor(ABC):

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -819,6 +819,10 @@ class DaytonaSessionRuntime(_RemoteRuntimeBase):
         self._schedule_snapshot(generation, snapshot_timeout)
         return first
 
+    async def _cancel_running_command(self) -> bool:
+        await asyncio.to_thread(self._close_shell_sync)
+        return True
+
     async def execute(self, command: str, timeout: float | None = None) -> ExecuteResult:
         return await self._execute_background_command(command, timeout=timeout)
 

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -664,6 +664,12 @@ class DockerPtyRuntime(_RemoteRuntimeBase):
             await asyncio.to_thread(self._pty_session.close)
             self._pty_session = None
 
+    async def _cancel_running_command(self) -> bool:
+        if self._pty_session is None:
+            return False
+        await asyncio.to_thread(self._close_shell_sync)
+        return True
+
     async def execute(self, command: str, timeout: float | None = None) -> ExecuteResult:
         return await self._execute_background_command(command, timeout=timeout)
 

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -489,6 +489,13 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
             await asyncio.to_thread(self._pty_session.close)
             self._pty_session = None
 
+    async def _cancel_running_command(self) -> bool:
+        if self._use_windows_shell or self._pty_session is None:
+            return False
+        await asyncio.to_thread(self._pty_session.close)
+        self._pty_session = None
+        return True
+
     async def execute(self, command: str, timeout: float | None = None) -> ExecuteResult:
         """Execute command in local shell."""
         return await self._execute_background_command(command, timeout=timeout)

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -579,6 +579,19 @@ class PhysicalTerminalRuntime(ABC):
             except Exception as exc:
                 result = ExecuteResult(exit_code=1, stdout="", stderr=f"Error: {exc}")
                 status = "failed"
+            # @@@cancelled-terminal-truth - Runtime-level cancel may tear down the active PTY/session from another task.
+            # When that happens, this background runner must not overwrite the authoritative cancelled state with a late
+            # success/failure finalizer.
+            if async_cmd.cancelled:
+                self._last_stream_flush_at.pop(command_id, None)
+                self._persisted_stdout_chunk_count.pop(command_id, None)
+                self._persisted_stderr_chunk_count.pop(command_id, None)
+                return ExecuteResult(
+                    exit_code=130,
+                    stdout="".join(async_cmd.stdout_buffer),
+                    stderr="Command cancelled",
+                    command_id=command_id,
+                )
             self._flush_running_output_if_needed(command_id, force=True)
             async_cmd.stdout_buffer = [result.stdout]
             async_cmd.stderr_buffer = [result.stderr]
@@ -600,6 +613,9 @@ class PhysicalTerminalRuntime(ABC):
 
         self._tasks[command_id] = asyncio.create_task(_run())
         return async_cmd
+
+    async def _cancel_running_command(self) -> bool:
+        return False
 
     async def _execute_background_command(
         self,
@@ -675,8 +691,17 @@ class PhysicalTerminalRuntime(ABC):
             return False
         if task.done():
             return False
-        task.cancel()
-        self._flush_running_output_if_needed(command_id, force=True)
+        # @@@runtime-owned-cancel - Async task cancellation is not sufficient for PTY/session runtimes.
+        # The runtime must stop the live command source, then this method records the single terminal truth.
+        cmd.cancelled = True
+        stopped = await self._cancel_running_command()
+        if stopped:
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+            except (TimeoutError, asyncio.CancelledError):
+                task.cancel()
+        else:
+            task.cancel()
         cmd.done = True
         cmd.exit_code = 130
         cmd.stderr_buffer = ["Command cancelled"]

--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -11,7 +11,7 @@ import pytest
 from langchain_core.messages import AIMessage
 
 from core.agents.registry import AgentEntry, AgentRegistry
-from core.agents.service import AgentService, BackgroundRun, _BashBackgroundRun, _RunningTask
+from core.agents.service import AgentService, BackgroundRun, _BashBackgroundRun, _RunningTask, request_background_run_stop
 from core.runtime.middleware.queue import MessageQueueManager
 from core.runtime.middleware.queue.middleware import SteeringMiddleware
 from core.runtime.registry import ToolRegistry
@@ -176,6 +176,30 @@ def test_taskstop_terminates_real_background_bash_run(tmp_path):
         assert stop_result == f"Task {task_id} cancelled"
         assert task_id not in shared_runs
         assert bash_run._cmd.process.returncode is not None
+
+    asyncio.run(run())
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="bash background cleanup integration requires Unix-compatible bash",
+)
+def test_request_background_run_stop_kills_real_shell_command_tree(tmp_path):
+    async def run():
+        executor = BashExecutor(default_cwd=str(tmp_path))
+        async_cmd = await executor.execute_async(
+            "sleep 2; echo NEVER_BACKGROUND_CANCEL_TREE",
+            cwd=str(tmp_path),
+        )
+        running = _BashBackgroundRun(async_cmd, "sleep 2; echo NEVER_BACKGROUND_CANCEL_TREE")
+
+        await request_background_run_stop(running)
+        await asyncio.sleep(2.5)
+
+        assert async_cmd.cancelled is True
+        assert async_cmd.done is True
+        assert async_cmd.exit_code not in (None, 0)
+        assert "NEVER_BACKGROUND_CANCEL_TREE" not in "".join(async_cmd.stdout_buffer)
 
     asyncio.run(run())
 

--- a/tests/Integration/test_query_loop_backend_bridge.py
+++ b/tests/Integration/test_query_loop_backend_bridge.py
@@ -319,6 +319,31 @@ class _StreamingRuntime:
         return True
 
 
+class _StubbornProcess:
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self._waiters: list[asyncio.Future[int]] = []
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+        for waiter in self._waiters:
+            if not waiter.done():
+                waiter.set_result(self.returncode)
+
+    async def wait(self) -> int:
+        if self.returncode is not None:
+            return self.returncode
+        waiter = asyncio.get_running_loop().create_future()
+        self._waiters.append(waiter)
+        return await waiter
+
+
 async def _wait_for_followthrough_text(loop: QueryLoop, thread_id: str, expected: str) -> None:
     for _ in range(100):
         state = await loop.aget_state({"configurable": {"thread_id": thread_id}})
@@ -1770,6 +1795,50 @@ async def test_cancelled_task_notification_wakes_followthrough_run(monkeypatch, 
     assert [item["role"] for item in history["messages"]] == ["notification", "assistant"]
     assert "cancelled" in history["messages"][0]["text"]
     assert history["messages"][1]["text"] == "AFTER_CANCEL_WAKE"
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_route_marks_bash_run_cancelled_and_forces_process_stop(monkeypatch, tmp_path):
+    _patch_streaming_event_store(monkeypatch)
+    _patch_fake_event_bus(monkeypatch)
+
+    from core.agents.service import _BashBackgroundRun
+
+    thread_id = "thread-route-cancel-bash"
+    checkpointer = _MemoryCheckpointer()
+    loop = _make_loop(text="AFTER_CANCEL_ROUTE", checkpointer=checkpointer)
+    _queue_manager, agent, app = _make_route_followthrough_context(tmp_path, thread_id=thread_id, loop=loop)
+
+    process = _StubbornProcess()
+    async_cmd = SimpleNamespace(
+        done=False,
+        exit_code=None,
+        stdout_buffer=[],
+        stderr_buffer=[],
+        process=process,
+    )
+    run = _BashBackgroundRun(async_cmd, "sleep 30; echo NEVER", description="stubborn cancel task")
+    agent._background_runs = {"cmd-cancel-route": run}
+
+    async def _raise_timeout(_awaitable, timeout=None):
+        _awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr("core.agents.service.asyncio.wait_for", _raise_timeout)
+
+    response = await threads_router.cancel_task(
+        thread_id,
+        "cmd-cancel-route",
+        SimpleNamespace(app=app),
+    )
+
+    assert response == {"success": True}
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert async_cmd.cancelled is True
+    assert async_cmd.done is True
+    assert async_cmd.exit_code == -9
+    assert threads_router._serialize_background_run("cmd-cancel-route", run, include_result=False)["status"] == "cancelled"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_command_middleware.py
+++ b/tests/Unit/core/test_command_middleware.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -302,3 +303,41 @@ class TestFailLoudBlankExceptions:
         out = await service._bash("pwd")
 
         assert out == "Error executing command: BlankCommandError"
+
+
+class TestCommandServiceCancellation:
+    @pytest.mark.asyncio
+    async def test_notify_bash_completion_skips_terminal_notice_for_cancelled_command(self, tmp_path):
+        queue_manager = MagicMock()
+        service = CommandService(
+            registry=ToolRegistry(),
+            workspace_root=tmp_path,
+            queue_manager=queue_manager,
+        )
+        emitted: list[dict] = []
+
+        async def _emit(event: dict) -> None:
+            emitted.append(event)
+
+        async_cmd = AsyncCommand(
+            command_id="cmd_cancelled",
+            command_line="sleep 30; echo NEVER",
+            cwd=str(tmp_path),
+            stdout_buffer=["NEVER\n"],
+            stderr_buffer=[],
+            exit_code=-9,
+            done=True,
+        )
+        async_cmd.cancelled = True
+
+        await service._notify_bash_completion(
+            "cmd_cancelled",
+            async_cmd,
+            "sleep 30; echo NEVER",
+            "thread-cancelled",
+            _emit,
+            description="cancelled command",
+        )
+
+        assert emitted == []
+        queue_manager.enqueue.assert_not_called()

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -464,6 +464,37 @@ class TestRuntimeIntegration:
 
         await runtime2.close()
 
+    @pytest.mark.asyncio
+    async def test_cancelled_background_command_releases_local_shell_prompt(self, terminal_store, lease_store):
+        terminal = terminal_from_row(
+            terminal_store.create("term-cancel-shell", "thread-cancel-shell", "lease-cancel-shell", "/tmp"),
+            terminal_store.db_path,
+        )
+        lease = lease_store.create("lease-cancel-shell", "local")
+        provider = MagicMock()
+        provider.create_runtime.side_effect = lambda t, lease: LocalPersistentShellRuntime(t, lease)
+        ChatSessionManager(provider=provider, db_path=terminal_store.db_path)
+
+        runtime = provider.create_runtime(terminal, lease)
+
+        async_cmd = await runtime.start_command("sleep 3; echo SHOULD_NOT_APPEAR", "/tmp")
+        await asyncio.sleep(0.2)
+
+        cancelled = await runtime.cancel_command(async_cmd.command_id)
+        assert cancelled is True
+
+        followup = await asyncio.wait_for(runtime.execute("echo prompt-back"), timeout=1.0)
+        assert followup.exit_code == 0
+        assert "prompt-back" in followup.stdout
+
+        status = await runtime.get_command(async_cmd.command_id)
+        assert status is not None
+        assert status.done is True
+        assert status.exit_code == 130
+        assert "SHOULD_NOT_APPEAR" not in "".join(status.stdout_buffer)
+
+        await runtime.close()
+
 
 def test_docker_provider_create_runtime(terminal_store, lease_store):
     pytest.importorskip("docker")


### PR DESCRIPTION
## Summary
- make background task cancellation runtime-authoritative instead of relying on async task cancellation alone
- teach PTY/session runtimes to tear down the active shell session on cancel and preserve cancelled terminal truth
- add runtime, backend-route, and command-middleware regression coverage for cancelled background bash tasks

## Test Plan
- uv run pytest -q tests/Unit/core/test_runtime.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_query_loop_backend_bridge.py tests/Unit/core/test_command_middleware.py
- uv run ruff check sandbox/runtime.py sandbox/providers/local.py sandbox/providers/docker.py sandbox/providers/daytona.py tests/Unit/core/test_runtime.py backend/web/routers/threads.py core/agents/service.py core/tools/command/service.py core/tools/command/middleware.py core/runtime/middleware/queue/formatters.py tests/Integration/test_query_loop_backend_bridge.py tests/Integration/test_background_task_cleanup.py tests/Unit/core/test_command_middleware.py
- real backend API brutal probe on :18013: start background bash -> cancel -> verify /tasks stays cancelled and same thread can immediately run foreground bash returning exact token