### PR TITLE
simplify: share publish version bump

### DIFF
--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel
 
+from backend.web.utils.versioning import BumpType
+
 # ── Agents ──
 
 
@@ -26,7 +28,7 @@ class UpdateAgentRequest(BaseModel):
 
 
 class PublishAgentRequest(BaseModel):
-    bump_type: str = "patch"  # patch | minor | major
+    bump_type: BumpType = "patch"
     notes: str = ""
 
 

--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -8,6 +8,7 @@ from typing import Any
 import yaml
 
 from backend.web.utils.serializers import avatar_url
+from backend.web.utils.versioning import BumpType, bump_semver
 from config.defaults.tool_catalog import TOOLS_BY_NAME, ToolDef
 from config.loader import AgentLoader
 
@@ -483,24 +484,14 @@ def _sync_agent_config_patch_to_repo(
 
 def publish_agent_user(
     agent_user_id: str,
-    bump_type: str = "patch",
+    bump_type: BumpType = "patch",
     user_repo: Any = None,
     agent_config_repo: Any = None,
 ) -> dict[str, Any] | None:
     user, config = _resolve_repo_backed_agent(agent_user_id, user_repo, agent_config_repo)
     if user is None or config is None:
         return None
-    current_version = config.get("version", "0.1.0")
-
-    parts = current_version.split(".")
-    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
-    if bump_type == "major":
-        major, minor, patch = major + 1, 0, 0
-    elif bump_type == "minor":
-        minor, patch = minor + 1, 0
-    else:
-        patch += 1
-    next_version = f"{major}.{minor}.{patch}"
+    next_version = bump_semver(config.get("version", "0.1.0"), bump_type)
     updated_at = int(time.time() * 1000)
 
     agent_config_repo.save_config(

--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -12,6 +12,7 @@ import httpx
 import yaml
 from fastapi import HTTPException
 
+from backend.web.utils.versioning import BumpType, bump_semver
 from config.loader import load_bundle_from_repo
 from config.types import AgentBundle
 
@@ -100,7 +101,7 @@ def _load_repo_publish_material(user_id: str, user_repo: Any, agent_config_repo:
 def publish(
     user_id: str,
     type_: str,
-    bump_type: str,
+    bump_type: BumpType,
     release_notes: str,
     tags: list[str],
     visibility: str,
@@ -117,17 +118,7 @@ def publish(
     snapshot = _bundle_snapshot(bundle)
     snapshot["meta"] = copy.deepcopy(meta)
 
-    # Calculate new version
-    current_version = meta.get("version", "0.1.0")
-    parts = current_version.split(".")
-    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
-    if bump_type == "major":
-        major, minor, patch = major + 1, 0, 0
-    elif bump_type == "minor":
-        minor, patch = minor + 1, 0
-    else:
-        patch += 1
-    new_version = f"{major}.{minor}.{patch}"
+    new_version = bump_semver(meta.get("version", "0.1.0"), bump_type)
 
     # Get slug from agent name
     slug = bundle.agent.name.lower().replace(" ", "-")

--- a/backend/web/utils/versioning.py
+++ b/backend/web/utils/versioning.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+BumpType = Literal["major", "minor", "patch"]
+
+
+def bump_semver(version: str, bump_type: BumpType) -> str:
+    major, minor, patch = (int(part) for part in version.split("."))
+    if bump_type == "major":
+        return f"{major + 1}.0.0"
+    if bump_type == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -8,35 +8,23 @@ from unittest.mock import patch
 import pytest
 
 import backend.web.services.library_service as _lib_svc
+from backend.web.utils.versioning import bump_semver
 
 # ── Version Bump (tested via publish internals) ──
 
 
-def _bump_version(current: str, bump_type: str) -> str:
-    """Reproduce the version bump logic from marketplace_client.publish."""
-    parts = current.split(".")
-    major, minor, p = int(parts[0]), int(parts[1]), int(parts[2])
-    if bump_type == "major":
-        major, minor, p = major + 1, 0, 0
-    elif bump_type == "minor":
-        minor, p = minor + 1, 0
-    else:
-        p += 1
-    return f"{major}.{minor}.{p}"
-
-
 class TestVersionBump:
     def test_patch_bump(self):
-        assert _bump_version("1.2.3", "patch") == "1.2.4"
+        assert bump_semver("1.2.3", "patch") == "1.2.4"
 
     def test_minor_bump(self):
-        assert _bump_version("1.2.3", "minor") == "1.3.0"
+        assert bump_semver("1.2.3", "minor") == "1.3.0"
 
     def test_major_bump(self):
-        assert _bump_version("1.2.3", "major") == "2.0.0"
+        assert bump_semver("1.2.3", "major") == "2.0.0"
 
     def test_initial_version(self):
-        assert _bump_version("0.1.0", "patch") == "0.1.1"
+        assert bump_semver("0.1.0", "patch") == "0.1.1"
 
 
 # ── Hub client contract ──


### PR DESCRIPTION
## Summary
- extract shared bump_semver helper for agent and marketplace publish paths
- type panel publish bump_type with the same Literal contract
- make marketplace tests exercise the real helper instead of a copied algorithm

## Test Plan
- uv run pytest tests/Unit/platform/test_marketplace_client.py tests/Unit/platform/test_marketplace_models.py tests/Integration/test_panel_auth_shell_coherence.py
- uv run ruff check backend/web/utils/versioning.py backend/web/models/panel.py backend/web/services/agent_user_service.py backend/web/services/marketplace_client.py tests/Unit/platform/test_marketplace_client.py
- uv run pyright backend/web/utils/versioning.py backend/web/models/panel.py backend/web/services/agent_user_service.py backend/web/services/marketplace_client.py