### PR TITLE
fix: chunk monitor supabase bulk reads

### DIFF
--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -64,17 +64,21 @@ def list_snapshots_by_lease_ids(
         return {}
     from storage.providers.supabase import _query as q
 
-    rows = q.rows(
-        q.in_(
-            client.table("lease_resource_snapshots").select("*"),
-            "lease_id",
-            unique_ids,
-            "resource_snapshot",
-            "list_by_ids",
-        ).execute(),
-        "resource_snapshot",
-        "list_by_ids",
-    )
+    rows: list[dict[str, Any]] = []
+    for chunk in q.value_chunks(unique_ids):
+        rows.extend(
+            q.rows(
+                q.in_(
+                    client.table("lease_resource_snapshots").select("*"),
+                    "lease_id",
+                    chunk,
+                    "resource_snapshot",
+                    "list_by_ids",
+                ).execute(),
+                "resource_snapshot",
+                "list_by_ids",
+            )
+        )
     return {str(r["lease_id"]): dict(r) for r in rows}
 
 

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -298,17 +298,21 @@ class SupabaseSandboxMonitorRepo:
             return {}
 
         instance_map: dict[str, str | None] = {lease_id: None for lease_id in ordered_ids}
-        instances = q.rows(
-            q.in_(
-                self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
-                "lease_id",
-                ordered_ids,
-                _REPO,
-                "query_lease_instance_ids instances",
-            ).execute(),
-            _REPO,
-            "query_lease_instance_ids instances",
-        )
+        instances = []
+        for chunk in q.value_chunks(ordered_ids):
+            instances.extend(
+                q.rows(
+                    q.in_(
+                        self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
+                        "lease_id",
+                        chunk,
+                        _REPO,
+                        "query_lease_instance_ids instances",
+                    ).execute(),
+                    _REPO,
+                    "query_lease_instance_ids instances",
+                )
+            )
         for row in instances:
             lease_id = str(row.get("lease_id") or "").strip()
             provider_session_id = str(row.get("provider_session_id") or "").strip()
@@ -319,17 +323,21 @@ class SupabaseSandboxMonitorRepo:
         if not missing_ids:
             return instance_map
 
-        leases = q.rows(
-            q.in_(
-                self._client.table("sandbox_leases").select("lease_id,current_instance_id"),
-                "lease_id",
-                missing_ids,
-                _REPO,
-                "query_lease_instance_ids leases",
-            ).execute(),
-            _REPO,
-            "query_lease_instance_ids leases",
-        )
+        leases = []
+        for chunk in q.value_chunks(missing_ids):
+            leases.extend(
+                q.rows(
+                    q.in_(
+                        self._client.table("sandbox_leases").select("lease_id,current_instance_id"),
+                        "lease_id",
+                        chunk,
+                        _REPO,
+                        "query_lease_instance_ids leases",
+                    ).execute(),
+                    _REPO,
+                    "query_lease_instance_ids leases",
+                )
+            )
         for row in leases:
             lease_id = str(row.get("lease_id") or "").strip()
             current_instance_id = str(row.get("current_instance_id") or "").strip()
@@ -341,17 +349,21 @@ class SupabaseSandboxMonitorRepo:
         ordered_ids = sorted({str(lease_id or "").strip() for lease_id in lease_ids if str(lease_id or "").strip()})
         if not ordered_ids:
             return {}
-        rows = q.rows(
-            q.in_(
-                self._client.table("sandbox_leases").select(select),
-                "lease_id",
-                ordered_ids,
-                _REPO,
-                operation,
-            ).execute(),
-            _REPO,
-            operation,
-        )
+        rows: list[dict[str, Any]] = []
+        for chunk in q.value_chunks(ordered_ids):
+            rows.extend(
+                q.rows(
+                    q.in_(
+                        self._client.table("sandbox_leases").select(select),
+                        "lease_id",
+                        chunk,
+                        _REPO,
+                        operation,
+                    ).execute(),
+                    _REPO,
+                    operation,
+                )
+            )
         return {row["lease_id"]: row for row in rows}
 
     def _session_with_lease(self, session: dict, lease: dict | None, *, include_thread: bool = False) -> dict:

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -111,6 +111,27 @@ def test_query_threads_accepts_optional_thread_filter() -> None:
     ]
 
 
+def test_query_threads_chunks_lease_lookup() -> None:
+    sessions = [
+        _session(f"sess-{index}", f"thread-{index}", f"lease-{index}", last_active_at=f"2026-04-05T10:{index % 60:02d}:00")
+        for index in range(175)
+    ]
+    leases = [_lease(f"lease-{index}", current_instance_id=f"instance-{index}") for index in range(175)]
+    repo = SupabaseSandboxMonitorRepo(
+        _MaxInFilterClient(
+            {
+                "chat_sessions": sessions,
+                "sandbox_leases": leases,
+            }
+        )
+    )
+
+    rows = repo.query_threads()
+
+    assert len(rows) == 175
+    assert next(row for row in rows if row["thread_id"] == "thread-174")["current_instance_id"] == "instance-174"
+
+
 def test_query_leases_uses_latest_terminal_binding() -> None:
     repo = _repo(
         {
@@ -203,6 +224,23 @@ def test_query_lease_instance_id_prefers_provider_session_id() -> None:
     )
 
     assert repo.query_lease_instance_id("lease-1") == "provider-session-1"
+
+
+def test_query_lease_instance_ids_chunks_large_lookup() -> None:
+    lease_ids = [f"lease-{index}" for index in range(175)]
+    repo = SupabaseSandboxMonitorRepo(
+        _MaxInFilterClient(
+            {
+                "sandbox_leases": [{"lease_id": lease_id, "current_instance_id": f"fallback-{lease_id}"} for lease_id in lease_ids],
+                "sandbox_instances": [{"lease_id": "lease-174", "provider_session_id": "provider-session-174"}],
+            }
+        )
+    )
+
+    result = repo.query_lease_instance_ids(lease_ids)
+
+    assert result["lease-0"] == "fallback-lease-0"
+    assert result["lease-174"] == "provider-session-174"
 
 
 def test_list_probe_targets_prefers_provider_session_id() -> None:

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -5,6 +5,7 @@ class _FakeTable:
     def __init__(self) -> None:
         self.upsert_payload = None
         self.in_calls: list[tuple[str, list[str]]] = []
+        self.max_in_values: int | None = None
         self.rows = [{"lease_id": "lease-1", "cpu_used": 1.0}]
 
     def upsert(self, payload):
@@ -15,6 +16,8 @@ class _FakeTable:
         return self
 
     def in_(self, key, values):
+        if self.max_in_values is not None:
+            assert len(values) <= self.max_in_values
         self.in_calls.append((key, list(values)))
         return self
 
@@ -54,3 +57,14 @@ def test_supabase_resource_snapshot_repo_lists_snapshots_by_lease_ids() -> None:
 
     assert rows == {"lease-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
     assert ("lease_id", ["lease-1", "lease-2"]) in client.table_obj.in_calls
+
+
+def test_supabase_resource_snapshot_repo_chunks_large_snapshot_lookup() -> None:
+    client = _FakeClient()
+    client.table_obj.max_in_values = 80
+    repo = SupabaseResourceSnapshotRepo(client)
+
+    rows = repo.list_snapshots_by_lease_ids([f"lease-{index}" for index in range(175)])
+
+    assert rows == {"lease-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
+    assert [len(values) for _, values in client.table_obj.in_calls] == [80, 80, 15]


### PR DESCRIPTION
## Summary
- chunk Monitor Supabase lease/instance/snapshot `.in_()` lookups through the shared PostgREST chunk helper
- add focused regression coverage for 175-id monitor/resource reads
- preserve fail-loud behavior; this does not hide Supabase errors or add UI fallbacks

## Verification
- `uv run pytest -q tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_monitor_resources_route.py` -> 49 passed
- `uv run ruff check storage/providers/supabase/resource_snapshot_repo.py storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Integration/test_monitor_resources_route.py` -> passed
- `git diff --check` -> passed
- Real backend on 127.0.0.1:8010: login 200; `/api/monitor/leases` 200 count=178; `/api/monitor/threads` 200; `/api/monitor/resources/refresh` 200 refresh_status=ok; `/api/monitor/resources` 200; `/api/monitor/dashboard` 200

## Root Cause
The earlier Monitor 500 was a live-data PostgREST bulk-read issue, not an upstream model API issue. Large data-driven `.in_()` filters against staging caused Supabase/PostgREST to return an HTML nginx 502 payload, which the client surfaced as `JSON could not be generated`.
