### PR TITLE
fix: stream chat events with auth header

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -244,22 +244,17 @@ def delete_chat(
 
 
 # ---------------------------------------------------------------------------
-# SSE stream (typing indicators fallback, messages come via Supabase Realtime)
+# SSE stream
 # ---------------------------------------------------------------------------
 
 
 @router.get("/{chat_id}/events")
 async def stream_chat_events(
     chat_id: str,
-    token: str | None = None,
+    user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ):
-    if not token:
-        raise HTTPException(401, "Missing token")
-    try:
-        app.state.auth_service.verify_token(token)
-    except ValueError as e:
-        raise HTTPException(401, str(e))
+    _get_accessible_chat_or_404(app, chat_id, user_id)
 
     from fastapi.responses import StreamingResponse
 

--- a/frontend/app/src/api/chat-events.test.ts
+++ b/frontend/app/src/api/chat-events.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetch = vi.fn();
+
+vi.mock("../store/auth-store", () => ({
+  authFetch,
+}));
+
+function eventStream(lines: string[]): Response {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines.join("\n")));
+      controller.close();
+    },
+  });
+  return new Response(body);
+}
+
+describe("chat event stream", () => {
+  let api: typeof import("./chat-events");
+
+  beforeEach(async () => {
+    authFetch.mockReset();
+    vi.resetModules();
+    api = await import("./chat-events");
+  });
+
+  it("streams chat events through authenticated fetch without putting token in the URL", async () => {
+    authFetch.mockResolvedValue(
+      eventStream([
+        "event: message",
+        'data: {"id":"msg-1","content":"hello"}',
+        "",
+        "event: typing_start",
+        'data: {"user_id":"agent-1"}',
+        "",
+      ]),
+    );
+    const ac = new AbortController();
+    const seen: Array<{ type: string; data: unknown }> = [];
+
+    await api.streamChatEvents("chat-1", (event) => seen.push(event), ac.signal);
+
+    expect(authFetch).toHaveBeenCalledWith("/api/chats/chat-1/events", {
+      headers: { Accept: "text/event-stream" },
+      signal: ac.signal,
+    });
+    expect(seen).toEqual([
+      { type: "message", data: { id: "msg-1", content: "hello" } },
+      { type: "typing_start", data: { user_id: "agent-1" } },
+    ]);
+  });
+});

--- a/frontend/app/src/api/chat-events.ts
+++ b/frontend/app/src/api/chat-events.ts
@@ -1,0 +1,56 @@
+import { authFetch } from "../store/auth-store";
+
+export interface ChatStreamEvent {
+  type: string;
+  data: unknown;
+}
+
+function parseEvent(raw: string): ChatStreamEvent | null {
+  if (!raw.trim()) return null;
+  let type = "message";
+  const dataLines: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("event:")) type = line.slice(6).trim();
+    else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+  }
+  const dataRaw = dataLines.join("\n");
+  if (!dataRaw) return null;
+  return { type, data: JSON.parse(dataRaw) };
+}
+
+export async function streamChatEvents(
+  chatId: string,
+  onEvent: (event: ChatStreamEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await authFetch(`/api/chats/${encodeURIComponent(chatId)}/events`, {
+    headers: { Accept: "text/event-stream" },
+    signal,
+  });
+  if (!res.ok) throw new Error(`Chat event stream failed: ${res.status}: ${await res.text()}`);
+  if (!res.body) throw new Error("Chat event stream response has no body");
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const onAbort = () => reader.cancel();
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    while (!signal?.aborted) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const chunks = buffer.split(/\r?\n\r?\n/);
+      buffer = chunks.pop() ?? "";
+      for (const chunk of chunks) {
+        const event = parseEvent(chunk);
+        if (event) onEvent(event);
+      }
+    }
+    const trailing = parseEvent(buffer);
+    if (trailing) onEvent(trailing);
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+}

--- a/frontend/app/src/api/index.ts
+++ b/frontend/app/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./client";
 export * from "./streaming";
+export * from "./chat-events";

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router-dom";
 import { PanelLeft, Send } from "lucide-react";
 import { authFetch, useAuthStore } from "../store/auth-store";
+import { streamChatEvents } from "../api/chat-events";
 import { UserBubble } from "../components/chat-area/UserBubble";
 import { ChatBubble } from "../components/chat-area/ChatBubble";
 import type { ChatMember, ChatMessage, ChatDetail } from "../api/types";
@@ -115,66 +116,59 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
 
   // SSE for real-time messages
   useEffect(() => {
-    const token = useAuthStore.getState().token;
-    if (!token) return;
+    const ac = new AbortController();
 
-    const es = new EventSource(`/api/chats/${chatId}/events?token=${encodeURIComponent(token)}`);
-
-    // @@@sse-dedup — SSE message dedup: skip if real id exists, replace optimistic if content matches
-    es.addEventListener("message", (e) => {
-      try {
-        const msg: ChatMessage = JSON.parse(e.data);
-        setMessages(prev => {
-          // Skip if we already have this exact message id
-          if (prev.some(m => m.id === msg.id)) return prev;
-          // Replace optimistic message if sender+content matches
-          const optimisticIdx = prev.findIndex(
-            m => m.id.startsWith("optimistic-") && m.sender_id === msg.sender_id && m.content === msg.content,
-          );
-          if (optimisticIdx >= 0) {
-            const next = [...prev];
-            next[optimisticIdx] = msg;
-            return next;
+    void streamChatEvents(
+      chatId,
+      (event) => {
+        if (event.type === "message") {
+          const msg = event.data as ChatMessage;
+          setMessages(prev => {
+            // Skip if we already have this exact message id
+            if (prev.some(m => m.id === msg.id)) return prev;
+            // Replace optimistic message if sender+content matches
+            const optimisticIdx = prev.findIndex(
+              m => m.id.startsWith("optimistic-") && m.sender_id === msg.sender_id && m.content === msg.content,
+            );
+            if (optimisticIdx >= 0) {
+              const next = [...prev];
+              next[optimisticIdx] = msg;
+              return next;
+            }
+            return [...prev, msg];
+          });
+          if (isAtBottomRef.current) {
+            setTimeout(scrollToBottom, 50);
+            // User is viewing → mark read + refresh sidebar
+            authFetch(`/api/chats/${chatId}/read`, { method: "POST" }).catch(err => console.warn("[mark_read] failed:", err));
+            refreshChatList();
           }
-          return [...prev, msg];
-        });
-        if (isAtBottomRef.current) {
-          setTimeout(scrollToBottom, 50);
-          // User is viewing → mark read + refresh sidebar
-          authFetch(`/api/chats/${chatId}/read`, { method: "POST" }).catch(err => console.warn("[mark_read] failed:", err));
-          refreshChatList();
+          return;
         }
-      } catch (err) {
-        console.error("[ChatSSE] parse error:", err);
-      }
+        if (event.type === "typing_start") {
+          const data = event.data as { user_id?: string };
+          const userId = data.user_id;
+          if (userId) setTypingEntities(prev => new Set([...prev, userId]));
+          return;
+        }
+        if (event.type === "typing_stop") {
+          const data = event.data as { user_id?: string };
+          const userId = data.user_id;
+          if (!userId) return;
+          setTypingEntities(prev => {
+            const next = new Set(prev);
+            next.delete(userId);
+            return next;
+          });
+        }
+      },
+      ac.signal,
+    ).catch((err) => {
+      if (!ac.signal.aborted) console.error("[ChatSSE] connection failed:", err);
     });
-
-    es.addEventListener("typing_start", (e) => {
-      try {
-        const data = JSON.parse(e.data);
-        setTypingEntities(prev => new Set([...prev, data.user_id]));
-      } catch (err) { console.warn("[ChatSSE] typing_start parse error:", err); }
-    });
-
-    es.addEventListener("typing_stop", (e) => {
-      try {
-        const data = JSON.parse(e.data);
-        setTypingEntities(prev => {
-          const next = new Set(prev);
-          next.delete(data.user_id);
-          return next;
-        });
-      } catch (err) { console.warn("[ChatSSE] typing_stop parse error:", err); }
-    });
-
-    es.onerror = () => {
-      if (es.readyState === EventSource.CLOSED) {
-        console.error("[ChatSSE] connection permanently closed");
-      }
-    };
 
     return () => {
-      es.close();
+      ac.abort();
       refreshChatList(); // refresh sidebar on leave
     };
   }, [chatId, scrollToBottom, refreshChatList]);

--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -165,42 +165,48 @@ async def test_call_auth_service_maps_value_error_to_given_status():
     assert exc_info.value.detail == "邀请码无效"
 
 
-class _VerifyOnlyAuthService:
+class _ChatEventBus:
     def __init__(self) -> None:
-        self.tokens: list[str] = []
+        self.subscribed: list[str] = []
+        self.unsubscribed: list[tuple[str, object]] = []
 
-    def verify_token(self, token: str) -> dict:
-        self.tokens.append(token)
-        return {"user_id": "user-1"}
+    def subscribe(self, chat_id: str) -> object:
+        self.subscribed.append(chat_id)
+        return object()
+
+    def unsubscribe(self, chat_id: str, queue: object) -> None:
+        self.unsubscribed.append((chat_id, queue))
 
 
 @pytest.mark.asyncio
-async def test_chat_events_requires_token():
+async def test_chat_events_requires_chat_membership():
     app = SimpleNamespace(
         state=SimpleNamespace(
-            auth_service=_VerifyOnlyAuthService(),
-            chat_event_bus=SimpleNamespace(subscribe=lambda _chat_id: None),
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: {"id": "chat-1"}),
+            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False),
+            chat_event_bus=_ChatEventBus(),
         )
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await chats_router.stream_chat_events("chat-1", token=None, app=app)
+        await chats_router.stream_chat_events("chat-1", user_id="user-1", app=app)
 
-    assert exc_info.value.status_code == 401
-    assert exc_info.value.detail == "Missing token"
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Not a participant of this chat"
 
 
 @pytest.mark.asyncio
-async def test_chat_events_verifies_provided_token():
-    auth_service = _VerifyOnlyAuthService()
+async def test_chat_events_uses_authenticated_participant():
+    event_bus = _ChatEventBus()
     app = SimpleNamespace(
         state=SimpleNamespace(
-            auth_service=auth_service,
-            chat_event_bus=SimpleNamespace(subscribe=lambda _chat_id: None),
+            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: {"id": "chat-1"}),
+            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, user_id: user_id == "user-1"),
+            chat_event_bus=event_bus,
         )
     )
 
-    response = await chats_router.stream_chat_events("chat-1", token="tok-chat", app=app)
+    response = await chats_router.stream_chat_events("chat-1", user_id="user-1", app=app)
 
-    assert auth_service.tokens == ["tok-chat"]
+    assert event_bus.subscribed == ["chat-1"]
     assert response.media_type == "text/event-stream"


### PR DESCRIPTION
## Summary
- replace social chat native EventSource token-query stream with authenticated fetch streaming
- require chat membership before subscribing to chat event streams
- add focused frontend/backend coverage for the header-auth chat SSE contract

## Test Plan
- [x] cd frontend/app && npm test -- chat-events.test.ts streaming.test.ts
- [x] uv run pytest tests/Integration/test_auth_router.py tests/Integration/test_messaging_router.py -q
- [x] uv run ruff check backend/web/routers/messaging.py tests/Integration/test_auth_router.py
- [x] uv run ruff format --check backend/web/routers/messaging.py tests/Integration/test_auth_router.py
- [x] uv run pyright backend/web/routers/messaging.py
- [x] cd frontend/app && npx eslint src/api/chat-events.ts src/api/chat-events.test.ts src/pages/ChatConversationPage.tsx src/api/index.ts
- [x] cd frontend/app && npm run build
- [x] real backend: chat SSE with Authorization header -> 200 text/event-stream; legacy query-token-only path -> 401
- [x] real frontend Playwright capture: /api/chats/{id}/events uses Authorization header and no token query