### PR TITLE
docs: refresh supabase runtime parity ledger

### DIFF
--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -8,69 +8,60 @@ created: 2026-04-09
 
 # Supabase-First Runtime Parity
 
-目标：把当前仍然直接依赖 SQLite、或只在 SQLite 语义下成立的运行路径，继续推进到 `LEON_STORAGE_STRATEGY=supabase` 可独立运行的状态，并把默认运行面收成 Supabase-first，而不是继续让系统名义上支持多数据库、实际上某些关键路径仍然隐含依赖 SQLite。
+目标：把运行时主线收成“Supabase 是 canonical strategy，SQLite 只保留为显式本地 `db_path` 合同”，并用真实 caller-proof 区分哪些 checkpoint 已经闭环，哪些还只是局部对齐。
 
-## 背景
+## 当前 mainline truth
 
-`#191` 已完成的是抽象层 closure：
+这张卡现在以 `origin/dev = f0264bfdd1d204f1b0b24c924451c2097788e0c3` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
 
-- `storage_factory.py` 已删除
-- issue 点名的 bypass repos 已回到正式 composition root
+当前 `dev` 已经完成的事实：
 
-但这不等于系统已经达到下一层目标：
+- web/service composition root 已经回到 [backend/web/core/lifespan.py](backend/web/core/lifespan.py) + [storage/runtime.py](storage/runtime.py)
+- `file_channel / helpers / webhooks / threads / monitor` 这些 service surface 已不再直接 new SQLite repos
+- sandbox control-plane 已收口到 [sandbox/control_plane_repos.py](sandbox/control_plane_repos.py)
+- queue / summary / session cleanup / command registry / terminal state 这些 runtime seam 已有 strategy-aware path
 
-- `LEON_STORAGE_STRATEGY=supabase` 下无需 SQLite 也能独立运行
-- 默认配置就是 Supabase
-- storage abstraction 不再被局部 SQLite 直连打穿
+但这不等于 closure 已完成。
 
-当前 `origin/dev` 仍然能看到一批 SQLite 直接依赖或 SQLite-only 语义：
+2026-04-10 fresh audit 的关键事实是：
 
-- [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/services/file_channel_service.py)
-- [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
-- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
-- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
-
-用户已明确重新钉死最终 invariant：
-
-- 系统最终必须可以只靠 Supabase 跑起来
-- 默认配置应该就是 Supabase
-- 同时保留多数据库抽象
+- 真实 backend bringup + auth + thread/sandbox API proof 已能成立
+- 真实 Daytona self-hosted 单 agent proof 暴露出一个仍未进 `dev` 的 CP03 blocker：
+  - `SandboxManager._ensure_thread_volume()` 依赖 `lease_store.set_volume_id(...)`
+  - `SupabaseLeaseRepo` 在 `dev` 里还缺这条合同
+  - 该 fix 已单独送审于 [#396](https://github.com/OpenDCAI/Mycel/pull/396)
 
 ## 当前 ruling
 
-- 这条 lane 不是 `#191` 的继续加码，而是 `#191` 之后的新主任务
-- 第一阶段不急着写实现，先把“哪些路径仍然 SQLite-only、哪些只是临时 stopgap、哪些已经 strategy-aware”分层盘清
-- 只有在分层完成后，才开最小 implementation slices
-- 第一轮 inventory 已经确认：
-  - `backend/web/core/lifespan.py` 本身已经是 Supabase-first composition root
-  - 当前主要残余集中在 file channel、sandbox control-plane、session/checkpoint side-store、queue/summary middleware
+- `CP00` 已不该继续标 `in_progress`
+- `CP02` service surface parity 已基本收口
+- 当前 mainline 最大 residual 不再是 service 层，而是 sandbox control-plane 的剩余 contract gap
+- `CP05 Closure Proof` 已经开始，但还不能诚实地宣称完成
 
 ## 子任务
 
 | # | 子任务 | 说明 | 状态 |
 |---|--------|------|------|
-| 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 固化 current `dev` 下所有仍依赖 SQLite 的 runtime/service/control-plane 路径 | in_progress |
-| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需最小 contract | in_progress |
-| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | 收 web/service 层仍然 SQLite-only 的路径 | open |
-| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | 收 sandbox lease/terminal/chat-session/manager 等 control-plane seam | open |
-| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 把默认运行面收成 Supabase-first | open |
-| 05 | [Closure Proof](subtask-05-closure-proof.md) | 真实证明系统在 Supabase 下可独立运行，SQLite 不再是隐含前提 | open |
+| 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 用 current `dev` 重新分类 residual，去掉早期 stale inventory | done |
+| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 验证 `LEON_STORAGE_STRATEGY=supabase` bringup 所需最小 contract，并记录真实 blocker 分类 | in_progress |
+| 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | web/service 层 direct SQLite caller 收口 | done |
+| 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | lease / terminal / chat-session / manager 的剩余 strategy contract gap | in_progress |
+| 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 默认运行面与 env-less contract 的诚实边界 | in_progress |
+| 05 | [Closure Proof](subtask-05-closure-proof.md) | 高强度 caller-proof：shared sandbox / Daytona / multi-agent | in_progress |
 
-## 边界
+## 当前 stopline
 
-- 不把这条 lane 伪装成 `#191` 的自然尾巴
-- 不靠“保留 SQLite stopgap”来假装 provider parity
-- 不一上来重写整个 sandbox/runtime 架构
-- 每一刀都要显式区分：
-  - 真实产品验证
-  - 机制层验证
-  - 源码/测试层辅助证据
-
-## Stopline
-
-这条任务 closure 的标准是：
+这张卡现在不能靠“代码里 SQLite 痕迹变少了”来 closure。真正 stopline 仍然是：
 
 1. `LEON_STORAGE_STRATEGY=supabase` 下关键运行路径可独立成立
-2. 默认本地/开发主线配置是 Supabase-first
-3. SQLite 不再是某些关键路径的隐含必需品
-4. 多数据库抽象仍保留，不把业务层写死成 Supabase-only
+2. 默认本地/开发主线是 Supabase-first，或至少 ledger 明确写清 env-less 的诚实边界
+3. SQLite 不再是关键 caller 的隐含必需品
+4. closure 由真实产品验证 / 机制层验证 / 源码测试辅助证据共同支撑，而不是只靠局部单测
+
+## 默认 next move
+
+- 先合并或等价落下 [#396](https://github.com/OpenDCAI/Mycel/pull/396)
+- 然后在最新 `dev` 上重跑高强度 proof：
+  - shared sandbox file collaboration
+  - Daytona self-hosted agent path
+  - 更高层 multi-agent stress scenario

--- a/teams/tasks/supabase-first-runtime-parity/subtask-00-current-state-inventory.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-00-current-state-inventory.md
@@ -1,85 +1,49 @@
 ---
 title: Current State Inventory
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
 # Current State Inventory
 
-目标：固化 current `dev` 下所有仍依赖 SQLite、或仅在 SQLite 语义下成立的 runtime/service/control-plane 路径，避免后续“凭印象推进”。
+目标：给 `origin/dev = f0264bfdd1d204f1b0b24c924451c2097788e0c3` 做一次诚实 inventory，避免后续继续按 2026-04-09 的旧 worktree 结论推进。
 
-## 关注点
+## 当前结论
 
-- 直接 import `storage.providers.sqlite.*` 的 production path
-- 依赖 `sandbox.db` / `db_path` 的 caller
-- `LEON_STORAGE_STRATEGY=supabase` 下仍会退化到 SQLite 的路径
-- 默认配置仍非 Supabase-first 的入口
+### 已经对齐到 strategy/container seam 的部分
 
-## 第一轮 inventory 结论
+- [backend/web/core/lifespan.py](backend/web/core/lifespan.py)
+- [backend/web/services/file_channel_service.py](backend/web/services/file_channel_service.py)
+- [backend/web/services/monitor_service.py](backend/web/services/monitor_service.py)
+- [backend/web/utils/helpers.py](backend/web/utils/helpers.py)
+- [backend/web/routers/webhooks.py](backend/web/routers/webhooks.py)
+- [backend/web/routers/threads.py](backend/web/routers/threads.py)
+- [sandbox/control_plane_repos.py](sandbox/control_plane_repos.py)
+- [storage/runtime.py](storage/runtime.py)
 
-### 已经对齐到 Supabase-first 的部分
+### 仍然保留 SQLite 的部分，但并不都算 blocker
 
-- [backend/web/core/lifespan.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/core/lifespan.py)
-  - 当前 authoritative web composition root 已经直接创建 Supabase client
-  - 再通过 [storage/container.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/container.py) 注入：
-    - `user_repo`
-    - `thread_repo`
-    - `lease_repo`
-    - `terminal_repo`
-    - `chat_session_repo`
-    - `sandbox_volume_repo`
-    - `panel_task_repo`
-    - `cron_job_repo`
-- 这说明“默认 composition root 应该是 Supabase-first”已经有真实骨架，不是从零开始
+- [core/runtime/middleware/queue/manager.py](core/runtime/middleware/queue/manager.py)
+- [core/runtime/middleware/memory/summary_store.py](core/runtime/middleware/memory/summary_store.py)
+- [storage/session_manager.py](storage/session_manager.py)
+- [sandbox/runtime.py](sandbox/runtime.py)
+- [sandbox/capability.py](sandbox/capability.py)
+- [sandbox/terminal.py](sandbox/terminal.py)
 
-### 当前最明显的 SQLite-only 残余
+这些路径里有一部分是“显式本地 `db_path` 合同保留”，不应再被误记成同级 residual。
 
-#### 1. File channel / volume lookup
+### 当前最值钱的真实 residual
 
-- [backend/web/services/file_channel_service.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/services/file_channel_service.py)
-  - 直接 import:
-    - `SQLiteLeaseRepo`
-    - `SQLiteTerminalRepo`
-  - 通过 `SANDBOX_DB_PATH` 读取 thread -> terminal -> lease -> volume_id 链
+- sandbox control-plane 在 strategy path 下仍有 contract gap
+- fresh audit 直接打出来的是：
+  - [sandbox/manager.py](sandbox/manager.py) 依赖 `lease_store.set_volume_id(...)`
+  - `dev` 上的 [storage/providers/supabase/lease_repo.py](storage/providers/supabase/lease_repo.py) 尚未实现这条合同
 
-#### 2. Sandbox control-plane
+## Inventory ruling
 
-- [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
-  - 直接 new:
-    - `SQLiteChatSessionRepo`
-    - `SQLiteTerminalRepo`
-    - `SQLiteLeaseRepo`
-- [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
-  - `_make_lease_repo()` 直接返回 `SQLiteLeaseRepo`
-- [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
-  - 顶层 `make_chat_session_repo / make_lease_repo / make_terminal_repo` 都直接返回 SQLite repo
-
-#### 3. Session/checkpoint side-store
-
-- [storage/session_manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/session_manager.py)
-  - 仍直接依赖：
-    - `SQLiteCheckpointRepo`
-    - `SQLiteFileOperationRepo`
-
-#### 4. Runtime middleware side stores
-
-- [core/runtime/middleware/queue/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/queue/manager.py)
-  - 仍直接 new `SQLiteQueueRepo`
-- [core/runtime/middleware/memory/summary_store.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/memory/summary_store.py)
-  - 仍直接 new `SQLiteSummaryRepo`
-
-### 当前 ruling
-
-- `#191` 已完成的是“抽象层/旧桥 closure”
-- 新 lane 的核心不是再删桥，而是把这些仍然 SQLite-only 的运行路径继续推到 provider-parity
-- 第一刀不该先碰整个 sandbox 架构
-- 最自然的切分是：
-  1. `service surface`
-  2. `control-plane`
-  3. `side-store / middleware`
-  4. `default Supabase boot contract`
-
-## Stopline
-
-- 给出按 owner/seam 分层的残余清单
-- 明确哪些是 service surface，哪些是 sandbox control-plane，哪些是 boot/default contract
+- 早期“service surface / control-plane / side-store / default cut”这套分层仍然有效
+- 但 current `dev` 上真正优先级最高的 residual 已经不是 broad service surface
+- 当前应该把注意力集中到：
+  1. sandbox control-plane contract gap
+  2. closure proof 质量
+  3. default/env-less contract 的诚实边界

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -6,56 +6,42 @@ created: 2026-04-09
 
 # Supabase Boot Contract
 
-目标：定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需的最小 contract，不再把 SQLite 当成隐含前提。
+目标：定义并验证 `LEON_STORAGE_STRATEGY=supabase` 下系统独立启动所需的最小 contract，并把失败精确分类，而不是继续把所有 bringup 问题糊成“还是依赖 SQLite”。
 
-## 第一轮事实
+## Fresh audit facts
 
-### 已经存在的 Supabase-first 启动骨架
+2026-04-10 的真实 bringup / API proof 已经拿到这些事实：
 
-- [backend/web/core/lifespan.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/core/lifespan.py)
-  - 启动前先强制检查：
-    - `LEON_POSTGRES_URL`
-  - 再直接创建：
-    - `create_supabase_client()`
-    - `create_public_supabase_client()`
-  - 然后用 [storage/container.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/container.py) 把 repo 注入到 `app.state`
-- [backend/web/core/supabase_factory.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/backend/web/core/supabase_factory.py)
-  - 当前明确要求：
-    - `SUPABASE_INTERNAL_URL` 或 `SUPABASE_PUBLIC_URL`
-    - `LEON_SUPABASE_SERVICE_ROLE_KEY`
-    - `SUPABASE_ANON_KEY`
-    - `SUPABASE_AUTH_URL`（可选，未给则回退到 Supabase URL）
-- [storage/container.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/container.py)
-  - 当前已经是 `Supabase-only` composition root
-  - 不再做 sqlite/supabase 二选一
+- 只要给出完整 Supabase runtime env + tenant-aware `LEON_POSTGRES_URL`，backend 可以真实启动
+- 登录与基础 API caller-proof 已成立：
+  - `POST /api/auth/login`
+  - `GET /api/threads`
+  - `GET /api/sandbox/leases/mine`
+  - `GET /api/sandbox/types`
+- 这说明 boot contract 已经不再停留在“理论上应该可以”
 
-### 当前 boot contract 仍未完全闭环的原因
+## 当前 blocker 分类
 
-- 虽然 web composition root 已是 Supabase-first，但系统里仍有一批 side-store / control-plane caller 会把运行面重新拖回 SQLite：
-  - [storage/session_manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/storage/session_manager.py)
-  - [core/runtime/middleware/queue/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/queue/manager.py)
-  - [core/runtime/middleware/memory/summary_store.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/core/runtime/middleware/memory/summary_store.py)
-  - [sandbox/chat_session.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/chat_session.py)
-  - [sandbox/lease.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/lease.py)
-  - [sandbox/manager.py](/Users/lexicalmathical/worktrees/leonai--storage-factory-deletion-cut/sandbox/manager.py)
+当前未 closure 的部分，不应再归因到 boot root 本身：
 
-### 当前 ruling
+- code / contract blocker
+  - sandbox control-plane strategy path 仍缺 `LeaseRepo.set_volume_id(...)`
+  - 已单独送审于 [#396](https://github.com/OpenDCAI/Mycel/pull/396)
+- provider / runtime blocker
+  - Daytona self-hosted provider proof仍需持续回放
+- auth / bootstrap blocker
+  - 当前不再是主 blocker
+- postgres / checkpointer blocker
+  - tenant-aware DSN 是 bringup 前提，不能再沿用旧 `postgres@127.0.0.1:5432` 假设
 
-- `Supabase Boot Contract` 不是“设计上应该用 Supabase”这种泛话
-- 它必须最后落成 caller-proven truth：
-  - 在 `LEON_STORAGE_STRATEGY=supabase` 下，系统能独立 bringup
-  - 若失败，要明确失败属于：
-    - code/contract
-    - auth/bootstrap
-    - postgres/checkpointer
-    - provider/runtime
-- 在这之前，不应该把任何 SQLite stopgap 误写成“启动本来就该依赖 SQLite”
+## 当前 ruling
 
-## Stopline
+- `lifespan` 和 runtime storage builder 已足够支持 Supabase bringup
+- `CP01` 还不能关，因为高层 provider path 仍会把真实 blocker 暴露出来
+- 但它也不该继续写成“刚开始定义 contract”
 
-- 明确启动所需 env / repo / runtime 前提
-- caller-proven 区分：
-  - code/contract blocker
-  - auth/bootstrap blocker
-  - postgres/checkpointer blocker
-  - provider/runtime blocker
+## Default next move
+
+- 合并 [#396](https://github.com/OpenDCAI/Mycel/pull/396) 后
+- 用同一套真实 env 再跑一轮 backend + Daytona agent proof
+- 若失败，再继续按 blocker 分类推进，而不是回退成 broad inventory

--- a/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-02-service-surface-parity.md
@@ -1,14 +1,29 @@
 ---
 title: Service Surface Parity
-status: open
+status: done
 created: 2026-04-09
 ---
 
 # Service Surface Parity
 
-目标：收 web/service 层仍然 SQLite-only 的路径，让 service surface 在 `LEON_STORAGE_STRATEGY=supabase` 下不再隐含依赖 SQLite。
+目标：让 web/service 层在 `LEON_STORAGE_STRATEGY=supabase` 下不再依赖 direct SQLite caller。
 
-## Stopline
+## Current `dev` truth
 
-- service layer 不再通过 SQLite stopgap 维持运行
-- 变更按小簇切，不把 sandbox/control-plane 混进同一刀
+这条子任务现在不该继续标 `open`。`origin/dev = f0264bfd` 上，关键 service surface 已经回到 runtime / control-plane seam：
+
+- [backend/web/services/file_channel_service.py](backend/web/services/file_channel_service.py)
+- [backend/web/services/monitor_service.py](backend/web/services/monitor_service.py)
+- [backend/web/utils/helpers.py](backend/web/utils/helpers.py)
+- [backend/web/routers/webhooks.py](backend/web/routers/webhooks.py)
+- [backend/web/routers/threads.py](backend/web/routers/threads.py)
+
+这些路径当前的共同点是：
+
+- 不再 direct import `SQLite*Repo`
+- repo dispatch 已下沉到 [storage/runtime.py](storage/runtime.py) 或 [sandbox/control_plane_repos.py](sandbox/control_plane_repos.py)
+
+## Ruling
+
+- `CP02` 可以关
+- 后续如果 service 层再暴露新问题，应按新的 bounded slice 记账，不再把它们挂回这张子卡上

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -1,14 +1,43 @@
 ---
 title: Sandbox Control Plane Parity
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Sandbox Control Plane Parity
 
-目标：处理 sandbox lease / terminal / chat-session / manager 等 control-plane caller 的 provider parity，避免它们继续成为 SQLite-only 岛。
+目标：处理 lease / terminal / chat-session / manager 等 control-plane caller 的 provider parity，避免 canonical strategy path 继续被 raw sqlite side-write 打穿。
 
-## Stopline
+## Current `dev` truth
 
-- 不把 stopgap 描述成终局
-- 每一刀都先回答 owner boundary，再做实现
+当前 `dev` 上，这条子任务已经不是“从零开始”：
+
+- [sandbox/control_plane_repos.py](sandbox/control_plane_repos.py) 已经存在
+- [sandbox/chat_session.py](sandbox/chat_session.py)、[sandbox/manager.py](sandbox/manager.py)、[sandbox/lease.py](sandbox/lease.py)、[sandbox/terminal.py](sandbox/terminal.py) 都已经部分 strategy-aware
+
+所以当前真正的 residual 不是 broad import cleanup，而是更窄的 contract gap。
+
+## Fresh blocker
+
+2026-04-10 的真实 Daytona self-hosted agent proof 直接打出：
+
+- [sandbox/manager.py](sandbox/manager.py) 的 `_ensure_thread_volume()` 会调用 `lease_store.set_volume_id(...)`
+- 但 `dev` 上的 [storage/providers/supabase/lease_repo.py](storage/providers/supabase/lease_repo.py) 还没有这条实现
+
+这说明：
+
+- control-plane 大面已经收过
+- 但 `CP03` 还没 closure
+- 当前 stopline 落在一个明确、狭窄、可验证的 contract hole 上
+
+## Current next slice
+
+- [#396](https://github.com/OpenDCAI/Mycel/pull/396)
+  - 为 `LeaseRepo` 补 `set_volume_id(...)`
+  - 为 `SupabaseLeaseRepo` 补实现
+  - regression 已补
+
+## Ruling
+
+- `CP03` 继续保持 `in_progress`
+- 合并 [#396](https://github.com/OpenDCAI/Mycel/pull/396) 后，需要重跑高强度 provider proof，而不是只看单测

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -1,14 +1,33 @@
 ---
 title: Default Supabase Cut
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Default Supabase Cut
 
-目标：把默认本地/开发主线配置收成 Supabase-first，而不是继续默认落在 SQLite 假设上。
+目标：把默认运行面与 env-less 语义写成诚实合同，而不是继续把“名义上的 Supabase-first”与“实际未配置 runtime client 的本地路径”混成一个布尔值。
+
+## Current `dev` truth
+
+当前 `dev` 已经有这些事实：
+
+- [storage/runtime.py](storage/runtime.py) 的 `current_storage_strategy()` 默认名义上是 `supabase`
+- 但 `uses_supabase_runtime_defaults()` 只有在显式 `LEON_STORAGE_STRATEGY=supabase`，或存在 `LEON_SUPABASE_CLIENT_FACTORY` 时才返回真
+
+这意味着：
+
+- 默认名义 strategy 与真正可用的 runtime defaults 不是一回事
+- 当前系统已经不再粗暴地把 env-less path 全部扳成 Supabase
+- 但这张卡也还不能宣称“default cut 已完全 caller-proven”
+
+## Ruling
+
+- `CP04` 不能再按旧卡那样写成 `open`
+- 也不能过度宣称 `done`
+- 当前更诚实的状态是 `in_progress`
 
 ## Stopline
 
-- 默认 bringup/documented contract 明确是 Supabase
-- SQLite 仍可作为一种 strategy，但不是默认路径
+- documented/default contract 与 runtime truth 不再互相打脸
+- env-less path、显式 `supabase` path、显式本地 `db_path` path 的边界都有 caller-proof

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -1,12 +1,43 @@
 ---
 title: Closure Proof
-status: open
+status: in_progress
 created: 2026-04-09
 ---
 
 # Closure Proof
 
-目标：用真实证据证明系统在 Supabase 下可独立运行，SQLite 不再是关键路径的隐含前提。
+目标：用高强度 caller-proof 证明系统在 Supabase 下可独立运行，SQLite 不再是关键路径的隐含前提。
+
+## 当前进度
+
+这条子任务已经开始，不该继续标 `open`。
+
+2026-04-10 fresh audit 已经做过这些 proof：
+
+### 真实产品验证
+
+- 本地 backend 在完整 Supabase runtime env 下真实启动
+- login / threads / sandbox APIs 可调用
+
+### 机制层验证
+
+- 真实 Daytona self-hosted 单 agent path 已回放
+- shared Daytona lease / file collaboration 已设计并实际试跑
+
+### 当前未 closure 的原因
+
+proof 并没有只带来“都能跑”的结论，它同时暴露了 current `dev` 的真实 blocker：
+
+- `SupabaseLeaseRepo` 缺少 `set_volume_id(...)`
+- 这会在 Daytona agent path 的 volume bootstrap 上爆出真实 contract failure
+- 该 blocker 已被单独切成 [#396](https://github.com/OpenDCAI/Mycel/pull/396)
+
+## Ruling
+
+- `CP05` 已进入 `in_progress`
+- 但 closure 仍然要等两件事：
+  1. [#396](https://github.com/OpenDCAI/Mycel/pull/396) 这类 fresh blocker 进 mainline
+  2. 在最新 `dev` 上重跑 shared sandbox / Daytona / 更高层 multi-agent pressure proof
 
 ## 证据要求
 
@@ -14,6 +45,4 @@ created: 2026-04-09
 - 机制层验证
 - 源码/测试层辅助证据
 
-## Stopline
-
-- 不用“理论上可切换”代替 caller-proven truth
+三者缺一不可，不能继续用局部单测替代 closure proof。


### PR DESCRIPTION
## Summary
- refresh `teams/tasks/supabase-first-runtime-parity/*` against current `origin/dev`
- mark stale subtask statuses honestly
- record the fresh 2026-04-10 audit finding that current `dev` still has a CP03 blocker tracked separately in #396

## Why
The existing ledger was still frozen at the early 2026-04-09 inventory view and was materially behind current mainline truth. That made the checkpoint card low-quality: service-surface work already merged still showed as open, while the current real blocker was not captured.

## Scope
Docs/task-ledger only.
No runtime/code semantics changed.

## Evidence
- `git diff --check`
- fresh source audit against `origin/dev=f0264bfdd1d204f1b0b24c924451c2097788e0c3`
- fresh proof findings from 2026-04-10 audit lane:
  - backend Supabase bringup + auth/API proof
  - Daytona self-hosted agent proof
  - remaining control-plane blocker isolated into #396
