### PR TITLE
fix: surface monitor card memory and disk

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -407,6 +407,8 @@ function ProviderCard({
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const capabilityList = capabilityTags(provider.capabilities);
   const showCpuMetric = provider.cardCpu.used != null || provider.cardCpu.limit != null;
+  const showMemoryMetric = provider.telemetry.memory.used != null || provider.telemetry.memory.limit != null;
+  const showDiskMetric = provider.telemetry.disk.used != null || provider.telemetry.disk.limit != null;
   const runningMetric = {
     ...provider.telemetry.running,
     used: runningCount,
@@ -456,6 +458,8 @@ function ProviderCard({
         <div className="provider-card__metric-row">
           <MetricOrb label="运行数" metric={runningMetric} />
           {showCpuMetric && <MetricOrb label="CPU" metric={provider.cardCpu} />}
+          {showMemoryMetric && <MetricOrb label="RAM" metric={provider.telemetry.memory} />}
+          {showDiskMetric && <MetricOrb label="Disk" metric={provider.telemetry.disk} />}
         </div>
       )}
 
@@ -487,11 +491,16 @@ function ProviderCard({
 }
 
 function MetricOrb({ label, metric }: { label: string; metric: UsageMetric }) {
+  const value =
+    metric.used == null
+      ? "--"
+      : metric.unit === "%" || metric.unit === "GB"
+        ? formatMetric(metric.used, metric.unit)
+        : formatNumber(metric.used);
+
   return (
     <div className="metric-orb" title={metric.error || undefined}>
-      <div className="metric-orb__value">
-        {metric.used != null ? `${formatNumber(metric.used)}${metric.unit === "%" ? "%" : ""}` : "--"}
-      </div>
+      <div className="metric-orb__value">{value}</div>
       <div className="metric-orb__label">{label}</div>
       {metric.limit != null && <div className="metric-orb__sub">{formatMetric(metric.limit, metric.unit)}</div>}
     </div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1054,6 +1054,77 @@ describe("MonitorRoutes", () => {
     expect(within(providerCard).queryByText("CPU")).not.toBeInTheDocument();
   });
 
+  it("surfaces live memory and disk telemetry on the provider card when present", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const providerCard = await screen.findByRole("button", { name: /daytona_selfhost/i });
+    expect(within(providerCard).getByText("RAM")).toBeInTheDocument();
+    expect(within(providerCard).getByText("Disk")).toBeInTheDocument();
+    expect(within(providerCard).getByText("1GB")).toBeInTheDocument();
+    expect(within(providerCard).getByText("2GB")).toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary\n- surface live RAM and Disk telemetry on monitor provider cards when the backend already provides it\n- keep sandbox-level CPU truth when provider-level CPU is intentionally absent\n- lock the provider-card telemetry surface with a route regression test\n\n## Verification\n- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx\n- cd frontend/monitor && npm run build