### PR TITLE
Fix WebFetch extraction model credentials

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -731,21 +731,22 @@ class LeonAgent:
 
     def _create_extraction_model(self):
         """Create a small model for WebFetch AI extraction (leon:mini)."""
-        try:
-            model_name, overrides = self.models_config.resolve_model("leon:mini")
-            provider = self._resolve_provider_name(model_name, overrides)
-            kwargs: dict = {}
-            if provider:
-                kwargs["model_provider"] = provider
-            p = self.models_config.get_provider(provider) if provider else None
-            base_url = (p.base_url if p else None) or self.models_config.get_base_url()
-            if base_url:
-                kwargs["base_url"] = self._normalize_base_url(base_url, provider)
-            return init_chat_model(model_name, **kwargs)
-        except Exception as e:
-            if self.verbose:
-                print(f"[LeonAgent] Failed to create extraction model: {e}, extraction will be unavailable")
-            return None
+        model_name, overrides = self.models_config.resolve_model("leon:mini")
+        provider = self._resolve_provider_name(model_name, overrides)
+        kwargs: dict = {}
+        if provider:
+            kwargs["model_provider"] = provider
+
+        p = self.models_config.get_provider(provider) if provider else None
+        api_key = (p.api_key if p else None) or self.models_config.get_api_key() or getattr(self, "api_key", None)
+        if not api_key:
+            raise RuntimeError("API key required for WebFetch extraction model")
+        kwargs["api_key"] = api_key
+
+        base_url = (p.base_url if p else None) or self.models_config.get_base_url()
+        if base_url:
+            kwargs["base_url"] = self._normalize_base_url(base_url, provider)
+        return init_chat_model(model_name, **kwargs)
 
     def _build_model_kwargs(self) -> dict:
         """Build model parameters for model initialization and sub-agents."""

--- a/tests/Unit/core/test_agent_extraction_model.py
+++ b/tests/Unit/core/test_agent_extraction_model.py
@@ -1,0 +1,87 @@
+from typing import Any, cast
+
+import pytest
+
+from config.models_schema import ModelsConfig, ModelSpec, ProviderConfig
+from core.runtime.agent import LeonAgent
+
+
+class _ExtractionAgentProbe:
+    def __init__(self, config: ModelsConfig, *, api_key: str | None = None) -> None:
+        self.api_key = api_key
+        self.models_config = config
+        self.verbose = False
+
+    def _resolve_provider_name(self, _model_name: str, overrides: dict) -> str | None:
+        return overrides.get("model_provider")
+
+    def _normalize_base_url(self, base_url: str, provider: str | None) -> str:
+        normalized = base_url.strip().rstrip("/")
+        if normalized.endswith("/v1"):
+            normalized = normalized[:-3]
+        return normalized if provider == "anthropic" else f"{normalized}/v1"
+
+
+def test_extraction_model_uses_resolved_provider_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_init_chat_model(model_name: str, **kwargs):
+        calls.append((model_name, kwargs))
+        return object()
+
+    monkeypatch.setattr("core.runtime.agent.init_chat_model", fake_init_chat_model)
+
+    config = ModelsConfig(
+        providers={"anthropic": ProviderConfig(api_key="sk-mini", base_url="https://anthropic.example")},
+        mapping={
+            "leon:mini": ModelSpec(
+                model="claude-haiku-4-5-20250929",
+                provider="anthropic",
+                temperature=None,
+                max_tokens=None,
+                context_limit=None,
+            )
+        },
+    )
+    agent = _ExtractionAgentProbe(config)
+
+    result = LeonAgent._create_extraction_model(cast(Any, agent))
+
+    assert result is not None
+    assert calls == [
+        (
+            "claude-haiku-4-5-20250929",
+            {
+                "model_provider": "anthropic",
+                "api_key": "sk-mini",
+                "base_url": "https://anthropic.example",
+            },
+        )
+    ]
+
+
+def test_extraction_model_fails_loudly_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_init_chat_model(_model_name: str, **_kwargs):
+        raise AssertionError("init_chat_model should not run without an api key")
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr("core.runtime.agent.init_chat_model", fake_init_chat_model)
+
+    config = ModelsConfig(
+        providers={"anthropic": ProviderConfig(base_url="https://anthropic.example")},
+        mapping={
+            "leon:mini": ModelSpec(
+                model="claude-haiku-4-5-20250929",
+                provider="anthropic",
+                temperature=None,
+                max_tokens=None,
+                context_limit=None,
+            )
+        },
+    )
+    agent = _ExtractionAgentProbe(config)
+
+    with pytest.raises(RuntimeError, match="API key required for WebFetch extraction model"):
+        LeonAgent._create_extraction_model(cast(Any, agent))


### PR DESCRIPTION
## Summary
- Pass the resolved API key into the WebFetch extraction model (`leon:mini`).
- Fail loudly when no extraction-model API key is available instead of returning `None` and silently degrading WebFetch.

## Verification
- RED: `uv run pytest tests/Unit/core/test_agent_extraction_model.py -q` failed before the fix because `api_key` was not passed and missing-key startup did not raise.
- `uv run pytest tests/Unit/core/test_agent_extraction_model.py tests/Unit/core/test_tool_registry_runner.py::TestWebToolRegistration tests/Integration/test_leon_agent.py -q`
- `uv run ruff check core/runtime/agent.py tests/Unit/core/test_agent_extraction_model.py`
- `uv run ruff format --check core/runtime/agent.py tests/Unit/core/test_agent_extraction_model.py`
- `uv run pyright core/runtime/agent.py tests/Unit/core/test_agent_extraction_model.py`
- Real backend proof on temporary `8011`: login `200`, `/api/conversations` `200`, owned `/api/threads/{thread_id}/permissions` `200`; agent initialized without the previous extraction-model unavailable log.
