### PR TITLE
Refresh closure ledger with three-thread Daytona stress proof

### DIFF
--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -12,7 +12,7 @@ created: 2026-04-09
 
 ## 当前 mainline truth
 
-这张卡现在以 `origin/dev = df75922f54ed9a28443d8e80118fcc2027bf3b4f` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
+这张卡现在以 `origin/dev = b943583f7b067d90820105051a2be9ab0866b453` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
 
 当前 `dev` 已经完成的事实：
 
@@ -47,9 +47,20 @@ created: 2026-04-09
   - backend B 冷启动后，旧 `thread2` 仍能读到 restart 前的 remote file
   - `thread2` 在 restart 后继续上传并同步新文件，`thread1` 也能反向读到
   - cold start 初始 lease truth 一度表现为 `paused`，但在新一轮 thread activity 后收敛回 `running`
+- shared Daytona lease 的三线程压力 proof 已成立：
+  - `thread1 = m_dKjuBBLbR1bw-105`
+  - `thread2 = m_dKjuBBLbR1bw-106`
+  - `thread3 = m_dKjuBBLbR1bw-107`
+  - `lease_id = lease-135dd60b2aa1`
+  - 三轮 `upload -> public download -> attachment sync -> cross-thread remote read` 全部成功
+  - 远端 `/home/daytona/files` 最终稳定包含 3 个线程各自同步的文件
+  - 三边 lease truth 最终一致：同一个 `instance_id`，`desired_state=running / observed_state=running / version=19`
 - 这次 proof 还暴露出一个运行面前提：
   - fresh proof worktree 若只做默认 `uv sync`，`daytona_sdk` 不会进入 `.venv`
   - 自托管 Daytona caller-proof 需要先执行 `uv sync --extra daytona`
+  - fresh backend web caller-proof 还需要显式 `LEON_POSTGRES_URL`
+  - 远端 Supabase host `localhost:5432` 实际是 `supavisor`，不是裸 `supabase-db`
+  - 要让 backend web runtime 通过 checkpointer contract，本地需要直通 `supabase-db` 的 Postgres tunnel，而不是复用 Supavisor 口
 
 ## 当前 ruling
 
@@ -82,4 +93,4 @@ created: 2026-04-09
 
 - 在最新 `dev` 上继续更高强度 proof：
   - 更脏的 Daytona self-hosted 多线程 dirty-state / long-idle / restart-after-idle path
-  - 更高层 multi-agent stress scenario（例如多 agent 协议博弈）
+  - 更高层 multi-agent stress scenario（例如多 agent 协议博弈 / 斗地主类多回合场景）

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -48,6 +48,17 @@ created: 2026-04-09
   - restart 后 `thread2` 仍能读到旧文件
   - restart 后 `thread2` 新写入并同步 `longevity-b975998d-t2.txt`，`thread1` 也能反向读到
   - cold start 初始 lease truth 一度表现为 `paused/version=4`，但在新一轮 thread activity 后收敛回 `running/version=6`
+- 真实 Daytona self-hosted 三线程共享 lease 压力 proof 已成立：
+  - `thread1 = m_dKjuBBLbR1bw-105`
+  - `thread2 = m_dKjuBBLbR1bw-106`
+  - `thread3 = m_dKjuBBLbR1bw-107`
+  - `lease_id = lease-135dd60b2aa1`
+  - 三个 thread 初始都绑定到同一个 detached lease
+  - 第 1 轮：`thread1` 上传 `three-thread-8dcd17a0-t1.txt`，public download 成功，附件消息触发 sync 后，`thread2` 和 `thread3` 都能从 `/home/daytona/files` 读到
+  - 第 2 轮：`thread2` 上传 `three-thread-8dcd17a0-t2.txt`，`thread1` 和 `thread3` 都能读到
+  - 第 3 轮：`thread3` 上传 `three-thread-8dcd17a0-t3.txt`，`thread1` 和 `thread2` 都能读到
+  - 最终远端 `/home/daytona/files` 列表稳定包含这 3 个文件
+  - 三边 lease truth 最终一致：同一个 `instance_id = 50d883e8-ba58-4f62-886a-52881a948ad0`，`desired_state=running / observed_state=running / version=19`
 
 ### 机制层验证
 
@@ -56,20 +67,23 @@ created: 2026-04-09
 - 这轮 proof 还压实了一个运行面前提：
   - fresh proof worktree 的 `.venv` 若只执行默认 `uv sync`，`daytona_sdk` 不会安装
   - 自托管 Daytona caller-proof 前需要先执行 `uv sync --extra daytona`
+  - backend web runtime 还会在 startup 阶段硬要求 `LEON_POSTGRES_URL`
+  - 本地若把 `LEON_POSTGRES_URL` 指向远端 host 的 `localhost:5432`，实际会打到 `supavisor` 并得到 `Tenant or user not found`
+  - 真实 caller-proof 需要直通 `supabase-db` 容器的裸 Postgres，而不是复用 Supavisor 口
 
 ### 当前未 closure 的原因
 
 proof 并没有只带来“都能跑”的结论，但先前 blocker 已经进 mainline，当前未 closure 的原因也随之变化：
 
 - [#396](https://github.com/OpenDCAI/Mycel/pull/396) 已经补齐 `SupabaseLeaseRepo.set_volume_id(...)`
-- shared lease / file roundtrip、pause / resume、destroy persistence 与 backend-restart longevity 虽已成立，但 closure 还缺更高压场景：
+- shared lease / file roundtrip、pause / resume、destroy persistence、backend-restart longevity 与三线程共享 lease 压力场景虽已成立，但 closure 还缺更高压场景：
   - 更脏的 dirty-state / long-idle / restart-after-idle path
   - 更高层 multi-agent stress scenario
 
 ## Ruling
 
 - `CP05` 已进入 `in_progress`
-- shared Daytona lease / file collaboration、pause / resume、destroy persistence 与 backend-restart longevity 已经从“机制层试跑”提升为 `真实产品验证`
+- shared Daytona lease / file collaboration、pause / resume、destroy persistence、backend-restart longevity 与三线程共享 lease 压力场景已从“机制层试跑”提升为 `真实产品验证`
 - 但 closure 仍然要等更高压 proof：
   1. 更脏的 Daytona self-hosted dirty-state / long-idle / restart-after-idle path
   2. 更高层 multi-agent pressure proof


### PR DESCRIPTION
## Summary
- refresh `supabase-first-runtime-parity` ledger to `origin/dev = b943583f7b067d90820105051a2be9ab0866b453`
- record fresh three-thread shared Daytona lease stress proof
- record the web runtime checkpointer prerequisite: `LEON_POSTGRES_URL` must use raw `supabase-db`, not Supavisor

## Evidence
- real local web backend bringup with explicit `LEON_POSTGRES_URL`
- real auth + thread + lease + upload/download + attachment sync + cross-thread remote reads
- three shared threads converged on one running Daytona instance with one lease
