### PR TITLE
simplify: use actor type in chat bubble

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -62,7 +62,7 @@ def _verify_user_ownership(app: Any, sender_id: str, user_id: str) -> None:
     if not sender:
         raise HTTPException(403, "User not found")
     if sender.id == user_id:
-        return  # human member sending as themselves
+        return  # human user sending as themselves
     if sender.owner_user_id == user_id:
         return  # agent owned by current user
     raise HTTPException(403, "User does not belong to you")

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -155,7 +155,7 @@ export interface UserLeaseSummary {
   agents: Array<{
     /** Runtime actor identity for this visible lease participant. */
     thread_id: string;
-    /** Display label resolved from the actor's backing member shell. */
+    /** Display label resolved from the actor's backing agent user. */
     agent_name: string;
     avatar_url?: string | null;
   }>;

--- a/frontend/app/src/components/chat-area/ChatBubble.tsx
+++ b/frontend/app/src/components/chat-area/ChatBubble.tsx
@@ -7,7 +7,7 @@ interface ChatBubbleProps {
   content: string;
   senderName: string;
   avatarUrl?: string;
-  memberType?: string;
+  actorType?: string;
   timestamp?: number;
   showName?: boolean;
 }
@@ -16,13 +16,13 @@ export const ChatBubble = memo(function ChatBubble({
   content,
   senderName,
   avatarUrl,
-  memberType,
+  actorType,
   timestamp,
   showName = true,
 }: ChatBubbleProps) {
   return (
     <div className="flex gap-2.5 mb-1 animate-fade-in">
-      <ActorAvatar name={senderName} avatarUrl={avatarUrl} type={memberType} size="xs" />
+      <ActorAvatar name={senderName} avatarUrl={avatarUrl} type={actorType} size="xs" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           {showName && <span className="text-sm font-medium text-foreground">{senderName}</span>}

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -329,7 +329,7 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
                       content={msg.content}
                       senderName={chatMemberDisplayName(member, msg.sender_name)}
                       avatarUrl={member?.avatar_url}
-                      memberType={member?.type}
+                      actorType={member?.type}
                       timestamp={ts}
                       showName
                     />

--- a/frontend/app/src/pages/contacts/ContactList.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.tsx
@@ -26,8 +26,8 @@ export default function ContactList() {
     void fetchAgents();
   }, [fetchAgents]);
 
-  // Filter agents (non-builtin members)
-  const agents = agentsState.filter((m) => !m.builtin);
+  // Filter user-created agents.
+  const agents = agentsState.filter((agent) => !agent.builtin);
   const filtered = search
     ? agents.filter((m) => m.name.toLowerCase().includes(search.toLowerCase()))
     : agents;


### PR DESCRIPTION
## Summary
- rename ChatBubble prop from memberType to actorType
- update the chat conversation caller to match the actor-avatar contract
- clean stale member wording in nearby comments without changing schemas

## Test Plan
- cd frontend/app && npm test -- ChatConversationPage.test.tsx RootLayout.test.tsx
- cd frontend/app && npx eslint src/components/chat-area/ChatBubble.tsx src/pages/ChatConversationPage.tsx src/api/types.ts src/pages/contacts/ContactList.tsx
- cd frontend/app && npm run build
- uv run pytest tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff check backend/web/routers/messaging.py
- uv run pyright backend/web/routers/messaging.py