### PR TITLE
fix: surface sandbox metric notes

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -797,11 +797,13 @@ function SandboxInspector({
                 label="RAM"
                 value={group.metrics.memory != null ? formatMetric(group.metrics.memory, "GB") : "--"}
                 sub={group.metrics.memoryLimit != null ? formatMetric(group.metrics.memoryLimit, "GB") : undefined}
+                note={group.metrics.memoryNote || undefined}
               />
               <MetricBlock
                 label="Disk"
                 value={group.metrics.disk != null ? formatMetric(group.metrics.disk, "GB") : "--"}
                 sub={group.metrics.diskLimit != null ? formatMetric(group.metrics.diskLimit, "GB") : undefined}
+                note={group.metrics.diskNote || group.metrics.probeError || undefined}
               />
             </div>
           </div>
@@ -828,7 +830,17 @@ function SandboxInspector({
   );
 }
 
-function MetricBlock({ label, value, sub }: { label: string; value: string; sub?: string }) {
+function MetricBlock({
+  label,
+  value,
+  sub,
+  note,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  note?: string;
+}) {
   return (
     <div className="sandbox-metric-block">
       <div className="sandbox-metric-block__label">{label}</div>
@@ -836,6 +848,7 @@ function MetricBlock({ label, value, sub }: { label: string; value: string; sub?
         {value}
         {sub ? <span className="sandbox-metric-block__sub"> / {sub}</span> : null}
       </div>
+      {note ? <div className="sandbox-metric-block__note">{note}</div> : null}
     </div>
   );
 }

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1205,6 +1205,85 @@ describe("MonitorRoutes", () => {
     expect(within(sandboxCard).getByText("Disk limit 3GB")).toBeInTheDocument();
   });
 
+  it("surfaces sandbox metric notes when only quota is available", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: null,
+                  memory: null,
+                  memoryLimit: 1,
+                  memoryNote: null,
+                  disk: null,
+                  diskLimit: 3,
+                  diskNote: "disk usage not measurable inside container; showing quota only",
+                  networkIn: null,
+                  networkOut: null,
+                  probeError: null,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /remote agent/i }));
+    expect(await screen.findByText("disk usage not measurable inside container; showing quota only")).toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {

--- a/frontend/monitor/src/styles.css
+++ b/frontend/monitor/src/styles.css
@@ -1007,6 +1007,13 @@ div:has(> :only-child:is(div:contains("Loading"))) {
   font-weight: 400;
 }
 
+.sandbox-metric-block__note {
+  margin-top: 0.45rem;
+  color: #8f98aa;
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
 .file-browser {
   display: grid;
   grid-template-columns: 1fr 1.15fr;


### PR DESCRIPTION
## Summary\n- surface sandbox metric notes in the monitor inspector when quota-only data is all the backend has\n- keep the scope to the inspector metric blocks instead of widening the card surfaces\n- lock the quota-note truth with a route regression test\n\n## Verification\n- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx\n- cd frontend/monitor && npm run build