### PR TITLE
fix: surface monitor card cpu scope

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -411,6 +411,11 @@ function ProviderCard({
     ...provider.telemetry.running,
     used: runningCount,
   };
+  const showSandboxLevelCpuTruth =
+    provider.type !== "local" &&
+    runningCount > 0 &&
+    !showCpuMetric &&
+    provider.cardCpu.error === "CPU usage is per-sandbox, not a provider-level quota.";
   const showTelemetryGapTruth =
     provider.type !== "local" &&
     provider.status === "ready" &&
@@ -463,6 +468,9 @@ function ProviderCard({
 
       {showTelemetryGapTruth && (
         <div className="provider-card__truth">暂无 live telemetry</div>
+      )}
+      {showSandboxLevelCpuTruth && (
+        <div className="provider-card__truth">CPU 沙盒级</div>
       )}
 
       {capabilityList.length > 0 && (

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -985,6 +985,75 @@ describe("MonitorRoutes", () => {
     expect(screen.queryByText("1 运行会话")).not.toBeInTheDocument();
   });
 
+  it("surfaces when provider-card cpu is only meaningful at the sandbox level", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const providerCard = await screen.findByRole("button", { name: /daytona_selfhost/i });
+    expect(within(providerCard).getByText("CPU 沙盒级")).toBeInTheDocument();
+    expect(within(providerCard).queryByText("CPU")).not.toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- surface when provider-card CPU is only meaningful at the sandbox level
- stop making active remote cards look like they simply have no CPU signal
- lock the card-level CPU scope truth in monitor routes tests

## Test Plan
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build