### PR TITLE
fix: stop counting detached residue as running

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -156,6 +156,26 @@ def _resource_session_identity(session: dict[str, Any]) -> str:
     return f"{lease_id}:{thread_id or 'unbound'}"
 
 
+def _resource_display_status(
+    *,
+    observed_state: str | None,
+    desired_state: str | None,
+    runtime_session_id: str | None,
+    session_metrics: dict[str, Any] | None,
+) -> str:
+    status = map_lease_to_session_status(observed_state, desired_state)
+    observed = str(observed_state or "").strip().lower()
+    desired = str(desired_state or "").strip().lower()
+    if status != "running":
+        return status
+    # @@@resource-detached-residue - monitor/resources should not inflate running counts with
+    # detached leases that have neither a bound runtime nor any live/quota snapshot. Those rows
+    # are residue on this operator surface, even if the product-facing desired state still says running.
+    if observed == "detached" and desired == "running" and not runtime_session_id and session_metrics is None:
+        return "stopped"
+    return status
+
+
 def _project_user_visible_resource_sessions(repo: Any, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Project raw monitor rows into the user-visible resource surface."""
     grouped: dict[str, list[dict[str, Any]]] = {}
@@ -231,22 +251,27 @@ def list_resource_providers() -> dict[str, Any]:
         for session in provider_sessions:
             observed_state = session.get("observed_state")
             desired_state = session.get("desired_state")
-            normalized = map_lease_to_session_status(observed_state, desired_state)
             thread_id = str(session.get("thread_id") or "")
             lease_id = str(session.get("lease_id") or "")
+            runtime_session_id = runtime_session_ids.get(lease_id)
+            if lease_id and lease_id not in runtime_session_ids:
+                runtime_session_id = query_lease_instance_id(lease_id) if callable(query_lease_instance_id) else None
+                runtime_session_ids[lease_id] = runtime_session_id
+            session_metrics = _to_session_metrics(snapshot_by_lease.get(lease_id))
+            normalized = _resource_display_status(
+                observed_state=observed_state,
+                desired_state=desired_state,
+                runtime_session_id=runtime_session_id,
+                session_metrics=session_metrics,
+            )
             if normalized == "running" and lease_id not in seen_running_leases:
                 running_count += 1
                 seen_running_leases.add(lease_id)
-            session_metrics = _to_session_metrics(snapshot_by_lease.get(lease_id))
             owner = owners.get(thread_id, {"agent_name": "未绑定Agent", "avatar_url": None})
             session_identity = _resource_session_identity(session)
             if session_identity in seen_session_ids:
                 continue
             seen_session_ids.add(session_identity)
-            runtime_session_id = runtime_session_ids.get(lease_id)
-            if lease_id and lease_id not in runtime_session_ids:
-                runtime_session_id = query_lease_instance_id(lease_id) if callable(query_lease_instance_id) else None
-                runtime_session_ids[lease_id] = runtime_session_id
             normalized_sessions.append(
                 resource_service.build_resource_session_payload(
                     session_identity=session_identity,
@@ -314,9 +339,12 @@ def visible_resource_session_stats() -> dict[str, dict[str, int]]:
     try:
         raw_sessions = repo.list_sessions_with_leases()
         sessions = _project_user_visible_resource_sessions(repo, raw_sessions)
+        query_lease_instance_id = getattr(repo, "query_lease_instance_id", None)
     finally:
         repo.close()
 
+    runtime_session_ids: dict[str, str | None] = {}
+    snapshot_by_lease = list_resource_snapshots([str(session.get("lease_id") or "") for session in sessions])
     stats: dict[str, dict[str, int]] = {}
     seen_session_ids: set[str] = set()
     seen_running_leases: set[tuple[str, str]] = set()
@@ -329,7 +357,16 @@ def visible_resource_session_stats() -> dict[str, dict[str, int]]:
             provider_stats["sessions"] += 1
 
         lease_id = str(session.get("lease_id") or "")
-        normalized = map_lease_to_session_status(session.get("observed_state"), session.get("desired_state"))
+        runtime_session_id = runtime_session_ids.get(lease_id)
+        if lease_id and lease_id not in runtime_session_ids:
+            runtime_session_id = query_lease_instance_id(lease_id) if callable(query_lease_instance_id) else None
+            runtime_session_ids[lease_id] = runtime_session_id
+        normalized = _resource_display_status(
+            observed_state=session.get("observed_state"),
+            desired_state=session.get("desired_state"),
+            runtime_session_id=runtime_session_id,
+            session_metrics=_to_session_metrics(snapshot_by_lease.get(lease_id)),
+        )
         running_identity = (provider_instance, lease_id)
         if normalized == "running" and lease_id and running_identity not in seen_running_leases:
             seen_running_leases.add(running_identity)

--- a/tests/Unit/backend/web/services/test_resource_projection_service_contract.py
+++ b/tests/Unit/backend/web/services/test_resource_projection_service_contract.py
@@ -91,7 +91,7 @@ def test_list_resource_providers_keeps_unavailable_remote_card_with_reason(monke
     assert isinstance(remote["cardCpu"], dict)
 
 
-def test_list_resource_providers_inherits_desired_state_for_detached_sessions(monkeypatch):
+def test_list_resource_providers_keeps_bound_detached_sessions_running(monkeypatch):
     rows = [
         {
             "provider": "local",
@@ -104,7 +104,11 @@ def test_list_resource_providers_inherits_desired_state_for_detached_sessions(mo
         },
     ]
 
-    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _FakeRepo(rows))
+    monkeypatch.setattr(
+        resource_projection_service,
+        "make_sandbox_monitor_repo",
+        lambda: _FakeRepo(rows, instance_ids={"lease-1": "runtime-1"}),
+    )
     monkeypatch.setattr(
         resource_projection_service,
         "available_sandbox_types",
@@ -181,9 +185,9 @@ def test_list_resource_providers_keeps_sessions_under_unavailable_provider(monke
     assert provider["status"] == "unavailable"
     assert provider["unavailableReason"] == "provider unavailable in current process"
     assert [session["leaseId"] for session in provider["sessions"]] == ["lease-1", "lease-2"]
-    assert [session["status"] for session in provider["sessions"]] == ["running", "paused"]
+    assert [session["status"] for session in provider["sessions"]] == ["stopped", "paused"]
     assert [session["agentName"] for session in provider["sessions"]] == ["thread-1", "thread-2"]
-    assert payload["summary"]["running_sessions"] == 1
+    assert payload["summary"]["running_sessions"] == 0
 
 
 def test_list_resource_providers_keeps_remote_session_actor_first(monkeypatch):
@@ -242,3 +246,46 @@ def test_list_resource_providers_keeps_remote_session_actor_first(monkeypatch):
     }
     assert "memberId" not in session
     assert "memberName" not in session
+
+
+def test_list_resource_providers_treats_detached_unbound_rows_as_stopped_residue(monkeypatch):
+    rows = [
+        {
+            "provider": "local",
+            "session_id": None,
+            "thread_id": "thread-stale",
+            "lease_id": "lease-stale",
+            "observed_state": "detached",
+            "desired_state": "running",
+            "created_at": "2026-04-09T00:00:00",
+        },
+    ]
+
+    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _FakeRepo(rows))
+    monkeypatch.setattr(
+        resource_projection_service,
+        "available_sandbox_types",
+        lambda: [{"name": "local", "available": True}],
+    )
+    monkeypatch.setattr(resource_projection_service, "resolve_provider_name", lambda *_args, **_kwargs: "local")
+    monkeypatch.setattr(resource_projection_service, "_resolve_console_url", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_resolve_instance_capabilities",
+        lambda _config_name: (_caps(metrics=True), None),
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_thread_owners",
+        lambda thread_ids: {tid: {"agent_user_id": "agent-1", "agent_name": "Stale", "avatar_url": None} for tid in thread_ids},
+    )
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service.LocalSessionProvider, "get_metrics", lambda self, _session_id: None)
+
+    payload = resource_projection_service.list_resource_providers()
+    provider = payload["providers"][0]
+    session = provider["sessions"][0]
+
+    assert provider["telemetry"]["running"]["used"] == 0
+    assert payload["summary"]["running_sessions"] == 0
+    assert session["status"] == "stopped"

--- a/tests/Unit/monitor/test_monitor_resource_overview_cache.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_cache.py
@@ -22,6 +22,11 @@ def test_resource_overview_cache_refresh_adds_metadata(monkeypatch):
     cache.clear_monitor_resource_overview_cache()
     monkeypatch.setattr(
         cache.resource_projection_service,
+        "visible_resource_session_stats",
+        lambda: {"local": {"sessions": 0, "running": 0}},
+    )
+    monkeypatch.setattr(
+        cache.resource_projection_service,
         "list_resource_providers",
         lambda: {
             "summary": {
@@ -54,6 +59,11 @@ def test_resource_overview_cache_refresh_adds_metadata(monkeypatch):
 
 def test_resource_overview_cache_keeps_last_snapshot_on_refresh_error(monkeypatch):
     cache.clear_monitor_resource_overview_cache()
+    monkeypatch.setattr(
+        cache.resource_projection_service,
+        "visible_resource_session_stats",
+        lambda: {"docker": {"sessions": 1, "running": 1}},
+    )
     monkeypatch.setattr(
         cache.resource_projection_service,
         "list_resource_providers",


### PR DESCRIPTION
## Summary
- stop treating detached/unbound/no-snapshot monitor resource rows as running
- keep detached rows running only when they still have a bound runtime or live/quota metrics
- align cache drift tests with the new monitor/resources running-count contract

## Verification
- uv run pytest tests/Integration/test_monitor_resources_route.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q
- uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py tests/Unit/monitor/test_monitor_resource_overview_cache.py
- uv run python -m py_compile backend/web/services/resource_projection_service.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py tests/Unit/monitor/test_monitor_resource_overview_cache.py