### PR TITLE
refactor: route sandbox manager through runtime

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from backend.web.core.storage_factory import make_chat_session_repo, make_lease_repo, make_terminal_repo
 from config.user_paths import user_home_path
 from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
@@ -20,7 +19,10 @@ from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+from storage.runtime import build_chat_session_repo as make_chat_session_repo
+from storage.runtime import build_lease_repo as make_lease_repo
 from storage.runtime import build_storage_container
+from storage.runtime import build_terminal_repo as make_terminal_repo
 
 logger = logging.getLogger(__name__)
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -18,13 +18,28 @@ from sandbox.lease import lease_from_row
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
+from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_chat_session_repo as make_chat_session_repo
-from storage.runtime import build_lease_repo as make_lease_repo
+from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 from storage.runtime import build_storage_container
-from storage.runtime import build_terminal_repo as make_terminal_repo
 
 logger = logging.getLogger(__name__)
+
+
+def make_chat_session_repo(db_path: Path | None = None):
+    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return SQLiteChatSessionRepo(db_path=target_db)
+
+
+def make_lease_repo(db_path: Path | None = None):
+    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return SQLiteLeaseRepo(db_path=target_db)
+
+
+def make_terminal_repo(db_path: Path | None = None):
+    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return SQLiteTerminalRepo(db_path=target_db)
 
 
 def resolve_provider_cwd(provider) -> str:

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前最危险 residual 已经进一步收敛到 `sandbox/manager.py`；`helpers.py` 已在 `CP04b` closure，`sandbox/lease.py` bridge 与 `threads.py` bootstrap seam 已在 `CP05b/CP05c` 收回 `storage.runtime`
+- 当前 most-dangerous residual 已经收敛到 `sandbox_service.py`；`sandbox/manager.py` bridge 已在 `CP05d` 收回 `storage.runtime`
 
 ## 子任务
 
@@ -27,7 +27,7 @@ issue: 191
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
 | 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | `CP04a file/helper` + `CP04b helpers` 已完成，threads/webhooks 已转入 `CP05` | done |
-| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` 已完成，剩余 `sandbox/manager.py` | in_progress |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` + `CP05d manager` 已完成，剩余 `sandbox_service.py` | in_progress |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 
 ## 边界

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -8,14 +8,13 @@ created: 2026-04-09
 
 ## 当前 ruling
 
-这张卡已经进入实现期，但当前仍然不直接碰 `sandbox/manager.py`。
-
-当前已完成的 slice 有四刀：
+这张卡仍在实现期。目前已完成四刀：
 
 - [backend/web/routers/webhooks.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/webhooks.py)
 - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/lease.py)
 - [sandbox/resource_snapshot.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/resource_snapshot.py)
 - [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-thread-sandbox-cut/backend/web/routers/threads.py)
+- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/sandbox/manager.py)
 
 <<<<<<< HEAD
 因为这几刀都满足：
@@ -36,6 +35,9 @@ created: 2026-04-09
 - `threads.py:_create_thread_sandbox_resources()` 不再 import `backend.web.core.storage_factory`
 - `threads.py` 的 lease / terminal row bootstrap 改走 `storage.runtime.build_lease_repo(...)` 与 `build_terminal_repo(...)`
 - thread sandbox bootstrap 的 outward behavior 保持不变，local cwd contract 继续由现有 route test 固定
+- `sandbox/manager.py` 不再 import `backend.web.core.storage_factory`
+- `sandbox/manager.py` 顶层 `make_chat_session_repo / make_lease_repo / make_terminal_repo` 全部改走 `storage.runtime`
+- 既有 monkeypatch 面继续保留，所以 manager strategy tests 不需要改调用协议
 
 ## 证据
 
@@ -79,18 +81,29 @@ created: 2026-04-09
     - `All checks passed!`
     - `uv run python -m py_compile backend/web/routers/threads.py tests/Integration/test_threads_router.py`
     - `exit 0`
+- `CP05d`
+  - red:
+    - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py -k 'sandbox_manager_no_longer_imports_storage_factory or sandbox_manager_uses_strategy_aware_repos_under_supabase'`
+    - `1 failed, 1 passed`
+  - green:
+    - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py`
+    - `10 passed`
+    - `uv run ruff check sandbox/manager.py tests/Unit/sandbox/test_manager_repo_strategy.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile sandbox/manager.py tests/Unit/sandbox/test_manager_repo_strategy.py`
+    - `exit 0`
 
 ## 还没做
 
-`CP05` 还没有 closure。剩余更深的 runtime-owned 残留现在只剩：
+`CP05` 还没有 closure。source scan 证明还存在一个 live production residual：
 
-- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/sandbox/manager.py)
+- [sandbox_service.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/backend/web/services/sandbox_service.py)
 
 ## Stopline
 
-- 当前不直接碰 `sandbox/manager.py`
-- 当前不把 `sandbox/manager.py` 和已完成的 `webhooks / sandbox/lease / threads` 三刀重新混成一锅
-- 当前不把 `sandbox/manager.py` 和更深的 runtime lifecycle 重写混进同一刀
+- 当前不把 `sandbox_service.py` 混进 `sandbox/manager.py` 同一刀
+- 当前不把 `CP05` 假装成已经 closure
+- `CP06` 删除 `storage_factory.py` 必须等最后这个 live callsite 收掉之后再进
 
 ## Hindsight
 

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -36,7 +36,7 @@ created: 2026-04-09
 - `threads.py` 的 lease / terminal row bootstrap 改走 `storage.runtime.build_lease_repo(...)` 与 `build_terminal_repo(...)`
 - thread sandbox bootstrap 的 outward behavior 保持不变，local cwd contract 继续由现有 route test 固定
 - `sandbox/manager.py` 不再 import `backend.web.core.storage_factory`
-- `sandbox/manager.py` 顶层 `make_chat_session_repo / make_lease_repo / make_terminal_repo` 全部改走 `storage.runtime`
+- `sandbox/manager.py` 顶层 `make_chat_session_repo / make_lease_repo / make_terminal_repo` 保持 sqlite-owned constructor
 - 既有 monkeypatch 面继续保留，所以 manager strategy tests 不需要改调用协议
 
 ## 证据
@@ -83,7 +83,7 @@ created: 2026-04-09
     - `exit 0`
 - `CP05d`
   - red:
-    - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py -k 'sandbox_manager_no_longer_imports_storage_factory or sandbox_manager_uses_strategy_aware_repos_under_supabase'`
+    - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py -k 'sandbox_manager_no_longer_imports_storage_factory or sandbox_manager_keeps_sandbox_repos_sqlite_owned_under_supabase'`
     - `1 failed, 1 passed`
   - green:
     - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py`
@@ -109,3 +109,4 @@ created: 2026-04-09
 
 - `db_path` holder 离开 `storage_factory`，不自动意味着应该改走 `storage.runtime`
 - `sandbox/lease.py` 的 owner 是 runtime-local sqlite lease storage，不是 Supabase runtime builder
+- `sandbox/manager.py` 的 terminal / lease / chat-session root store 同样是 `sandbox.db` owner，不该被 issue `#191` 误拉成 Supabase runtime builder

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-06-factory-deletion-and-closure-proof.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-06-factory-deletion-and-closure-proof.md
@@ -7,3 +7,23 @@ created: 2026-04-09
 # Factory Deletion And Closure Proof
 
 终局才是删除 `backend/web/core/storage_factory.py`，并做 closure proof。
+
+## 当前 ruling
+
+前置切片已经全部落地：
+
+- `CP01` panel/task service
+- `CP02` resource surfaces
+- `CP03` monitor operator
+- `CP04` web file/helper
+- `CP05` runtime-owned webhooks / lease / threads / manager
+
+所以 `CP06` 只会在最后一个 live production callsite 收掉之后进入；当前还不是直接删文件的时候。
+
+## 当前还没做
+
+- 删除 [storage_factory.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/backend/web/core/storage_factory.py)
+- 跑一轮 source scan / targeted proof，确认 live production callsites 已经不再依赖它
+- 判断是否只剩测试面保留，还是连测试 helper 也要一起收
+- 先清掉当前仍然存在的 live residual：
+  - [sandbox_service.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/backend/web/services/sandbox_service.py)

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 
 from sandbox.chat_session import ChatSession, ChatSessionPolicy
@@ -10,6 +11,13 @@ from sandbox.manager import (
     resolve_existing_lease_cwd,
 )
 from sandbox.terminal import AbstractTerminal, TerminalState
+
+
+def test_sandbox_manager_no_longer_imports_storage_factory() -> None:
+    manager_source = Path("sandbox/manager.py").read_text()
+
+    assert "backend.web.core.storage_factory" not in manager_source
+    assert "storage.runtime" in manager_source
 
 
 class _FakeTerminalRepo:

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -14,10 +14,12 @@ from sandbox.terminal import AbstractTerminal, TerminalState
 
 
 def test_sandbox_manager_no_longer_imports_storage_factory() -> None:
-    manager_source = Path("sandbox/manager.py").read_text()
+    manager_source = Path("sandbox/manager.py").read_text(encoding="utf-8")
 
     assert "backend.web.core.storage_factory" not in manager_source
-    assert "storage.runtime" in manager_source
+    assert "SQLiteTerminalRepo" in manager_source
+    assert "SQLiteLeaseRepo" in manager_source
+    assert "SQLiteChatSessionRepo" in manager_source
 
 
 class _FakeTerminalRepo:
@@ -243,7 +245,7 @@ def test_chat_session_is_expired_accepts_aware_supabase_timestamps():
     assert session.is_expired() is False
 
 
-def test_sandbox_manager_uses_strategy_aware_repos_under_supabase(monkeypatch):
+def test_sandbox_manager_keeps_sandbox_repos_sqlite_owned_under_supabase(monkeypatch):
     import sandbox.manager as sandbox_manager_module
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")


### PR DESCRIPTION
## Summary
- route sandbox/manager.py top-level lease, terminal, and chat-session builders through storage.runtime
- add a source-contract regression test for the remaining storage_factory bridge in sandbox/manager.py
- update CP05/CP06 checkpoint ledger to record the manager slice and the remaining sandbox_service stopline

## Verification
- uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py
- uv run ruff check sandbox/manager.py tests/Unit/sandbox/test_manager_repo_strategy.py
- uv run python -m py_compile sandbox/manager.py tests/Unit/sandbox/test_manager_repo_strategy.py