### PR TITLE
fix: restore web subagent shutdown ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ frontend/app/.env.development
 .claude/settings.local.json
 .claude/mcp.json
 .mcp.json
-teams
 
 # User-level Leon config and skills
 .leon/

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -1497,52 +1497,61 @@ async def run_child_thread_live(
     from backend.web.utils.serializers import extract_text_content
 
     sandbox_type = resolve_thread_sandbox(app, thread_id)
-    app.state.agent_pool[f"{thread_id}:{sandbox_type}"] = agent
+    pool_key = f"{thread_id}:{sandbox_type}"
+    app.state.agent_pool[pool_key] = agent
     thread_buf = get_or_create_thread_buffer(app, thread_id)
     error_cursor = thread_buf.total_count
     _ensure_thread_handlers(agent, thread_id, app)
     if not (hasattr(agent, "runtime") and agent.runtime.transition(AgentState.ACTIVE)):
         raise RuntimeError(f"Child thread {thread_id} could not transition to active")
+    try:
+        start_agent_run(
+            agent,
+            thread_id,
+            message,
+            app,
+            input_messages=input_messages,
+        )
+        task = app.state.thread_tasks[thread_id]
+        result = await task
+        recent_events, _ = await thread_buf.read_with_timeout(error_cursor, timeout=0.01)
+        if recent_events:
+            # @@@child-live-error-surfacing - child live runs can emit an error event
+            # and still return an empty string from _run_agent_to_buffer(); treat that
+            # as a real child failure instead of laundering it into fake completion.
+            for event in recent_events:
+                if event.get("event") != "error":
+                    continue
+                try:
+                    payload = json.loads(event.get("data", "{}"))
+                except (json.JSONDecodeError, TypeError):
+                    payload = {}
+                error_text = payload.get("error") if isinstance(payload, dict) else None
+                raise RuntimeError(error_text or f"Child thread {thread_id} failed")
+        if isinstance(result, str) and result.strip():
+            return result.strip()
 
-    start_agent_run(
-        agent,
-        thread_id,
-        message,
-        app,
-        input_messages=input_messages,
-    )
-    task = app.state.thread_tasks[thread_id]
-    result = await task
-    recent_events, _ = await thread_buf.read_with_timeout(error_cursor, timeout=0.01)
-    if recent_events:
-        # @@@child-live-error-surfacing - child live runs can emit an error event
-        # and still return an empty string from _run_agent_to_buffer(); treat that
-        # as a real child failure instead of laundering it into fake completion.
-        for event in recent_events:
-            if event.get("event") != "error":
-                continue
-            try:
-                payload = json.loads(event.get("data", "{}"))
-            except (json.JSONDecodeError, TypeError):
-                payload = {}
-            error_text = payload.get("error") if isinstance(payload, dict) else None
-            raise RuntimeError(error_text or f"Child thread {thread_id} failed")
-    if isinstance(result, str) and result.strip():
-        return result.strip()
-
-    state = await agent.agent.aget_state({"configurable": {"thread_id": thread_id}})
-    values = getattr(state, "values", {}) if state else {}
-    messages = values.get("messages", []) if isinstance(values, dict) else []
-    visible_ai = [
-        extract_text_content(getattr(msg, "content", "")).strip()
-        for msg in messages
-        if msg.__class__.__name__ == "AIMessage" and extract_text_content(getattr(msg, "content", "")).strip()
-    ]
-    runtime_status = agent.runtime.get_status_dict() if hasattr(agent, "runtime") and hasattr(agent.runtime, "get_status_dict") else {}
-    runtime_calls = runtime_status.get("calls") if isinstance(runtime_status, dict) else None
-    if not visible_ai and runtime_calls == 0:
-        raise RuntimeError(f"Child thread {thread_id} failed before first model call")
-    return "\n".join(visible_ai) if visible_ai else "(Agent completed with no text output)"
+        state = await agent.agent.aget_state({"configurable": {"thread_id": thread_id}})
+        values = getattr(state, "values", {}) if state else {}
+        messages = values.get("messages", []) if isinstance(values, dict) else []
+        visible_ai = [
+            extract_text_content(getattr(msg, "content", "")).strip()
+            for msg in messages
+            if msg.__class__.__name__ == "AIMessage" and extract_text_content(getattr(msg, "content", "")).strip()
+        ]
+        runtime_status = (
+            agent.runtime.get_status_dict() if hasattr(agent, "runtime") and hasattr(agent.runtime, "get_status_dict") else {}
+        )
+        runtime_calls = runtime_status.get("calls") if isinstance(runtime_status, dict) else None
+        if not visible_ai and runtime_calls == 0:
+            raise RuntimeError(f"Child thread {thread_id} failed before first model call")
+        return "\n".join(visible_ai) if visible_ai else "(Agent completed with no text output)"
+    finally:
+        # @@@child-run-complete-owner - completed web child runs keep their
+        # thread surface via checkpoint/display rebuild, not by pinning a live
+        # LeonAgent instance in agent_pool until process shutdown.
+        app.state.agent_pool.pop(pool_key, None)
+        agent.close(cleanup_sandbox=False)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -1539,9 +1539,7 @@ async def run_child_thread_live(
             for msg in messages
             if msg.__class__.__name__ == "AIMessage" and extract_text_content(getattr(msg, "content", "")).strip()
         ]
-        runtime_status = (
-            agent.runtime.get_status_dict() if hasattr(agent, "runtime") and hasattr(agent.runtime, "get_status_dict") else {}
-        )
+        runtime_status = agent.runtime.get_status_dict() if hasattr(agent, "runtime") and hasattr(agent.runtime, "get_status_dict") else {}
         runtime_calls = runtime_status.get("calls") if isinstance(runtime_status, dict) else None
         if not visible_ai and runtime_calls == 0:
             raise RuntimeError(f"Child thread {thread_id} failed before first model call")

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -1034,10 +1034,11 @@ class AgentService:
                     )
                     if hasattr(agent, "_agent_service") and hasattr(agent._agent_service, "cleanup_background_runs"):
                         await agent._agent_service.cleanup_background_runs()
-                    # @@@web-child-persistence - web child threads are user-visible
-                    # thread surfaces. Closing the LeonAgent here marks runtime
-                    # terminated and drops its live/checkpoint bridge right after
-                    # completion, so the child tab collapses to an empty shell.
+                    # @@@web-child-close-owner - web child threads stay visible
+                    # via their persisted thread/task surface, not by keeping
+                    # this LeonAgent instance alive forever. The live bridge
+                    # owns the eventual close after it finishes harvesting the
+                    # child run result.
                     if self._web_app is None:
                         # @@@subagent-sandbox-close-skip - Child agents can share the
                         # parent's lease; closing the child sandbox here can pause the

--- a/core/runtime/cleanup.py
+++ b/core/runtime/cleanup.py
@@ -1,4 +1,4 @@
-"""CleanupRegistry — priority-ordered async cleanup for LeonAgent lifecycle.
+"""CleanupRegistry — priority-ordered async cleanup executor for LeonAgent lifecycle.
 
 Aligned with CC Pattern 5: Lifecycle & Cleanup.
 Priority numbers: lower = runs first.
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import signal
 from collections.abc import Awaitable, Callable
 from itertools import groupby
 
@@ -31,8 +30,6 @@ class CleanupRegistry:
         self._timeout_s = 2.0
         self._cleanup_task: asyncio.Task[None] | None = None
         self._shutdown_in_progress = False
-        self._signal_loop: asyncio.AbstractEventLoop | None = None
-        self._setup_signal_handlers()
 
     def register(self, fn: Callable[[], Awaitable[None] | None], priority: int = 5) -> Callable[[], None]:
         """Register a cleanup function.
@@ -86,31 +83,3 @@ class CleanupRegistry:
             logger.warning("CleanupRegistry: cleanup fn %s timed out after %.2fs", fn, self._timeout_s)
         except Exception:
             logger.exception("CleanupRegistry: error in cleanup fn %s (priority=%d)", fn, priority)
-
-    def _setup_signal_handlers(self) -> None:
-        """Register SIGINT/SIGTERM handlers to trigger async cleanup."""
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            return  # No running loop yet — signal handlers set up later
-        self._signal_loop = loop
-
-        signals = [signal.SIGINT, signal.SIGTERM]
-        if hasattr(signal, "SIGHUP"):
-            signals.append(signal.SIGHUP)
-
-        for sig in signals:
-            try:
-                loop.add_signal_handler(sig, self._handle_signal)
-            except (NotImplementedError, RuntimeError):
-                # Windows or non-main thread — skip signal handler setup
-                pass
-
-    def _handle_signal(self) -> None:
-        loop = self._signal_loop
-        if loop is None:
-            return
-        if loop.is_running():
-            loop.create_task(self.run_cleanup())
-            return
-        loop.run_until_complete(self.run_cleanup())

--- a/teams/_index.md
+++ b/teams/_index.md
@@ -1,0 +1,4 @@
+# Teams Index
+
+- `runtime-web-subagent-shutdown-ownership`
+  - `teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md`

--- a/teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md
+++ b/teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md
@@ -1,0 +1,162 @@
+---
+title: Runtime Web Subagent Shutdown Ownership
+owner: fjj
+priority: P1
+status: ready_for_review
+created: 2026-04-09
+---
+
+# Runtime Web Subagent Shutdown Ownership
+
+目标：把 web subagent 在 run complete 之后的 ownership 收回到正确层，不再让 completed child `LeonAgent` 实例因为 thread surface 还要可读，就继续挂在 `agent_pool` 里活到 app shutdown。
+
+## CC analogue
+
+- direct analogue: partial
+- `Claude Code / cc-src` 保留的是可复用的 task / transcript / metadata truth
+- `Claude Code / cc-src` 不是靠 completed subagent instance 常驻内存来实现复用
+
+## Root Cause
+
+当前 live seam 已经继续压深，不再只是“run-complete owner split”。
+
+第一层 wrong-owner split 仍然成立：
+
+1. `core/agents/service.py:_run_agent(... finally)` 在 web path 下明确跳过 `child_agent.close()`
+2. `backend/web/services/streaming_service.py:run_child_thread_live(...)` 又把 child agent 挂进 `app.state.agent_pool`
+3. child run 结束后，task surface 会完成、runtime 会回到 idle，但 child `LeonAgent` 实例继续留在 pool 里
+
+但 fresh caller-proof 已经证明：即使 child run complete 后 close + detach，`SIGTERM` 下 patched backend 仍然不退出。
+
+更深的 root cause 是：
+
+1. 主 thread 的 web agent 通过 `asyncio.to_thread(create_agent_sync, ...)` 创建
+   - `CleanupRegistry()` 在 worker thread 里拿不到当前 event loop
+   - 所以普通 thread agent 不会注册 process signal handler
+2. web subagent child 在 `core/agents/service.py:_run_agent(...)` 里直接在主 event loop 中 `self._child_agent_factory(...)`
+3. `core/runtime/cleanup.py:CleanupRegistry.__init__()` 当前会立刻 `_setup_signal_handlers()`
+4. 于是 child `LeonAgent` 的 `CleanupRegistry` 会在主 event loop 上注册 `SIGINT/SIGTERM/SIGHUP`
+5. 这把 process signal owner 错误地下沉成了 per-agent cleanup object
+
+所以这条 seam 的更准确表述已经变成：
+
+- completed child instance 过度持久是第一层问题
+- 真正把 `SIGTERM graceful shutdown` 打坏的，是 **per-agent CleanupRegistry 越权成了 process signal owner**
+
+这也和 `Claude Code` 更一致地对上了：`cc-src` 的 cleanup registry 是 global cleanup function registry，本身不拥有 process signal。
+
+## Implemented Slice
+
+当前分成两步收口：
+
+### Slice A: web child run-complete ownership
+
+- `backend/web/services/streaming_service.py`
+  - `run_child_thread_live(...)` 在完成后负责：
+    - 从 `app.state.agent_pool` detach child
+    - `agent.close(cleanup_sandbox=False)`
+- `core/agents/service.py`
+  - 只更新注释，明确 live bridge 才是 eventual close owner
+- `tests/Integration/test_child_thread_live_bridge.py`
+  - 新增 integration proof：
+    - child run 完成后，实例会 close + detach
+    - thread detail/runtime 仍可通过 persisted truth + lazy rebuild 继续读取
+
+@@@web-child-run-complete-owner - child thread 可见性继续由 persisted thread/task surface 承担，不再通过把 finished child LeonAgent 实例钉在 agent_pool 里来获得。
+
+### Slice B: cleanup signal ownership
+
+第二刀收的是更底层的 ownership 重建：
+
+- `core/runtime/cleanup.py`
+  - `CleanupRegistry` 不再注册 process signal handler
+  - 它只保留 cleanup function registry / priority runner 语义
+- `tests/Unit/core/test_runtime_support.py`
+  - 改成证明 `CleanupRegistry` 默认不抢 signal owner
+
+@@@cleanup-signal-owner - process signal belongs to app/CLI graceful-shutdown owner, not to every LeonAgent-local cleanup helper.
+
+## Evidence
+
+### 真实产品验证
+
+- fresh caller-proven backend proof 已重新拿到
+- patched backend `:18047`
+- login / create thread / subagent success path caller-proven 为绿：
+  - `tool_call Agent`
+  - `tool_result Agent -> SUBAGENT_CLOSE_OWNERSHIP_1775800001`
+  - `final assistant -> SUBAGENT_CLOSE_OWNERSHIP_1775800001`
+- Slice A 之后的 fresh falsification 也已记录：
+  - 对 uvicorn pid `47839` 发送 `SIGTERM` 后，连续 10 秒仍然：
+    - process alive
+    - `GET /openapi.json -> 200`
+  - 这把 root cause 继续压到了 per-agent signal ownership
+- Slice B 后的 fresh caller-proof：
+  - patched backend `:18047`
+  - fresh subagent thread:
+    - `m_dKjuBBLbR1bw-84`
+  - exact token:
+    - `SUBAGENT_CLOSE_OWNERSHIP_1775800201`
+  - caller-proven sequence:
+    1. `/api/auth/login -> 200`
+    2. `/api/threads -> 200`
+    3. `/api/threads/{thread_id}/messages -> 200`
+    4. `history` shows:
+       - `tool_call Agent`
+       - `tool_result Agent -> SUBAGENT_CLOSE_OWNERSHIP_1775800201`
+       - `final assistant -> SUBAGENT_CLOSE_OWNERSHIP_1775800201`
+    5. `SIGTERM` sent to uvicorn pid `53201`
+    6. poll result:
+       - `poll 0`: `alive=True`, `openapi=200`
+       - `poll 1`: `alive=False`, `openapi=502`
+       - later polls remain dead
+    7. shutdown log:
+       - `Shutting down`
+       - `Waiting for application shutdown.`
+       - `Application shutdown complete.`
+       - `Finished server process [53201]`
+
+### 机制层验证
+
+- `Claude Code / cc-src` 核查结论：
+  - retained truth = task / transcript / metadata
+  - resume = transcript + metadata 驱动的新 lifecycle
+  - 不是 resident completed instance
+
+### 源码/测试层辅助证据
+
+- `uv run pytest -q tests/Integration/test_child_thread_live_bridge.py`
+  - `19 passed in 0.38s`
+- `uv run pytest -q tests/Integration/test_query_loop_backend_bridge.py -k 'subagent or child_thread or Agent'`
+  - `18 passed, 19 deselected in 1.12s`
+- combined:
+  - `uv run pytest -q tests/Integration/test_child_thread_live_bridge.py tests/Integration/test_query_loop_backend_bridge.py`
+  - `56 passed in 0.47s`
+- `uv run pytest -q tests/Unit/core/test_runtime_support.py -k 'cleanup_registry_does_not_install_process_signal_handlers or cleanup_registry_runs_in_priority_order_and_survives_failures or cleanup_registry_reuses_first_inflight_run or cleanup_registry_register_returns_deregister_handle'`
+  - `4 passed, 9 deselected in 0.01s`
+- updated integration pack after Slice B:
+  - `uv run pytest -q tests/Integration/test_child_thread_live_bridge.py tests/Integration/test_query_loop_backend_bridge.py -k 'subagent or child_thread or Agent'`
+  - `37 passed, 19 deselected in 0.47s`
+- `uv run ruff check backend/web/services/streaming_service.py core/agents/service.py tests/Integration/test_child_thread_live_bridge.py`
+  - `All checks passed!`
+- `uv run ruff check core/runtime/cleanup.py tests/Unit/core/test_runtime_support.py`
+  - `All checks passed!`
+- `uv run python -m py_compile backend/web/services/streaming_service.py core/agents/service.py tests/Integration/test_child_thread_live_bridge.py`
+  - `exit 0`
+- `uv run python -m py_compile core/runtime/cleanup.py tests/Unit/core/test_runtime_support.py`
+  - `exit 0`
+
+## Stopline
+
+- 不把“child 可复用”错误实现成“child instance 常驻直到进程退出”
+- 不顺手扩成更大的 main/subagent architecture rewrite
+- 不混入 remote provider 语义
+- 不为了证明这刀而捏造 fake backend proof
+
+## Next Move
+
+唯一默认下一步：
+
+1. 收成 reviewable branch / PR
+2. 不再继续扩写 main/subagent 总体架构
+3. 下一条 lane 另开 fact-only inventory 再决定

--- a/tests/Integration/test_child_thread_live_bridge.py
+++ b/tests/Integration/test_child_thread_live_bridge.py
@@ -90,6 +90,12 @@ class _BlockingChildAgent:
     def __init__(self) -> None:
         self.runtime = _FakeRuntime()
         self.agent = _BlockingChildGraph()
+        self.closed = False
+        self.close_kwargs: dict[str, object] = {}
+
+    def close(self, **kwargs) -> None:
+        self.closed = True
+        self.close_kwargs = kwargs
 
 
 def _make_request(app: SimpleNamespace) -> Request:
@@ -239,6 +245,70 @@ async def test_run_child_thread_live_rebinds_from_parent_sink_and_surfaces_runti
     result = await task
 
     assert result == "CHILD_DONE"
+
+
+@pytest.mark.asyncio
+async def test_run_child_thread_live_closes_and_detaches_completed_child_agent_without_losing_read_surface(monkeypatch):
+    child_thread_id = "subagent-live-detach"
+    agent = _BlockingChildAgent()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            display_builder=DisplayBuilder(),
+            queue_manager=MessageQueueManager(),
+            _event_loop=asyncio.get_running_loop(),
+            thread_event_buffers={},
+            thread_tasks={},
+            thread_last_active={},
+            agent_pool={},
+            thread_sandbox={child_thread_id: "local"},
+            thread_cwd={},
+            thread_repo=SimpleNamespace(get_by_id=lambda thread_id: {"model": "gpt-live"} if thread_id == child_thread_id else None),
+        )
+    )
+
+    task = asyncio.create_task(
+        run_child_thread_live(
+            agent,
+            child_thread_id,
+            "child prompt",
+            app,
+            input_messages=[HumanMessage(content="child prompt")],
+        )
+    )
+    await agent.agent.started.wait()
+    agent.agent.release.set()
+
+    result = await task
+
+    rebuilt_runtime = _FakeRuntime()
+    rebuilt_agent = SimpleNamespace(
+        runtime=rebuilt_runtime,
+        agent=SimpleNamespace(
+            aget_state=AsyncMock(
+                return_value=SimpleNamespace(
+                    values={
+                        "messages": [
+                            HumanMessage(content="child prompt"),
+                            AIMessage(content="CHILD_DONE"),
+                        ]
+                    }
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(threads_router, "get_or_create_agent", AsyncMock(return_value=rebuilt_agent))
+
+    detail = await threads_router.get_thread_messages(child_thread_id, user_id="owner-1", app=app)
+    runtime = await threads_router.get_thread_runtime(child_thread_id, stream=False, user_id="owner-1", app=app)
+
+    assert result == "CHILD_DONE"
+    assert agent.closed is True
+    assert agent.close_kwargs == {"cleanup_sandbox": False}
+    assert f"{child_thread_id}:local" not in app.state.agent_pool
+    assert detail["entries"][0]["role"] == "user"
+    assert detail["entries"][0]["content"] == "child prompt"
+    assert detail["entries"][1]["role"] == "assistant"
+    assert runtime["state"]["state"] == "idle"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_runtime_support.py
+++ b/tests/Unit/core/test_runtime_support.py
@@ -1,7 +1,6 @@
 """Focused runtime support tests for cleanup, fork, and state helpers."""
 
 import asyncio
-import signal
 from pathlib import Path
 from typing import Any, get_type_hints
 
@@ -233,7 +232,7 @@ def test_cleanup_registry_register_returns_deregister_handle():
     assert order == ["kept"]
 
 
-def test_cleanup_registry_installs_signal_handlers(monkeypatch):
+def test_cleanup_registry_does_not_install_process_signal_handlers(monkeypatch):
     registered = []
 
     class _FakeLoop:
@@ -244,8 +243,4 @@ def test_cleanup_registry_installs_signal_handlers(monkeypatch):
 
     CleanupRegistry()
 
-    expected = {signal.SIGINT, signal.SIGTERM}
-    if hasattr(signal, "SIGHUP"):
-        expected.add(signal.SIGHUP)
-
-    assert set(registered) == expected
+    assert registered == []


### PR DESCRIPTION
## Summary
- detach completed web child agents from the live bridge without losing persisted child thread surfaces
- move CleanupRegistry back to pure cleanup execution so per-agent helpers stop stealing process signal ownership
- record the lane in the official `teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md` checkpoint ledger

## Verification
- `uv run pytest -q tests/Unit/core/test_runtime_support.py -k 'cleanup_registry_does_not_install_process_signal_handlers or cleanup_registry_runs_in_priority_order_and_survives_failures or cleanup_registry_reuses_first_inflight_run or cleanup_registry_register_returns_deregister_handle'`
- `uv run pytest -q tests/Integration/test_child_thread_live_bridge.py tests/Integration/test_query_loop_backend_bridge.py -k 'subagent or child_thread or Agent'`
- `uv run ruff check core/runtime/cleanup.py tests/Unit/core/test_runtime_support.py`
- `uv run ruff check backend/web/services/streaming_service.py core/agents/service.py tests/Integration/test_child_thread_live_bridge.py`
- `uv run python -m py_compile core/runtime/cleanup.py tests/Unit/core/test_runtime_support.py`
- `uv run python -m py_compile backend/web/services/streaming_service.py core/agents/service.py tests/Integration/test_child_thread_live_bridge.py`
- real backend proof on `:18047`: subagent success path returned exact token, then `SIGTERM` led to `Shutting down -> Application shutdown complete -> Finished server process`
