### PR TITLE
feat: align command registry with repo seam

### DIFF
--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -14,7 +14,8 @@ from typing import TYPE_CHECKING
 
 from sandbox.interfaces.executor import BaseExecutor
 from sandbox.interfaces.filesystem import FileSystemBackend
-from storage.providers.sqlite.kernel import connect_sqlite
+from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.runtime import uses_supabase_runtime_defaults
 
 if TYPE_CHECKING:
     from sandbox.chat_session import ChatSession
@@ -120,9 +121,15 @@ class _CommandWrapper(BaseExecutor):
     def _lookup_command_terminal_id(self, command_id: str) -> str | None:
         command_repo = getattr(self._session, "_session_repo", None)
         if command_repo is not None:
-            terminal_id = command_repo.find_command_terminal_id(command_id=command_id, thread_id=self._session.thread_id)
+            terminal_id = command_repo.find_command_terminal_id(
+                command_id=command_id,
+                thread_id=self._session.thread_id,
+            )
             if terminal_id is not None:
                 return terminal_id
+            return None
+        if self._db_path is not None and uses_supabase_runtime_defaults() and self._db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX):
+            raise RuntimeError("strategy-backed command lookup requires a bound command repo")
         if self._db_path is None:
             return None
         with connect_sqlite(self._db_path) as conn:

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 
 from sandbox.interfaces.executor import AsyncCommand, ExecuteResult
 from sandbox.shell_output import normalize_pty_result
-from storage.providers.sqlite.kernel import connect_sqlite
+from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.runtime import uses_supabase_runtime_defaults
 
 if platform.system() == "Windows":
     pty = None
@@ -34,6 +35,10 @@ else:
     import select
 
 ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _uses_strategy_command_registry(db_path: Path | None) -> bool:
+    return db_path is not None and uses_supabase_runtime_defaults() and db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
 def _require_select_module():
@@ -347,6 +352,14 @@ class PhysicalTerminalRuntime(ABC):
     def bind_command_repo(self, command_repo) -> None:
         self._command_repo = command_repo
 
+    def _require_command_repo(self):
+        if self._command_repo is not None:
+            return self._command_repo
+        db_path = getattr(self.terminal, "db_path", None)
+        if db_path and _uses_strategy_command_registry(Path(db_path)):
+            raise RuntimeError("strategy-backed terminal command registry requires a bound command repo")
+        return None
+
     def _db_path(self) -> Path:
         db_path = getattr(self.terminal, "db_path", None)
         if not db_path:
@@ -394,8 +407,9 @@ class PhysicalTerminalRuntime(ABC):
         if not stdout_chunks and not stderr_chunks:
             return
         created_at = datetime.now().isoformat()
-        if self._command_repo is not None:
-            self._command_repo.append_command_chunks(
+        command_repo = self._require_command_repo()
+        if command_repo is not None:
+            command_repo.append_command_chunks(
                 command_id=command_id,
                 stdout_chunks=stdout_chunks,
                 stderr_chunks=stderr_chunks,
@@ -441,8 +455,9 @@ class PhysicalTerminalRuntime(ABC):
     ) -> None:
         now = datetime.now().isoformat()
         finished_at = now if status in {"done", "cancelled", "failed"} else None
-        if self._command_repo is not None:
-            self._command_repo.upsert_command(
+        command_repo = self._require_command_repo()
+        if command_repo is not None:
+            command_repo.upsert_command(
                 command_id=command_id,
                 terminal_id=self.terminal.terminal_id,
                 chat_session_id=self.chat_session_id,
@@ -517,7 +532,7 @@ class PhysicalTerminalRuntime(ABC):
         if not force and now - last < self._stream_flush_interval_sec:
             return
         self._last_stream_flush_at[command_id] = now
-        if self._command_repo is not None:
+        if self._require_command_repo() is not None:
             self._append_unflushed_chunks(None, command_id=command_id, async_cmd=async_cmd)
             self._upsert_command_row(
                 command_id=command_id,
@@ -542,14 +557,15 @@ class PhysicalTerminalRuntime(ABC):
             conn.commit()
 
     def _load_command_from_db(self, command_id: str) -> AsyncCommand | None:
-        if self._command_repo is not None:
-            row = self._command_repo.get_command(command_id=command_id, terminal_id=self.terminal.terminal_id)
+        command_repo = self._require_command_repo()
+        if command_repo is not None:
+            row = command_repo.get_command(command_id=command_id, terminal_id=self.terminal.terminal_id)
             stdout_text = ""
             stderr_text = ""
             if row:
                 stdout_text = str(row.get("stdout") or "")
                 stderr_text = str(row.get("stderr") or "")
-                chunk_rows = self._command_repo.list_command_chunks(command_id=command_id)
+                chunk_rows = command_repo.list_command_chunks(command_id=command_id)
                 if chunk_rows:
                     stdout_chunks = [str(chunk.get("content") or "") for chunk in chunk_rows if chunk.get("stream") == "stdout"]
                     stderr_chunks = [str(chunk.get("content") or "") for chunk in chunk_rows if chunk.get("stream") == "stderr"]

--- a/tests/Unit/sandbox/test_command_registry_strategy_contract.py
+++ b/tests/Unit/sandbox/test_command_registry_strategy_contract.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import sandbox.capability as capability_module
+import sandbox.runtime as runtime_module
 from sandbox.capability import SandboxCapability
 from sandbox.interfaces.executor import AsyncCommand, ExecuteResult
 from sandbox.runtime import RemoteWrappedRuntime
@@ -187,3 +190,49 @@ async def test_command_wrapper_resolves_foreign_command_via_bound_command_repo_w
     status = await capability.command.get_status("cmd-foreign")
 
     assert status is expected
+
+
+def test_runtime_store_completed_result_requires_command_repo_for_strategy_default_terminal(monkeypatch):
+    canonical_db = Path("/tmp/strategy-sandbox.db")
+    monkeypatch.setattr(runtime_module, "uses_supabase_runtime_defaults", lambda: True, raising=False)
+    monkeypatch.setattr(runtime_module, "resolve_role_db_path", lambda role: canonical_db, raising=False)
+    monkeypatch.setattr(
+        runtime_module,
+        "connect_sqlite",
+        lambda db_path: (_ for _ in ()).throw(AssertionError(f"sqlite fallback hit for {db_path}")),
+    )
+
+    terminal = _FakeTerminal()
+    terminal.db_path = canonical_db
+    runtime = RemoteWrappedRuntime(terminal, SimpleNamespace(), SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match="command repo"):
+        runtime.store_completed_result(
+            "cmd-1",
+            "echo hi",
+            "/tmp",
+            ExecuteResult(exit_code=0, stdout="ok", stderr=""),
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_wrapper_requires_command_repo_for_strategy_default_lookup(monkeypatch):
+    canonical_db = Path("/tmp/strategy-sandbox.db")
+    monkeypatch.setattr(capability_module, "uses_supabase_runtime_defaults", lambda: True, raising=False)
+    monkeypatch.setattr(capability_module, "resolve_role_db_path", lambda role: canonical_db, raising=False)
+    monkeypatch.setattr(
+        capability_module,
+        "connect_sqlite",
+        lambda db_path: (_ for _ in ()).throw(AssertionError(f"sqlite fallback hit for {db_path}")),
+    )
+
+    session = SimpleNamespace(
+        thread_id="thread-1",
+        terminal=SimpleNamespace(terminal_id="term-1", db_path=canonical_db, get_state=lambda: SimpleNamespace(cwd="/tmp")),
+        runtime=_FakeRuntime(),
+        touch=lambda: None,
+    )
+    capability = SandboxCapability(session)
+
+    with pytest.raises(RuntimeError, match="command repo"):
+        await capability.command.get_status("cmd-missing")


### PR DESCRIPTION
## Summary
- require a bound ChatSessionRepo for command-registry reads/writes on canonical strategy-backed runtimes
- stop command status lookup from silently falling back to raw sqlite in capability lookup
- add regression tests that prove strategy-backed command registry fails loudly without the repo seam

## Verification
- uv run pytest -q tests/Unit/sandbox/test_command_registry_strategy_contract.py tests/Unit/core/test_runtime.py tests/Unit/core/test_capability_async.py -k 'command or terminal_id or execute_async or running_command_survives_runtime_reload_without_false_failure or get_status or wait_for_command'\n- uv run pytest -q tests/Unit/core/test_command_middleware.py -k 'execute_async or get_status or wait_for'\n- uv run ruff check sandbox/runtime.py sandbox/capability.py tests/Unit/sandbox/test_command_registry_strategy_contract.py tests/Unit/core/test_runtime.py tests/Unit/core/test_capability_async.py\n- uv run ruff format --check sandbox/runtime.py sandbox/capability.py tests/Unit/sandbox/test_command_registry_strategy_contract.py tests/Unit/core/test_runtime.py tests/Unit/core/test_capability_async.py\n- uv run python -m py_compile sandbox/runtime.py sandbox/capability.py tests/Unit/sandbox/test_command_registry_strategy_contract.py tests/Unit/core/test_runtime.py tests/Unit/core/test_capability_async.py\n- git diff --check