### PR TITLE
refactor: align chat event bus payload with message projection

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -195,14 +195,12 @@ class MessagingService:
         logger.debug("[messaging] send chat=%s sender=%s msg=%s type=%s", chat_id[:8], sender_id[:15], msg_id[:8], message_type)
 
         # Publish to event bus (SSE / Realtime bridge)
-        sender = self._resolve_display_user(sender_id)
-        sender_name = sender.display_name if sender else "unknown"
         if self._event_bus:
             self._event_bus.publish(
                 chat_id,
                 {
                     "event": "message",
-                    "data": {**created, "sender_name": sender_name},
+                    "data": self._project_message_response(created),
                 },
             )
 

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -318,6 +318,39 @@ def test_messaging_service_resolves_sender_name_from_thread_user_id() -> None:
     assert data["sender_name"] == "Toad"
 
 
+def test_messaging_service_event_bus_message_uses_service_owned_projection() -> None:
+    published: list[dict[str, object]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: []),
+        messages_repo=SimpleNamespace(create=lambda row: row),
+        message_read_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                None
+                if uid == "thread-user-1"
+                else SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
+                if uid == "human-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                if uid == "agent-user-1"
+                else None
+            )
+        ),
+        thread_repo=SimpleNamespace(
+            get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
+        ),
+        event_bus=SimpleNamespace(publish=lambda _chat_id, payload: published.append(payload)),
+    )
+
+    created = service.send("chat-1", "thread-user-1", "hello", mentions=["human-user-1"], signal="open")
+
+    payload = cast(dict[str, object], published[0])
+    assert payload == {
+        "event": "message",
+        "data": service.project_message_response(created),
+    }
+
+
 def test_messaging_service_list_message_responses_projects_sender_name_from_thread_user_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(),


### PR DESCRIPTION
## Summary
- reuse `MessagingService` message projection for chat event-bus message payloads
- keep SSE message payload aligned with `GET/POST /api/chats/{chat_id}/messages`
- add service contract proof for event-bus projection alignment

## Verification
- `uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py`
- `python3 -m py_compile messaging/service.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py`