### PR TITLE
feat: align runtime side-store repo builders

### DIFF
--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -230,6 +230,32 @@ def build_provider_event_repo(
     ).provider_event_repo()
 
 
+def build_checkpoint_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).checkpoint_repo()
+
+
+def build_file_operation_repo(
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+    **kwargs: Any,
+):
+    return build_storage_container(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        **kwargs,
+    ).file_operation_repo()
+
+
 def build_queue_repo(
     *,
     supabase_client: Any | None = None,

--- a/storage/session_manager.py
+++ b/storage/session_manager.py
@@ -3,9 +3,7 @@
 import json
 from pathlib import Path
 
-from storage.providers.sqlite.checkpoint_repo import SQLiteCheckpointRepo
-from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
-from storage.runtime import build_storage_container, uses_supabase_runtime_defaults
+from storage.runtime import build_checkpoint_repo, build_file_operation_repo, uses_supabase_runtime_defaults
 
 
 class SessionManager:
@@ -58,15 +56,13 @@ class SessionManager:
 
         if uses_supabase_runtime_defaults():
             try:
-                container = build_storage_container()
-
-                repo = container.checkpoint_repo()
+                repo = build_checkpoint_repo()
                 try:
                     repo.delete_thread_data(thread_id)
                 finally:
                     repo.close()
 
-                file_repo = container.file_operation_repo()
+                file_repo = build_file_operation_repo()
                 try:
                     file_repo.delete_thread_operations(thread_id)
                 finally:
@@ -78,6 +74,9 @@ class SessionManager:
 
         if self.db_path.exists():
             try:
+                from storage.providers.sqlite.checkpoint_repo import SQLiteCheckpointRepo
+                from storage.providers.sqlite.file_operation_repo import SQLiteFileOperationRepo
+
                 repo = SQLiteCheckpointRepo(db_path=self.db_path)
                 try:
                     repo.delete_thread_data(thread_id)

--- a/tests/Unit/storage/test_runtime_builder_contract.py
+++ b/tests/Unit/storage/test_runtime_builder_contract.py
@@ -5,6 +5,8 @@ import pytest
 from storage import runtime as storage_runtime
 from storage.providers.sqlite.sandbox_monitor_repo import SQLiteSandboxMonitorRepo
 from storage.providers.supabase.chat_session_repo import SupabaseChatSessionRepo
+from storage.providers.supabase.checkpoint_repo import SupabaseCheckpointRepo
+from storage.providers.supabase.file_operation_repo import SupabaseFileOperationRepo
 from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
 from storage.providers.supabase.panel_task_repo import SupabasePanelTaskRepo
 from storage.providers.supabase.provider_event_repo import SupabaseProviderEventRepo
@@ -53,6 +55,8 @@ def test_build_runtime_health_monitor_repo_uses_sqlite_under_explicit_sqlite(mon
 @pytest.mark.parametrize(
     ("builder_name", "repo_cls"),
     [
+        ("build_checkpoint_repo", SupabaseCheckpointRepo),
+        ("build_file_operation_repo", SupabaseFileOperationRepo),
         ("build_lease_repo", SupabaseLeaseRepo),
         ("build_terminal_repo", SupabaseTerminalRepo),
         ("build_chat_session_repo", SupabaseChatSessionRepo),

--- a/tests/Unit/storage/test_session_file_operations_cleanup.py
+++ b/tests/Unit/storage/test_session_file_operations_cleanup.py
@@ -35,7 +35,7 @@ def test_session_delete_thread_cleans_file_operations(monkeypatch, tmp_path):
     assert n_other == 1
 
 
-def test_session_delete_thread_uses_runtime_container_under_supabase(monkeypatch, tmp_path):
+def test_session_delete_thread_uses_runtime_repo_builders_under_supabase(monkeypatch, tmp_path):
     deleted: list[tuple[str, str]] = []
     closed: list[str] = []
 
@@ -53,20 +53,14 @@ def test_session_delete_thread_uses_runtime_container_under_supabase(monkeypatch
         def close(self) -> None:
             closed.append("file_operation")
 
-    class _FakeContainer:
-        def checkpoint_repo(self):
-            return _FakeCheckpointRepo()
-
-        def file_operation_repo(self):
-            return _FakeFileOperationRepo()
-
     session_dir = tmp_path / ".leon"
     session_dir.mkdir(parents=True)
     manager = SessionManager(session_dir=session_dir)
     manager.save_session("t-supabase")
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
-    monkeypatch.setattr("storage.session_manager.build_storage_container", lambda **kwargs: _FakeContainer())
+    monkeypatch.setattr("storage.session_manager.build_checkpoint_repo", lambda **kwargs: _FakeCheckpointRepo())
+    monkeypatch.setattr("storage.session_manager.build_file_operation_repo", lambda **kwargs: _FakeFileOperationRepo())
 
     ok = manager.delete_thread("t-supabase")
 
@@ -76,7 +70,7 @@ def test_session_delete_thread_uses_runtime_container_under_supabase(monkeypatch
     assert manager.db_path == Path(session_dir / "leon.db")
 
 
-def test_session_delete_thread_defaults_to_runtime_container_when_strategy_missing(monkeypatch, tmp_path):
+def test_session_delete_thread_uses_runtime_repo_builders_under_explicit_supabase(monkeypatch, tmp_path):
     deleted: list[tuple[str, str]] = []
     closed: list[str] = []
 
@@ -94,12 +88,47 @@ def test_session_delete_thread_defaults_to_runtime_container_when_strategy_missi
         def close(self) -> None:
             closed.append("file_operation")
 
-    class _FakeContainer:
-        def checkpoint_repo(self):
-            return _FakeCheckpointRepo()
+    session_dir = tmp_path / ".leon"
+    session_dir.mkdir(parents=True)
+    manager = SessionManager(session_dir=session_dir)
+    manager.save_session("t-supabase-builders")
 
-        def file_operation_repo(self):
-            return _FakeFileOperationRepo()
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setattr(
+        "storage.session_manager.build_checkpoint_repo",
+        lambda **_kwargs: _FakeCheckpointRepo(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "storage.session_manager.build_file_operation_repo",
+        lambda **_kwargs: _FakeFileOperationRepo(),
+        raising=False,
+    )
+
+    ok = manager.delete_thread("t-supabase-builders")
+
+    assert ok is True
+    assert deleted == [("checkpoint", "t-supabase-builders"), ("file_operation", "t-supabase-builders")]
+    assert closed == ["checkpoint", "file_operation"]
+
+
+def test_session_delete_thread_defaults_to_runtime_repo_builders_when_strategy_missing(monkeypatch, tmp_path):
+    deleted: list[tuple[str, str]] = []
+    closed: list[str] = []
+
+    class _FakeCheckpointRepo:
+        def delete_thread_data(self, thread_id: str) -> None:
+            deleted.append(("checkpoint", thread_id))
+
+        def close(self) -> None:
+            closed.append("checkpoint")
+
+    class _FakeFileOperationRepo:
+        def delete_thread_operations(self, thread_id: str) -> None:
+            deleted.append(("file_operation", thread_id))
+
+        def close(self) -> None:
+            closed.append("file_operation")
 
     session_dir = tmp_path / ".leon"
     session_dir.mkdir(parents=True)
@@ -108,7 +137,8 @@ def test_session_delete_thread_defaults_to_runtime_container_when_strategy_missi
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
     monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.fake:create_client")
-    monkeypatch.setattr("storage.session_manager.build_storage_container", lambda **kwargs: _FakeContainer())
+    monkeypatch.setattr("storage.session_manager.build_checkpoint_repo", lambda **kwargs: _FakeCheckpointRepo())
+    monkeypatch.setattr("storage.session_manager.build_file_operation_repo", lambda **kwargs: _FakeFileOperationRepo())
 
     ok = manager.delete_thread("t-default")
 
@@ -149,8 +179,8 @@ def test_session_delete_thread_keeps_local_db_when_strategy_missing_and_runtime_
 
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
     monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
-    monkeypatch.setattr("storage.session_manager.SQLiteCheckpointRepo", _FakeCheckpointRepo)
-    monkeypatch.setattr("storage.session_manager.SQLiteFileOperationRepo", _FakeFileOperationRepo)
+    monkeypatch.setattr("storage.providers.sqlite.checkpoint_repo.SQLiteCheckpointRepo", _FakeCheckpointRepo)
+    monkeypatch.setattr("storage.providers.sqlite.file_operation_repo.SQLiteFileOperationRepo", _FakeFileOperationRepo)
 
     ok = manager.delete_thread("t-local")
 


### PR DESCRIPTION
## Summary
- route checkpoint and file-operation runtime builders through `storage.runtime`
- align `SessionManager.delete_thread()` with the runtime side-store seam instead of container/sqlite-specific wiring
- expand unit coverage for explicit supabase and runtime-default cleanup paths

## Test Plan
- uv run pytest -q tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_runtime_builder_contract.py tests/Unit/storage/test_session_file_operations_cleanup.py
- uv run ruff check storage/runtime.py storage/session_manager.py tests/Unit/storage/test_runtime_builder_contract.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Unit/core/test_runtime_side_store_defaults.py
- uv run ruff format --check storage/runtime.py storage/session_manager.py tests/Unit/storage/test_runtime_builder_contract.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Unit/core/test_runtime_side_store_defaults.py
- uv run python -m py_compile storage/runtime.py storage/session_manager.py tests/Unit/storage/test_runtime_builder_contract.py tests/Unit/storage/test_session_file_operations_cleanup.py tests/Unit/core/test_runtime_side_store_defaults.py
- git diff --check