### PR TITLE
simplify: rename member avatar to actor avatar

### DIFF
--- a/frontend/app/src/components/ActorAvatar.tsx
+++ b/frontend/app/src/components/ActorAvatar.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { colorForType, colorForId, getInitials } from "@/lib/member-colors";
+import { colorForType, colorForId, getInitials } from "@/lib/actor-colors";
 import { cn } from "@/lib/utils";
 
 const SIZE_MAP = {
@@ -16,7 +16,7 @@ const SIZE_MAP = {
   lg: "w-16 h-16 text-lg",
 } as const;
 
-interface MemberAvatarProps {
+interface ActorAvatarProps {
   name: string;
   /** Avatar image URL from backend. Frontend doesn't build URLs. */
   avatarUrl?: string;
@@ -28,14 +28,14 @@ interface MemberAvatarProps {
   rev?: number;
 }
 
-export default function MemberAvatar({
+export default function ActorAvatar({
   name,
   avatarUrl,
   type,
   size = "md",
   className,
   rev,
-}: MemberAvatarProps) {
+}: ActorAvatarProps) {
   const sizeClass = SIZE_MAP[size];
   const fallbackColor = type ? colorForType(type).tw : colorForId(name);
   const src = avatarUrl ? `${avatarUrl}${rev ? `?v=${rev}` : ""}` : undefined;

--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Search, MessageSquare } from "lucide-react";
-import MemberAvatar from "./MemberAvatar";
+import ActorAvatar from "./ActorAvatar";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Input } from "./ui/input";
 import { useAppStore } from "@/store/app-store";
@@ -18,10 +18,7 @@ export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps
   const [filter, setFilter] = useState("");
 
   useEffect(() => {
-    if (open) {
-      loadAll();
-      setFilter("");
-    }
+    if (open) loadAll();
   }, [open, loadAll]);
 
   const filtered = useMemo(() => {
@@ -68,7 +65,7 @@ export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps
                 onClick={() => handleSelect(member)}
                 className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted transition-colors duration-fast"
               >
-                <MemberAvatar name={member.name} avatarUrl={member.avatar_url} type="mycel_agent" size="sm" />
+                <ActorAvatar name={member.name} avatarUrl={member.avatar_url} type="mycel_agent" size="sm" />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium truncate">{member.name}</span>

--- a/frontend/app/src/components/agent-shell-contract.test.tsx
+++ b/frontend/app/src/components/agent-shell-contract.test.tsx
@@ -18,7 +18,7 @@ vi.mock("zustand/middleware", async () => {
   };
 });
 
-vi.mock("./MemberAvatar", () => ({
+vi.mock("./ActorAvatar", () => ({
   default: ({ name }: { name: string }) => <div>{name}</div>,
 }));
 

--- a/frontend/app/src/components/chat-area/AssistantBlock.tsx
+++ b/frontend/app/src/components/chat-area/AssistantBlock.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Loader2 } from "lucide-react";
 import type { AssistantTurn, NoticeSegment, NotificationType, RetrySegment, StreamStatus, ToolSegment, TurnSegment } from "../../api";
 import MarkdownContent from "../MarkdownContent";
-import MemberAvatar from "../MemberAvatar";
+import ActorAvatar from "../ActorAvatar";
 import { CopyButton } from "./CopyButton";
 import { InlineNotice } from "./NoticeBubble";
 import { ThinkingIndicator } from "./ThinkingIndicator";
@@ -122,7 +122,7 @@ export const AssistantBlock = memo(function AssistantBlock({ entry, isStreamingT
 
   return (
     <div className="flex gap-2.5 animate-fade-in group/block">
-      <MemberAvatar name={displayName} avatarUrl={agentAvatarUrl} size="xs" type="mycel_agent" className={`mt-0.5${isBooting ? " avatar-booting" : ""}`} />
+      <ActorAvatar name={displayName} avatarUrl={agentAvatarUrl} size="xs" type="mycel_agent" className={`mt-0.5${isBooting ? " avatar-booting" : ""}`} />
       <div className="flex-1 min-w-0 space-y-1.5 overflow-hidden">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-foreground">{displayName}</span>

--- a/frontend/app/src/components/chat-area/ChatBubble.tsx
+++ b/frontend/app/src/components/chat-area/ChatBubble.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import MemberAvatar from "../MemberAvatar";
+import ActorAvatar from "../ActorAvatar";
 import MarkdownContent from "../MarkdownContent";
 import { formatTime } from "./utils";
 
@@ -22,7 +22,7 @@ export const ChatBubble = memo(function ChatBubble({
 }: ChatBubbleProps) {
   return (
     <div className="flex gap-2.5 mb-1 animate-fade-in">
-      <MemberAvatar name={senderName} avatarUrl={avatarUrl} type={memberType} size="xs" />
+      <ActorAvatar name={senderName} avatarUrl={avatarUrl} type={memberType} size="xs" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           {showName && <span className="text-sm font-medium text-foreground">{senderName}</span>}

--- a/frontend/app/src/components/chat-area/UserBubble.tsx
+++ b/frontend/app/src/components/chat-area/UserBubble.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { FileText } from "lucide-react";
 import type { UserMessage } from "../../api";
 import { getSandboxDownloadUrl } from "../../api";
-import MemberAvatar from "../MemberAvatar";
+import ActorAvatar from "../ActorAvatar";
 import { formatTime } from "./utils";
 
 /** Strip "[User uploaded N file(s)...]" prefix from message content. */
@@ -56,7 +56,7 @@ export const UserBubble = memo(function UserBubble(props: UserBubbleProps) {
           </div>
         )}
       </div>
-      <MemberAvatar name={props.userName || "You"} avatarUrl={props.avatarUrl} size="xs" type="human" />
+      <ActorAvatar name={props.userName || "You"} avatarUrl={props.avatarUrl} size="xs" type="human" />
     </div>
   );
 });

--- a/frontend/app/src/lib/actor-colors.ts
+++ b/frontend/app/src/lib/actor-colors.ts
@@ -1,6 +1,6 @@
 /**
- * @@@member-colors - single source of truth for member type colors.
- * Used by MemberAvatar (DOM/Tailwind) and NetworkPage (Canvas/hex).
+ * @@@actor-colors - single source of truth for actor type colors.
+ * Used by ActorAvatar (DOM/Tailwind) and NetworkPage (Canvas/hex).
  */
 
 // Type → color mapping. Each entry has both Canvas hex and Tailwind classes.
@@ -12,7 +12,7 @@ const TYPE_COLORS: Record<string, { hex: string; tw: string }> = {
 
 const FALLBACK = { hex: "#a78bfa", tw: "bg-purple-100 text-purple-700" };
 
-/** Resolve color by member type. Returns both hex (Canvas) and tw (DOM) variants. */
+/** Resolve color by actor type. Returns both hex (Canvas) and tw (DOM) variants. */
 export function colorForType(type?: string): { hex: string; tw: string } {
   return (type && TYPE_COLORS[type]) || FALLBACK;
 }

--- a/frontend/app/src/pages/MembersPage.tsx
+++ b/frontend/app/src/pages/MembersPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Search, Plus, Zap, Users, Wrench, Plug, SearchX, ArrowUpDown, AlertTriangle, RefreshCw, MessageSquare, Copy, Trash2, Bot, Camera } from "lucide-react";
-import MemberAvatar from "@/components/MemberAvatar";
+import ActorAvatar from "@/components/ActorAvatar";
 import { uploadUserAvatar } from "@/api/client";
 import { useNavigate } from "react-router-dom";
 import CreateMemberDialog from "@/components/CreateMemberDialog";
@@ -37,7 +37,7 @@ function AvatarUploadTrigger({ memberId, name, hasAvatar }: { memberId: string; 
 
   return (
     <div className="relative group/avatar" onClick={(e) => { e.stopPropagation(); inputRef.current?.click(); }}>
-      <MemberAvatar avatarUrl={(hasAvatar || rev > 0) ? `/api/users/${memberId}/avatar` : undefined} name={name} size="md" className="rounded-xl" rev={rev} type="mycel_agent" />
+      <ActorAvatar avatarUrl={(hasAvatar || rev > 0) ? `/api/users/${memberId}/avatar` : undefined} name={name} size="md" className="rounded-xl" rev={rev} type="mycel_agent" />
       <div className="absolute inset-0 rounded-xl bg-black/40 opacity-0 group-hover/avatar:opacity-100 transition-opacity duration-fast flex items-center justify-center cursor-pointer">
         {uploading ? (
           <div className="w-4 h-4 border-2 border-white/60 border-t-white rounded-full animate-spin" />

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -32,7 +32,7 @@ vi.mock("../components/FilesystemBrowser", () => ({
   default: () => null,
 }));
 
-vi.mock("../components/MemberAvatar", () => ({
+vi.mock("../components/ActorAvatar", () => ({
   default: ({ name }: { name: string }) => <div>{name}</div>,
 }));
 

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -7,7 +7,7 @@ import type { ThreadManagerState, ThreadManagerActions } from "../hooks/use-thre
 import { useWorkspaceSettings } from "../hooks/use-workspace-settings";
 import { useAuthStore } from "../store/auth-store";
 import { useAppStore } from "../store/app-store";
-import MemberAvatar from "../components/MemberAvatar";
+import ActorAvatar from "../components/ActorAvatar";
 import FilesystemBrowser from "../components/FilesystemBrowser";
 import { getDefaultThreadConfig, listMyLeases, saveDefaultThreadConfig } from "../api/client";
 import type { RecipeFeatureOption, RecipeSnapshot, ThreadLaunchConfig, UserLeaseSummary } from "../api/types";
@@ -39,7 +39,7 @@ function ResolveStateCard({
     <div className="flex-1 flex items-center justify-center relative">
       <div className="w-full max-w-[420px] px-6 text-center">
         <div className="flex justify-center mb-4">
-          <MemberAvatar name={memberName} avatarUrl={memberAvatarUrl} type="mycel_agent" size="lg" />
+          <ActorAvatar name={memberName} avatarUrl={memberAvatarUrl} type="mycel_agent" size="lg" />
         </div>
         <h1 className="text-xl font-medium text-foreground mb-2">{title}</h1>
         <p className={`text-sm ${destructive ? "text-destructive" : "text-muted-foreground"}`}>
@@ -544,7 +544,7 @@ export default function NewChatPage({ mode = "member" }: { mode?: "member" | "ne
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[600px] px-4">
         <div className="text-center mb-8">
           <div className="flex justify-center mb-4">
-            <MemberAvatar name={memberName} avatarUrl={memberAvatarUrl} type="mycel_agent" size="lg" />
+            <ActorAvatar name={memberName} avatarUrl={memberAvatarUrl} type="mycel_agent" size="lg" />
           </div>
           <h1 className="text-2xl font-medium text-foreground mb-2">
             {mode === "new" ? `为 ${memberName} 创建新对话` : `开始与 ${memberName} 对话`}
@@ -815,7 +815,7 @@ export default function NewChatPage({ mode = "member" }: { mode?: "member" | "ne
                                     </div>
                                     <div className="flex -space-x-2">
                                       {lease.agents.slice(0, 4).map((agent) => (
-                                        <MemberAvatar
+                                        <ActorAvatar
                                           key={agent.thread_id}
                                           name={agent.agent_name}
                                           avatarUrl={agent.avatar_url ?? undefined}

--- a/frontend/app/src/pages/RootLayout.test.tsx
+++ b/frontend/app/src/pages/RootLayout.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/components/NewChatDialog", () => ({
   default: () => null,
 }));
 
-vi.mock("@/components/MemberAvatar", () => ({
+vi.mock("@/components/ActorAvatar", () => ({
   default: () => null,
 }));
 

--- a/frontend/app/src/pages/RootLayout.tsx
+++ b/frontend/app/src/pages/RootLayout.tsx
@@ -2,7 +2,7 @@ import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { MessageSquare, Users, Store, Settings, Plus, ChevronLeft, ChevronRight, LogOut, Camera, Eye, EyeOff } from "lucide-react";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { uploadUserAvatar } from "@/api/client";
-import MemberAvatar from "@/components/MemberAvatar";
+import ActorAvatar from "@/components/ActorAvatar";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import CreateMemberDialog from "@/components/CreateMemberDialog";
 import NewChatDialog from "@/components/NewChatDialog";
@@ -252,7 +252,7 @@ function AuthenticatedLayout() {
             <Popover>
               <PopoverTrigger asChild>
                 <button className={`flex items-center ${showLabels ? "px-3 gap-3" : "justify-center"} h-10 mb-1 rounded-xl hover:bg-muted transition-colors duration-fast w-full`}>
-                  <MemberAvatar name={authUser?.name || "User"} avatarUrl={(authUser?.avatar || avatarRev > 0) && authUser?.id ? `/api/users/${authUser.id}/avatar` : undefined} size="sm" type="human" rev={avatarRev} />
+                  <ActorAvatar name={authUser?.name || "User"} avatarUrl={(authUser?.avatar || avatarRev > 0) && authUser?.id ? `/api/users/${authUser.id}/avatar` : undefined} size="sm" type="human" rev={avatarRev} />
                   {showLabels && (
                     <div className="min-w-0 flex-1 text-left">
                       <p className="text-xs font-medium text-foreground truncate">{authUser?.name || "User"}</p>
@@ -263,7 +263,7 @@ function AuthenticatedLayout() {
               <PopoverContent side="top" align="start" className="w-56">
                 <div className="flex flex-col items-center gap-3">
                   <div className="relative group/avatar cursor-pointer" onClick={() => avatarInputRef.current?.click()}>
-                    <MemberAvatar name={authUser?.name || "User"} avatarUrl={(authUser?.avatar || avatarRev > 0) && authUser?.id ? `/api/users/${authUser.id}/avatar` : undefined} size="lg" type="human" rev={avatarRev} />
+                    <ActorAvatar name={authUser?.name || "User"} avatarUrl={(authUser?.avatar || avatarRev > 0) && authUser?.id ? `/api/users/${authUser.id}/avatar` : undefined} size="lg" type="human" rev={avatarRev} />
                     <div className="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover/avatar:opacity-100 transition-opacity duration-fast flex items-center justify-center">
                       <Camera className="w-5 h-5 text-white" />
                     </div>

--- a/frontend/app/src/pages/chat/ConversationList.tsx
+++ b/frontend/app/src/pages/chat/ConversationList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Plus, Search } from "lucide-react";
-import MemberAvatar from "@/components/MemberAvatar";
+import ActorAvatar from "@/components/ActorAvatar";
 import { useConversationStore } from "@/store/conversation-store";
 import type { ConversationItem } from "@/types/conversation";
 import type { ThreadSummary } from "@/api";
@@ -112,7 +112,7 @@ export default function ConversationList({ threads }: { threads: ThreadSummary[]
                 }`}
               >
                 <div className="relative">
-                  <MemberAvatar
+                  <ActorAvatar
                     name={title}
                     avatarUrl={item.avatar_url ?? undefined}
                     type={item.type === "hire" ? "mycel_agent" : "human"}

--- a/frontend/app/src/pages/contacts/ContactList.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Bot, Search, User, Plus } from "lucide-react";
-import MemberAvatar from "@/components/MemberAvatar";
+import ActorAvatar from "@/components/ActorAvatar";
 import { useAppStore } from "@/store/app-store";
 import CreateMemberDialog from "@/components/CreateMemberDialog";
 
@@ -108,7 +108,7 @@ export default function ContactList() {
                     isActive ? "bg-background shadow-sm" : "hover:bg-muted"
                   }`}
                 >
-                  <MemberAvatar
+                  <ActorAvatar
                     name={agent.name}
                     avatarUrl={agent.avatar_url}
                     type="mycel_agent"


### PR DESCRIPTION
## Summary
- rename the universal avatar component from `MemberAvatar` to `ActorAvatar`
- rename `member-colors` to `actor-colors`
- remove the effect-body filter reset in `NewChatDialog` while touching that import path

## Test Plan
- [x] cd frontend/app && npm test -- agent-shell-contract.test.tsx RootLayout.test.tsx NewChatPage.test.tsx
- [x] cd frontend/app && npx eslint src/components/ActorAvatar.tsx src/lib/actor-colors.ts src/components/NewChatDialog.tsx src/components/agent-shell-contract.test.tsx src/components/chat-area/AssistantBlock.tsx src/components/chat-area/ChatBubble.tsx src/components/chat-area/UserBubble.tsx src/pages/MembersPage.tsx src/pages/NewChatPage.test.tsx src/pages/NewChatPage.tsx src/pages/RootLayout.test.tsx src/pages/RootLayout.tsx src/pages/chat/ConversationList.tsx src/pages/contacts/ContactList.tsx
- [x] cd frontend/app && npm run build
- [x] rg MemberAvatar/member-colors frontend/app/src