### PR TITLE
fix: surface provider detached residue truth

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -632,6 +632,9 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
   const [selectedGroup, setSelectedGroup] = React.useState<LeaseGroup | null>(null);
   const groups = React.useMemo(() => groupByLease(provider.sessions), [provider.sessions]);
   const runningCount = provider.sessions.filter((session) => session.status === "running").length;
+  const detachedResidueCount = provider.sessions.filter(
+    (session) => session.status === "stopped" && !session.runtimeSessionId && session.metrics == null,
+  ).length;
   const runtimeUnboundUsageCount = provider.sessions.filter((session) => {
     const metrics = session.metrics;
     return (
@@ -745,6 +748,7 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
                   {missingLiveTelemetryRunningCount > 0 && (
                     <InlineMetric label="无 live telemetry" value={String(missingLiveTelemetryRunningCount)} />
                   )}
+                  {detachedResidueCount > 0 && <InlineMetric label="Detached Residue" value={String(detachedResidueCount)} />}
                   <InlineMetric label="CPU" value={formatMetricRange(provider.cardCpu)} />
                   <InlineMetric label="RAM" value={formatMetricRange(provider.telemetry.memory)} />
                   <InlineMetric label="Disk" value={formatMetricRange(provider.telemetry.disk)} />
@@ -767,6 +771,7 @@ function ProviderDetail({ provider }: { provider: ProviderInfo }) {
                   {runtimeUnboundRunningCount > 0 && <InlineMetric label="无 runtime" value={String(runtimeUnboundRunningCount)} />}
                   {quotaOnlyRunningCount > 0 && <InlineMetric label="仅配额" value={String(quotaOnlyRunningCount)} />}
                   <InlineMetric label="已暂停" value={String(pausedCount)} />
+                  {detachedResidueCount > 0 && <InlineMetric label="Detached Residue" value={String(detachedResidueCount)} />}
                   <InlineMetric label="已结束" value={String(stoppedCount)} />
                 </div>
               )}

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -3230,4 +3230,86 @@ describe("MonitorRoutes", () => {
 
     expect(await screen.findByText("38 Detached Residue")).toBeInTheDocument();
   });
+
+  it("surfaces detached residue in the provider detail overview", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "local",
+            name: "local",
+            description: "Local runtime",
+            type: "local",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+              memory: { used: 5, limit: 32, unit: "GB", source: "direct", freshness: "live" },
+              disk: { used: 40, limit: 100, unit: "GB", source: "direct", freshness: "live" },
+            },
+            cardCpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+            sessions: [
+              {
+                id: "running-1",
+                threadId: "thread-running",
+                agentName: "Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 12,
+                  memory: 5,
+                  memoryLimit: 32,
+                  disk: 40,
+                  diskLimit: 100,
+                  networkIn: null,
+                  networkOut: null,
+                },
+                runtimeSessionId: "runtime-1",
+              },
+              {
+                id: "stopped-residue",
+                threadId: "thread-stopped",
+                agentName: "Agent 2",
+                status: "stopped",
+                startedAt: "2026-04-07T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const detailLabel = (await screen.findAllByText("Detached Residue")).find((node) =>
+      node.classList.contains("inline-metric__label"),
+    );
+    expect(detailLabel).toBeDefined();
+    if (!detailLabel) {
+      throw new Error("Expected provider detail detached residue metric");
+    }
+    expect(detailLabel.nextElementSibling).toHaveTextContent("1");
+  });
 });


### PR DESCRIPTION
## Summary
- surface detached residue in the provider detail overview on monitor/resources
- keep the summary strip detail slice aligned by letting providers explain which stopped rows are detached residue
- lock the read-surface change with a route regression test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build