### PR TITLE
refactor: move panel and cron service fallback to storage runtime

### DIFF
--- a/backend/web/services/cron_job_service.py
+++ b/backend/web/services/cron_job_service.py
@@ -2,11 +2,11 @@
 
 from typing import Any
 
-from backend.web.core.storage_factory import make_cron_job_repo
+from storage.runtime import build_cron_job_repo
 
 
 def _repo() -> Any:
-    return make_cron_job_repo()
+    return build_cron_job_repo()
 
 
 def list_cron_jobs(owner_user_id: str | None = None, repo: Any = None) -> list[dict[str, Any]]:

--- a/backend/web/services/task_service.py
+++ b/backend/web/services/task_service.py
@@ -2,11 +2,11 @@
 
 from typing import Any
 
-from backend.web.core.storage_factory import make_panel_task_repo
+from storage.runtime import build_panel_task_repo
 
 
 def _repo() -> Any:
-    return make_panel_task_repo()
+    return build_panel_task_repo()
 
 
 def list_tasks(owner_user_id: str | None = None, repo: Any = None) -> list[dict[str, Any]]:

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -67,6 +67,33 @@ def build_tool_task_repo(
     ).tool_task_repo()
 
 
+def build_panel_task_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        public_supabase_client_factory="backend.web.core.supabase_factory:create_public_supabase_client",
+        **kwargs,
+    ).panel_task_repo()
+
+
+def build_cron_job_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).cron_job_repo()
+
+
 def build_agent_registry_repo(
     *,
     supabase_client: Any | None = None,

--- a/tests/Integration/test_panel_task_owner_contract.py
+++ b/tests/Integration/test_panel_task_owner_contract.py
@@ -180,7 +180,7 @@ def test_task_service_prefers_injected_repos_over_storage_factory(monkeypatch: p
             seen["get"] = (task_id, owner_user_id)
             return {"id": task_id}
 
-    monkeypatch.setattr(task_service, "_repo", lambda: (_ for _ in ()).throw(AssertionError("unexpected storage factory repo")))
+    monkeypatch.setattr(task_service, "_repo", lambda: (_ for _ in ()).throw(AssertionError("unexpected runtime repo")))
     items = task_service.list_tasks(owner_user_id="user-1", repo=_FakeRepo())
     item = task_service.get_task("t-1", owner_user_id="user-1", repo=_FakeRepo())
 
@@ -236,7 +236,7 @@ def test_cron_job_service_prefers_injected_repo_over_storage_factory(monkeypatch
             seen["create"] = (name, cron_expression, fields)
             return {"id": "job-1", "name": name}
 
-    monkeypatch.setattr(cron_job_service, "_repo", lambda: (_ for _ in ()).throw(AssertionError("unexpected storage factory repo")))
+    monkeypatch.setattr(cron_job_service, "_repo", lambda: (_ for _ in ()).throw(AssertionError("unexpected runtime repo")))
 
     jobs = cron_job_service.list_cron_jobs(owner_user_id="user-1", repo=_FakeRepo())
     created = cron_job_service.create_cron_job(
@@ -250,6 +250,18 @@ def test_cron_job_service_prefers_injected_repo_over_storage_factory(monkeypatch
     assert jobs == [{"id": "job-1"}]
     assert seen["create"] == ("Nightly", "0 0 * * *", {"owner_user_id": "user-1"})
     assert created == {"id": "job-1", "name": "Nightly"}
+
+
+def test_panel_and_cron_services_no_longer_import_storage_factory() -> None:
+    import inspect
+
+    task_source = inspect.getsource(task_service)
+    cron_source = inspect.getsource(cron_job_service)
+
+    assert "backend.web.core.storage_factory" not in task_source
+    assert "backend.web.core.storage_factory" not in cron_source
+    assert "storage.runtime" in task_source
+    assert "storage.runtime" in cron_source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move task_service and cron_job_service default repo construction off backend/web/core/storage_factory.py
- add runtime builders for panel_task_repo and cron_job_repo in storage/runtime.py
- pin the service seam with integration coverage that asserts these services no longer import storage_factory

## Verification
- uv run pytest -q tests/Integration/test_panel_task_owner_contract.py -k 'no_longer_import_storage_factory or prefers_injected'
- uv run pytest -q tests/Integration/test_panel_task_owner_contract.py
- uv run ruff check storage/runtime.py backend/web/services/task_service.py backend/web/services/cron_job_service.py tests/Integration/test_panel_task_owner_contract.py
- uv run python -m py_compile storage/runtime.py backend/web/services/task_service.py backend/web/services/cron_job_service.py tests/Integration/test_panel_task_owner_contract.py

## Context
- issue #191
- this is CP01 only; no monitor/resource/thread-helper widening