### PR TITLE
refactor: drop sandbox service db-path ownership

### DIFF
--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -16,12 +16,9 @@ from sandbox.manager import SandboxManager
 from sandbox.provider import ProviderCapability
 from sandbox.recipes import default_recipe_id, list_builtin_recipes, normalize_recipe_snapshot, provider_type_from_name
 from storage.models import map_lease_to_session_status
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 logger = logging.getLogger(__name__)
-
-SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 _SANDBOX_INVENTORY_LOCK = threading.Lock()
 _SANDBOX_INVENTORY: tuple[dict[str, Any], dict[str, Any]] | None = None
@@ -215,7 +212,7 @@ def _build_providers_and_managers() -> tuple[dict[str, Any], dict[str, Any]]:
         "local": LocalSessionProvider(default_cwd=str(LOCAL_WORKSPACE_ROOT)),
     }
     if not SANDBOXES_DIR.exists():
-        managers = {name: SandboxManager(provider=p, db_path=SANDBOX_DB_PATH) for name, p in providers.items()}
+        managers = {name: SandboxManager(provider=p) for name, p in providers.items()}
         return providers, managers
 
     for config_file in SANDBOXES_DIR.glob("*.json"):
@@ -280,7 +277,7 @@ def _build_providers_and_managers() -> tuple[dict[str, Any], dict[str, Any]]:
         except Exception:
             logger.exception("[sandbox] Failed to load %s", name)
 
-    managers = {name: SandboxManager(provider=p, db_path=SANDBOX_DB_PATH) for name, p in providers.items()}
+    managers = {name: SandboxManager(provider=p) for name, p in providers.items()}
     return providers, managers
 
 

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -1,0 +1,141 @@
+# Sandbox Control-Plane Owner Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Narrow the sandbox control-plane so `backend/web/services/sandbox_service.py` stops owning `sandbox.db` details, then continue toward true Supabase-first parity from the real fused core.
+
+**Architecture:** The first honest cut is not “make SandboxManager Supabase-backed” in one jump. It is to remove `sandbox_service` as an owner of sqlite-kernel details and push that ownership back into `SandboxManager`, then continue by isolating the still-fused `manager + chat_session + sandbox.db` contract.
+
+**Tech Stack:** Python, FastAPI service layer, sandbox runtime/control-plane code, pytest
+
+---
+
+### Task 1: Record the First CP03 Slice
+
+**Files:**
+- Modify: `teams/tasks/supabase-first-runtime-parity/_index.md`
+- Modify: `teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md`
+- Create: `teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md`
+
+- [ ] **Step 1: Record that `sandbox_service.py` is no longer the db-path owner**
+
+Note that the first `CP03` slice only moves `sandbox.db` ownership from `sandbox_service.py` down into `SandboxManager`; it does not claim provider parity is done.
+
+- [ ] **Step 2: Save the remaining fused core**
+
+Document that the remaining control-plane core still lives in:
+
+```text
+sandbox/manager.py
+sandbox/chat_session.py
+```
+
+and that `monitor_service.py` is not part of this first slice.
+
+### Task 2: Write the Failing Test for Service-Level Ownership
+
+**Files:**
+- Modify: `tests/Unit/sandbox/test_sandbox_user_leases.py`
+- Modify: `backend/web/services/sandbox_service.py`
+
+- [ ] **Step 1: Tighten the source-level contract**
+
+Change the existing source assertion test so it requires:
+
+```python
+service_source = Path("backend/web/services/sandbox_service.py").read_text(encoding="utf-8")
+assert "storage.providers.sqlite.kernel" not in service_source
+assert "resolve_role_db_path" not in service_source
+```
+
+- [ ] **Step 2: Run the focused test and watch it fail**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py -k 'sandbox_service_no_longer_imports_storage_factory'
+```
+
+Expected:
+- fail because `sandbox_service.py` still imports sqlite kernel directly
+
+- [ ] **Step 3: Make the minimal production change**
+
+Update `backend/web/services/sandbox_service.py` so both manager construction sites become:
+
+```python
+SandboxManager(provider=p)
+```
+
+and remove:
+
+```python
+from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+SANDBOX_DB_PATH = ...
+```
+
+- [ ] **Step 4: Re-run the focused test to verify green**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py -k 'sandbox_service_no_longer_imports_storage_factory'
+```
+
+Expected:
+- pass
+
+### Task 3: Run the Narrow Verification Cluster
+
+**Files:**
+- No additional file changes required
+
+- [ ] **Step 1: Verify service/user-lease/provider-availability behavior still holds**
+
+Run:
+
+```bash
+uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py -k 'sandbox_service or list_user_leases or available_sandbox_types or sandbox_types'
+```
+
+Expected:
+- selected tests pass
+
+- [ ] **Step 2: Run lint and compile checks**
+
+Run:
+
+```bash
+uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py
+uv run python -m py_compile backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py
+```
+
+Expected:
+- `All checks passed!`
+- `exit 0`
+
+### Task 4: Narrow the Real Fused Core Before Another Implementation Cut
+
+**Files:**
+- Read: `sandbox/manager.py`
+- Read: `sandbox/chat_session.py`
+- Modify: `teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md`
+
+- [ ] **Step 1: Record why `sandbox_service.py` was only the outer shell**
+
+Document that the still-fused owner boundary is:
+
+```text
+SandboxManager
+ChatSessionManager
+SQLite chat_session / lease / terminal repos
+connect_sqlite / sandbox.db contract
+```
+
+- [ ] **Step 2: Declare the next bounded slice**
+
+Nominate one next move only:
+- either `sandbox.manager` repo-construction narrowing
+- or `sandbox.chat_session` storage-contract narrowing
+
+Do not combine them in the same implementation slice until the evidence says they are inseparable.

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -60,8 +60,8 @@ created: 2026-04-09
 |---|--------|------|------|
 | 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
 | 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | done |
-| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | in_progress |
-| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |
+| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | done |
+| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | in_progress |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
 | 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
 
@@ -86,6 +86,7 @@ created: 2026-04-09
 
 ## Default Next Move
 
-- `CP02 Service Surface Parity`
-  - `file_channel_service.py` 这一刀已完成：service surface 不再直连 `SQLiteLeaseRepo` / `SQLiteTerminalRepo`
-  - 下一步继续盘 service surface residual，再决定是继续切 web/service caller，还是转入 `CP03 Sandbox Control Plane Parity`
+- `CP03 Sandbox Control Plane Parity`
+  - `CP02` 已收口：`backend/web/services` 里剩余 SQLite residual 只剩 `monitor_service.py` / `sandbox_service.py`，两者都已更像 control-plane seam
+  - 第一轮已完成：`sandbox_service.py` 不再 import sqlite kernel / 不再自己持有 `SANDBOX_DB_PATH`
+  - 下一步继续收窄 `sandbox.manager / sandbox.chat_session` 这一组真正仍然持有 `sandbox.db` contract 的 control-plane core

--- a/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
@@ -1,6 +1,6 @@
 ---
 title: Service Surface Parity
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -28,8 +28,11 @@ created: 2026-04-09
 
 ## Remaining
 
-- service surface 里是否还存在其他 SQLite-only caller 尚未重新分类
-- 如果剩余 caller 已不再是 service seam，就应转入 `CP03 Sandbox Control Plane Parity`
+- 当前 `backend/web/services` 里的剩余 SQLite residual 只剩：
+  - `monitor_service.py`
+  - `sandbox_service.py`
+- 两者都已不再是单纯的 service repo construction seam，而更接近 sandbox/monitor control-plane owner
+- 所以下一阶段应转入 `CP03 Sandbox Control Plane Parity`
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -1,12 +1,55 @@
 ---
 title: Sandbox Control Plane Parity
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Sandbox Control Plane Parity
 
 目标：处理 sandbox lease / terminal / chat-session / manager 等 control-plane caller 的 provider parity，避免它们继续成为 SQLite-only 岛。
+
+## Current Ruling
+
+- `backend/web/services/sandbox_service.py` 已不再是普通 service-surface repo seam。
+- 当前残余的真实 owner boundary 是：
+  - `SandboxManager(provider=p, db_path=SANDBOX_DB_PATH)`
+  - 以及与之配套的 sandbox lease / terminal / chat-session local stores
+- 这说明 `sandbox_service.py` 的 SQLite residual 不是单独一个 import 可以诚实切掉的问题，而是 `SandboxManager` control-plane contract 仍然要求本地 `sandbox.db`。
+- 因此第一轮不直接写实现，而先把这条 boundary 明确钉住，避免把 `monitor_service.py` / `sandbox_service.py` 错当成 `CP02` 的延续小刀。
+
+## First Slice
+
+- `backend/web/services/sandbox_service.py`
+  - 不再 import `storage.providers.sqlite.kernel`
+  - 不再自己定义 `SANDBOX_DB_PATH`
+  - 不再在 `SandboxManager(...)` 构造处显式传 `db_path`
+  - `sandbox.db` 的默认 owner 下沉回 `SandboxManager`
+
+## Evidence
+
+- `机制层验证`
+  - `uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py -k 'sandbox_service or list_user_leases or available_sandbox_types or sandbox_types'`
+    - `7 passed, 2 deselected`
+- `源码/测试层辅助证据`
+  - `uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py`
+    - `All checks passed!`
+  - `uv run python -m py_compile backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py`
+    - `exit 0`
+
+## Remaining
+
+- `sandbox.manager.py` 仍直接构造：
+  - `SQLiteChatSessionRepo`
+  - `SQLiteLeaseRepo`
+  - `SQLiteTerminalRepo`
+- `sandbox.chat_session.py` 仍直接依赖 sqlite kernel / sqlite connection
+- 这说明 control-plane 的真实 fused core 在 `manager + chat_session + sandbox.db`，不是 `sandbox_service.py`
+
+## Default Next Move
+
+- 优先继续收窄 `sandbox/manager.py` 和 `sandbox/chat_session.py`
+- 不直接改 `monitor_service.py`
+- 下一刀要先回答：`chat_session / lease / terminal` 哪部分是必须保留的 local runtime persistence，哪部分才该提升到 strategy/container seam
 
 ## Stopline
 

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -5,10 +5,12 @@ from backend.web.services import sandbox_service
 
 
 def test_sandbox_service_no_longer_imports_storage_factory() -> None:
-    service_source = Path("backend/web/services/sandbox_service.py").read_text()
+    service_source = Path("backend/web/services/sandbox_service.py").read_text(encoding="utf-8")
 
     assert "backend.web.core.storage_factory" not in service_source
     assert "storage.runtime" in service_source
+    assert "storage.providers.sqlite.kernel" not in service_source
+    assert "resolve_role_db_path" not in service_source
 
 
 class _FakeMonitorRepo:


### PR DESCRIPTION
## Summary
- remove sqlite-kernel ownership from backend.web.services.sandbox_service
- let SandboxManager own the default sandbox.db path again
- record CP03 status, evidence, and next stopline in the checkpoint ledger

## Testing
- uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py -k 'sandbox_service_no_longer_imports_storage_factory'
- uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py -k 'sandbox_service or list_user_leases or available_sandbox_types or sandbox_types'
- uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py
- uv run python -m py_compile backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py