### PR TITLE
simplify: remove unused members path helper

### DIFF
--- a/backend/web/core/paths.py
+++ b/backend/web/core/paths.py
@@ -12,10 +12,6 @@ def leon_home_dir() -> Path:
     return preferred_user_home_dir()
 
 
-def members_dir() -> Path:
-    return leon_home_dir() / "members"
-
-
 def library_dir() -> Path:
     return leon_home_dir() / "library"
 


### PR DESCRIPTION
## Summary
- remove unused `members_dir()` helper from web runtime paths
- keep live `library_dir()` and `avatars_dir()` helpers unchanged

## Test Plan
- [x] rg members_dir backend storage tests
- [x] uv run ruff check backend/web/core/paths.py
- [x] uv run ruff format --check backend/web/core/paths.py
- [x] uv run pyright backend/web/core/paths.py