### PR TITLE
feat: persist pause and resume transitions through strategy repos

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -599,6 +599,74 @@ class SQLiteLease(SandboxLease):
             repo.close()
         self._sync_from(lease_from_row(final_row, self.db_path))
 
+    def _transition_instance_via_strategy_repos(
+        self,
+        provider: SandboxProvider,
+        *,
+        event_type: str,
+        source: str,
+        desired_state: str,
+        observed_state: str,
+        capability_name: str,
+        provider_method_name: str,
+    ) -> None:
+        capability = provider.get_capability()
+        if not getattr(capability, capability_name):
+            raise RuntimeError(f"Provider {provider.name} does not support {event_type.split('.')[-1]}")
+        if not self._current_instance:
+            raise RuntimeError(f"Lease {self.lease_id} has no instance to {event_type.split('.')[-1]}")
+
+        instance_id = self._current_instance.instance_id
+        provider_method = getattr(provider, provider_method_name)
+        try:
+            ok = provider_method(instance_id)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.lease_id}: {exc}") from exc
+        if not ok:
+            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.lease_id}")
+
+        self.desired_state = desired_state
+        self._set_observed_state(observed_state, reason=event_type)
+        self.status = "active"
+        self.last_error = None
+        self.needs_refresh = False
+        self.refresh_hint_at = None
+
+        repo = _make_lease_repo(self.db_path)
+        event_repo = _make_provider_event_repo()
+        try:
+            observed_row = repo.observe_status(
+                lease_id=self.lease_id,
+                status=observed_state,
+                observed_at=utc_now_iso(),
+            )
+            self.version = int(observed_row.get("version") or self.version)
+            final_row = repo.persist_metadata(
+                lease_id=self.lease_id,
+                recipe_id=observed_row.get("recipe_id"),
+                recipe_json=observed_row.get("recipe_json"),
+                desired_state=desired_state,
+                observed_state=observed_row.get("observed_state") or observed_state,
+                version=int(observed_row.get("version") or 0),
+                observed_at=observed_row.get("observed_at"),
+                last_error=None,
+                needs_refresh=False,
+                refresh_hint_at=None,
+                status="active",
+            )
+            self.version = int(final_row.get("version") or self.version)
+            event_repo.record(
+                provider_name=self.provider_name,
+                instance_id=instance_id,
+                event_type=event_type,
+                payload={"instance_id": instance_id, "source": source},
+                matched_lease_id=self.lease_id,
+            )
+        finally:
+            event_repo.close()
+            repo.close()
+        self._sync_from(lease_from_row(final_row, self.db_path))
+
     def _reload_from_storage(self) -> None:
         repo = _make_lease_repo(self.db_path)
         try:
@@ -912,10 +980,44 @@ class SQLiteLease(SandboxLease):
         self.apply(provider, event_type="intent.destroy", source=source)
 
     def pause_instance(self, provider: SandboxProvider, *, source: str = "api") -> bool:
+        if _use_supabase_storage():
+            with self._instance_lock():
+                self._reload_from_storage()
+                try:
+                    self._transition_instance_via_strategy_repos(
+                        provider,
+                        event_type="intent.pause",
+                        source=source,
+                        desired_state="paused",
+                        observed_state="paused",
+                        capability_name="can_pause",
+                        provider_method_name="pause_session",
+                    )
+                except Exception as exc:
+                    self._record_provider_error(str(exc), source=f"{source}.pause")
+                    raise
+            return True
         self.apply(provider, event_type="intent.pause", source=source)
         return True
 
     def resume_instance(self, provider: SandboxProvider, *, source: str = "api") -> bool:
+        if _use_supabase_storage():
+            with self._instance_lock():
+                self._reload_from_storage()
+                try:
+                    self._transition_instance_via_strategy_repos(
+                        provider,
+                        event_type="intent.resume",
+                        source=source,
+                        desired_state="running",
+                        observed_state="running",
+                        capability_name="can_resume",
+                        provider_method_name="resume_session",
+                    )
+                except Exception as exc:
+                    self._record_provider_error(str(exc), source=f"{source}.resume")
+                    raise
+            return True
         self.apply(provider, event_type="intent.resume", source=source)
         return True
 

--- a/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
+++ b/teams/doc/core/2026-04-09-sandbox-control-plane-owner-plan.md
@@ -278,6 +278,20 @@ remaining wider transitions:
 - intent.pause / intent.resume
 ```
 
+Latest update after the pause/resume slice:
+
+```text
+completed fifth transition cut:
+- intent.pause / intent.resume now use strategy repos under supabase
+- pause/resume keep lease-level lock + reload before mutation
+- pause/resume failures reuse provider.error persistence/event parity
+- post-write failures preserve pause-state truth and version parity
+
+current bounded stopline:
+- transition set for CP03 is complete
+- next work should move to CP04 / higher-level closure proof
+```
+
 - [ ] **Step 3: Record the transaction question**
 
 Make the plan explicit that SQLite currently gets atomicity from one local connection in:

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -61,7 +61,7 @@ created: 2026-04-09
 | 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
 | 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | done |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | done |
-| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | in_progress |
+| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | done |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
 | 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
 
@@ -94,5 +94,6 @@ created: 2026-04-09
   - 第四轮已完成：`LeaseRepo.persist_metadata(...)` 已补进 protocol / sqlite provider / supabase provider，且 `sandbox.lease.py:_record_provider_error()` 在 `LEON_STORAGE_STRATEGY=supabase` 下已改为通过 `storage.runtime.build_lease_repo(...)` 持久化 metadata，而不是继续落回本地 sqlite refresh flag
   - 第五轮已完成：`LeaseRepo.observe_status(...)` 已补进 protocol / sqlite provider / supabase provider，且 `SQLiteLease.refresh_instance_status()` 在 `LEON_STORAGE_STRATEGY=supabase` 下会通过 strategy lease repo + provider event repo 落 `observe.status` transition
   - 第六轮已完成：`provider.error` 的 strategy event parity 已补上；`_record_provider_error(..., source=...)` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会同时持久化 lease metadata 和 `provider_events`
-  - 第七轮已完成：`intent.destroy` 的 strategy success path 已补上；`destroy_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会通过 strategy lease repo + provider event repo 落 detached/expired truth，而不是继续走本地 sqlite `apply(intent.destroy)`
-  - 当前 stopline 已压清：下一步如果继续，只剩 `pause / resume` 这一组更宽 transition，而不是再回头做底层 sqlite helper 清理
+  - 第七轮已完成：`intent.destroy` 的 strategy path 已补上；`destroy_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会通过 strategy lease repo + provider event repo 落 detached/expired truth，并保留 destroy-side error/version parity
+  - 第八轮已完成：`intent.pause / intent.resume` 的 strategy path 已补上；`pause_instance()` / `resume_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会通过同一条 strategy transition helper 落 paused/running truth，并保留 failure-side provider.error / version parity
+  - `CP03` 当前授权边界已收口完成；下一步如果继续，应离开这张卡，进入 `CP04 Default Supabase Cut` 或更高层 closure proof

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -174,13 +174,42 @@ created: 2026-04-09
   - `intent.pause`
   - `intent.resume`
 
+## Latest Pause/Resume Slice
+
+- 当前又补了一条对偶 transition：
+  - `intent.pause`
+  - `intent.resume`
+- 具体变化：
+  - `pause_instance()` / `resume_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下不再落回本地 sqlite `apply(...)`
+  - 两者现在都会先走 `_instance_lock() + _reload_from_storage()`
+  - 然后共用同一个 strategy transition helper，而不是复制两套 repo/event 写法
+  - success path 会通过 strategy `lease_repo.observe_status(...)` + `persist_metadata(...)` 落 `paused/running` truth
+  - 同时通过 strategy `provider_event_repo` 记录 `intent.pause` / `intent.resume`
+  - failure path 会复用 `_record_provider_error(..., source=f"{source}.pause|resume")`
+  - 即使 post-write failure 发生在 event 写入之后，也会保留 pause-state truth，并保持后续 error transition 的 version bump
+
+## Current Stopline
+
+- 当前 bounded transition set 已经覆盖：
+  - `persist_metadata`
+  - `observe.status`
+  - `provider.error`
+  - `intent.destroy`
+  - `intent.pause`
+  - `intent.resume`
+- 所以 `CP03` 这条 control-plane transition lane 到这里应视为已完成当前授权边界
+- 下一步不该再在这张卡里追加新的 sqlite helper 清理
+- 如果继续，应切回更上层的：
+  - `CP04 Default Supabase Cut`
+  - 或新的 closure-proof / boot/runtime proof slice
+
 ## Default Next Move
 
 - 不直接改 `monitor_service.py`
-- 不继续追加底层 sqlite helper 清理
-- 下一刀如果继续，应在更宽的 transition 之间选一个：
-  - `intent.pause / intent.resume`
-- 不要把 pause / resume 再拆成无边界的大扫除；要么做成一个对偶 slice，要么先 park
+- 不继续在 `CP03` 里追加新的 sqlite helper 清理
+- 下一步如果继续，应离开这张卡：
+  - 进入 `CP04 Default Supabase Cut`
+  - 或转向更高层 closure proof
 
 ## Stopline
 

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -11,7 +11,7 @@ class _FakeProvider:
     name = "daytona_selfhost"
 
     def get_capability(self):
-        return SimpleNamespace(supports_status_probe=True, can_destroy=True)
+        return SimpleNamespace(supports_status_probe=True, can_destroy=True, can_pause=True, can_resume=True)
 
     def create_session(self, context_id=None, thread_id=None):
         return SimpleNamespace(session_id="instance-created")
@@ -20,6 +20,12 @@ class _FakeProvider:
         return "running"
 
     def destroy_session(self, _instance_id: str) -> bool:
+        return True
+
+    def pause_session(self, _instance_id: str) -> bool:
+        return True
+
+    def resume_session(self, _instance_id: str) -> bool:
         return True
 
 
@@ -491,3 +497,125 @@ def test_destroy_instance_bumps_version_again_when_event_write_fails(monkeypatch
     assert repo.persist_calls[-1]["version"] == 2
     assert repo.persist_calls[-1]["desired_state"] == "destroyed"
     assert repo.persist_calls[-1]["observed_state"] == "detached"
+
+
+def test_pause_instance_uses_strategy_pause_transition(monkeypatch):
+    repo = _FakeLeaseRepo()
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    lease.pause_instance(_FakeProvider(), source="api")
+
+    assert repo.observe_calls == [
+        {
+            "lease_id": "lease-1",
+            "status": "paused",
+            "observed_at": repo.observe_calls[0]["observed_at"],
+        }
+    ]
+    assert len(repo.persist_calls) == 1
+    persist = repo.persist_calls[0]
+    assert persist["desired_state"] == "paused"
+    assert persist["observed_state"] == "paused"
+    assert persist["status"] == "active"
+    assert persist["needs_refresh"] is False
+    assert event_repo.record_calls == [
+        {
+            "provider_name": "daytona_selfhost",
+            "instance_id": "inst-1",
+            "event_type": "intent.pause",
+            "payload": {"instance_id": "inst-1", "source": "api"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
+
+
+def test_resume_instance_uses_strategy_resume_transition(monkeypatch):
+    repo = _FakeLeaseRepo()
+    repo._row = {
+        **repo._row,
+        "desired_state": "paused",
+        "observed_state": "paused",
+        "_instance": {
+            **repo._row["_instance"],
+            "status": "paused",
+        },
+    }
+    event_repo = _FakeProviderEventRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: event_repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    lease.resume_instance(_FakeProvider(), source="api")
+
+    assert repo.observe_calls == [
+        {
+            "lease_id": "lease-1",
+            "status": "running",
+            "observed_at": repo.observe_calls[0]["observed_at"],
+        }
+    ]
+    assert len(repo.persist_calls) == 1
+    persist = repo.persist_calls[0]
+    assert persist["desired_state"] == "running"
+    assert persist["observed_state"] == "running"
+    assert persist["status"] == "active"
+    assert persist["needs_refresh"] is False
+    assert event_repo.record_calls == [
+        {
+            "provider_name": "daytona_selfhost",
+            "instance_id": "inst-1",
+            "event_type": "intent.resume",
+            "payload": {"instance_id": "inst-1", "source": "api"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
+
+
+def test_pause_instance_preserves_paused_state_when_event_write_fails(monkeypatch):
+    repo = _FakeLeaseRepo()
+    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+
+    class _EventFailRepo(_FakeProviderEventRepo):
+        def record(
+            self,
+            *,
+            provider_name: str,
+            instance_id: str,
+            event_type: str,
+            payload: dict[str, object],
+            matched_lease_id: str | None,
+        ) -> None:
+            if event_type == "intent.pause":
+                raise RuntimeError("event boom")
+            super().record(
+                provider_name=provider_name,
+                instance_id=instance_id,
+                event_type=event_type,
+                payload=payload,
+                matched_lease_id=matched_lease_id,
+            )
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._make_provider_event_repo", lambda: _EventFailRepo())
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
+
+    with pytest.raises(RuntimeError, match="event boom"):
+        lease.pause_instance(_FakeProvider(), source="api")
+
+    assert len(repo.persist_calls) == 2
+    assert repo.persist_calls[0]["version"] == 1
+    assert repo.persist_calls[-1]["version"] == 2
+    assert repo.persist_calls[-1]["desired_state"] == "paused"
+    assert repo.persist_calls[-1]["observed_state"] == "paused"
+    assert repo.persist_calls[-1]["last_error"] == "event boom"
+    assert repo.persist_calls[-1]["needs_refresh"] is True


### PR DESCRIPTION
## Summary
- persist `intent.pause` and `intent.resume` through strategy repos under supabase
- keep lease-level lock/reload and failure-side provider.error parity for pause/resume
- mark CP03 sandbox control-plane transition set as complete at the current boundary

## Verification
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py -k 'pause_instance_uses_strategy_pause_transition or resume_instance_uses_strategy_resume_transition or pause_instance_preserves_paused_state_when_event_write_fails'
- uv run pytest -q tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/core/test_capability_async.py tests/Unit/core/test_runtime.py tests/Unit/storage/test_runtime_builder_contract.py -k 'lease or sandbox_lease or local_sandbox_rebuilds_stale_closed_capability_before_execute_async or lookup_sandbox_for_thread or bind_thread_to_existing_lease or resolve_existing_lease_cwd or runtime_repo_builders_use_supabase_factory'
- uv run ruff check sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py storage/contracts.py storage/providers/sqlite/lease_repo.py storage/providers/supabase/lease_repo.py storage/runtime.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run python -m py_compile sandbox/lease.py tests/Unit/sandbox/test_lease_probe_contract.py storage/contracts.py storage/providers/sqlite/lease_repo.py storage/providers/supabase/lease_repo.py storage/runtime.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_runtime_builder_contract.py