### PR TITLE
refactor: move chat message projection into messaging service

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -102,22 +102,6 @@ def _validate_chat_participant_ids(app: Any, participant_ids: list[str], request
     return validated
 
 
-def _msg_response(m: dict[str, Any], app: Any) -> dict[str, Any]:
-    sender = _resolve_display_user(app, m.get("sender_id", ""))
-    return {
-        "id": m["id"],
-        "chat_id": m["chat_id"],
-        "sender_id": m.get("sender_id"),
-        "sender_name": sender.display_name if sender else "unknown",
-        "content": m["content"],
-        "message_type": m.get("message_type", "human"),
-        "mentioned_ids": m.get("mentioned_ids") or m.get("mentions") or [],
-        "signal": m.get("signal"),
-        "retracted_at": m.get("retracted_at"),
-        "created_at": m.get("created_at"),
-    }
-
-
 # ---------------------------------------------------------------------------
 # Chat list / create
 # ---------------------------------------------------------------------------
@@ -183,8 +167,7 @@ async def list_messages(
 ):
     if not _messaging(app).is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
-    msgs = _messaging(app).list_messages(chat_id, limit=limit, before=before, viewer_id=user_id)
-    return [_msg_response(m, app) for m in msgs]
+    return _messaging(app).list_message_responses(chat_id, limit=limit, before=before, viewer_id=user_id)
 
 
 @router.post("/{chat_id}/messages")
@@ -205,7 +188,7 @@ async def send_message(
         signal=body.signal,
         message_type=body.message_type,
     )
-    return _msg_response(msg, app)
+    return _messaging(app).project_message_response(msg)
 
 
 @router.post("/{chat_id}/messages/{message_id}/retract")

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -56,6 +56,24 @@ class MessagingService:
             "ai_metadata": row.get("ai_metadata") or row.get("ai_metadata_json") or {},
         }
 
+    def _project_message_response(self, row: dict[str, Any]) -> dict[str, Any]:
+        # @@@message-response-projection - public chat message payload must keep
+        # sender projection ownership in MessagingService so route send/list stay thin.
+        message = self._normalize_message_row(row)
+        sender = self._resolve_display_user(message.get("sender_id", ""))
+        return {
+            "id": message["id"],
+            "chat_id": message["chat_id"],
+            "sender_id": message.get("sender_id"),
+            "sender_name": sender.display_name if sender else "unknown",
+            "content": message["content"],
+            "message_type": message.get("message_type", "human"),
+            "mentioned_ids": message.get("mentioned_ids") or [],
+            "signal": message.get("signal"),
+            "retracted_at": message.get("retracted_at"),
+            "created_at": message.get("created_at"),
+        }
+
     def _resolve_display_user(self, social_user_id: str) -> Any | None:
         return resolve_messaging_display_user(
             user_repo=self._user_repo,
@@ -65,6 +83,9 @@ class MessagingService:
 
     def resolve_display_user(self, social_user_id: str) -> Any | None:
         return self._resolve_display_user(social_user_id)
+
+    def project_message_response(self, row: dict[str, Any]) -> dict[str, Any]:
+        return self._project_message_response(row)
 
     def _build_chat_entities(self, chat_id: str) -> list[dict[str, Any]]:
         entities_info = []
@@ -275,6 +296,17 @@ class MessagingService:
             viewer_id=viewer_id,
         )
         return [self._normalize_message_row(row) for row in rows]
+
+    def list_message_responses(
+        self, chat_id: str, *, limit: int = 50, before: str | None = None, viewer_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        rows = self._messages.list_by_chat(
+            chat_id,
+            limit=limit,
+            before=before,
+            viewer_id=viewer_id,
+        )
+        return [self._project_message_response(row) for row in rows]
 
     def list_unread(self, chat_id: str, user_id: str) -> list[dict[str, Any]]:
         return [self._normalize_message_row(row) for row in self._messages.list_unread(chat_id, user_id)]

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -223,13 +223,17 @@ async def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
         state=SimpleNamespace(
             messaging_service=SimpleNamespace(
                 is_chat_member=lambda _chat_id, _user_id: True,
-                list_messages=lambda _chat_id, **_kwargs: [
+                list_message_responses=lambda _chat_id, **_kwargs: [
                     {
                         "id": "msg-1",
                         "chat_id": "chat-1",
                         "sender_id": "thread-user-1",
+                        "sender_name": "Toad",
                         "content": "hello",
                         "message_type": "human",
+                        "mentioned_ids": [],
+                        "signal": None,
+                        "retracted_at": None,
                         "created_at": "2026-04-07T00:00:00Z",
                     }
                 ],
@@ -279,18 +283,22 @@ def test_list_messages_route_resolves_sender_name_via_messaging_service() -> Non
         SimpleNamespace(
             messaging_service=SimpleNamespace(
                 is_chat_member=lambda _chat_id, _user_id: True,
-                list_messages=lambda _chat_id, **_kwargs: [
+                list_message_responses=lambda _chat_id, **_kwargs: [
                     {
                         "id": "msg-1",
                         "chat_id": "chat-1",
                         "sender_id": "thread-user-1",
+                        "sender_name": "Projected Toad",
                         "content": "hello",
                         "message_type": "human",
+                        "mentioned_ids": [],
+                        "signal": None,
+                        "retracted_at": None,
                         "created_at": "2026-04-07T00:00:00Z",
                     }
                 ],
-                resolve_display_user=lambda uid: (
-                    SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None) if uid == "thread-user-1" else None
+                list_messages=lambda _chat_id, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("route should consume service-owned message projection")
                 ),
             )
         )
@@ -308,7 +316,7 @@ def test_list_messages_route_resolves_sender_name_via_messaging_service() -> Non
             "id": "msg-1",
             "chat_id": "chat-1",
             "sender_id": "thread-user-1",
-            "sender_name": "Toad",
+            "sender_name": "Projected Toad",
             "content": "hello",
             "message_type": "human",
             "mentioned_ids": [],
@@ -317,6 +325,72 @@ def test_list_messages_route_resolves_sender_name_via_messaging_service() -> Non
             "created_at": "2026-04-07T00:00:00Z",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_send_message_consumes_service_owned_message_projection() -> None:
+    seen: list[tuple[str, str, str]] = []
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            messaging_service=SimpleNamespace(
+                resolve_display_user=lambda uid: (
+                    SimpleNamespace(
+                        id="agent-user-1",
+                        display_name="Ownership Toad",
+                        type="agent",
+                        avatar=None,
+                        owner_user_id="owner-user-1",
+                    )
+                    if uid == "thread-user-1"
+                    else None
+                ),
+                send=lambda chat_id, sender_id, content, **_kwargs: (
+                    seen.append((chat_id, sender_id, content))
+                    or {
+                        "id": "msg-1",
+                        "chat_id": chat_id,
+                        "sender_id": sender_id,
+                        "content": content,
+                        "message_type": "human",
+                        "created_at": "2026-04-07T00:00:00Z",
+                    }
+                ),
+                project_message_response=lambda msg: {
+                    "id": msg["id"],
+                    "chat_id": msg["chat_id"],
+                    "sender_id": msg["sender_id"],
+                    "sender_name": "Projected Toad",
+                    "content": msg["content"],
+                    "message_type": msg["message_type"],
+                    "mentioned_ids": [],
+                    "signal": None,
+                    "retracted_at": None,
+                    "created_at": msg["created_at"],
+                },
+            ),
+        )
+    )
+
+    result = await messaging_router.send_message(
+        "chat-1",
+        messaging_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
+        user_id="owner-user-1",
+        app=app,
+    )
+
+    assert seen == [("chat-1", "thread-user-1", "hello")]
+    assert result == {
+        "id": "msg-1",
+        "chat_id": "chat-1",
+        "sender_id": "thread-user-1",
+        "sender_name": "Projected Toad",
+        "content": "hello",
+        "message_type": "human",
+        "mentioned_ids": [],
+        "signal": None,
+        "retracted_at": None,
+        "created_at": "2026-04-07T00:00:00Z",
+    }
 
 
 @pytest.mark.asyncio
@@ -359,6 +433,18 @@ async def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo(
                         "created_at": "2026-04-07T00:00:00Z",
                     }
                 ),
+                project_message_response=lambda msg: {
+                    "id": msg["id"],
+                    "chat_id": msg["chat_id"],
+                    "sender_id": msg["sender_id"],
+                    "sender_name": "Toad",
+                    "content": msg["content"],
+                    "message_type": msg["message_type"],
+                    "mentioned_ids": [],
+                    "signal": None,
+                    "retracted_at": None,
+                    "created_at": msg["created_at"],
+                },
             ),
         )
     )

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -318,6 +318,55 @@ def test_messaging_service_resolves_sender_name_from_thread_user_id() -> None:
     assert data["sender_name"] == "Toad"
 
 
+def test_messaging_service_list_message_responses_projects_sender_name_from_thread_user_id() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(),
+        messages_repo=SimpleNamespace(
+            list_by_chat=lambda _chat_id, **_kwargs: [
+                {
+                    "id": "msg-1",
+                    "chat_id": "chat-1",
+                    "sender_user_id": "thread-user-1",
+                    "content": "hello",
+                    "message_type": "human",
+                    "created_at": "2026-04-07T00:00:00Z",
+                }
+            ]
+        ),
+        message_read_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                if uid == "agent-user-1"
+                else None
+            )
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+    )
+
+    result = service.list_message_responses("chat-1", viewer_id="human-user-1")
+
+    assert result == [
+        {
+            "id": "msg-1",
+            "chat_id": "chat-1",
+            "sender_id": "thread-user-1",
+            "sender_name": "Toad",
+            "content": "hello",
+            "message_type": "human",
+            "mentioned_ids": [],
+            "signal": None,
+            "retracted_at": None,
+            "created_at": "2026-04-07T00:00:00Z",
+        }
+    ]
+
+
 def test_messaging_service_agent_send_passes_expected_read_seq_to_messages_repo() -> None:
     created_rows: list[tuple[dict[str, Any], int | None]] = []
 


### PR DESCRIPTION
## Summary
- move public chat message response projection ownership into `MessagingService`
- keep `/api/chats/{chat_id}/messages` list/send payload shape unchanged
- add router and service integration proofs for sender_name projection

## Verification
- `uv run pytest -q tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`
- `python3 -m py_compile backend/web/routers/messaging.py messaging/service.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff check backend/web/routers/messaging.py messaging/service.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff format --check backend/web/routers/messaging.py messaging/service.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py`