### PR TITLE
refactor: align monitor operator repos with storage runtime

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -8,26 +8,17 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
-from backend.web.core.storage_factory import make_sandbox_monitor_repo
 from backend.web.services.sandbox_service import init_providers_and_managers, load_all_sessions
 from eval.storage import TrajectoryStore
-from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+from storage.runtime import build_chat_session_repo as make_chat_session_repo
+from storage.runtime import build_lease_repo as make_lease_repo
+from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
+
 
 # ---------------------------------------------------------------------------
 # Mapping helpers (private)
 # ---------------------------------------------------------------------------
-
-
-def make_chat_session_repo() -> SQLiteChatSessionRepo:
-    return SQLiteChatSessionRepo(db_path=resolve_role_db_path(SQLiteDBRole.SANDBOX))
-
-
-def make_lease_repo() -> SQLiteLeaseRepo:
-    return SQLiteLeaseRepo(db_path=resolve_role_db_path(SQLiteDBRole.SANDBOX))
-
-
 def make_eval_store() -> TrajectoryStore:
     return TrajectoryStore()
 

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -94,6 +94,32 @@ def build_cron_job_repo(
     ).cron_job_repo()
 
 
+def build_lease_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).lease_repo()
+
+
+def build_chat_session_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).chat_session_repo()
+
+
 def build_agent_registry_repo(
     *,
     supabase_client: Any | None = None,

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -25,7 +25,7 @@ issue: 191
 | 00 | [Current State & Stopline](subtask-00-current-state-and-stopline.md) | 固化 current `dev` 与 issue 的真实差距 | done |
 | 01 | [Web Service Injection Cut](subtask-01-web-service-injection-cut.md) | 先收 `task_service / cron_job_service` | done |
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
-| 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | open |
+| 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
 | 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 收 thread/file/webhook helpers | open |
 | 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | 最后处理 runtime-owned builder residuals | open |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
@@ -36,4 +36,3 @@ issue: 191
 - 不把 `CP02` 和 `monitor_service` 混成一刀
 - 不顺手改 monitor/resource payload 语义
 - 每一刀只搬一小簇 callsite，然后回到真实 proof
-

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-03-monitor-operator-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-03-monitor-operator-cut.md
@@ -1,10 +1,46 @@
 ---
 title: Monitor Operator Cut
-status: open
+status: done
 created: 2026-04-09
 ---
 
 # Monitor Operator Cut
 
-下一刀专门处理 `monitor_service.py` 的 split-brain correctness seam，不与 resource surface 混刀。
+## 实际边界
 
+这刀只收：
+
+- [backend/web/services/monitor_service.py](/Users/lexicalmathical/worktrees/leonai--storage-monitor-operator-cut/backend/web/services/monitor_service.py)
+- [storage/runtime.py](/Users/lexicalmathical/worktrees/leonai--storage-monitor-operator-cut/storage/runtime.py)
+
+目标只有一个：不再让 operator monitor 一边走 Supabase monitor repo，一边再从 SQLite-only lease/chat_session repo 取 truth。
+
+## 已完成事实
+
+- `monitor_service.py` 不再 import `backend.web.core.storage_factory`
+- `monitor_service.py` 不再 hard-import SQLite-only `LeaseRepo` / `ChatSessionRepo`
+- `storage.runtime` 新增最小 builder：
+  - `build_lease_repo(...)`
+  - `build_chat_session_repo(...)`
+- `make_sandbox_monitor_repo / make_lease_repo / make_chat_session_repo` 这组 module-local monkeypatch 名字仍保留
+
+## 证据
+
+- red:
+  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py -k 'monitor_service_no_longer_imports_storage_factory_or_sqlite_repos'`
+  - `1 failed, 14 deselected`
+- green:
+  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py`
+  - `15 passed`
+  - `uv run pytest -q tests/Integration/test_monitor_resources_route.py`
+  - `15 passed`
+  - `uv run ruff check storage/runtime.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py`
+  - `All checks passed!`
+  - `uv run python -m py_compile storage/runtime.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py`
+  - `exit 0`
+
+## Stopline
+
+- 不碰 `resource_service.py`
+- 不碰 thread/file/webhook helper
+- 不删 `storage_factory.py`

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -1,6 +1,17 @@
+import inspect
+
 import pytest
 
 from backend.web.services import monitor_service
+
+
+def test_monitor_service_no_longer_imports_storage_factory_or_sqlite_repos() -> None:
+    source = inspect.getsource(monitor_service)
+
+    assert "backend.web.core.storage_factory" not in source
+    assert "storage.providers.sqlite.chat_session_repo" not in source
+    assert "storage.providers.sqlite.lease_repo" not in source
+    assert "storage.runtime" in source
 
 
 def test_list_leases_exposes_semantic_groups_and_summary(monkeypatch):


### PR DESCRIPTION
## Summary
- move monitor_service off storage_factory and SQLite-only lease/chat session repos
- add minimal storage.runtime builders for lease and chat session repos
- record CP03 completion in the #191 checkpoint ledger

## Verification
- uv run pytest -q tests/Unit/monitor/test_monitor_compat.py
- uv run pytest -q tests/Integration/test_monitor_resources_route.py
- uv run ruff check storage/runtime.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py
- uv run python -m py_compile storage/runtime.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_compat.py

## Stacking
- base branch: feat/storage-resource-surfaces-cut (#364)
- issue: #191