### PR TITLE
refactor: centralize supabase chunked reads

### DIFF
--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 IN_FILTER_CHUNK_SIZE = 80
@@ -52,6 +53,20 @@ def in_(query: Any, column: str, values: list[str], repo: str, operation: str) -
 
 def value_chunks(values: list[str]) -> list[list[str]]:
     return [values[i : i + IN_FILTER_CHUNK_SIZE] for i in range(0, len(values), IN_FILTER_CHUNK_SIZE)]
+
+
+def rows_in_chunks(
+    query_factory: Callable[[], Any],
+    column: str,
+    values: list[str],
+    repo: str,
+    operation: str,
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for chunk in value_chunks(values):
+        response = in_(query_factory(), column, chunk, repo, operation).execute()
+        result.extend(rows(response, repo, operation))
+    return result
 
 
 def gt(query: Any, column: str, value: Any, repo: str, operation: str) -> Any:

--- a/storage/providers/supabase/chat_repo.py
+++ b/storage/providers/supabase/chat_repo.py
@@ -44,10 +44,7 @@ class SupabaseChatRepo:
     def list_by_ids(self, chat_ids: list[str]) -> list[ChatRow]:
         if not chat_ids:
             return []
-        rows: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(chat_ids):
-            response = q.in_(self._t().select("*"), "id", chunk, _REPO_CHAT, "list_by_ids").execute()
-            rows.extend(q.rows(response, _REPO_CHAT, "list_by_ids"))
+        rows = q.rows_in_chunks(lambda: self._t().select("*"), "id", chat_ids, _REPO_CHAT, "list_by_ids")
         by_id = {row["id"]: _row_to_chat(row) for row in rows}
         return [by_id[chat_id] for chat_id in chat_ids if chat_id in by_id]
 

--- a/storage/providers/supabase/chat_session_repo.py
+++ b/storage/providers/supabase/chat_session_repo.py
@@ -355,14 +355,10 @@ class SupabaseChatSessionRepo:
 
         if terminal_ids:
             # Find command_ids for these terminals
-            command_rows = q.rows(
-                q.in_(
-                    self._commands().select("command_id"),
-                    "terminal_id",
-                    terminal_ids,
-                    _REPO,
-                    "delete_by_thread command lookup",
-                ).execute(),
+            command_rows = q.rows_in_chunks(
+                lambda: self._commands().select("command_id"),
+                "terminal_id",
+                terminal_ids,
                 _REPO,
                 "delete_by_thread command lookup",
             )
@@ -398,19 +394,15 @@ class SupabaseChatSessionRepo:
         terminal_ids = [str(r["terminal_id"]) for r in terminal_rows]
         if not terminal_ids:
             return False
-        raw = q.rows(
-            q.limit(
-                q.in_(
-                    self._commands().select("command_id").eq("status", "running"),
-                    "terminal_id",
-                    terminal_ids,
-                    _REPO,
-                    "lease_has_running_command",
-                ),
+        raw = q.rows_in_chunks(
+            lambda: q.limit(
+                self._commands().select("command_id").eq("status", "running"),
                 1,
                 _REPO,
                 "lease_has_running_command",
-            ).execute(),
+            ),
+            "terminal_id",
+            terminal_ids,
             _REPO,
             "lease_has_running_command",
         )

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -39,17 +39,13 @@ class SupabaseChatMemberRepo:
     def list_members_for_chats(self, chat_ids: list[str]) -> list[dict[str, Any]]:
         if not chat_ids:
             return []
-        rows: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(chat_ids):
-            res = q.in_(
-                self._client.table("chat_members").select("chat_id,user_id,last_read_seq"),
-                "chat_id",
-                chunk,
-                "chat member repo",
-                "list_members_for_chats",
-            ).execute()
-            rows.extend(res.data or [])
-        return rows
+        return q.rows_in_chunks(
+            lambda: self._client.table("chat_members").select("chat_id,user_id,last_read_seq"),
+            "chat_id",
+            chat_ids,
+            "chat member repo",
+            "list_members_for_chats",
+        )
 
     def is_member(self, chat_id: str, user_id: str) -> bool:
         res = self._client.table("chat_members").select("user_id").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
@@ -145,19 +141,23 @@ class SupabaseMessagesRepo:
         if not chat_ids:
             return {}
         latest_by_chat: dict[str, dict[str, Any]] = {}
-        for chunk in q.value_chunks(chat_ids):
-            query = q.in_(
+        rows = q.rows_in_chunks(
+            lambda: q.order(
                 self._client.table("messages").select("*").is_("deleted_at", "null"),
-                "chat_id",
-                chunk,
-                "messages repo",
-                "list_latest_by_chat_ids",
-            )
-            rows = q.order(query, "seq", desc=True, repo="messages repo", operation="list_latest_by_chat_ids").execute().data or []
-            for row in rows:
-                chat_id = str(row.get("chat_id") or "")
-                if chat_id and chat_id not in latest_by_chat:
-                    latest_by_chat[chat_id] = row
+                "seq",
+                desc=True,
+                repo="messages repo",
+                operation="list_latest_by_chat_ids",
+            ),
+            "chat_id",
+            chat_ids,
+            "messages repo",
+            "list_latest_by_chat_ids",
+        )
+        for row in rows:
+            chat_id = str(row.get("chat_id") or "")
+            if chat_id and chat_id not in latest_by_chat:
+                latest_by_chat[chat_id] = row
         return latest_by_chat
 
     def list_unread(self, chat_id: str, user_id: str) -> list[dict[str, Any]]:
@@ -192,16 +192,18 @@ class SupabaseMessagesRepo:
             return {}
         counts = {chat_id: 0 for chat_id in last_read_by_chat}
         min_last_read_seq = min(last_read_by_chat.values())
-        for chunk in q.value_chunks(list(last_read_by_chat)):
+
+        def unread_query():
             query = self._client.table("messages").select("chat_id,seq").neq("sender_user_id", user_id).is_("deleted_at", "null")
-            query = q.in_(query, "chat_id", chunk, "messages repo", "count_unread_by_chat_ids")
             if min_last_read_seq > 0:
                 query = query.gt("seq", min_last_read_seq)
-            for row in query.execute().data or []:
-                chat_id = str(row.get("chat_id") or "")
-                if int(row.get("seq") or 0) <= last_read_by_chat.get(chat_id, 0):
-                    continue
-                counts[chat_id] += 1
+            return query
+
+        for row in q.rows_in_chunks(unread_query, "chat_id", list(last_read_by_chat), "messages repo", "count_unread_by_chat_ids"):
+            chat_id = str(row.get("chat_id") or "")
+            if int(row.get("seq") or 0) <= last_read_by_chat.get(chat_id, 0):
+                continue
+            counts[chat_id] += 1
         return counts
 
     def _last_read_seq(self, chat_id: str, user_id: str) -> int:
@@ -294,9 +296,7 @@ class SupabaseRelationshipRepo:
     def _relationship_id(self, user_low: str, user_high: str, kind: str = "hire_visit") -> str:
         return f"{kind}:{user_low}:{user_high}"
 
-    def _normalize(self, row: dict[str, Any] | None) -> dict[str, Any] | None:
-        if row is None:
-            return None
+    def _normalize(self, row: dict[str, Any]) -> dict[str, Any]:
         normalized = dict(row)
         normalized.setdefault("kind", "hire_visit")
         normalized.setdefault("id", self._relationship_id(normalized["user_low"], normalized["user_high"], normalized["kind"]))
@@ -313,7 +313,9 @@ class SupabaseRelationshipRepo:
             .limit(1)
             .execute()
         )
-        return self._normalize(res.data[0] if res.data else None)
+        if not res.data:
+            return None
+        return self._normalize(res.data[0])
 
     def get_by_id(self, relationship_id: str) -> dict[str, Any] | None:
         parts = relationship_id.split(":", 2)
@@ -329,7 +331,9 @@ class SupabaseRelationshipRepo:
             .limit(1)
             .execute()
         )
-        return self._normalize(res.data[0] if res.data else None)
+        if not res.data:
+            return None
+        return self._normalize(res.data[0])
 
     def upsert(self, user_a: str, user_b: str, **fields: Any) -> dict[str, Any]:
         user_low, user_high = self._ordered(user_a, user_b)
@@ -370,4 +374,4 @@ class SupabaseRelationshipRepo:
     def list_for_user(self, user_id: str) -> list[dict[str, Any]]:
         # Single query with OR filter
         res = self._client.table("relationships").select("*").or_(f"user_low.eq.{user_id},user_high.eq.{user_id}").execute()
-        return [row for raw in (res.data or []) if (row := self._normalize(raw)) is not None]
+        return [self._normalize(raw) for raw in (res.data or [])]

--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -64,21 +64,13 @@ def list_snapshots_by_lease_ids(
         return {}
     from storage.providers.supabase import _query as q
 
-    rows: list[dict[str, Any]] = []
-    for chunk in q.value_chunks(unique_ids):
-        rows.extend(
-            q.rows(
-                q.in_(
-                    client.table("lease_resource_snapshots").select("*"),
-                    "lease_id",
-                    chunk,
-                    "resource_snapshot",
-                    "list_by_ids",
-                ).execute(),
-                "resource_snapshot",
-                "list_by_ids",
-            )
-        )
+    rows = q.rows_in_chunks(
+        lambda: client.table("lease_resource_snapshots").select("*"),
+        "lease_id",
+        unique_ids,
+        "resource_snapshot",
+        "list_by_ids",
+    )
     return {str(r["lease_id"]): dict(r) for r in rows}
 
 

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -106,21 +106,13 @@ class SupabaseSandboxMonitorRepo:
             return []
 
         lease_ids = [le["lease_id"] for le in leases]
-        terminals: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(lease_ids):
-            terminals.extend(
-                q.rows(
-                    q.in_(
-                        self._client.table("abstract_terminals").select("lease_id,thread_id,created_at"),
-                        "lease_id",
-                        chunk,
-                        _REPO,
-                        "query_leases terminals",
-                    ).execute(),
-                    _REPO,
-                    "query_leases terminals",
-                )
-            )
+        terminals = q.rows_in_chunks(
+            lambda: self._client.table("abstract_terminals").select("lease_id,thread_id,created_at"),
+            "lease_id",
+            lease_ids,
+            _REPO,
+            "query_leases terminals",
+        )
         # Pick most recent terminal per lease
         term_map: dict[str, str] = {}
         for t in sorted(terminals, key=lambda x: x.get("created_at") or ""):
@@ -298,21 +290,13 @@ class SupabaseSandboxMonitorRepo:
             return {}
 
         instance_map: dict[str, str | None] = {lease_id: None for lease_id in ordered_ids}
-        instances = []
-        for chunk in q.value_chunks(ordered_ids):
-            instances.extend(
-                q.rows(
-                    q.in_(
-                        self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
-                        "lease_id",
-                        chunk,
-                        _REPO,
-                        "query_lease_instance_ids instances",
-                    ).execute(),
-                    _REPO,
-                    "query_lease_instance_ids instances",
-                )
-            )
+        instances = q.rows_in_chunks(
+            lambda: self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
+            "lease_id",
+            ordered_ids,
+            _REPO,
+            "query_lease_instance_ids instances",
+        )
         for row in instances:
             lease_id = str(row.get("lease_id") or "").strip()
             provider_session_id = str(row.get("provider_session_id") or "").strip()
@@ -323,21 +307,13 @@ class SupabaseSandboxMonitorRepo:
         if not missing_ids:
             return instance_map
 
-        leases = []
-        for chunk in q.value_chunks(missing_ids):
-            leases.extend(
-                q.rows(
-                    q.in_(
-                        self._client.table("sandbox_leases").select("lease_id,current_instance_id"),
-                        "lease_id",
-                        chunk,
-                        _REPO,
-                        "query_lease_instance_ids leases",
-                    ).execute(),
-                    _REPO,
-                    "query_lease_instance_ids leases",
-                )
-            )
+        leases = q.rows_in_chunks(
+            lambda: self._client.table("sandbox_leases").select("lease_id,current_instance_id"),
+            "lease_id",
+            missing_ids,
+            _REPO,
+            "query_lease_instance_ids leases",
+        )
         for row in leases:
             lease_id = str(row.get("lease_id") or "").strip()
             current_instance_id = str(row.get("current_instance_id") or "").strip()
@@ -349,21 +325,13 @@ class SupabaseSandboxMonitorRepo:
         ordered_ids = sorted({str(lease_id or "").strip() for lease_id in lease_ids if str(lease_id or "").strip()})
         if not ordered_ids:
             return {}
-        rows: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(ordered_ids):
-            rows.extend(
-                q.rows(
-                    q.in_(
-                        self._client.table("sandbox_leases").select(select),
-                        "lease_id",
-                        chunk,
-                        _REPO,
-                        operation,
-                    ).execute(),
-                    _REPO,
-                    operation,
-                )
-            )
+        rows = q.rows_in_chunks(
+            lambda: self._client.table("sandbox_leases").select(select),
+            "lease_id",
+            ordered_ids,
+            _REPO,
+            operation,
+        )
         return {row["lease_id"]: row for row in rows}
 
     def _session_with_lease(self, session: dict, lease: dict | None, *, include_thread: bool = False) -> dict:

--- a/storage/providers/supabase/terminal_repo.py
+++ b/storage/providers/supabase/terminal_repo.py
@@ -74,41 +74,26 @@ class SupabaseTerminalRepo:
         if not normalized_ids:
             return {}
 
-        pointer_rows: list[dict[str, Any]] = []
-        terminal_rows: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(normalized_ids):
-            pointer_rows.extend(
-                q.rows(
-                    q.in_(
-                        self._pointers().select("thread_id,active_terminal_id"),
-                        "thread_id",
-                        chunk,
-                        _REPO,
-                        "summarize_threads pointers",
-                    ).execute(),
-                    _REPO,
-                    "summarize_threads pointers",
-                )
-            )
-            terminal_rows.extend(
-                q.rows(
-                    q.in_(
-                        q.order(
-                            self._terminals().select("thread_id,terminal_id,created_at"),
-                            "created_at",
-                            desc=True,
-                            repo=_REPO,
-                            operation="summarize_threads terminals",
-                        ),
-                        "thread_id",
-                        chunk,
-                        _REPO,
-                        "summarize_threads terminals",
-                    ).execute(),
-                    _REPO,
-                    "summarize_threads terminals",
-                )
-            )
+        pointer_rows = q.rows_in_chunks(
+            lambda: self._pointers().select("thread_id,active_terminal_id"),
+            "thread_id",
+            normalized_ids,
+            _REPO,
+            "summarize_threads pointers",
+        )
+        terminal_rows = q.rows_in_chunks(
+            lambda: q.order(
+                self._terminals().select("thread_id,terminal_id,created_at"),
+                "created_at",
+                desc=True,
+                repo=_REPO,
+                operation="summarize_threads terminals",
+            ),
+            "thread_id",
+            normalized_ids,
+            _REPO,
+            "summarize_threads terminals",
+        )
 
         summary: dict[str, dict[str, str | None]] = {
             thread_id: {"active_terminal_id": None, "latest_terminal_id": None} for thread_id in normalized_ids

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -95,10 +95,7 @@ class SupabaseThreadRepo:
         if not ordered_ids:
             return []
         select = ", ".join(_COLS)
-        rows: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(ordered_ids):
-            response = q.in_(self._t().select(select), "id", chunk, _REPO, "list_by_ids").execute()
-            rows.extend(q.rows(response, _REPO, "list_by_ids"))
+        rows = q.rows_in_chunks(lambda: self._t().select(select), "id", ordered_ids, _REPO, "list_by_ids")
         normalized_rows = [_to_dict(row) for row in rows]
         indexed = {row["id"]: row for row in normalized_rows}
         return [indexed[thread_id] for thread_id in ordered_ids if thread_id in indexed]
@@ -160,20 +157,25 @@ class SupabaseThreadRepo:
 
         # Step 2: get threads for those agent users
         thread_cols = ", ".join(_COLS)
-        query = q.order(
-            q.order(
-                q.in_(self._t().select(thread_cols), "agent_user_id", agent_user_ids, _REPO, "list_by_owner_user_id"),
-                "is_main",
-                desc=True,
+        thread_rows = q.rows_in_chunks(
+            lambda: q.order(
+                q.order(
+                    self._t().select(thread_cols),
+                    "is_main",
+                    desc=True,
+                    repo=_REPO,
+                    operation="list_by_owner_user_id",
+                ),
+                "created_at",
+                desc=False,
                 repo=_REPO,
                 operation="list_by_owner_user_id",
             ),
-            "created_at",
-            desc=False,
-            repo=_REPO,
-            operation="list_by_owner_user_id",
+            "agent_user_id",
+            agent_user_ids,
+            _REPO,
+            "list_by_owner_user_id:threads",
         )
-        thread_rows = q.rows(query.execute(), _REPO, "list_by_owner_user_id:threads")
 
         # Step 3: enrich with agent display data from user_map
         result: list[dict[str, Any]] = []

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -60,10 +60,7 @@ class SupabaseUserRepo:
     def list_by_ids(self, user_ids: list[str]) -> list[UserRow]:
         if not user_ids:
             return []
-        rows: list[dict[str, Any]] = []
-        for chunk in q.value_chunks(user_ids):
-            response = q.in_(self._t().select(", ".join(_COLS)), "id", chunk, _USER_REPO, "list_by_ids").execute()
-            rows.extend(q.rows(response, _USER_REPO, "list_by_ids"))
+        rows = q.rows_in_chunks(lambda: self._t().select(", ".join(_COLS)), "id", user_ids, _USER_REPO, "list_by_ids")
         users_by_id = {row["id"]: UserRow.model_validate(row) for row in rows}
         return [users_by_id[user_id] for user_id in user_ids if user_id in users_by_id]
 

--- a/tests/Unit/storage/test_supabase_query_helpers.py
+++ b/tests/Unit/storage/test_supabase_query_helpers.py
@@ -1,0 +1,51 @@
+import pytest
+
+from storage.providers.supabase import _query as q
+
+
+class _Response:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = rows
+        self.in_calls: list[tuple[str, list[str]]] = []
+
+    def in_(self, column: str, values: list[str]):
+        if len(values) > q.IN_FILTER_CHUNK_SIZE:
+            raise AssertionError("query was not chunked")
+        self.in_calls.append((column, list(values)))
+        return self
+
+    def execute(self):
+        column, values = self.in_calls[-1]
+        return _Response([row for row in self._rows if row.get(column) in values])
+
+
+def test_rows_in_chunks_splits_large_in_filters() -> None:
+    rows = [{"id": f"item-{index}", "value": index} for index in range(175)]
+    queries: list[_Query] = []
+
+    def make_query() -> _Query:
+        query = _Query(rows)
+        queries.append(query)
+        return query
+
+    result = q.rows_in_chunks(make_query, "id", [f"item-{index}" for index in range(175)], "test repo", "list")
+
+    assert len(result) == 175
+    assert [len(query.in_calls[0][1]) for query in queries] == [80, 80, 15]
+
+
+def test_rows_in_chunks_raises_for_invalid_payload() -> None:
+    class BadQuery:
+        def in_(self, _column: str, _values: list[str]):
+            return self
+
+        def execute(self):
+            return _Response({"not": "a list"})
+
+    with pytest.raises(RuntimeError, match="expected list payload"):
+        q.rows_in_chunks(BadQuery, "id", ["item-1"], "test repo", "bad")


### PR DESCRIPTION
## Summary
- add `q.rows_in_chunks(...)` for variable-size Supabase/PostgREST `.in_()` row reads
- replace repeated hand-written chunk loops across Supabase chat/user/thread/terminal/messaging/monitor/resource repos
- tighten relationship row normalization so missing-row handling stays at the caller boundary

## Verification
- RED: `tests/Unit/storage/test_supabase_query_helpers.py` initially failed because `q.rows_in_chunks` did not exist
- `uv run pytest -q tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/storage/test_supabase_query_helpers.py tests/Unit/storage tests/Unit/monitor tests/Integration/test_monitor_resources_route.py tests/Integration/test_conversations_router.py tests/Integration/test_threads_router.py tests/Integration/test_messaging_social_handle_contract.py` -> 213 passed
- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- targeted `uv run pyright --pythonversion 3.12 ...changed Supabase files...` -> 0 errors
- CI-shaped `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q` -> 1101 passed, 8 skipped
- Real backend on 127.0.0.1:8010 after restart: login 200; `/api/conversations` 200; `/api/threads` 200; `/api/monitor/leases` 200 count=178; `/api/monitor/threads` 200; `/api/monitor/resources/refresh` 200 refresh_status=ok; `/api/monitor/resources` 200; `/api/monitor/dashboard` 200

## Notes
- This intentionally covers row-read paths only. Fixed enum filters and destructive write/delete chunking are not mixed into this slice.
