### PR TITLE
refactor: route thread sandbox bootstrap through runtime

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -491,10 +491,11 @@ def _create_thread_sandbox_resources(
     from datetime import datetime
 
     from backend.web.core.config import SANDBOX_VOLUME_ROOT
-    from backend.web.core.storage_factory import make_lease_repo, make_terminal_repo
     from backend.web.utils.helpers import _get_container
     from sandbox.volume_source import HostVolume
     from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+    from storage.runtime import build_lease_repo as make_lease_repo
+    from storage.runtime import build_terminal_repo as make_terminal_repo
 
     sandbox_db = resolve_role_db_path(SQLiteDBRole.SANDBOX)
     now_str = datetime.now().isoformat()

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前最危险 residual 已经进一步收敛到 `sandbox/manager.py` 与 thread/runtime helper 残留；`sandbox/lease.py` bridge 已在 `CP05b` 收回 `storage.runtime`
+- 当前最危险 residual 已经进一步收敛到 `sandbox/manager.py` 与 `backend/web/utils/helpers.py`；`sandbox/lease.py` bridge 与 `threads.py` bootstrap seam 已在 `CP05b/CP05c` 收回 `storage.runtime`
 
 ## 子任务
 
@@ -27,7 +27,7 @@ issue: 191
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
 | 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 先收 file/helper slice，再处理 threads/webhooks | in_progress |
-| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` 已完成，剩余 `sandbox/manager.py` 与 thread/runtime helper 残留 | in_progress |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` 已完成，剩余 `sandbox/manager.py` 与 `helpers.py` 残留 | in_progress |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 
 ## 边界

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
@@ -15,8 +15,8 @@ created: 2026-04-09
   - [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/backend/web/services/file_channel_service.py)
 - 剩余 residual
   - `backend/web/utils/helpers.py`
-  - `backend/web/routers/threads.py`
-  - `backend/web/routers/webhooks.py`
+
+`threads.py / webhooks.py` 这两块已经被重分流到 `CP05`，因为它们更像 runtime-owned lease/terminal seam，而不是普通 web helper seam。
 
 ## 已完成事实
 
@@ -46,16 +46,17 @@ created: 2026-04-09
 
 ## 还没做
 
-这张卡还没有 closure。剩余更像下一刀的是：
+这张卡还没有 closure。当前只剩一个 residual：
 
 - `helpers.py` 的 runtime/db-path helper seam
-- `threads.py` / `webhooks.py` 的 lease/terminal helper seam
 
 ## Stopline
 
 - 当前不碰 `backend/web/utils/helpers.py`
-- 当前不碰 `backend/web/routers/threads.py`
-- 当前不碰 `backend/web/routers/webhooks.py`
-- hindsight:
-  - `no longer imports storage_factory` 不等于 `应该改走 storage.runtime`
-  - 如果代码本身就是 `sandbox.db` / `db_path` lookup owner，最小而诚实的落点仍然可能是本地 sqlite constructor
+- 当前不把 `helpers.py` 和 `sandbox/manager.py` 混成一刀
+- 当前不把已经转入 `CP05` 的 `threads.py / webhooks.py` 再拉回这张卡
+
+### Hindsight
+
+- `no longer imports storage_factory` 不等于 `应该改走 storage.runtime`
+- 如果代码本身就是 `sandbox.db` / `db_path` lookup owner，最小而诚实的落点仍然可能是本地 sqlite constructor

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -10,13 +10,14 @@ created: 2026-04-09
 
 这张卡已经进入实现期，但当前仍然不直接碰 `sandbox/manager.py`。
 
-当前已完成的 slice 有两刀：
+当前已完成的 slice 有四刀：
 
 - [backend/web/routers/webhooks.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/webhooks.py)
 - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/lease.py)
 - [sandbox/resource_snapshot.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/resource_snapshot.py)
+- [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-thread-sandbox-cut/backend/web/routers/threads.py)
 
-因为这两刀都满足：
+因为这些切口都满足：
 
 - runtime-owned 语义明显
 - write set 足够窄
@@ -31,6 +32,9 @@ created: 2026-04-09
 - `sandbox/lease.py:_make_lease_repo()` 保持 runtime-owned sqlite constructor
 - `_make_lease_repo(db_path=None)` 的 monkeypatch surface 继续保留，没有顺手改 lease contract
 - `sandbox/resource_snapshot.py` 不再让 snapshot write failure 反向变成 local runtime bringup contract
+- `threads.py:_create_thread_sandbox_resources()` 不再 import `backend.web.core.storage_factory`
+- `threads.py` 的 lease / terminal row bootstrap 改走 `storage.runtime.build_lease_repo(...)` 与 `build_terminal_repo(...)`
+- thread sandbox bootstrap 的 outward behavior 保持不变，local cwd contract 继续由现有 route test 固定
 
 ## 证据
 
@@ -62,7 +66,18 @@ created: 2026-04-09
     - `1 failed`
   - green:
     - same command
-    - expected `1 passed`
+    - `1 passed`
+- `CP05c`
+  - red:
+    - `uv run pytest -q tests/Integration/test_threads_router.py -k 'threads_router_sandbox_bootstrap_no_longer_imports_storage_factory or create_thread_route_passes_local_cwd_into_sandbox_bootstrap'`
+    - `1 failed, 1 passed`
+  - green:
+    - `uv run pytest -q tests/Integration/test_threads_router.py -k 'threads_router_sandbox_bootstrap_no_longer_imports_storage_factory or create_thread_route_passes_local_cwd_into_sandbox_bootstrap'`
+    - `2 passed, 25 deselected`
+    - `uv run ruff check backend/web/routers/threads.py tests/Integration/test_threads_router.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile backend/web/routers/threads.py tests/Integration/test_threads_router.py`
+    - `exit 0`
 
 ## 还没做
 
@@ -70,12 +85,11 @@ created: 2026-04-09
 
 - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/manager.py)
 - [backend/web/utils/helpers.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/utils/helpers.py)
-- [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/threads.py)
 
 ## Stopline
 
 - 当前不直接碰 `sandbox/manager.py`
-- 当前不把 `helpers.py / threads.py` 混进 `sandbox/lease.py` 同一刀
+- 当前不把 `helpers.py` 混进 `threads.py / sandbox/lease.py` 同一刀
 - 当前不把 `sandbox/manager.py` 和更深的 runtime lifecycle 重写混进同一刀
 
 ## Hindsight

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -121,7 +121,7 @@ def _require_app_state(loop: QueryLoop) -> AppState:
 
 
 def test_threads_router_sandbox_bootstrap_no_longer_imports_storage_factory() -> None:
-    threads_source = Path("backend/web/routers/threads.py").read_text()
+    threads_source = Path("backend/web/routers/threads.py").read_text(encoding="utf-8")
 
     assert "from backend.web.core.storage_factory import make_lease_repo, make_terminal_repo" not in threads_source
 

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -120,6 +120,12 @@ def _require_app_state(loop: QueryLoop) -> AppState:
     return app_state
 
 
+def test_threads_router_sandbox_bootstrap_no_longer_imports_storage_factory() -> None:
+    threads_source = Path("backend/web/routers/threads.py").read_text()
+
+    assert "from backend.web.core.storage_factory import make_lease_repo, make_terminal_repo" not in threads_source
+
+
 def _require_await_kwargs(mock: AsyncMock) -> dict[str, Any]:
     await_args = mock.await_args
     assert await_args is not None


### PR DESCRIPTION
## Summary
- route backend/web/routers/threads.py sandbox bootstrap lease and terminal repos through storage.runtime
- add a source-contract regression test for the storage_factory bridge in threads router
- update CP04/CP05 checkpoint ledger to reflect the threads slice reclassification and completion

## Verification
- uv run pytest -q tests/Integration/test_threads_router.py -k 'threads_router_sandbox_bootstrap_no_longer_imports_storage_factory or create_thread_route_passes_local_cwd_into_sandbox_bootstrap'
- uv run ruff check backend/web/routers/threads.py tests/Integration/test_threads_router.py
- uv run python -m py_compile backend/web/routers/threads.py tests/Integration/test_threads_router.py