### PR TITLE
feat: harden supabase runtime side stores

### DIFF
--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -13,6 +13,7 @@ Architecture:
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 import time
 import uuid
@@ -24,6 +25,7 @@ from typing import Any
 from storage.contracts import SummaryRepo, SummaryRow
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
 from storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
+from storage.runtime import build_summary_repo
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +65,10 @@ class SummaryStore:
         self._repo: SummaryRepo
         if summary_repo is not None:
             self._repo = summary_repo
+        elif db_path is None and os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+            # @@@explicit-db-path-wins - an explicit local path is an operator choice,
+            # so only path-less construction is allowed to switch to runtime storage.
+            self._repo = build_summary_repo()
         else:
             resolved_db_path = self.db_path
             # @@@connect_injection - keep _connect as an indirection point so existing retry/rollback tests can patch it.

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -7,11 +7,13 @@ Wake handlers notify the host when messages arrive for idle agents.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from collections.abc import Callable
 from pathlib import Path
 
 from storage.contracts import NotificationType, QueueItem, QueueRepo
+from storage.runtime import build_queue_repo
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +24,8 @@ class MessageQueueManager:
     def __init__(self, repo: QueueRepo | None = None, *, db_path: str | None = None) -> None:
         if repo is not None:
             self._repo = repo
+        elif db_path is None and os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+            self._repo = build_queue_repo()
         else:
             from storage.providers.sqlite.queue_repo import SQLiteQueueRepo
 

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -198,6 +198,32 @@ def build_provider_event_repo(
     ).provider_event_repo()
 
 
+def build_queue_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).queue_repo()
+
+
+def build_summary_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).summary_repo()
+
+
 def list_resource_snapshots(
     lease_ids: list[str],
     *,

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.runtime.middleware.memory.summary_store import SummaryStore
+from core.runtime.middleware.queue.manager import MessageQueueManager
+from storage.providers.sqlite.queue_repo import SQLiteQueueRepo
+from storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
+
+
+class _FakeQueueRepo:
+    def close(self) -> None:
+        return None
+
+
+class _FakeSummaryRepo:
+    def ensure_tables(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def test_message_queue_manager_uses_runtime_repo_under_explicit_supabase(monkeypatch) -> None:
+    fake_repo = _FakeQueueRepo()
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr(
+        "core.runtime.middleware.queue.manager.build_queue_repo",
+        lambda **_kwargs: fake_repo,
+    )
+
+    manager = MessageQueueManager()
+
+    assert manager._repo is fake_repo
+
+
+def test_message_queue_manager_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+
+    manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
+
+    try:
+        assert isinstance(manager._repo, SQLiteQueueRepo)
+    finally:
+        manager._repo.close()
+
+
+def test_summary_store_uses_runtime_repo_under_explicit_supabase(monkeypatch) -> None:
+    fake_repo = _FakeSummaryRepo()
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr(
+        "core.runtime.middleware.memory.summary_store.build_summary_repo",
+        lambda **_kwargs: fake_repo,
+    )
+
+    store = SummaryStore()
+
+    assert store._repo is fake_repo
+
+
+def test_summary_store_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+
+    store = SummaryStore(Path(tmp_path / "summary.db"))
+
+    try:
+        assert isinstance(store._repo, SQLiteSummaryRepo)
+    finally:
+        store._repo.close()

--- a/tests/Unit/storage/test_runtime_builder_contract.py
+++ b/tests/Unit/storage/test_runtime_builder_contract.py
@@ -7,7 +7,9 @@ from storage.providers.supabase.chat_session_repo import SupabaseChatSessionRepo
 from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
 from storage.providers.supabase.panel_task_repo import SupabasePanelTaskRepo
 from storage.providers.supabase.provider_event_repo import SupabaseProviderEventRepo
+from storage.providers.supabase.queue_repo import SupabaseQueueRepo
 from storage.providers.supabase.sandbox_monitor_repo import SupabaseSandboxMonitorRepo
+from storage.providers.supabase.summary_repo import SupabaseSummaryRepo
 from storage.providers.supabase.terminal_repo import SupabaseTerminalRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
@@ -44,6 +46,8 @@ def test_build_sandbox_monitor_repo_requires_runtime_config(monkeypatch: pytest.
         ("build_terminal_repo", SupabaseTerminalRepo),
         ("build_chat_session_repo", SupabaseChatSessionRepo),
         ("build_provider_event_repo", SupabaseProviderEventRepo),
+        ("build_queue_repo", SupabaseQueueRepo),
+        ("build_summary_repo", SupabaseSummaryRepo),
     ],
 )
 def test_runtime_repo_builders_use_supabase_factory(


### PR DESCRIPTION
## Summary
- add runtime builders for queue and summary repos
- make queue and summary default construction honor explicit `LEON_STORAGE_STRATEGY=supabase`
- keep explicit `db_path` on local SQLite semantics
- add focused runtime-side-store regression coverage

## Verification
- `uv run pytest -q tests/Unit/core/test_runtime_side_store_defaults.py`
- `uv run pytest -q tests/Unit/storage/test_runtime_builder_contract.py -k 'runtime_repo_builders_use_supabase_factory'`
- `uv run pytest -q tests/Unit/storage/test_session_file_operations_cleanup.py tests/Integration/test_followup_requeue.py tests/Unit/storage/test_summary_repo.py`
- `uv run pytest -q tests/Integration/test_leon_agent.py -k 'create_leon_agent_supabase_defaults_wire_runtime_container or leon_agent_simple_run or leon_agent_ainit_pushes_late_checkpointer_into_memory_middleware'`
- `uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py`
- `uv run ruff check storage/runtime.py core/runtime/middleware/queue/manager.py core/runtime/middleware/memory/summary_store.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_runtime_builder_contract.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Unit/storage/test_summary_repo.py tests/Integration/test_followup_requeue.py tests/Integration/test_leon_agent.py tests/Integration/test_storage_repo_abstraction_unification.py`
- `uv run python -m py_compile storage/runtime.py core/runtime/middleware/queue/manager.py core/runtime/middleware/memory/summary_store.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_runtime_builder_contract.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Unit/storage/test_summary_repo.py tests/Integration/test_followup_requeue.py tests/Integration/test_leon_agent.py tests/Integration/test_storage_repo_abstraction_unification.py`
