### PR TITLE
refactor: move resource surfaces to storage runtime

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from typing import Any
 
 from backend.web.core.config import SANDBOXES_DIR
-from backend.web.core.storage_factory import list_resource_snapshots, make_sandbox_monitor_repo
 from backend.web.services import resource_service, sandbox_service
 from backend.web.services.resource_common import CATALOG as _CATALOG
 from backend.web.services.resource_common import CatalogEntry as _CatalogEntry
@@ -24,6 +23,8 @@ from backend.web.services.sandbox_service import available_sandbox_types
 from sandbox.provider import RESOURCE_CAPABILITY_KEYS
 from sandbox.providers.local import LocalSessionProvider
 from storage.models import map_lease_to_session_status
+from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
+from storage.runtime import list_resource_snapshots
 
 
 def _now_iso() -> str:

--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from backend.web.core.config import SANDBOXES_DIR
-from backend.web.core.storage_factory import make_sandbox_monitor_repo
 from backend.web.services.resource_common import CATALOG as _CATALOG
 from backend.web.services.resource_common import CatalogEntry as _CatalogEntry
 from backend.web.services.resource_common import empty_capabilities, resolve_provider_name
@@ -14,6 +13,7 @@ from backend.web.services.resource_common import resolve_instance_capabilities a
 from backend.web.services.resource_common import resolve_provider_type as _resolve_provider_type
 from backend.web.services.sandbox_service import build_provider_from_config_name
 from sandbox.resource_snapshot import ensure_resource_snapshot_table, probe_and_upsert_for_instance, upsert_lease_resource_snapshot
+from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 
 def get_provider_display_contract(config_name: str) -> dict[str, Any]:

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -135,6 +135,35 @@ def build_resource_snapshot_repo(
     ).resource_snapshot_repo()
 
 
+def build_sandbox_monitor_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+):
+    client = _resolve_supabase_client(supabase_client, supabase_client_factory or _WEB_SUPABASE_CLIENT_FACTORY)
+    from storage.providers.supabase.sandbox_monitor_repo import SupabaseSandboxMonitorRepo
+
+    return SupabaseSandboxMonitorRepo(client)
+
+
+def list_resource_snapshots(
+    lease_ids: list[str],
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    repo = build_resource_snapshot_repo(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    )
+    try:
+        return repo.list_snapshots_by_lease_ids(lease_ids)
+    finally:
+        repo.close()
+
+
 def _resolve_supabase_client(
     client: Any | None = None,
     factory_ref: str | None = None,

--- a/teams/_index.md
+++ b/teams/_index.md
@@ -1,4 +1,6 @@
 # Teams Index
 
+- `storage-repo-abstraction-unification`
+  - `teams/tasks/storage-repo-abstraction-unification/_index.md`
 - `runtime-web-subagent-shutdown-ownership`
   - `teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md`

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -1,0 +1,39 @@
+---
+title: Storage Repo Abstraction Unification
+owner: fjj
+priority: P1
+status: open
+created: 2026-04-09
+issue: 191
+---
+
+# Storage Repo Abstraction Unification
+
+目标：把 `#191` 里仍残留的 `backend/web/core/storage_factory.py` 临时桥逐簇收回正式主线，让 repo 选择统一落在 `storage/contracts.py -> storage/container.py -> storage.runtime / explicit injection`，而不是继续在 web/service/helper 边角各自 new provider。
+
+## 当前 ruling
+
+- `storage_factory.py` 仍是 live production bridge
+- `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
+- `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
+- 当前最危险 residual 是 `monitor_service` 的 split-brain correctness seam
+
+## 子任务
+
+| # | 子任务 | 说明 | 状态 |
+|---|--------|------|------|
+| 00 | [Current State & Stopline](subtask-00-current-state-and-stopline.md) | 固化 current `dev` 与 issue 的真实差距 | done |
+| 01 | [Web Service Injection Cut](subtask-01-web-service-injection-cut.md) | 先收 `task_service / cron_job_service` | done |
+| 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
+| 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | open |
+| 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 收 thread/file/webhook helpers | open |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | 最后处理 runtime-owned builder residuals | open |
+| 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
+
+## 边界
+
+- 不继续给 `storage_factory.py` 添能力
+- 不把 `CP02` 和 `monitor_service` 混成一刀
+- 不顺手改 monitor/resource payload 语义
+- 每一刀只搬一小簇 callsite，然后回到真实 proof
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-00-current-state-and-stopline.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-00-current-state-and-stopline.md
@@ -1,0 +1,23 @@
+---
+title: Current State & Stopline
+status: done
+created: 2026-04-09
+---
+
+# Current State & Stopline
+
+## 已确认事实
+
+1. `storage/contracts.py` 已补出 issue 需要的 repo protocol 面
+2. `storage/container.py` 已具备大部分 repo wiring
+3. `backend/web/core/storage_factory.py` 仍在 current `dev` 上承担 live bridge
+
+## 结论
+
+`#191` 现在不是“缺设计”，而是“还有临时桥没拆完”。
+
+## Stopline
+
+- 这一刀只固化 current-state ruling
+- 不写实现代码
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-01-web-service-injection-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-01-web-service-injection-cut.md
@@ -1,0 +1,21 @@
+---
+title: Web Service Injection Cut
+status: done
+created: 2026-04-09
+---
+
+# Web Service Injection Cut
+
+## 已完成事实
+
+- `task_service.py` 与 `cron_job_service.py` 默认 repo path 已不再 import `backend.web.core.storage_factory`
+- 默认 path 改走 `storage.runtime`
+- 没有顺手扩大到 monitor/resource
+
+## 证据
+
+- `uv run pytest -q tests/Integration/test_panel_task_owner_contract.py`
+  - `9 passed`
+- `uv run ruff check storage/runtime.py backend/web/services/task_service.py backend/web/services/cron_job_service.py tests/Integration/test_panel_task_owner_contract.py`
+  - `All checks passed!`
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-02-resource-surfaces-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-02-resource-surfaces-cut.md
@@ -1,0 +1,50 @@
+---
+title: Resource Surfaces Cut
+status: done
+created: 2026-04-09
+---
+
+# Resource Surfaces Cut
+
+## 实际边界
+
+这刀只收两处：
+
+- [backend/web/services/resource_service.py](/Users/lexicalmathical/worktrees/leonai--storage-resource-surfaces-cut/backend/web/services/resource_service.py)
+- [backend/web/services/resource_projection_service.py](/Users/lexicalmathical/worktrees/leonai--storage-resource-surfaces-cut/backend/web/services/resource_projection_service.py)
+
+同时在 [storage/runtime.py](/Users/lexicalmathical/worktrees/leonai--storage-resource-surfaces-cut/storage/runtime.py) 增加最小 runtime seam：
+
+- `build_sandbox_monitor_repo(...)`
+- `list_resource_snapshots(...)`
+
+`sandbox_service.py`、`resource_cache.py`、`monitor_service.py` 都不在这刀里。
+
+## 已完成事实
+
+- `resource_service.py` 不再 import `backend.web.core.storage_factory`
+- `resource_projection_service.py` 不再 import `backend.web.core.storage_factory`
+- 两个模块继续保留 `make_sandbox_monitor_repo` / `list_resource_snapshots` 这组 module-local 名字，所以现有 monkeypatch contract 没被打断
+- resource/product 与 monitor/operator 两条面仍然保持分离
+
+## 证据
+
+- red:
+  - `uv run pytest -q tests/Integration/test_resource_overview_contract_split.py -k 'resource_services_no_longer_import_storage_factory'`
+  - `1 failed, 7 deselected`
+- green:
+  - `uv run pytest -q tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_monitor_resources_route.py`
+  - `23 passed`
+  - `uv run pytest -q tests/Unit/backend/web/services/test_resource_projection_service_contract.py`
+  - `6 passed`
+  - `uv run ruff check storage/runtime.py backend/web/services/resource_service.py backend/web/services/resource_projection_service.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py`
+  - `All checks passed!`
+  - `uv run python -m py_compile storage/runtime.py backend/web/services/resource_service.py backend/web/services/resource_projection_service.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py`
+  - `exit 0`
+
+## Stopline
+
+- 不碰 `monitor_service.py`
+- 不碰 `sandbox_service.py`
+- 不碰 thread/file helper
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-03-monitor-operator-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-03-monitor-operator-cut.md
@@ -1,0 +1,10 @@
+---
+title: Monitor Operator Cut
+status: open
+created: 2026-04-09
+---
+
+# Monitor Operator Cut
+
+下一刀专门处理 `monitor_service.py` 的 split-brain correctness seam，不与 resource surface 混刀。
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
@@ -1,0 +1,10 @@
+---
+title: Web Thread/File Helper Cut
+status: open
+created: 2026-04-09
+---
+
+# Web Thread/File Helper Cut
+
+后续单独处理 thread/file/webhook helper 对 `storage_factory.py` 的残留依赖。
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -1,0 +1,10 @@
+---
+title: Sandbox Runtime Owner Cut
+status: open
+created: 2026-04-09
+---
+
+# Sandbox Runtime Owner Cut
+
+最后再处理 `sandbox/manager.py`、`sandbox/lease.py` 等 runtime-owned builder 残留。
+

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-06-factory-deletion-and-closure-proof.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-06-factory-deletion-and-closure-proof.md
@@ -1,0 +1,9 @@
+---
+title: Factory Deletion And Closure Proof
+status: open
+created: 2026-04-09
+---
+
+# Factory Deletion And Closure Proof
+
+终局才是删除 `backend/web/core/storage_factory.py`，并做 closure proof。

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -11,6 +12,16 @@ from backend.web.main import app
 from backend.web.routers import monitor as monitor_router
 from backend.web.routers import resources as resources_router
 from backend.web.services import resource_projection_service, resource_service
+
+
+def test_resource_services_no_longer_import_storage_factory() -> None:
+    resource_service_source = inspect.getsource(resource_service)
+    projection_service_source = inspect.getsource(resource_projection_service)
+
+    assert "backend.web.core.storage_factory" not in resource_service_source
+    assert "backend.web.core.storage_factory" not in projection_service_source
+    assert "storage.runtime" in resource_service_source
+    assert "storage.runtime" in projection_service_source
 
 
 def test_resources_overview_route_exists() -> None:


### PR DESCRIPTION
## Summary
- move resource_service and resource_projection_service off backend.web.core.storage_factory
- add minimal storage.runtime builders for sandbox monitor repo and resource snapshot listing
- record #191 checkpoint state in teams/task cards

## Verification
- uv run pytest -q tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_monitor_resources_route.py
- uv run pytest -q tests/Unit/backend/web/services/test_resource_projection_service_contract.py
- uv run ruff check storage/runtime.py backend/web/services/resource_service.py backend/web/services/resource_projection_service.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py
- uv run python -m py_compile storage/runtime.py backend/web/services/resource_service.py backend/web/services/resource_projection_service.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/backend/web/services/test_resource_projection_service_contract.py

## Stacking
- base branch: feat/storage-web-service-injection-cut (#363)
- issue: #191