### PR TITLE
refactor: route sandbox service through runtime

### DIFF
--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 from backend.web.core.config import LOCAL_WORKSPACE_ROOT, SANDBOXES_DIR
-from backend.web.core.storage_factory import make_sandbox_monitor_repo
 from backend.web.utils.helpers import is_virtual_thread_id
 from backend.web.utils.serializers import avatar_url
 from sandbox.config import SandboxConfig
@@ -18,6 +17,7 @@ from sandbox.provider import ProviderCapability
 from sandbox.recipes import default_recipe_id, list_builtin_recipes, normalize_recipe_snapshot, provider_type_from_name
 from storage.models import map_lease_to_session_status
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 logger = logging.getLogger(__name__)
 

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -16,7 +16,7 @@ issue: 191
 - `storage_factory.py` 仍是 live production bridge
 - `CP01` 已完成：`task_service / cron_job_service` 默认路径已离开 `storage_factory.py`
 - `CP02` 已完成：`resource_service / resource_projection_service` 已离开 `storage_factory.py`
-- 当前 most-dangerous residual 已经收敛到 `sandbox_service.py`；`sandbox/manager.py` bridge 已在 `CP05d` 收回 `storage.runtime`
+- 当前 live production callsites 已全部离开 `storage_factory.py`；下一步只剩 `CP06` 删除文件并完成 closure proof
 
 ## 子任务
 
@@ -27,7 +27,7 @@ issue: 191
 | 02 | [Resource Surfaces Cut](subtask-02-resource-surfaces-cut.md) | 再收 `resource_service / resource_projection_service` | done |
 | 03 | [Monitor Operator Cut](subtask-03-monitor-operator-cut.md) | 单独收 `monitor_service` split-brain seam | done |
 | 04 | [Web Thread/File Helper Cut](subtask-04-web-thread-file-helper-cut.md) | `CP04a file/helper` + `CP04b helpers` 已完成，threads/webhooks 已转入 `CP05` | done |
-| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` + `CP05d manager` 已完成，剩余 `sandbox_service.py` | in_progress |
+| 05 | [Sandbox Runtime Owner Cut](subtask-05-sandbox-runtime-owner-cut.md) | `CP05a webhooks` + `CP05b sandbox/lease` + `CP05c threads bootstrap` + `CP05d manager` + `CP05e sandbox_service` 已完成 | done |
 | 06 | [Factory Deletion And Closure Proof](subtask-06-factory-deletion-and-closure-proof.md) | 删除 `storage_factory.py` 并做 closure proof | open |
 
 ## 边界

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-05-sandbox-runtime-owner-cut.md
@@ -1,6 +1,6 @@
 ---
 title: Sandbox Runtime Owner Cut
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -8,15 +8,15 @@ created: 2026-04-09
 
 ## 当前 ruling
 
-这张卡仍在实现期。目前已完成四刀：
+这张卡已经 closure。最终是五刀：
 
 - [backend/web/routers/webhooks.py](/Users/lexicalmathical/worktrees/leonai--storage-webhooks-lease-cut/backend/web/routers/webhooks.py)
 - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/lease.py)
 - [sandbox/resource_snapshot.py](/Users/lexicalmathical/worktrees/leonai--storage-lease-owner-cut/sandbox/resource_snapshot.py)
 - [backend/web/routers/threads.py](/Users/lexicalmathical/worktrees/leonai--storage-thread-sandbox-cut/backend/web/routers/threads.py)
 - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/sandbox/manager.py)
-
-<<<<<<< HEAD
+- [backend/web/services/sandbox_service.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-service-cut/backend/web/services/sandbox_service.py)
+ 
 因为这几刀都满足：
 
 - runtime-owned 语义明显
@@ -38,6 +38,9 @@ created: 2026-04-09
 - `sandbox/manager.py` 不再 import `backend.web.core.storage_factory`
 - `sandbox/manager.py` 顶层 `make_chat_session_repo / make_lease_repo / make_terminal_repo` 保持 sqlite-owned constructor
 - 既有 monkeypatch 面继续保留，所以 manager strategy tests 不需要改调用协议
+- `sandbox_service.py` 不再 import `backend.web.core.storage_factory`
+- `sandbox_service.py` 的 monitor repo builder 改走 `storage.runtime.build_sandbox_monitor_repo(...)`
+- user-facing lease list behavior 不变，现有 `sandbox_user_leases` 与 provider availability 测试继续成立
 
 ## 证据
 
@@ -92,18 +95,22 @@ created: 2026-04-09
     - `All checks passed!`
     - `uv run python -m py_compile sandbox/manager.py tests/Unit/sandbox/test_manager_repo_strategy.py`
     - `exit 0`
-
-## 还没做
-
-`CP05` 还没有 closure。source scan 证明还存在一个 live production residual：
-
-- [sandbox_service.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/backend/web/services/sandbox_service.py)
+- `CP05e`
+  - red:
+    - `uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py -k 'sandbox_service_no_longer_imports_storage_factory or list_user_leases_hides_subagent_threads_and_deduplicates_visible_agents'`
+    - `1 failed, 1 passed`
+  - green:
+    - `uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py`
+    - `8 passed`
+    - `uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py`
+    - `All checks passed!`
+    - `uv run python -m py_compile backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py`
+    - `exit 0`
 
 ## Stopline
 
-- 当前不把 `sandbox_service.py` 混进 `sandbox/manager.py` 同一刀
-- 当前不把 `CP05` 假装成已经 closure
-- `CP06` 删除 `storage_factory.py` 必须等最后这个 live callsite 收掉之后再进
+- `CP05` 到这里已经 closure
+- 下一步进入 `CP06`，处理 `storage_factory.py` 删除和 closure proof
 
 ## Hindsight
 

--- a/teams/tasks/storage-repo-abstraction-unification/subtask-06-factory-deletion-and-closure-proof.md
+++ b/teams/tasks/storage-repo-abstraction-unification/subtask-06-factory-deletion-and-closure-proof.md
@@ -18,12 +18,11 @@ created: 2026-04-09
 - `CP04` web file/helper
 - `CP05` runtime-owned webhooks / lease / threads / manager
 
-所以 `CP06` 只会在最后一个 live production callsite 收掉之后进入；当前还不是直接删文件的时候。
+所以 `CP06` 现在已经成为当前主线：production callsites 已经清空，可以开始删除文件和迁移测试面。
 
 ## 当前还没做
 
 - 删除 [storage_factory.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/backend/web/core/storage_factory.py)
 - 跑一轮 source scan / targeted proof，确认 live production callsites 已经不再依赖它
 - 判断是否只剩测试面保留，还是连测试 helper 也要一起收
-- 先清掉当前仍然存在的 live residual：
-  - [sandbox_service.py](/Users/lexicalmathical/worktrees/leonai--storage-sandbox-manager-cut/backend/web/services/sandbox_service.py)
+- 迁移或删除仍直接依赖 `storage_factory.py` 的测试面

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -1,6 +1,14 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 from backend.web.services import sandbox_service
+
+
+def test_sandbox_service_no_longer_imports_storage_factory() -> None:
+    service_source = Path("backend/web/services/sandbox_service.py").read_text()
+
+    assert "backend.web.core.storage_factory" not in service_source
+    assert "storage.runtime" in service_source
 
 
 class _FakeMonitorRepo:


### PR DESCRIPTION
## Summary
- route backend/web/services/sandbox_service.py monitor repo builder through storage.runtime
- add a source-contract regression test for the remaining storage_factory bridge in sandbox_service.py
- close CP05 and advance CP06 to file-deletion and closure-proof mode

## Verification
- uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py
- uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py
- uv run python -m py_compile backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py