### PR TITLE
refactor: chunk supabase execute paths

### DIFF
--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -69,6 +69,17 @@ def rows_in_chunks(
     return result
 
 
+def execute_in_chunks(
+    query_factory: Callable[[], Any],
+    column: str,
+    values: list[str],
+    repo: str,
+    operation: str,
+) -> None:
+    for chunk in value_chunks(values):
+        in_(query_factory(), column, chunk, repo, operation).execute()
+
+
 def gt(query: Any, column: str, value: Any, repo: str, operation: str) -> Any:
     if not hasattr(query, "gt"):
         raise RuntimeError(f"Supabase {repo} expects query.gt() for {operation}. Use supabase-py.")

--- a/storage/providers/supabase/chat_session_repo.py
+++ b/storage/providers/supabase/chat_session_repo.py
@@ -365,9 +365,9 @@ class SupabaseChatSessionRepo:
             command_ids = [str(r["command_id"]) for r in command_rows]
 
             if command_ids:
-                q.in_(self._chunks().delete(), "command_id", command_ids, _REPO, "delete_by_thread chunks").execute()
+                q.execute_in_chunks(lambda: self._chunks().delete(), "command_id", command_ids, _REPO, "delete_by_thread chunks")
 
-            q.in_(self._commands().delete(), "terminal_id", terminal_ids, _REPO, "delete_by_thread commands").execute()
+            q.execute_in_chunks(lambda: self._commands().delete(), "terminal_id", terminal_ids, _REPO, "delete_by_thread commands")
 
         self._sessions().delete().eq("thread_id", thread_id).execute()
 

--- a/storage/providers/supabase/checkpoint_repo.py
+++ b/storage/providers/supabase/checkpoint_repo.py
@@ -32,11 +32,10 @@ class SupabaseCheckpointRepo:
         if not checkpoint_ids:
             return
         for table in _TABLES:
-            # @@@supabase-in-clause - keep values in explicit list for PostgREST in_.
-            q.in_(
-                self._client.table(table).delete().eq("thread_id", thread_id),
+            q.execute_in_chunks(
+                lambda table=table: self._client.table(table).delete().eq("thread_id", thread_id),
                 "checkpoint_id",
                 checkpoint_ids,
                 _REPO,
                 "delete_checkpoints_by_ids",
-            ).execute()
+            )

--- a/storage/providers/supabase/run_event_repo.py
+++ b/storage/providers/supabase/run_event_repo.py
@@ -191,12 +191,14 @@ class SupabaseRunEventRepo:
     def delete_runs(self, thread_id: str, run_ids: list[str]) -> int:
         if not run_ids:
             return 0
-        pre = q.rows(
-            q.in_(self._t().select("seq").eq("thread_id", thread_id), "run_id", run_ids, _REPO, "delete_runs").execute(),
+        pre = q.rows_in_chunks(
+            lambda: self._t().select("seq").eq("thread_id", thread_id),
+            "run_id",
+            run_ids,
             _REPO,
             "delete_runs pre-count",
         )
-        q.in_(self._t().delete().eq("thread_id", thread_id), "run_id", run_ids, _REPO, "delete_runs").execute()
+        q.execute_in_chunks(lambda: self._t().delete().eq("thread_id", thread_id), "run_id", run_ids, _REPO, "delete_runs")
         return len(pre)
 
     def delete_thread_events(self, thread_id: str) -> int:

--- a/storage/providers/supabase/terminal_repo.py
+++ b/storage/providers/supabase/terminal_repo.py
@@ -297,17 +297,20 @@ class SupabaseTerminalRepo:
                 ).eq("thread_id", thread_id).execute()
 
         # Delete associated command chunks and commands (best-effort via chat_session_repo pattern)
-        self._client.table("terminal_command_chunks").delete().in_(
+        command_ids = [
+            r["command_id"]
+            for r in q.rows(
+                self._client.table("terminal_commands").select("command_id").eq("terminal_id", terminal_id).execute(),
+                _REPO,
+                "delete chunks pre-select",
+            )
+        ]
+        q.execute_in_chunks(
+            lambda: self._client.table("terminal_command_chunks").delete(),
             "command_id",
-            # subquery via RPC is not available in supabase-py directly; use a select first
-            [
-                r["command_id"]
-                for r in q.rows(
-                    self._client.table("terminal_commands").select("command_id").eq("terminal_id", terminal_id).execute(),
-                    _REPO,
-                    "delete chunks pre-select",
-                )
-            ],
-        ).execute()
+            command_ids,
+            _REPO,
+            "delete chunks",
+        )
         self._client.table("terminal_commands").delete().eq("terminal_id", terminal_id).execute()
         self._terminals().delete().eq("terminal_id", terminal_id).execute()

--- a/tests/Unit/storage/test_supabase_query_helpers.py
+++ b/tests/Unit/storage/test_supabase_query_helpers.py
@@ -49,3 +49,16 @@ def test_rows_in_chunks_raises_for_invalid_payload() -> None:
 
     with pytest.raises(RuntimeError, match="expected list payload"):
         q.rows_in_chunks(BadQuery, "id", ["item-1"], "test repo", "bad")
+
+
+def test_execute_in_chunks_splits_large_in_filters() -> None:
+    queries: list[_Query] = []
+
+    def make_query() -> _Query:
+        query = _Query([])
+        queries.append(query)
+        return query
+
+    q.execute_in_chunks(make_query, "id", [f"item-{index}" for index in range(175)], "test repo", "delete")
+
+    assert [len(query.in_calls[0][1]) for query in queries] == [80, 80, 15]


### PR DESCRIPTION
## Summary
- add `q.execute_in_chunks(...)` for variable-size Supabase/PostgREST `.in_()` execute paths
- replace raw large-list delete/execute calls in checkpoint, run-event, terminal, and chat-session Supabase repos
- leave fixed enum status filters untouched

## Verification
- RED: `test_execute_in_chunks_splits_large_in_filters` initially failed because `q.execute_in_chunks` did not exist
- `uv run pytest -q tests/Unit/storage/test_supabase_query_helpers.py tests/Unit/storage/test_supabase_terminal_repo.py tests/Unit/storage tests/Unit/monitor tests/Integration/test_monitor_resources_route.py tests/Integration/test_conversations_router.py tests/Integration/test_threads_router.py tests/Integration/test_messaging_social_handle_contract.py` -> 214 passed
- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- targeted `uv run pyright --pythonversion 3.12 ...changed Supabase execute-path files...` -> 0 errors
- Real backend smoke after restart: login 200; `/api/conversations` 200; `/api/threads` 200; `/api/monitor/leases` 200 count=178; `/api/monitor/resources` 200; `/api/monitor/dashboard` 200
- CI-shaped `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q` -> 1102 passed, 8 skipped

## Notes
- This intentionally does not change product cleanup semantics. It only keeps variable-size PostgREST `.in_()` execute calls under the shared chunk limit.
