### PR TITLE
fix: surface sandbox card quota truth

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -671,6 +671,11 @@ function SandboxCard({
     group.status === "running" &&
     Boolean(group.leaseId) &&
     !group.sessions.some((session) => Boolean(session.runtimeSessionId));
+  const showQuotaOnlyDiskTruth =
+    metrics != null &&
+    metrics.disk == null &&
+    metrics.diskLimit != null &&
+    Boolean(metrics.diskNote || metrics.probeError);
 
   return (
     <button type="button" className={`sandbox-card sandbox-card--${group.status}`} onClick={onOpen}>
@@ -699,6 +704,7 @@ function SandboxCard({
           // before the operator drills into a guaranteed-failing file browser.
           <div className="sandbox-card__warning">无 active runtime</div>
         )}
+        {showQuotaOnlyDiskTruth && <div className="sandbox-card__warning">Disk 仅配额</div>}
         <div className="sandbox-card__thread-list">
           {group.sessions.slice(0, 2).map((session) => (
             <div key={session.id} className="sandbox-card__thread">

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1284,6 +1284,85 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("disk usage not measurable inside container; showing quota only")).toBeInTheDocument();
   });
 
+  it("surfaces quota-only disk truth directly on the sandbox card", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: null,
+                  memory: null,
+                  memoryLimit: 1,
+                  memoryNote: null,
+                  disk: null,
+                  diskLimit: 3,
+                  diskNote: "disk usage not measurable inside container; showing quota only",
+                  networkIn: null,
+                  networkOut: null,
+                  probeError: null,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const sandboxCard = await screen.findByRole("button", { name: /remote agent/i });
+    expect(within(sandboxCard).getByText("Disk 仅配额")).toBeInTheDocument();
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary\n- surface quota-only disk truth directly on monitor sandbox cards\n- keep the scope to the sandbox card truth chip instead of widening provider-level surfaces\n- lock the card-level quota truth with a route regression test\n\n## Verification\n- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx\n- cd frontend/monitor && npm run build