### PR TITLE
refactor: route file channel repos through runtime

### DIFF
--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -11,20 +11,10 @@ import json
 import logging
 
 from backend.web.utils.helpers import _get_container
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
-from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
+from storage.runtime import build_lease_repo as make_lease_repo
+from storage.runtime import build_terminal_repo as make_terminal_repo
 
 logger = logging.getLogger(__name__)
-SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
-
-
-def make_terminal_repo():
-    return SQLiteTerminalRepo(db_path=SANDBOX_DB_PATH)
-
-
-def make_lease_repo():
-    return SQLiteLeaseRepo(db_path=SANDBOX_DB_PATH)
 
 
 def _resolve_volume_source(thread_id: str):

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -60,7 +60,7 @@ created: 2026-04-09
 |---|--------|------|------|
 | 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
 | 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | done |
-| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | open |
+| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | in_progress |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
 | 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
@@ -87,6 +87,5 @@ created: 2026-04-09
 ## Default Next Move
 
 - `CP02 Service Surface Parity`
-  - 先处理 web/service 层仍然 SQLite-only 的最窄 caller
-  - 优先从 `backend/web/services/file_channel_service.py` 起刀
-  - 目标是把 service surface 的 SQLite 直连继续收回正式 storage strategy 链
+  - `file_channel_service.py` 这一刀已完成：service surface 不再直连 `SQLiteLeaseRepo` / `SQLiteTerminalRepo`
+  - 下一步继续盘 service surface residual，再决定是继续切 web/service caller，还是转入 `CP03 Sandbox Control Plane Parity`

--- a/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
@@ -1,12 +1,35 @@
 ---
 title: Service Surface Parity
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Service Surface Parity
 
 目标：收 web/service 层仍然 SQLite-only 的路径，让 service surface 在 `LEON_STORAGE_STRATEGY=supabase` 下不再隐含依赖 SQLite。
+
+## Current Slice
+
+- `backend/web/services/file_channel_service.py`
+  - 不再直接 import `SQLiteLeaseRepo` / `SQLiteTerminalRepo`
+  - 改为通过 `storage.runtime.build_lease_repo(...)` / `build_terminal_repo(...)` 取 repo
+  - `_resolve_volume_source(...)` 的 lease -> terminal -> sandbox volume 逻辑保持不变
+
+## Evidence
+
+- `机制层验证`
+  - `uv run pytest -q tests/Integration/test_thread_files_channel_shell.py`
+    - `7 passed`
+- `源码/测试层辅助证据`
+  - `uv run ruff check backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+    - `All checks passed!`
+  - `uv run python -m py_compile backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py`
+    - `exit 0`
+
+## Remaining
+
+- service surface 里是否还存在其他 SQLite-only caller 尚未重新分类
+- 如果剩余 caller 已不再是 service seam，就应转入 `CP03 Sandbox Control Plane Parity`
 
 ## Stopline
 

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -18,8 +18,9 @@ def test_file_channel_and_activity_tracker_no_longer_import_storage_factory() ->
     assert "backend.web.core.storage_factory" not in activity_source
     assert "backend.web.core.storage_factory" not in file_channel_source
     assert "storage.runtime" in activity_source
-    assert "SQLiteTerminalRepo" in file_channel_source
-    assert "SQLiteLeaseRepo" in file_channel_source
+    assert "storage.runtime" in file_channel_source
+    assert "SQLiteTerminalRepo" not in file_channel_source
+    assert "SQLiteLeaseRepo" not in file_channel_source
 
 
 def test_helpers_no_longer_import_storage_factory() -> None:


### PR DESCRIPTION
## Summary
- route file channel lease/terminal repo construction through storage.runtime builders
- tighten the integration contract so file_channel_service no longer imports SQLite repos directly
- record CP02 progress in the supabase-first-runtime-parity checkpoint ledger

## Testing
- uv run pytest -q tests/Integration/test_thread_files_channel_shell.py
- uv run ruff check backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py
- uv run python -m py_compile backend/web/services/file_channel_service.py tests/Integration/test_thread_files_channel_shell.py