### PR TITLE
refactor: route chat display resolution through messaging service

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -15,7 +15,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
-from messaging.display_user import resolve_messaging_display_user
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
@@ -79,11 +78,7 @@ def _get_accessible_chat_or_404(app: Any, chat_id: str, user_id: str) -> Any:
 
 
 def _resolve_display_user(app: Any, social_user_id: str) -> Any | None:
-    return resolve_messaging_display_user(
-        user_repo=app.state.user_repo,
-        thread_repo=getattr(app.state, "thread_repo", None),
-        social_user_id=social_user_id,
-    )
+    return _messaging(app).resolve_display_user(social_user_id)
 
 
 def _validate_chat_participant_ids(app: Any, participant_ids: list[str], requester_user_id: str) -> list[str]:

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
+from backend.web.core.dependencies import get_app, get_current_user_id
 from backend.web.routers import messaging as messaging_router
 from backend.web.utils.serializers import avatar_url
 
@@ -16,6 +18,15 @@ def _chat(chat_id: str) -> SimpleNamespace:
         status="active",
         created_at="2026-04-07T00:00:00Z",
     )
+
+
+def _route_test_app(state: SimpleNamespace) -> FastAPI:
+    app = FastAPI()
+    app.state = state
+    app.include_router(messaging_router.router)
+    app.dependency_overrides[get_current_user_id] = lambda: "human-user-1"
+    app.dependency_overrides[get_app] = lambda: app
+    return app
 
 
 def test_get_accessible_chat_or_404_returns_chat():
@@ -62,24 +73,15 @@ def test_get_accessible_chat_or_404_raises_403_for_non_member():
     assert exc_info.value.detail == "Not a participant of this chat"
 
 
-def test_resolve_display_user_delegates_to_messaging_local_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
-    seen: dict[str, object] = {}
+def test_resolve_display_user_delegates_to_messaging_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, str]] = []
     expected = SimpleNamespace(id="agent-user-1", display_name="Toad")
-
-    def fake_resolver(*, user_repo, thread_repo, social_user_id: str):
-        seen.update(
-            {
-                "user_repo": user_repo,
-                "thread_repo": thread_repo,
-                "social_user_id": social_user_id,
-            }
-        )
-        return expected
-
-    monkeypatch.setattr(messaging_router, "resolve_messaging_display_user", fake_resolver)
 
     app = SimpleNamespace(
         state=SimpleNamespace(
+            messaging_service=SimpleNamespace(
+                resolve_display_user=lambda social_user_id: seen.append(("resolve_display_user", social_user_id)) or expected
+            ),
             user_repo=SimpleNamespace(name="user-repo"),
             thread_repo=SimpleNamespace(name="thread-repo"),
         )
@@ -88,11 +90,7 @@ def test_resolve_display_user_delegates_to_messaging_local_resolver(monkeypatch:
     result = messaging_router._resolve_display_user(app, "thread-user-1")
 
     assert result is expected
-    assert seen == {
-        "user_repo": app.state.user_repo,
-        "thread_repo": app.state.thread_repo,
-        "social_user_id": "thread-user-1",
-    }
+    assert seen == [("resolve_display_user", "thread-user-1")]
 
 
 @pytest.mark.asyncio
@@ -235,6 +233,13 @@ async def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
                         "created_at": "2026-04-07T00:00:00Z",
                     }
                 ],
+                resolve_display_user=lambda uid: (
+                    SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None)
+                    if uid == "thread-user-1"
+                    else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                    if uid == "agent-user-1"
+                    else None
+                ),
             ),
             user_repo=SimpleNamespace(
                 get_by_id=lambda uid: (
@@ -269,6 +274,51 @@ async def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
     ]
 
 
+def test_list_messages_route_resolves_sender_name_via_messaging_service() -> None:
+    test_app = _route_test_app(
+        SimpleNamespace(
+            messaging_service=SimpleNamespace(
+                is_chat_member=lambda _chat_id, _user_id: True,
+                list_messages=lambda _chat_id, **_kwargs: [
+                    {
+                        "id": "msg-1",
+                        "chat_id": "chat-1",
+                        "sender_id": "thread-user-1",
+                        "content": "hello",
+                        "message_type": "human",
+                        "created_at": "2026-04-07T00:00:00Z",
+                    }
+                ],
+                resolve_display_user=lambda uid: (
+                    SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None) if uid == "thread-user-1" else None
+                ),
+            )
+        )
+    )
+
+    try:
+        with TestClient(test_app) as client:
+            response = client.get("/api/chats/chat-1/messages")
+    finally:
+        test_app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": "msg-1",
+            "chat_id": "chat-1",
+            "sender_id": "thread-user-1",
+            "sender_name": "Toad",
+            "content": "hello",
+            "message_type": "human",
+            "mentioned_ids": [],
+            "signal": None,
+            "retracted_at": None,
+            "created_at": "2026-04-07T00:00:00Z",
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
     seen: list[tuple[str, str, str]] = []
@@ -287,6 +337,17 @@ async def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo(
                 get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
             ),
             messaging_service=SimpleNamespace(
+                resolve_display_user=lambda uid: (
+                    SimpleNamespace(
+                        id="agent-user-1",
+                        display_name="Toad",
+                        type="agent",
+                        avatar=None,
+                        owner_user_id="owner-user-1",
+                    )
+                    if uid == "thread-user-1"
+                    else None
+                ),
                 send=lambda chat_id, sender_id, content, **_kwargs: (
                     seen.append((chat_id, sender_id, content))
                     or {
@@ -297,7 +358,7 @@ async def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo(
                         "message_type": "human",
                         "created_at": "2026-04-07T00:00:00Z",
                     }
-                )
+                ),
             ),
         )
     )


### PR DESCRIPTION
## Summary\n- route chat router display resolution through MessagingService instead of bypassing it locally\n- keep outward /api/chats message payloads unchanged\n- add router-level and API-level proof for sender_name resolution\n\n## Verification\n- uv run pytest -q tests/Integration/test_messaging_router.py\n- python3 -m py_compile backend/web/routers/messaging.py tests/Integration/test_messaging_router.py\n- uv run ruff check backend/web/routers/messaging.py tests/Integration/test_messaging_router.py\n- uv run ruff format backend/web/routers/messaging.py tests/Integration/test_messaging_router.py