### PR TITLE
fix: preserve remote sandboxes on web shutdown

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -190,7 +190,7 @@ async def lifespan(app: FastAPI):
         # Cleanup: close all agents
         for agent in app.state.agent_pool.values():
             try:
-                agent.close()
+                agent.close(cleanup_sandbox=False)
             except Exception as e:
                 print(f"[web] Agent cleanup error: {e}")
 

--- a/tests/Integration/test_storage_repo_abstraction_unification.py
+++ b/tests/Integration/test_storage_repo_abstraction_unification.py
@@ -392,6 +392,29 @@ async def test_lifespan_wires_user_and_thread_repos_from_storage_runtime_contain
         assert not hasattr(app.state, "member_repo")
 
 
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_closes_agents_without_sandbox_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _RecordingAgent:
+        def __init__(self) -> None:
+            self.cleanup_flags: list[bool] = []
+
+        def close(self, *, cleanup_sandbox: bool = True) -> None:
+            self.cleanup_flags.append(cleanup_sandbox)
+
+    container = _FakeContainer()
+    app = FastAPI()
+    _install_lifespan_noop_dependencies(monkeypatch)
+    monkeypatch.setattr("storage.runtime.build_storage_container", lambda **_: container)
+    agent = _RecordingAgent()
+
+    async with lifespan_module.lifespan(app):
+        app.state.agent_pool["thread-1:daytona_selfhost"] = agent
+
+    assert agent.cleanup_flags == [False]
+
+
 def test_runtime_services_default_to_storage_runtime_container(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     class _FakeRuntimeContainer:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- keep FastAPI lifespan shutdown from mutating remote sandbox state by closing agents with `cleanup_sandbox=False`
- add a regression test proving web shutdown preserves shared remote leases during agent cleanup
- validate the fix with a real Daytona dirty-state restart proof across 3 threads sharing one lease

## Test Plan
- uv run pytest -q tests/Integration/test_storage_repo_abstraction_unification.py -k 'lifespan_shutdown_closes_agents_without_sandbox_cleanup or lifespan_wires_user_and_thread_repos_from_storage_runtime_container'
- uv run ruff check backend/web/core/lifespan.py tests/Integration/test_storage_repo_abstraction_unification.py
- uv run python -m py_compile backend/web/core/lifespan.py tests/Integration/test_storage_repo_abstraction_unification.py
- git diff --check
- real product proof: 3 shared Daytona threads survive backend restart, retain `desired_state=running` / `observed_state=running`, cross-read old files, and sync a new post-restart file
