### PR TITLE
refactor: move file helpers to storage runtime

### DIFF
--- a/backend/web/services/activity_tracker.py
+++ b/backend/web/services/activity_tracker.py
@@ -6,6 +6,7 @@ Decouples activity sources (file uploads, API calls) from session management.
 import logging
 
 from sandbox.clock import utc_now_iso
+from storage.runtime import build_chat_session_repo as make_chat_session_repo
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +19,6 @@ def track_thread_activity(thread_id: str, activity_type: str = "activity") -> No
     # to bump last_active_at to prevent idle reaper from pausing during file uploads.
     # Does NOT change session status — preserves paused/active state as-is.
     """
-    from backend.web.core.storage_factory import make_chat_session_repo
-
     now = utc_now_iso()
     repo = make_chat_session_repo()
     try:

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -11,10 +11,20 @@ import json
 import logging
 
 from backend.web.utils.helpers import _get_container
-from storage.runtime import build_lease_repo as make_lease_repo
-from storage.runtime import build_terminal_repo as make_terminal_repo
+from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
 logger = logging.getLogger(__name__)
+SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
+
+
+def make_terminal_repo():
+    return SQLiteTerminalRepo(db_path=SANDBOX_DB_PATH)
+
+
+def make_lease_repo():
+    return SQLiteLeaseRepo(db_path=SANDBOX_DB_PATH)
 
 
 def _resolve_volume_source(thread_id: str):

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -11,6 +11,8 @@ import json
 import logging
 
 from backend.web.utils.helpers import _get_container
+from storage.runtime import build_lease_repo as make_lease_repo
+from storage.runtime import build_terminal_repo as make_terminal_repo
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +23,6 @@ def _resolve_volume_source(thread_id: str):
     This is the application-layer entry point. Uses sandbox-layer stores
     to walk: thread → terminal → lease → volume_id → sandbox_volumes.
     """
-    from backend.web.core.storage_factory import make_lease_repo, make_terminal_repo
     from sandbox.volume_source import deserialize_volume_source
 
     terminal_repo = make_terminal_repo()

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -120,6 +120,19 @@ def build_chat_session_repo(
     ).chat_session_repo()
 
 
+def build_terminal_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).terminal_repo()
+
+
 def build_agent_registry_repo(
     *,
     supabase_client: Any | None = None,

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前最危险 residual 是 `monitor_service` 的 split-brain correctness seam
+- 当前最危险 residual 已从 `monitor_service` 推进到 thread/file/webhook helper 与 runtime-owned helper 残留
 
 ## 子任务
 
@@ -26,7 +26,7 @@ issue: 191
 | 01 | [Web Service Injection Cut](subtask-01-web-service-injection-cut.md) | 先收 `task_service / cron_job_service` | done |
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
-| 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 收 thread/file/webhook helpers | open |
+| 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 先收 file/helper slice，再处理 threads/webhooks | in_progress |
 | 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | 最后处理 runtime-owned builder residuals | open |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
@@ -24,8 +24,10 @@ created: 2026-04-09
 
 - `activity_tracker.py` 不再 import `backend.web.core.storage_factory`
 - `file_channel_service.py` 不再 import `backend.web.core.storage_factory`
-- [storage/runtime.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/storage/runtime.py) 新增 `build_terminal_repo(...)`
-- module-local `make_chat_session_repo / make_lease_repo / make_terminal_repo` 名字仍保留
+- `file_channel_service.py` 最终没有保留 `storage.runtime` terminal/lease builder 路径
+- 因为 thread -> terminal -> lease 这条 file-channel lookup 仍然是 `sandbox.db` 的 `db_path` owner seam
+- 所以 `file_channel_service.py` 现在显式持有本地 sqlite `lease/terminal` constructor，而不是误接到 Supabase-only runtime builder
+- module-local `make_lease_repo / make_terminal_repo` 名字仍保留
 
 ## 证据
 
@@ -33,11 +35,13 @@ created: 2026-04-09
   - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py -k 'file_channel_and_activity_tracker_no_longer_import_storage_factory'`
   - `1 failed, 5 deselected`
 - green:
+  - `uv run pytest -q tests/Unit/core/test_agent_pool.py -k 'creates_once_per_thread or ignores_unavailable_local_cwd or honors_fresh_local_thread_cwd_even_when_missing or prefers_repo_backed_runtime_startup_even_with_conflicting_legacy_member_shell or uses_thread_user_id_for_chat_identity'`
+  - `5 passed, 2 deselected`
   - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py`
   - `6 passed`
-  - `uv run ruff check storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+  - `uv run ruff check backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py tests/Unit/core/test_agent_pool.py`
   - `All checks passed!`
-  - `uv run python -m py_compile storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+  - `uv run python -m py_compile backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py tests/Unit/core/test_agent_pool.py`
   - `exit 0`
 
 ## 还没做
@@ -52,3 +56,6 @@ created: 2026-04-09
 - 当前不碰 `backend/web/utils/helpers.py`
 - 当前不碰 `backend/web/routers/threads.py`
 - 当前不碰 `backend/web/routers/webhooks.py`
+- hindsight:
+  - `no longer imports storage_factory` 不等于 `应该改走 storage.runtime`
+  - 如果代码本身就是 `sandbox.db` / `db_path` lookup owner，最小而诚实的落点仍然可能是本地 sqlite constructor

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
@@ -1,10 +1,54 @@
 ---
 title: Web Thread/File Helper Cut
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Web Thread/File Helper Cut
 
-后续单独处理 thread/file/webhook helper 对 `storage_factory.py` 的残留依赖。
+## 当前 ruling
 
+这张卡现在已经拆成两层：
+
+- `CP04a file/helper slice`
+  - [backend/web/services/activity_tracker.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/backend/web/services/activity_tracker.py)
+  - [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/backend/web/services/file_channel_service.py)
+- 剩余 residual
+  - `backend/web/utils/helpers.py`
+  - `backend/web/routers/threads.py`
+  - `backend/web/routers/webhooks.py`
+
+## 已完成事实
+
+`CP04a` 已落地：
+
+- `activity_tracker.py` 不再 import `backend.web.core.storage_factory`
+- `file_channel_service.py` 不再 import `backend.web.core.storage_factory`
+- [storage/runtime.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/storage/runtime.py) 新增 `build_terminal_repo(...)`
+- module-local `make_chat_session_repo / make_lease_repo / make_terminal_repo` 名字仍保留
+
+## 证据
+
+- red:
+  - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py -k 'file_channel_and_activity_tracker_no_longer_import_storage_factory'`
+  - `1 failed, 5 deselected`
+- green:
+  - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py`
+  - `6 passed`
+  - `uv run ruff check storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+  - `All checks passed!`
+  - `uv run python -m py_compile storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+  - `exit 0`
+
+## 还没做
+
+这张卡还没有 closure。剩余更像下一刀的是：
+
+- `helpers.py` 的 runtime/db-path helper seam
+- `threads.py` / `webhooks.py` 的 lease/terminal helper seam
+
+## Stopline
+
+- 当前不碰 `backend/web/utils/helpers.py`
+- 当前不碰 `backend/web/routers/threads.py`
+- 当前不碰 `backend/web/routers/webhooks.py`

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -18,7 +18,8 @@ def test_file_channel_and_activity_tracker_no_longer_import_storage_factory() ->
     assert "backend.web.core.storage_factory" not in activity_source
     assert "backend.web.core.storage_factory" not in file_channel_source
     assert "storage.runtime" in activity_source
-    assert "storage.runtime" in file_channel_source
+    assert "SQLiteTerminalRepo" in file_channel_source
+    assert "SQLiteLeaseRepo" in file_channel_source
 
 
 @pytest.mark.asyncio

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,17 @@ from fastapi import HTTPException
 from fastapi.responses import FileResponse
 
 from backend.web.routers import thread_files as thread_files_router
+from backend.web.services import activity_tracker, file_channel_service
+
+
+def test_file_channel_and_activity_tracker_no_longer_import_storage_factory() -> None:
+    activity_source = inspect.getsource(activity_tracker)
+    file_channel_source = inspect.getsource(file_channel_service)
+
+    assert "backend.web.core.storage_factory" not in activity_source
+    assert "backend.web.core.storage_factory" not in file_channel_source
+    assert "storage.runtime" in activity_source
+    assert "storage.runtime" in file_channel_source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move activity_tracker and file_channel_service off backend.web.core.storage_factory
- add a minimal storage.runtime terminal repo builder
- record the CP04a file/helper slice in the #191 checkpoint ledger

## Verification
- uv run pytest -q tests/Integration/test_thread_files_channel_shell.py
- uv run ruff check storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py
- uv run python -m py_compile storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py

## Stacking
- base branch: feat/storage-monitor-operator-cut (#365)
- issue: #191