### PR TITLE
Fix default agent avatars and agent-user id naming

### DIFF
--- a/backend/web/routers/entities.py
+++ b/backend/web/routers/entities.py
@@ -57,11 +57,11 @@ users_router = APIRouter(prefix="/api/users", tags=["users"])
 
 
 @users_router.get("")
-async def list_members(
+async def list_users(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    """List all agent users for the member directory page."""
+    """List all agent users for the user directory page."""
     user_repo = app.state.user_repo
 
     all_users = user_repo.list_all()

--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -92,7 +92,7 @@ def _validate_chat_participant_ids(app: Any, participant_ids: list[str], request
         if thread_repo is not None and thread_repo.get_by_user_id(participant_id) is not None:
             validated.append(participant_id)
             continue
-        # @@@group-chat-actor-boundary - template member ids are display/config identities,
+        # @@@group-chat-actor-boundary - agent user ids are display/config identities,
         # not deliverable chat actors. Reject them loudly at ingress instead of guessing.
         if user_repo is not None:
             candidate = user_repo.get_by_id(participant_id)

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -589,7 +589,7 @@ def _create_owned_thread(
     # @@@non-atomic-create - these 3 steps (seq++, thread) are not atomic.
     # @@@user-owned-thread-seq - thread ids are now allocated from the unified
     # user identity root, so create-path sequencing must fail loudly through
-    # user_repo instead of silently reaching back into member_repo.
+    # user_repo instead of silently reaching back into a legacy member repo.
     seq = app.state.user_repo.increment_thread_seq(agent_user_id)
     new_thread_id = f"{agent_user_id}-{seq}"
     has_main = app.state.thread_repo.get_default_thread(agent_user_id) is not None
@@ -663,7 +663,7 @@ async def create_thread(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any] | JSONResponse:
-    """Create a new child thread for an agent member."""
+    """Create a new child thread for an agent user."""
     provider_error = _validate_sandbox_provider_gate(app, user_id, payload)
     if provider_error is not None:
         return provider_error
@@ -690,7 +690,7 @@ async def resolve_main_thread(
     agent_user_id = payload.agent_user_id
     agent_member = _find_owned_agent(app, agent_user_id, user_id)
     if agent_member is None:
-        # Return null instead of 403 — member may not exist yet (stale client state)
+        # Return null instead of 403 — agent user may not exist yet (stale client state)
         # or belong to another user (harmless to reveal "no thread")
         return {
             "agent_user_id": agent_user_id,
@@ -712,8 +712,8 @@ async def resolve_main_thread(
             "thread": _thread_payload(app, default_thread["id"], default_thread.get("sandbox_type", "local")),
         }
     except HTTPException as exc:
-        # @@@orphan-default-thread - stale bootstrap data can leave the member pointing at a thread whose
-        # member rows are gone. Treat that as "no resolvable default thread" instead of surfacing a 500.
+        # @@@orphan-default-thread - stale bootstrap data can leave the agent user pointing at a thread whose
+        # user rows are gone. Treat that as "no resolvable default thread" instead of surfacing a 500.
         if exc.status_code == 500 and "missing agent user" in str(exc.detail):
             logger.warning(
                 "resolve_main_thread ignored orphaned default thread %s for agent user %s",

--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -123,7 +123,7 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
                 settings_row = user_settings_repo.get(owner_user_id) or {}
                 model_name = settings_row.get("default_model")
 
-        # @@@agent-vs-member - thread_config.agent stores a member ID (e.g. "__leon__") for display,
+        # @@@agent-vs-agent-user - thread_config.agent stores an agent user id (e.g. "__leon__") for display,
         # NOT an agent type name ("bash", "general", etc.). Never pass it to create_leon_agent.
         agent_name = agent  # explicit caller-provided type only; None → default Leon agent
         bundle_dir = None

--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -235,11 +235,11 @@ def create_agent_user(
     agent_config_repo: Any = None,
 ) -> dict[str, Any]:
     from storage.contracts import UserRow, UserType
-    from storage.utils import generate_agent_config_id, generate_member_id
+    from storage.utils import generate_agent_config_id, generate_agent_user_id
 
     now = time.time()
     now_ms = int(now * 1000)
-    agent_user_id = generate_member_id()
+    agent_user_id = generate_agent_user_id()
     agent_config_id = generate_agent_config_id()
 
     # Persist to users table so panel/auth shells see a unified agent identity
@@ -580,7 +580,7 @@ def install_from_snapshot(
 ) -> str:
     """Create or update a marketplace-backed agent user via repos only."""
     from storage.contracts import UserRow, UserType
-    from storage.utils import generate_agent_config_id, generate_member_id
+    from storage.utils import generate_agent_config_id, generate_agent_user_id
 
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required to install marketplace user snapshot")
@@ -606,7 +606,7 @@ def install_from_snapshot(
         created_at = int(current_config.get("created_at", now_ms))
         user_repo.update(user_id, display_name=agent_name)
     else:
-        user_id = generate_member_id()
+        user_id = generate_agent_user_id()
         agent_config_id = generate_agent_config_id()
         created_at = now_ms
         row = UserRow(

--- a/backend/web/services/auth_service.py
+++ b/backend/web/services/auth_service.py
@@ -37,7 +37,7 @@ class AuthService:
     # Registration flow (standard Supabase signUp)
     # Step 1: send_otp(email, password) → signUp creates user, GoTrue sends OTP
     # Step 2: verify_register_otp(...)  → verifyOtp(type:signup), returns temp_token
-    # Step 3: complete_register(...)    → validate invite, create member records
+    # Step 3: complete_register(...)    → validate invite, create user + agent records
     # ------------------------------------------------------------------
 
     def send_otp(self, email: str, password: str, invite_code: str) -> None:
@@ -153,7 +153,7 @@ class AuthService:
         auth_user_id = str(resp.user.id)
         token = resp.session.access_token
 
-        # Load member info
+        # Load user info
         user = self._users.get_by_id(auth_user_id)
         if user is None:
             raise ValueError("账号数据异常，请联系支持")
@@ -235,7 +235,7 @@ class AuthService:
             raise RuntimeError("Agent config repo required for initial agent creation during schema cutover.")
         from pathlib import Path
 
-        from storage.utils import generate_agent_config_id, generate_member_id
+        from storage.utils import generate_agent_config_id, generate_agent_user_id
 
         initial_agents = [
             {"name": "Toad", "description": "Curious and energetic assistant", "avatar": "toad.jpeg"},
@@ -245,7 +245,7 @@ class AuthService:
         first_agent_info = None
 
         for i, agent_def in enumerate(initial_agents):
-            agent_id = generate_member_id()
+            agent_id = generate_agent_user_id()
             agent_config_id = generate_agent_config_id()
             self._users.create(
                 UserRow(
@@ -270,14 +270,13 @@ class AuthService:
                 },
             )
             src_avatar = assets_dir / agent_def["avatar"]
-            if src_avatar.exists():
-                try:
-                    from backend.web.routers.entities import process_and_save_avatar
+            if not src_avatar.exists():
+                raise RuntimeError(f"Default agent avatar missing: {src_avatar}")
+            from backend.web.routers.entities import process_and_save_avatar
 
-                    process_and_save_avatar(src_avatar, agent_id)
-                except Exception as e:
-                    logger.warning("Avatar copy failed for %s: %s", agent_def["name"], e)
+            avatar_path = process_and_save_avatar(src_avatar, agent_id)
+            self._users.update(agent_id, avatar=avatar_path)
             if i == 0:
-                first_agent_info = {"id": agent_id, "name": agent_def["name"], "type": "agent", "avatar": None}
+                first_agent_info = {"id": agent_id, "name": agent_def["name"], "type": "agent", "avatar": avatar_path}
 
         return first_agent_info

--- a/backend/web/services/resource_common.py
+++ b/backend/web/services/resource_common.py
@@ -217,7 +217,7 @@ def thread_owners(thread_ids: list[str], user_repo: Any = None, thread_repo: Any
         if own_thread_repo:
             repo.close()
 
-    member_meta: dict[str, dict[str, str | None]] = {}
+    agent_user_meta: dict[str, dict[str, str | None]] = {}
     if refs:
         repo = user_repo
         own_user_repo = False
@@ -225,7 +225,7 @@ def thread_owners(thread_ids: list[str], user_repo: Any = None, thread_repo: Any
             repo = build_user_repo()
             own_user_repo = True
         try:
-            member_meta = {
+            agent_user_meta = {
                 user.id: {
                     "agent_name": user.display_name,
                     "avatar_url": f"/api/users/{user.id}/avatar" if user.id and user.avatar else None,
@@ -243,8 +243,8 @@ def thread_owners(thread_ids: list[str], user_repo: Any = None, thread_repo: Any
         if not agent_ref:
             owners[thread_id] = {"agent_user_id": None, "agent_name": "未绑定Agent", "avatar_url": None}
             continue
-        # @@@agent-name-resolution - thread_config.agent may be member id or direct display name.
-        meta = member_meta.get(agent_ref, {})
+        # @@@agent-name-resolution - thread_config.agent may be agent user id or direct display name.
+        meta = agent_user_meta.get(agent_ref, {})
         owners[thread_id] = {
             "agent_user_id": agent_ref,
             "agent_name": meta.get("agent_name") or agent_ref,

--- a/backend/web/services/typing_tracker.py
+++ b/backend/web/services/typing_tracker.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class _ChatEntry:
     chat_id: str
-    user_id: str  # social identity: user_id for humans, member_id for agents
+    user_id: str  # social identity: user id for humans and agent users
 
 
 class TypingTracker:

--- a/core/agents/communication/delivery.py
+++ b/core/agents/communication/delivery.py
@@ -2,7 +2,7 @@
 
 v3: no full message text injected. Agent must read_messages to see content.
 MessagingService._deliver_to_agents calls the delivery function for each
-non-sender agent member.
+non-sender agent user.
 """
 
 from __future__ import annotations
@@ -93,13 +93,13 @@ def make_chat_delivery_fn(app: Any):
     return _deliver
 
 
-def _log_delivery_result(member_id: str, f: Any) -> None:
+def _log_delivery_result(recipient_id: str, f: Any) -> None:
     """Done-callback for async delivery futures."""
     exc = f.exception()
     if exc:
-        logger.error("[delivery] async delivery failed for %s: %s", member_id, exc, exc_info=exc)
+        logger.error("[delivery] async delivery failed for %s: %s", recipient_id, exc, exc_info=exc)
     else:
-        logger.info("[delivery] async delivery completed for %s", member_id)
+        logger.info("[delivery] async delivery completed for %s", recipient_id)
 
 
 async def _async_deliver(

--- a/storage/utils.py
+++ b/storage/utils.py
@@ -6,8 +6,8 @@ import string
 _ID_ALPHABET = string.ascii_letters + string.digits
 
 
-def generate_member_id() -> str:
-    """Generate member ID: m_{12 random alphanumeric chars}."""
+def generate_agent_user_id() -> str:
+    """Generate agent user ID: m_{12 random alphanumeric chars}."""
     return "m_" + "".join(secrets.choice(_ID_ALPHABET) for _ in range(12))
 
 

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -96,10 +97,12 @@ def _service(
     supabase_auth_client=None,
     supabase_auth_client_factory=None,
     user_repo=None,
+    agent_configs=None,
     invite_codes=None,
 ) -> AuthService:
     return AuthService(
-        users=user_repo or SimpleNamespace(),
+        users=cast(Any, user_repo or SimpleNamespace()),
+        agent_configs=agent_configs,
         supabase_client=supabase_client,
         supabase_auth_client=supabase_auth_client,
         supabase_auth_client_factory=supabase_auth_client_factory,
@@ -235,6 +238,38 @@ def test_verify_register_otp_accepts_direct_gotrue_client_without_auth_wrapper()
 
     assert auth_client.calls == [{"email": "fresh@example.com", "token": "123456", "type": "signup"}]
     assert result == {"temp_token": "temp-token-1"}
+
+
+def test_create_initial_agents_persists_default_agent_avatars(monkeypatch: pytest.MonkeyPatch):
+    created_users: list[SimpleNamespace] = []
+    updates: list[tuple[str, dict[str, object]]] = []
+    saved_configs: list[tuple[str, dict[str, object]]] = []
+    user_ids = iter(["agent-toad", "agent-morel"])
+    config_ids = iter(["cfg-toad", "cfg-morel"])
+
+    monkeypatch.setattr("storage.utils.generate_agent_user_id", lambda: next(user_ids))
+    monkeypatch.setattr("storage.utils.generate_agent_config_id", lambda: next(config_ids))
+    monkeypatch.setattr(
+        "backend.web.routers.entities.process_and_save_avatar",
+        lambda _source, user_id: f"avatars/{user_id}.png",
+    )
+
+    user_repo = SimpleNamespace(
+        create=lambda row: created_users.append(row),
+        update=lambda user_id, **fields: updates.append((user_id, fields)),
+    )
+    agent_configs = SimpleNamespace(save_config=lambda config_id, payload: saved_configs.append((config_id, payload)))
+
+    result = _service(user_repo=user_repo, agent_configs=agent_configs)._create_initial_agents("owner-1", 123.0)
+
+    assert [row.id for row in created_users] == ["agent-toad", "agent-morel"]
+    assert [row.display_name for row in created_users] == ["Toad", "Morel"]
+    assert [item[0] for item in saved_configs] == ["cfg-toad", "cfg-morel"]
+    assert updates == [
+        ("agent-toad", {"avatar": "avatars/agent-toad.png"}),
+        ("agent-morel", {"avatar": "avatars/agent-morel.png"}),
+    ]
+    assert result == {"id": "agent-toad", "name": "Toad", "type": "agent", "avatar": "avatars/agent-toad.png"}
 
 
 def test_login_resolves_numeric_mycel_id_via_user_repo():

--- a/tests/Unit/storage/test_utils.py
+++ b/tests/Unit/storage/test_utils.py
@@ -1,0 +1,15 @@
+from storage.utils import generate_agent_config_id, generate_agent_user_id
+
+
+def test_generate_agent_user_id_uses_agent_user_prefix() -> None:
+    agent_user_id = generate_agent_user_id()
+
+    assert agent_user_id.startswith("m_")
+    assert len(agent_user_id) == 14
+
+
+def test_generate_agent_config_id_uses_config_prefix() -> None:
+    agent_config_id = generate_agent_config_id()
+
+    assert agent_config_id.startswith("cfg_")
+    assert len(agent_config_id) == 16


### PR DESCRIPTION
## Summary
- Persist generated default Toad/Morel avatar paths back to user rows during registration.
- Return the first default agent with its avatar path instead of hard-coded null.
- Rename the agent-user id generator away from legacy member terminology and clean nearby comments/local names.

## Verification
- RED: `uv run pytest tests/Unit/backend/test_auth_service_token_verification.py::test_create_initial_agents_persists_default_agent_avatars -q` failed before the fix because no avatar updates were written.
- `uv run pytest tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/storage/test_utils.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_auth_router.py tests/Integration/test_entities_router.py tests/Integration/test_entities_avatar_auth_shell.py tests/Integration/test_messaging_router.py tests/Unit/backend/test_auth_entity_resolution.py tests/Unit/backend/web/services/test_resource_common.py tests/Unit/core/test_agent_pool.py -q`
- `uv run ruff check backend/web/services/auth_service.py backend/web/services/agent_user_service.py backend/web/routers/entities.py backend/web/routers/messaging.py backend/web/routers/threads.py backend/web/services/agent_pool.py backend/web/services/resource_common.py backend/web/services/typing_tracker.py core/agents/communication/delivery.py storage/utils.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/storage/test_utils.py`
- `uv run ruff format --check backend/web/services/auth_service.py backend/web/services/agent_user_service.py backend/web/routers/entities.py backend/web/routers/messaging.py backend/web/routers/threads.py backend/web/services/agent_pool.py backend/web/services/resource_common.py backend/web/services/typing_tracker.py core/agents/communication/delivery.py storage/utils.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/storage/test_utils.py`
- `uv run pyright backend/web/services/auth_service.py backend/web/services/agent_user_service.py backend/web/routers/entities.py backend/web/routers/messaging.py backend/web/services/agent_pool.py backend/web/services/resource_common.py backend/web/services/typing_tracker.py core/agents/communication/delivery.py storage/utils.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/storage/test_utils.py`

Note: pyright on changed `backend/web/routers/threads.py` is still blocked by pre-existing `Lock | None` errors at lines 957 and 982; this PR only touches comments in that file.
