### PR TITLE
fix: surface sandbox telemetry gap

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -746,6 +746,11 @@ function SandboxCard({
     metrics.disk == null &&
     metrics.diskLimit != null &&
     Boolean(metrics.diskNote || metrics.probeError);
+  const showMissingLiveTelemetryTruth =
+    group.status === "running" &&
+    !showRuntimeBindingWarning &&
+    !showQuotaOnlyDiskTruth &&
+    (metrics == null || (metrics.cpu == null && metrics.memory == null && metrics.disk == null));
 
   return (
     <button type="button" className={`sandbox-card sandbox-card--${group.status}`} onClick={onOpen}>
@@ -775,6 +780,7 @@ function SandboxCard({
           <div className="sandbox-card__warning">无 active runtime</div>
         )}
         {showQuotaOnlyDiskTruth && <div className="sandbox-card__warning">Disk 仅配额</div>}
+        {showMissingLiveTelemetryTruth && <div className="sandbox-card__warning">无 live telemetry</div>}
         <div className="sandbox-card__thread-list">
           {group.sessions.slice(0, 2).map((session) => (
             <div key={session.id} className="sandbox-card__thread">

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1513,6 +1513,74 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("disk usage not measurable inside container; showing quota only")).toBeInTheDocument();
   });
 
+  it("surfaces missing live telemetry truth directly on the sandbox card", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const sandboxCard = await screen.findByRole("button", { name: /remote agent/i });
+    expect(within(sandboxCard).getByText("无 live telemetry")).toBeInTheDocument();
+  });
+
   it("surfaces quota-only disk truth directly on the sandbox card", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- surface missing live telemetry truth directly on running sandbox cards
- keep the change frontend-only on the monitor resources surface
- lock the regression in the monitor route test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build