### PR TITLE
refactor: drop chat tool constructor user id fallback

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -86,14 +86,12 @@ class ChatToolService:
         self,
         registry: ToolRegistry,
         *,
-        chat_identity_id: str | None = None,
-        user_id: str | None = None,
+        chat_identity_id: str,
         messaging_service: Any = None,  # MessagingService (new)
     ) -> None:
-        identity_id = chat_identity_id or user_id
-        if not identity_id:
-            raise ValueError("ChatToolService requires chat_identity_id or legacy user_id")
-        self._chat_identity_id: str = identity_id
+        if not chat_identity_id:
+            raise ValueError("ChatToolService requires chat_identity_id")
+        self._chat_identity_id: str = chat_identity_id
         self._messaging = messaging_service
         self._register(registry)
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -1051,6 +1051,7 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     LeonAgent._init_services(agent)
 
     assert captured["chat_identity_id"] == "thread-user-9"
+    assert "user_id" not in captured
     assert "chat_member_repo" not in captured
     assert "messages_repo" not in captured
     assert "owner_id" not in captured

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -193,7 +193,7 @@ def test_chat_tool_registry_exposes_final_contract_only() -> None:
     registry = ToolRegistry()
     ChatToolService(
         registry=registry,
-        user_id="owner-user-1",
+        chat_identity_id="owner-user-1",
         messaging_service=_messaging_display_service(),
     )
 
@@ -208,7 +208,7 @@ def test_send_message_schema_marks_user_id_name_as_legacy() -> None:
     registry = ToolRegistry()
     ChatToolService(
         registry=registry,
-        user_id="agent-user-1",
+        chat_identity_id="agent-user-1",
     )
 
     send_message = registry.get("send_message")
@@ -225,7 +225,7 @@ def test_read_messages_schema_requires_non_empty_chat_or_user_identifier() -> No
     registry = ToolRegistry()
     ChatToolService(
         registry=registry,
-        user_id="agent-user-1",
+        chat_identity_id="agent-user-1",
     )
 
     read_messages = registry.get("read_messages")
@@ -247,6 +247,29 @@ def test_chat_tool_service_accepts_chat_identity_id_without_legacy_user_id() -> 
     )
 
     assert registry.get("list_chats") is not None
+
+
+def test_chat_tool_service_rejects_legacy_constructor_user_id() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(TypeError, match="user_id"):
+        ChatToolService(
+            registry=registry,
+            user_id="agent-user-1",
+            messaging_service=_messaging_display_service(),
+        )
+
+
+@pytest.mark.parametrize("chat_identity_id", [None, ""])
+def test_chat_tool_service_rejects_empty_chat_identity_id(chat_identity_id: str | None) -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(ValueError, match="chat_identity_id"):
+        ChatToolService(
+            registry=registry,
+            chat_identity_id=chat_identity_id,  # type: ignore[arg-type]
+            messaging_service=_messaging_display_service(),
+        )
 
 
 def test_chat_tool_service_rejects_dead_repo_constructor_kwargs() -> None:


### PR DESCRIPTION
## Summary\n- remove the legacy ChatToolService constructor user_id fallback\n- keep outward chat tool user_id parameter contracts unchanged\n- tighten contract and wiring tests around chat_identity_id-only runtime construction\n\n## Verification\n- uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py\n- uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py -k "send_message_route_then_agent_terminal_notification_reenters_followthrough or run_agent_to_buffer_turns_silent_chat_notification_into_visible_followthrough"\n- python3 -m py_compile messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py\n- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py\n- uv run ruff format --check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py