### PR TITLE
fix: summarize monitor telemetry gap

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -283,6 +283,15 @@ export default function ResourcesPage() {
       ).length,
     0,
   );
+  const readyWithoutLiveTelemetryCount = providers.filter(
+    (provider) =>
+      provider.type !== "local" &&
+      provider.status === "ready" &&
+      provider.sessions.length === 0 &&
+      provider.telemetry.cpu.freshness === "stale" &&
+      provider.telemetry.memory.freshness === "stale" &&
+      provider.telemetry.disk.freshness === "stale",
+  ).length;
   const refreshedAt = summary?.last_refreshed_at
     ? new Date(summary.last_refreshed_at).toLocaleTimeString()
     : "--:--:--";
@@ -336,6 +345,9 @@ export default function ResourcesPage() {
           <div className="resources-summary-pill">{summary?.running_sessions ?? 0} 运行会话</div>
           {runtimeUnboundRunningCount > 0 && (
             <div className="resources-summary-pill">{runtimeUnboundRunningCount} 无 runtime</div>
+          )}
+          {readyWithoutLiveTelemetryCount > 0 && (
+            <div className="resources-summary-pill">{readyWithoutLiveTelemetryCount} 遥测未知</div>
           )}
           <div className="resources-summary-pill">
             <span

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -717,6 +717,105 @@ describe("MonitorRoutes", () => {
     expect(screen.queryByText(/无 runtime/)).not.toBeInTheDocument();
   });
 
+  it("surfaces ready remote providers that still have no live telemetry in the summary strip", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 3,
+          active_providers: 0,
+          unavailable_providers: 0,
+          running_sessions: 0,
+        },
+        providers: [
+          {
+            id: "agentbay",
+            name: "agentbay",
+            description: "AgentBay cloud sandbox",
+            type: "cloud",
+            status: "ready",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 0, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: null, limit: null, unit: "%", source: "unknown", freshness: "stale" },
+              memory: { used: null, limit: null, unit: "GB", source: "unknown", freshness: "stale" },
+              disk: { used: null, limit: null, unit: "GB", source: "unknown", freshness: "stale" },
+            },
+            cardCpu: { used: null, limit: null, unit: "%", source: "unknown", freshness: "stale" },
+            sessions: [],
+          },
+          {
+            id: "docker",
+            name: "docker",
+            description: "Docker sandbox",
+            type: "container",
+            status: "ready",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 0, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: null, limit: null, unit: "%", source: "unknown", freshness: "stale" },
+              memory: { used: null, limit: null, unit: "GB", source: "unknown", freshness: "stale" },
+              disk: { used: null, limit: null, unit: "GB", source: "unknown", freshness: "stale" },
+            },
+            cardCpu: { used: null, limit: null, unit: "%", source: "unknown", freshness: "stale" },
+            sessions: [],
+          },
+          {
+            id: "local",
+            name: "local",
+            description: "Local provider",
+            type: "local",
+            status: "ready",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 0, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 0, limit: 100, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 0, limit: 8, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 0, limit: 20, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: { used: 0, limit: 100, unit: "%", source: "api", freshness: "live" },
+            sessions: [],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("2 遥测未知")).toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- surface ready remote providers with no live telemetry in the resource summary strip
- quantify top-level telemetry truth instead of hiding it only in provider cards/details
- lock the summary-pill telemetry gap in monitor routes tests

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build