### PR TITLE
feat: align monitor runtime health repo dispatch

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -13,6 +13,7 @@ from eval.storage import TrajectoryStore
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
 from storage.runtime import build_lease_repo as make_lease_repo
+from storage.runtime import build_runtime_health_monitor_repo as make_runtime_health_monitor_repo
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 from storage.runtime import current_storage_strategy
 
@@ -1070,9 +1071,7 @@ def runtime_health_snapshot() -> dict[str, Any]:
         db_exists = db_path.exists()
         db_payload = {"path": str(db_path), "exists": db_exists, "counts": tables}
         if db_exists:
-            from storage.providers.sqlite.sandbox_monitor_repo import SQLiteSandboxMonitorRepo
-
-            repo = SQLiteSandboxMonitorRepo(db_path=db_path)
+            repo = make_runtime_health_monitor_repo(db_path=db_path)
             try:
                 tables = repo.count_rows(list(tables))
             finally:

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from storage.container import StorageContainer
@@ -198,6 +199,22 @@ def build_sandbox_monitor_repo(
     from storage.providers.supabase.sandbox_monitor_repo import SupabaseSandboxMonitorRepo
 
     return SupabaseSandboxMonitorRepo(client)
+
+
+def build_runtime_health_monitor_repo(
+    *,
+    db_path: str | Path | None = None,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+):
+    if current_storage_strategy() == "supabase":
+        return build_sandbox_monitor_repo(
+            supabase_client=supabase_client,
+            supabase_client_factory=supabase_client_factory,
+        )
+    from storage.providers.sqlite.sandbox_monitor_repo import SQLiteSandboxMonitorRepo
+
+    return SQLiteSandboxMonitorRepo(db_path=db_path)
 
 
 def build_provider_event_repo(

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -11,6 +11,7 @@ def test_monitor_service_no_longer_imports_storage_factory_or_sqlite_repos() -> 
     assert "backend.web.core.storage_factory" not in source
     assert "storage.providers.sqlite.chat_session_repo" not in source
     assert "storage.providers.sqlite.lease_repo" not in source
+    assert "storage.providers.sqlite.sandbox_monitor_repo" not in source
     assert "storage.runtime" in source
 
 
@@ -763,5 +764,38 @@ def test_runtime_health_snapshot_keeps_supabase_contract_when_strategy_missing(m
             "chat_sessions": 1,
             "sandbox_leases": 2,
             "lease_events": 3,
+        },
+    }
+
+
+def test_runtime_health_snapshot_reports_sqlite_contract_under_explicit_sqlite(monkeypatch, tmp_path):
+    class FakeRepo:
+        def count_rows(self, _tables):
+            return {
+                "chat_sessions": 4,
+                "sandbox_leases": 5,
+                "lease_events": 6,
+            }
+
+        def close(self):
+            return None
+
+    db_path = tmp_path / "sandbox.db"
+    db_path.write_text("")
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
+    monkeypatch.setattr(monitor_service, "make_runtime_health_monitor_repo", lambda db_path=None: FakeRepo())
+    monkeypatch.setattr(monitor_service, "resolve_role_db_path", lambda role: db_path)
+    monkeypatch.setattr(monitor_service, "init_providers_and_managers", lambda: ({}, {}))
+    monkeypatch.setattr(monitor_service, "load_all_sessions", lambda _managers: [])
+
+    payload = monitor_service.runtime_health_snapshot()
+
+    assert payload["db"] == {
+        "path": str(db_path),
+        "exists": True,
+        "counts": {
+            "chat_sessions": 4,
+            "sandbox_leases": 5,
+            "lease_events": 6,
         },
     }

--- a/tests/Unit/storage/test_runtime_builder_contract.py
+++ b/tests/Unit/storage/test_runtime_builder_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from storage import runtime as storage_runtime
+from storage.providers.sqlite.sandbox_monitor_repo import SQLiteSandboxMonitorRepo
 from storage.providers.supabase.chat_session_repo import SupabaseChatSessionRepo
 from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
 from storage.providers.supabase.panel_task_repo import SupabasePanelTaskRepo
@@ -37,6 +38,16 @@ def test_build_sandbox_monitor_repo_requires_runtime_config(monkeypatch: pytest.
 
     with pytest.raises(RuntimeError, match="missing runtime config"):
         storage_runtime.build_sandbox_monitor_repo()
+
+
+def test_build_runtime_health_monitor_repo_uses_sqlite_under_explicit_sqlite(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
+
+    repo = storage_runtime.build_runtime_health_monitor_repo(db_path=tmp_path / "sandbox.db")
+    try:
+        assert isinstance(repo, SQLiteSandboxMonitorRepo)
+    finally:
+        repo.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- route runtime health monitor repo construction through storage.runtime instead of direct sqlite imports
- keep explicit sqlite behavior intact while preserving supabase and strategy-missing monitor contracts
- add focused monitor/runtime builder regression tests

## Test Plan
- uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run ruff check backend/web/services/monitor_service.py storage/runtime.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run ruff format --check backend/web/services/monitor_service.py storage/runtime.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run python -m py_compile backend/web/services/monitor_service.py storage/runtime.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- git diff --check