### PR TITLE
feat: default runtime strategy to supabase

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -14,6 +14,7 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
 from storage.runtime import build_lease_repo as make_lease_repo
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
+from storage.runtime import current_storage_strategy
 
 
 # ---------------------------------------------------------------------------
@@ -1051,7 +1052,7 @@ def get_event(event_id: str) -> dict[str, Any]:
 def runtime_health_snapshot() -> dict[str, Any]:
     """Lightweight control-plane health snapshot."""
     tables: dict[str, int] = {"chat_sessions": 0, "sandbox_leases": 0, "lease_events": 0}
-    storage_strategy = str(os.getenv("LEON_STORAGE_STRATEGY") or "sqlite").strip().lower()
+    storage_strategy = current_storage_strategy()
 
     if storage_strategy == "supabase":
         repo = make_sandbox_monitor_repo()

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1782,11 +1782,10 @@ def create_leon_agent(
     """
     # Filter out kwargs that LeonAgent.__init__ doesn't accept (e.g. profile from CLI)
     import inspect as _inspect
-    import os as _os
 
-    if storage_container is None and _os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
-        from storage.runtime import build_storage_container
+    from storage.runtime import build_storage_container, uses_supabase_storage
 
+    if storage_container is None and uses_supabase_storage():
         storage_container = build_storage_container()
 
     _valid = set(_inspect.signature(LeonAgent.__init__).parameters) - {"self"}

--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -24,7 +24,7 @@ from typing import Any
 from storage.contracts import SummaryRepo, SummaryRow
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
 from storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
-from storage.runtime import build_summary_repo, uses_supabase_storage
+from storage.runtime import build_summary_repo, uses_supabase_runtime_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class SummaryStore:
         self._repo: SummaryRepo
         if summary_repo is not None:
             self._repo = summary_repo
-        elif db_path is None and uses_supabase_storage():
+        elif db_path is None and uses_supabase_runtime_defaults():
             # @@@explicit-db-path-wins - an explicit local path is an operator choice,
             # so only path-less construction is allowed to switch to runtime storage.
             self._repo = build_summary_repo()

--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -13,7 +13,6 @@ Architecture:
 from __future__ import annotations
 
 import logging
-import os
 import sqlite3
 import time
 import uuid
@@ -25,7 +24,7 @@ from typing import Any
 from storage.contracts import SummaryRepo, SummaryRow
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
 from storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
-from storage.runtime import build_summary_repo
+from storage.runtime import build_summary_repo, uses_supabase_storage
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ class SummaryStore:
         self._repo: SummaryRepo
         if summary_repo is not None:
             self._repo = summary_repo
-        elif db_path is None and os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+        elif db_path is None and uses_supabase_storage():
             # @@@explicit-db-path-wins - an explicit local path is an operator choice,
             # so only path-less construction is allowed to switch to runtime storage.
             self._repo = build_summary_repo()

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from storage.contracts import NotificationType, QueueItem, QueueRepo
-from storage.runtime import build_queue_repo, uses_supabase_storage
+from storage.runtime import build_queue_repo, uses_supabase_runtime_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class MessageQueueManager:
     def __init__(self, repo: QueueRepo | None = None, *, db_path: str | None = None) -> None:
         if repo is not None:
             self._repo = repo
-        elif db_path is None and uses_supabase_storage():
+        elif db_path is None and uses_supabase_runtime_defaults():
             self._repo = build_queue_repo()
         else:
             from storage.providers.sqlite.queue_repo import SQLiteQueueRepo

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -7,13 +7,12 @@ Wake handlers notify the host when messages arrive for idle agents.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from collections.abc import Callable
 from pathlib import Path
 
 from storage.contracts import NotificationType, QueueItem, QueueRepo
-from storage.runtime import build_queue_repo
+from storage.runtime import build_queue_repo, uses_supabase_storage
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ class MessageQueueManager:
     def __init__(self, repo: QueueRepo | None = None, *, db_path: str | None = None) -> None:
         if repo is not None:
             self._repo = repo
-        elif db_path is None and os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+        elif db_path is None and uses_supabase_storage():
             self._repo = build_queue_repo()
         else:
             from storage.providers.sqlite.queue_repo import SQLiteQueueRepo

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_chat_session_repo, build_lease_repo, build_terminal_repo
+from storage.runtime import build_chat_session_repo, build_lease_repo, build_terminal_repo, uses_supabase_storage
 
 
 def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
@@ -12,9 +11,7 @@ def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
 
 
 def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
-    return os.environ.get("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase" and resolve_sandbox_db_path(
-        db_path
-    ) == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return uses_supabase_storage() and resolve_sandbox_db_path(db_path) == resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
 def make_chat_session_repo(db_path: Path | None = None):

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_chat_session_repo, build_lease_repo, build_terminal_repo, uses_supabase_storage
+from storage.runtime import (
+    build_chat_session_repo,
+    build_lease_repo,
+    build_terminal_repo,
+    uses_supabase_runtime_defaults,
+)
 
 
 def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
@@ -11,7 +16,7 @@ def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
 
 
 def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
-    return uses_supabase_storage() and resolve_sandbox_db_path(db_path) == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return uses_supabase_runtime_defaults() and resolve_sandbox_db_path(db_path) == resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
 def make_chat_session_repo(db_path: Path | None = None):

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -31,7 +31,7 @@ from sandbox.lifecycle import (
 from storage.providers.sqlite.kernel import connect_sqlite
 from storage.runtime import build_lease_repo as _build_strategy_lease_repo
 from storage.runtime import build_provider_event_repo as _build_strategy_provider_event_repo
-from storage.runtime import uses_supabase_storage
+from storage.runtime import uses_supabase_runtime_defaults
 
 if TYPE_CHECKING:
     from sandbox.provider import SandboxProvider
@@ -82,7 +82,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _use_supabase_storage(db_path: Path | None = None) -> bool:
-    return uses_supabase_storage() and resolve_sandbox_db_path(db_path) == resolve_sandbox_db_path()
+    return uses_supabase_runtime_defaults() and resolve_sandbox_db_path(db_path) == resolve_sandbox_db_path()
 
 
 def _make_lease_repo(db_path: Path | None = None):

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -11,7 +11,6 @@ State machine contract:
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import threading
 import uuid
@@ -32,6 +31,7 @@ from sandbox.lifecycle import (
 from storage.providers.sqlite.kernel import connect_sqlite
 from storage.runtime import build_lease_repo as _build_strategy_lease_repo
 from storage.runtime import build_provider_event_repo as _build_strategy_provider_event_repo
+from storage.runtime import uses_supabase_storage
 
 if TYPE_CHECKING:
     from sandbox.provider import SandboxProvider
@@ -81,12 +81,12 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     return connect_sqlite(db_path)
 
 
-def _use_supabase_storage() -> bool:
-    return os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase"
+def _use_supabase_storage(db_path: Path | None = None) -> bool:
+    return uses_supabase_storage() and resolve_sandbox_db_path(db_path) == resolve_sandbox_db_path()
 
 
 def _make_lease_repo(db_path: Path | None = None):
-    if _use_supabase_storage():
+    if _use_supabase_storage(db_path):
         return _build_strategy_lease_repo()
     return _make_sqlite_lease_repo(db_path)
 
@@ -488,7 +488,7 @@ class SQLiteLease(SandboxLease):
         self.refresh_hint_at = utc_now()
         self.observed_at = utc_now()
         self.version += 1
-        if _use_supabase_storage():
+        if _use_supabase_storage(self.db_path):
             repo = _make_lease_repo(self.db_path)
             event_repo = _make_provider_event_repo()
             try:
@@ -853,7 +853,7 @@ class SQLiteLease(SandboxLease):
                     return resolved
             try:
                 status = provider.get_session_status(self._current_instance.instance_id)
-                if _use_supabase_storage():
+                if _use_supabase_storage(self.db_path):
                     repo = _make_lease_repo(self.db_path)
                     try:
                         row = repo.adopt_instance(
@@ -891,7 +891,7 @@ class SQLiteLease(SandboxLease):
                         return resolved
                 try:
                     status = provider.get_session_status(self._current_instance.instance_id)
-                    if _use_supabase_storage():
+                    if _use_supabase_storage(self.db_path):
                         repo = _make_lease_repo(self.db_path)
                         try:
                             row = repo.adopt_instance(
@@ -920,7 +920,7 @@ class SQLiteLease(SandboxLease):
                     self._record_provider_error(str(exc), source="run.refresh_locked")
 
             self.status = "recovering"
-            if not _use_supabase_storage():
+            if not _use_supabase_storage(self.db_path):
                 self._persist_lease_metadata()
             from sandbox.thread_context import get_current_thread_id
 
@@ -932,7 +932,7 @@ class SQLiteLease(SandboxLease):
                 status="running",
                 created_at=utc_now(),
             )
-            if _use_supabase_storage():
+            if _use_supabase_storage(self.db_path):
                 repo = _make_lease_repo(self.db_path)
                 try:
                     row = repo.adopt_instance(
@@ -969,7 +969,7 @@ class SQLiteLease(SandboxLease):
             return self._current_instance
 
     def destroy_instance(self, provider: SandboxProvider, *, source: str = "api") -> None:
-        if _use_supabase_storage():
+        if _use_supabase_storage(self.db_path):
             with self._instance_lock():
                 self._reload_from_storage()
                 try:
@@ -981,7 +981,7 @@ class SQLiteLease(SandboxLease):
         self.apply(provider, event_type="intent.destroy", source=source)
 
     def pause_instance(self, provider: SandboxProvider, *, source: str = "api") -> bool:
-        if _use_supabase_storage():
+        if _use_supabase_storage(self.db_path):
             with self._instance_lock():
                 self._reload_from_storage()
                 try:
@@ -1002,7 +1002,7 @@ class SQLiteLease(SandboxLease):
         return True
 
     def resume_instance(self, provider: SandboxProvider, *, source: str = "api") -> bool:
-        if _use_supabase_storage():
+        if _use_supabase_storage(self.db_path):
             with self._instance_lock():
                 self._reload_from_storage()
                 try:
@@ -1044,7 +1044,7 @@ class SQLiteLease(SandboxLease):
 
         try:
             status = provider.get_session_status(self._current_instance.instance_id)
-            if _use_supabase_storage():
+            if _use_supabase_storage(self.db_path):
                 self._observe_status_via_strategy_repo(status, source="read.status")
             else:
                 self.apply(
@@ -1054,7 +1054,7 @@ class SQLiteLease(SandboxLease):
                     payload={"status": status},
                 )
         except Exception as exc:
-            if _use_supabase_storage():
+            if _use_supabase_storage(self.db_path):
                 self._record_provider_error(str(exc), source="read.status")
             else:
                 self.apply(
@@ -1069,7 +1069,7 @@ class SQLiteLease(SandboxLease):
         self.needs_refresh = True
         self.refresh_hint_at = hint_at or utc_now()
         self.version += 1
-        if _use_supabase_storage():
+        if _use_supabase_storage(self.db_path):
             repo = _make_lease_repo(self.db_path)
             try:
                 repo.mark_needs_refresh(self.lease_id, hint_at=self.refresh_hint_at)

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -20,7 +20,7 @@ from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_storage_container, uses_supabase_storage
+from storage.runtime import build_storage_container, uses_supabase_runtime_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def lookup_sandbox_for_thread(
     lease_repo: Any | None = None,
 ) -> str | None:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    uses_strategy_default_sandbox = uses_supabase_storage() and target_db == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    uses_strategy_default_sandbox = uses_supabase_runtime_defaults() and target_db == resolve_role_db_path(SQLiteDBRole.SANDBOX)
     if terminal_repo is None and lease_repo is None and not target_db.exists() and not uses_strategy_default_sandbox:
         return None
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -4,7 +4,6 @@ Orchestrates: Thread → ChatSession → Runtime → Terminal → Lease → Inst
 """
 
 import logging
-import os
 import uuid
 from collections.abc import Callable
 from datetime import datetime
@@ -21,7 +20,7 @@ from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_storage_container
+from storage.runtime import build_storage_container, uses_supabase_storage
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +42,7 @@ def lookup_sandbox_for_thread(
     lease_repo: Any | None = None,
 ) -> str | None:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    uses_strategy_default_sandbox = os.getenv(
-        "LEON_STORAGE_STRATEGY", "sqlite"
-    ).strip().lower() == "supabase" and target_db == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    uses_strategy_default_sandbox = uses_supabase_storage() and target_db == resolve_role_db_path(SQLiteDBRole.SANDBOX)
     if terminal_repo is None and lease_repo is None and not target_db.exists() and not uses_strategy_default_sandbox:
         return None
 

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -11,7 +11,6 @@ Architecture:
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -19,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
-from storage.runtime import build_terminal_repo
+from storage.runtime import build_terminal_repo, uses_supabase_storage
 
 REQUIRED_ABSTRACT_TERMINAL_COLUMNS = {
     "terminal_id",
@@ -45,9 +44,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _use_strategy_terminal(db_path: Path) -> bool:
-    return os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase" and db_path == resolve_role_db_path(
-        SQLiteDBRole.SANDBOX
-    )
+    return uses_supabase_storage() and db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
 @dataclass

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
-from storage.runtime import build_terminal_repo, uses_supabase_storage
+from storage.runtime import build_terminal_repo, uses_supabase_runtime_defaults
 
 REQUIRED_ABSTRACT_TERMINAL_COLUMNS = {
     "terminal_id",
@@ -44,7 +44,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _use_strategy_terminal(db_path: Path) -> bool:
-    return uses_supabase_storage() and db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return uses_supabase_runtime_defaults() and db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
 @dataclass

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -12,6 +12,14 @@ from storage.container import StorageContainer
 _WEB_SUPABASE_CLIENT_FACTORY = "backend.web.core.supabase_factory:create_supabase_client"
 
 
+def current_storage_strategy() -> str:
+    return str(os.getenv("LEON_STORAGE_STRATEGY") or "supabase").strip().lower()
+
+
+def uses_supabase_storage() -> bool:
+    return current_storage_strategy() == "supabase"
+
+
 def build_storage_container(
     *,
     supabase_client: Any | None = None,

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -20,6 +20,13 @@ def uses_supabase_storage() -> bool:
     return current_storage_strategy() == "supabase"
 
 
+def uses_supabase_runtime_defaults() -> bool:
+    explicit_strategy = os.getenv("LEON_STORAGE_STRATEGY")
+    if explicit_strategy is not None:
+        return explicit_strategy.strip().lower() == "supabase"
+    return bool(os.getenv("LEON_SUPABASE_CLIENT_FACTORY"))
+
+
 def build_storage_container(
     *,
     supabase_client: Any | None = None,

--- a/storage/session_manager.py
+++ b/storage/session_manager.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from storage.providers.sqlite.checkpoint_repo import SQLiteCheckpointRepo
 from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
-from storage.runtime import build_storage_container, uses_supabase_storage
+from storage.runtime import build_storage_container, uses_supabase_runtime_defaults
 
 
 class SessionManager:
@@ -56,7 +56,7 @@ class SessionManager:
                 data["last_thread_id"] = threads[0] if threads else None
             self.session_file.write_text(json.dumps(data, indent=2))
 
-        if uses_supabase_storage():
+        if uses_supabase_runtime_defaults():
             try:
                 container = build_storage_container()
 

--- a/storage/session_manager.py
+++ b/storage/session_manager.py
@@ -1,12 +1,11 @@
 """Session management for agent thread persistence"""
 
 import json
-import os
 from pathlib import Path
 
 from storage.providers.sqlite.checkpoint_repo import SQLiteCheckpointRepo
 from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
-from storage.runtime import build_storage_container
+from storage.runtime import build_storage_container, uses_supabase_storage
 
 
 class SessionManager:
@@ -57,7 +56,7 @@ class SessionManager:
                 data["last_thread_id"] = threads[0] if threads else None
             self.session_file.write_text(json.dumps(data, indent=2))
 
-        if os.getenv("LEON_STORAGE_STRATEGY", "sqlite").strip().lower() == "supabase":
+        if uses_supabase_storage():
             try:
                 container = build_storage_container()
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -332,6 +332,29 @@ def test_create_leon_agent_supabase_defaults_wire_runtime_container(monkeypatch,
         agent.close()
 
 
+@_patch_env_api_key()
+def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing(
+    monkeypatch, tmp_path, _patch_runtime_storage_container
+):
+    from core.runtime.agent import create_leon_agent
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=_mock_model("queue wiring")),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+    ):
+        agent = create_leon_agent(workspace_root=str(tmp_path))
+
+    try:
+        assert agent.storage_container is _patch_runtime_storage_container
+        assert agent.queue_manager._repo is _patch_runtime_storage_container.queue_repo()
+        assert agent._memory_middleware.summary_store is not None
+        assert agent._memory_middleware.summary_store._repo is _patch_runtime_storage_container.summary_repo()
+    finally:
+        agent.close()
+
+
 # ---------------------------------------------------------------------------
 # Integration Tests
 # ---------------------------------------------------------------------------
@@ -339,10 +362,11 @@ def test_create_leon_agent_supabase_defaults_wire_runtime_container(monkeypatch,
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_simple_run(tmp_path):
+async def test_leon_agent_simple_run(monkeypatch, tmp_path):
     """LeonAgent with mock model: astream completes and yields chunks."""
     from core.runtime.agent import LeonAgent
 
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
     mock_model = _mock_model("Hello from integration test")
 
     with (

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -333,9 +333,7 @@ def test_create_leon_agent_supabase_defaults_wire_runtime_container(monkeypatch,
 
 
 @_patch_env_api_key()
-def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing(
-    monkeypatch, tmp_path, _patch_runtime_storage_container
-):
+def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing(monkeypatch, tmp_path, _patch_runtime_storage_container):
     from core.runtime.agent import create_leon_agent
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -35,6 +35,20 @@ def test_message_queue_manager_uses_runtime_repo_under_explicit_supabase(monkeyp
     assert manager._repo is fake_repo
 
 
+def test_message_queue_manager_defaults_to_runtime_repo_when_strategy_missing(monkeypatch) -> None:
+    fake_repo = _FakeQueueRepo()
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setattr(
+        "core.runtime.middleware.queue.manager.build_queue_repo",
+        lambda **_kwargs: fake_repo,
+    )
+
+    manager = MessageQueueManager()
+
+    assert manager._repo is fake_repo
+
+
 def test_message_queue_manager_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
 
@@ -50,6 +64,20 @@ def test_summary_store_uses_runtime_repo_under_explicit_supabase(monkeypatch) ->
     fake_repo = _FakeSummaryRepo()
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr(
+        "core.runtime.middleware.memory.summary_store.build_summary_repo",
+        lambda **_kwargs: fake_repo,
+    )
+
+    store = SummaryStore()
+
+    assert store._repo is fake_repo
+
+
+def test_summary_store_defaults_to_runtime_repo_when_strategy_missing(monkeypatch) -> None:
+    fake_repo = _FakeSummaryRepo()
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
     monkeypatch.setattr(
         "core.runtime.middleware.memory.summary_store.build_summary_repo",
         lambda **_kwargs: fake_repo,

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -39,6 +39,7 @@ def test_message_queue_manager_defaults_to_runtime_repo_when_strategy_missing(mo
     fake_repo = _FakeQueueRepo()
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
     monkeypatch.setattr(
         "core.runtime.middleware.queue.manager.build_queue_repo",
         lambda **_kwargs: fake_repo,
@@ -47,6 +48,28 @@ def test_message_queue_manager_defaults_to_runtime_repo_when_strategy_missing(mo
     manager = MessageQueueManager()
 
     assert manager._repo is fake_repo
+
+
+def test_message_queue_manager_keeps_sqlite_when_strategy_missing_and_runtime_config_missing(monkeypatch) -> None:
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setattr(
+        "core.runtime.middleware.queue.manager.build_queue_repo",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("runtime repo should not be used")),
+    )
+
+    class _SQLiteQueueRepoStub:
+        def __init__(self, db_path=None):
+            self.db_path = db_path
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("storage.providers.sqlite.queue_repo.SQLiteQueueRepo", _SQLiteQueueRepoStub)
+
+    manager = MessageQueueManager()
+
+    assert isinstance(manager._repo, _SQLiteQueueRepoStub)
 
 
 def test_message_queue_manager_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch, tmp_path) -> None:
@@ -78,6 +101,7 @@ def test_summary_store_defaults_to_runtime_repo_when_strategy_missing(monkeypatc
     fake_repo = _FakeSummaryRepo()
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
     monkeypatch.setattr(
         "core.runtime.middleware.memory.summary_store.build_summary_repo",
         lambda **_kwargs: fake_repo,
@@ -86,6 +110,31 @@ def test_summary_store_defaults_to_runtime_repo_when_strategy_missing(monkeypatc
     store = SummaryStore()
 
     assert store._repo is fake_repo
+
+
+def test_summary_store_keeps_sqlite_when_strategy_missing_and_runtime_config_missing(monkeypatch) -> None:
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setattr(
+        "core.runtime.middleware.memory.summary_store.build_summary_repo",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("runtime repo should not be used")),
+    )
+
+    class _SQLiteSummaryRepoStub:
+        def __init__(self, db_path, connect_fn=None):
+            self.db_path = db_path
+
+        def ensure_tables(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("core.runtime.middleware.memory.summary_store.SQLiteSummaryRepo", _SQLiteSummaryRepoStub)
+
+    store = SummaryStore()
+
+    assert isinstance(store._repo, _SQLiteSummaryRepoStub)
 
 
 def test_summary_store_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch, tmp_path) -> None:

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -14,15 +14,31 @@ def test_monitor_service_no_longer_imports_storage_factory_or_sqlite_repos() -> 
     assert "storage.runtime" in source
 
 
-def test_runtime_health_snapshot_defaults_to_sqlite_when_strategy_missing(monkeypatch) -> None:
+def test_runtime_health_snapshot_defaults_to_supabase_when_strategy_missing(monkeypatch) -> None:
+    class FakeRepo:
+        def count_rows(self, _tables):
+            return {
+                "chat_sessions": 0,
+                "sandbox_leases": 0,
+                "lease_events": 0,
+            }
+
+        def close(self):
+            return None
+
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
-    monkeypatch.delenv("SUPABASE_INTERNAL_URL", raising=False)
-    monkeypatch.delenv("SUPABASE_PUBLIC_URL", raising=False)
+    monkeypatch.setattr(monitor_service, "make_sandbox_monitor_repo", lambda: FakeRepo())
+    monkeypatch.setattr(monitor_service, "init_providers_and_managers", lambda: ({}, {}))
+    monkeypatch.setattr(monitor_service, "load_all_sessions", lambda _managers: [])
 
     payload = monitor_service.runtime_health_snapshot()
 
-    assert payload["db"]["path"].endswith("sandbox.db")
-    assert "strategy" not in payload["db"]
+    assert payload["db"]["strategy"] == "supabase"
+    assert payload["db"]["counts"] == {
+        "chat_sessions": 0,
+        "sandbox_leases": 0,
+        "lease_events": 0,
+    }
 
 
 def test_list_leases_exposes_semantic_groups_and_summary(monkeypatch):
@@ -720,14 +736,32 @@ def test_runtime_health_snapshot_reports_supabase_storage_contract(monkeypatch):
     assert payload["sessions"] == {"total": 0, "providers": {}}
 
 
-def test_runtime_health_snapshot_keeps_sqlite_contract_when_strategy_missing(monkeypatch, tmp_path):
+def test_runtime_health_snapshot_keeps_supabase_contract_when_strategy_missing(monkeypatch):
+    class FakeRepo:
+        def count_rows(self, _tables):
+            return {
+                "chat_sessions": 1,
+                "sandbox_leases": 2,
+                "lease_events": 3,
+            }
+
+        def close(self):
+            return None
+
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
-    monkeypatch.setattr(monitor_service, "resolve_role_db_path", lambda role: tmp_path / "sandbox.db")
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    monkeypatch.setattr(monitor_service, "make_sandbox_monitor_repo", lambda: FakeRepo())
     monkeypatch.setattr(monitor_service, "init_providers_and_managers", lambda: ({}, {}))
     monkeypatch.setattr(monitor_service, "load_all_sessions", lambda _managers: [])
 
     payload = monitor_service.runtime_health_snapshot()
 
-    assert payload["db"]["path"].endswith("sandbox.db")
-    assert payload["db"]["exists"] is False
-    assert "strategy" not in payload["db"]
+    assert payload["db"] == {
+        "strategy": "supabase",
+        "schema": "staging",
+        "counts": {
+            "chat_sessions": 1,
+            "sandbox_leases": 2,
+            "lease_events": 3,
+        },
+    }

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -233,14 +233,23 @@ def test_sandbox_lease_no_longer_imports_storage_factory() -> None:
     assert "SQLiteLeaseRepo" not in lease_source
 
 
-def test_use_supabase_storage_defaults_true_when_strategy_missing(monkeypatch):
+def test_use_supabase_storage_defaults_true_when_strategy_missing_with_runtime_config(monkeypatch):
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
 
     assert sandbox_lease._use_supabase_storage() is True
 
 
-def test_mark_needs_refresh_without_strategy_env_uses_strategy_repo(monkeypatch):
+def test_use_supabase_storage_defaults_false_when_strategy_missing_and_runtime_config_missing(monkeypatch):
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+
+    assert sandbox_lease._use_supabase_storage() is False
+
+
+def test_mark_needs_refresh_without_strategy_env_uses_strategy_repo_when_runtime_config_exists(monkeypatch):
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
     repo = _FakeLeaseRepo()
     default_db = _bind_default_sandbox_db(monkeypatch)
     lease = lease_from_row(repo.get("lease-1"), default_db)
@@ -256,6 +265,37 @@ def test_mark_needs_refresh_without_strategy_env_uses_strategy_repo(monkeypatch)
     assert persisted["lease_id"] == "lease-1"
     assert persisted["needs_refresh"] is True
     assert persisted["refresh_hint_at"] == hint_at.isoformat()
+
+
+def test_mark_needs_refresh_without_strategy_env_keeps_local_sqlite_when_runtime_config_missing(monkeypatch):
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    default_db = _bind_default_sandbox_db(monkeypatch)
+    lease = lease_from_row(_FakeLeaseRepo().get("lease-1"), default_db)
+    hint_at = datetime.fromisoformat("2026-04-09T00:00:00+00:00")
+    seen_db_paths: list[Path] = []
+
+    class _Conn:
+        def execute(self, *_args, **_kwargs):
+            return None
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "sandbox.lease._connect",
+        lambda db_path: seen_db_paths.append(db_path) or _Conn(),
+    )
+
+    lease.mark_needs_refresh(hint_at=hint_at)
+
+    assert seen_db_paths == [default_db]
 
 
 def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(monkeypatch):

--- a/tests/Unit/sandbox/test_lease_probe_contract.py
+++ b/tests/Unit/sandbox/test_lease_probe_contract.py
@@ -7,7 +7,16 @@ import pytest
 
 import sandbox.lease as sandbox_lease
 from sandbox.lease import lease_from_row
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+
+DEFAULT_SANDBOX_DB = Path("/tmp/fake-sandbox.db")
+
+
+def _bind_default_sandbox_db(monkeypatch: pytest.MonkeyPatch, path: Path = DEFAULT_SANDBOX_DB) -> Path:
+    monkeypatch.setattr(
+        "sandbox.lease.resolve_sandbox_db_path",
+        lambda db_path=None: path if db_path is None else Path(db_path),
+    )
+    return path
 
 
 class _FakeProvider:
@@ -170,6 +179,21 @@ class _FakeLeaseRepo:
         }
         return dict(self._row)
 
+    def mark_needs_refresh(self, lease_id: str, *, hint_at) -> dict[str, object]:
+        return self.persist_metadata(
+            lease_id=lease_id,
+            recipe_id=self._row.get("recipe_id"),
+            recipe_json=self._row.get("recipe_json"),
+            desired_state=str(self._row["desired_state"]),
+            observed_state=str(self._row["observed_state"]),
+            version=int(self._row["version"]) + 1,
+            observed_at=self._row.get("observed_at"),
+            last_error=self._row.get("last_error"),
+            needs_refresh=True,
+            refresh_hint_at=hint_at.isoformat(),
+            status=str(self._row["status"]),
+        )
+
     def close(self) -> None:
         return None
 
@@ -209,33 +233,29 @@ def test_sandbox_lease_no_longer_imports_storage_factory() -> None:
     assert "SQLiteLeaseRepo" not in lease_source
 
 
-def test_use_supabase_storage_defaults_false_when_strategy_missing(monkeypatch):
+def test_use_supabase_storage_defaults_true_when_strategy_missing(monkeypatch):
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
 
-    assert sandbox_lease._use_supabase_storage() is False
+    assert sandbox_lease._use_supabase_storage() is True
 
 
-def test_mark_needs_refresh_without_strategy_env_uses_local_sqlite(tmp_path, monkeypatch):
+def test_mark_needs_refresh_without_strategy_env_uses_strategy_repo(monkeypatch):
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
-    db_path = tmp_path / "sandbox.db"
-    repo = SQLiteLeaseRepo(db_path=db_path)
-    try:
-        row = repo.create(lease_id="lease-local", provider_name="local")
-    finally:
-        repo.close()
-
-    lease = lease_from_row(row, db_path)
+    repo = _FakeLeaseRepo()
+    default_db = _bind_default_sandbox_db(monkeypatch)
+    lease = lease_from_row(repo.get("lease-1"), default_db)
     hint_at = datetime.fromisoformat("2026-04-09T00:00:00+00:00")
+
+    monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
+    monkeypatch.setattr("sandbox.lease._connect", lambda _db_path: (_ for _ in ()).throw(AssertionError("should not touch sqlite")))
 
     lease.mark_needs_refresh(hint_at=hint_at)
 
-    verify_repo = SQLiteLeaseRepo(db_path=db_path)
-    try:
-        persisted = verify_repo.get("lease-local")
-    finally:
-        verify_repo.close()
-    assert persisted is not None
-    assert persisted["needs_refresh"] == 1
+    assert len(repo.persist_calls) == 1
+    persisted = repo.persist_calls[0]
+    assert persisted["lease_id"] == "lease-1"
+    assert persisted["needs_refresh"] is True
+    assert persisted["refresh_hint_at"] == hint_at.isoformat()
 
 
 def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(monkeypatch):
@@ -247,7 +267,7 @@ def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(mon
         "observed_state": "detached",
         "_instance": None,
     }
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
@@ -268,7 +288,7 @@ def test_ensure_active_instance_persists_strategy_lease_before_probe_failure(mon
 def test_record_provider_error_persists_strategy_metadata(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
@@ -297,7 +317,7 @@ def test_record_provider_error_persists_strategy_metadata(monkeypatch):
 def test_refresh_instance_status_uses_strategy_observe_status_transition(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
@@ -324,7 +344,7 @@ def test_refresh_instance_status_uses_strategy_observe_status_transition(monkeyp
 def test_refresh_instance_status_records_strategy_provider_error_event(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     class _FailingProvider(_FakeProvider):
         def get_session_status(self, _instance_id: str) -> str:
@@ -356,7 +376,7 @@ def test_refresh_instance_status_records_strategy_provider_error_event(monkeypat
 def test_destroy_instance_uses_strategy_destroy_transition(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
@@ -392,7 +412,7 @@ def test_destroy_instance_uses_strategy_destroy_transition(monkeypatch):
 def test_destroy_instance_strategy_path_reloads_under_lock(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
     order: list[str] = []
 
     class _OrderedProvider(_FakeProvider):
@@ -424,7 +444,7 @@ def test_destroy_instance_strategy_path_reloads_under_lock(monkeypatch):
 def test_destroy_instance_records_strategy_provider_error_on_failure(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     class _FailingDestroyProvider(_FakeProvider):
         def destroy_session(self, _instance_id: str) -> bool:
@@ -457,7 +477,7 @@ def test_destroy_instance_records_strategy_provider_error_on_failure(monkeypatch
 def test_destroy_instance_preserves_destroy_state_when_strategy_write_fails(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     class _WriteFailRepo(_FakeLeaseRepo):
         def observe_status(self, *, lease_id: str, status: str, observed_at):
@@ -494,7 +514,7 @@ def test_destroy_instance_preserves_destroy_state_when_strategy_write_fails(monk
 
 def test_destroy_instance_bumps_version_again_when_event_write_fails(monkeypatch):
     repo = _FakeLeaseRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     class _EventFailRepo(_FakeProviderEventRepo):
         def record(
@@ -534,7 +554,7 @@ def test_destroy_instance_bumps_version_again_when_event_write_fails(monkeypatch
 def test_pause_instance_uses_strategy_pause_transition(monkeypatch):
     repo = _FakeLeaseRepo()
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
@@ -579,7 +599,7 @@ def test_resume_instance_uses_strategy_resume_transition(monkeypatch):
         },
     }
     event_repo = _FakeProviderEventRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
     monkeypatch.setattr("sandbox.lease._make_lease_repo", lambda db_path=None: repo)
@@ -614,7 +634,7 @@ def test_resume_instance_uses_strategy_resume_transition(monkeypatch):
 
 def test_pause_instance_preserves_paused_state_when_event_write_fails(monkeypatch):
     repo = _FakeLeaseRepo()
-    lease = lease_from_row(repo.get("lease-1"), Path("/tmp/fake-sandbox.db"))
+    lease = lease_from_row(repo.get("lease-1"), _bind_default_sandbox_db(monkeypatch))
 
     class _EventFailRepo(_FakeProviderEventRepo):
         def record(

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -342,6 +342,7 @@ def test_sandbox_manager_uses_strategy_control_plane_repos_when_strategy_missing
     import sandbox.manager as sandbox_manager_module
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
     default_db = tmp_path / "sandbox.db"
     monkeypatch.setattr(sandbox_manager_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
     monkeypatch.setattr(control_plane_repos_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
@@ -359,6 +360,41 @@ def test_sandbox_manager_uses_strategy_control_plane_repos_when_strategy_missing
     assert manager.terminal_store is strategy_terminal_repo
     assert manager.lease_store is strategy_lease_repo
     assert manager.session_manager._repo is strategy_chat_repo
+
+
+def test_sandbox_manager_keeps_sqlite_control_plane_when_strategy_missing_and_runtime_config_missing(monkeypatch, tmp_path):
+    import sandbox.control_plane_repos as control_plane_repos_module
+    import sandbox.manager as sandbox_manager_module
+    import storage.providers.sqlite.chat_session_repo as sqlite_chat_session_repo_module
+    import storage.providers.sqlite.lease_repo as sqlite_lease_repo_module
+    import storage.providers.sqlite.terminal_repo as sqlite_terminal_repo_module
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setattr(control_plane_repos_module, "resolve_role_db_path", lambda role, db_path=None: tmp_path / "sandbox.db")
+
+    class _SQLiteTerminalRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    class _SQLiteLeaseRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    class _SQLiteChatRepoStub(_RepoStub):
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+    monkeypatch.setattr(sqlite_terminal_repo_module, "SQLiteTerminalRepo", _SQLiteTerminalRepoStub)
+    monkeypatch.setattr(sqlite_lease_repo_module, "SQLiteLeaseRepo", _SQLiteLeaseRepoStub)
+    monkeypatch.setattr(sqlite_chat_session_repo_module, "SQLiteChatSessionRepo", _SQLiteChatRepoStub)
+
+    provider = SimpleNamespace(get_capability=lambda: SimpleNamespace(runtime_kind="local"))
+    manager = sandbox_manager_module.SandboxManager(provider=provider)
+
+    assert isinstance(manager.terminal_store, _SQLiteTerminalRepoStub)
+    assert isinstance(manager.lease_store, _SQLiteLeaseRepoStub)
+    assert isinstance(manager.session_manager._repo, _SQLiteChatRepoStub)
 
 
 def test_lookup_sandbox_for_thread_uses_strategy_repos_without_local_db_under_supabase(monkeypatch, tmp_path):

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -337,62 +337,28 @@ def test_sandbox_manager_keeps_custom_db_path_sqlite_owned_under_supabase(monkey
     assert manager.session_manager._repo.db_path == custom_db_path
 
 
-def test_sandbox_manager_keeps_default_sandbox_repos_sqlite_owned_when_strategy_missing(monkeypatch, tmp_path):
+def test_sandbox_manager_uses_strategy_control_plane_repos_when_strategy_missing(monkeypatch, tmp_path):
     import sandbox.control_plane_repos as control_plane_repos_module
     import sandbox.manager as sandbox_manager_module
-    import storage.providers.sqlite.chat_session_repo as sqlite_chat_session_repo_module
-    import storage.providers.sqlite.lease_repo as sqlite_lease_repo_module
-    import storage.providers.sqlite.terminal_repo as sqlite_terminal_repo_module
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
     default_db = tmp_path / "sandbox.db"
     monkeypatch.setattr(sandbox_manager_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
     monkeypatch.setattr(control_plane_repos_module, "resolve_role_db_path", lambda role, db_path=None: default_db)
-    monkeypatch.setattr(
-        control_plane_repos_module,
-        "build_terminal_repo",
-        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy terminal repo should not be used without env")),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        control_plane_repos_module,
-        "build_lease_repo",
-        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy lease repo should not be used without env")),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        control_plane_repos_module,
-        "build_chat_session_repo",
-        lambda **kwargs: (_ for _ in ()).throw(AssertionError("strategy chat repo should not be used without env")),
-        raising=False,
-    )
-
-    class _SQLiteTerminalRepoStub(_RepoStub):
-        def __init__(self, *, db_path):
-            self.db_path = db_path
-
-    class _SQLiteLeaseRepoStub(_RepoStub):
-        def __init__(self, *, db_path):
-            self.db_path = db_path
-
-    class _SQLiteChatRepoStub(_RepoStub):
-        def __init__(self, *, db_path):
-            self.db_path = db_path
-
-    monkeypatch.setattr(sqlite_terminal_repo_module, "SQLiteTerminalRepo", _SQLiteTerminalRepoStub)
-    monkeypatch.setattr(sqlite_lease_repo_module, "SQLiteLeaseRepo", _SQLiteLeaseRepoStub)
-    monkeypatch.setattr(sqlite_chat_session_repo_module, "SQLiteChatSessionRepo", _SQLiteChatRepoStub)
+    strategy_terminal_repo = _RepoStub()
+    strategy_lease_repo = _RepoStub()
+    strategy_chat_repo = _RepoStub()
+    monkeypatch.setattr(control_plane_repos_module, "build_terminal_repo", lambda **kwargs: strategy_terminal_repo, raising=False)
+    monkeypatch.setattr(control_plane_repos_module, "build_lease_repo", lambda **kwargs: strategy_lease_repo, raising=False)
+    monkeypatch.setattr(control_plane_repos_module, "build_chat_session_repo", lambda **kwargs: strategy_chat_repo, raising=False)
 
     provider = SimpleNamespace(get_capability=lambda: SimpleNamespace(runtime_kind="local"))
 
     manager = sandbox_manager_module.SandboxManager(provider=provider)
 
-    assert isinstance(manager.terminal_store, _SQLiteTerminalRepoStub)
-    assert isinstance(manager.lease_store, _SQLiteLeaseRepoStub)
-    assert isinstance(manager.session_manager._repo, _SQLiteChatRepoStub)
-    assert manager.terminal_store.db_path == default_db
-    assert manager.lease_store.db_path == default_db
-    assert manager.session_manager._repo.db_path == default_db
+    assert manager.terminal_store is strategy_terminal_repo
+    assert manager.lease_store is strategy_lease_repo
+    assert manager.session_manager._repo is strategy_chat_repo
 
 
 def test_lookup_sandbox_for_thread_uses_strategy_repos_without_local_db_under_supabase(monkeypatch, tmp_path):

--- a/tests/Unit/storage/test_session_file_operations_cleanup.py
+++ b/tests/Unit/storage/test_session_file_operations_cleanup.py
@@ -107,10 +107,53 @@ def test_session_delete_thread_defaults_to_runtime_container_when_strategy_missi
     manager.save_session("t-default")
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
     monkeypatch.setattr("storage.session_manager.build_storage_container", lambda **kwargs: _FakeContainer())
 
     ok = manager.delete_thread("t-default")
 
     assert ok is True
     assert deleted == [("checkpoint", "t-default"), ("file_operation", "t-default")]
+    assert closed == ["checkpoint", "file_operation"]
+
+
+def test_session_delete_thread_keeps_local_db_when_strategy_missing_and_runtime_config_missing(monkeypatch, tmp_path):
+    deleted: list[tuple[str, str]] = []
+    closed: list[str] = []
+
+    class _FakeCheckpointRepo:
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+        def delete_thread_data(self, thread_id: str) -> None:
+            deleted.append(("checkpoint", thread_id))
+
+        def close(self) -> None:
+            closed.append("checkpoint")
+
+    class _FakeFileOperationRepo:
+        def __init__(self, *, db_path):
+            self.db_path = db_path
+
+        def delete_thread_operations(self, thread_id: str) -> None:
+            deleted.append(("file_operation", thread_id))
+
+        def close(self) -> None:
+            closed.append("file_operation")
+
+    session_dir = tmp_path / ".leon"
+    session_dir.mkdir(parents=True)
+    manager = SessionManager(session_dir=session_dir)
+    manager.save_session("t-local")
+    manager.db_path.touch()
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setattr("storage.session_manager.SQLiteCheckpointRepo", _FakeCheckpointRepo)
+    monkeypatch.setattr("storage.session_manager.SQLiteFileOperationRepo", _FakeFileOperationRepo)
+
+    ok = manager.delete_thread("t-local")
+
+    assert ok is True
+    assert deleted == [("checkpoint", "t-local"), ("file_operation", "t-local")]
     assert closed == ["checkpoint", "file_operation"]

--- a/tests/Unit/storage/test_session_file_operations_cleanup.py
+++ b/tests/Unit/storage/test_session_file_operations_cleanup.py
@@ -5,7 +5,8 @@ from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
 from storage.session_manager import SessionManager
 
 
-def test_session_delete_thread_cleans_file_operations(tmp_path):
+def test_session_delete_thread_cleans_file_operations(monkeypatch, tmp_path):
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
     session_dir = tmp_path / ".leon"
     session_dir.mkdir(parents=True)
     db_path = session_dir / "leon.db"
@@ -73,3 +74,43 @@ def test_session_delete_thread_uses_runtime_container_under_supabase(monkeypatch
     assert deleted == [("checkpoint", "t-supabase"), ("file_operation", "t-supabase")]
     assert closed == ["checkpoint", "file_operation"]
     assert manager.db_path == Path(session_dir / "leon.db")
+
+
+def test_session_delete_thread_defaults_to_runtime_container_when_strategy_missing(monkeypatch, tmp_path):
+    deleted: list[tuple[str, str]] = []
+    closed: list[str] = []
+
+    class _FakeCheckpointRepo:
+        def delete_thread_data(self, thread_id: str) -> None:
+            deleted.append(("checkpoint", thread_id))
+
+        def close(self) -> None:
+            closed.append("checkpoint")
+
+    class _FakeFileOperationRepo:
+        def delete_thread_operations(self, thread_id: str) -> None:
+            deleted.append(("file_operation", thread_id))
+
+        def close(self) -> None:
+            closed.append("file_operation")
+
+    class _FakeContainer:
+        def checkpoint_repo(self):
+            return _FakeCheckpointRepo()
+
+        def file_operation_repo(self):
+            return _FakeFileOperationRepo()
+
+    session_dir = tmp_path / ".leon"
+    session_dir.mkdir(parents=True)
+    manager = SessionManager(session_dir=session_dir)
+    manager.save_session("t-default")
+
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.setattr("storage.session_manager.build_storage_container", lambda **kwargs: _FakeContainer())
+
+    ok = manager.delete_thread("t-default")
+
+    assert ok is True
+    assert deleted == [("checkpoint", "t-default"), ("file_operation", "t-default")]
+    assert closed == ["checkpoint", "file_operation"]


### PR DESCRIPTION
## Summary
- make env-less runtime storage semantics default to Supabase-first via shared runtime helpers
- flip canonical control-plane, queue/summary, session cleanup, agent bootstrap, and monitor paths to use runtime/container wiring by default
- keep explicit local db_path contracts sqlite-owned and update focused regression coverage

## Verification
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run pytest -q tests/Integration/test_leon_agent.py -k "create_leon_agent_supabase_defaults_wire_runtime_container or create_leon_agent_defaults_wire_runtime_container_when_strategy_missing or leon_agent_simple_run or leon_agent_ainit_pushes_late_checkpointer_into_memory_middleware"
- uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py tests/Integration/test_thread_files_channel_shell.py
- uv run ruff check storage/runtime.py storage/session_manager.py sandbox/control_plane_repos.py sandbox/lease.py sandbox/manager.py sandbox/terminal.py backend/web/services/monitor_service.py core/runtime/agent.py core/runtime/middleware/queue/manager.py core/runtime/middleware/memory/summary_store.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Integration/test_leon_agent.py
- uv run python -m py_compile storage/runtime.py storage/session_manager.py sandbox/control_plane_repos.py sandbox/lease.py sandbox/manager.py sandbox/terminal.py backend/web/services/monitor_service.py core/runtime/agent.py core/runtime/middleware/queue/manager.py core/runtime/middleware/memory/summary_store.py tests/Integration/test_leon_agent.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/storage/test_session_file_operations_cleanup.py
- git diff --check