### PR TITLE
refactor: move monitor sqlite path resolution into runtime builder

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -10,12 +10,22 @@ from typing import Any
 
 from backend.web.services.sandbox_service import init_providers_and_managers, load_all_sessions
 from eval.storage import TrajectoryStore
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_chat_session_repo as make_chat_session_repo
-from storage.runtime import build_lease_repo as make_lease_repo
-from storage.runtime import build_runtime_health_monitor_repo as make_runtime_health_monitor_repo
-from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
-from storage.runtime import current_storage_strategy
+from storage.runtime import (
+    build_chat_session_repo as make_chat_session_repo,
+)
+from storage.runtime import (
+    build_lease_repo as make_lease_repo,
+)
+from storage.runtime import (
+    build_runtime_health_monitor_repo as make_runtime_health_monitor_repo,
+)
+from storage.runtime import (
+    build_sandbox_monitor_repo as make_sandbox_monitor_repo,
+)
+from storage.runtime import (
+    current_storage_strategy,
+    resolve_runtime_health_monitor_db_path,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1067,11 +1077,13 @@ def runtime_health_snapshot() -> dict[str, Any]:
             "counts": tables,
         }
     else:
-        db_path = resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        db_path = resolve_runtime_health_monitor_db_path()
+        if db_path is None:
+            raise RuntimeError("sqlite runtime health snapshot requires a sandbox db path")
         db_exists = db_path.exists()
         db_payload = {"path": str(db_path), "exists": db_exists, "counts": tables}
         if db_exists:
-            repo = make_runtime_health_monitor_repo(db_path=db_path)
+            repo = make_runtime_health_monitor_repo()
             try:
                 tables = repo.count_rows(list(tables))
             finally:

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -201,6 +201,16 @@ def build_sandbox_monitor_repo(
     return SupabaseSandboxMonitorRepo(client)
 
 
+def resolve_runtime_health_monitor_db_path(*, db_path: str | Path | None = None) -> Path | None:
+    if current_storage_strategy() == "supabase":
+        return None
+    if db_path is not None:
+        return Path(db_path)
+    from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
+
+    return resolve_role_db_path(SQLiteDBRole.SANDBOX)
+
+
 def build_runtime_health_monitor_repo(
     *,
     db_path: str | Path | None = None,
@@ -214,7 +224,7 @@ def build_runtime_health_monitor_repo(
         )
     from storage.providers.sqlite.sandbox_monitor_repo import SQLiteSandboxMonitorRepo
 
-    return SQLiteSandboxMonitorRepo(db_path=db_path)
+    return SQLiteSandboxMonitorRepo(db_path=resolve_runtime_health_monitor_db_path(db_path=db_path))
 
 
 def build_provider_event_repo(

--- a/tests/Unit/monitor/test_monitor_compat.py
+++ b/tests/Unit/monitor/test_monitor_compat.py
@@ -9,6 +9,7 @@ def test_monitor_service_no_longer_imports_storage_factory_or_sqlite_repos() -> 
     source = inspect.getsource(monitor_service)
 
     assert "backend.web.core.storage_factory" not in source
+    assert "storage.providers.sqlite.kernel" not in source
     assert "storage.providers.sqlite.chat_session_repo" not in source
     assert "storage.providers.sqlite.lease_repo" not in source
     assert "storage.providers.sqlite.sandbox_monitor_repo" not in source
@@ -784,7 +785,7 @@ def test_runtime_health_snapshot_reports_sqlite_contract_under_explicit_sqlite(m
     db_path.write_text("")
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
     monkeypatch.setattr(monitor_service, "make_runtime_health_monitor_repo", lambda db_path=None: FakeRepo())
-    monkeypatch.setattr(monitor_service, "resolve_role_db_path", lambda role: db_path)
+    monkeypatch.setattr(monitor_service, "resolve_runtime_health_monitor_db_path", lambda: db_path)
     monkeypatch.setattr(monitor_service, "init_providers_and_managers", lambda: ({}, {}))
     monkeypatch.setattr(monitor_service, "load_all_sessions", lambda _managers: [])
 
@@ -799,3 +800,36 @@ def test_runtime_health_snapshot_reports_sqlite_contract_under_explicit_sqlite(m
             "lease_events": 6,
         },
     }
+
+
+def test_runtime_health_snapshot_sqlite_path_comes_from_runtime_builder(monkeypatch, tmp_path):
+    class FakeRepo:
+        def count_rows(self, _tables):
+            return {
+                "chat_sessions": 7,
+                "sandbox_leases": 8,
+                "lease_events": 9,
+            }
+
+        def close(self):
+            return None
+
+    db_path = tmp_path / "sandbox.db"
+    db_path.write_text("")
+    captured: dict[str, object] = {}
+
+    def _build_runtime_health_monitor_repo(*, db_path=None):
+        captured["db_path"] = db_path
+        return FakeRepo()
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
+    monkeypatch.setattr(monitor_service, "make_runtime_health_monitor_repo", _build_runtime_health_monitor_repo)
+    monkeypatch.setattr(monitor_service, "init_providers_and_managers", lambda: ({}, {}))
+    monkeypatch.setattr(monitor_service, "load_all_sessions", lambda _managers: [])
+    monkeypatch.setattr(monitor_service, "os", __import__("os"))
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(db_path))
+
+    payload = monitor_service.runtime_health_snapshot()
+
+    assert captured["db_path"] is None
+    assert payload["db"]["path"] == str(db_path)

--- a/tests/Unit/storage/test_runtime_builder_contract.py
+++ b/tests/Unit/storage/test_runtime_builder_contract.py
@@ -52,6 +52,31 @@ def test_build_runtime_health_monitor_repo_uses_sqlite_under_explicit_sqlite(mon
         repo.close()
 
 
+def test_build_runtime_health_monitor_repo_resolves_default_sqlite_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeSQLiteSandboxMonitorRepo:
+        def __init__(self, db_path=None) -> None:
+            captured["db_path"] = db_path
+
+        def close(self) -> None:
+            return None
+
+    resolved = tmp_path / "sandbox.db"
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "sqlite")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(resolved))
+    monkeypatch.setattr(
+        "storage.providers.sqlite.sandbox_monitor_repo.SQLiteSandboxMonitorRepo",
+        _FakeSQLiteSandboxMonitorRepo,
+    )
+
+    repo = storage_runtime.build_runtime_health_monitor_repo()
+    try:
+        assert captured["db_path"] == resolved
+    finally:
+        repo.close()
+
+
 @pytest.mark.parametrize(
     ("builder_name", "repo_cls"),
     [


### PR DESCRIPTION
## Summary
- move sqlite sandbox path resolution for runtime health monitoring into `storage.runtime`
- stop `monitor_service` from importing sqlite kernel directly for runtime health snapshot
- add regression tests for builder-owned sqlite default path resolution

## Test Plan
- uv run pytest -q tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run ruff check backend/web/services/monitor_service.py storage/runtime.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run ruff format --check backend/web/services/monitor_service.py storage/runtime.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- uv run python -m py_compile backend/web/services/monitor_service.py storage/runtime.py tests/Unit/monitor/test_monitor_compat.py tests/Unit/storage/test_runtime_builder_contract.py
- git diff --check
