### PR TITLE
Fix Supabase queue sender column mapping

### DIFF
--- a/storage/providers/supabase/queue_repo.py
+++ b/storage/providers/supabase/queue_repo.py
@@ -9,6 +9,7 @@ from storage.providers.supabase import _query as q
 
 _REPO = "queue repo"
 _TABLE = "message_queue"
+_SENDER_USER_ID = "sender_user_id"
 
 
 class SupabaseQueueRepo:
@@ -22,6 +23,15 @@ class SupabaseQueueRepo:
 
     def _t(self) -> Any:
         return self._client.table(_TABLE)
+
+    def _hydrate_item(self, row: dict[str, Any]) -> QueueItem:
+        return QueueItem(
+            content=str(row.get("content") or ""),
+            notification_type=row.get("notification_type") or "steer",
+            source=row.get("source"),
+            sender_id=row.get(_SENDER_USER_ID),
+            sender_name=row.get("sender_name"),
+        )
 
     def enqueue(
         self,
@@ -38,7 +48,7 @@ class SupabaseQueueRepo:
                 "content": content,
                 "notification_type": notification_type,
                 "source": source,
-                "sender_id": sender_id,
+                _SENDER_USER_ID: sender_id,
                 "sender_name": sender_name,
             }
         ).execute()
@@ -48,7 +58,7 @@ class SupabaseQueueRepo:
         head = q.rows(
             q.limit(
                 q.order(
-                    self._t().select("id,content,notification_type,source,sender_id,sender_name").eq("thread_id", thread_id),
+                    self._t().select(f"id,content,notification_type,source,{_SENDER_USER_ID},sender_name").eq("thread_id", thread_id),
                     "id",
                     desc=False,
                     repo=_REPO,
@@ -69,19 +79,13 @@ class SupabaseQueueRepo:
             raise RuntimeError("Supabase queue repo expected non-null id in dequeue row. Check message_queue table schema.")
         # Delete the row we just selected
         self._t().delete().eq("id", row_id).execute()
-        return QueueItem(
-            content=str(row.get("content") or ""),
-            notification_type=row.get("notification_type") or "steer",
-            source=row.get("source"),
-            sender_id=row.get("sender_id"),
-            sender_name=row.get("sender_name"),
-        )
+        return self._hydrate_item(row)
 
     def drain_all(self, thread_id: str) -> list[QueueItem]:
         # Fetch all rows ordered by id, then delete them all
         raw = q.rows(
             q.order(
-                self._t().select("id,content,notification_type,source,sender_id,sender_name").eq("thread_id", thread_id),
+                self._t().select(f"id,content,notification_type,source,{_SENDER_USER_ID},sender_name").eq("thread_id", thread_id),
                 "id",
                 desc=False,
                 repo=_REPO,
@@ -93,16 +97,7 @@ class SupabaseQueueRepo:
         if not raw:
             return []
         self._t().delete().eq("thread_id", thread_id).execute()
-        return [
-            QueueItem(
-                content=str(r.get("content") or ""),
-                notification_type=r.get("notification_type") or "steer",
-                source=r.get("source"),
-                sender_id=r.get("sender_id"),
-                sender_name=r.get("sender_name"),
-            )
-            for r in raw
-        ]
+        return [self._hydrate_item(r) for r in raw]
 
     def peek(self, thread_id: str) -> bool:
         rows = q.rows(

--- a/tests/Unit/storage/test_supabase_queue_repo.py
+++ b/tests/Unit/storage/test_supabase_queue_repo.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from storage.providers.supabase.queue_repo import SupabaseQueueRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_supabase_queue_repo_enqueue_persists_sender_user_id() -> None:
+    tables = {"message_queue": []}
+    repo = SupabaseQueueRepo(client=FakeSupabaseClient(tables=tables))
+
+    repo.enqueue(
+        "thread-1",
+        "hello",
+        notification_type="steer",
+        source="owner",
+        sender_id="user-1",
+        sender_name="Alice",
+    )
+
+    row = tables["message_queue"][0]
+    assert row["thread_id"] == "thread-1"
+    assert row["sender_user_id"] == "user-1"
+    assert "sender_id" not in row
+
+
+def test_supabase_queue_repo_dequeue_maps_sender_user_id_to_sender_id() -> None:
+    tables = {
+        "message_queue": [
+            {
+                "id": 1,
+                "thread_id": "thread-1",
+                "content": "hello",
+                "notification_type": "steer",
+                "source": "owner",
+                "sender_user_id": "user-1",
+                "sender_name": "Alice",
+            }
+        ]
+    }
+    repo = SupabaseQueueRepo(client=FakeSupabaseClient(tables=tables))
+
+    item = repo.dequeue("thread-1")
+
+    assert item is not None
+    assert item.sender_id == "user-1"
+    assert tables["message_queue"] == []
+
+
+def test_supabase_queue_repo_drain_all_maps_sender_user_id_to_sender_id() -> None:
+    tables = {
+        "message_queue": [
+            {
+                "id": 1,
+                "thread_id": "thread-1",
+                "content": "hello",
+                "notification_type": "steer",
+                "source": "owner",
+                "sender_user_id": "user-1",
+                "sender_name": "Alice",
+            },
+            {
+                "id": 2,
+                "thread_id": "thread-1",
+                "content": "world",
+                "notification_type": "agent",
+                "source": "external",
+                "sender_user_id": "user-2",
+                "sender_name": "Bob",
+            },
+        ]
+    }
+    repo = SupabaseQueueRepo(client=FakeSupabaseClient(tables=tables))
+
+    items = repo.drain_all("thread-1")
+
+    assert [item.sender_id for item in items] == ["user-1", "user-2"]
+    assert tables["message_queue"] == []


### PR DESCRIPTION
## Summary
- map Supabase queue persistence to the real `sender_user_id` physical column while keeping logical `QueueItem.sender_id`
- add focused Supabase queue repo regression tests for enqueue, dequeue, and drain-all mapping
- verify the fix with fresh unit/static checks and a real `/api/threads/{thread_id}/messages` proof on a fresh self-hosted Daytona backend

## Test Plan
- uv run pytest -q tests/Unit/storage/test_supabase_queue_repo.py
- uv run pytest -q tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_runtime_builder_contract.py -k 'queue or runtime_repo_builders_use_supabase_factory'
- uv run ruff check storage/providers/supabase/queue_repo.py tests/Unit/storage/test_supabase_queue_repo.py
- uv run ruff format --check storage/providers/supabase/queue_repo.py tests/Unit/storage/test_supabase_queue_repo.py
- uv run python -m py_compile storage/providers/supabase/queue_repo.py tests/Unit/storage/test_supabase_queue_repo.py
- git diff --check
- Real product proof on fresh backend `127.0.0.1:8013`: login -> create `daytona_selfhost` thread -> `POST /api/threads/{thread_id}/messages` returned `200`, and backend logs no longer emitted `message_queue.sender_id does not exist`
