### PR TITLE
fix: surface sandbox metric limits

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -79,6 +79,19 @@ function formatMetricRange(metric: UsageMetric): string {
   return `limit ${formatMetric(metric.limit, metric.unit)}`;
 }
 
+function formatSessionMetricRange(used: number | null | undefined, limit: number | null | undefined, unit: string): string {
+  if (used == null && limit == null) {
+    return "--";
+  }
+  if (used != null && limit != null) {
+    return `${formatMetric(used, unit)} / ${formatMetric(limit, unit)}`;
+  }
+  if (used != null) {
+    return formatMetric(used, unit);
+  }
+  return `limit ${formatMetric(limit, unit)}`;
+}
+
 function calculateDuration(createdAt: string): number | null {
   const startedAt = new Date(createdAt).getTime();
   if (Number.isNaN(startedAt)) {
@@ -696,9 +709,9 @@ function SandboxCard({
       </div>
       {hasMetrics && (
         <div className="sandbox-card__metrics">
-          <span>CPU {formatMetric(metrics?.cpu, "%")}</span>
-          <span>RAM {formatMetric(metrics?.memory, "GB")}</span>
-          <span>Disk {formatMetric(metrics?.disk, "GB")}</span>
+          <span>CPU {formatSessionMetricRange(metrics?.cpu, null, "%")}</span>
+          <span>RAM {formatSessionMetricRange(metrics?.memory, metrics?.memoryLimit, "GB")}</span>
+          <span>Disk {formatSessionMetricRange(metrics?.disk, metrics?.diskLimit, "GB")}</span>
         </div>
       )}
       <div className="sandbox-card__lease">{group.leaseId || "local"}</div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1125,6 +1125,86 @@ describe("MonitorRoutes", () => {
     expect(within(providerCard).getByText("2GB")).toBeInTheDocument();
   });
 
+  it("surfaces quota-only sandbox metrics instead of pretending they are fully missing", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: null,
+                  memory: null,
+                  memoryLimit: 1,
+                  memoryNote: null,
+                  disk: null,
+                  diskLimit: 3,
+                  diskNote: "disk usage not measurable inside container; showing quota only",
+                  networkIn: null,
+                  networkOut: null,
+                  probeError: null,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const sandboxCard = await screen.findByRole("button", { name: /remote agent/i });
+    expect(within(sandboxCard).getByText("RAM limit 1GB")).toBeInTheDocument();
+    expect(within(sandboxCard).getByText("Disk limit 3GB")).toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary\n- stop showing quota-only sandbox metrics as fully missing on monitor sandbox cards\n- surface RAM/Disk limits when session usage is absent but quota exists\n- lock the sandbox-card truth with a route regression test\n\n## Verification\n- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx\n- cd frontend/monitor && npm run build