### PR TITLE
fix: surface detached residue in resources summary

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -180,6 +180,7 @@ export default function ResourcesPage() {
   const [providers, setProviders] = React.useState<ProviderInfo[]>([]);
   const [selectedId, setSelectedId] = React.useState("");
   const [summary, setSummary] = React.useState<ResourceOverviewResponse["summary"] | null>(null);
+  const [triage, setTriage] = React.useState<ResourceOverviewResponse["triage"] | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [refreshing, setRefreshing] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -187,6 +188,7 @@ export default function ResourcesPage() {
   const applyPayload = React.useCallback((payload: ResourceOverviewResponse) => {
     setProviders(payload.providers);
     setSummary(payload.summary);
+    setTriage(payload.triage ?? null);
     setSelectedId((previous) => {
       if (payload.providers.some((provider) => provider.id === previous)) {
         return previous;
@@ -354,6 +356,7 @@ export default function ResourcesPage() {
       }).length,
     0,
   );
+  const detachedResidueCount = triage?.summary?.detached_residue ?? 0;
   const refreshedAt = summary?.last_refreshed_at
     ? new Date(summary.last_refreshed_at).toLocaleTimeString()
     : "--:--:--";
@@ -422,6 +425,9 @@ export default function ResourcesPage() {
           )}
           {quotaOnlyRunningCount > 0 && (
             <div className="resources-summary-pill">{quotaOnlyRunningCount} 仅配额</div>
+          )}
+          {detachedResidueCount > 0 && (
+            <div className="resources-summary-pill">{detachedResidueCount} Detached Residue</div>
           )}
           <div className="resources-summary-pill">
             <span

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -3158,4 +3158,76 @@ describe("MonitorRoutes", () => {
     fireEvent.click(providerCard);
     expect(await screen.findByText("当前 provider 暂无 live telemetry，CPU / RAM / Disk 仍是未知状态。")).toBeInTheDocument();
   });
+
+  it("surfaces detached residue in the resources summary strip", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 3,
+        },
+        triage: {
+          summary: {
+            detached_residue: 38,
+          },
+        },
+        providers: [
+          {
+            id: "local",
+            name: "local",
+            description: "Local runtime",
+            type: "local",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 3, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+              memory: { used: 5, limit: 32, unit: "GB", source: "direct", freshness: "live" },
+              disk: { used: 40, limit: 100, unit: "GB", source: "direct", freshness: "live" },
+            },
+            cardCpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+            sessions: [
+              {
+                id: "session-1",
+                threadId: "thread-1",
+                agentName: "Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 12,
+                  memory: 5,
+                  memoryLimit: 32,
+                  disk: 40,
+                  diskLimit: 100,
+                  networkIn: null,
+                  networkOut: null,
+                },
+                runtimeSessionId: "runtime-1",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("38 Detached Residue")).toBeInTheDocument();
+  });
 });

--- a/frontend/monitor/src/resources/types.ts
+++ b/frontend/monitor/src/resources/types.ts
@@ -102,6 +102,11 @@ export interface ResourceSummary {
 export interface ResourceOverviewResponse {
   summary: ResourceSummary;
   providers: ProviderInfo[];
+  triage?: {
+    summary?: {
+      detached_residue?: number;
+    };
+  };
 }
 
 export interface BrowseItem {


### PR DESCRIPTION
## Summary
- surface `triage.summary.detached_residue` directly in the monitor resources summary strip
- extend the monitor resources DTO type to accept the triage summary used by the page
- lock the new read-surface truth with a route test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build
- local live proxy proof: `LEON_BACKEND_PORT=8015 LEON_MONITOR_PORT=5189 npm run dev` then `GET http://127.0.0.1:5189/api/monitor/resources` returned `detached_residue = 38`