### PR TITLE
refactor: align chat tool runtime truth surface

### DIFF
--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -154,7 +154,6 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
                     "owner_id": owner_id,
                     "user_repo": user_repo,
                     "messaging_service": getattr(app_obj.state, "messaging_service", None),
-                    "relationship_repo": getattr(app_obj.state, "relationship_repo", None),
                     "agent_config_repo": getattr(app_obj.state, "agent_config_repo", None),
                 }
 

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1255,18 +1255,15 @@ class LeonAgent:
         if self._chat_repos:
             repos = self._chat_repos
             chat_identity_id = self._runtime_chat_identity_id()
-            owner_id = repos.get("owner_id", "")
             if chat_identity_id:
                 from messaging.tools.chat_tool_service import ChatToolService
 
                 self._chat_tool_service = ChatToolService(
                     registry=self._tool_registry,
                     chat_identity_id=chat_identity_id,
-                    owner_id=owner_id,
                     messaging_service=repos.get("messaging_service"),
                     user_repo=repos.get("user_repo"),
                     thread_repo=self._thread_repo,
-                    relationship_repo=repos.get("relationship_repo"),
                 )
 
         # LSP tools — DEFERRED, always registered, multilspy checked at call time

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -85,24 +85,20 @@ class ChatToolService:
     def __init__(
         self,
         registry: ToolRegistry,
-        owner_id: str,
         *,
         chat_identity_id: str | None = None,
         user_id: str | None = None,
         messaging_service: Any = None,  # MessagingService (new)
         user_repo: Any = None,
         thread_repo: Any = None,
-        relationship_repo: Any = None,
     ) -> None:
         identity_id = chat_identity_id or user_id
         if not identity_id:
             raise ValueError("ChatToolService requires chat_identity_id or legacy user_id")
         self._chat_identity_id: str = identity_id
-        self._owner_id = owner_id
         self._messaging = messaging_service
         self._user_repo = user_repo
         self._thread_repo = thread_repo
-        self._relationships = relationship_repo
         self._register(registry)
 
     def _resolve_display_user(self, social_user_id: str) -> Any | None:

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -1051,9 +1051,10 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     LeonAgent._init_services(agent)
 
     assert captured["chat_identity_id"] == "thread-user-9"
-    assert captured["owner_id"] == "human-user-9"
     assert "chat_member_repo" not in captured
     assert "messages_repo" not in captured
+    assert "owner_id" not in captured
+    assert "relationship_repo" not in captured
 
 
 def test_build_rules_section_includes_function_result_clearing_guidance_when_spill_buffer_enabled():

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -181,7 +181,6 @@ def test_chat_tool_registry_exposes_final_contract_only() -> None:
     ChatToolService(
         registry=registry,
         user_id="owner-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             list_all=lambda: [
                 SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", owner_user_id="owner-user-1"),
@@ -193,7 +192,6 @@ def test_chat_tool_registry_exposes_final_contract_only() -> None:
         thread_repo=SimpleNamespace(
             get_default_thread=lambda member_id: {"id": "thread-1", "user_id": "thread-user-1"} if member_id == "agent-user-1" else None
         ),
-        relationship_repo=None,
     )
 
     for tool_name in ("list_chats", "read_messages", "send_message", "search_messages"):
@@ -208,7 +206,6 @@ def test_send_message_schema_marks_user_id_name_as_legacy() -> None:
     ChatToolService(
         registry=registry,
         user_id="agent-user-1",
-        owner_id="owner-user-1",
     )
 
     send_message = registry.get("send_message")
@@ -226,7 +223,6 @@ def test_read_messages_schema_requires_non_empty_chat_or_user_identifier() -> No
     ChatToolService(
         registry=registry,
         user_id="agent-user-1",
-        owner_id="owner-user-1",
     )
 
     read_messages = registry.get("read_messages")
@@ -244,7 +240,6 @@ def test_chat_tool_service_accepts_chat_identity_id_without_legacy_user_id() -> 
     ChatToolService(
         registry=registry,
         chat_identity_id="agent-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             list_all=lambda: [
                 SimpleNamespace(id="agent-user-2", display_name="Morel", type="agent", owner_user_id="owner-user-1"),
@@ -256,7 +251,6 @@ def test_chat_tool_service_accepts_chat_identity_id_without_legacy_user_id() -> 
         thread_repo=SimpleNamespace(
             get_default_thread=lambda member_id: {"id": "thread-2", "user_id": "thread-user-2"} if member_id == "agent-user-2" else None
         ),
-        relationship_repo=None,
     )
 
     assert registry.get("list_chats") is not None
@@ -265,13 +259,14 @@ def test_chat_tool_service_accepts_chat_identity_id_without_legacy_user_id() -> 
 def test_chat_tool_service_rejects_dead_repo_constructor_kwargs() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(TypeError, match="chat_member_repo|messages_repo"):
+    with pytest.raises(TypeError, match="chat_member_repo|messages_repo|owner_id|relationship_repo"):
         ChatToolService(
             registry=registry,
             chat_identity_id="agent-user-1",
             owner_id="owner-user-1",
             messaging_service=SimpleNamespace(),
             chat_member_repo=SimpleNamespace(),
+            relationship_repo=SimpleNamespace(),
         )
 
 
@@ -590,7 +585,6 @@ def test_chat_tool_formats_thread_user_id_sender_as_agent_name() -> None:
     service = ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 None
@@ -616,7 +610,6 @@ def test_chat_tool_send_accepts_thread_user_target_id() -> None:
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 None
@@ -651,7 +644,6 @@ def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: True,
             count_unread=lambda _chat_id, _user_id: 0,
@@ -689,7 +681,6 @@ def test_chat_tool_send_checks_group_membership_via_messaging_service_without_me
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: False,
         ),
@@ -708,7 +699,6 @@ def test_chat_tool_send_requires_group_reply_to_consume_peer_unread() -> None:
     ChatToolService(
         registry=registry,
         chat_identity_id="thread-user-1",
-        owner_id="owner-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: True,
             count_unread=lambda _chat_id, _user_id: 1,
@@ -744,7 +734,6 @@ def test_chat_tool_send_returns_tool_error_when_chat_advances_after_read() -> No
     ChatToolService(
         registry=registry,
         chat_identity_id="thread-user-1",
-        owner_id="owner-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: True,
             count_unread=lambda _chat_id, _user_id: 0,
@@ -768,7 +757,6 @@ def test_read_messages_uses_thread_user_target_name_on_no_history() -> None:
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 None
@@ -797,7 +785,6 @@ def test_read_messages_uses_messaging_service_direct_chat_lookup_without_member_
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 None
@@ -828,7 +815,6 @@ def test_read_messages_uses_messaging_service_time_range_history_without_message
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         messaging_service=SimpleNamespace(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
                 {
@@ -866,7 +852,6 @@ def test_chat_tool_search_does_not_fall_back_to_global_search_for_thread_user_ta
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 None
@@ -900,7 +885,6 @@ def test_chat_tool_search_uses_messaging_service_direct_chat_lookup_without_memb
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
-        owner_id="owner-user-1",
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 None

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -282,6 +282,7 @@ async def test_get_or_create_agent_uses_thread_user_id_for_chat_identity(monkeyp
     assert "user_id" not in chat_repos
     assert "chat_member_repo" not in chat_repos
     assert "messages_repo" not in chat_repos
+    assert "relationship_repo" not in chat_repos
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove dead owner_id and relationship_repo constructor surface from ChatToolService
- stop passing those dead fields from LeonAgent chat-tool wiring
- stop carrying relationship_repo in agent_pool chat_repos while keeping owner_id alive for prompt truth

## Verification
- uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py tests/Unit/core/test_agent_pool.py
- uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py -k "send_message_route_then_agent_terminal_notification_reenters_followthrough or run_agent_to_buffer_turns_silent_chat_notification_into_visible_followthrough"
- python3 -m py_compile backend/web/services/agent_pool.py core/runtime/agent.py messaging/tools/chat_tool_service.py tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff check backend/web/services/agent_pool.py core/runtime/agent.py messaging/tools/chat_tool_service.py tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff format --check backend/web/services/agent_pool.py core/runtime/agent.py messaging/tools/chat_tool_service.py tests/Unit/core/test_agent_pool.py tests/Integration/test_leon_agent.py tests/Integration/test_messaging_social_handle_contract.py