### PR TITLE
feat: align chat session repo persistence

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -9,7 +9,6 @@ Architecture:
 from __future__ import annotations
 
 import asyncio
-import sqlite3
 import threading
 from dataclasses import dataclass
 from datetime import datetime
@@ -23,7 +22,7 @@ from sandbox.lifecycle import (
     assert_chat_session_transition,
     parse_chat_session_state,
 )
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 
 if TYPE_CHECKING:
     from sandbox.lease import SandboxLease
@@ -46,10 +45,6 @@ REQUIRED_CHAT_SESSION_COLUMNS = {
     "ended_at",
     "close_reason",
 }
-
-
-def _connect(db_path: Path) -> sqlite3.Connection:
-    return connect_sqlite(db_path)
 
 
 def _require_row_text(row: dict[str, object], key: str) -> str:
@@ -104,7 +99,7 @@ class ChatSession:
         self.ended_at = ended_at
         self.close_reason = close_reason
         self._db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-        self._session_repo = session_repo
+        self._session_repo = session_repo or make_chat_session_repo(db_path=self._db_path)
 
     def is_expired(self) -> bool:
         now = utc_now()
@@ -122,19 +117,7 @@ class ChatSession:
                 reason="touch",
             )
             self.status = "active"
-        if self._session_repo is not None:
-            self._session_repo.touch(self.session_id, last_active_at=now.isoformat(), status=self.status)
-            return
-        with _connect(self._db_path) as conn:
-            conn.execute(
-                """
-                UPDATE chat_sessions
-                SET last_active_at = ?, status = ?
-                WHERE chat_session_id = ?
-                """,
-                (now.isoformat(), self.status, self.session_id),
-            )
-            conn.commit()
+        self._session_repo.touch(self.session_id, last_active_at=now.isoformat(), status=self.status)
 
     async def close(self, reason: str = "closed") -> None:
         await self.runtime.close()
@@ -146,24 +129,7 @@ class ChatSession:
         self.status = "closed"
         self.ended_at = utc_now()
         self.close_reason = reason
-        if self._session_repo is not None:
-            self._session_repo.delete_session(self.session_id, reason=self.close_reason)
-            return
-        with _connect(self._db_path) as conn:
-            conn.execute(
-                """
-                UPDATE chat_sessions
-                SET status = ?, ended_at = ?, close_reason = ?
-                WHERE chat_session_id = ?
-                """,
-                (
-                    self.status,
-                    self.ended_at.isoformat(),
-                    self.close_reason,
-                    self.session_id,
-                ),
-            )
-            conn.commit()
+        self._session_repo.delete_session(self.session_id, reason=self.close_reason)
 
 
 class ChatSessionManager:

--- a/tests/Unit/sandbox/test_manager_repo_strategy.py
+++ b/tests/Unit/sandbox/test_manager_repo_strategy.py
@@ -238,6 +238,64 @@ def test_chat_session_close_uses_injected_repo():
     assert repo.deletes == [("sess-1", "closed")]
 
 
+def test_chat_session_touch_without_injected_repo_uses_control_plane_repo_seam(monkeypatch):
+    import sandbox.chat_session as chat_session_module
+
+    repo = _FakeSessionRepo()
+    monkeypatch.setattr(chat_session_module, "make_chat_session_repo", lambda db_path=None: repo)
+
+    session = ChatSession(
+        session_id="sess-1",
+        thread_id="thread-1",
+        terminal=_FakeTerminal(),
+        lease=_FakeLease(),
+        runtime=object(),
+        policy=ChatSessionPolicy(),
+        started_at=__import__("datetime").datetime.now(),
+        last_active_at=__import__("datetime").datetime.now(),
+    )
+
+    session.touch()
+
+    assert hasattr(chat_session_module, "_connect") is False
+    assert repo.touches
+    assert repo.touches[0][0] == "sess-1"
+
+
+def test_chat_session_close_without_injected_repo_uses_control_plane_repo_seam(monkeypatch):
+    import sandbox.chat_session as chat_session_module
+
+    class _Runtime:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    repo = _FakeSessionRepo()
+    monkeypatch.setattr(chat_session_module, "make_chat_session_repo", lambda db_path=None: repo)
+
+    runtime = _Runtime()
+    session = ChatSession(
+        session_id="sess-1",
+        thread_id="thread-1",
+        terminal=_FakeTerminal(),
+        lease=_FakeLease(),
+        runtime=runtime,
+        policy=ChatSessionPolicy(),
+        started_at=__import__("datetime").datetime.now(),
+        last_active_at=__import__("datetime").datetime.now(),
+    )
+
+    import asyncio
+
+    asyncio.run(session.close(reason="closed"))
+
+    assert hasattr(chat_session_module, "_connect") is False
+    assert runtime.closed is True
+    assert repo.deletes == [("sess-1", "closed")]
+
+
 def test_chat_session_is_expired_accepts_aware_supabase_timestamps():
     aware = datetime.fromisoformat("2099-04-08T00:00:00+00:00")
     session = ChatSession(


### PR DESCRIPTION
## Summary
- route ChatSession touch/close persistence through the chat-session repo seam
- remove direct sqlite fallback writes from sandbox/chat_session.py
- add regression tests for default control-plane repo construction

## Test Plan
- uv run pytest -q tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- uv run ruff check sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- uv run ruff format --check sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- uv run python -m py_compile sandbox/chat_session.py tests/Unit/sandbox/test_manager_repo_strategy.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- git diff --check