### PR TITLE
Refresh closure ledger with shared-sandbox longevity proof

### DIFF
--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -12,7 +12,7 @@ created: 2026-04-09
 
 ## 当前 mainline truth
 
-这张卡现在以 `origin/dev = 4cec440a7144b58cf76fad23f89bb7d9a7fe50ad` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
+这张卡现在以 `origin/dev = df75922f54ed9a28443d8e80118fcc2027bf3b4f` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
 
 当前 `dev` 已经完成的事实：
 
@@ -38,6 +38,15 @@ created: 2026-04-09
   - resume 后 lease 回到 `running`
   - 同一 instance id 保持不变
   - pause 前同步进去的文件在 resume 后仍可跨线程读取
+- shared Daytona lease 的 destroy persistence proof 也已成立：
+  - `thread1` destroy 自己的 sandbox 后，surviving `thread2` 不再被一起拖进 destroyed lease
+  - `thread2` 仍保持 `desired_state=running / observed_state=running`
+  - destroy 前已同步的 remote file 在 destroy 后仍可继续读取
+- shared Daytona lease 的 backend-restart longevity proof 已成立：
+  - backend A 建立 shared lease 并同步 `thread1` 文件后完全退出
+  - backend B 冷启动后，旧 `thread2` 仍能读到 restart 前的 remote file
+  - `thread2` 在 restart 后继续上传并同步新文件，`thread1` 也能反向读到
+  - cold start 初始 lease truth 一度表现为 `paused`，但在新一轮 thread activity 后收敛回 `running`
 - 这次 proof 还暴露出一个运行面前提：
   - fresh proof worktree 若只做默认 `uv sync`，`daytona_sdk` 不会进入 `.venv`
   - 自托管 Daytona caller-proof 需要先执行 `uv sync --extra daytona`
@@ -47,7 +56,7 @@ created: 2026-04-09
 - `CP00` 已不该继续标 `in_progress`
 - `CP02` service surface parity 已基本收口
 - 当前 mainline 最大 residual 不再是 service 层，而是 sandbox control-plane 的剩余 contract gap
-- `CP05 Closure Proof` 已经拿到一轮强 caller-proof，但还不能诚实地宣称完成
+- `CP05 Closure Proof` 已经拿到多轮高强度 caller-proof，但还不能诚实地宣称完成
 
 ## 子任务
 
@@ -72,6 +81,5 @@ created: 2026-04-09
 ## 默认 next move
 
 - 在最新 `dev` 上继续更高强度 proof：
-  - destroy 后的 shared sandbox file persistence
-  - Daytona self-hosted 多线程 dirty-state path
+  - 更脏的 Daytona self-hosted 多线程 dirty-state / long-idle / restart-after-idle path
   - 更高层 multi-agent stress scenario（例如多 agent 协议博弈）

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -33,6 +33,21 @@ created: 2026-04-09
   - resume 后 lease 回到 `running`
   - 同一 instance id 持续复用
   - pause 前后 shared files 都能跨线程继续读取
+- 真实 Daytona self-hosted destroy persistence proof 已成立：
+  - `thread1 = m_dKjuBBLbR1bw-99`
+  - `thread2 = m_dKjuBBLbR1bw-100`
+  - `lease_id = lease-876d9e57240b`
+  - `DELETE /api/threads/{thread1}/sandbox -> 200`
+  - surviving `thread2` 在 destroy 后仍保持 `desired_state=running / observed_state=running`
+  - destroy 前已同步的 `remote file` 在 destroy 后仍继续可读
+- 真实 Daytona self-hosted backend-restart longevity proof 已成立：
+  - backend A 上建立 shared lease：`thread1 = m_dKjuBBLbR1bw-101`，`thread2 = m_dKjuBBLbR1bw-102`
+  - `lease_id = lease-20045fcfa4b3`
+  - restart 前 `thread2` 能读到 `thread1` 同步的 `longevity-d3a3d42d-t1.txt`
+  - backend A 完全退出后，backend B 冷启动
+  - restart 后 `thread2` 仍能读到旧文件
+  - restart 后 `thread2` 新写入并同步 `longevity-b975998d-t2.txt`，`thread1` 也能反向读到
+  - cold start 初始 lease truth 一度表现为 `paused/version=4`，但在新一轮 thread activity 后收敛回 `running/version=6`
 
 ### 机制层验证
 
@@ -47,19 +62,17 @@ created: 2026-04-09
 proof 并没有只带来“都能跑”的结论，但先前 blocker 已经进 mainline，当前未 closure 的原因也随之变化：
 
 - [#396](https://github.com/OpenDCAI/Mycel/pull/396) 已经补齐 `SupabaseLeaseRepo.set_volume_id(...)`
-- shared lease / file roundtrip 与 pause / resume persistence 虽已成立，但 closure 还缺更高压场景：
-  - destroy 后的文件持久性
-  - dirty state 下连续多轮 shared lease 协作
+- shared lease / file roundtrip、pause / resume、destroy persistence 与 backend-restart longevity 虽已成立，但 closure 还缺更高压场景：
+  - 更脏的 dirty-state / long-idle / restart-after-idle path
   - 更高层 multi-agent stress scenario
 
 ## Ruling
 
 - `CP05` 已进入 `in_progress`
-- shared Daytona lease / file collaboration 与 pause / resume persistence 已经从“机制层试跑”提升为 `真实产品验证`
+- shared Daytona lease / file collaboration、pause / resume、destroy persistence 与 backend-restart longevity 已经从“机制层试跑”提升为 `真实产品验证`
 - 但 closure 仍然要等更高压 proof：
-  1. destroy 后的 shared sandbox file persistence
-  2. Daytona self-hosted dirty-state / long-lifecycle path
-  3. 更高层 multi-agent pressure proof
+  1. 更脏的 Daytona self-hosted dirty-state / long-idle / restart-after-idle path
+  2. 更高层 multi-agent pressure proof
 
 ## 证据要求
 


### PR DESCRIPTION
## Summary
- refresh `supabase-first-runtime-parity` ledger to current `origin/dev`
- record the fresh shared-sandbox destroy persistence proof
- record the fresh backend-restart longevity proof and narrow the remaining CP05 stopline to dirtier idle/restart and multi-agent stress scenarios

## Test Plan
- git diff --check
- Manual ledger audit against fresh real-proof evidence
