### PR TITLE
fix: summarize monitor runtime overlap

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -292,6 +292,21 @@ export default function ResourcesPage() {
     (total, provider) => total + provider.sessions.filter((session) => session.status === "running").length,
     0,
   );
+  const runtimeUnboundUsageCount = providers.reduce(
+    (total, provider) =>
+      total +
+      provider.sessions.filter((session) => {
+        const metrics = session.metrics;
+        return (
+          session.status === "running" &&
+          provider.type !== "local" &&
+          !session.runtimeSessionId &&
+          metrics != null &&
+          (metrics.cpu != null || metrics.memory != null || metrics.disk != null)
+        );
+      }).length,
+    0,
+  );
   const runtimeUnboundRunningCount = providers.reduce(
     (total, provider) =>
       total +
@@ -392,6 +407,9 @@ export default function ResourcesPage() {
           <div className="resources-summary-pill">{runningSessionCount} 运行会话</div>
           {liveUsageRunningCount > 0 && liveUsageRunningCount < runningSessionCount && (
             <div className="resources-summary-pill">{liveUsageRunningCount} 有用量</div>
+          )}
+          {runtimeUnboundUsageCount > 0 && (
+            <div className="resources-summary-pill">{runtimeUnboundUsageCount} 无 runtime有用量</div>
           )}
           {missingLiveTelemetryRunningCount > 0 && (
             <div className="resources-summary-pill">{missingLiveTelemetryRunningCount} 无 live telemetry</div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -1558,6 +1558,112 @@ describe("MonitorRoutes", () => {
     expect(summaryPills[0]).toHaveClass("resources-summary-pill");
   });
 
+  it("surfaces runtime-unbound usage overlap in the summary strip", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 3,
+        },
+        providers: [
+          {
+            id: "daytona_selfhost",
+            name: "daytona_selfhost",
+            description: "Self-hosted Daytona",
+            type: "cloud",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: true,
+            },
+            telemetry: {
+              running: { used: 3, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 1.5, limit: null, unit: "%", source: "api", freshness: "live" },
+              memory: { used: 1, limit: 4, unit: "GB", source: "api", freshness: "live" },
+              disk: { used: 2, limit: 10, unit: "GB", source: "api", freshness: "live" },
+            },
+            cardCpu: {
+              used: null,
+              limit: null,
+              unit: "%",
+              source: "unknown",
+              freshness: "live",
+              error: "CPU usage is per-sandbox, not a provider-level quota.",
+            },
+            sessions: [
+              {
+                id: "lease-1:thread-1",
+                leaseId: "lease-1",
+                threadId: "thread-1",
+                runtimeSessionId: "runtime-1",
+                agentName: "Remote Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 0.4,
+                  memory: 0.5,
+                  memoryLimit: 1,
+                  disk: 0.2,
+                  diskLimit: 3,
+                  cpuNote: null,
+                  memoryNote: null,
+                  diskNote: null,
+                  probeError: null,
+                },
+              },
+              {
+                id: "lease-2:thread-2",
+                leaseId: "lease-2",
+                threadId: "thread-2",
+                agentName: "Remote Agent 2",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 0.2,
+                  memory: 0.3,
+                  memoryLimit: 1,
+                  disk: 0.1,
+                  diskLimit: 3,
+                  cpuNote: null,
+                  memoryNote: null,
+                  diskNote: null,
+                  probeError: null,
+                },
+              },
+              {
+                id: "lease-3:thread-3",
+                leaseId: "lease-3",
+                threadId: "thread-3",
+                agentName: "Remote Agent 3",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const summaryPills = await screen.findAllByText("1 无 runtime有用量");
+    expect(summaryPills[0]).toHaveClass("resources-summary-pill");
+  });
+
   it("surfaces the global live telemetry gap in the summary strip", async () => {
     mockRoutePayloads({
       "/resources": {


### PR DESCRIPTION
## Summary
- surface runtime-unbound sessions that still report live usage in the resources summary strip
- keep the slice frontend/monitor-only and facts-first
- lock the overlap with a route regression test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build