### PR TITLE
fix: surface provider detached residue card truth

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -518,6 +518,9 @@ function ProviderCard({
       Boolean(metrics.memoryNote || metrics.diskNote || metrics.probeError)
     );
   }).length;
+  const detachedResidueCount = provider.sessions.filter(
+    (session) => session.status === "stopped" && !session.runtimeSessionId && session.metrics == null,
+  ).length;
   const missingLiveTelemetryRunningCount = runningCount - liveUsageRunningCount;
   const pausedCount = provider.sessions.filter((session) => session.status === "paused").length;
   const stoppedCount = provider.sessions.filter((session) => session.status === "stopped").length;
@@ -587,6 +590,7 @@ function ProviderCard({
         {runtimeUnboundUsageCount > 0 && <span>{runtimeUnboundUsageCount} 无 runtime有用量</span>}
         {quotaOnlyRunningCount > 0 && <span>{quotaOnlyRunningCount} 仅配额</span>}
         {runtimeUnboundRunningCount > 0 && <span>{runtimeUnboundRunningCount} 无 runtime</span>}
+        {detachedResidueCount > 0 && <span>{detachedResidueCount} Detached Residue</span>}
         {pausedCount > 0 && <span>{pausedCount} 暂停</span>}
         {stoppedCount > 0 && <span>{stoppedCount} 已结束</span>}
       </div>

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -3312,4 +3312,86 @@ describe("MonitorRoutes", () => {
     }
     expect(detailLabel.nextElementSibling).toHaveTextContent("1");
   });
+
+  it("surfaces detached residue on the provider card footer", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 1,
+        },
+        providers: [
+          {
+            id: "local",
+            name: "local",
+            description: "Local runtime",
+            type: "local",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 1, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+              memory: { used: 5, limit: 32, unit: "GB", source: "direct", freshness: "live" },
+              disk: { used: 40, limit: 100, unit: "GB", source: "direct", freshness: "live" },
+            },
+            cardCpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+            sessions: [
+              {
+                id: "running-1",
+                threadId: "thread-running",
+                agentName: "Agent 1",
+                status: "running",
+                startedAt: "2026-04-08T00:00:00Z",
+                metrics: {
+                  cpu: 12,
+                  memory: 5,
+                  memoryLimit: 32,
+                  disk: 40,
+                  diskLimit: 100,
+                  networkIn: null,
+                  networkOut: null,
+                },
+                runtimeSessionId: "runtime-1",
+              },
+              {
+                id: "stopped-residue",
+                threadId: "thread-stopped",
+                agentName: "Agent 2",
+                status: "stopped",
+                startedAt: "2026-04-07T00:00:00Z",
+                metrics: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    const providerCard = (await screen.findAllByRole("button", { name: /local/i })).find((element) =>
+      element.className.includes("provider-card"),
+    );
+    expect(providerCard).toBeDefined();
+    if (!providerCard) {
+      throw new Error("Expected provider card");
+    }
+    expect(within(providerCard).getByText("1 Detached Residue")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- surface Detached Residue directly on the monitor resource provider card footer
- keep the provider card aligned with the already-landed summary strip and provider detail residue truth
- lock the read-surface change with a route regression test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build