### PR TITLE
simplify: rename create member dialog to create agent dialog

### DIFF
--- a/frontend/app/src/components/CreateAgentDialog.tsx
+++ b/frontend/app/src/components/CreateAgentDialog.tsx
@@ -16,7 +16,7 @@ interface Props {
   onOpenChange: (open: boolean) => void;
 }
 
-export default function CreateMemberDialog({ open, onOpenChange }: Props) {
+export default function CreateAgentDialog({ open, onOpenChange }: Props) {
   const navigate = useNavigate();
   const addAgent = useAppStore(s => s.addAgent);
   const [name, setName] = useState("");
@@ -25,12 +25,12 @@ export default function CreateMemberDialog({ open, onOpenChange }: Props) {
   const handleCreate = async () => {
     if (!name.trim()) return;
     try {
-      const member = await addAgent(name.trim(), description.trim());
+      const agent = await addAgent(name.trim(), description.trim());
       onOpenChange(false);
       setName("");
       setDescription("");
-      navigate(`/contacts/agents/${member.id}`);
-    } catch (e) {
+      navigate(`/contacts/agents/${agent.id}`);
+    } catch {
       toast.error("创建失败，请重试");
     }
   };

--- a/frontend/app/src/components/agent-shell-contract.test.tsx
+++ b/frontend/app/src/components/agent-shell-contract.test.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import CreateMemberDialog from "./CreateMemberDialog";
+import CreateAgentDialog from "./CreateAgentDialog";
 import NewChatDialog from "./NewChatDialog";
 import MembersPage from "../pages/MembersPage";
 import { useAppStore } from "../store/app-store";
@@ -91,10 +91,10 @@ describe("frontend agent wording contract", () => {
     });
   });
 
-  it("CreateMemberDialog presents agent wording", () => {
+  it("CreateAgentDialog presents agent wording", () => {
     render(
       <MemoryRouter>
-        <CreateMemberDialog open onOpenChange={() => undefined} />
+        <CreateAgentDialog open onOpenChange={() => undefined} />
       </MemoryRouter>,
     );
 

--- a/frontend/app/src/pages/MembersPage.tsx
+++ b/frontend/app/src/pages/MembersPage.tsx
@@ -3,7 +3,7 @@ import { Search, Plus, Zap, Users, Wrench, Plug, SearchX, ArrowUpDown, AlertTria
 import ActorAvatar from "@/components/ActorAvatar";
 import { uploadUserAvatar } from "@/api/client";
 import { useNavigate } from "react-router-dom";
-import CreateMemberDialog from "@/components/CreateMemberDialog";
+import CreateAgentDialog from "@/components/CreateAgentDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAppStore } from "@/store/app-store";
@@ -258,7 +258,7 @@ export default function MembersPage() {
         )}
       </div>
 
-      <CreateMemberDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <CreateAgentDialog open={createOpen} onOpenChange={setCreateOpen} />
     </div>
   );
 }

--- a/frontend/app/src/pages/RootLayout.test.tsx
+++ b/frontend/app/src/pages/RootLayout.test.tsx
@@ -27,7 +27,7 @@ vi.mock("@/components/ui/popover", () => ({
   PopoverContent: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("@/components/CreateMemberDialog", () => ({
+vi.mock("@/components/CreateAgentDialog", () => ({
   default: () => null,
 }));
 

--- a/frontend/app/src/pages/RootLayout.tsx
+++ b/frontend/app/src/pages/RootLayout.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { uploadUserAvatar } from "@/api/client";
 import ActorAvatar from "@/components/ActorAvatar";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
-import CreateMemberDialog from "@/components/CreateMemberDialog";
+import CreateAgentDialog from "@/components/CreateAgentDialog";
 import NewChatDialog from "@/components/NewChatDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAppStore } from "@/store/app-store";
@@ -38,7 +38,7 @@ function AuthenticatedLayout() {
   const location = useLocation();
   const isMobile = useIsMobile();
   const [showCreate, setShowCreate] = useState(false);
-  const [createMemberOpen, setCreateMemberOpen] = useState(false);
+  const [createAgentOpen, setCreateAgentOpen] = useState(false);
   const [newChatOpen, setNewChatOpen] = useState(false);
   const [avatarRev, setAvatarRev] = useState(0);
   const avatarInputRef = useRef<HTMLInputElement>(null);
@@ -94,7 +94,7 @@ function AuthenticatedLayout() {
   const handleCreateAction = useCallback(async (action: string) => {
     setShowCreate(false);
     switch (action) {
-      case "staff": setCreateMemberOpen(true); break;
+      case "staff": setCreateAgentOpen(true); break;
       case "chat": setNewChatOpen(true); break;
     }
   }, []);
@@ -211,7 +211,7 @@ function AuthenticatedLayout() {
           })}
         </nav>
 
-        <CreateMemberDialog open={createMemberOpen} onOpenChange={setCreateMemberOpen} />
+        <CreateAgentDialog open={createAgentOpen} onOpenChange={setCreateAgentOpen} />
         <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
       </div>
     );
@@ -314,7 +314,7 @@ function AuthenticatedLayout() {
       <main className="flex-1 overflow-hidden">
         <div className="h-full animate-page-in"><Outlet /></div>
       </main>
-      <CreateMemberDialog open={createMemberOpen} onOpenChange={setCreateMemberOpen} />
+      <CreateAgentDialog open={createAgentOpen} onOpenChange={setCreateAgentOpen} />
       <NewChatDialog open={newChatOpen} onOpenChange={setNewChatOpen} />
     </div>
   );

--- a/frontend/app/src/pages/contacts/ContactList.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.tsx
@@ -3,7 +3,7 @@ import { Link, useParams } from "react-router-dom";
 import { Bot, Search, User, Plus } from "lucide-react";
 import ActorAvatar from "@/components/ActorAvatar";
 import { useAppStore } from "@/store/app-store";
-import CreateMemberDialog from "@/components/CreateMemberDialog";
+import CreateAgentDialog from "@/components/CreateAgentDialog";
 
 type Tab = "agents" | "contacts";
 
@@ -134,7 +134,7 @@ export default function ContactList() {
         )}
       </div>
 
-      <CreateMemberDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <CreateAgentDialog open={createOpen} onOpenChange={setCreateOpen} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- rename `CreateMemberDialog` to `CreateAgentDialog`
- rename the root-layout open state to `createAgentOpen`
- keep the dialog behavior and Agent wording unchanged

## Test Plan
- [x] cd frontend/app && npm test -- agent-shell-contract.test.tsx RootLayout.test.tsx
- [x] cd frontend/app && npx eslint src/components/CreateAgentDialog.tsx src/components/agent-shell-contract.test.tsx src/pages/MembersPage.tsx src/pages/RootLayout.test.tsx src/pages/RootLayout.tsx src/pages/contacts/ContactList.tsx
- [x] cd frontend/app && npm run build
- [x] rg CreateMemberDialog/createMemberOpen residue in frontend/app/src