### PR TITLE
docs: split issue 191 closure from supabase parity

### DIFF
--- a/teams/_index.md
+++ b/teams/_index.md
@@ -2,5 +2,7 @@
 
 - `storage-repo-abstraction-unification`
   - `teams/tasks/storage-repo-abstraction-unification/_index.md`
+- `supabase-first-runtime-parity`
+  - `teams/tasks/supabase-first-runtime-parity/_index.md`
 - `runtime-web-subagent-shutdown-ownership`
   - `teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md`

--- a/teams/tasks/storage-repo-abstraction-unification/_index.md
+++ b/teams/tasks/storage-repo-abstraction-unification/_index.md
@@ -2,7 +2,7 @@
 title: Storage Repo Abstraction Unification
 owner: fjj
 priority: P1
-status: open
+status: done
 created: 2026-04-09
 issue: 191
 ---
@@ -19,6 +19,8 @@ issue: 191
 - 这条任务的 closure 只证明 issue `#191` 这簇 bypass path 已回到正式 composition root
 - 它不自动证明整个 sandbox/control-plane 已达到“无需 SQLite 也能独立跑”的最终架构
 - `sandbox/lease.py` / `sandbox/manager.py` 这类 `db_path` caller 在本轮里只是为了删桥做最小收口；是否继续推进到完整 strategy/container 语义，不在 `#191` 的 closure 里宣称完成
+- `#373` 已 merged：
+  - merge commit: `48e44b22aea32570749c9715b20e9b78e4c72d60`
 
 ## 子任务
 
@@ -39,3 +41,9 @@ issue: 191
 - 不顺手改 monitor/resource payload 语义
 - 不把 sandbox/control-plane stopgap 写成 `#191` 的最终架构胜利
 - 每一刀只搬一小簇 callsite，然后回到真实 proof
+
+## Checkpoint hindsight
+
+- `删桥` 和 `全域 provider parity` 不是同一条任务
+- `#191` 的诚实 closure 是：issue 点名的 bypass repos 重新回到正式 composition root
+- 如果目标升级成“系统可在 `LEON_STORAGE_STRATEGY=supabase` 下独立运行、默认即 Supabase”，那必须单独立新 lane，不能在 `#191` 的 closure 里偷换完成

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -50,7 +50,7 @@ created: 2026-04-09
 | # | 子任务 | 说明 | 状态 |
 |---|--------|------|------|
 | 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
-| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | open |
+| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | in_progress |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | open |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -2,7 +2,7 @@
 title: Supabase-First Runtime Parity
 owner: fjj
 priority: P1
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
@@ -41,12 +41,15 @@ created: 2026-04-09
 - 这条 lane 不是 `#191` 的继续加码，而是 `#191` 之后的新主任务
 - 第一阶段不急着写实现，先把“哪些路径仍然 SQLite-only、哪些只是临时 stopgap、哪些已经 strategy-aware”分层盘清
 - 只有在分层完成后，才开最小 implementation slices
+- 第一轮 inventory 已经确认：
+  - `backend/web/core/lifespan.py` 本身已经是 Supabase-first composition root
+  - 当前主要残余集中在 file channel、sandbox control-plane、session/checkpoint side-store、queue/summary middleware
 
 ## 子任务
 
 | # | 子任务 | 说明 | 状态 |
 |---|--------|------|------|
-| 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | open |
+| 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
 | 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | open |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | open |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -1,0 +1,73 @@
+---
+title: Supabase-First Runtime Parity
+owner: fjj
+priority: P1
+status: open
+created: 2026-04-09
+---
+
+# Supabase-First Runtime Parity
+
+目标：把当前仍然直接依赖 SQLite、或只在 SQLite 语义下成立的运行路径，继续推进到 `LEON_STORAGE_STRATEGY=supabase` 可独立运行的状态，并把默认运行面收成 Supabase-first，而不是继续让系统名义上支持多数据库、实际上某些关键路径仍然隐含依赖 SQLite。
+
+## 背景
+
+`#191` 已完成的是抽象层 closure：
+
+- `storage_factory.py` 已删除
+- issue 点名的 bypass repos 已回到正式 composition root
+
+但这不等于系统已经达到下一层目标：
+
+- `LEON_STORAGE_STRATEGY=supabase` 下无需 SQLite 也能独立运行
+- 默认配置就是 Supabase
+- storage abstraction 不再被局部 SQLite 直连打穿
+
+当前 `origin/dev` 仍然能看到一批 SQLite 直接依赖或 SQLite-only 语义：
+
+- [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/services/file_channel_service.py)
+- [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
+- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
+- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
+
+用户已明确重新钉死最终 invariant：
+
+- 系统最终必须可以只靠 Supabase 跑起来
+- 默认配置应该就是 Supabase
+- 同时保留多数据库抽象
+
+## 当前 ruling
+
+- 这条 lane 不是 `#191` 的继续加码，而是 `#191` 之后的新主任务
+- 第一阶段不急着写实现，先把“哪些路径仍然 SQLite-only、哪些只是临时 stopgap、哪些已经 strategy-aware”分层盘清
+- 只有在分层完成后，才开最小 implementation slices
+
+## 子任务
+
+| # | 子任务 | 说明 | 状态 |
+|---|--------|------|------|
+| 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | open |
+| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | open |
+| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | open |
+| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |
+| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
+| 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
+
+## 边界
+
+- 不把这条 lane 伪装成 `#191` 的自然尾巴
+- 不靠“保留 SQLite stopgap”来假装 provider parity
+- 不一上来重写整个 sandbox/runtime 架构
+- 每一刀都要显式区分：
+  - 真实产品验证
+  - 机制层验证
+  - 源码/测试层辅助证据
+
+## Stopline
+
+这条任务 closure 的标准是：
+
+1. `LEON_STORAGE_STRATEGY=supabase` 下关键运行路径可独立成立
+2. 默认本地/开发主线配置是 Supabase-first
+3. SQLite 不再是某些关键路径的隐含必需品
+4. 多数据库抽象仍保留，不把业务层写死成 Supabase-only

--- a/teams/tasks/supabase-first-runtime-parity/subtask-00-current-state-inventory.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-00-current-state-inventory.md
@@ -1,0 +1,21 @@
+---
+title: Current State Inventory
+status: open
+created: 2026-04-09
+---
+
+# Current State Inventory
+
+目标：固化 current `dev` 下所有仍依赖 SQLite、或仅在 SQLite 语义下成立的 runtime/service/control-plane 路径，避免后续“凭印象推进”。
+
+## 关注点
+
+- 直接 import `storage.providers.sqlite.*` 的 production path
+- 依赖 `sandbox.db` / `db_path` 的 caller
+- `LEON_STORAGE_STRATEGY=supabase` 下仍会退化到 SQLite 的路径
+- 默认配置仍非 Supabase-first 的入口
+
+## Stopline
+
+- 给出按 owner/seam 分层的残余清单
+- 明确哪些是 service surface，哪些是 sandbox control-plane，哪些是 boot/default contract

--- a/teams/tasks/supabase-first-runtime-parity/subtask-00-current-state-inventory.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-00-current-state-inventory.md
@@ -1,6 +1,6 @@
 ---
 title: Current State Inventory
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
@@ -14,6 +14,70 @@ created: 2026-04-09
 - 依赖 `sandbox.db` / `db_path` 的 caller
 - `LEON_STORAGE_STRATEGY=supabase` 下仍会退化到 SQLite 的路径
 - 默认配置仍非 Supabase-first 的入口
+
+## 第一轮 inventory 结论
+
+### 已经对齐到 Supabase-first 的部分
+
+- [backend/web/core/lifespan.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/core/lifespan.py)
+  - 当前 authoritative web composition root 已经直接创建 Supabase client
+  - 再通过 [storage/container.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/container.py) 注入：
+    - `user_repo`
+    - `thread_repo`
+    - `lease_repo`
+    - `terminal_repo`
+    - `chat_session_repo`
+    - `sandbox_volume_repo`
+    - `panel_task_repo`
+    - `cron_job_repo`
+- 这说明“默认 composition root 应该是 Supabase-first”已经有真实骨架，不是从零开始
+
+### 当前最明显的 SQLite-only 残余
+
+#### 1. File channel / volume lookup
+
+- [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/services/file_channel_service.py)
+  - 直接 import:
+    - `SQLiteLeaseRepo`
+    - `SQLiteTerminalRepo`
+  - 通过 `SANDBOX_DB_PATH` 读取 thread -> terminal -> lease -> volume_id 链
+
+#### 2. Sandbox control-plane
+
+- [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
+  - 直接 new:
+    - `SQLiteChatSessionRepo`
+    - `SQLiteTerminalRepo`
+    - `SQLiteLeaseRepo`
+- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
+  - `_make_lease_repo()` 直接返回 `SQLiteLeaseRepo`
+- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
+  - 顶层 `make_chat_session_repo / make_lease_repo / make_terminal_repo` 都直接返回 SQLite repo
+
+#### 3. Session/checkpoint side-store
+
+- [storage/session_manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/session_manager.py)
+  - 仍直接依赖：
+    - `SQLiteCheckpointRepo`
+    - `SQLiteFileOperationRepo`
+
+#### 4. Runtime middleware side stores
+
+- [core/runtime/middleware/queue/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/queue/manager.py)
+  - 仍直接 new `SQLiteQueueRepo`
+- [core/runtime/middleware/memory/summary_store.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/memory/summary_store.py)
+  - 仍直接 new `SQLiteSummaryRepo`
+
+### 当前 ruling
+
+- `#191` 已完成的是“抽象层/旧桥 closure”
+- 新 lane 的核心不是再删桥，而是把这些仍然 SQLite-only 的运行路径继续推到 provider-parity
+- 第一刀不该先碰整个 sandbox 架构
+- 最自然的切分是：
+  1. `service surface`
+  2. `control-plane`
+  3. `side-store / middleware`
+  4. `default Supabase boot contract`
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -1,12 +1,55 @@
 ---
 title: Supabase Boot Contract
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Supabase Boot Contract
 
 目标：定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需的最小 contract，不再把 SQLite 当成隐含前提。
+
+## 第一轮事实
+
+### 已经存在的 Supabase-first 启动骨架
+
+- [backend/web/core/lifespan.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/core/lifespan.py)
+  - 启动前先强制检查：
+    - `LEON_POSTGRES_URL`
+  - 再直接创建：
+    - `create_supabase_client()`
+    - `create_public_supabase_client()`
+  - 然后用 [storage/container.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/container.py) 把 repo 注入到 `app.state`
+- [backend/web/core/supabase_factory.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/core/supabase_factory.py)
+  - 当前明确要求：
+    - `SUPABASE_INTERNAL_URL` 或 `SUPABASE_PUBLIC_URL`
+    - `LEON_SUPABASE_SERVICE_ROLE_KEY`
+    - `SUPABASE_ANON_KEY`
+    - `SUPABASE_AUTH_URL`（可选，未给则回退到 Supabase URL）
+- [storage/container.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/container.py)
+  - 当前已经是 `Supabase-only` composition root
+  - 不再做 sqlite/supabase 二选一
+
+### 当前 boot contract 仍未完全闭环的原因
+
+- 虽然 web composition root 已是 Supabase-first，但系统里仍有一批 side-store / control-plane caller 会把运行面重新拖回 SQLite：
+  - [storage/session_manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/session_manager.py)
+  - [core/runtime/middleware/queue/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/queue/manager.py)
+  - [core/runtime/middleware/memory/summary_store.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/memory/summary_store.py)
+  - [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
+  - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
+  - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
+
+### 当前 ruling
+
+- `Supabase Boot Contract` 不是“设计上应该用 Supabase”这种泛话
+- 它必须最后落成 caller-proven truth：
+  - 在 `LEON_STORAGE_STRATEGY=supabase` 下，系统能独立 bringup
+  - 若失败，要明确失败属于：
+    - code/contract
+    - auth/bootstrap
+    - postgres/checkpointer
+    - provider/runtime
+- 在这之前，不应该把任何 SQLite stopgap 误写成“启动本来就该依赖 SQLite”
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -1,0 +1,18 @@
+---
+title: Supabase Boot Contract
+status: open
+created: 2026-04-09
+---
+
+# Supabase Boot Contract
+
+目标：定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需的最小 contract，不再把 SQLite 当成隐含前提。
+
+## Stopline
+
+- 明确启动所需 env / repo / runtime 前提
+- caller-proven 区分：
+  - code/contract blocker
+  - auth/bootstrap blocker
+  - postgres/checkpointer blocker
+  - provider/runtime blocker

--- a/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
@@ -1,0 +1,14 @@
+---
+title: Service Surface Parity
+status: open
+created: 2026-04-09
+---
+
+# Service Surface Parity
+
+目标：收 web/service 层仍然 SQLite-only 的路径，让 service surface 在 `LEON_STORAGE_STRATEGY=supabase` 下不再隐含依赖 SQLite。
+
+## Stopline
+
+- service layer 不再通过 SQLite stopgap 维持运行
+- 变更按小簇切，不把 sandbox/control-plane 混进同一刀

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -1,0 +1,14 @@
+---
+title: Sandbox Control Plane Parity
+status: open
+created: 2026-04-09
+---
+
+# Sandbox Control Plane Parity
+
+目标：处理 sandbox lease / terminal / chat-session / manager 等 control-plane caller 的 provider parity，避免它们继续成为 SQLite-only 岛。
+
+## Stopline
+
+- 不把 stopgap 描述成终局
+- 每一刀都先回答 owner boundary，再做实现

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -1,0 +1,14 @@
+---
+title: Default Supabase Cut
+status: open
+created: 2026-04-09
+---
+
+# Default Supabase Cut
+
+目标：把默认本地/开发主线配置收成 Supabase-first，而不是继续默认落在 SQLite 假设上。
+
+## Stopline
+
+- 默认 bringup/documented contract 明确是 Supabase
+- SQLite 仍可作为一种 strategy，但不是默认路径

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -1,0 +1,19 @@
+---
+title: Closure Proof
+status: open
+created: 2026-04-09
+---
+
+# Closure Proof
+
+目标：用真实证据证明系统在 Supabase 下可独立运行，SQLite 不再是关键路径的隐含前提。
+
+## 证据要求
+
+- 真实产品验证
+- 机制层验证
+- 源码/测试层辅助证据
+
+## Stopline
+
+- 不用“理论上可切换”代替 caller-proven truth


### PR DESCRIPTION
## Summary
- mark storage repo abstraction unification as done after #373 merged
- clarify that #191 closure is bridge/composition-root cleanup, not full supabase-only parity
- add a new supabase-first runtime parity task card with initial checkpoints

## Testing
- not run (docs only)
