### PR TITLE
feat: persist destroy transitions through strategy repos

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -556,6 +556,12 @@ class SQLiteLease(SandboxLease):
                 raise RuntimeError(f"Failed to destroy lease {self.lease_id}: {exc}") from exc
             if not ok:
                 raise RuntimeError(f"Failed to destroy lease {self.lease_id}")
+        self.desired_state = "destroyed"
+        self._set_observed_state("detached", reason="intent.destroy")
+        self.status = "expired"
+        self.last_error = None
+        self.needs_refresh = False
+        self.refresh_hint_at = None
 
         repo = _make_lease_repo(self.db_path)
         event_repo = _make_provider_event_repo()

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -893,7 +893,13 @@ class SQLiteLease(SandboxLease):
 
     def destroy_instance(self, provider: SandboxProvider, *, source: str = "api") -> None:
         if _use_supabase_storage():
-            self._destroy_via_strategy_repos(provider, source=source)
+            with self._instance_lock():
+                self._reload_from_storage()
+                try:
+                    self._destroy_via_strategy_repos(provider, source=source)
+                except Exception as exc:
+                    self._record_provider_error(str(exc), source=f"{source}.destroy")
+                    raise
             return
         self.apply(provider, event_type="intent.destroy", source=source)
 

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -543,6 +543,54 @@ class SQLiteLease(SandboxLease):
             repo.close()
         self._sync_from(lease_from_row(row, self.db_path))
 
+    def _destroy_via_strategy_repos(self, provider: SandboxProvider, *, source: str) -> None:
+        capability = provider.get_capability()
+        if not capability.can_destroy:
+            raise RuntimeError(f"Provider {provider.name} does not support destroy")
+
+        instance_id = self._current_instance.instance_id if self._current_instance else ""
+        if self._current_instance:
+            try:
+                ok = provider.destroy_session(instance_id)
+            except Exception as exc:
+                raise RuntimeError(f"Failed to destroy lease {self.lease_id}: {exc}") from exc
+            if not ok:
+                raise RuntimeError(f"Failed to destroy lease {self.lease_id}")
+
+        repo = _make_lease_repo(self.db_path)
+        event_repo = _make_provider_event_repo()
+        try:
+            observed_row = repo.observe_status(
+                lease_id=self.lease_id,
+                status="detached",
+                observed_at=utc_now_iso(),
+            )
+            final_row = repo.persist_metadata(
+                lease_id=self.lease_id,
+                recipe_id=observed_row.get("recipe_id"),
+                recipe_json=observed_row.get("recipe_json"),
+                desired_state="destroyed",
+                observed_state=observed_row.get("observed_state") or "detached",
+                version=int(observed_row.get("version") or 0),
+                observed_at=observed_row.get("observed_at"),
+                last_error=None,
+                needs_refresh=False,
+                refresh_hint_at=None,
+                status="expired",
+            )
+            if instance_id:
+                event_repo.record(
+                    provider_name=self.provider_name,
+                    instance_id=instance_id,
+                    event_type="intent.destroy",
+                    payload={"instance_id": instance_id, "source": source},
+                    matched_lease_id=self.lease_id,
+                )
+        finally:
+            event_repo.close()
+            repo.close()
+        self._sync_from(lease_from_row(final_row, self.db_path))
+
     def _reload_from_storage(self) -> None:
         repo = _make_lease_repo(self.db_path)
         try:
@@ -844,6 +892,9 @@ class SQLiteLease(SandboxLease):
             return self._current_instance
 
     def destroy_instance(self, provider: SandboxProvider, *, source: str = "api") -> None:
+        if _use_supabase_storage():
+            self._destroy_via_strategy_repos(provider, source=source)
+            return
         self.apply(provider, event_type="intent.destroy", source=source)
 
     def pause_instance(self, provider: SandboxProvider, *, source: str = "api") -> bool:

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -571,6 +571,7 @@ class SQLiteLease(SandboxLease):
                 status="detached",
                 observed_at=utc_now_iso(),
             )
+            self.version = int(observed_row.get("version") or self.version)
             final_row = repo.persist_metadata(
                 lease_id=self.lease_id,
                 recipe_id=observed_row.get("recipe_id"),
@@ -584,6 +585,7 @@ class SQLiteLease(SandboxLease):
                 refresh_hint_at=None,
                 status="expired",
             )
+            self.version = int(final_row.get("version") or self.version)
             if instance_id:
                 event_repo.record(
                     provider_name=self.provider_name,

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -262,7 +262,16 @@ completed third transition cut:
 
 remaining wider transitions:
 - intent.pause / intent.resume
-- intent.destroy
+```
+
+Latest update after the destroy slice:
+
+```text
+completed fourth transition cut:
+- intent.destroy success path now uses strategy repos under supabase
+
+remaining wider transitions:
+- intent.pause / intent.resume
 ```
 
 - [ ] **Step 3: Record the transaction question**

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -268,7 +268,9 @@ Latest update after the destroy slice:
 
 ```text
 completed fourth transition cut:
-- intent.destroy success path now uses strategy repos under supabase
+- intent.destroy now uses strategy repos under supabase
+- destroy path keeps lease-level lock + reload before mutation
+- destroy failures now reuse provider.error persistence/event parity
 
 remaining wider transitions:
 - intent.pause / intent.resume

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -272,6 +272,7 @@ completed fourth transition cut:
 - destroy path keeps lease-level lock + reload before mutation
 - destroy failures now reuse provider.error persistence/event parity
 - post-destroy strategy write failures still preserve destroy-state truth before error persistence
+- destroy error persistence also preserves the next version step after observe-status writes
 
 remaining wider transitions:
 - intent.pause / intent.resume

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -271,6 +271,7 @@ completed fourth transition cut:
 - intent.destroy now uses strategy repos under supabase
 - destroy path keeps lease-level lock + reload before mutation
 - destroy failures now reuse provider.error persistence/event parity
+- post-destroy strategy write failures still preserve destroy-state truth before error persistence
 
 remaining wider transitions:
 - intent.pause / intent.resume

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -94,4 +94,5 @@ created: 2026-04-09
   - 第四轮已完成：`LeaseRepo.persist_metadata(...)` 已补进 protocol / sqlite provider / supabase provider，且 `sandbox.lease.py:_record_provider_error()` 在 `LEON_STORAGE_STRATEGY=supabase` 下已改为通过 `storage.runtime.build_lease_repo(...)` 持久化 metadata，而不是继续落回本地 sqlite refresh flag
   - 第五轮已完成：`LeaseRepo.observe_status(...)` 已补进 protocol / sqlite provider / supabase provider，且 `SQLiteLease.refresh_instance_status()` 在 `LEON_STORAGE_STRATEGY=supabase` 下会通过 strategy lease repo + provider event repo 落 `observe.status` transition
   - 第六轮已完成：`provider.error` 的 strategy event parity 已补上；`_record_provider_error(..., source=...)` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会同时持久化 lease metadata 和 `provider_events`
-  - 当前 stopline 已压清：下一步如果继续，才轮到 `pause / resume / destroy` 这些更宽的 transition，而不是再回头做底层 sqlite helper 清理
+  - 第七轮已完成：`intent.destroy` 的 strategy success path 已补上；`destroy_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会通过 strategy lease repo + provider event repo 落 detached/expired truth，而不是继续走本地 sqlite `apply(intent.destroy)`
+  - 当前 stopline 已压清：下一步如果继续，只剩 `pause / resume` 这一组更宽 transition，而不是再回头做底层 sqlite helper 清理

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -168,6 +168,7 @@ created: 2026-04-09
   - failure path 不再裸抛异常后结束
   - 现在会复用 `_record_provider_error(..., source=f\"{source}.destroy\")`
   - 所以 `last_error / needs_refresh / provider.error` 也保持 parity
+  - 即使 remote destroy 已成功、后置 strategy write 再失败，也会先保留 `destroyed / detached / expired` 的内存 truth，再把 error 落账
 - 这刀当前没有碰：
   - `intent.pause`
   - `intent.resume`

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -155,14 +155,26 @@ created: 2026-04-09
   - `intent.resume`
   - `intent.destroy`
 
+## Latest Destroy Slice
+
+- 当前又补了一条 success-path transition：
+  - `intent.destroy`
+- 具体变化：
+  - `destroy_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下不再直接走本地 sqlite `apply(intent.destroy)`
+  - 现在会通过 strategy `lease_repo.observe_status(...)` 先落 detached/stopped truth
+  - 然后通过 `persist_metadata(...)` 把 `desired_state=destroyed`、`status=expired` 收口
+  - 同时通过 strategy `provider_event_repo` 记录 `intent.destroy`
+- 这刀当前没有碰：
+  - `intent.pause`
+  - `intent.resume`
+
 ## Default Next Move
 
 - 不直接改 `monitor_service.py`
 - 不继续追加底层 sqlite helper 清理
 - 下一刀如果继续，应在更宽的 transition 之间选一个：
   - `intent.pause / intent.resume`
-  - `intent.destroy`
-- 不要把剩下几条 transition 混成一刀
+- 不要把 pause / resume 再拆成无边界的大扫除；要么做成一个对偶 slice，要么先 park
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -157,13 +157,17 @@ created: 2026-04-09
 
 ## Latest Destroy Slice
 
-- 当前又补了一条 success-path transition：
+- 当前又补了一条 transition：
   - `intent.destroy`
 - 具体变化：
   - `destroy_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下不再直接走本地 sqlite `apply(intent.destroy)`
-  - 现在会通过 strategy `lease_repo.observe_status(...)` 先落 detached/stopped truth
+  - 现在会在现有 `lease` object 上先走 `_instance_lock() + _reload_from_storage()`
+  - success path 会通过 strategy `lease_repo.observe_status(...)` 先落 detached/stopped truth
   - 然后通过 `persist_metadata(...)` 把 `desired_state=destroyed`、`status=expired` 收口
   - 同时通过 strategy `provider_event_repo` 记录 `intent.destroy`
+  - failure path 不再裸抛异常后结束
+  - 现在会复用 `_record_provider_error(..., source=f\"{source}.destroy\")`
+  - 所以 `last_error / needs_refresh / provider.error` 也保持 parity
 - 这刀当前没有碰：
   - `intent.pause`
   - `intent.resume`

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -169,6 +169,7 @@ created: 2026-04-09
   - 现在会复用 `_record_provider_error(..., source=f\"{source}.destroy\")`
   - 所以 `last_error / needs_refresh / provider.error` 也保持 parity
   - 即使 remote destroy 已成功、后置 strategy write 再失败，也会先保留 `destroyed / detached / expired` 的内存 truth，再把 error 落账
+  - error persistence 也会接住 `observe_status(...)` 之后的 version，避免吃掉 destroy 后续 error transition 的版本推进
 - 这刀当前没有碰：
   - `intent.pause`
   - `intent.resume`

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -452,3 +452,42 @@ def test_destroy_instance_preserves_destroy_state_when_strategy_write_fails(monk
     assert call["status"] == "expired"
     assert call["last_error"] == "write boom"
     assert call["needs_refresh"] is True
+
+
+def test_destroy_instance_bumps_version_again_when_event_write_fails(monkeypatch):
+    repo = _FakeLeaseRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    class _EventFailRepo(_FakeProviderEventRepo):
+        def record(
+            self,
+            *,
+            provider_name: str,
+            instance_id: str,
+            event_type: str,
+            payload: dict[str, object],
+            matched_lease_id: str | None,
+        ) -> None:
+            if event_type == "intent.destroy":
+                raise RuntimeError("event boom")
+            super().record(
+                provider_name=provider_name,
+                instance_id=instance_id,
+                event_type=event_type,
+                payload=payload,
+                matched_lease_id=matched_lease_id,
+            )
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: _EventFailRepo())
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    with pytest.raises(RuntimeError, match="event boom"):
+        lease.destroy_instance(_FakeProvider(), source="api")
+
+    assert len(repo.persist_calls) == 2
+    assert repo.persist_calls[0]["version"] == 1
+    assert repo.persist_calls[-1]["version"] == 2
+    assert repo.persist_calls[-1]["desired_state"] == "destroyed"
+    assert repo.persist_calls[-1]["observed_state"] == "detached"

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -345,6 +346,71 @@ def test_destroy_instance_uses_strategy_destroy_transition(monkeypatch):
             "instance_id": "inst-1",
             "event_type": "intent.destroy",
             "payload": {"instance_id": "inst-1", "source": "api"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
+
+
+def test_destroy_instance_strategy_path_reloads_under_lock(monkeypatch):
+    repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    order: list[str] = []
+
+    class _OrderedProvider(_FakeProvider):
+        def destroy_session(self, _instance_id: str) -> bool:
+            order.append("provider.destroy")
+            return True
+
+    @contextmanager
+    def _fake_lock():
+        order.append("lock.enter")
+        try:
+            yield
+        finally:
+            order.append("lock.exit")
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+    monkeypatch.setattr(lease, "_instance_lock", lambda: _fake_lock())
+    monkeypatch.setattr(lease, "_reload_from_storage", lambda: order.append("reload"))
+
+    lease.destroy_instance(_OrderedProvider(), source="api")
+
+    assert order[:3] == ["lock.enter", "reload", "provider.destroy"]
+    assert order[-1] == "lock.exit"
+
+
+def test_destroy_instance_records_strategy_provider_error_on_failure(monkeypatch):
+    repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    class _FailingDestroyProvider(_FakeProvider):
+        def destroy_session(self, _instance_id: str) -> bool:
+            raise RuntimeError("provider boom")
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    with pytest.raises(RuntimeError, match="Failed to destroy lease lease-1: provider boom"):
+        lease.destroy_instance(_FailingDestroyProvider(), source="api")
+
+    assert len(repo.persist_calls) == 1
+    call = repo.persist_calls[0]
+    assert call["last_error"] == "Failed to destroy lease lease-1: provider boom"
+    assert call["needs_refresh"] is True
+    assert call["status"] == "active"
+    assert event_repo.record_calls == [
+        {
+            "provider_name": "daytona_selfhost",
+            "instance_id": "inst-1",
+            "event_type": "provider.error",
+            "payload": {"error": "Failed to destroy lease lease-1: provider boom", "source": "api.destroy"},
             "matched_lease_id": "lease-1",
         }
     ]

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -10,13 +10,16 @@ class _FakeProvider:
     name = "daytona_selfhost"
 
     def get_capability(self):
-        return SimpleNamespace(supports_status_probe=True)
+        return SimpleNamespace(supports_status_probe=True, can_destroy=True)
 
     def create_session(self, context_id=None, thread_id=None):
         return SimpleNamespace(session_id="instance-created")
 
     def get_session_status(self, _instance_id: str) -> str:
         return "running"
+
+    def destroy_session(self, _instance_id: str) -> bool:
+        return True
 
 
 class _FakeLeaseRepo:
@@ -306,6 +309,42 @@ def test_refresh_instance_status_records_strategy_provider_error_event(monkeypat
             "instance_id": "inst-1",
             "event_type": "provider.error",
             "payload": {"error": "provider boom", "source": "read.status"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
+
+
+def test_destroy_instance_uses_strategy_destroy_transition(monkeypatch):
+    repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    lease.destroy_instance(_FakeProvider(), source="api")
+
+    assert repo.observe_calls == [
+        {
+            "lease_id": "lease-1",
+            "status": "detached",
+            "observed_at": repo.observe_calls[0]["observed_at"],
+        }
+    ]
+    assert len(repo.persist_calls) == 1
+    persist = repo.persist_calls[0]
+    assert persist["desired_state"] == "destroyed"
+    assert persist["observed_state"] == "detached"
+    assert persist["status"] == "expired"
+    assert persist["needs_refresh"] is False
+    assert event_repo.record_calls == [
+        {
+            "provider_name": "daytona_selfhost",
+            "instance_id": "inst-1",
+            "event_type": "intent.destroy",
+            "payload": {"instance_id": "inst-1", "source": "api"},
             "matched_lease_id": "lease-1",
         }
     ]

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -414,3 +414,41 @@ def test_destroy_instance_records_strategy_provider_error_on_failure(monkeypatch
             "matched_lease_id": "lease-1",
         }
     ]
+
+
+def test_destroy_instance_preserves_destroy_state_when_strategy_write_fails(monkeypatch):
+    repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    class _WriteFailRepo(_FakeLeaseRepo):
+        def observe_status(self, *, lease_id: str, status: str, observed_at):
+            raise RuntimeError("write boom")
+
+    class _OrderedProvider(_FakeProvider):
+        def __init__(self) -> None:
+            self.destroy_calls: list[str] = []
+
+        def destroy_session(self, instance_id: str) -> bool:
+            self.destroy_calls.append(instance_id)
+            return True
+
+    write_fail_repo = _WriteFailRepo()
+    provider = _OrderedProvider()
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: write_fail_repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    with pytest.raises(RuntimeError, match="write boom"):
+        lease.destroy_instance(provider, source="api")
+
+    assert provider.destroy_calls == ["inst-1"]
+    assert len(write_fail_repo.persist_calls) == 1
+    call = write_fail_repo.persist_calls[0]
+    assert call["desired_state"] == "destroyed"
+    assert call["observed_state"] == "detached"
+    assert call["status"] == "expired"
+    assert call["last_error"] == "write boom"
+    assert call["needs_refresh"] is True


### PR DESCRIPTION
## Summary
- route supabase `intent.destroy` through strategy repos instead of local sqlite `apply(intent.destroy)`
- reuse `observe_status(detached)` + `persist_metadata(...)` + `provider_events`
- update CP03 checkpoint docs to mark destroy parity done and narrow the remaining stopline to pause/resume

## Verification
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py -k 'destroy_instance_uses_strategy_destroy_transition'
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py -k 'destroy_instance_uses_strategy_destroy_transition or refresh_instance_status_uses_strategy_observe_status_transition or record_provider_error_persists_strategy_metadata or refresh_instance_status_records_strategy_provider_error_event or ensure_active_instance_persists_strategy_lease_before_probe_failure'
- uv run pytest -q tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/core/test_capability_async.py tests/Unit/core/test_runtime.py tests/Unit/storage/test_runtime_builder_contract.py -k 'lease or sandbox_lease or local_sandbox_rebuilds_stale_closed_capability_before_execute_async or lookup_sandbox_for_thread or bind_thread_to_existing_lease or resolve_existing_lease_cwd or runtime_repo_builders_use_supabase_factory'
- uv run ruff check sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py storage/contracts.py storage/providers/sqlite/lease_repo.py storage/providers/supabase/lease_repo.py storage/runtime.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run python -m py_compile sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py storage/contracts.py storage/providers/sqlite/lease_repo.py storage/providers/supabase/lease_repo.py storage/runtime.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_runtime_builder_contract.py
