### PR TITLE
fix: surface resource orphan cleanup truth

### DIFF
--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -357,6 +357,7 @@ export default function ResourcesPage() {
     0,
   );
   const detachedResidueCount = triage?.summary?.detached_residue ?? 0;
+  const orphanCleanupCount = triage?.summary?.orphan_cleanup ?? 0;
   const refreshedAt = summary?.last_refreshed_at
     ? new Date(summary.last_refreshed_at).toLocaleTimeString()
     : "--:--:--";
@@ -428,6 +429,9 @@ export default function ResourcesPage() {
           )}
           {detachedResidueCount > 0 && (
             <div className="resources-summary-pill">{detachedResidueCount} Detached Residue</div>
+          )}
+          {orphanCleanupCount > 0 && (
+            <div className="resources-summary-pill">{orphanCleanupCount} Orphan Cleanup</div>
           )}
           <div className="resources-summary-pill">
             <span

--- a/frontend/monitor/src/app/routes.test.tsx
+++ b/frontend/monitor/src/app/routes.test.tsx
@@ -3231,6 +3231,60 @@ describe("MonitorRoutes", () => {
     expect(await screen.findByText("38 Detached Residue")).toBeInTheDocument();
   });
 
+  it("surfaces orphan cleanup in the resources summary strip", async () => {
+    mockRoutePayloads({
+      "/resources": {
+        summary: {
+          snapshot_at: "2026-04-08T00:00:00Z",
+          total_providers: 1,
+          active_providers: 1,
+          unavailable_providers: 0,
+          running_sessions: 0,
+        },
+        triage: {
+          summary: {
+            orphan_cleanup: 3,
+          },
+        },
+        providers: [
+          {
+            id: "local",
+            name: "local",
+            description: "Local runtime",
+            type: "local",
+            status: "active",
+            capabilities: {
+              filesystem: true,
+              terminal: true,
+              metrics: true,
+              screenshot: false,
+              web: false,
+              process: false,
+              hooks: false,
+              mount: false,
+            },
+            telemetry: {
+              running: { used: 0, limit: null, unit: "sandbox", source: "sandbox_db", freshness: "cached" },
+              cpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+              memory: { used: 5, limit: 32, unit: "GB", source: "direct", freshness: "live" },
+              disk: { used: 40, limit: 100, unit: "GB", source: "direct", freshness: "live" },
+            },
+            cardCpu: { used: 12, limit: null, unit: "%", source: "direct", freshness: "live" },
+            sessions: [],
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/resources"]}>
+        <MonitorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("3 Orphan Cleanup")).toBeInTheDocument();
+  });
+
   it("surfaces detached residue in the provider detail overview", async () => {
     mockRoutePayloads({
       "/resources": {

--- a/frontend/monitor/src/resources/types.ts
+++ b/frontend/monitor/src/resources/types.ts
@@ -105,6 +105,7 @@ export interface ResourceOverviewResponse {
   triage?: {
     summary?: {
       detached_residue?: number;
+      orphan_cleanup?: number;
     };
   };
 }


### PR DESCRIPTION
## Summary
- surface Orphan Cleanup directly in the monitor resources summary strip
- wire the existing triage.summary.orphan_cleanup payload into the frontend resource types
- lock the summary-strip change with a route regression test

## Verification
- cd frontend/monitor && npm test -- --run src/app/routes.test.tsx
- cd frontend/monitor && npm run build