### PR TITLE
fix: hard-delete thread cleanup before terminal teardown

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -418,6 +418,22 @@ class ChatSessionManager:
 
         self._repo.delete_session(session_id, reason=reason)
 
+    def delete_thread(self, thread_id: str, *, reason: str = "thread_deleted") -> None:
+        # @@@thread-hard-delete-before-terminal-delete - thread teardown must
+        # remove chat_session rows before terminal rows or live Supabase FKs block terminal deletion.
+        for live_terminal_id, session in list(self._live_sessions.items()):
+            if session.thread_id != thread_id:
+                continue
+            assert_chat_session_transition(
+                parse_chat_session_state(session.status),
+                ChatSessionState.CLOSED,
+                reason=reason,
+            )
+            self._close_runtime(session, reason=reason)
+            self._live_sessions.pop(live_terminal_id, None)
+
+        self._repo.delete_by_thread(thread_id)
+
     def close(self, reason: str = "manager_close") -> None:
         for live_terminal_id, session in list(self._live_sessions.items()):
             assert_chat_session_transition(

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -836,10 +836,7 @@ class SandboxManager:
 
         lease_ids = {terminal.lease_id for terminal in terminals}
 
-        for terminal in terminals:
-            session = self.session_manager.get(thread_id, terminal.terminal_id)
-            if session:
-                self.session_manager.delete(session.session_id, reason="thread_deleted")
+        self.session_manager.delete_thread(thread_id, reason="thread_deleted")
 
         for terminal in terminals:
             self.terminal_store.delete(terminal.terminal_id)

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -298,6 +298,7 @@ def test_destroy_thread_resources_skips_local_sync_when_lease_has_no_volume_id()
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: SimpleNamespace(session_id="sess-1"),
         delete=lambda session_id, reason: deleted_sessions.append((session_id, reason)),
+        delete_thread=lambda thread_id, reason="thread_deleted": deleted_sessions.append((thread_id, reason)),
     )
     deleted_terminals: list[str] = []
     deleted_sessions: list[tuple[str, str]] = []
@@ -321,9 +322,56 @@ def test_destroy_thread_resources_skips_local_sync_when_lease_has_no_volume_id()
     assert manager.destroy_thread_resources("thread-1") is True
     assert manager.volume.download_calls == []
     assert manager.volume.cleared == ["thread-1"]
-    assert deleted_sessions == [("sess-1", "thread_deleted")]
+    assert deleted_sessions == [("thread-1", "thread_deleted")]
     assert deleted_terminals == ["term-1"]
     assert destroy_calls == ["lease-1"]
+    assert deleted_leases == ["lease-1"]
+
+
+def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_terminal_delete():
+    manager = _new_test_manager()
+    manager.provider_capability = SimpleNamespace(runtime_kind="local")
+    manager.provider = SimpleNamespace(name="local")
+    manager.volume = _FakeVolume()
+    deleted_terminals: list[str] = []
+    delete_order: list[str] = []
+    destroyed_leases: list[str] = []
+    deleted_leases: list[str] = []
+
+    class _Lease:
+        lease_id = "lease-1"
+        observed_state = "running"
+        volume_id = None
+
+        def get_instance(self):
+            return SimpleNamespace(instance_id="instance-1")
+
+        def destroy_instance(self, _provider):
+            destroyed_leases.append("lease-1")
+
+    lease = _Lease()
+    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_lease = lambda _lease_id: lease
+    manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        AssertionError("volume lookup should not happen")
+    )
+    manager.terminal_store = SimpleNamespace(
+        list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}],
+        delete=lambda terminal_id: (delete_order.append(f"terminal:{terminal_id}"), deleted_terminals.append(terminal_id)),
+        list_all=lambda: [],
+        db_path=Path("/tmp/fake-sandbox.db"),
+    )
+    manager.session_manager = SimpleNamespace(
+        get=lambda _thread_id, _terminal_id: SimpleNamespace(session_id="sess-1"),
+        delete=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("soft delete should not be used")),
+        delete_thread=lambda thread_id, reason="thread_deleted": delete_order.append(f"thread:{thread_id}:{reason}"),
+    )
+    manager.lease_store = SimpleNamespace(delete=lambda lease_id: deleted_leases.append(lease_id))
+
+    assert manager.destroy_thread_resources("thread-1") is True
+    assert delete_order == ["thread:thread-1:thread_deleted", "terminal:term-1"]
+    assert deleted_terminals == ["term-1"]
+    assert destroyed_leases == ["lease-1"]
     assert deleted_leases == ["lease-1"]
 
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -352,9 +352,7 @@ def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_termi
     lease = _Lease()
     manager._get_thread_lease = lambda _thread_id: lease
     manager._get_lease = lambda _lease_id: lease
-    manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(
-        AssertionError("volume lookup should not happen")
-    )
+    manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}],
         delete=lambda terminal_id: (delete_order.append(f"terminal:{terminal_id}"), deleted_terminals.append(terminal_id)),


### PR DESCRIPTION
## Summary
- add a thread-level hard-delete path to `ChatSessionManager`
- use that path from `SandboxManager.destroy_thread_resources()` before deleting terminals
- pin the delete-order contract in sandbox manager tests

## Verification
- `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -k 'destroy_thread_resources_skips_local_sync_when_lease_has_no_volume_id or destroy_thread_resources_hard_deletes_thread_chat_sessions_before_terminal_delete'`
- `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
- `uv run ruff check sandbox/manager.py sandbox/chat_session.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/core/test_capability_async.py`
- `uv run python -m py_compile sandbox/manager.py sandbox/chat_session.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
- real backend proof on `:18027`: shared lease + concurrent background bash + followup readback stayed green, then shutdown completed cleanly with no `chat_sessions_terminal_id_fkey` traceback

## Notes
- A broader local run of `tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/core/test_capability_async.py` exposed a pre-existing env-bound failure in `test_local_sandbox_rebuilds_stale_closed_capability_before_execute_async` when Supabase runtime env is absent; this branch does not change that test's contract.
