### PR TITLE
fix: align monitor card running count

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -403,6 +403,10 @@ function ProviderCard({
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const capabilityList = capabilityTags(provider.capabilities);
   const showCpuMetric = provider.cardCpu.used != null || provider.cardCpu.limit != null;
+  const runningMetric = {
+    ...provider.telemetry.running,
+    used: runningCount,
+  };
   const showTelemetryGapTruth =
     provider.type !== "local" &&
     provider.status === "ready" &&
@@ -441,7 +445,7 @@ function ProviderCard({
         </div>
       ) : (
         <div className="provider-card__metric-row">
-          <MetricOrb label="运行数" metric={provider.telemetry.running} />
+          <MetricOrb label="运行数" metric={runningMetric} />
           {showCpuMetric && <MetricOrb label="CPU" metric={provider.cardCpu} />}
         </div>
       )}

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -816,6 +816,74 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("2 遥测未知")).toBeInTheDocument();
   });
 
+  it("uses live session rows as the provider-card running truth when telemetry count lags", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 2,
+        },
+        providers: [
+          {
+            id: "local",
+            name: "local",
+            description: "Local provider",
+            type: "local",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 5, limit: 100, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 8, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 20, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: { used: 5, limit: 100, unit: "%", source: "api", freshness: "live" },
+            sessions: [
+              {
+                id: "session-1",
+                threadId: "thread-1",
+                agentName: "Local Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+              },
+              {
+                id: "session-2",
+                threadId: "thread-2",
+                agentName: "Local Agent 2",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const providerCard = (await screen.findAllByRole("button", { name: /local/i })).find((element) =>
+      element.className.includes("provider-card"),
+    ) as HTMLElement;
+    expect(within(providerCard).getByText("2")).toBeInTheDocument();
+    expect(within(providerCard).queryByText(/^1$/)).not.toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- use live session rows as the provider-card running count truth
- stop showing stale telemetry.running values that disagree with the same card footer
- lock the running-count truth regression in monitor routes tests

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build