### PR TITLE
feat: align backend control-plane sandbox db seam

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -492,12 +492,12 @@ def _create_thread_sandbox_resources(
 
     from backend.web.core.config import SANDBOX_VOLUME_ROOT
     from backend.web.utils.helpers import _get_container
+    from sandbox.control_plane_repos import resolve_sandbox_db_path
     from sandbox.volume_source import HostVolume
-    from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
     from storage.runtime import build_lease_repo as make_lease_repo
     from storage.runtime import build_terminal_repo as make_terminal_repo
 
-    sandbox_db = resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    sandbox_db = resolve_sandbox_db_path()
     now_str = datetime.now().isoformat()
     volume_id = str(uuid.uuid4())
     vol_path = SANDBOX_VOLUME_ROOT / volume_id

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -7,11 +7,9 @@ from fastapi import APIRouter, HTTPException, Query
 
 from backend.web.services.sandbox_service import init_providers_and_managers
 from backend.web.utils.helpers import _get_container, extract_webhook_instance_id
+from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.lease import lease_from_row
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import build_lease_repo as make_lease_repo
-
-SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 
@@ -28,7 +26,7 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
     event_repo = _get_container().provider_event_repo()
     try:
         lease_row = await asyncio.to_thread(lease_repo.find_by_instance, provider_name=provider_name, instance_id=instance_id)
-        lease = lease_from_row(lease_row, SANDBOX_DB_PATH) if lease_row else None
+        lease = lease_from_row(lease_row, resolve_sandbox_db_path()) if lease_row else None
         matched_lease_id = lease.lease_id if lease else None
 
         # @@@webhook-invalidation-only - Webhook is optimization only: persist event + mark lease stale.

--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -5,15 +5,13 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.sync.state import SyncState
 from storage.container import StorageContainer
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
 from storage.runtime import build_lease_repo as make_lease_repo
 from storage.runtime import build_storage_container, build_thread_repo
 from storage.runtime import build_terminal_repo as make_terminal_repo
-
-SANDBOX_DB_PATH = resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 _cached_container: StorageContainer | None = None
 
@@ -25,9 +23,10 @@ def is_virtual_thread_id(thread_id: str | None) -> bool:
 
 def get_terminal_timestamps(terminal_id: str) -> tuple[str | None, str | None]:
     """Get created_at and updated_at timestamps for a terminal."""
-    if not SANDBOX_DB_PATH.exists():
+    sandbox_db = resolve_sandbox_db_path()
+    if not sandbox_db.exists():
         return None, None
-    repo = make_terminal_repo(db_path=SANDBOX_DB_PATH)
+    repo = make_terminal_repo(db_path=sandbox_db)
     try:
         return repo.get_timestamps(terminal_id)
     finally:
@@ -36,9 +35,10 @@ def get_terminal_timestamps(terminal_id: str) -> tuple[str | None, str | None]:
 
 def get_lease_timestamps(lease_id: str) -> tuple[str | None, str | None]:
     """Get created_at and updated_at timestamps for a lease."""
-    if not SANDBOX_DB_PATH.exists():
+    sandbox_db = resolve_sandbox_db_path()
+    if not sandbox_db.exists():
         return None, None
-    repo = make_lease_repo(db_path=SANDBOX_DB_PATH)
+    repo = make_lease_repo(db_path=sandbox_db)
     try:
         row = repo.get(lease_id)
     finally:
@@ -136,11 +136,12 @@ def delete_thread_in_db(thread_id: str) -> None:
     # Purge storage-managed repos (works for both sqlite and supabase strategies)
     _get_container().purge_thread(thread_id)
 
-    if not SANDBOX_DB_PATH.exists():
+    sandbox_db = resolve_sandbox_db_path()
+    if not sandbox_db.exists():
         return
 
-    session_repo = make_chat_session_repo(db_path=SANDBOX_DB_PATH)
-    terminal_repo = make_terminal_repo(db_path=SANDBOX_DB_PATH)
+    session_repo = make_chat_session_repo(db_path=sandbox_db)
+    terminal_repo = make_terminal_repo(db_path=sandbox_db)
     sync_state = SyncState()
     try:
         session_repo.delete_by_thread(thread_id)

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -28,6 +28,8 @@ def test_helpers_no_longer_import_storage_factory() -> None:
 
     assert "backend.web.core.storage_factory" not in helpers_source
     assert "storage.runtime" in helpers_source
+    assert "resolve_role_db_path" not in helpers_source
+    assert "sandbox.control_plane_repos" in helpers_source
 
 
 @pytest.mark.asyncio

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -124,6 +124,8 @@ def test_threads_router_sandbox_bootstrap_no_longer_imports_storage_factory() ->
     threads_source = Path("backend/web/routers/threads.py").read_text(encoding="utf-8")
 
     assert "from backend.web.core.storage_factory import make_lease_repo, make_terminal_repo" not in threads_source
+    assert "resolve_role_db_path" not in threads_source
+    assert "sandbox.control_plane_repos" in threads_source
 
 
 def _require_await_kwargs(mock: AsyncMock) -> dict[str, Any]:

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -11,7 +11,9 @@ def test_webhooks_router_no_longer_imports_sqlite_lease_repo() -> None:
     source = inspect.getsource(webhooks)
 
     assert "storage.providers.sqlite.lease_repo" not in source
+    assert "storage.providers.sqlite.kernel" not in source
     assert "storage.runtime" in source
+    assert "sandbox.control_plane_repos" in source
 
 
 @pytest.mark.asyncio
@@ -67,5 +69,79 @@ async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch
             "event_type": "provider.updated",
             "payload": {"instance_id": "inst-1", "event": "provider.updated"},
             "matched_lease_id": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_lease(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    class _LeaseRepo:
+        def find_by_instance(self, *, provider_name: str, instance_id: str):
+            assert provider_name == "local"
+            assert instance_id == "inst-2"
+            return {"lease_id": "lease-1"}
+
+        def close(self) -> None:
+            return None
+
+    class _EventRepo:
+        def record(self, **_kwargs):
+            return None
+
+        def close(self) -> None:
+            return None
+
+    class _Container:
+        def provider_event_repo(self) -> _EventRepo:
+            return _EventRepo()
+
+    class _Lease:
+        lease_id = "lease-1"
+
+        def __init__(self) -> None:
+            self.applied: list[dict[str, object]] = []
+
+        def apply(self, provider, *, event_type: str, source: str, payload: dict[str, object]) -> None:
+            self.applied.append(
+                {
+                    "provider": provider,
+                    "event_type": event_type,
+                    "source": source,
+                    "payload": payload,
+                }
+            )
+
+    class _Manager:
+        def __init__(self) -> None:
+            self.provider = object()
+
+    expected_db_path = tmp_path / "sandbox.db"
+    lease = _Lease()
+
+    monkeypatch.setattr(webhooks, "resolve_sandbox_db_path", lambda: expected_db_path, raising=False)
+    monkeypatch.setattr(webhooks, "make_lease_repo", lambda: _LeaseRepo())
+    monkeypatch.setattr(webhooks, "_get_container", lambda: _Container())
+    monkeypatch.setattr(webhooks, "init_providers_and_managers", lambda: ({}, {"local": _Manager()}))
+
+    def _fake_lease_from_row(row, db_path):
+        assert row == {"lease_id": "lease-1"}
+        assert db_path == expected_db_path
+        return lease
+
+    monkeypatch.setattr(webhooks, "lease_from_row", _fake_lease_from_row)
+
+    payload = await webhooks.ingest_provider_webhook(
+        "local",
+        {"instance_id": "inst-2", "event": "provider.running"},
+    )
+
+    assert payload["matched"] is True
+    assert payload["lease_id"] == "lease-1"
+    assert lease.applied == [
+        {
+            "provider": lease.applied[0]["provider"],
+            "event_type": "observe.status",
+            "source": "webhook",
+            "payload": {"status": "running", "raw_event_type": "provider.running"},
         }
     ]


### PR DESCRIPTION
## Summary
- route backend control-plane callers through the existing sandbox db seam instead of resolving the canonical sqlite path inline
- keep webhook and thread bootstrap behavior unchanged while removing direct sqlite kernel coupling from helpers, webhooks, and threads router
- add focused integration regressions for helper/webhook/thread control-plane seam usage

## Test Plan
- uv run pytest -q tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_webhooks_router_contract.py tests/Integration/test_threads_router.py
- uv run ruff check backend/web/utils/helpers.py backend/web/routers/webhooks.py backend/web/routers/threads.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_webhooks_router_contract.py tests/Integration/test_threads_router.py
- uv run ruff format --check backend/web/utils/helpers.py backend/web/routers/webhooks.py backend/web/routers/threads.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_webhooks_router_contract.py tests/Integration/test_threads_router.py
- uv run python -m py_compile backend/web/utils/helpers.py backend/web/routers/webhooks.py backend/web/routers/threads.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_webhooks_router_contract.py tests/Integration/test_threads_router.py
- git diff --check