### PR TITLE
feat: persist provider errors through strategy events

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -481,7 +481,7 @@ class SQLiteLease(SandboxLease):
             if should_commit:
                 target.close()
 
-    def _record_provider_error(self, message: str) -> None:
+    def _record_provider_error(self, message: str, *, source: str = "provider") -> None:
         self.last_error = message[:500]
         self.needs_refresh = True
         self.refresh_hint_at = utc_now()
@@ -489,6 +489,7 @@ class SQLiteLease(SandboxLease):
         self.version += 1
         if _use_supabase_storage():
             repo = _make_lease_repo(self.db_path)
+            event_repo = _make_provider_event_repo()
             try:
                 row = repo.persist_metadata(
                     lease_id=self.lease_id,
@@ -503,7 +504,16 @@ class SQLiteLease(SandboxLease):
                     refresh_hint_at=self.refresh_hint_at.isoformat() if self.refresh_hint_at else None,
                     status=self.status,
                 )
+                if self._current_instance:
+                    event_repo.record(
+                        provider_name=self.provider_name,
+                        instance_id=self._current_instance.instance_id,
+                        event_type="provider.error",
+                        payload={"error": self.last_error, "source": source},
+                        matched_lease_id=self.lease_id,
+                    )
             finally:
+                event_repo.close()
                 repo.close()
             self._sync_from(lease_from_row(row, self.db_path))
             return
@@ -744,7 +754,7 @@ class SQLiteLease(SandboxLease):
             except RuntimeError:
                 raise
             except Exception as exc:
-                self._record_provider_error(str(exc))
+                self._record_provider_error(str(exc), source="run.refresh")
 
         with self._instance_lock():
             self._reload_from_storage()
@@ -782,7 +792,7 @@ class SQLiteLease(SandboxLease):
                 except RuntimeError:
                     raise
                 except Exception as exc:
-                    self._record_provider_error(str(exc))
+                    self._record_provider_error(str(exc), source="run.refresh_locked")
 
             self.status = "recovering"
             if not _use_supabase_storage():
@@ -877,7 +887,7 @@ class SQLiteLease(SandboxLease):
                 )
         except Exception as exc:
             if _use_supabase_storage():
-                self._record_provider_error(str(exc))
+                self._record_provider_error(str(exc), source="read.status")
             else:
                 self.apply(
                     provider,

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -249,7 +249,18 @@ completed second transition cut:
 - refresh_instance_status() supabase success path now uses strategy repos
 
 remaining wider transitions:
-- provider.error event parity
+- intent.pause / intent.resume
+- intent.destroy
+```
+
+Latest update after the provider-error slice:
+
+```text
+completed third transition cut:
+- _record_provider_error(..., source=...)
+- supabase strategy now records provider.error into provider_events
+
+remaining wider transitions:
 - intent.pause / intent.resume
 - intent.destroy
 ```

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -93,4 +93,5 @@ created: 2026-04-09
   - 第三轮已完成：`sandbox.lease.py` 不再直接 import `SQLiteLeaseRepo`，lease-store construction 已接入 `sandbox.control_plane_repos`
   - 第四轮已完成：`LeaseRepo.persist_metadata(...)` 已补进 protocol / sqlite provider / supabase provider，且 `sandbox.lease.py:_record_provider_error()` 在 `LEON_STORAGE_STRATEGY=supabase` 下已改为通过 `storage.runtime.build_lease_repo(...)` 持久化 metadata，而不是继续落回本地 sqlite refresh flag
   - 第五轮已完成：`LeaseRepo.observe_status(...)` 已补进 protocol / sqlite provider / supabase provider，且 `SQLiteLease.refresh_instance_status()` 在 `LEON_STORAGE_STRATEGY=supabase` 下会通过 strategy lease repo + provider event repo 落 `observe.status` transition
-  - 当前 stopline 已压清：下一步如果继续，才轮到 `pause / resume / destroy / provider.error` 这些更宽的 transition，而不是再回头做底层 sqlite helper 清理
+  - 第六轮已完成：`provider.error` 的 strategy event parity 已补上；`_record_provider_error(..., source=...)` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会同时持久化 lease metadata 和 `provider_events`
+  - 当前 stopline 已压清：下一步如果继续，才轮到 `pause / resume / destroy` 这些更宽的 transition，而不是再回头做底层 sqlite helper 清理

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -134,15 +134,35 @@ created: 2026-04-09
   - `intent.destroy`
   - `provider.error` 的 event-side parity
 
+## Latest Provider-Error Slice
+
+- 当前又补了一条更窄的 event parity：
+  - `_record_provider_error(..., source=...)`
+- 具体变化：
+  - `sandbox/lease.py` 在 `LEON_STORAGE_STRATEGY=supabase` 下，provider 异常不再只落 metadata
+  - 现在会同时通过 strategy `provider_event_repo` 记录一条 `provider.error`
+  - 这条 event 会带：
+    - `matched_lease_id`
+    - `instance_id`
+    - `payload.error`
+    - `payload.source`
+- 这刀当前覆盖到的 caller：
+  - `run.refresh`
+  - `run.refresh_locked`
+  - `read.status`
+- 这刀仍然没有碰：
+  - `intent.pause`
+  - `intent.resume`
+  - `intent.destroy`
+
 ## Default Next Move
 
 - 不直接改 `monitor_service.py`
 - 不继续追加底层 sqlite helper 清理
 - 下一刀如果继续，应在更宽的 transition 之间选一个：
-  - `provider.error` event-side parity
   - `intent.pause / intent.resume`
   - `intent.destroy`
-- 不要把三者混成一刀
+- 不要把剩下几条 transition 混成一刀
 
 ## Stopline
 

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -225,10 +225,12 @@ def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(mon
 
 def test_record_provider_error_persists_strategy_metadata(monkeypatch):
     repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
     lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
 
     lease._record_provider_error("provider boom")
 
@@ -239,6 +241,15 @@ def test_record_provider_error_persists_strategy_metadata(monkeypatch):
     assert call["needs_refresh"] is True
     assert call["status"] == "active"
     assert call["version"] == 1
+    assert event_repo.record_calls == [
+        {
+            "provider_name": "daytona_selfhost",
+            "instance_id": "inst-1",
+            "event_type": "provider.error",
+            "payload": {"error": "provider boom", "source": "provider"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
 
 
 def test_refresh_instance_status_uses_strategy_observe_status_transition(monkeypatch):
@@ -263,6 +274,38 @@ def test_refresh_instance_status_uses_strategy_observe_status_transition(monkeyp
             "instance_id": "inst-1",
             "event_type": "observe.status",
             "payload": {"status": "running", "instance_id": "inst-1"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
+
+
+def test_refresh_instance_status_records_strategy_provider_error_event(monkeypatch):
+    repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    class _FailingProvider(_FakeProvider):
+        def get_session_status(self, _instance_id: str) -> str:
+            raise RuntimeError("provider boom")
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    observed = lease.refresh_instance_status(_FailingProvider(), force=True)
+
+    assert observed == "running"
+    assert len(repo.persist_calls) == 1
+    call = repo.persist_calls[0]
+    assert call["last_error"] == "provider boom"
+    assert call["needs_refresh"] is True
+    assert event_repo.record_calls == [
+        {
+            "provider_name": "daytona_selfhost",
+            "instance_id": "inst-1",
+            "event_type": "provider.error",
+            "payload": {"error": "provider boom", "source": "read.status"},
             "matched_lease_id": "lease-1",
         }
     ]


### PR DESCRIPTION
## Summary
- record `provider.error` through strategy repos under supabase storage
- teach `_record_provider_error(..., source=...)` to emit `provider_events`
- update CP03 checkpoint docs to mark provider-error parity done and narrow the remaining stopline

## Verification
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py -k 'record_provider_error_persists_strategy_metadata or refresh_instance_status_records_strategy_provider_error_event'
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py -k 'refresh_instance_status_uses_strategy_observe_status_transition or ensure_active_instance_persists_strategy_lease_before_probe_failure'
- uv run pytest -q tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/core/test_capability_async.py tests/Unit/core/test_runtime.py tests/Unit/storage/test_runtime_builder_contract.py -k 'lease or sandbox_lease or local_sandbox_rebuilds_stale_closed_capability_before_execute_async or lookup_sandbox_for_thread or bind_thread_to_existing_lease or resolve_existing_lease_cwd or runtime_repo_builders_use_supabase_factory'
- uv run ruff check sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py storage/contracts.py storage/providers/sqlite/lease_repo.py storage/providers/supabase/lease_repo.py storage/runtime.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run python -m py_compile sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py storage/contracts.py storage/providers/sqlite/lease_repo.py storage/providers/supabase/lease_repo.py storage/runtime.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_runtime_builder_contract.py
