### PR TITLE
refactor: route web storage through runtime entry

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -44,11 +44,14 @@ async def lifespan(app: FastAPI):
 
     # ---- Member-Chat repos + services ----
     from backend.web.core.supabase_factory import create_public_supabase_client, create_supabase_auth_client, create_supabase_client
-    from storage.container import StorageContainer
+    from storage.runtime import build_storage_container
 
     _supabase_client = create_supabase_client()
     _public_supabase_client = create_public_supabase_client()
-    storage_container = StorageContainer(supabase_client=_supabase_client, public_supabase_client=_public_supabase_client)
+    storage_container = build_storage_container(
+        supabase_client=_supabase_client,
+        public_supabase_client=_public_supabase_client,
+    )
     app.state.user_repo = storage_container.user_repo()
     app.state.thread_repo = storage_container.thread_repo()
     app.state.lease_repo = storage_container.lease_repo()

--- a/teams/doc/core/2026-04-09-supabase-first-runtime-parity-plan.md
+++ b/teams/doc/core/2026-04-09-supabase-first-runtime-parity-plan.md
@@ -1,0 +1,147 @@
+# Supabase-First Runtime Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Supabase-first runtime path explicit and authoritative before continuing provider-parity cuts.
+
+**Architecture:** Current `origin/dev` already has two layers: a Supabase-only `StorageContainer` and a `storage.runtime.build_storage_container(...)` entry point. The first implementation slice should not invent a third abstraction. It should make `storage.runtime` the single runtime entry and route the web composition root through it, while preserving current repo wiring and public-client islands.
+
+**Tech Stack:** Python, FastAPI lifespan wiring, Supabase repo providers, pytest
+
+---
+
+### Task 1: Checkpoint + Plan Alignment
+
+**Files:**
+- Modify: `teams/tasks/supabase-first-runtime-parity/_index.md`
+- Modify: `teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md`
+- Create: `teams/doc/core/2026-04-09-supabase-first-runtime-parity-plan.md`
+
+- [ ] **Step 1: Record the current first-slice ruling**
+
+Add a short ruling that the first implementation slice is `strategy entry alignment`, not full provider parity.
+
+- [ ] **Step 2: Carry forward the boot-contract evidence**
+
+Copy the caller-proven Supabase boot findings into `subtask-01-supabase-boot-contract.md` so the implementation branch carries the latest evidence.
+
+- [ ] **Step 3: Save this plan**
+
+Keep the plan in `teams/doc/core/2026-04-09-supabase-first-runtime-parity-plan.md`.
+
+### Task 2: Write the Failing Tests for Runtime Entry Alignment
+
+**Files:**
+- Modify: `tests/Unit/storage/test_runtime_builder_contract.py`
+- Modify: `tests/Integration/test_storage_repo_abstraction_unification.py`
+
+- [ ] **Step 1: Add a unit test for public-client passthrough on `build_storage_container(...)`**
+
+Add a test that calls:
+
+```python
+container = storage_runtime.build_storage_container(
+    supabase_client=runtime_client,
+    public_supabase_client=public_client,
+)
+repo = container.panel_task_repo()
+```
+
+and asserts the repo is built from `public_client`, not `runtime_client`.
+
+- [ ] **Step 2: Add an integration test that `lifespan` uses `storage.runtime.build_storage_container`**
+
+Monkeypatch:
+
+```python
+monkeypatch.setattr("storage.runtime.build_storage_container", _fake_build_storage_container)
+```
+
+then assert `lifespan` wires `app.state.user_repo`, `thread_repo`, `lease_repo`, `panel_task_repo`, etc. from the returned container.
+
+- [ ] **Step 3: Run the targeted tests to verify red/green behavior**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py -k 'build_storage_container or lifespan_wires_user_and_thread_repos_from_storage_runtime_container'
+```
+
+Expected:
+- initially fails until implementation is updated
+- then passes after the minimal change
+
+### Task 3: Minimal Implementation
+
+**Files:**
+- Modify: `backend/web/core/lifespan.py`
+- Modify: `storage/runtime.py`
+
+- [ ] **Step 1: Route `lifespan` through the runtime entry**
+
+Replace direct `StorageContainer(...)` construction in `lifespan.py` with:
+
+```python
+from storage.runtime import build_storage_container
+
+storage_container = build_storage_container(
+    supabase_client=_supabase_client,
+    public_supabase_client=_public_supabase_client,
+)
+```
+
+- [ ] **Step 2: Keep runtime entry explicit about both clients**
+
+Ensure `storage.runtime.build_storage_container(...)` remains the single authoritative runtime constructor and passes both:
+
+```python
+StorageContainer(
+    supabase_client=client,
+    public_supabase_client=public_client,
+)
+```
+
+- [ ] **Step 3: Do not widen provider parity in this slice**
+
+Leave SQLite residual callers alone in this task:
+- `backend/web/services/file_channel_service.py`
+- `sandbox/chat_session.py`
+- `sandbox/lease.py`
+- `sandbox/manager.py`
+- `core/runtime/middleware/queue/manager.py`
+- `core/runtime/middleware/memory/summary_store.py`
+
+### Task 4: Verification
+
+**Files:**
+- No additional file changes required
+
+- [ ] **Step 1: Run focused unit/integration tests**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py
+```
+
+Expected:
+- all selected tests pass
+
+- [ ] **Step 2: Run lint + py_compile on touched files**
+
+Run:
+
+```bash
+uv run ruff check storage/runtime.py backend/web/core/lifespan.py tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py
+uv run python -m py_compile storage/runtime.py backend/web/core/lifespan.py tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py
+```
+
+Expected:
+- `All checks passed!`
+- `exit 0`
+
+- [ ] **Step 3: Record the next slice**
+
+Update the task ledger with the result of this cut and nominate the next bounded move:
+- either `service surface parity`
+- or a narrower `runtime-side-store alignment` cut if the test evidence points there

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -59,7 +59,7 @@ created: 2026-04-09
 | # | 子任务 | 说明 | 状态 |
 |---|--------|------|------|
 | 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
-| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | in_progress |
+| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | done |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | open |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
@@ -86,8 +86,7 @@ created: 2026-04-09
 
 ## Default Next Move
 
-- `CP01b Postgres Checkpointer Contract Narrowing`
-  - 继续 caller-proven `Supabase Boot Contract`
-  - 找到 canonical `LEON_POSTGRES_URL` 来源
-  - 在提供该 contract 后重跑 latest `dev` backend bringup
-  - 只回答“下一个真实 blocker 是什么”，不提前扩到 service/control-plane parity
+- `CP02 Service Surface Parity`
+  - 先处理 web/service 层仍然 SQLite-only 的最窄 caller
+  - 优先从 `backend/web/services/file_channel_service.py` 起刀
+  - 目标是把 service surface 的 SQLite 直连继续收回正式 storage strategy 链

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -44,6 +44,15 @@ created: 2026-04-09
 - 第一轮 inventory 已经确认：
   - `backend/web/core/lifespan.py` 本身已经是 Supabase-first composition root
   - 当前主要残余集中在 file channel、sandbox control-plane、session/checkpoint side-store、queue/summary middleware
+- 第一刀 implementation slice 已收窄为：
+  - 不扩 provider parity write set
+  - 先把已有 `storage.runtime.build_storage_container(...)` 提升成 authoritative runtime entry
+  - 再让 `backend/web/core/lifespan.py` 改为只经由 runtime entry 取 container
+  - 目的不是新功能，而是先把 `StorageContainer` 与 `storage.runtime` 的语义对齐
+- 当前这刀已完成：
+  - `backend/web/core/lifespan.py` 已改为只经由 `storage.runtime.build_storage_container(...)` 获取 runtime container
+  - 对应 unit/integration contract tests 已补齐并通过
+  - SQLite residual 仍保持原边界，未在本刀扩写
 
 ## 子任务
 
@@ -74,3 +83,11 @@ created: 2026-04-09
 2. 默认本地/开发主线配置是 Supabase-first
 3. SQLite 不再是某些关键路径的隐含必需品
 4. 多数据库抽象仍保留，不把业务层写死成 Supabase-only
+
+## Default Next Move
+
+- `CP01b Postgres Checkpointer Contract Narrowing`
+  - 继续 caller-proven `Supabase Boot Contract`
+  - 找到 canonical `LEON_POSTGRES_URL` 来源
+  - 在提供该 contract 后重跑 latest `dev` backend bringup
+  - 只回答“下一个真实 blocker 是什么”，不提前扩到 service/control-plane parity

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -1,6 +1,6 @@
 ---
 title: Supabase Boot Contract
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -149,6 +149,81 @@ current classification:
   - 提供 canonical `LEON_POSTGRES_URL`
   - 然后重跑 latest `dev` backend bringup
 
+## 第二轮 caller-proven 证据
+
+### 真实产品验证
+
+- local `ops/tunnel.sh` 当前只开：
+  - `54320 -> Kong`
+  - `54321 -> GoTrue`
+- 不开 Postgres，所以 `LEON_POSTGRES_URL` 的 local contract 还缺显式接入路径
+
+为避免和现有 tunnel 冲突，补了一条临时 SSH tunnel：
+
+- `127.0.0.1:15432 -> remote:5432`
+
+first probe:
+
+- DSN:
+  - `postgresql://postgres:<password>@127.0.0.1:15432/postgres`
+- result:
+  - `psycopg.OperationalError: FATAL: Tenant or user not found`
+
+second probe:
+
+- DSN:
+  - `postgresql://postgres.51440a93464db390:<password>@127.0.0.1:15432/postgres?sslmode=disable`
+- result:
+  - `SELECT 1 -> (1,)`
+
+latest `dev` backend bringup with:
+
+- `LEON_BACKEND_PORT=18080`
+- `LEON_POSTGRES_URL=postgresql://postgres.51440a93464db390:<password>@127.0.0.1:15432/postgres?sslmode=disable`
+- same Supabase auth/storage envs as first probe
+
+observed result:
+
+- `Started server process`
+- `Waiting for application startup.`
+- `Application startup complete.`
+
+so `postgres/checkpointer blocker` is no longer the first hard blocker once the DSN shape is correct.
+
+### 机制层验证
+
+- remote `/opt/supabase/repo/docker/.env` exposes:
+  - `POSTGRES_PASSWORD=...`
+  - `POSTGRES_DB=postgres`
+  - `POSTGRES_HOST=db`
+  - `POOLER_TENANT_ID=51440a93464db390`
+- `supabase-pooler` runtime env also confirms:
+  - `POSTGRES_PORT=5432`
+  - `POOLER_TENANT_ID=51440a93464db390`
+
+pooler log during the failed plain-username probe showed:
+
+- `Either external_id or sni_hostname must be provided`
+- `User not found: {:single, "postgres", nil}`
+
+which is consistent with the successful tenant-qualified username probe.
+
+### 当前 ruling（再次更新）
+
+- canonical local `LEON_POSTGRES_URL` contract is not “just any postgres DSN”
+- it must include:
+  - the local Postgres tunnel
+  - the Supavisor tenant-qualified username
+  - `sslmode=disable` for the localhost SSH-tunnel path
+
+current next blocker classification after Postgres is fixed:
+
+- no longer `postgres/checkpointer blocker`
+- next visible failures are `provider/runtime blocker`
+  - missing `e2b`
+  - missing `daytona_sdk`
+  - missing `agentbay`
+
 ## Stopline
 
 - 明确启动所需 env / repo / runtime 前提
@@ -157,3 +232,13 @@ current classification:
   - auth/bootstrap blocker
   - postgres/checkpointer blocker
   - provider/runtime blocker
+
+## Closure
+
+- `CP01` 已 caller-proven 收口：
+  - correct Supabase auth/storage envs 已确认
+  - canonical local `LEON_POSTGRES_URL` 形状已确认
+  - latest `dev` web runtime 已在 Supabase contract 下完成 startup
+- 当前剩余问题不再属于 boot contract 本身，而是：
+  - provider/runtime dependency availability
+  - service/control-plane/middleware parity

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -36,8 +36,67 @@ created: 2026-04-09
   - [core/runtime/middleware/queue/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/queue/manager.py)
   - [core/runtime/middleware/memory/summary_store.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/memory/summary_store.py)
   - [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
-  - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
-  - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
+- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
+- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
+
+## 第一轮 caller-proven 证据
+
+### 真实产品验证
+
+- authoritative base:
+  - `origin/dev = 48e44b22aea32570749c9715b20e9b78e4c72d60`
+- local tunnel truth:
+  - `127.0.0.1:54320 -> 401 Unauthorized`
+  - `127.0.0.1:54321/health -> 200`
+- local backend port:
+  - `8010` was free before probe
+
+probe shape:
+
+- started latest `dev` backend with:
+  - `LEON_STORAGE_STRATEGY=supabase`
+  - `LEON_DB_SCHEMA=staging`
+  - `SUPABASE_PUBLIC_URL=http://127.0.0.1:54320`
+  - `SUPABASE_AUTH_URL=http://127.0.0.1:54321`
+  - `SUPABASE_ANON_KEY=<mapped from remote .env ANON_KEY>`
+  - `SUPABASE_JWT_SECRET=<mapped from remote .env JWT_SECRET>`
+  - `LEON_SUPABASE_SERVICE_ROLE_KEY=<mapped from remote .env SERVICE_ROLE_KEY>`
+- intentionally did **not** provide `LEON_POSTGRES_URL`
+
+observed result:
+
+- uvicorn boot reaches:
+  - `Started server process`
+  - `Waiting for application startup.`
+- then fail-loud exits with:
+  - `RuntimeError: LEON_POSTGRES_URL is required for backend web runtime`
+
+current classification:
+
+- this first hard blocker is `postgres/checkpointer blocker`
+- not `SQLite blocker`
+- not `Supabase auth blocker`
+
+### 机制层验证
+
+- remote Supabase `.env` currently uses names:
+  - `ANON_KEY`
+  - `SERVICE_ROLE_KEY`
+  - `JWT_SECRET`
+- local backend code expects:
+  - `SUPABASE_ANON_KEY`
+  - `LEON_SUPABASE_SERVICE_ROLE_KEY`
+  - `SUPABASE_JWT_SECRET`
+- so current boot contract must explicitly include env-name mapping; otherwise an operator can have healthy remote Supabase secrets and still fail local bringup
+
+### 当前 ruling（更新）
+
+- latest `dev` already proves one important thing:
+  - web startup is fail-loud about missing Postgres checkpointer contract before any late request-time ambiguity
+- so the next narrowing question for `CP01` is no longer “does Supabase runtime basically boot?”
+- it is:
+  - where should `LEON_POSTGRES_URL` come from in the canonical local contract
+  - and after supplying it, what is the next real blocker, if any
 
 ### 当前 ruling
 
@@ -50,6 +109,45 @@ created: 2026-04-09
     - postgres/checkpointer
     - provider/runtime
 - 在这之前，不应该把任何 SQLite stopgap 误写成“启动本来就该依赖 SQLite”
+
+## 当前实现切口
+
+- `CP01` 的第一刀实现不是直接追所有 SQLite residual
+- 先修正当前 runtime entry 语义：
+  - `storage.runtime.build_storage_container(...)` 已存在
+  - `backend/web/core/lifespan.py` 仍直接 new `StorageContainer`
+- 所以第一刀要先让 web composition root 只走 runtime entry
+- 这样后续再推进 service/control-plane/middleware parity 时，正式入口才是单一的
+
+## 第一刀实现结果
+
+### 源码/测试层辅助证据
+
+- [backend/web/core/lifespan.py](/Users/lexicalmathical/worktrees/leonai--supabase-strategy-entry-alignment/backend/web/core/lifespan.py)
+  - 已不再直接 new `StorageContainer`
+  - 改为经由 `storage.runtime.build_storage_container(...)` 获取 runtime container
+- [tests/Unit/storage/test_runtime_builder_contract.py](/Users/lexicalmathical/worktrees/leonai--supabase-strategy-entry-alignment/tests/Unit/storage/test_runtime_builder_contract.py)
+  - 新增 `build_storage_container(...)` 保留显式 `public_supabase_client` 的 contract
+- [tests/Integration/test_storage_repo_abstraction_unification.py](/Users/lexicalmathical/worktrees/leonai--supabase-strategy-entry-alignment/tests/Integration/test_storage_repo_abstraction_unification.py)
+  - `lifespan` wiring test 已更新为 authoritative runtime entry path
+
+### 机制层验证
+
+- `uv run pytest -q tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py`
+  - `21 passed`
+- `uv run ruff check backend/web/core/lifespan.py storage/runtime.py tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py`
+  - `All checks passed!`
+- `uv run python -m py_compile backend/web/core/lifespan.py storage/runtime.py tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py`
+  - `exit 0`
+
+### 当前 ruling（再次更新）
+
+- 当前第一刀已经完成它该完成的事：
+  - web composition root 的 runtime container 入口已经单一化
+- 这不等于 Supabase parity 已完成
+- 下一合法动作仍然是回到 `CP01` 的 boot contract narrowing：
+  - 提供 canonical `LEON_POSTGRES_URL`
+  - 然后重跑 latest `dev` backend bringup
 
 ## Stopline
 

--- a/tests/Integration/test_storage_repo_abstraction_unification.py
+++ b/tests/Integration/test_storage_repo_abstraction_unification.py
@@ -367,13 +367,13 @@ def test_storage_container_routes_agent_registry_repo_through_public_client(monk
 
 
 @pytest.mark.asyncio
-async def test_lifespan_wires_user_and_thread_repos_from_storage_container(
+async def test_lifespan_wires_user_and_thread_repos_from_storage_runtime_container(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     container = _FakeContainer()
     app = FastAPI()
     _install_lifespan_noop_dependencies(monkeypatch)
-    monkeypatch.setattr("storage.container.StorageContainer", lambda **_: container)
+    monkeypatch.setattr("storage.runtime.build_storage_container", lambda **_: container)
 
     async with lifespan_module.lifespan(app):
         assert app.state.user_repo is container.user_repo_value
@@ -383,6 +383,7 @@ async def test_lifespan_wires_user_and_thread_repos_from_storage_container(
         assert app.state.chat_session_repo is container.chat_session_repo_value
         assert app.state.sandbox_volume_repo is container.sandbox_volume_repo_value
         assert app.state.panel_task_repo is container.panel_task_repo_value
+        assert app.state._storage_container is container
         assert not hasattr(app.state, "member_repo")
 
 

--- a/tests/Unit/storage/test_runtime_builder_contract.py
+++ b/tests/Unit/storage/test_runtime_builder_contract.py
@@ -74,3 +74,31 @@ def test_build_panel_task_repo_uses_public_supabase_factory(monkeypatch: pytest.
         assert isinstance(repo, SupabasePanelTaskRepo)
     finally:
         repo.close()
+
+
+def test_build_storage_container_preserves_explicit_public_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakePanelTaskRepo:
+        def __init__(self, client: object) -> None:
+            captured["client"] = client
+
+        def close(self) -> None:
+            return None
+
+    runtime_client = _build_fake_supabase_client()
+    public_client = _build_fake_supabase_client()
+    monkeypatch.setattr(
+        "storage.providers.supabase.panel_task_repo.SupabasePanelTaskRepo",
+        _FakePanelTaskRepo,
+    )
+
+    repo = storage_runtime.build_storage_container(
+        supabase_client=runtime_client,
+        public_supabase_client=public_client,
+    ).panel_task_repo()
+    try:
+        assert isinstance(repo, _FakePanelTaskRepo)
+        assert captured["client"] is public_client
+    finally:
+        repo.close()


### PR DESCRIPTION
## Summary\n- route backend web lifespan through storage.runtime.build_storage_container\n- add runtime-entry contract coverage for public client passthrough and lifespan wiring\n- record the supabase-first runtime parity plan and CP01 evidence in teams\n\n## Testing\n- uv run pytest -q tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py\n- uv run ruff check backend/web/core/lifespan.py storage/runtime.py tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py\n- uv run python -m py_compile backend/web/core/lifespan.py storage/runtime.py tests/Unit/storage/test_runtime_builder_contract.py tests/Integration/test_storage_repo_abstraction_unification.py