### PR TITLE
fix: surface provider quota-only truth

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -546,6 +546,17 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
   const runtimeUnboundRunningCount = provider.sessions.filter(
     (session) => session.status === "running" && !session.runtimeSessionId,
   ).length;
+  const quotaOnlyRunningCount = provider.sessions.filter((session) => {
+    const metrics = session.metrics;
+    return (
+      session.status === "running" &&
+      metrics != null &&
+      metrics.memory == null &&
+      metrics.disk == null &&
+      (metrics.memoryLimit != null || metrics.diskLimit != null) &&
+      Boolean(metrics.memoryNote || metrics.diskNote || metrics.probeError)
+    );
+  }).length;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const isLocal = provider.type === "local";
@@ -618,6 +629,7 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
                 <div className="provider-inline-metrics">
                   <InlineMetric label="运行中" value={String(runningCount)} />
                   {runtimeUnboundRunningCount > 0 && <InlineMetric label="无 runtime" value={String(runtimeUnboundRunningCount)} />}
+                  {quotaOnlyRunningCount > 0 && <InlineMetric label="仅配额" value={String(quotaOnlyRunningCount)} />}
                   <InlineMetric label="已暂停" value={String(pausedCount)} />
                   <InlineMetric label="已结束" value={String(stoppedCount)} />
                 </div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1462,6 +1462,109 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("2 仅配额")).toBeInTheDocument();
   });
 
+  it("surfaces quota-only running sandboxes in the provider detail overview", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 2,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 2, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: null,
+                  memory: null,
+                  memoryLimit: 1,
+                  memoryNote: null,
+                  disk: null,
+                  diskLimit: 3,
+                  diskNote: "disk usage not measurable inside container; showing quota only",
+                  networkIn: null,
+                  networkOut: null,
+                  probeError: null,
+                },
+              },
+              {
+                id: "lease-2:thread-2",
+                leaseId: "lease-2",
+                threadId: "thread-2",
+                runtimeSessionId: "runtime-2",
+                agentName: "Remote Agent 2",
+                status: "running",
+                startedAt: "2026-04-08T00:05:00Z",
+                metrics: {
+                  cpu: null,
+                  memory: null,
+                  memoryLimit: 1,
+                  memoryNote: null,
+                  disk: null,
+                  diskLimit: 3,
+                  diskNote: "disk usage not measurable inside container; showing quota only",
+                  networkIn: null,
+                  networkOut: null,
+                  probeError: null,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const summaryPills = await screen.findAllByText("2 仅配额");
+    expect(summaryPills[0]).toHaveClass("resources-summary-pill");
+    const detailLabel = screen.getByText("仅配额");
+    expect(detailLabel).toHaveClass("inline-metric__label");
+    expect(detailLabel.nextElementSibling).toHaveTextContent("2");
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary\n- surface quota-only running sandboxes in the monitor provider detail overview\n- keep the scope to truthful inline metrics based on existing session metrics\n- lock the provider-detail quota truth with a route regression test\n\n## Verification\n- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx\n- cd frontend/monitor && npm run build