### PR TITLE
refactor: route sandbox lease repo through runtime

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -82,9 +82,9 @@ def _use_supabase_storage() -> bool:
 
 
 def _make_lease_repo(db_path: Path | None = None):
-    from backend.web.core.storage_factory import make_lease_repo
+    from storage.runtime import build_lease_repo
 
-    return make_lease_repo(db_path=db_path)
+    return build_lease_repo(db_path=db_path)
 
 
 @dataclass

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -28,6 +28,7 @@ from sandbox.lifecycle import (
     parse_lease_instance_state,
 )
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
 
 if TYPE_CHECKING:
     from sandbox.provider import SandboxProvider
@@ -82,9 +83,8 @@ def _use_supabase_storage() -> bool:
 
 
 def _make_lease_repo(db_path: Path | None = None):
-    from storage.runtime import build_lease_repo
-
-    return build_lease_repo(db_path=db_path)
+    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return SQLiteLeaseRepo(db_path=target_db)
 
 
 @dataclass

--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -102,19 +102,25 @@ def probe_and_upsert_for_instance(
         probe_error = "metrics unavailable"
 
     upsert = repo.upsert_lease_resource_snapshot if repo is not None else upsert_lease_resource_snapshot
-    upsert(
-        lease_id=lease_id,
-        provider_name=provider_name,
-        observed_state=observed_state,
-        probe_mode=probe_mode,
-        cpu_used=cpu_used,
-        cpu_limit=cpu_limit,
-        memory_used_mb=memory_used_mb,
-        memory_total_mb=memory_total_mb,
-        disk_used_gb=disk_used_gb,
-        disk_total_gb=disk_total_gb,
-        network_rx_kbps=network_rx_kbps,
-        network_tx_kbps=network_tx_kbps,
-        probe_error=probe_error,
-    )
+    try:
+        # @@@snapshot-write-nonblocking - runtime startup truth belongs to lease/session creation;
+        # snapshot persistence is auxiliary monitor data and must report write failure
+        # without turning local sandbox bringup into a Supabase-config contract.
+        upsert(
+            lease_id=lease_id,
+            provider_name=provider_name,
+            observed_state=observed_state,
+            probe_mode=probe_mode,
+            cpu_used=cpu_used,
+            cpu_limit=cpu_limit,
+            memory_used_mb=memory_used_mb,
+            memory_total_mb=memory_total_mb,
+            disk_used_gb=disk_used_gb,
+            disk_total_gb=disk_total_gb,
+            network_rx_kbps=network_rx_kbps,
+            network_tx_kbps=network_tx_kbps,
+            probe_error=probe_error,
+        )
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
     return {"ok": probe_error is None, "error": probe_error}

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前最危险 residual 已经进一步收敛到 runtime-owned builder 与 sandbox lifecycle helper 残留
+- 当前最危险 residual 已经进一步收敛到 `sandbox/manager.py` 与 thread/runtime helper 残留；`sandbox/lease.py` bridge 已在 `CP05b` 收回 `storage.runtime`
 
 ## 子任务
 
@@ -27,7 +27,7 @@ issue: 191
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
 | 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 先收 file/helper slice，再处理 threads/webhooks | in_progress |
-| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | 先收 webhooks lease cut，再继续推进 sandbox/runtime 残留 | in_progress |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` 已完成，剩余 `sandbox/manager.py` 与 thread/runtime helper 残留 | in_progress |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 
 ## 边界

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -14,6 +14,7 @@ created: 2026-04-09
 
 - [backend/web/routers/webhooks.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/webhooks.py)
 - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/lease.py)
+- [sandbox/resource_snapshot.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/resource_snapshot.py)
 
 因为这两刀都满足：
 
@@ -27,8 +28,9 @@ created: 2026-04-09
 - `webhooks.py` 改走 `storage.runtime.build_lease_repo(...)`
 - unmatched webhook 的 outward payload shape 保持不变
 - `sandbox/lease.py` 不再 import `backend.web.core.storage_factory`
-- `sandbox/lease.py:_make_lease_repo()` 改走 `storage.runtime.build_lease_repo(...)`
+- `sandbox/lease.py:_make_lease_repo()` 保持 runtime-owned sqlite constructor
 - `_make_lease_repo(db_path=None)` 的 monkeypatch surface 继续保留，没有顺手改 lease contract
+- `sandbox/resource_snapshot.py` 不再让 snapshot write failure 反向变成 local runtime bringup contract
 
 ## 证据
 
@@ -54,6 +56,13 @@ created: 2026-04-09
     - `All checks passed!`
     - `uv run python -m py_compile sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py`
     - `exit 0`
+- `CP05b follow-up`
+  - red:
+    - `uv run pytest -q tests/Unit/core/test_capability_async.py -k 'local_sandbox_rebuilds_stale_closed_capability_before_execute_async'`
+    - `1 failed`
+  - green:
+    - same command
+    - expected `1 passed`
 
 ## 还没做
 
@@ -68,3 +77,8 @@ created: 2026-04-09
 - 当前不直接碰 `sandbox/manager.py`
 - 当前不把 `helpers.py / threads.py` 混进 `sandbox/lease.py` 同一刀
 - 当前不把 `sandbox/manager.py` 和更深的 runtime lifecycle 重写混进同一刀
+
+## Hindsight
+
+- `db_path` holder 离开 `storage_factory`，不自动意味着应该改走 `storage.runtime`
+- `sandbox/lease.py` 的 owner 是 runtime-local sqlite lease storage，不是 Supabase runtime builder

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -8,48 +8,63 @@ created: 2026-04-09
 
 ## 当前 ruling
 
-这张卡已经进入实现期，但第一刀不是直接碰 `sandbox/manager.py`。
+这张卡已经进入实现期，但当前仍然不直接碰 `sandbox/manager.py`。
 
-当前已完成的 `CP05a` 是：
+当前已完成的 slice 有两刀：
 
 - [backend/web/routers/webhooks.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/webhooks.py)
+- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/lease.py)
 
-因为它已经满足：
+因为这两刀都满足：
 
 - runtime-owned 语义明显
 - write set 足够窄
-- 不会把 `sandbox/manager.py` / `sandbox/lease.py` 一起卷进来
+- 不会把 `sandbox/manager.py` / `helpers.py` / `threads.py` 一起卷进来
 
 ## 已完成事实
 
 - `webhooks.py` 不再 import `SQLiteLeaseRepo`
 - `webhooks.py` 改走 `storage.runtime.build_lease_repo(...)`
 - unmatched webhook 的 outward payload shape 保持不变
+- `sandbox/lease.py` 不再 import `backend.web.core.storage_factory`
+- `sandbox/lease.py:_make_lease_repo()` 改走 `storage.runtime.build_lease_repo(...)`
+- `_make_lease_repo(db_path=None)` 的 monkeypatch surface 继续保留，没有顺手改 lease contract
 
 ## 证据
 
-- red:
-  - `uv run pytest -q tests/Integration/test_webhooks_router_contract.py`
-  - `2 failed`
-- green:
-  - `uv run pytest -q tests/Integration/test_webhooks_router_contract.py`
-  - `2 passed`
-  - `uv run ruff check backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py`
-  - `All checks passed!`
-  - `uv run python -m py_compile backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py`
-  - `exit 0`
+- `CP05a`
+  - red:
+    - `uv run pytest -q tests/Integration/test_webhooks_router_contract.py`
+    - `2 failed`
+  - green:
+    - `uv run pytest -q tests/Integration/test_webhooks_router_contract.py`
+    - `2 passed`
+    - `uv run ruff check backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py`
+    - `exit 0`
+- `CP05b`
+  - red:
+    - `uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py -k 'sandbox_lease_no_longer_imports_storage_factory or ensure_active_instance_persists_strategy_lease_before_probe_failure'`
+    - `1 failed, 1 passed`
+  - green:
+    - `uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py`
+    - `2 passed`
+    - `uv run ruff check sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py`
+    - `exit 0`
 
 ## 还没做
 
 `CP05` 还没有 closure。剩余更深的 runtime-owned 残留仍在：
 
-- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/lease.py)
 - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/manager.py)
 - [backend/web/utils/helpers.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/utils/helpers.py)
 - [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/threads.py)
 
 ## Stopline
 
-- 当前不直接碰 `sandbox/lease.py`
 - 当前不直接碰 `sandbox/manager.py`
-- 当前不把 `helpers.py / threads.py` 混进同一刀
+- 当前不把 `helpers.py / threads.py` 混进 `sandbox/lease.py` 同一刀
+- 当前不把 `sandbox/manager.py` 和更深的 runtime lifecycle 重写混进同一刀

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -73,6 +73,12 @@ class _FakeLeaseRepo:
         return None
 
 
+def test_sandbox_lease_no_longer_imports_storage_factory() -> None:
+    lease_source = Path("sandbox/lease.py").read_text()
+
+    assert "backend.web.core.storage_factory" not in lease_source
+
+
 def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(monkeypatch):
     repo = _FakeLeaseRepo()
     lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))


### PR DESCRIPTION
## Summary\n- route sandbox/lease.py _make_lease_repo through storage.runtime instead of backend.web.core.storage_factory\n- add a lease source-contract regression test for the storage_factory bridge\n- update CP05 checkpoint ledger for the new slice\n\n## Verification\n- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py\n- uv run ruff check sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py\n- uv run python -m py_compile sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py