### PR TITLE
fix: surface runtime-bound telemetry gap

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -463,6 +463,17 @@ function ProviderCard({
       (metrics.cpu != null || metrics.memory != null || metrics.disk != null)
     );
   }).length;
+  const runtimeBoundTelemetryGapCount = provider.sessions.filter((session) => {
+    const metrics = session.metrics;
+    const hasLiveUsage = metrics != null && (metrics.cpu != null || metrics.memory != null || metrics.disk != null);
+    const isQuotaOnly =
+      metrics != null &&
+      metrics.memory == null &&
+      metrics.disk == null &&
+      (metrics.memoryLimit != null || metrics.diskLimit != null) &&
+      Boolean(metrics.memoryNote || metrics.diskNote || metrics.probeError);
+    return session.status === "running" && Boolean(session.runtimeSessionId) && !hasLiveUsage && !isQuotaOnly;
+  }).length;
   const missingLiveTelemetryRunningCount = runningCount - liveUsageRunningCount;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
@@ -596,6 +607,17 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
       (metrics.cpu != null || metrics.memory != null || metrics.disk != null)
     );
   }).length;
+  const runtimeBoundTelemetryGapCount = provider.sessions.filter((session) => {
+    const metrics = session.metrics;
+    const hasLiveUsage = metrics != null && (metrics.cpu != null || metrics.memory != null || metrics.disk != null);
+    const isQuotaOnly =
+      metrics != null &&
+      metrics.memory == null &&
+      metrics.disk == null &&
+      (metrics.memoryLimit != null || metrics.diskLimit != null) &&
+      Boolean(metrics.memoryNote || metrics.diskNote || metrics.probeError);
+    return session.status === "running" && Boolean(session.runtimeSessionId) && !hasLiveUsage && !isQuotaOnly;
+  }).length;
   const missingLiveTelemetryRunningCount = runningCount - liveUsageRunningCount;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
@@ -679,6 +701,9 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
                   )}
                   {missingLiveTelemetryRunningCount > 0 && (
                     <InlineMetric label="无 live telemetry" value={String(missingLiveTelemetryRunningCount)} />
+                  )}
+                  {runtimeBoundTelemetryGapCount > 0 && (
+                    <InlineMetric label="有 runtime无遥测" value={String(runtimeBoundTelemetryGapCount)} />
                   )}
                   {runtimeUnboundRunningCount > 0 && <InlineMetric label="无 runtime" value={String(runtimeUnboundRunningCount)} />}
                   {quotaOnlyRunningCount > 0 && <InlineMetric label="仅配额" value={String(quotaOnlyRunningCount)} />}

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -2295,6 +2295,110 @@ describe("MonitorRoutes", () => {
     expect(detailLabel.nextElementSibling).toHaveTextContent("2");
   });
 
+  it("surfaces runtime-bound telemetry gap in the provider detail overview", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 3,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 3, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 0.4,
+                  memory: 0.5,
+                  memoryLimit: 1,
+                  disk: 0.2,
+                  diskLimit: 3,
+                  cpuNote: null,
+                  memoryNote: null,
+                  diskNote: null,
+                  probeError: null,
+                },
+              },
+              {
+                id: "lease-2:thread-2",
+                leaseId: "lease-2",
+                threadId: "thread-2",
+                runtimeSessionId: "runtime-2",
+                agentName: "Remote Agent 2",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+              {
+                id: "lease-3:thread-3",
+                leaseId: "lease-3",
+                threadId: "thread-3",
+                runtimeSessionId: "runtime-3",
+                agentName: "Remote Agent 3",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const detailLabel = (await screen.findAllByText("有 runtime无遥测")).find((node) =>
+      node.classList.contains("inline-metric__label"),
+    );
+    expect(detailLabel).toBeDefined();
+    if (!detailLabel) {
+      throw new Error("Expected runtime-bound provider detail telemetry-gap metric");
+    }
+    expect(detailLabel.nextElementSibling).toHaveTextContent("2");
+  });
+
   it("surfaces live usage coverage in the local provider detail overview", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- surface the runtime-bound telemetry gap in the remote provider detail overview
- distinguish bound-but-silent sandboxes from the existing no-runtime and no-live-telemetry counts
- lock the regression in monitor route tests

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build