### PR TITLE
refactor: remove legacy chat tool constructor user id

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -87,13 +87,11 @@ class ChatToolService:
         registry: ToolRegistry,
         *,
         chat_identity_id: str | None = None,
-        user_id: str | None = None,
         messaging_service: Any = None,  # MessagingService (new)
     ) -> None:
-        identity_id = chat_identity_id or user_id
-        if not identity_id:
-            raise ValueError("ChatToolService requires chat_identity_id or legacy user_id")
-        self._chat_identity_id: str = identity_id
+        if not chat_identity_id:
+            raise ValueError("ChatToolService requires chat_identity_id")
+        self._chat_identity_id = chat_identity_id
         self._messaging = messaging_service
         self._register(registry)
 

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -193,7 +193,7 @@ def test_chat_tool_registry_exposes_final_contract_only() -> None:
     registry = ToolRegistry()
     ChatToolService(
         registry=registry,
-        user_id="owner-user-1",
+        chat_identity_id="owner-user-1",
         messaging_service=_messaging_display_service(),
     )
 
@@ -208,7 +208,7 @@ def test_send_message_schema_marks_user_id_name_as_legacy() -> None:
     registry = ToolRegistry()
     ChatToolService(
         registry=registry,
-        user_id="agent-user-1",
+        chat_identity_id="agent-user-1",
     )
 
     send_message = registry.get("send_message")
@@ -225,7 +225,7 @@ def test_read_messages_schema_requires_non_empty_chat_or_user_identifier() -> No
     registry = ToolRegistry()
     ChatToolService(
         registry=registry,
-        user_id="agent-user-1",
+        chat_identity_id="agent-user-1",
     )
 
     read_messages = registry.get("read_messages")
@@ -247,6 +247,16 @@ def test_chat_tool_service_accepts_chat_identity_id_without_legacy_user_id() -> 
     )
 
     assert registry.get("list_chats") is not None
+
+
+def test_chat_tool_service_rejects_legacy_constructor_user_id() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(TypeError):
+        ChatToolService(
+            registry=registry,
+            user_id="agent-user-1",
+        )
 
 
 def test_chat_tool_service_rejects_dead_repo_constructor_kwargs() -> None:


### PR DESCRIPTION
## Summary
- remove the internal `ChatToolService(..., user_id=...)` constructor fallback
- require `chat_identity_id` for runtime chat-tool wiring while preserving outward tool parameter `user_id`
- tighten messaging contract tests around the constructor truth

## Test Plan
- uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py
- uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py
- uv run python -m py_compile messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py
