### PR TITLE
refactor: move webhook lease lookup to storage runtime

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -9,7 +9,7 @@ from backend.web.services.sandbox_service import init_providers_and_managers
 from backend.web.utils.helpers import _get_container, extract_webhook_instance_id
 from sandbox.lease import lease_from_row
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+from storage.runtime import build_lease_repo as make_lease_repo
 
 SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
@@ -24,11 +24,11 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
         raise HTTPException(400, "Webhook payload missing instance/session id")
 
     event_type = str(payload.get("event") or payload.get("type") or "unknown")
-    lease_repo = SQLiteLeaseRepo(db_path=SANDBOX_DB_PATH)
+    lease_repo = make_lease_repo()
     event_repo = _get_container().provider_event_repo()
     try:
         lease_row = await asyncio.to_thread(lease_repo.find_by_instance, provider_name=provider_name, instance_id=instance_id)
-        lease = lease_from_row(lease_row, lease_repo.db_path) if lease_row else None
+        lease = lease_from_row(lease_row, SANDBOX_DB_PATH) if lease_row else None
         matched_lease_id = lease.lease_id if lease else None
 
         # @@@webhook-invalidation-only - Webhook is optimization only: persist event + mark lease stale.

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前最危险 residual 已从 `monitor_service` 推进到 thread/file/webhook helper 与 runtime-owned helper 残留
+- 当前最危险 residual 已经进一步收敛到 runtime-owned builder 与 sandbox lifecycle helper 残留
 
 ## 子任务
 
@@ -27,7 +27,7 @@ issue: 191
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
 | 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 先收 file/helper slice，再处理 threads/webhooks | in_progress |
-| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | 最后处理 runtime-owned builder residuals | open |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | 先收 webhooks lease cut，再继续推进 sandbox/runtime 残留 | in_progress |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 
 ## 边界

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -1,10 +1,55 @@
 ---
 title: Sandbox Runtime Owner Cut
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Sandbox Runtime Owner Cut
 
-最后再处理 `sandbox/manager.py`、`sandbox/lease.py` 等 runtime-owned builder 残留。
+## 当前 ruling
 
+这张卡已经进入实现期，但第一刀不是直接碰 `sandbox/manager.py`。
+
+当前已完成的 `CP05a` 是：
+
+- [backend/web/routers/webhooks.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/webhooks.py)
+
+因为它已经满足：
+
+- runtime-owned 语义明显
+- write set 足够窄
+- 不会把 `sandbox/manager.py` / `sandbox/lease.py` 一起卷进来
+
+## 已完成事实
+
+- `webhooks.py` 不再 import `SQLiteLeaseRepo`
+- `webhooks.py` 改走 `storage.runtime.build_lease_repo(...)`
+- unmatched webhook 的 outward payload shape 保持不变
+
+## 证据
+
+- red:
+  - `uv run pytest -q tests/Integration/test_webhooks_router_contract.py`
+  - `2 failed`
+- green:
+  - `uv run pytest -q tests/Integration/test_webhooks_router_contract.py`
+  - `2 passed`
+  - `uv run ruff check backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py`
+  - `All checks passed!`
+  - `uv run python -m py_compile backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py`
+  - `exit 0`
+
+## 还没做
+
+`CP05` 还没有 closure。剩余更深的 runtime-owned 残留仍在：
+
+- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/lease.py)
+- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/manager.py)
+- [backend/web/utils/helpers.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/utils/helpers.py)
+- [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/threads.py)
+
+## Stopline
+
+- 当前不直接碰 `sandbox/lease.py`
+- 当前不直接碰 `sandbox/manager.py`
+- 当前不把 `helpers.py / threads.py` 混进同一刀

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.web.routers import webhooks
+
+
+def test_webhooks_router_no_longer_imports_sqlite_lease_repo() -> None:
+    source = inspect.getsource(webhooks)
+
+    assert "storage.providers.sqlite.lease_repo" not in source
+    assert "storage.runtime" in source
+
+
+@pytest.mark.asyncio
+async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _LeaseRepo:
+        db_path = "/tmp/fake-sandbox.db"
+
+        def find_by_instance(self, *, provider_name: str, instance_id: str):
+            assert provider_name == "local"
+            assert instance_id == "inst-1"
+            return None
+
+        def close(self) -> None:
+            return None
+
+    class _EventRepo:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def record(self, **kwargs):
+            self.calls.append(kwargs)
+
+        def close(self) -> None:
+            return None
+
+    class _Container:
+        def __init__(self, event_repo: _EventRepo) -> None:
+            self._event_repo = event_repo
+
+        def provider_event_repo(self) -> _EventRepo:
+            return self._event_repo
+
+    event_repo = _EventRepo()
+    monkeypatch.setattr(webhooks, "make_lease_repo", lambda: _LeaseRepo())
+    monkeypatch.setattr(webhooks, "_get_container", lambda: _Container(event_repo))
+
+    payload = await webhooks.ingest_provider_webhook(
+        "local",
+        {"instance_id": "inst-1", "event": "provider.updated"},
+    )
+
+    assert payload == {
+        "ok": True,
+        "provider": "local",
+        "instance_id": "inst-1",
+        "event_type": "provider.updated",
+        "matched": False,
+    }
+    assert event_repo.calls == [
+        {
+            "provider_name": "local",
+            "instance_id": "inst-1",
+            "event_type": "provider.updated",
+            "payload": {"instance_id": "inst-1", "event": "provider.updated"},
+            "matched_lease_id": None,
+        }
+    ]


### PR DESCRIPTION
## Summary
- move webhooks lease lookup off SQLiteLeaseRepo and onto storage.runtime
- preserve unmatched webhook payload shape
- record CP05a in the #191 checkpoint ledger

## Verification
- uv run pytest -q tests/Integration/test_webhooks_router_contract.py
- uv run ruff check backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py
- uv run python -m py_compile backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py

## Stacking
- base branch: feat/storage-file-helper-cut (#366)
- issue: #191