### PR TITLE
refactor: route web helpers through runtime

### DIFF
--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -5,11 +5,13 @@ from typing import Any
 
 from fastapi import HTTPException
 
-from backend.web.core.storage_factory import make_chat_session_repo, make_lease_repo, make_terminal_repo
 from sandbox.sync.state import SyncState
 from storage.container import StorageContainer
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+from storage.runtime import build_chat_session_repo as make_chat_session_repo
+from storage.runtime import build_lease_repo as make_lease_repo
 from storage.runtime import build_storage_container, build_thread_repo
+from storage.runtime import build_terminal_repo as make_terminal_repo
 
 SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
 

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前最危险 residual 已经进一步收敛到 `sandbox/manager.py` 与 `backend/web/utils/helpers.py`；`sandbox/lease.py` bridge 与 `threads.py` bootstrap seam 已在 `CP05b/CP05c` 收回 `storage.runtime`
+- 当前最危险 residual 已经进一步收敛到 `sandbox/manager.py`；`helpers.py` 已在 `CP04b` closure，`sandbox/lease.py` bridge 与 `threads.py` bootstrap seam 已在 `CP05b/CP05c` 收回 `storage.runtime`
 
 ## 子任务
 
@@ -26,8 +26,8 @@ issue: 191
 | 01 | [Web Service Injection Cut](subtask-01-web-service-injection-cut.md) | 先收 `task_service / cron_job_service` | done |
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
-| 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | 先收 file/helper slice，再处理 threads/webhooks | in_progress |
-| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` 已完成，剩余 `sandbox/manager.py` 与 `helpers.py` 残留 | in_progress |
+| 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | `CP04a file/helper` + `CP04b helpers` 已完成，threads/webhooks 已转入 `CP05` | done |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` 已完成，剩余 `sandbox/manager.py` | in_progress |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 
 ## 边界

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-04-web-thread-file-helper-cut.md
@@ -1,6 +1,6 @@
 ---
 title: Web Thread/File Helper Cut
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -8,13 +8,13 @@ created: 2026-04-09
 
 ## 当前 ruling
 
-这张卡现在已经拆成两层：
+这张卡已经完成 closure，实际是两刀：
 
 - `CP04a file/helper slice`
   - [backend/web/services/activity_tracker.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/backend/web/services/activity_tracker.py)
   - [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-file-helper-cut/backend/web/services/file_channel_service.py)
-- 剩余 residual
-  - `backend/web/utils/helpers.py`
+- `CP04b helpers slice`
+  - [backend/web/utils/helpers.py](/Users/lexicalmathical/worktrees/leonai--storage-helpers-cut/backend/web/utils/helpers.py)
 
 `threads.py / webhooks.py` 这两块已经被重分流到 `CP05`，因为它们更像 runtime-owned lease/terminal seam，而不是普通 web helper seam。
 
@@ -29,32 +29,42 @@ created: 2026-04-09
 - 所以 `file_channel_service.py` 现在显式持有本地 sqlite `lease/terminal` constructor，而不是误接到 Supabase-only runtime builder
 - module-local `make_lease_repo / make_terminal_repo` 名字仍保留
 
+`CP04b` 已落地：
+
+- `helpers.py` 不再 import `backend.web.core.storage_factory`
+- `helpers.py` 改走 `storage.runtime.build_chat_session_repo(...)` / `build_lease_repo(...)` / `build_terminal_repo(...)`
+- `SANDBOX_DB_PATH`、timestamp helper、thread purge helper 的现有行为保持不变
+
 ## 证据
 
-- red:
-  - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py -k 'file_channel_and_activity_tracker_no_longer_import_storage_factory'`
-  - `1 failed, 5 deselected`
-- green:
-  - `uv run pytest -q tests/Unit/core/test_agent_pool.py -k 'creates_once_per_thread or ignores_unavailable_local_cwd or honors_fresh_local_thread_cwd_even_when_missing or prefers_repo_backed_runtime_startup_even_with_conflicting_legacy_member_shell or uses_thread_user_id_for_chat_identity'`
-  - `5 passed, 2 deselected`
-  - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py`
-  - `6 passed`
-  - `uv run ruff check backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py tests/Unit/core/test_agent_pool.py`
-  - `All checks passed!`
-  - `uv run python -m py_compile backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py tests/Unit/core/test_agent_pool.py`
-  - `exit 0`
-
-## 还没做
-
-这张卡还没有 closure。当前只剩一个 residual：
-
-- `helpers.py` 的 runtime/db-path helper seam
+- `CP04a`
+  - red:
+    - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py -k 'file_channel_and_activity_tracker_no_longer_import_storage_factory'`
+    - `1 failed, 5 deselected`
+  - green:
+    - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py`
+    - `6 passed`
+    - `uv run ruff check storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile storage/runtime.py backend/web/services/activity_tracker.py backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+    - `exit 0`
+- `CP04b`
+  - red:
+    - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py -k 'helpers_no_longer_import_storage_factory or file_channel_and_activity_tracker_no_longer_import_storage_factory'`
+    - `1 failed, 1 passed`
+  - green:
+    - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py`
+    - `7 passed`
+    - `uv run ruff check backend/web/utils/helpers.py tests/Integration/test_thread_files_channel_shell.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile backend/web/utils/helpers.py tests/Integration/test_thread_files_channel_shell.py`
+    - `exit 0`
 
 ## Stopline
 
-- 当前不碰 `backend/web/utils/helpers.py`
-- 当前不把 `helpers.py` 和 `sandbox/manager.py` 混成一刀
-- 当前不把已经转入 `CP05` 的 `threads.py / webhooks.py` 再拉回这张卡
+- `CP04` 到这里已经 closure
+- 已经转入 `CP05` 的 `threads.py / webhooks.py` 不再回拉
+- 当前不把 `helpers.py` closure 假装成 `sandbox/manager.py` 的默认下一刀
 
 ### Hindsight
 

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -17,7 +17,8 @@ created: 2026-04-09
 - [sandbox/resource_snapshot.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/resource_snapshot.py)
 - [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-thread-sandbox-cut/backend/web/routers/threads.py)
 
-因为这些切口都满足：
+<<<<<<< HEAD
+因为这几刀都满足：
 
 - runtime-owned 语义明显
 - write set 足够窄
@@ -81,15 +82,14 @@ created: 2026-04-09
 
 ## 还没做
 
-`CP05` 还没有 closure。剩余更深的 runtime-owned 残留仍在：
+`CP05` 还没有 closure。剩余更深的 runtime-owned 残留现在只剩：
 
 - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/manager.py)
-- [backend/web/utils/helpers.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/utils/helpers.py)
 
 ## Stopline
 
 - 当前不直接碰 `sandbox/manager.py`
-- 当前不把 `helpers.py` 混进 `threads.py / sandbox/lease.py` 同一刀
+- 当前不把 `sandbox/manager.py` 和已完成的 `webhooks / sandbox/lease / threads` 三刀重新混成一锅
 - 当前不把 `sandbox/manager.py` 和更深的 runtime lifecycle 重写混进同一刀
 
 ## Hindsight

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -22,6 +22,20 @@ def test_file_channel_and_activity_tracker_no_longer_import_storage_factory() ->
     assert "SQLiteLeaseRepo" in file_channel_source
 
 
+def test_helpers_no_longer_import_storage_factory() -> None:
+    helpers_source = Path("backend/web/utils/helpers.py").read_text(encoding="utf-8")
+
+    assert "backend.web.core.storage_factory" not in helpers_source
+    assert "storage.runtime" in helpers_source
+
+
+def test_helpers_no_longer_import_storage_factory() -> None:
+    helpers_source = Path("backend/web/utils/helpers.py").read_text()
+
+    assert "backend.web.core.storage_factory" not in helpers_source
+    assert "storage.runtime" in helpers_source
+
+
 @pytest.mark.asyncio
 async def test_call_channel_file_service_maps_value_error_to_400():
     def fake_method(*_args: object, **_kwargs: object):

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -29,13 +29,6 @@ def test_helpers_no_longer_import_storage_factory() -> None:
     assert "storage.runtime" in helpers_source
 
 
-def test_helpers_no_longer_import_storage_factory() -> None:
-    helpers_source = Path("backend/web/utils/helpers.py").read_text()
-
-    assert "backend.web.core.storage_factory" not in helpers_source
-    assert "storage.runtime" in helpers_source
-
-
 @pytest.mark.asyncio
 async def test_call_channel_file_service_maps_value_error_to_400():
     def fake_method(*_args: object, **_kwargs: object):


### PR DESCRIPTION
## Summary
- route backend/web/utils/helpers.py lease, terminal, and chat-session repos through storage.runtime
- add a source-contract regression test for the storage_factory bridge in helpers.py
- close CP04 and update the #191 checkpoint ledger to reflect the remaining sandbox/manager stopline

## Verification
- uv run pytest -q tests/Integration/test_thread_files_channel_shell.py
- uv run ruff check backend/web/utils/helpers.py tests/Integration/test_thread_files_channel_shell.py
- uv run python -m py_compile backend/web/utils/helpers.py tests/Integration/test_thread_files_channel_shell.py