### PR TITLE
Fix thread SSE auth header contract

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1185,22 +1185,16 @@ SSE_HEADERS = {
 async def stream_thread_events(
     thread_id: str,
     request: Request,
+    user_id: Annotated[str, Depends(get_current_user_id)],
     after: int = 0,
-    token: str | None = None,
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> EventSourceResponse:
-    """Persistent SSE event stream — uses ?token= for auth (EventSource can't set headers)."""
-    if not token:
-        raise HTTPException(401, "Missing token")
-    try:
-        sse_user_id = app.state.auth_service.verify_token(token)["user_id"]
-    except ValueError as e:
-        raise HTTPException(401, str(e))
+    """Persistent SSE event stream over the standard Authorization header."""
     thread = app.state.thread_repo.get_by_id(thread_id)
     if not thread:
         raise HTTPException(404, "Thread not found")
     agent_member = app.state.user_repo.get_by_id(thread["agent_user_id"])
-    if not agent_member or agent_member.owner_user_id != sse_user_id:
+    if not agent_member or agent_member.owner_user_id != user_id:
         raise HTTPException(403, "Not authorized")
 
     last_id = request.headers.get("Last-Event-ID")

--- a/eval/harness/client.py
+++ b/eval/harness/client.py
@@ -61,8 +61,6 @@ class EvalClient:
 
         after = self._thread_event_cursors.get(thread_id, 0)
         stream_path = f"/api/threads/{thread_id}/events?after={after}"
-        if self.token:
-            stream_path = f"{stream_path}&token={self.token}"
 
         # @@@public-thread-sse-handoff - the current public contract starts a run
         # with POST /messages, then delivers lifecycle/text over persistent
@@ -71,7 +69,7 @@ class EvalClient:
         async with self._client.stream(
             "GET",
             stream_path,
-            headers={"Accept": "text/event-stream"},
+            headers={"Accept": "text/event-stream", **self._auth_headers()},
         ) as resp:
             resp.raise_for_status()
             event_type = ""

--- a/frontend/app/src/api/streaming.test.ts
+++ b/frontend/app/src/api/streaming.test.ts
@@ -36,4 +36,19 @@ describe("streaming api contract", () => {
 
     await expect(api.postRun("thread-1", "hello")).rejects.toThrow("Run cancelled");
   });
+
+  it("streams thread events through authenticated fetch without leaking token in the URL", async () => {
+    const ac = new AbortController();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('event: status\ndata: {"_seq":8}\n\n'));
+        controller.close();
+      },
+    });
+    authFetch.mockResolvedValue(new Response(body));
+
+    await api.streamThreadEvents("thread-1", () => ac.abort(), ac.signal, 7);
+
+    expect(authFetch).toHaveBeenCalledWith("/api/threads/thread-1/events?after=7", { signal: ac.signal });
+  });
 });

--- a/frontend/app/src/api/streaming.ts
+++ b/frontend/app/src/api/streaming.ts
@@ -80,11 +80,9 @@ export async function streamThreadEvents(
 
   while (!signal?.aborted) {
     try {
-      const { useAuthStore } = await import("../store/auth-store");
-      const token = useAuthStore.getState().token || "";
-      const url = `/api/threads/${encodeURIComponent(threadId)}/events?after=${after}&token=${encodeURIComponent(token)}`;
-      console.log(`[SSE-FETCH] fetching ${url.replace(/token=[^&]+/, "token=***")}`);
-      const res = await fetch(url, { signal: signal });
+      const url = `/api/threads/${encodeURIComponent(threadId)}/events?after=${after}`;
+      console.log(`[SSE-FETCH] fetching ${url}`);
+      const res = await authFetch(url, { signal });
       if (signal?.aborted) return;
       console.log(`[SSE-FETCH] response status=${res.status}, ok=${res.ok}`);
 

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -744,26 +744,6 @@ async def test_create_thread_route_rejects_unavailable_provider_for_existing_lea
 
 
 @pytest.mark.asyncio
-async def test_stream_thread_events_requires_token():
-    app = _make_threads_app(
-        auth_service=_FakeAuthService(),
-        thread_repo=SimpleNamespace(get_by_id=lambda _thread_id: None),
-        thread_event_buffers={},
-    )
-
-    with pytest.raises(threads_router.HTTPException) as exc_info:
-        await threads_router.stream_thread_events(
-            "thread-1",
-            request=_make_request(),
-            token=None,
-            app=app,
-        )
-
-    assert exc_info.value.status_code == 401
-    assert exc_info.value.detail == "Missing token"
-
-
-@pytest.mark.asyncio
 async def test_delete_thread_route_does_not_delete_thread_row_when_resource_destroy_fails():
     deleted_db: list[str] = []
     deleted_rows: list[str] = []
@@ -794,7 +774,7 @@ async def test_delete_thread_route_does_not_delete_thread_row_when_resource_dest
 
 
 @pytest.mark.asyncio
-async def test_stream_thread_events_verifies_token_before_owner_check():
+async def test_stream_thread_events_uses_authenticated_owner_id():
     auth_service = _FakeAuthService()
     thread_repo = SimpleNamespace(get_by_id=lambda _thread_id: {"agent_user_id": "member-1"})
     app = _make_threads_app(
@@ -806,11 +786,11 @@ async def test_stream_thread_events_verifies_token_before_owner_check():
     response = await threads_router.stream_thread_events(
         "thread-1",
         request=_make_request(),
-        token="tok-thread",
+        user_id="owner-1",
         app=app,
     )
 
-    assert auth_service.tokens == ["tok-thread"]
+    assert auth_service.tokens == []
     assert response is not None
 
 

--- a/tests/Unit/eval/test_harness_client.py
+++ b/tests/Unit/eval/test_harness_client.py
@@ -97,8 +97,8 @@ async def test_run_message_uses_public_messages_path_then_thread_events_stream()
     ]
     assert stream_calls == [
         (
-            "/api/threads/thread-1/events?after=0&token=tok-1",
-            {"Accept": "text/event-stream"},
+            "/api/threads/thread-1/events?after=0",
+            {"Accept": "text/event-stream", "Authorization": "Bearer tok-1"},
         )
     ]
 


### PR DESCRIPTION
## Summary
- Move first-party thread SSE from query-token URLs to the standard `Authorization` header path.
- Update the eval harness to stream thread events with headers instead of `?token=`.
- Add a frontend regression test that fails if the stream URL leaks the token again.

## Verification
- `cd frontend/app && npm test -- streaming.test.ts`
- `uv run pytest tests/Unit/eval/test_harness_client.py tests/Integration/test_threads_router.py -q`
- `uv run ruff check backend/web/routers/threads.py eval/harness/client.py tests/Integration/test_threads_router.py tests/Unit/eval/test_harness_client.py`
- `uv run ruff format --check backend/web/routers/threads.py eval/harness/client.py tests/Integration/test_threads_router.py tests/Unit/eval/test_harness_client.py`
- `uv run pyright backend/web/routers/threads.py eval/harness/client.py`
- `cd frontend/app && npx eslint src/api/streaming.ts src/api/streaming.test.ts`
- `cd frontend/app && npm run build`
- Real backend `GET /api/threads/:id/events?after=0` with `Authorization` header returned `200 text/event-stream`.
- Real frontend Playwright console showed `/api/threads/.../events?after=...` with no token query and response `200`.

## Notes
- Full `npm run lint -- ...` still invokes `eslint .` and reports existing unrelated lint errors outside this change.
- Native chat `EventSource` still uses query token; this PR intentionally scopes only fetch-based thread SSE.
