### PR TITLE
fix: fail loudly on invalid chat participant ids

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -98,7 +98,9 @@ def _validate_chat_participant_ids(app: Any, participant_ids: list[str], request
             candidate = user_repo.get_by_id(participant_id)
             if candidate is not None and getattr(candidate, "owner_user_id", None) is not None:
                 raise ValueError(f"Agent participant ids must be actor user_ids, not agent_user_id: {participant_id}")
-        validated.append(participant_id)
+        # @@@chat-participant-ingress-boundary - group chat creation must reject
+        # unknown ids loudly at ingress instead of letting storage FKs decide.
+        raise ValueError(f"Unknown chat participant id: {participant_id}")
     return validated
 
 

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -572,3 +572,33 @@ async def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_pa
         "status": "active",
         "created_at": 0,
     }
+
+
+@pytest.mark.asyncio
+async def test_create_chat_rejects_unknown_participant_ids_instead_of_falling_to_storage_fk() -> None:
+    called: list[tuple[list[str], str | None]] = []
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            user_repo=SimpleNamespace(get_by_id=lambda _uid: None),
+            thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None),
+            messaging_service=SimpleNamespace(
+                create_group_chat=lambda user_ids, title: (
+                    called.append((user_ids, title)) or {"id": "chat-1", "title": title, "status": "active", "created_at": 0}
+                )
+            ),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await messaging_router.create_chat(
+            messaging_router.CreateChatBody(
+                user_ids=["human-user-1", "thread-id-not-a-user", "thread-user-2"],
+                title="bad-group",
+            ),
+            user_id="human-user-1",
+            app=app,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "participant" in str(exc_info.value.detail).lower()
+    assert called == []


### PR DESCRIPTION
## Summary
- reject unknown chat participant ids in `/api/chats` at router ingress instead of letting storage FK failures surface as `500`
- preserve the existing actor-id contract: human user ids and thread social user ids still pass, template member ids still fail loudly
- pin the regression in `tests/Integration/test_messaging_router.py`

## Test Plan
- uv run pytest -q tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff check backend/web/routers/messaging.py tests/Integration/test_messaging_router.py
- uv run python -m py_compile backend/web/routers/messaging.py tests/Integration/test_messaging_router.py
- real API probe on `:18015`: bad `/api/chats` payload with thread id -> `400`; good payload with actor ids -> `200`
