### PR TITLE
feat: default storage strategy to supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,25 @@ uv sync --extra daytona     # Daytona
 
 Docker sandbox works out of the box (just needs Docker installed). See [Sandbox docs](docs/en/sandbox.mdx) for provider setup.
 
-### 3. Start the services
+### 3. Configure the default Supabase storage contract
+
+Create `.env` or `~/.leon/config.env` from [.env.example](.env.example) and keep the storage strategy on Supabase:
+
+```env
+LEON_STORAGE_STRATEGY=supabase
+SUPABASE_PUBLIC_URL=http://localhost:54320
+SUPABASE_INTERNAL_URL=http://localhost:54320
+SUPABASE_AUTH_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your-anon-key
+LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+LEON_DB_SCHEMA=staging
+LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+```
+
+For local dev, start your Supabase/tunnel endpoints first. Mycel's current web/runtime mainline is Supabase-first; SQLite should not be treated as the default startup contract.
+
+### 4. Start the services
 
 ```bash
 # Terminal 1: Backend
@@ -73,7 +91,7 @@ cd frontend/app && npm run dev
 # → http://localhost:5173
 ```
 
-### 4. Open and configure
+### 5. Open and configure
 
 1. Open **http://localhost:5173** in your browser
 2. **Register** an account

--- a/README.zh.md
+++ b/README.zh.md
@@ -61,7 +61,25 @@ uv sync --extra daytona     # Daytona
 
 Docker 沙箱开箱即用（只需安装 Docker）。详见[沙箱文档](docs/zh/sandbox.mdx)。
 
-### 3. 启动服务
+### 3. 配置默认的 Supabase 存储契约
+
+从 [.env.example](.env.example) 复制配置到 `.env` 或 `~/.leon/config.env`，并保持存储策略为 Supabase：
+
+```env
+LEON_STORAGE_STRATEGY=supabase
+SUPABASE_PUBLIC_URL=http://localhost:54320
+SUPABASE_INTERNAL_URL=http://localhost:54320
+SUPABASE_AUTH_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your-anon-key
+LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+LEON_DB_SCHEMA=staging
+LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+```
+
+本地开发时先确保 Supabase / tunnel 端点已经启动。当前的 web/runtime 主线是 Supabase-first，不应再把 SQLite 当成默认启动契约。
+
+### 4. 启动服务
 
 ```bash
 # 终端 1：后端
@@ -73,7 +91,7 @@ cd frontend/app && npm run dev
 # → http://localhost:5173
 ```
 
-### 4. 打开并配置
+### 5. 打开并配置
 
 1. 浏览器打开 **http://localhost:5173**
 2. **注册**账号

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -132,7 +132,7 @@ async def lifespan(app: FastAPI):
     app.state.messaging_service.set_delivery_fn(make_chat_delivery_fn(app))
 
     # ---- Existing state ----
-    app.state.queue_manager = MessageQueueManager()
+    app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.agent_pool = cast(dict[str, Any], {})
     app.state.thread_sandbox = cast(dict[str, str], {})
     app.state.thread_cwd = cast(dict[str, str], {})

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -1051,7 +1051,7 @@ def get_event(event_id: str) -> dict[str, Any]:
 def runtime_health_snapshot() -> dict[str, Any]:
     """Lightweight control-plane health snapshot."""
     tables: dict[str, int] = {"chat_sessions": 0, "sandbox_leases": 0, "lease_events": 0}
-    storage_strategy = str(os.getenv("LEON_STORAGE_STRATEGY") or "sqlite").strip().lower()
+    storage_strategy = str(os.getenv("LEON_STORAGE_STRATEGY") or "supabase").strip().lower()
 
     if storage_strategy == "supabase":
         repo = make_sandbox_monitor_repo()

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -192,10 +192,14 @@ class LeonAgent:
             permission_resolver_scope: Permission request surface for this agent ("none" or "thread")
             verbose: Whether to output detailed logs (default False)
         """
+        runtime_storage = storage_container
+
         self.agent_id: str | None = None
         self.verbose = verbose
         self.extra_allowed_paths = extra_allowed_paths
-        self.queue_manager = queue_manager or MessageQueueManager()
+        self.queue_manager = queue_manager or (
+            MessageQueueManager(repo=runtime_storage.queue_repo()) if runtime_storage is not None else MessageQueueManager()
+        )
         self._chat_repos: dict | None = chat_repos
         self._thread_repo = thread_repo
         self._user_repo = user_repo
@@ -257,7 +261,7 @@ class LeonAgent:
         # Initialize workspace and configuration
         self.workspace_root = self._resolve_workspace_root()
         self._init_config_attributes()
-        self.storage_container: StorageContainer | None = storage_container
+        self.storage_container: StorageContainer | None = runtime_storage
         self._sandbox = self._init_sandbox(sandbox)
 
         # Override workspace_root for sandbox mode
@@ -1778,6 +1782,12 @@ def create_leon_agent(
     """
     # Filter out kwargs that LeonAgent.__init__ doesn't accept (e.g. profile from CLI)
     import inspect as _inspect
+    import os as _os
+
+    if storage_container is None and _os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+        from storage.runtime import build_storage_container
+
+        storage_container = build_storage_container()
 
     _valid = set(_inspect.signature(LeonAgent.__init__).parameters) - {"self"}
     kwargs = {k: v for k, v in kwargs.items() if k in _valid}

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -52,7 +52,18 @@ Create `~/.leon/config.env`:
 OPENAI_API_KEY=sk-xxx
 OPENAI_BASE_URL=https://api.openai.com/v1
 MODEL_NAME=claude-sonnet-4-5-20250929
+LEON_STORAGE_STRATEGY=supabase
+SUPABASE_PUBLIC_URL=http://localhost:54320
+SUPABASE_INTERNAL_URL=http://localhost:54320
+SUPABASE_AUTH_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your-anon-key
+LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+LEON_DB_SCHEMA=staging
+LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 ```
+
+The current default storage contract is Supabase-first. If `LEON_STORAGE_STRATEGY` is omitted in documented web/dev flows, treat that as incomplete configuration rather than a signal to fall back to SQLite.
 
 ## runtime.json
 

--- a/docs/en/deployment.mdx
+++ b/docs/en/deployment.mdx
@@ -81,11 +81,21 @@ Create `~/.leon/config.env` manually:
 
 ```env
 ANTHROPIC_API_KEY=sk-ant-xxx
-# Or use OpenAI-compatible format:
-# OPENAI_API_KEY=your-key
-# OPENAI_BASE_URL=https://api.openai.com/v1
-# MODEL_NAME=gpt-4o
+OPENAI_API_KEY=your-key
+OPENAI_BASE_URL=https://api.openai.com/v1
+MODEL_NAME=claude-sonnet-4-5-20250929
+LEON_STORAGE_STRATEGY=supabase
+SUPABASE_PUBLIC_URL=http://localhost:54320
+SUPABASE_INTERNAL_URL=http://localhost:54320
+SUPABASE_AUTH_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your-anon-key
+LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+LEON_DB_SCHEMA=staging
+LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 ```
+
+The production and local web runtime contract is Supabase-first. SQLite files under `~/.leon/*.db` may still exist for residual/local surfaces, but they are not the documented default startup path.
 
 ## Starting services
 
@@ -222,14 +232,11 @@ Open the Web UI at `http://localhost:5173`, register an account, and confirm the
 
 ### Database
 
-Mycel uses SQLite by default. For production:
+The documented default storage path is Supabase plus a Postgres checkpointer.
 
-```bash
-# Backup regularly
-cp ~/.leon/leon.db ~/.leon/leon.db.backup
-```
-
-Multi-user deployments may require PostgreSQL — this requires code changes to the storage layer.
+- Supabase handles web/runtime storage and auth
+- `LEON_POSTGRES_URL` is required for the backend web runtime checkpointer contract
+- SQLite files under `~/.leon/*.db` should be treated as residual/local surfaces, not the primary production database contract
 
 ### Security
 

--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -11,6 +11,7 @@ keywords: [quickstart, install, setup, first agent]
 - Python 3.11+
 - Node.js 18+
 - An OpenAI-compatible API key (Anthropic, OpenAI, OpenRouter, etc.)
+- A reachable Supabase stack for storage/auth plus a Postgres checkpointer URL
 
 ## Install and run
 
@@ -30,6 +31,26 @@ keywords: [quickstart, install, setup, first agent]
     # Frontend
     cd frontend/app && npm install && cd ../..
     ```
+  </Step>
+
+  <Step title="Configure the default Supabase storage contract">
+    Copy `.env.example` into `.env` or `~/.leon/config.env`, then keep the storage strategy on Supabase:
+
+    ```env
+    LEON_STORAGE_STRATEGY=supabase
+    SUPABASE_PUBLIC_URL=http://localhost:54320
+    SUPABASE_INTERNAL_URL=http://localhost:54320
+    SUPABASE_AUTH_URL=http://127.0.0.1:54321
+    SUPABASE_ANON_KEY=your-anon-key
+    LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+    SUPABASE_JWT_SECRET=your-jwt-secret
+    LEON_DB_SCHEMA=staging
+    LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+    ```
+
+    <Tip>
+      Mycel's current web/runtime mainline is Supabase-first. Do not treat SQLite as the default local startup contract.
+    </Tip>
   </Step>
 
   <Step title="Start services">

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -42,7 +42,18 @@ Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置
 OPENAI_API_KEY=sk-xxx
 OPENAI_BASE_URL=https://api.openai.com/v1
 MODEL_NAME=claude-sonnet-4-5-20250929
+LEON_STORAGE_STRATEGY=supabase
+SUPABASE_PUBLIC_URL=http://localhost:54320
+SUPABASE_INTERNAL_URL=http://localhost:54320
+SUPABASE_AUTH_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your-anon-key
+LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+LEON_DB_SCHEMA=staging
+LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 ```
+
+当前默认存储契约是 Supabase-first。在文档化的 web/dev 启动路径里，如果缺少 `LEON_STORAGE_STRATEGY`，应视为配置不完整，而不是自动退回 SQLite。
 
 ## runtime.json
 

--- a/docs/zh/deployment.mdx
+++ b/docs/zh/deployment.mdx
@@ -81,11 +81,21 @@ Mycel 配置存储在 `~/.leon/`：
 
 ```env
 ANTHROPIC_API_KEY=sk-ant-xxx
-# 或使用 OpenAI 兼容格式：
-# OPENAI_API_KEY=your-key
-# OPENAI_BASE_URL=https://api.openai.com/v1
-# MODEL_NAME=gpt-4o
+OPENAI_API_KEY=your-key
+OPENAI_BASE_URL=https://api.openai.com/v1
+MODEL_NAME=claude-sonnet-4-5-20250929
+LEON_STORAGE_STRATEGY=supabase
+SUPABASE_PUBLIC_URL=http://localhost:54320
+SUPABASE_INTERNAL_URL=http://localhost:54320
+SUPABASE_AUTH_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your-anon-key
+LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+LEON_DB_SCHEMA=staging
+LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 ```
+
+当前 production/local web runtime 的文档化默认契约是 Supabase-first。`~/.leon/*.db` 下的 SQLite 文件即使仍然存在，也不应再被描述成默认启动路径。
 
 ## 启动服务
 
@@ -222,14 +232,11 @@ Daytona Proxy（端口 4000）必须从 Runner 可访问，文件操作依赖它
 
 ### 数据库
 
-Mycel 默认使用 SQLite。生产环境建议：
+文档化的默认存储路径是 Supabase 加 Postgres checkpointer。
 
-```bash
-# 定期备份
-cp ~/.leon/leon.db ~/.leon/leon.db.backup
-```
-
-多用户部署可能需要 PostgreSQL — 需要对存储层进行代码改动。
+- Supabase 承担 web/runtime 存储和认证
+- `LEON_POSTGRES_URL` 是 backend web runtime checkpointer 契约的必填项
+- `~/.leon/*.db` 下的 SQLite 文件应被视为 residual/local surface，而不是主要的生产数据库契约
 
 ### 安全
 

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -11,6 +11,7 @@ keywords: [快速开始, 安装, 配置, 第一个 Agent]
 - Python 3.11+
 - Node.js 18+
 - 一个 OpenAI 兼容的 API Key（Anthropic、OpenAI、OpenRouter 等均可）
+- 可访问的 Supabase 存储/认证端点，以及一个 Postgres checkpointer URL
 
 ## 安装与启动
 
@@ -30,6 +31,26 @@ keywords: [快速开始, 安装, 配置, 第一个 Agent]
     # 前端
     cd frontend/app && npm install && cd ../..
     ```
+  </Step>
+
+  <Step title="配置默认的 Supabase 存储契约">
+    从 `.env.example` 复制配置到 `.env` 或 `~/.leon/config.env`，并保持存储策略为 Supabase：
+
+    ```env
+    LEON_STORAGE_STRATEGY=supabase
+    SUPABASE_PUBLIC_URL=http://localhost:54320
+    SUPABASE_INTERNAL_URL=http://localhost:54320
+    SUPABASE_AUTH_URL=http://127.0.0.1:54321
+    SUPABASE_ANON_KEY=your-anon-key
+    LEON_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+    SUPABASE_JWT_SECRET=your-jwt-secret
+    LEON_DB_SCHEMA=staging
+    LEON_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+    ```
+
+    <Tip>
+      当前的 web/runtime 主线是 Supabase-first，不应再把 SQLite 当成默认本地启动契约。
+    </Tip>
   </Step>
 
   <Step title="启动服务">

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -1,27 +1,41 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+from storage.runtime import build_chat_session_repo, build_lease_repo, build_terminal_repo
 
 
 def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
     return db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
+def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
+    return os.environ.get("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase" and resolve_sandbox_db_path(
+        db_path
+    ) == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+
+
 def make_chat_session_repo(db_path: Path | None = None):
+    if _use_strategy_control_plane_repo(db_path):
+        return build_chat_session_repo()
     from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 
     return SQLiteChatSessionRepo(db_path=resolve_sandbox_db_path(db_path))
 
 
 def make_lease_repo(db_path: Path | None = None):
+    if _use_strategy_control_plane_repo(db_path):
+        return build_lease_repo()
     from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
 
     return SQLiteLeaseRepo(db_path=resolve_sandbox_db_path(db_path))
 
 
 def make_terminal_repo(db_path: Path | None = None):
+    if _use_strategy_control_plane_repo(db_path):
+        return build_terminal_repo()
     from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
     return SQLiteTerminalRepo(db_path=resolve_sandbox_db_path(db_path))

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -82,7 +82,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _use_supabase_storage() -> bool:
-    return os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase"
+    return os.getenv("LEON_STORAGE_STRATEGY", "supabase").strip().lower() == "supabase"
 
 
 def _make_lease_repo(db_path: Path | None = None):

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -82,7 +82,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _use_supabase_storage() -> bool:
-    return os.getenv("LEON_STORAGE_STRATEGY", "supabase").strip().lower() == "supabase"
+    return os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase"
 
 
 def _make_lease_repo(db_path: Path | None = None):

--- a/storage/session_manager.py
+++ b/storage/session_manager.py
@@ -1,10 +1,12 @@
 """Session management for agent thread persistence"""
 
 import json
+import os
 from pathlib import Path
 
 from storage.providers.sqlite.checkpoint_repo import SQLiteCheckpointRepo
 from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
+from storage.runtime import build_storage_container
 
 
 class SessionManager:
@@ -54,6 +56,26 @@ class SessionManager:
             if data.get("last_thread_id") == thread_id:
                 data["last_thread_id"] = threads[0] if threads else None
             self.session_file.write_text(json.dumps(data, indent=2))
+
+        if os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+            try:
+                container = build_storage_container()
+
+                repo = container.checkpoint_repo()
+                try:
+                    repo.delete_thread_data(thread_id)
+                finally:
+                    repo.close()
+
+                file_repo = container.file_operation_repo()
+                try:
+                    file_repo.delete_thread_operations(thread_id)
+                finally:
+                    file_repo.close()
+                return True
+            except Exception as e:
+                print(f"[SessionManager] Error deleting thread from storage container: {e}")
+                return False
 
         if self.db_path.exists():
             try:

--- a/teams/doc/core/2026-04-09-closure-proof-plan.md
+++ b/teams/doc/core/2026-04-09-closure-proof-plan.md
@@ -37,6 +37,8 @@ Stopline:
 - after this slice, we can honestly say:
   - explicit Supabase + default sandbox path no longer forces sqlite control-plane repo construction
   - custom `db_path` still preserves local sqlite semantics
+- after the follow-up proof, we can also honestly say:
+  - missing `LEON_STORAGE_STRATEGY` still keeps the default sandbox control-plane on sqlite truth
 - we still cannot honestly say:
   - env-less sandbox control-plane is closed
   - the whole system boots without SQLite
@@ -45,5 +47,5 @@ Stopline:
 Default next move:
 
 - continue `CP05` with the next narrow proof:
-  - env-less sandbox control-plane residual audit/proof
+  - env-less sandbox control-plane residual narrowing
   - or another concrete default-boot blocker if it appears first in caller-level evidence

--- a/teams/doc/core/2026-04-09-closure-proof-plan.md
+++ b/teams/doc/core/2026-04-09-closure-proof-plan.md
@@ -1,0 +1,49 @@
+# Closure Proof Plan
+
+Goal: prove the Supabase runtime contract with caller-level evidence instead of assuming that earlier abstraction work already removed SQLite from the critical path.
+
+Current narrow ruling:
+
+- Do not jump straight to "Supabase-only boot is done".
+- First prove that explicit `LEON_STORAGE_STRATEGY=supabase` does not silently route sandbox control-plane repo construction back through SQLite on the default sandbox path.
+- Keep custom/local `db_path` semantics intact for harnesses and explicit local callers.
+
+First bounded slice:
+
+1. `sandbox/control_plane_repos.py`
+   - add the smallest strategy gate:
+     - if strategy is explicit `supabase`
+     - and the target db path matches the canonical default sandbox db path
+     - use runtime builders for:
+       - chat session repo
+       - lease repo
+       - terminal repo
+2. `tests/Unit/sandbox/test_manager_repo_strategy.py`
+   - prove `SandboxManager(provider=...)` now gets strategy repos under explicit Supabase
+   - prove `SandboxManager(provider=..., db_path=custom)` still gets sqlite repos
+
+Evidence target:
+
+- focused control-plane caller proof:
+  - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py`
+- adjacent manager regression guard:
+  - `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
+- source-level hygiene:
+  - `uv run ruff check sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
+  - `uv run python -m py_compile sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
+
+Stopline:
+
+- after this slice, we can honestly say:
+  - explicit Supabase + default sandbox path no longer forces sqlite control-plane repo construction
+  - custom `db_path` still preserves local sqlite semantics
+- we still cannot honestly say:
+  - env-less sandbox control-plane is closed
+  - the whole system boots without SQLite
+  - real product Supabase closure proof is complete
+
+Default next move:
+
+- continue `CP05` with the next narrow proof:
+  - env-less sandbox control-plane residual audit/proof
+  - or another concrete default-boot blocker if it appears first in caller-level evidence

--- a/teams/doc/core/2026-04-09-closure-proof-plan.md
+++ b/teams/doc/core/2026-04-09-closure-proof-plan.md
@@ -22,12 +22,25 @@ First bounded slice:
    - prove `SandboxManager(provider=...)` now gets strategy repos under explicit Supabase
    - prove `SandboxManager(provider=..., db_path=custom)` still gets sqlite repos
 
+Second bounded slice:
+
+1. `storage/session_manager.py`
+   - when `LEON_STORAGE_STRATEGY=supabase`, route thread cleanup through runtime container
+   - remove the local `leon.db.exists()` gate from the Supabase path
+2. `tests/Unit/storage/test_session_file_operations_cleanup.py`
+   - prove Supabase cleanup uses:
+     - `checkpoint_repo()`
+     - `file_operation_repo()`
+   - keep the sqlite local cleanup path pinned
+
 Evidence target:
 
 - focused control-plane caller proof:
   - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py`
 - adjacent manager regression guard:
   - `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
+- focused session cleanup proof:
+  - `uv run pytest -q tests/Unit/storage/test_session_file_operations_cleanup.py`
 - source-level hygiene:
   - `uv run ruff check sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
   - `uv run python -m py_compile sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
@@ -39,6 +52,8 @@ Stopline:
   - custom `db_path` still preserves local sqlite semantics
 - after the follow-up proof, we can also honestly say:
   - missing `LEON_STORAGE_STRATEGY` still keeps the default sandbox control-plane on sqlite truth
+- after the second follow-up proof, we can also honestly say:
+  - explicit Supabase thread cleanup no longer depends on local `leon.db` existence
 - we still cannot honestly say:
   - env-less sandbox control-plane is closed
   - the whole system boots without SQLite

--- a/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
+++ b/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
@@ -1,0 +1,37 @@
+# Default Supabase Cut Plan
+
+Goal: make the code-level default strategy Supabase-first before claiming higher-level boot/runtime closure.
+
+Current narrow ruling:
+
+- Do not mix this slice with closure proof.
+- Do not sweep all remaining SQLite callers.
+- First cut only answers:
+  - when `LEON_STORAGE_STRATEGY` is missing, what strategy does the code assume?
+
+First bounded slice:
+
+1. `backend/web/services/monitor_service.py`
+   - change missing-env fallback from `sqlite` to `supabase`
+2. `sandbox/lease.py`
+   - change `_use_supabase_storage()` missing-env fallback from `sqlite` to `supabase`
+3. add regression tests that pin both defaults
+
+Evidence target:
+
+- focused unit tests for:
+  - `runtime_health_snapshot()` missing-env behavior
+  - `_use_supabase_storage()` missing-env behavior
+- full local unit files for:
+  - `tests/Unit/monitor/test_monitor_compat.py`
+  - `tests/Unit/sandbox/test_lease_probe_contract.py`
+
+Stopline:
+
+- after this slice, we can honestly say:
+  - code-level default fallback is Supabase-first
+- we still cannot honestly say:
+  - the full system has boot/runtime closure without SQLite
+- next move should be:
+  - broader default/dev contract proof
+  - or `CP05 Closure Proof`

--- a/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
+++ b/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
@@ -16,6 +16,9 @@ Current narrow ruling:
   - web startup queue wiring must not silently fall back to `SQLiteQueueRepo`
   - generic `create_leon_agent()` must auto-build runtime storage container in Supabase mode
   - this also pulls summary persistence for `langgraph_app.py` back onto the runtime container seam
+- After the third pass, the ruling tightened again:
+  - documented startup/configuration text must also become Supabase-first
+  - `.env.example` alone is not enough if README / quickstart / deployment still imply sqlite-default
 
 First bounded slice:
 
@@ -37,6 +40,17 @@ Second bounded slice:
    - web lifespan queue manager uses runtime container queue repo
    - `create_leon_agent()` Supabase path wires runtime queue + summary repos
 
+Third bounded slice:
+
+1. Update `README.md` / `README.zh.md`
+   - add Supabase-first startup contract
+2. Update `docs/en/quickstart.mdx` / `docs/zh/quickstart.mdx`
+   - require Supabase + Postgres checkpointer in quickstart
+3. Update `docs/en/configuration.mdx` / `docs/zh/configuration.mdx`
+   - make first-run config explicitly Supabase-first
+4. Update `docs/en/deployment.mdx` / `docs/zh/deployment.mdx`
+   - remove sqlite-default wording from deployment/database guidance
+
 Evidence target:
 
 - focused unit tests for:
@@ -56,10 +70,10 @@ Stopline:
   - monitor read-surface default fallback is Supabase-first
   - lease default is still blocked by env-less sqlite control-plane ownership
   - web startup queue and generic agent startup queue/summary now consume runtime storage container in Supabase mode
+  - documented/default startup contract is also Supabase-first
 - we still cannot honestly say:
   - code-level defaults are uniformly Supabase-first
   - the full system has boot/runtime closure without SQLite
 - next move should be:
-  - broader default/dev contract proof
-  - especially README / quickstart / deployment / configuration docs
+  - `CP05 Closure Proof`
   - plus any env-less sandbox control-plane residual that still contradicts default Supabase

--- a/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
+++ b/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
@@ -12,6 +12,10 @@ Current narrow ruling:
   - monitor default can safely move to Supabase-first
   - lease default cannot safely move yet
   - env-less sandbox control-plane still creates sqlite lease truth before strategy repos are available
+- After the second pass, the ruling tightened again:
+  - web startup queue wiring must not silently fall back to `SQLiteQueueRepo`
+  - generic `create_leon_agent()` must auto-build runtime storage container in Supabase mode
+  - this also pulls summary persistence for `langgraph_app.py` back onto the runtime container seam
 
 First bounded slice:
 
@@ -22,6 +26,17 @@ First bounded slice:
    - add regression proving env-less `mark_needs_refresh()` still writes local sqlite lease state
 3. add regression tests that pin the safe monitor default and the unsafe lease-default stopline
 
+Second bounded slice:
+
+1. `backend/web/core/lifespan.py`
+   - wire `app.state.queue_manager` through `storage_container.queue_repo()`
+2. `core/runtime/agent.py`
+   - if `LEON_STORAGE_STRATEGY=supabase` and no container was injected, auto-build runtime storage container
+   - if a runtime container exists and no queue manager was injected, default to `MessageQueueManager(repo=container.queue_repo())`
+3. add integration tests that pin:
+   - web lifespan queue manager uses runtime container queue repo
+   - `create_leon_agent()` Supabase path wires runtime queue + summary repos
+
 Evidence target:
 
 - focused unit tests for:
@@ -31,15 +46,20 @@ Evidence target:
 - full local unit files for:
   - `tests/Unit/monitor/test_monitor_compat.py`
   - `tests/Unit/sandbox/test_lease_probe_contract.py`
+- integration files for:
+  - `tests/Integration/test_storage_repo_abstraction_unification.py`
+  - `tests/Integration/test_leon_agent.py`
 
 Stopline:
 
 - after this slice, we can honestly say:
   - monitor read-surface default fallback is Supabase-first
   - lease default is still blocked by env-less sqlite control-plane ownership
+  - web startup queue and generic agent startup queue/summary now consume runtime storage container in Supabase mode
 - we still cannot honestly say:
   - code-level defaults are uniformly Supabase-first
   - the full system has boot/runtime closure without SQLite
 - next move should be:
   - broader default/dev contract proof
-  - especially README / quickstart / deployment / configuration docs plus queue / summary / langgraph dev startup paths
+  - especially README / quickstart / deployment / configuration docs
+  - plus any env-less sandbox control-plane residual that still contradicts default Supabase

--- a/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
+++ b/teams/doc/core/2026-04-09-default-supabase-cut-plan.md
@@ -8,20 +8,26 @@ Current narrow ruling:
 - Do not sweep all remaining SQLite callers.
 - First cut only answers:
   - when `LEON_STORAGE_STRATEGY` is missing, what strategy does the code assume?
+- After the first pass, the ruling tightened:
+  - monitor default can safely move to Supabase-first
+  - lease default cannot safely move yet
+  - env-less sandbox control-plane still creates sqlite lease truth before strategy repos are available
 
 First bounded slice:
 
 1. `backend/web/services/monitor_service.py`
    - change missing-env fallback from `sqlite` to `supabase`
 2. `sandbox/lease.py`
-   - change `_use_supabase_storage()` missing-env fallback from `sqlite` to `supabase`
-3. add regression tests that pin both defaults
+   - keep `_use_supabase_storage()` missing-env fallback at `sqlite`
+   - add regression proving env-less `mark_needs_refresh()` still writes local sqlite lease state
+3. add regression tests that pin the safe monitor default and the unsafe lease-default stopline
 
 Evidence target:
 
 - focused unit tests for:
   - `runtime_health_snapshot()` missing-env behavior
   - `_use_supabase_storage()` missing-env behavior
+  - env-less `mark_needs_refresh()` local sqlite persistence
 - full local unit files for:
   - `tests/Unit/monitor/test_monitor_compat.py`
   - `tests/Unit/sandbox/test_lease_probe_contract.py`
@@ -29,9 +35,11 @@ Evidence target:
 Stopline:
 
 - after this slice, we can honestly say:
-  - code-level default fallback is Supabase-first
+  - monitor read-surface default fallback is Supabase-first
+  - lease default is still blocked by env-less sqlite control-plane ownership
 - we still cannot honestly say:
+  - code-level defaults are uniformly Supabase-first
   - the full system has boot/runtime closure without SQLite
 - next move should be:
   - broader default/dev contract proof
-  - or `CP05 Closure Proof`
+  - especially README / quickstart / deployment / configuration docs plus queue / summary / langgraph dev startup paths

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -90,6 +90,7 @@ created: 2026-04-09
   - `CP05a` 已完成第一条 caller proof：
     - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，默认 sandbox control-plane repo construction 已切回 strategy seam
     - 显式自定义 `db_path` 仍保持 sqlite-owned
+    - env-less 时，默认 sandbox control-plane caller 仍保持 sqlite-owned
   - 下一步不要扩成“大而全 closure”
-    - 应继续核对 env-less sandbox control-plane residual
+    - 应继续核对 env-less sandbox control-plane residual 是否还能进一步收窄
     - 以及任何仍要求本地 sqlite truth 才能跑通的 default boot blocker

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -91,6 +91,8 @@ created: 2026-04-09
     - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，默认 sandbox control-plane repo construction 已切回 strategy seam
     - 显式自定义 `db_path` 仍保持 sqlite-owned
     - env-less 时，默认 sandbox control-plane caller 仍保持 sqlite-owned
+  - `CP05b` 又补了一条 cleanup proof：
+    - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，`SessionManager.delete_thread()` 已通过 runtime container 清理 checkpoint/file operations
   - 下一步不要扩成“大而全 closure”
     - 应继续核对 env-less sandbox control-plane residual 是否还能进一步收窄
     - 以及任何仍要求本地 sqlite truth 才能跑通的 default boot blocker

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -87,11 +87,14 @@ created: 2026-04-09
 ## Default Next Move
 
 - `CP04 Default Supabase Cut`
-  - 第一轮已完成：
+  - 第一轮 ruling 已压实：
     - `backend/web/services/monitor_service.py` 的缺省 strategy fallback 已从 sqlite 改成 supabase
-    - `sandbox/lease.py::_use_supabase_storage()` 的缺省 strategy fallback 已从 sqlite 改成 supabase
-    - 对应 unit tests 已补齐并通过
+    - `sandbox/lease.py::_use_supabase_storage()` 不能安全改成 supabase-first
+    - env 缺省时，`sandbox/control_plane_repos.py` / `sandbox/manager.py` 仍先落本地 sqlite lease truth
+    - 已补 regression，证明 `mark_needs_refresh()` 在缺省 env 下仍必须写回 sqlite
   - 当前 stopline：
-    - 这只说明“env 缺省时代码默认按 Supabase 解释”
+    - 这只说明 monitor read surface 已切到 Supabase-first
+    - 还不能说整个默认运行面已切完
     - 还不等于 boot/runtime closure proof 已完成
-  - 下一步如果继续，应在 `CP04` 里补更高层 default/dev contract proof，或直接转向 `CP05 Closure Proof`
+  - 下一步如果继续，应在 `CP04` 里补更高层 default/dev contract proof
+    - 重点核对 queue / summary / langgraph dev / sandbox control-plane 这些仍绕开 strategy 的默认启动旁路

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -92,9 +92,15 @@ created: 2026-04-09
     - `sandbox/lease.py::_use_supabase_storage()` 不能安全改成 supabase-first
     - env 缺省时，`sandbox/control_plane_repos.py` / `sandbox/manager.py` 仍先落本地 sqlite lease truth
     - 已补 regression，证明 `mark_needs_refresh()` 在缺省 env 下仍必须写回 sqlite
+  - 第二轮 ruling 已压实：
+    - `backend/web/core/lifespan.py` 的 `queue_manager` 已改为消费 `storage_container.queue_repo()`
+    - `create_leon_agent()` 在 `LEON_STORAGE_STRATEGY=supabase` 下会自动接 runtime storage container
+    - `LeonAgent` 在有 runtime container 且未显式注入 queue manager 时，默认走 container queue repo
+    - generic agent / `langgraph_app.py` 的 summary persistence 因此也回到 runtime container
   - 当前 stopline：
-    - 这只说明 monitor read surface 已切到 Supabase-first
+    - 这只说明 monitor read surface 以及 default startup queue/summary wiring 已切到 Supabase-first
     - 还不能说整个默认运行面已切完
     - 还不等于 boot/runtime closure proof 已完成
   - 下一步如果继续，应在 `CP04` 里补更高层 default/dev contract proof
-    - 重点核对 queue / summary / langgraph dev / sandbox control-plane 这些仍绕开 strategy 的默认启动旁路
+    - 重点核对 README / quickstart / deployment / configuration 的 documented truth
+    - 以及 env-less sandbox control-plane 这类仍未被证明可默认切到 Supabase 的 residual

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -62,7 +62,7 @@ created: 2026-04-09
 | 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | done |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | done |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | done |
-| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | in_progress |
+| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | done |
 | 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
 
 ## 边界
@@ -86,21 +86,13 @@ created: 2026-04-09
 
 ## Default Next Move
 
-- `CP04 Default Supabase Cut`
-  - 第一轮 ruling 已压实：
-    - `backend/web/services/monitor_service.py` 的缺省 strategy fallback 已从 sqlite 改成 supabase
-    - `sandbox/lease.py::_use_supabase_storage()` 不能安全改成 supabase-first
-    - env 缺省时，`sandbox/control_plane_repos.py` / `sandbox/manager.py` 仍先落本地 sqlite lease truth
-    - 已补 regression，证明 `mark_needs_refresh()` 在缺省 env 下仍必须写回 sqlite
-  - 第二轮 ruling 已压实：
-    - `backend/web/core/lifespan.py` 的 `queue_manager` 已改为消费 `storage_container.queue_repo()`
-    - `create_leon_agent()` 在 `LEON_STORAGE_STRATEGY=supabase` 下会自动接 runtime storage container
-    - `LeonAgent` 在有 runtime container 且未显式注入 queue manager 时，默认走 container queue repo
-    - generic agent / `langgraph_app.py` 的 summary persistence 因此也回到 runtime container
-  - 当前 stopline：
-    - 这只说明 monitor read surface 以及 default startup queue/summary wiring 已切到 Supabase-first
-    - 还不能说整个默认运行面已切完
-    - 还不等于 boot/runtime closure proof 已完成
-  - 下一步如果继续，应在 `CP04` 里补更高层 default/dev contract proof
-    - 重点核对 README / quickstart / deployment / configuration 的 documented truth
-    - 以及 env-less sandbox control-plane 这类仍未被证明可默认切到 Supabase 的 residual
+- `CP05 Closure Proof`
+  - `CP04` 已完成：
+    - monitor read fallback 已切到 Supabase-first
+    - startup queue / summary wiring 已接回 runtime storage container
+    - README / quickstart / configuration / deployment 的 documented default 已对齐
+  - 下一步要回答的已经不是“默认是什么”
+    - 而是关键运行路径在 Supabase contract 下是否真的独立成立
+  - 重点残余：
+    - env-less sandbox control-plane sqlite ownership
+    - 任何仍要求本地 sqlite truth 才能跑通的 closure blocker

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -63,7 +63,7 @@ created: 2026-04-09
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | done |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | done |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | done |
-| 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
+| 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | in_progress |
 
 ## 边界
 
@@ -87,12 +87,9 @@ created: 2026-04-09
 ## Default Next Move
 
 - `CP05 Closure Proof`
-  - `CP04` 已完成：
-    - monitor read fallback 已切到 Supabase-first
-    - startup queue / summary wiring 已接回 runtime storage container
-    - README / quickstart / configuration / deployment 的 documented default 已对齐
-  - 下一步要回答的已经不是“默认是什么”
-    - 而是关键运行路径在 Supabase contract 下是否真的独立成立
-  - 重点残余：
-    - env-less sandbox control-plane sqlite ownership
-    - 任何仍要求本地 sqlite truth 才能跑通的 closure blocker
+  - `CP05a` 已完成第一条 caller proof：
+    - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，默认 sandbox control-plane repo construction 已切回 strategy seam
+    - 显式自定义 `db_path` 仍保持 sqlite-owned
+  - 下一步不要扩成“大而全 closure”
+    - 应继续核对 env-less sandbox control-plane residual
+    - 以及任何仍要求本地 sqlite truth 才能跑通的 default boot blocker

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -62,7 +62,7 @@ created: 2026-04-09
 | 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | done |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | done |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | done |
-| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
+| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | in_progress |
 | 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
 
 ## 边界
@@ -86,14 +86,12 @@ created: 2026-04-09
 
 ## Default Next Move
 
-- `CP03 Sandbox Control Plane Parity`
-  - `CP02` 已收口：`backend/web/services` 里剩余 SQLite residual 只剩 `monitor_service.py` / `sandbox_service.py`，两者都已更像 control-plane seam
-  - 第一轮已完成：`sandbox_service.py` 不再 import sqlite kernel / 不再自己持有 `SANDBOX_DB_PATH`
-  - 第二轮已完成：`sandbox.manager / sandbox.chat_session` 不再各自直接 import `SQLite*Repo`，而是共用 `sandbox.control_plane_repos`
-  - 第三轮已完成：`sandbox.lease.py` 不再直接 import `SQLiteLeaseRepo`，lease-store construction 已接入 `sandbox.control_plane_repos`
-  - 第四轮已完成：`LeaseRepo.persist_metadata(...)` 已补进 protocol / sqlite provider / supabase provider，且 `sandbox.lease.py:_record_provider_error()` 在 `LEON_STORAGE_STRATEGY=supabase` 下已改为通过 `storage.runtime.build_lease_repo(...)` 持久化 metadata，而不是继续落回本地 sqlite refresh flag
-  - 第五轮已完成：`LeaseRepo.observe_status(...)` 已补进 protocol / sqlite provider / supabase provider，且 `SQLiteLease.refresh_instance_status()` 在 `LEON_STORAGE_STRATEGY=supabase` 下会通过 strategy lease repo + provider event repo 落 `observe.status` transition
-  - 第六轮已完成：`provider.error` 的 strategy event parity 已补上；`_record_provider_error(..., source=...)` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会同时持久化 lease metadata 和 `provider_events`
-  - 第七轮已完成：`intent.destroy` 的 strategy path 已补上；`destroy_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会通过 strategy lease repo + provider event repo 落 detached/expired truth，并保留 destroy-side error/version parity
-  - 第八轮已完成：`intent.pause / intent.resume` 的 strategy path 已补上；`pause_instance()` / `resume_instance()` 在 `LEON_STORAGE_STRATEGY=supabase` 下现在会通过同一条 strategy transition helper 落 paused/running truth，并保留 failure-side provider.error / version parity
-  - `CP03` 当前授权边界已收口完成；下一步如果继续，应离开这张卡，进入 `CP04 Default Supabase Cut` 或更高层 closure proof
+- `CP04 Default Supabase Cut`
+  - 第一轮已完成：
+    - `backend/web/services/monitor_service.py` 的缺省 strategy fallback 已从 sqlite 改成 supabase
+    - `sandbox/lease.py::_use_supabase_storage()` 的缺省 strategy fallback 已从 sqlite 改成 supabase
+    - 对应 unit tests 已补齐并通过
+  - 当前 stopline：
+    - 这只说明“env 缺省时代码默认按 Supabase 解释”
+    - 还不等于 boot/runtime closure proof 已完成
+  - 下一步如果继续，应在 `CP04` 里补更高层 default/dev contract proof，或直接转向 `CP05 Closure Proof`

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -13,33 +13,36 @@ created: 2026-04-09
 - `CP04` 第一刀不碰更高层 boot/runtime proof。
 - 这刀只回答一个更小的问题：
   - 当 `LEON_STORAGE_STRATEGY` 没有显式设置时，代码默认把系统解释成什么 strategy。
-- 当前代码里最硬的 default fallback 只剩两处：
+- 当前代码里最硬的 default fallback 看起来只剩两处：
   - `backend/web/services/monitor_service.py`
   - `sandbox/lease.py`
-- 所以第一轮实现只收这两个 fallback：
-  - `runtime_health_snapshot()` 不再把缺省 strategy 当成 sqlite
-  - `_use_supabase_storage()` 不再把缺省 strategy 当成 sqlite
+- 但第一轮实现后确认：
+  - `runtime_health_snapshot()` 可以安全改成 supabase-first
+  - `_use_supabase_storage()` 不能直接改成 supabase-first
+  - 因为 env 缺省时，sandbox control-plane 仍会先走本地 sqlite lease truth
 
 ## First Slice
 
 - `backend/web/services/monitor_service.py`
   - `os.getenv("LEON_STORAGE_STRATEGY") or "supabase"`
 - `sandbox/lease.py`
-  - `os.getenv("LEON_STORAGE_STRATEGY", "supabase")`
+  - 保持 `os.getenv("LEON_STORAGE_STRATEGY", "sqlite")`
+  - 新增 regression，证明 env 缺省时 `mark_needs_refresh()` 仍必须写回本地 sqlite lease row
 - 这刀不碰：
   - `monitor_service.py` 更深的 sqlite diagnostics seam
   - `sandbox/lease.py` 更深的 sqlite local persistence helpers
+  - `sandbox/control_plane_repos.py` / `sandbox/manager.py` 的 env-less sqlite ownership
   - `CP05 closure proof`
 
 ## Evidence
 
 - `机制层验证`
-  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py -k 'defaults_to_supabase_when_strategy_missing or use_supabase_storage_defaults_true_when_strategy_missing or runtime_health_snapshot_reports_supabase_storage_contract'`
-    - `3 passed, 27 deselected`
+  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py -k 'defaults_to_supabase_when_strategy_missing or use_supabase_storage_defaults_false_when_strategy_missing or mark_needs_refresh_without_strategy_env_uses_local_sqlite or runtime_health_snapshot_reports_supabase_storage_contract'`
+    - `4 passed, 27 deselected`
   - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py`
     - `16 passed`
   - `uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py`
-    - `14 passed`
+    - `15 passed`
 - `源码/测试层辅助证据`
   - `uv run ruff check backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py`
     - `All checks passed!`
@@ -49,15 +52,18 @@ created: 2026-04-09
 ## Current Stopline
 
 - 这刀只说明：
-  - 当前代码的缺省 strategy fallback 已改成 Supabase
+  - web-facing monitor read surface 的缺省 strategy fallback 已改成 Supabase
+  - `sandbox/lease.py` 的缺省 strategy fallback 还不能改
+  - 否则会把 env-less sqlite control-plane 和 strategy lease repo 撕成 split-brain
 - 这不等于：
   - 系统在“完全不依赖 SQLite”下已经 closure
   - boot/runtime proof 已完成
 - 下一步如果继续，应转向：
   - 补 `CP04` 更高层的 default/dev contract proof
-  - 或直接进入 `CP05 Closure Proof`
+  - 盘清 queue/summary/langgraph dev 这些仍绕开 strategy 的默认启动旁路
+  - 再决定 `CP05 Closure Proof` 的真实入口
 
 ## Stopline
 
-- 默认 bringup/documented contract 明确是 Supabase
-- SQLite 仍可作为一种 strategy，但不是默认路径
+- documented/default bringup contract 明确是 Supabase-first
+- 不再把 env-less sqlite residual 假装成“默认已经切完”

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -20,6 +20,10 @@ created: 2026-04-09
   - `runtime_health_snapshot()` 可以安全改成 supabase-first
   - `_use_supabase_storage()` 不能直接改成 supabase-first
   - 因为 env 缺省时，sandbox control-plane 仍会先走本地 sqlite lease truth
+- 第二轮实现后又确认：
+  - web startup 里的 `queue_manager` 也不能继续裸建 sqlite repo
+  - generic `create_leon_agent()` 在 `LEON_STORAGE_STRATEGY=supabase` 下也必须自动接上 runtime storage container
+  - 否则 queue / summary 会继续绕开 strategy，和 documented default contract 冲突
 
 ## First Slice
 
@@ -34,6 +38,20 @@ created: 2026-04-09
   - `sandbox/control_plane_repos.py` / `sandbox/manager.py` 的 env-less sqlite ownership
   - `CP05 closure proof`
 
+## Second Slice
+
+- `backend/web/core/lifespan.py`
+  - `app.state.queue_manager` 改为 `MessageQueueManager(repo=storage_container.queue_repo())`
+- `core/runtime/agent.py`
+  - `create_leon_agent()` 在 `LEON_STORAGE_STRATEGY=supabase` 且未显式注入 container 时，自动 `build_storage_container()`
+  - `LeonAgent` 在已有 `storage_container` 且未显式注入 `queue_manager` 时，默认走 `storage_container.queue_repo()`
+- 这一刀顺带把 generic agent / `langgraph_app.py` 的 summary persistence 也拉回 runtime container
+  - 因为 `LeonAgent._add_memory_middleware()` 已经优先消费 `storage_container.summary_repo()`
+- 这刀仍不碰：
+  - queue repo / summary repo 更深的 provider parity 实现
+  - README / quickstart / deployment / configuration 文档 truth
+  - env-less sandbox control-plane sqlite ownership
+
 ## Evidence
 
 - `机制层验证`
@@ -43,10 +61,14 @@ created: 2026-04-09
     - `16 passed`
   - `uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py`
     - `15 passed`
+  - `uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py`
+    - `14 passed`
+  - `uv run pytest -q tests/Integration/test_leon_agent.py -k 'create_leon_agent_supabase_defaults_wire_runtime_container or leon_agent_simple_run or leon_agent_ainit_pushes_late_checkpointer_into_memory_middleware'`
+    - `3 passed, 33 deselected`
 - `源码/测试层辅助证据`
-  - `uv run ruff check backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py`
+  - `uv run ruff check backend/web/services/monitor_service.py sandbox/lease.py backend/web/core/lifespan.py core/runtime/agent.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Integration/test_storage_repo_abstraction_unification.py tests/Integration/test_leon_agent.py`
     - `All checks passed!`
-  - `uv run python -m py_compile backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py`
+  - `uv run python -m py_compile backend/web/services/monitor_service.py sandbox/lease.py backend/web/core/lifespan.py core/runtime/agent.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Integration/test_storage_repo_abstraction_unification.py tests/Integration/test_leon_agent.py`
     - `exit 0`
 
 ## Current Stopline
@@ -55,12 +77,13 @@ created: 2026-04-09
   - web-facing monitor read surface 的缺省 strategy fallback 已改成 Supabase
   - `sandbox/lease.py` 的缺省 strategy fallback 还不能改
   - 否则会把 env-less sqlite control-plane 和 strategy lease repo 撕成 split-brain
+  - web startup queue 和 generic agent startup queue/summary 已经接回 runtime storage container
 - 这不等于：
   - 系统在“完全不依赖 SQLite”下已经 closure
   - boot/runtime proof 已完成
 - 下一步如果继续，应转向：
   - 补 `CP04` 更高层的 default/dev contract proof
-  - 盘清 queue/summary/langgraph dev 这些仍绕开 strategy 的默认启动旁路
+  - 盘清 README / quickstart / deployment / configuration 的 documented truth
   - 再决定 `CP05 Closure Proof` 的真实入口
 
 ## Stopline

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -1,12 +1,61 @@
 ---
 title: Default Supabase Cut
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Default Supabase Cut
 
 目标：把默认本地/开发主线配置收成 Supabase-first，而不是继续默认落在 SQLite 假设上。
+
+## Current Ruling
+
+- `CP04` 第一刀不碰更高层 boot/runtime proof。
+- 这刀只回答一个更小的问题：
+  - 当 `LEON_STORAGE_STRATEGY` 没有显式设置时，代码默认把系统解释成什么 strategy。
+- 当前代码里最硬的 default fallback 只剩两处：
+  - `backend/web/services/monitor_service.py`
+  - `sandbox/lease.py`
+- 所以第一轮实现只收这两个 fallback：
+  - `runtime_health_snapshot()` 不再把缺省 strategy 当成 sqlite
+  - `_use_supabase_storage()` 不再把缺省 strategy 当成 sqlite
+
+## First Slice
+
+- `backend/web/services/monitor_service.py`
+  - `os.getenv("LEON_STORAGE_STRATEGY") or "supabase"`
+- `sandbox/lease.py`
+  - `os.getenv("LEON_STORAGE_STRATEGY", "supabase")`
+- 这刀不碰：
+  - `monitor_service.py` 更深的 sqlite diagnostics seam
+  - `sandbox/lease.py` 更深的 sqlite local persistence helpers
+  - `CP05 closure proof`
+
+## Evidence
+
+- `机制层验证`
+  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py -k 'defaults_to_supabase_when_strategy_missing or use_supabase_storage_defaults_true_when_strategy_missing or runtime_health_snapshot_reports_supabase_storage_contract'`
+    - `3 passed, 27 deselected`
+  - `uv run pytest -q tests/Unit/monitor/test_monitor_compat.py`
+    - `16 passed`
+  - `uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py`
+    - `14 passed`
+- `源码/测试层辅助证据`
+  - `uv run ruff check backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py`
+    - `All checks passed!`
+  - `uv run python -m py_compile backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py`
+    - `exit 0`
+
+## Current Stopline
+
+- 这刀只说明：
+  - 当前代码的缺省 strategy fallback 已改成 Supabase
+- 这不等于：
+  - 系统在“完全不依赖 SQLite”下已经 closure
+  - boot/runtime proof 已完成
+- 下一步如果继续，应转向：
+  - 补 `CP04` 更高层的 default/dev contract proof
+  - 或直接进入 `CP05 Closure Proof`
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -1,6 +1,6 @@
 ---
 title: Default Supabase Cut
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -24,6 +24,9 @@ created: 2026-04-09
   - web startup 里的 `queue_manager` 也不能继续裸建 sqlite repo
   - generic `create_leon_agent()` 在 `LEON_STORAGE_STRATEGY=supabase` 下也必须自动接上 runtime storage container
   - 否则 queue / summary 会继续绕开 strategy，和 documented default contract 冲突
+- 第三轮实现后确认：
+  - documented/default contract 也必须同步到 Supabase-first
+  - 否则 README / quickstart / configuration / deployment 会继续把人引向过时的 sqlite-default 心智模型
 
 ## First Slice
 
@@ -52,6 +55,20 @@ created: 2026-04-09
   - README / quickstart / deployment / configuration 文档 truth
   - env-less sandbox control-plane sqlite ownership
 
+## Third Slice
+
+- 文档 truth realignment：
+  - `README.md` / `README.zh.md`
+  - `docs/en/quickstart.mdx` / `docs/zh/quickstart.mdx`
+  - `docs/en/configuration.mdx` / `docs/zh/configuration.mdx`
+  - `docs/en/deployment.mdx` / `docs/zh/deployment.mdx`
+- 这一刀只做一件事：
+  - 把 documented/default startup contract 明确写成 Supabase-first
+  - 不再把 sqlite 描述成 web/runtime 默认启动路径
+- 这刀仍不碰：
+  - sandbox control-plane 更深的 env-less sqlite residual
+  - `CP05` 的真实产品 closure proof
+
 ## Evidence
 
 - `机制层验证`
@@ -66,6 +83,11 @@ created: 2026-04-09
   - `uv run pytest -q tests/Integration/test_leon_agent.py -k 'create_leon_agent_supabase_defaults_wire_runtime_container or leon_agent_simple_run or leon_agent_ainit_pushes_late_checkpointer_into_memory_middleware'`
     - `3 passed, 33 deselected`
 - `源码/测试层辅助证据`
+  - `git diff --check`
+    - `exit 0`
+  - `rg -n 'LEON_STORAGE_STRATEGY=supabase|Supabase-first|默认.*Supabase|Supabase.*默认' README.md README.zh.md docs/en/quickstart.mdx docs/zh/quickstart.mdx docs/en/configuration.mdx docs/zh/configuration.mdx docs/en/deployment.mdx docs/zh/deployment.mdx`
+    - documented/default contract strings present in all targeted docs
+- `源码/测试层辅助证据`
   - `uv run ruff check backend/web/services/monitor_service.py sandbox/lease.py backend/web/core/lifespan.py core/runtime/agent.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Integration/test_storage_repo_abstraction_unification.py tests/Integration/test_leon_agent.py`
     - `All checks passed!`
   - `uv run python -m py_compile backend/web/services/monitor_service.py sandbox/lease.py backend/web/core/lifespan.py core/runtime/agent.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Integration/test_storage_repo_abstraction_unification.py tests/Integration/test_leon_agent.py`
@@ -78,13 +100,13 @@ created: 2026-04-09
   - `sandbox/lease.py` 的缺省 strategy fallback 还不能改
   - 否则会把 env-less sqlite control-plane 和 strategy lease repo 撕成 split-brain
   - web startup queue 和 generic agent startup queue/summary 已经接回 runtime storage container
+  - README / quickstart / configuration / deployment 的 documented default 也已经对齐到 Supabase-first
 - 这不等于：
   - 系统在“完全不依赖 SQLite”下已经 closure
   - boot/runtime proof 已完成
 - 下一步如果继续，应转向：
-  - 补 `CP04` 更高层的 default/dev contract proof
-  - 盘清 README / quickstart / deployment / configuration 的 documented truth
-  - 再决定 `CP05 Closure Proof` 的真实入口
+  - 进入 `CP05 Closure Proof`
+  - 正面验证在 Supabase contract 下关键运行路径可独立成立
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -34,6 +34,18 @@ created: 2026-04-09
     - `SandboxManager(provider=...)` 在显式 Supabase + 默认 sandbox path 下，会用 strategy control-plane repos
     - `SandboxManager(provider=..., db_path=custom)` 在显式 Supabase 下仍保持本地 sqlite repo
 
+## Second Slice
+
+- `storage/session_manager.py`
+  - `delete_thread()` 在显式 `LEON_STORAGE_STRATEGY=supabase` 下不再要求本地 `leon.db` 存在
+  - 现在会通过 `storage.runtime.build_storage_container()` 取得：
+    - `checkpoint_repo()`
+    - `file_operation_repo()`
+- `tests/Unit/storage/test_session_file_operations_cleanup.py`
+  - 新增 caller-proof：
+    - 显式 Supabase 下 thread cleanup 走 runtime container
+    - env-less / sqlite 路径仍保持原有本地行为
+
 ## 证据要求
 
 - 真实产品验证
@@ -47,6 +59,8 @@ created: 2026-04-09
     - `29 passed`
   - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py -k 'sandbox_manager_keeps_default_sandbox_repos_sqlite_owned_when_strategy_missing or sandbox_manager_uses_strategy_control_plane_repos_for_default_sandbox_db_under_supabase or sandbox_manager_keeps_custom_db_path_sqlite_owned_under_supabase'`
     - `3 passed, 10 deselected`
+  - `uv run pytest -q tests/Unit/storage/test_session_file_operations_cleanup.py`
+    - `2 passed`
   - `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
     - 已包含在上一条 focused batch 中
 - `源码/测试层辅助证据`
@@ -54,6 +68,10 @@ created: 2026-04-09
     - `All checks passed!`
   - `uv run python -m py_compile sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
     - `exit 0`
+  - `uv run ruff check storage/session_manager.py tests/Unit/storage/test_session_file_operations_cleanup.py`
+    - pending fresh run for this slice
+  - `uv run python -m py_compile storage/session_manager.py tests/Unit/storage/test_session_file_operations_cleanup.py`
+    - pending fresh run for this slice
   - `git diff --check`
     - `exit 0`
 
@@ -63,6 +81,7 @@ created: 2026-04-09
   - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，默认 sandbox control-plane repo construction 已回到 strategy seam
   - 显式自定义 `db_path` 仍然保留本地 sqlite 语义
   - env-less 时，默认 sandbox control-plane caller 仍然会走本地 sqlite repo truth
+  - 显式 Supabase 下，`SessionManager.delete_thread()` 已不再被本地 `leon.db` existence gate 卡住
 - 这不等于：
   - env-less sandbox control-plane 已经切完
   - queue / summary / other residual 已完成 closure

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -1,6 +1,6 @@
 ---
 title: Closure Proof
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
@@ -8,11 +8,69 @@ created: 2026-04-09
 
 目标：用真实证据证明系统在 Supabase 下可独立运行，SQLite 不再是关键路径的隐含前提。
 
+## Current Ruling
+
+- `CP05` 不能一上来假装完成真实产品 boot proof。
+- 第一刀只回答一个更小但更硬的问题：
+  - 当 `LEON_STORAGE_STRATEGY=supabase` 明确开启时，sandbox control-plane 默认 `sandbox.db` 路径是否仍然偷偷把 repo 构造绑回 SQLite。
+- 当前代码在 `sandbox/control_plane_repos.py` 里仍然直接 new：
+  - `SQLiteChatSessionRepo`
+  - `SQLiteLeaseRepo`
+  - `SQLiteTerminalRepo`
+- 而 `SandboxManager(provider=p)` 会把默认 `sandbox.db` 路径显式传进这组 helper。
+- 所以如果这里不先收口，后面任何 “Supabase can run independently” 的 closure 说法都不诚实。
+
+## First Slice
+
+- `sandbox/control_plane_repos.py`
+  - 新增最小 ruling：
+    - 只有在 `LEON_STORAGE_STRATEGY=supabase` 且目标路径就是默认 `sandbox.db` 时，才走：
+      - `storage.runtime.build_chat_session_repo()`
+      - `storage.runtime.build_lease_repo()`
+      - `storage.runtime.build_terminal_repo()`
+    - 显式自定义 `db_path` 仍保持 sqlite-owned
+- `tests/Unit/sandbox/test_manager_repo_strategy.py`
+  - 新增/翻转两条 caller-proven contract：
+    - `SandboxManager(provider=...)` 在显式 Supabase + 默认 sandbox path 下，会用 strategy control-plane repos
+    - `SandboxManager(provider=..., db_path=custom)` 在显式 Supabase 下仍保持本地 sqlite repo
+
 ## 证据要求
 
 - 真实产品验证
 - 机制层验证
 - 源码/测试层辅助证据
+
+## Evidence
+
+- `机制层验证`
+  - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
+    - `29 passed`
+  - `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
+    - 已包含在上一条 focused batch 中
+- `源码/测试层辅助证据`
+  - `uv run ruff check sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
+    - `All checks passed!`
+  - `uv run python -m py_compile sandbox/control_plane_repos.py tests/Unit/sandbox/test_manager_repo_strategy.py`
+    - `exit 0`
+  - `git diff --check`
+    - `exit 0`
+
+## Current Stopline
+
+- 这刀只说明：
+  - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，默认 sandbox control-plane repo construction 已回到 strategy seam
+  - 显式自定义 `db_path` 仍然保留本地 sqlite 语义
+- 这不等于：
+  - env-less sandbox control-plane 已经切完
+  - queue / summary / other residual 已完成 closure
+  - 真实产品级 Supabase boot proof 已完成
+
+## Default Next Move
+
+- 继续 `CP05`
+  - 不扩成新的 provider parity 大刀
+  - 先核对 env-less sandbox control-plane residual
+  - 以及任何仍要求本地 sqlite truth 才能跑通的 default boot blocker
 
 ## Stopline
 

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -45,6 +45,8 @@ created: 2026-04-09
 - `机制层验证`
   - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
     - `29 passed`
+  - `uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py -k 'sandbox_manager_keeps_default_sandbox_repos_sqlite_owned_when_strategy_missing or sandbox_manager_uses_strategy_control_plane_repos_for_default_sandbox_db_under_supabase or sandbox_manager_keeps_custom_db_path_sqlite_owned_under_supabase'`
+    - `3 passed, 10 deselected`
   - `uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
     - 已包含在上一条 focused batch 中
 - `源码/测试层辅助证据`
@@ -60,6 +62,7 @@ created: 2026-04-09
 - 这刀只说明：
   - 显式 `LEON_STORAGE_STRATEGY=supabase` 下，默认 sandbox control-plane repo construction 已回到 strategy seam
   - 显式自定义 `db_path` 仍然保留本地 sqlite 语义
+  - env-less 时，默认 sandbox control-plane caller 仍然会走本地 sqlite repo truth
 - 这不等于：
   - env-less sandbox control-plane 已经切完
   - queue / summary / other residual 已完成 closure

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -152,6 +152,14 @@ class _FakeSyncFileRepo:
         return removed
 
 
+class _FakeSummaryRepo:
+    def ensure_tables(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
 @pytest.fixture(autouse=True)
 def _patch_runtime_storage_container(monkeypatch: pytest.MonkeyPatch):
     class _FakeRuntimeContainer:
@@ -159,6 +167,8 @@ def _patch_runtime_storage_container(monkeypatch: pytest.MonkeyPatch):
             self._tool_task_repo = _FakeToolTaskRepo()
             self._agent_registry_repo = _FakeAgentRegistryRepo()
             self._sync_file_repo = _FakeSyncFileRepo()
+            self._queue_repo = object()
+            self._summary_repo = _FakeSummaryRepo()
 
         def tool_task_repo(self) -> _FakeToolTaskRepo:
             return self._tool_task_repo
@@ -168,6 +178,12 @@ def _patch_runtime_storage_container(monkeypatch: pytest.MonkeyPatch):
 
         def sync_file_repo(self) -> _FakeSyncFileRepo:
             return self._sync_file_repo
+
+        def queue_repo(self) -> object:
+            return self._queue_repo
+
+        def summary_repo(self) -> object:
+            return self._summary_repo
 
     container = _FakeRuntimeContainer()
     monkeypatch.setattr("storage.runtime.build_storage_container", lambda **_kwargs: container)
@@ -276,6 +292,27 @@ def test_leon_agent_destructor_does_not_reenable_skipped_sandbox_cleanup():
     LeonAgent.__del__(agent)
 
     agent._cleanup_sandbox.assert_not_called()
+
+
+@_patch_env_api_key()
+def test_create_leon_agent_supabase_defaults_wire_runtime_container(monkeypatch, tmp_path, _patch_runtime_storage_container):
+    from core.runtime.agent import create_leon_agent
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=_mock_model("queue wiring")),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+    ):
+        agent = create_leon_agent(workspace_root=str(tmp_path))
+
+    try:
+        assert agent.storage_container is _patch_runtime_storage_container
+        assert agent.queue_manager._repo is _patch_runtime_storage_container.queue_repo()
+        assert agent._memory_middleware.summary_store is not None
+        assert agent._memory_middleware.summary_store._repo is _patch_runtime_storage_container.summary_repo()
+    finally:
+        agent.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/Integration/test_storage_repo_abstraction_unification.py
+++ b/tests/Integration/test_storage_repo_abstraction_unification.py
@@ -34,6 +34,7 @@ class _FakeContainer:
         self.lease_repo_value = _FakeRepo()
         self.terminal_repo_value = _FakeRepo()
         self.chat_session_repo_value = _FakeRepo()
+        self.queue_repo_value = _FakeRepo()
         self.sandbox_volume_repo_value = _FakeRepo()
         self.thread_launch_pref_repo_value = _FakeRepo()
         self.recipe_repo_value = _FakeRepo()
@@ -58,6 +59,9 @@ class _FakeContainer:
 
     def chat_session_repo(self) -> _FakeRepo:
         return self.chat_session_repo_value
+
+    def queue_repo(self) -> _FakeRepo:
+        return self.queue_repo_value
 
     def sandbox_volume_repo(self) -> _FakeRepo:
         return self.sandbox_volume_repo_value
@@ -381,6 +385,7 @@ async def test_lifespan_wires_user_and_thread_repos_from_storage_runtime_contain
         assert app.state.lease_repo is container.lease_repo_value
         assert app.state.terminal_repo is container.terminal_repo_value
         assert app.state.chat_session_repo is container.chat_session_repo_value
+        assert app.state.queue_manager._repo is container.queue_repo_value
         assert app.state.sandbox_volume_repo is container.sandbox_volume_repo_value
         assert app.state.panel_task_repo is container.panel_task_repo_value
         assert app.state._storage_container is container

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -707,3 +707,22 @@ def test_runtime_health_snapshot_reports_supabase_storage_contract(monkeypatch):
         },
     }
     assert payload["sessions"] == {"total": 0, "providers": {}}
+
+
+def test_runtime_health_snapshot_defaults_to_supabase_when_strategy_missing(monkeypatch):
+    class FakeRepo:
+        def count_rows(self, table_names):
+            return {name: idx + 1 for idx, name in enumerate(table_names)}
+
+        def close(self):
+            return None
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    monkeypatch.setattr(monitor_service, "make_sandbox_monitor_repo", lambda: FakeRepo())
+    monkeypatch.setattr(monitor_service, "init_providers_and_managers", lambda: ({}, {}))
+    monkeypatch.setattr(monitor_service, "load_all_sessions", lambda _managers: [])
+
+    payload = monitor_service.runtime_health_snapshot()
+
+    assert payload["db"]["strategy"] == "supabase"

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import sandbox.lease as sandbox_lease
 from sandbox.lease import lease_from_row
 
 
@@ -204,6 +205,12 @@ def test_sandbox_lease_no_longer_imports_storage_factory() -> None:
     assert "backend.web.core.storage_factory" not in lease_source
     assert "sandbox.control_plane_repos" in lease_source
     assert "SQLiteLeaseRepo" not in lease_source
+
+
+def test_use_supabase_storage_defaults_true_when_strategy_missing(monkeypatch):
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+
+    assert sandbox_lease._use_supabase_storage() is True
 
 
 def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(monkeypatch):

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -6,6 +7,7 @@ import pytest
 
 import sandbox.lease as sandbox_lease
 from sandbox.lease import lease_from_row
+from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
 
 
 class _FakeProvider:
@@ -207,10 +209,33 @@ def test_sandbox_lease_no_longer_imports_storage_factory() -> None:
     assert "SQLiteLeaseRepo" not in lease_source
 
 
-def test_use_supabase_storage_defaults_true_when_strategy_missing(monkeypatch):
+def test_use_supabase_storage_defaults_false_when_strategy_missing(monkeypatch):
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
 
-    assert sandbox_lease._use_supabase_storage() is True
+    assert sandbox_lease._use_supabase_storage() is False
+
+
+def test_mark_needs_refresh_without_strategy_env_uses_local_sqlite(tmp_path, monkeypatch):
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    db_path = tmp_path / "sandbox.db"
+    repo = SQLiteLeaseRepo(db_path=db_path)
+    try:
+        row = repo.create(lease_id="lease-local", provider_name="local")
+    finally:
+        repo.close()
+
+    lease = lease_from_row(row, db_path)
+    hint_at = datetime.fromisoformat("2026-04-09T00:00:00+00:00")
+
+    lease.mark_needs_refresh(hint_at=hint_at)
+
+    verify_repo = SQLiteLeaseRepo(db_path=db_path)
+    try:
+        persisted = verify_repo.get("lease-local")
+    finally:
+        verify_repo.close()
+    assert persisted is not None
+    assert persisted["needs_refresh"] == 1
 
 
 def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(monkeypatch):

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -337,6 +337,64 @@ def test_sandbox_manager_keeps_custom_db_path_sqlite_owned_under_supabase(monkey
     assert manager.session_manager._repo.db_path == custom_db_path
 
 
+def test_sandbox_manager_keeps_default_sandbox_repos_sqlite_owned_when_strategy_missing(monkeypatch, tmp_path):
+    import sandbox.control_plane_repos as control_plane_repos_module
+    import sandbox.manager as sandbox_manager_module
+    import storage.providers.sqlite.chat_session_repo as sqlite_chat_session_repo_module
+    import storage.providers.sqlite.lease_repo as sqlite_lease_repo_module
+    import storage.providers.sqlite.terminal_repo as sqlite_terminal_repo_module
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    default_db = tmp_path / "sandbox.db"
+    monkeypatch.setattr(sandbox_manager_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
+    monkeypatch.setattr(control_plane_repos_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
+    monkeypatch.setattr(
+        control_plane_repos_module,
+        "build_terminal_repo",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy terminal repo should not be used without env")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        control_plane_repos_module,
+        "build_lease_repo",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy lease repo should not be used without env")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        control_plane_repos_module,
+        "build_chat_session_repo",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy chat repo should not be used without env")),
+        raising=False,
+    )
+
+    class _SQLiteTerminalRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    class _SQLiteLeaseRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    class _SQLiteChatRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    monkeypatch.setattr(sqlite_terminal_repo_module, "SQLiteTerminalRepo", _SQLiteTerminalRepoStub)
+    monkeypatch.setattr(sqlite_lease_repo_module, "SQLiteLeaseRepo", _SQLiteLeaseRepoStub)
+    monkeypatch.setattr(sqlite_chat_session_repo_module, "SQLiteChatSessionRepo", _SQLiteChatRepoStub)
+
+    provider = SimpleNamespace(get_capability=lambda: SimpleNamespace(runtime_kind="local"))
+
+    manager = sandbox_manager_module.SandboxManager(provider=provider)
+
+    assert isinstance(manager.terminal_store, _SQLiteTerminalRepoStub)
+    assert isinstance(manager.lease_store, _SQLiteLeaseRepoStub)
+    assert isinstance(manager.session_manager._repo, _SQLiteChatRepoStub)
+    assert manager.terminal_store.db_path == default_db
+    assert manager.lease_store.db_path == default_db
+    assert manager.session_manager._repo.db_path == default_db
+
+
 def test_sandbox_manager_uses_own_db_path_when_repo_has_no_db_path(monkeypatch, tmp_path):
     import sandbox.manager as sandbox_manager_module
 

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -255,20 +255,86 @@ def test_chat_session_is_expired_accepts_aware_supabase_timestamps():
     assert session.is_expired() is False
 
 
-def test_sandbox_manager_keeps_sandbox_repos_sqlite_owned_under_supabase(monkeypatch):
+def test_sandbox_manager_uses_strategy_control_plane_repos_for_default_sandbox_db_under_supabase(monkeypatch):
+    import sandbox.control_plane_repos as control_plane_repos_module
     import sandbox.manager as sandbox_manager_module
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
-    monkeypatch.setattr(sandbox_manager_module, "make_terminal_repo", lambda db_path=None: _RepoStub())
-    monkeypatch.setattr(sandbox_manager_module, "make_lease_repo", lambda db_path=None: _RepoStub())
-    monkeypatch.setattr(sandbox_manager_module, "make_chat_session_repo", lambda db_path=None: _RepoStub(), raising=False)
+    default_db = Path("/tmp/default-sandbox.db")
+    monkeypatch.setattr(sandbox_manager_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
+    monkeypatch.setattr(control_plane_repos_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
+
+    strategy_terminal_repo = _RepoStub()
+    strategy_lease_repo = _RepoStub()
+    strategy_chat_repo = _RepoStub()
+    monkeypatch.setattr(control_plane_repos_module, "build_terminal_repo", lambda **kwargs: strategy_terminal_repo, raising=False)
+    monkeypatch.setattr(control_plane_repos_module, "build_lease_repo", lambda **kwargs: strategy_lease_repo, raising=False)
+    monkeypatch.setattr(control_plane_repos_module, "build_chat_session_repo", lambda **kwargs: strategy_chat_repo, raising=False)
 
     provider = SimpleNamespace(get_capability=lambda: SimpleNamespace(runtime_kind="local"))
 
     manager = sandbox_manager_module.SandboxManager(provider=provider)
 
-    assert isinstance(manager.terminal_store, _RepoStub)
-    assert isinstance(manager.lease_store, _RepoStub)
+    assert manager.terminal_store is strategy_terminal_repo
+    assert manager.lease_store is strategy_lease_repo
+    assert manager.session_manager._repo is strategy_chat_repo
+
+
+def test_sandbox_manager_keeps_custom_db_path_sqlite_owned_under_supabase(monkeypatch, tmp_path):
+    import sandbox.control_plane_repos as control_plane_repos_module
+    import sandbox.manager as sandbox_manager_module
+    import storage.providers.sqlite.chat_session_repo as sqlite_chat_session_repo_module
+    import storage.providers.sqlite.lease_repo as sqlite_lease_repo_module
+    import storage.providers.sqlite.terminal_repo as sqlite_terminal_repo_module
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr(control_plane_repos_module, "resolve_role_db_path", lambda role, db_path=None: tmp_path / "default-sandbox.db")
+    monkeypatch.setattr(
+        control_plane_repos_module,
+        "build_terminal_repo",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy terminal repo should not be used")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        control_plane_repos_module,
+        "build_lease_repo",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy lease repo should not be used")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        control_plane_repos_module,
+        "build_chat_session_repo",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy chat repo should not be used")),
+        raising=False,
+    )
+
+    class _SQLiteTerminalRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    class _SQLiteLeaseRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    class _SQLiteChatRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    monkeypatch.setattr(sqlite_terminal_repo_module, "SQLiteTerminalRepo", _SQLiteTerminalRepoStub)
+    monkeypatch.setattr(sqlite_lease_repo_module, "SQLiteLeaseRepo", _SQLiteLeaseRepoStub)
+    monkeypatch.setattr(sqlite_chat_session_repo_module, "SQLiteChatSessionRepo", _SQLiteChatRepoStub)
+
+    provider = SimpleNamespace(get_capability=lambda: SimpleNamespace(runtime_kind="local"))
+    custom_db_path = tmp_path / "custom-sandbox.db"
+
+    manager = sandbox_manager_module.SandboxManager(provider=provider, db_path=custom_db_path)
+
+    assert isinstance(manager.terminal_store, _SQLiteTerminalRepoStub)
+    assert isinstance(manager.lease_store, _SQLiteLeaseRepoStub)
+    assert isinstance(manager.session_manager._repo, _SQLiteChatRepoStub)
+    assert manager.terminal_store.db_path == custom_db_path
+    assert manager.lease_store.db_path == custom_db_path
+    assert manager.session_manager._repo.db_path == custom_db_path
 
 
 def test_sandbox_manager_uses_own_db_path_when_repo_has_no_db_path(monkeypatch, tmp_path):

--- a/tests/Unit/storage/test_session_file_operations_cleanup.py
+++ b/tests/Unit/storage/test_session_file_operations_cleanup.py
@@ -1,4 +1,5 @@
 import sqlite3
+from pathlib import Path
 
 from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
 from storage.session_manager import SessionManager
@@ -31,3 +32,44 @@ def test_session_delete_thread_cleans_file_operations(tmp_path):
 
     assert n_clean == 0
     assert n_other == 1
+
+
+def test_session_delete_thread_uses_runtime_container_under_supabase(monkeypatch, tmp_path):
+    deleted: list[tuple[str, str]] = []
+    closed: list[str] = []
+
+    class _FakeCheckpointRepo:
+        def delete_thread_data(self, thread_id: str) -> None:
+            deleted.append(("checkpoint", thread_id))
+
+        def close(self) -> None:
+            closed.append("checkpoint")
+
+    class _FakeFileOperationRepo:
+        def delete_thread_operations(self, thread_id: str) -> None:
+            deleted.append(("file_operation", thread_id))
+
+        def close(self) -> None:
+            closed.append("file_operation")
+
+    class _FakeContainer:
+        def checkpoint_repo(self):
+            return _FakeCheckpointRepo()
+
+        def file_operation_repo(self):
+            return _FakeFileOperationRepo()
+
+    session_dir = tmp_path / ".leon"
+    session_dir.mkdir(parents=True)
+    manager = SessionManager(session_dir=session_dir)
+    manager.save_session("t-supabase")
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr("storage.session_manager.build_storage_container", lambda **kwargs: _FakeContainer())
+
+    ok = manager.delete_thread("t-supabase")
+
+    assert ok is True
+    assert deleted == [("checkpoint", "t-supabase"), ("file_operation", "t-supabase")]
+    assert closed == ["checkpoint", "file_operation"]
+    assert manager.db_path == Path(session_dir / "leon.db")


### PR DESCRIPTION
## Summary
- change missing `LEON_STORAGE_STRATEGY` fallbacks to default to supabase in monitor and lease code paths
- add regression tests that pin missing-env default behavior
- activate CP04 and record the first bounded default-strategy slice

## Verification
- uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py -k 'defaults_to_supabase_when_strategy_missing or use_supabase_storage_defaults_true_when_strategy_missing or runtime_health_snapshot_reports_supabase_storage_contract'
- uv run pytest -q tests/Unit/monitor/test_monitor_compat.py
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py
- uv run ruff check backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py
- uv run python -m py_compile backend/web/services/monitor_service.py sandbox/lease.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py