### PR TITLE
fix: surface provider telemetry coverage

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -582,6 +582,14 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
       Boolean(metrics.memoryNote || metrics.diskNote || metrics.probeError)
     );
   }).length;
+  const liveUsageRunningCount = provider.sessions.filter((session) => {
+    const metrics = session.metrics;
+    return (
+      session.status === "running" &&
+      metrics != null &&
+      (metrics.cpu != null || metrics.memory != null || metrics.disk != null)
+    );
+  }).length;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
   const isLocal = provider.type === "local";
@@ -653,6 +661,9 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
               ) : (
                 <div className="provider-inline-metrics">
                   <InlineMetric label="运行中" value={String(runningCount)} />
+                  {liveUsageRunningCount > 0 && liveUsageRunningCount < runningCount && (
+                    <InlineMetric label="有用量" value={String(liveUsageRunningCount)} />
+                  )}
                   {runtimeUnboundRunningCount > 0 && <InlineMetric label="无 runtime" value={String(runtimeUnboundRunningCount)} />}
                   {quotaOnlyRunningCount > 0 && <InlineMetric label="仅配额" value={String(quotaOnlyRunningCount)} />}
                   <InlineMetric label="已暂停" value={String(pausedCount)} />

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1794,6 +1794,105 @@ describe("MonitorRoutes", () => {
     expect(detailLabel.nextElementSibling).toHaveTextContent("2");
   });
 
+  it("surfaces live usage coverage in the provider detail overview", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 3,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 3, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 0.4,
+                  memory: 0.5,
+                  memoryLimit: 1,
+                  disk: 0.2,
+                  diskLimit: 3,
+                  cpuNote: null,
+                  memoryNote: null,
+                  diskNote: null,
+                  probeError: null,
+                },
+              },
+              {
+                id: "lease-2:thread-2",
+                leaseId: "lease-2",
+                threadId: "thread-2",
+                runtimeSessionId: "runtime-2",
+                agentName: "Remote Agent 2",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+              {
+                id: "lease-3:thread-3",
+                leaseId: "lease-3",
+                threadId: "thread-3",
+                runtimeSessionId: "runtime-3",
+                agentName: "Remote Agent 3",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const detailLabel = await screen.findByText("有用量");
+    expect(detailLabel).toHaveClass("inline-metric__label");
+    expect(detailLabel.nextElementSibling).toHaveTextContent("1");
+  });
+
   it("surfaces when a ready provider still has no live telemetry", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- surface live-usage coverage inside the provider detail overview
- keep the change frontend-only on the monitor resources surface
- lock the regression in the monitor route test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build