### PR TITLE
Fix thread lock dependency typing

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -953,8 +953,8 @@ async def get_thread_history(
 @router.get("/{thread_id}/permissions")
 async def get_thread_permissions(
     thread_id: str,
+    thread_lock: Annotated[asyncio.Lock, Depends(get_thread_lock)],
     user_id: Annotated[str | None, Depends(verify_thread_owner)] = None,
-    thread_lock: Annotated[asyncio.Lock, Depends(get_thread_lock)] = None,
     agent: Annotated[Any, Depends(get_thread_agent)] = None,
 ) -> dict[str, Any]:
     # @@@permission-state-lock - owner polling and resolve can race on idle
@@ -976,10 +976,10 @@ async def resolve_thread_permission_request(
     thread_id: str,
     request_id: str,
     payload: ResolvePermissionRequest,
+    thread_lock: Annotated[asyncio.Lock, Depends(get_thread_lock)],
     user_id: Annotated[str | None, Depends(verify_thread_owner)] = None,
     agent: Annotated[Any, Depends(get_thread_agent)] = None,
     app: Annotated[Any, Depends(get_app)] = None,
-    thread_lock: Annotated[asyncio.Lock, Depends(get_thread_lock)] = None,
 ) -> dict[str, Any]:
     async with thread_lock:
         await agent.agent.aget_state({"configurable": {"thread_id": thread_id}})


### PR DESCRIPTION
## Summary
- Treat permission-route thread locks as required FastAPI dependencies instead of `Lock` parameters with `None` defaults.
- Keep runtime behavior unchanged; direct tests still pass locks by keyword.

## Verification
- `uv run pyright backend/web/routers/threads.py`
- `uv run pytest tests/Integration/test_threads_router.py -q`
- `uv run ruff check backend/web/routers/threads.py`
- `uv run ruff format --check backend/web/routers/threads.py`
