### PR TITLE
Preserve shared leases on thread destroy

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -843,13 +843,16 @@ class SandboxManager:
             self.terminal_store.delete(terminal.terminal_id)
 
         for lease_id in lease_ids:
+            # @@@shared-lease-destroy-boundary - destroying one thread must not tear down
+            # a lease that still has surviving terminals bound to it.
+            lease_in_use = any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all())
+            if lease_in_use:
+                continue
             lease = self._get_lease(lease_id)
             if not lease:
                 raise RuntimeError(f"Missing lease {lease_id} for thread {thread_id}")
             lease.destroy_instance(self.provider)
-            lease_in_use = any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all())
-            if not lease_in_use:
-                self.lease_store.delete(lease_id)
+            self.lease_store.delete(lease_id)
         return True
 
     def list_sessions(self) -> list[dict]:

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -373,6 +373,57 @@ def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_termi
     assert deleted_leases == ["lease-1"]
 
 
+def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
+    manager = _new_test_manager()
+    manager.provider_capability = SimpleNamespace(runtime_kind="local")
+    manager.provider = SimpleNamespace(name="local")
+    manager.volume = _FakeVolume()
+    deleted_sessions: list[tuple[str, str]] = []
+    deleted_terminals: list[str] = []
+    destroyed_leases: list[str] = []
+    deleted_leases: list[str] = []
+    all_terminals = [
+        {"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"},
+        {"terminal_id": "term-2", "lease_id": "lease-1", "thread_id": "thread-2"},
+    ]
+
+    class _Lease:
+        lease_id = "lease-1"
+        observed_state = "detached"
+        volume_id = None
+
+        def get_instance(self):
+            return None
+
+        def destroy_instance(self, _provider):
+            destroyed_leases.append("lease-1")
+
+    lease = _Lease()
+    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_lease = lambda _lease_id: lease
+    manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
+    manager.terminal_store = SimpleNamespace(
+        list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
+        delete=lambda terminal_id: (
+            deleted_terminals.append(terminal_id),
+            all_terminals.__setitem__(slice(None), [row for row in all_terminals if row["terminal_id"] != terminal_id]),
+        ),
+        list_all=lambda: list(all_terminals),
+        db_path=Path("/tmp/fake-sandbox.db"),
+    )
+    manager.session_manager = SimpleNamespace(
+        delete_thread=lambda thread_id, reason="thread_deleted": deleted_sessions.append((thread_id, reason)),
+    )
+    manager.lease_store = SimpleNamespace(delete=lambda lease_id: deleted_leases.append(lease_id))
+
+    assert manager.destroy_thread_resources("thread-1") is True
+    assert deleted_sessions == [("thread-1", "thread_deleted")]
+    assert deleted_terminals == ["term-1"]
+    assert destroyed_leases == []
+    assert deleted_leases == []
+    assert all_terminals == [{"terminal_id": "term-2", "lease_id": "lease-1", "thread_id": "thread-2"}]
+
+
 def test_sync_uploads_skips_local_volume_sync_when_lease_has_no_volume_id():
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="local")


### PR DESCRIPTION
## Summary
- keep shared leases alive when destroying one thread's sandbox so surviving threads do not inherit a destroyed lease
- add a focused regression test for `destroy_thread_resources()` with two terminals bound to the same lease
- verify the fix with fresh self-hosted Daytona destroy-persistence proof on a rebased latest-`dev` backend

## Test Plan
- uv run pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -k 'keeps_shared_lease_for_surviving_threads or destroy_thread_resources_hard_deletes_thread_chat_sessions_before_terminal_delete'
- uv run pytest -q tests/Unit/sandbox/test_lease_probe_contract.py tests/Unit/sandbox/test_manager_repo_strategy.py -k 'destroy_instance or chat_session or sandbox_manager'
- uv run ruff check sandbox/manager.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- uv run python -m py_compile sandbox/manager.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- git diff --check
- Real product proof on fresh backend `127.0.0.1:8015`:
  - create shared `daytona_selfhost` lease across two threads
  - sync a file from thread1 into `/home/daytona/files`
  - `DELETE /api/threads/{thread1}/sandbox` returned `200`
  - surviving thread's lease stayed `desired_state=running, observed_state=running`
  - surviving thread could still `POST /messages` and `GET /files/read` the same remote file after destroy
