### PR TITLE
fix: prefer active child thread for chat delivery

### DIFF
--- a/core/agents/communication/delivery.py
+++ b/core/agents/communication/delivery.py
@@ -37,6 +37,7 @@ def _resolve_unique_active_thread_id(app: Any, recipient_id: str, thread: dict[s
 
     pool = getattr(app.state, "agent_pool", {}) or {}
     active_thread_ids: list[str] = []
+    live_child_thread_ids: list[str] = []
     for candidate in thread_repo.list_by_agent_user(agent_user_id):
         thread_id = str(candidate.get("id") or "").strip()
         if not thread_id:
@@ -46,14 +47,21 @@ def _resolve_unique_active_thread_id(app: Any, recipient_id: str, thread: dict[s
         for pool_key, agent in pool.items():
             if not str(pool_key).startswith(f"{thread_id}:"):
                 continue
-            runtime = getattr(agent, "runtime", None)
-            if getattr(runtime, "current_state", None) == AgentState.ACTIVE:
+            state = getattr(getattr(agent, "runtime", None), "current_state", None)
+            if state in {AgentState.READY, AgentState.ACTIVE, AgentState.IDLE, AgentState.SUSPENDED, AgentState.INITIALIZING} and not bool(
+                candidate.get("is_main")
+            ):
+                live_child_thread_ids.append(thread_id)
+            if state == AgentState.ACTIVE:
                 active_thread_ids.append(thread_id)
                 break
 
     unique_active_thread_ids = list(dict.fromkeys(active_thread_ids))
     if len(unique_active_thread_ids) == 1:
         return unique_active_thread_ids[0]
+    unique_live_child_thread_ids = list(dict.fromkeys(live_child_thread_ids))
+    if len(unique_live_child_thread_ids) == 1:
+        return unique_live_child_thread_ids[0]
     return None
 
 

--- a/core/agents/communication/delivery.py
+++ b/core/agents/communication/delivery.py
@@ -11,16 +11,47 @@ import functools
 import logging
 from typing import Any
 
+from core.runtime.middleware.monitor import AgentState
 from storage.contracts import UserRow
 
 logger = logging.getLogger(__name__)
 
 
 def _resolve_recipient_thread_id(app: Any, recipient_id: str) -> str | None:
+    active_thread_id = _resolve_unique_active_thread_id(app, recipient_id)
+    if active_thread_id is not None:
+        return active_thread_id
     thread = app.state.thread_repo.get_by_user_id(recipient_id)
     if thread is None:
         return None
     return thread["id"]
+
+
+def _resolve_unique_active_thread_id(app: Any, recipient_id: str) -> str | None:
+    thread_repo = getattr(app.state, "thread_repo", None)
+    if thread_repo is None or not hasattr(thread_repo, "list_by_agent_user"):
+        return None
+
+    pool = getattr(app.state, "agent_pool", {}) or {}
+    active_thread_ids: list[str] = []
+    for thread in thread_repo.list_by_agent_user(recipient_id):
+        thread_id = str(thread.get("id") or "").strip()
+        if not thread_id:
+            continue
+        # @@@active-thread-delivery-precedence - fresh chat delivery should prefer the
+        # recipient's unique active thread over a stale default-main thread with dirty history.
+        for pool_key, agent in pool.items():
+            if not str(pool_key).startswith(f"{thread_id}:"):
+                continue
+            runtime = getattr(agent, "runtime", None)
+            if getattr(runtime, "current_state", None) == AgentState.ACTIVE:
+                active_thread_ids.append(thread_id)
+                break
+
+    unique_active_thread_ids = list(dict.fromkeys(active_thread_ids))
+    if len(unique_active_thread_ids) == 1:
+        return unique_active_thread_ids[0]
+    return None
 
 
 def make_chat_delivery_fn(app: Any):

--- a/core/agents/communication/delivery.py
+++ b/core/agents/communication/delivery.py
@@ -18,24 +18,27 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_recipient_thread_id(app: Any, recipient_id: str) -> str | None:
-    active_thread_id = _resolve_unique_active_thread_id(app, recipient_id)
+    thread = app.state.thread_repo.get_by_user_id(recipient_id)
+    active_thread_id = _resolve_unique_active_thread_id(app, recipient_id, thread)
     if active_thread_id is not None:
         return active_thread_id
-    thread = app.state.thread_repo.get_by_user_id(recipient_id)
     if thread is None:
         return None
     return thread["id"]
 
 
-def _resolve_unique_active_thread_id(app: Any, recipient_id: str) -> str | None:
+def _resolve_unique_active_thread_id(app: Any, recipient_id: str, thread: dict[str, Any] | None) -> str | None:
     thread_repo = getattr(app.state, "thread_repo", None)
     if thread_repo is None or not hasattr(thread_repo, "list_by_agent_user"):
+        return None
+    agent_user_id = str((thread or {}).get("agent_user_id") or recipient_id).strip()
+    if not agent_user_id:
         return None
 
     pool = getattr(app.state, "agent_pool", {}) or {}
     active_thread_ids: list[str] = []
-    for thread in thread_repo.list_by_agent_user(recipient_id):
-        thread_id = str(thread.get("id") or "").strip()
+    for candidate in thread_repo.list_by_agent_user(agent_user_id):
+        thread_id = str(candidate.get("id") or "").strip()
         if not thread_id:
             continue
         # @@@active-thread-delivery-precedence - fresh chat delivery should prefer the

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -7,6 +7,7 @@ import pytest
 
 from backend.web.utils.serializers import avatar_url
 from core.agents.communication import delivery as delivery_module
+from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope
 from messaging.delivery.actions import DeliveryAction
@@ -1152,3 +1153,62 @@ async def test_async_deliver_uses_recipient_social_user_id_for_thread_lookup_and
     assert started == [("thread-1", "chat-1", "thread-user-1")]
     assert unread_calls == [("chat-1", "thread-user-1")]
     assert enqueued == [("Human|chat-1|7|ping", "thread-1", "human-user-1", "Human")]
+
+
+@pytest.mark.asyncio
+async def test_async_deliver_prefers_unique_active_child_thread_over_default_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    started: list[tuple[str, str, str]] = []
+    unread_calls: list[tuple[str, str]] = []
+    enqueued: list[tuple[str, str, str | None, str | None]] = []
+
+    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
+        return SimpleNamespace(id=f"agent-for-{thread_id}")
+
+    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "core.runtime.middleware.queue.formatters.format_chat_notification",
+        lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                get_by_user_id=lambda uid: {"id": "thread-main", "agent_user_id": "thread-user-1"} if uid == "thread-user-1" else None,
+                list_by_agent_user=lambda uid: (
+                    [
+                        {"id": "thread-main", "agent_user_id": "thread-user-1", "is_main": True, "branch_index": 0},
+                        {"id": "thread-child", "agent_user_id": "thread-user-1", "is_main": False, "branch_index": 1},
+                    ]
+                    if uid == "thread-user-1"
+                    else []
+                ),
+            ),
+            agent_pool={
+                "thread-main:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.IDLE)),
+                "thread-child:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.ACTIVE)),
+            },
+            typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
+            messaging_service=SimpleNamespace(count_unread=lambda chat_id, user_id: unread_calls.append((chat_id, user_id)) or 3),
+            queue_manager=SimpleNamespace(
+                enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
+                    (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
+                )
+            ),
+        )
+    )
+
+    await delivery_module._async_deliver(
+        app,
+        "thread-user-1",
+        cast(Any, SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None)),
+        "Human",
+        "chat-2",
+        "human-user-1",
+        signal="ping",
+    )
+
+    assert started == [("thread-child", "chat-2", "thread-user-1")]
+    assert unread_calls == [("chat-2", "thread-user-1")]
+    assert enqueued == [("Human|chat-2|3|ping", "thread-child", "human-user-1", "Human")]

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1212,3 +1212,60 @@ async def test_async_deliver_prefers_unique_active_child_thread_over_default_mai
     assert started == [("thread-child", "chat-2", "thread-user-1")]
     assert unread_calls == [("chat-2", "thread-user-1")]
     assert enqueued == [("Human|chat-2|3|ping", "thread-child", "human-user-1", "Human")]
+
+
+@pytest.mark.asyncio
+async def test_async_deliver_prefers_unique_ready_child_thread_over_default_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    started: list[tuple[str, str, str]] = []
+    enqueued: list[tuple[str, str, str | None, str | None]] = []
+
+    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
+        return SimpleNamespace(id=f"agent-for-{thread_id}")
+
+    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "core.runtime.middleware.queue.formatters.format_chat_notification",
+        lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                get_by_user_id=lambda uid: {"id": "thread-main", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None,
+                list_by_agent_user=lambda uid: (
+                    [
+                        {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0},
+                        {"id": "thread-child", "agent_user_id": "agent-user-1", "is_main": False, "branch_index": 1},
+                    ]
+                    if uid == "agent-user-1"
+                    else []
+                ),
+            ),
+            agent_pool={
+                "thread-main:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.IDLE)),
+                "thread-child:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.READY)),
+            },
+            typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
+            messaging_service=SimpleNamespace(count_unread=lambda _chat_id, _user_id: 1),
+            queue_manager=SimpleNamespace(
+                enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
+                    (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
+                )
+            ),
+        )
+    )
+
+    await delivery_module._async_deliver(
+        app,
+        "thread-user-1",
+        cast(Any, SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None)),
+        "Human",
+        "chat-3",
+        "human-user-1",
+        signal="ping",
+    )
+
+    assert started == [("thread-child", "chat-3", "thread-user-1")]
+    assert enqueued == [("Human|chat-3|1|ping", "thread-child", "human-user-1", "Human")]

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1175,13 +1175,13 @@ async def test_async_deliver_prefers_unique_active_child_thread_over_default_mai
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(
-                get_by_user_id=lambda uid: {"id": "thread-main", "agent_user_id": "thread-user-1"} if uid == "thread-user-1" else None,
+                get_by_user_id=lambda uid: {"id": "thread-main", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None,
                 list_by_agent_user=lambda uid: (
                     [
-                        {"id": "thread-main", "agent_user_id": "thread-user-1", "is_main": True, "branch_index": 0},
-                        {"id": "thread-child", "agent_user_id": "thread-user-1", "is_main": False, "branch_index": 1},
+                        {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0},
+                        {"id": "thread-child", "agent_user_id": "agent-user-1", "is_main": False, "branch_index": 1},
                     ]
-                    if uid == "thread-user-1"
+                    if uid == "agent-user-1"
                     else []
                 ),
             ),


### PR DESCRIPTION
## Summary
- prefer a recipient's unique active child thread before falling back to the default main thread for chat delivery
- cover the new delivery precedence with a focused integration test

## Verification
- uv run pytest -q tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff check core/agents/communication/delivery.py tests/Integration/test_messaging_social_handle_contract.py
- uv run python -m py_compile core/agents/communication/delivery.py tests/Integration/test_messaging_social_handle_contract.py && git diff --check

## Evidence
- root cause narrowed from brutal multi-agent coordination proof on merged dev
- pre-fix live logs caller-proven delivery waking stale default main threads with very large dirty histories
- post-fix fresh rerun no longer immediately re-entered those stale main-thread contexts, though the full owner-facing rerun then hit a separate upstream runtime stall before completing