### PR TITLE
fix: bound local sandbox shutdown cleanup

### DIFF
--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -257,6 +257,7 @@ class LocalSandbox(Sandbox):
         self._provider = LocalSessionProvider(default_cwd=workspace_root)
         self._manager = SandboxManager(provider=self._provider, db_path=db_path or (Path.home() / ".leon" / "sandbox.db"))
         self._capability_cache: dict[str, SandboxCapability] = {}
+        self._owned_thread_ids: set[str] = set()
 
     @property
     def name(self) -> str:
@@ -280,6 +281,7 @@ class LocalSandbox(Sandbox):
         thread_id = get_current_thread_id()
         if not thread_id:
             raise RuntimeError("No thread_id set. Call set_current_thread_id first.")
+        self._owned_thread_ids.add(thread_id)
         cached = self._capability_cache.get(thread_id)
         if cached is not None and _cached_capability_is_stale(self._manager, thread_id, cached):
             self._capability_cache.pop(thread_id, None)
@@ -301,16 +303,21 @@ class LocalSandbox(Sandbox):
         self._get_capability()
 
     def pause_thread(self, thread_id: str) -> bool:
+        self._owned_thread_ids.add(thread_id)
         self._capability_cache.pop(thread_id, None)
         return self._manager.pause_session(thread_id)
 
     def resume_thread(self, thread_id: str) -> bool:
+        self._owned_thread_ids.add(thread_id)
         self._capability_cache.pop(thread_id, None)
         return self._manager.resume_session(thread_id)
 
     def close(self) -> None:
-        for session in self._manager.list_sessions():
+        # @@@local-close-owned-threads - backend shutdown must only clean
+        # threads this sandbox instance actually touched, not sweep the shared runtime universe.
+        for thread_id in sorted(self._owned_thread_ids):
             try:
-                self._manager.destroy_session(session["thread_id"])
+                self._manager.destroy_session(thread_id)
             except Exception:
-                logger.exception("[LocalSandbox] Failed to destroy session %s", session.get("thread_id"))
+                logger.exception("[LocalSandbox] Failed to destroy session %s", thread_id)
+        self._owned_thread_ids.clear()

--- a/tests/Unit/core/test_capability_async.py
+++ b/tests/Unit/core/test_capability_async.py
@@ -114,6 +114,50 @@ def test_local_sandbox_rebuilds_stale_closed_capability_before_execute_async(tmp
     assert "hi" in result.stdout
 
 
+def test_local_sandbox_close_destroys_only_owned_threads_without_global_inventory():
+    class _Manager:
+        def __init__(self):
+            self.destroyed: list[str] = []
+
+        def list_sessions(self):
+            raise AssertionError("LocalSandbox.close must not scan shared session inventory")
+
+        def destroy_session(self, thread_id: str):
+            self.destroyed.append(thread_id)
+
+    sandbox = object.__new__(LocalSandbox)
+    sandbox._manager = _Manager()
+    sandbox._capability_cache = {}
+    sandbox._owned_thread_ids = {"thread-b", "thread-a"}
+
+    sandbox.close()
+
+    assert sandbox._manager.destroyed == ["thread-a", "thread-b"]
+
+
+def test_local_sandbox_records_thread_id_when_building_capability():
+    class _Manager:
+        def __init__(self):
+            self.requested: list[str] = []
+
+        def get_sandbox(self, thread_id: str):
+            self.requested.append(thread_id)
+            return SimpleNamespace(_session=SimpleNamespace(session_id=f"sess-{thread_id}", status="active"))
+
+    sandbox = object.__new__(LocalSandbox)
+    sandbox._manager = _Manager()
+    sandbox._capability_cache = {}
+    sandbox._owned_thread_ids = set()
+
+    set_current_thread_id("thread-owned")
+
+    capability = sandbox._get_capability()
+
+    assert capability._session.session_id == "sess-thread-owned"
+    assert sandbox._manager.requested == ["thread-owned"]
+    assert sandbox._owned_thread_ids == {"thread-owned"}
+
+
 def test_filesystem_wrapper_auto_resumes_paused_lease_before_listing():
     class _PausedLease:
         def __init__(self):


### PR DESCRIPTION
## Summary
- bound `LocalSandbox.close()` to the threads this sandbox instance actually touched
- stop local sandbox shutdown from scanning shared session inventory via `manager.list_sessions()`
- add unit tests that lock the new ownership-bounded close contract

## Verification
- `uv run pytest -q tests/Unit/core/test_capability_async.py -k 'local_sandbox_close_destroys_only_owned_threads_without_global_inventory or local_sandbox_records_thread_id_when_building_capability'`
- `uv run ruff check sandbox/base.py tests/Unit/core/test_capability_async.py`
- `uv run python -m py_compile sandbox/base.py tests/Unit/core/test_capability_async.py`
- real probe on isolated backend `:18025`: thread `m_dKjuBBLbR1bw-56` replied `CLOSE_OWNERSHIP_PROBE_1775692001`, then shutdown completed without the earlier shared cleanup tracebacks