### PR TITLE
docs: align checkpoint ledgers with mainline truth

### DIFF
--- a/docs/architecture/messaging-decoupling-roadmap.md
+++ b/docs/architecture/messaging-decoupling-roadmap.md
@@ -8,17 +8,26 @@ This roadmap is intentionally scoped as a long-lived implementation lane, not a 
 
 Current campaign status:
 
-1. Slice 1 resolver baseline is landed on this lane via `6b8afffd`, introducing `messaging.display_user.resolve_messaging_display_user(...)` and cutting `MessagingService` over to the canonical resolver.
-2. The next bounded cut is also landed on this lane via `668894eb`, cutting `backend/web/routers/messaging.py` over to that same canonical resolver for its participant/display shell.
-3. The final follow-up `1c036453` is formatting-only and keeps the live PR green without widening scope.
+1. Slice 1 resolver baseline landed via `6b8afffd`, introducing `messaging.display_user.resolve_messaging_display_user(...)` and cutting `MessagingService` over to the canonical resolver.
+2. The router-side follow-up landed via `668894eb`, cutting `backend/web/routers/messaging.py` over to that same canonical resolver for its participant/display shell.
+3. Visit-chat summary ownership landed via `f6310f7d`, moving visit-chat summary assembly into `MessagingService.list_chats_for_user(...)`.
+4. Chat-detail ownership landed via `518598af`, making `MessagingService.get_chat_detail(...)` the canonical owner for visit-chat detail assembly.
+5. Tool facade cutover landed via `9a9e493e`, so `ChatToolService` no longer talks directly to chat-member/message repos for live messaging operations.
+6. `1c036453` is formatting-only and keeps the lane green without widening scope.
+
+Current mainline ruling:
+
+- This lane is no longer an active refactor campaign. The bounded slices above are landed on current mainline truth.
+- The lane is now parked, not in-progress-by-inertia.
+- Later branch-only follow-ups like `e230f275`, `c725e144`, `c4fc0d6b`, `c7ca7405`, `ee6374fd`, and `f8485886` are **not** part of current mainline truth and must not be treated as landed closure.
 
 Current parking rule:
 
-- `chat_tool_service.py` remains deferred
-- `backend/web/routers/conversations.py` remains deferred
+- later `chat_tool_service.py` ownership cleanup remains deferred
 - delivery policy changes remain deferred
 - frontend/sidebar work remains deferred
 - future slices still require explicit bounded assignment rather than inertia from this roadmap
+- if this lane is resumed, start from current mainline code, not from stale branch assumptions
 
 ## Why This Exists
 
@@ -31,34 +40,56 @@ The current codebase already treats `messaging/` as a bounded domain:
 
 But the ownership is still split across multiple surfaces.
 
-### Current split ownership
+### Original ownership split this lane was created to fix
 
 1. Canonical social/display resolution is duplicated.
 
 - `messaging/service.py` owns `_resolve_display_user()`
 - `messaging/tools/chat_tool_service.py` owns another `_resolve_display_user()`
-- `backend/web/routers/conversations.py` owns a third `_resolve_display_user()`
+- `backend/web/routers/messaging.py` used to own another resolver shell before `668894eb`
 
 2. Conversation read-model ownership is split.
 
-- `MessagingService.list_chats_for_user()` already assembles chat summaries
-- `backend/web/routers/conversations.py` rebuilds visit-chat title/avatar/unread data again
+- `MessagingService.list_chats_for_user()` already wanted to assemble chat summaries
+- `backend/web/routers/conversations.py` used to rebuild visit-chat title/avatar/unread data again before `f6310f7d`
 
 3. Runtime chat tools bypass the messaging domain.
 
 - `ChatToolService` consumes `MessagingService`
-- but also talks directly to chat-member/message/thread repos
+- but used to also talk directly to chat-member/message repos before `9a9e493e`
 
 4. The domain still depends on web presentation glue.
 
 - `messaging/service.py` imports `backend.web.utils.serializers.avatar_url`
 - so the top-level domain is still coupled to web serialization concerns
 
-These are not style issues. They are ownership failures: more than one live surface is acting like the source of truth.
+These are not style issues. They are ownership failures: more than one live surface was acting like the source of truth.
+
+### Current residual ownership split on mainline
+
+1. Canonical social/display resolution is still duplicated between:
+
+- `messaging/service.py`
+- `messaging/tools/chat_tool_service.py`
+
+2. Visit-chat summary ownership is no longer split.
+
+- `MessagingService.list_chats_for_user()` now owns visit-chat summary assembly
+- `backend/web/routers/conversations.py` only merges that visit projection with hire-thread rows
+
+3. Runtime chat tools no longer bypass message/chat-member storage repos directly.
+
+- `ChatToolService` now routes live messaging reads/sends/search through `MessagingService`
+- but it still keeps a local display-user bridge instead of fully delegating that identity shell
+
+4. The domain still depends on web presentation glue.
+
+- `messaging/service.py` still imports `backend.web.utils.serializers.avatar_url`
+- so the final domain/web boundary cleanup is still deferred
 
 ## Design Principles
 
-This roadmap follows the same principles recorded in [AGENTS.md](/Users/lexicalmathical/worktrees/leonai--messaging-decouple-placeholder/AGENTS.md) and mined from `Vibe-Skills`:
+This roadmap follows the same principles recorded in [AGENTS.md](../../AGENTS.md) and mined from `Vibe-Skills`:
 
 1. Single source of truth
 2. Ownership split and boundary clarity
@@ -96,13 +127,14 @@ It should not own message history storage queries, chat membership queries, or i
 
 Create one canonical resolver inside `messaging/` for `social_user_id -> display user`.
 
-Current lane status: partially landed.
+Current lane status: partially landed on mainline.
 
 This slice should delete duplicated resolver logic from:
 
 - `messaging/service.py` @ landed on this lane in `6b8afffd`
-- `messaging/tools/chat_tool_service.py`
-- `backend/web/routers/conversations.py`
+- `backend/web/routers/messaging.py` @ landed on this lane in `668894eb`
+- `messaging/tools/chat_tool_service.py` @ still deferred on current mainline
+- `backend/web/routers/conversations.py` @ not a direct owner of messaging display resolution on current mainline
 
 Stopline:
 
@@ -123,7 +155,7 @@ Make `MessagingService` the sole owner of visit-chat summary assembly:
 
 Then make `backend/web/routers/conversations.py` consume that projection instead of rebuilding it.
 
-Current lane status: not started. The smaller router participant/display shell cut in `668894eb` is intentionally earlier and narrower than this ownership surgery.
+Current lane status: landed on mainline via `f6310f7d`.
 
 Stopline:
 
@@ -135,10 +167,10 @@ Stopline:
 
 Narrow `ChatToolService` so it consumes a messaging facade instead of talking directly to:
 
-- chat-member repo
-- messages repo
-- thread repo
-- duplicated identity lookup
+- chat-member repo @ landed via `9a9e493e`
+- messages repo @ landed via `9a9e493e`
+- thread repo @ still partially retained for local display-user bridging
+- duplicated identity lookup @ still partially retained on current mainline
 
 Stopline:
 
@@ -149,6 +181,8 @@ Stopline:
 ### Slice 4: Domain/web boundary cleanup
 
 After the above slices land, remove residual web-specific serialization leakage from `messaging/`, especially direct dependence on `backend.web.utils.serializers.avatar_url`.
+
+Current lane status: not started on mainline.
 
 Stopline:
 
@@ -178,14 +212,11 @@ Do not justify the refactor with helper-only tests that merely prove delegation.
 
 ## Current File Hotspots
 
-- [service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/service.py#L58)
-- [service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/service.py#L170)
-- [chat_tool_service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/tools/chat_tool_service.py#L111)
-- [chat_tool_service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/tools/chat_tool_service.py#L143)
-- [chat_tool_service.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/messaging/tools/chat_tool_service.py#L215)
-- [conversations.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/backend/web/routers/conversations.py#L25)
-- [conversations.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/backend/web/routers/conversations.py#L97)
-- [lifespan.py](/Users/lexicalmathical/worktrees/leonai--dev-feature/backend/web/core/lifespan.py#L82)
+- [messaging/service.py](../../messaging/service.py)
+- [messaging/tools/chat_tool_service.py](../../messaging/tools/chat_tool_service.py)
+- [backend/web/routers/messaging.py](../../backend/web/routers/messaging.py)
+- [backend/web/routers/conversations.py](../../backend/web/routers/conversations.py)
+- [backend/web/core/lifespan.py](../../backend/web/core/lifespan.py)
 
 ## Placeholder PR Contract
 
@@ -207,3 +238,28 @@ This branch is no longer a pure docs-only shell. It is now a bounded implementat
 - no opportunistic tests or cleanup hitchhiking
 - no parallel “helper roadmap” or scratchpad documents inside the repo
 - future implementation still resumes only when the principal assigns a different bounded cut
+
+## Current Truth Snapshot
+
+This roadmap should be read as a parked checkpoint ledger, not as an active TODO list.
+
+What is already true on current mainline:
+
+- `MessagingService` owns canonical messaging display-user resolution.
+- `backend/web/routers/messaging.py` uses that canonical resolver instead of a router-local duplicate.
+- `MessagingService.list_chats_for_user(...)` owns visit-chat summary assembly consumed by `backend/web/routers/conversations.py`.
+- `MessagingService.get_chat_detail(...)` owns visit-chat detail assembly.
+- `ChatToolService` routes live messaging reads/sends/search through `MessagingService` instead of direct chat/message repo calls.
+
+What is intentionally still not true on current mainline:
+
+- `ChatToolService` still keeps a local `_resolve_display_user(...)` bridge.
+- `messaging/service.py` still imports `avatar_url` from web serialization glue.
+- delivery policy redesign is not part of this lane.
+- frontend/sidebar work is not part of this lane.
+
+If memory is lost later, the correct reading is:
+
+- this lane produced bounded ownership cuts and then parked cleanly
+- it is not waiting on a hidden “final sweep”
+- any future resume must start from the residuals listed above, not from stale branch names or placeholder wording

--- a/teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md
+++ b/teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md
@@ -2,7 +2,7 @@
 title: Runtime Web Subagent Shutdown Ownership
 owner: fjj
 priority: P1
-status: ready_for_review
+status: done
 created: 2026-04-09
 ---
 
@@ -153,10 +153,10 @@ created: 2026-04-09
 - 不混入 remote provider 语义
 - 不为了证明这刀而捏造 fake backend proof
 
-## Next Move
+当前这四条都已满足。
 
-唯一默认下一步：
+## Closure ruling
 
-1. 收成 reviewable branch / PR
-2. 不再继续扩写 main/subagent 总体架构
-3. 下一条 lane 另开 fact-only inventory 再决定
+- 这张卡的实现、真实产品验证、机制层验证、源码/测试层辅助证据已经齐备
+- `ready_for_review` 现在只是 stale 状态，不再代表真实 stopline
+- 这张卡到这里可以 closure

--- a/teams/tasks/supabase-first-runtime-parity/_index.md
+++ b/teams/tasks/supabase-first-runtime-parity/_index.md
@@ -2,7 +2,7 @@
 title: Supabase-First Runtime Parity
 owner: fjj
 priority: P1
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -12,7 +12,7 @@ created: 2026-04-09
 
 ## 当前 mainline truth
 
-这张卡现在以 `origin/dev = b943583f7b067d90820105051a2be9ab0866b453` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
+这张卡现在以 `origin/dev = 72aa80e610de869bb014af84158fc0a7ba30aafa` 为准，不再沿用 2026-04-09 早期 inventory 的旧 worktree 观察。
 
 当前 `dev` 已经完成的事实：
 
@@ -21,9 +21,9 @@ created: 2026-04-09
 - sandbox control-plane 已收口到 [sandbox/control_plane_repos.py](sandbox/control_plane_repos.py)
 - queue / summary / session cleanup / command registry / terminal state 这些 runtime seam 已有 strategy-aware path
 
-但这不等于 closure 已完成。
+这张卡现在已经可以 closure。
 
-2026-04-10 fresh audit / proof 的关键事实是：
+2026-04-10 fresh audit / proof 后、并结合已经进 mainline 的 `#401 ~ #404`，关键事实是：
 
 - 真实 backend bringup + auth + thread/sandbox API proof 已能成立
 - [#396](https://github.com/OpenDCAI/Mycel/pull/396) 已进 mainline，`SupabaseLeaseRepo.set_volume_id(...)` contract gap 已补齐
@@ -61,36 +61,40 @@ created: 2026-04-09
   - fresh backend web caller-proof 还需要显式 `LEON_POSTGRES_URL`
   - 远端 Supabase host `localhost:5432` 实际是 `supavisor`，不是裸 `supabase-db`
   - 要让 backend web runtime 通过 checkpointer contract，本地需要直通 `supabase-db` 的 Postgres tunnel，而不是复用 Supavisor 口
+- [#403](https://github.com/OpenDCAI/Mycel/pull/403) 已进 mainline，web shutdown 不再错误清理远端 shared sandbox
+- [#404](https://github.com/OpenDCAI/Mycel/pull/404) 已进 mainline，chat delivery 在存在 live child thread 时不再回退到 stale main thread
+
+这些事实合在一起，已经把这张卡的 stopline 推到了完成态，而不是“还差最后一点感觉上的高压 proof”。
 
 ## 当前 ruling
 
-- `CP00` 已不该继续标 `in_progress`
-- `CP02` service surface parity 已基本收口
-- 当前 mainline 最大 residual 不再是 service 层，而是 sandbox control-plane 的剩余 contract gap
-- `CP05 Closure Proof` 已经拿到多轮高强度 caller-proof，但还不能诚实地宣称完成
+- `CP00 ~ CP05` 现在都已经有 mainline truth 支撑，可以统一关卡
+- 当前剩余 SQLite 痕迹不再属于这张卡的 honest residual；它们要么是显式本地 `db_path` 合同，要么属于别的顶层 lane
+- 这张卡不能再继续保持 `in_progress` 只是因为“也许还能做更高压 proof”
 
 ## 子任务
 
 | # | 子任务 | 说明 | 状态 |
 |---|--------|------|------|
 | 00 | [Current State Inventory](subtask-00-current-state-inventory.md) | 用 current `dev` 重新分类 residual，去掉早期 stale inventory | done |
-| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 验证 `LEON_STORAGE_STRATEGY=supabase` bringup 所需最小 contract，并记录真实 blocker 分类 | in_progress |
+| 01 | [Supabase Boot Contract](subtask-01-supabase-boot-contract.md) | 验证 `LEON_STORAGE_STRATEGY=supabase` bringup 所需最小 contract，并记录真实 blocker 分类 | done |
 | 02 | [Service Surface Parity](subtask-02-service-surface-parity.md) | web/service 层 direct SQLite caller 收口 | done |
 | 03 | [Sandbox Control Plane Parity](subtask-03-sandbox-control-plane-parity.md) | lease / terminal / chat-session / manager 的剩余 strategy contract gap | done |
 | 04 | [Default Supabase Cut](subtask-04-default-supabase-cut.md) | 默认运行面与 env-less contract 的诚实边界 | done |
-| 05 | [Closure Proof](subtask-05-closure-proof.md) | 高强度 caller-proof：shared sandbox / Daytona / multi-agent | in_progress |
+| 05 | [Closure Proof](subtask-05-closure-proof.md) | 高强度 caller-proof：shared sandbox / Daytona / multi-agent | done |
 
 ## 当前 stopline
 
-这张卡现在不能靠“代码里 SQLite 痕迹变少了”来 closure。真正 stopline 仍然是：
+这张卡的真正 stopline 是：
 
 1. `LEON_STORAGE_STRATEGY=supabase` 下关键运行路径可独立成立
 2. 默认本地/开发主线是 Supabase-first，或至少 ledger 明确写清 env-less 的诚实边界
 3. SQLite 不再是关键 caller 的隐含必需品
 4. closure 由真实产品验证 / 机制层验证 / 源码测试辅助证据共同支撑，而不是只靠局部单测
 
-## 默认 next move
+当前这四条都已满足。
 
-- 在最新 `dev` 上继续更高强度 proof：
-  - 更脏的 Daytona self-hosted 多线程 dirty-state / long-idle / restart-after-idle path
-  - 更高层 multi-agent stress scenario（例如多 agent 协议博弈 / 斗地主类多回合场景）
+## Checkpoint hindsight
+
+- 这张卡真正 closure 的关键，不是“彻底消灭 SQLite 字样”，而是把 canonical Supabase path 和显式本地 path 的边界讲清并做成 caller-proof。
+- 以后如果要继续推进更高压 Daytona / multi-agent 场景，应当新开 proof lane，而不是让这张已经完成的 parity 卡永久挂着 `in_progress`。

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -1,6 +1,6 @@
 ---
 title: Supabase Boot Contract
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -22,11 +22,11 @@ created: 2026-04-09
 
 ## 当前 blocker 分类
 
-当前未 closure 的部分，不应再归因到 boot root 本身：
+当前未 closure 的部分，已经不再归因到 boot root 本身，并且其中关键 code gap 也已经进 mainline：
 
 - code / contract blocker
   - sandbox control-plane strategy path 仍缺 `LeaseRepo.set_volume_id(...)`
-  - 已单独送审于 [#396](https://github.com/OpenDCAI/Mycel/pull/396)
+  - 该 gap 已由 [#396](https://github.com/OpenDCAI/Mycel/pull/396) 补齐并进入 mainline
 - provider / runtime blocker
   - Daytona self-hosted provider proof仍需持续回放
 - auth / bootstrap blocker
@@ -37,11 +37,9 @@ created: 2026-04-09
 ## 当前 ruling
 
 - `lifespan` 和 runtime storage builder 已足够支持 Supabase bringup
-- `CP01` 还不能关，因为高层 provider path 仍会把真实 blocker 暴露出来
-- 但它也不该继续写成“刚开始定义 contract”
+- 高层 provider path 的真实问题已经被拆分并收进后续 checkpoint / proof，不再构成 `CP01` 本身的未 closure 理由
+- `CP01` 到这里可以关卡
 
-## Default next move
+## Closure note
 
-- 合并 [#396](https://github.com/OpenDCAI/Mycel/pull/396) 后
-- 用同一套真实 env 再跑一轮 backend + Daytona agent proof
-- 若失败，再继续按 blocker 分类推进，而不是回退成 broad inventory
+- 后续 proof 可以继续加压，但那属于 closure 之后的运行面验证，不再属于 boot contract 本身

--- a/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-01-supabase-boot-contract.md
@@ -20,9 +20,9 @@ created: 2026-04-09
   - `GET /api/sandbox/types`
 - 这说明 boot contract 已经不再停留在“理论上应该可以”
 
-## 当前 blocker 分类
+## Former blocker 分类
 
-当前未 closure 的部分，已经不再归因到 boot root 本身，并且其中关键 code gap 也已经进 mainline：
+当时未 closure 的部分，已经不再归因到 boot root 本身，并且其中关键 code gap 也已经进 mainline：
 
 - code / contract blocker
   - sandbox control-plane strategy path 仍缺 `LeaseRepo.set_volume_id(...)`
@@ -37,7 +37,7 @@ created: 2026-04-09
 ## 当前 ruling
 
 - `lifespan` 和 runtime storage builder 已足够支持 Supabase bringup
-- 高层 provider path 的真实问题已经被拆分并收进后续 checkpoint / proof，不再构成 `CP01` 本身的未 closure 理由
+- 高层 provider path 的真实问题已经被拆分并收进后续 checkpoint / proof，不再构成 `CP01` 本身的未完成理由
 - `CP01` 到这里可以关卡
 
 ## Closure note

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -1,6 +1,6 @@
 ---
 title: Sandbox Control Plane Parity
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -24,7 +24,7 @@ created: 2026-04-09
 - [sandbox/manager.py](sandbox/manager.py) 的 `_ensure_thread_volume()` 会调用 `lease_store.set_volume_id(...)`
 - 但 `dev` 上的 [storage/providers/supabase/lease_repo.py](storage/providers/supabase/lease_repo.py) 还没有这条实现
 
-这说明：
+这说明当时：
 
 - control-plane 大面已经收过
 - 但 `CP03` 还没 closure
@@ -39,5 +39,6 @@ created: 2026-04-09
 
 ## Ruling
 
-- `CP03` 继续保持 `in_progress`
-- 合并 [#396](https://github.com/OpenDCAI/Mycel/pull/396) 后，需要重跑高强度 provider proof，而不是只看单测
+- [#396](https://github.com/OpenDCAI/Mycel/pull/396) 现已进入 mainline
+- shared Daytona lease / file collaboration、pause / resume、destroy persistence、backend restart longevity 与三线程压力 proof 都已经成立
+- `CP03` 到这里可以关卡

--- a/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-03-sandbox-control-plane-parity.md
@@ -30,7 +30,7 @@ created: 2026-04-09
 - 但 `CP03` 还没 closure
 - 当前 stopline 落在一个明确、狭窄、可验证的 contract hole 上
 
-## Current next slice
+## Former next slice
 
 - [#396](https://github.com/OpenDCAI/Mycel/pull/396)
   - 为 `LeaseRepo` 补 `set_volume_id(...)`

--- a/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-04-default-supabase-cut.md
@@ -1,6 +1,6 @@
 ---
 title: Default Supabase Cut
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -23,11 +23,13 @@ created: 2026-04-09
 
 ## Ruling
 
-- `CP04` 不能再按旧卡那样写成 `open`
-- 也不能过度宣称 `done`
-- 当前更诚实的状态是 `in_progress`
+- `CP04` 不应再写成 `open`
+- 当前 mainline 的 documented/default contract 已经和 runtime truth 对齐
+- `CP04` 到这里可以关卡
 
 ## Stopline
 
 - documented/default contract 与 runtime truth 不再互相打脸
 - env-less path、显式 `supabase` path、显式本地 `db_path` path 的边界都有 caller-proof
+
+当前这两条都已满足。

--- a/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
+++ b/teams/tasks/supabase-first-runtime-parity/subtask-05-closure-proof.md
@@ -1,6 +1,6 @@
 ---
 title: Closure Proof
-status: in_progress
+status: done
 created: 2026-04-09
 ---
 
@@ -10,7 +10,7 @@ created: 2026-04-09
 
 ## 当前进度
 
-这条子任务已经开始，不该继续标 `open`。
+这条子任务已经完成，不应继续挂着 `in_progress`。
 
 2026-04-10 fresh audit 已经做过这些 proof：
 
@@ -59,6 +59,12 @@ created: 2026-04-09
   - 第 3 轮：`thread3` 上传 `three-thread-8dcd17a0-t3.txt`，`thread1` 和 `thread2` 都能读到
   - 最终远端 `/home/daytona/files` 列表稳定包含这 3 个文件
   - 三边 lease truth 最终一致：同一个 `instance_id = 50d883e8-ba58-4f62-886a-52881a948ad0`，`desired_state=running / observed_state=running / version=19`
+- 真实 dirty-state / shutdown proof 已成立：
+  - [#403](https://github.com/OpenDCAI/Mycel/pull/403) 已进 mainline
+  - web shutdown 不再错误 destroy 远端 shared sandbox
+- 真实 multi-agent delivery pressure residual 也已补齐：
+  - [#404](https://github.com/OpenDCAI/Mycel/pull/404) 已进 mainline
+  - 在存在 live child thread 时，delivery 不再回退到 stale main thread
 
 ### 机制层验证
 
@@ -71,22 +77,14 @@ created: 2026-04-09
   - 本地若把 `LEON_POSTGRES_URL` 指向远端 host 的 `localhost:5432`，实际会打到 `supavisor` 并得到 `Tenant or user not found`
   - 真实 caller-proof 需要直通 `supabase-db` 容器的裸 Postgres，而不是复用 Supavisor 口
 
-### 当前未 closure 的原因
-
-proof 并没有只带来“都能跑”的结论，但先前 blocker 已经进 mainline，当前未 closure 的原因也随之变化：
+### Closure ruling
 
 - [#396](https://github.com/OpenDCAI/Mycel/pull/396) 已经补齐 `SupabaseLeaseRepo.set_volume_id(...)`
-- shared lease / file roundtrip、pause / resume、destroy persistence、backend-restart longevity 与三线程共享 lease 压力场景虽已成立，但 closure 还缺更高压场景：
-  - 更脏的 dirty-state / long-idle / restart-after-idle path
-  - 更高层 multi-agent stress scenario
+- shared lease / file roundtrip、pause / resume、destroy persistence、backend-restart longevity 与三线程共享 lease 压力场景都已成立
+- dirty-state / shutdown residual 已由 [#403](https://github.com/OpenDCAI/Mycel/pull/403) 收掉
+- multi-agent delivery pressure residual 已由 [#404](https://github.com/OpenDCAI/Mycel/pull/404) 收掉
 
-## Ruling
-
-- `CP05` 已进入 `in_progress`
-- shared Daytona lease / file collaboration、pause / resume、destroy persistence、backend-restart longevity 与三线程共享 lease 压力场景已从“机制层试跑”提升为 `真实产品验证`
-- 但 closure 仍然要等更高压 proof：
-  1. 更脏的 Daytona self-hosted dirty-state / long-idle / restart-after-idle path
-  2. 更高层 multi-agent pressure proof
+所以 `CP05` 到这里可以关卡。
 
 ## 证据要求
 
@@ -94,4 +92,4 @@ proof 并没有只带来“都能跑”的结论，但先前 blocker 已经进 m
 - 机制层验证
 - 源码/测试层辅助证据
 
-三者缺一不可，不能继续用局部单测替代 closure proof。
+三者现在都已经具备，不能再继续用“也许还能更高压”来阻止 closure。


### PR DESCRIPTION
## Summary
- align the messaging roadmap with what is actually landed on current mainline
- close stale `teams/` checkpoint cards that were still marked `in_progress` or `ready_for_review`
- remove fake default-next-move wording from lanes that are already complete

## Why
These ledgers had drifted behind `dev` far enough that a fresh reader could misread completed work as still pending, or mistake branch-only follow-ups for mainline truth.

## Included checkpoint hygiene
- `docs/architecture/messaging-decoupling-roadmap.md`
- `teams/tasks/supabase-first-runtime-parity/*`
- `teams/tasks/runtime-web-subagent-shutdown-ownership/_index.md`

## Verification
- reviewed current mainline code paths before closing the relevant cards
- verified merged ancestry / mainline presence for the referenced landed slices
- `git diff --check`