### PR TITLE
refactor: share sandbox control-plane repo seam

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
+from sandbox.control_plane_repos import make_chat_session_repo, make_lease_repo, make_terminal_repo
 from sandbox.lifecycle import (
     ChatSessionState,
     assert_chat_session_transition,
@@ -184,9 +185,7 @@ class ChatSessionManager:
         if chat_session_repo:
             self._repo = chat_session_repo
         else:
-            from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
-
-            self._repo = SQLiteChatSessionRepo(db_path=db_path)
+            self._repo = make_chat_session_repo(db_path=self.db_path)
         self._terminal_repo = terminal_repo
         self._lease_repo = lease_repo
 
@@ -225,9 +224,7 @@ class ChatSessionManager:
             _term_repo = self._terminal_repo
             own_term_repo = _term_repo is None
             if _term_repo is None:
-                from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
-
-                _term_repo = SQLiteTerminalRepo(db_path=self.db_path)
+                _term_repo = make_terminal_repo(db_path=self.db_path)
             try:
                 _term_row = _term_repo.get_active(thread_id)
             finally:
@@ -257,9 +254,7 @@ class ChatSessionManager:
         _term_repo = self._terminal_repo
         own_term_repo = _term_repo is None
         if _term_repo is None:
-            from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
-
-            _term_repo = SQLiteTerminalRepo(db_path=self.db_path)
+            _term_repo = make_terminal_repo(db_path=self.db_path)
         try:
             _term_row = _term_repo.get_by_id(row["terminal_id"])
         finally:
@@ -269,9 +264,7 @@ class ChatSessionManager:
         _lease_repo = self._lease_repo
         own_lease_repo = _lease_repo is None
         if _lease_repo is None:
-            from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
-
-            _lease_repo = SQLiteLeaseRepo(db_path=self.db_path)
+            _lease_repo = make_lease_repo(db_path=self.db_path)
         try:
             _lease_row = _lease_repo.get(row["lease_id"])
         finally:

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+
+
+def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
+    return db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+
+
+def make_chat_session_repo(db_path: Path | None = None):
+    from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
+
+    return SQLiteChatSessionRepo(db_path=resolve_sandbox_db_path(db_path))
+
+
+def make_lease_repo(db_path: Path | None = None):
+    from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+
+    return SQLiteLeaseRepo(db_path=resolve_sandbox_db_path(db_path))
+
+
+def make_terminal_repo(db_path: Path | None = None):
+    from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
+
+    return SQLiteTerminalRepo(db_path=resolve_sandbox_db_path(db_path))

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -14,34 +14,15 @@ from config.user_paths import user_home_path
 from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
 from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
+from sandbox.control_plane_repos import make_chat_session_repo, make_lease_repo, make_terminal_repo
 from sandbox.lease import lease_from_row
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
-from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
-from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 from storage.runtime import build_storage_container
 
 logger = logging.getLogger(__name__)
-
-
-def make_chat_session_repo(db_path: Path | None = None):
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    return SQLiteChatSessionRepo(db_path=target_db)
-
-
-def make_lease_repo(db_path: Path | None = None):
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    return SQLiteLeaseRepo(db_path=target_db)
-
-
-def make_terminal_repo(db_path: Path | None = None):
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    return SQLiteTerminalRepo(db_path=target_db)
-
-
 def resolve_provider_cwd(provider) -> str:
     """Get the default working directory for a provider."""
     for attr in ("default_cwd", "default_context_path", "mount_path"):

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -89,4 +89,5 @@ created: 2026-04-09
 - `CP03 Sandbox Control Plane Parity`
   - `CP02` 已收口：`backend/web/services` 里剩余 SQLite residual 只剩 `monitor_service.py` / `sandbox_service.py`，两者都已更像 control-plane seam
   - 第一轮已完成：`sandbox_service.py` 不再 import sqlite kernel / 不再自己持有 `SANDBOX_DB_PATH`
-  - 下一步继续收窄 `sandbox.manager / sandbox.chat_session` 这一组真正仍然持有 `sandbox.db` contract 的 control-plane core
+  - 第二轮已完成：`sandbox.manager / sandbox.chat_session` 不再各自直接 import `SQLite*Repo`，而是共用 `sandbox.control_plane_repos`
+  - 下一步继续收窄 `sandbox.lease.py` 这一层真正仍然直接持有 lease-store sqlite contract 的 core

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -30,26 +30,32 @@ created: 2026-04-09
 - `机制层验证`
   - `uv run pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py -k 'sandbox_service or list_user_leases or available_sandbox_types or sandbox_types'`
     - `7 passed, 2 deselected`
+  - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py -k 'chat_session or sandbox_manager or lookup_sandbox_for_thread or bind_thread_to_existing_lease or resolve_existing_lease_cwd'`
+    - `10 passed, 29 deselected`
 - `源码/测试层辅助证据`
   - `uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py`
     - `All checks passed!`
   - `uv run python -m py_compile backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py`
     - `exit 0`
+  - `uv run ruff check sandbox/control_plane_repos.py sandbox/manager.py sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py`
+    - `All checks passed!`
+  - `uv run python -m py_compile sandbox/control_plane_repos.py sandbox/manager.py sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py`
+    - `exit 0`
 
 ## Remaining
 
-- `sandbox.manager.py` 仍直接构造：
-  - `SQLiteChatSessionRepo`
-  - `SQLiteLeaseRepo`
-  - `SQLiteTerminalRepo`
-- `sandbox.chat_session.py` 仍直接依赖 sqlite kernel / sqlite connection
-- 这说明 control-plane 的真实 fused core 在 `manager + chat_session + sandbox.db`，不是 `sandbox_service.py`
+- 第二轮已完成：
+  - `sandbox.manager.py`
+  - `sandbox.chat_session.py`
+  - 两者不再各自直接 import `SQLiteChatSessionRepo / SQLiteLeaseRepo / SQLiteTerminalRepo`
+  - 当前统一改走 `sandbox.control_plane_repos`
+- 这说明 control-plane 的 sqlite repo construction 已经收口成单一 seam，但更深的 lease-store / sqlite connection contract 仍然存在
 
 ## Default Next Move
 
-- 优先继续收窄 `sandbox/manager.py` 和 `sandbox/chat_session.py`
+- 优先继续收窄 `sandbox/lease.py`
 - 不直接改 `monitor_service.py`
-- 下一刀要先回答：`chat_session / lease / terminal` 哪部分是必须保留的 local runtime persistence，哪部分才该提升到 strategy/container seam
+- 下一刀要先回答：`sandbox.lease.py` 里哪些 lease-store contract 是真正必须保留的 local runtime persistence，哪些才该提升到 strategy/container seam
 
 ## Stopline
 

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -17,9 +17,19 @@ def test_sandbox_manager_no_longer_imports_storage_factory() -> None:
     manager_source = Path("sandbox/manager.py").read_text(encoding="utf-8")
 
     assert "backend.web.core.storage_factory" not in manager_source
-    assert "SQLiteTerminalRepo" in manager_source
-    assert "SQLiteLeaseRepo" in manager_source
-    assert "SQLiteChatSessionRepo" in manager_source
+    assert "sandbox.control_plane_repos" in manager_source
+    assert "SQLiteTerminalRepo" not in manager_source
+    assert "SQLiteLeaseRepo" not in manager_source
+    assert "SQLiteChatSessionRepo" not in manager_source
+
+
+def test_chat_session_manager_uses_control_plane_repo_seam() -> None:
+    session_source = Path("sandbox/chat_session.py").read_text(encoding="utf-8")
+
+    assert "sandbox.control_plane_repos" in session_source
+    assert "SQLiteTerminalRepo" not in session_source
+    assert "SQLiteLeaseRepo" not in session_source
+    assert "SQLiteChatSessionRepo" not in session_source
 
 
 class _FakeTerminalRepo:


### PR DESCRIPTION
## Summary
- add a shared sandbox.control_plane_repos seam for chat-session / lease / terminal repo construction
- route sandbox.manager and sandbox.chat_session through that seam instead of importing SQLite repo classes directly
- update CP03 ledger to reflect the new stopline and next residual in sandbox.lease

## Testing
- uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py -k 'sandbox_manager_no_longer_imports_storage_factory or chat_session_manager_uses_control_plane_repo_seam'
- uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py -k 'chat_session or sandbox_manager or lookup_sandbox_for_thread or bind_thread_to_existing_lease or resolve_existing_lease_cwd'
- uv run ruff check sandbox/control_plane_repos.py sandbox/manager.py sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py
- uv run python -m py_compile sandbox/control_plane_repos.py sandbox/manager.py sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py