### PR TITLE
simplify: remove remaining frontend any types

### DIFF
--- a/frontend/app/src/hooks/use-background-tasks.ts
+++ b/frontend/app/src/hooks/use-background-tasks.ts
@@ -17,7 +17,21 @@ interface UseBackgroundTasksProps {
   subscribe: UseThreadStreamResult["subscribe"];
 }
 
+interface BackgroundTaskEventData {
+  background: true;
+  task_id: string;
+  task_type?: BackgroundTask["task_type"];
+  command_line?: string;
+  description?: string;
+}
+
 const threadTasksInflight = new Map<string, Promise<BackgroundTask[]>>();
+
+function isBackgroundTaskEventData(data: unknown): data is BackgroundTaskEventData {
+  if (!data || typeof data !== "object") return false;
+  const value = data as Record<string, unknown>;
+  return value.background === true && typeof value.task_id === "string";
+}
 
 function isActiveThreadRoute(threadId: string): boolean {
   const path = window.location.pathname.replace(/\/+$/, "");
@@ -64,11 +78,9 @@ export function useBackgroundTasks({ threadId, subscribe }: UseBackgroundTasksPr
   // 监听 SSE 事件
   useEffect(() => {
     const unsubscribe = subscribe((event: StreamEvent) => {
-      const data = event.data as any;
-
       // 只处理 background task 事件
-      const isBackgroundTask = data?.background === true;
-      if (!isBackgroundTask) return;
+      if (!isBackgroundTaskEventData(event.data)) return;
+      const data = event.data;
 
       if (event.type === 'task_start') {
         // Optimistic update
@@ -90,8 +102,19 @@ export function useBackgroundTasks({ threadId, subscribe }: UseBackgroundTasksPr
 
   // 初始加载
   useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
+    let cancelled = false;
+    void loadThreadTasks(threadId)
+      .then((data) => {
+        if (!cancelled) setTasks(data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled || !isActiveThreadRoute(threadId)) return;
+        console.error('[BackgroundTasks] Error fetching tasks:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [threadId]);
 
   const getTask = useCallback((taskId: string) => {
     return tasks.find(t => t.task_id === taskId);

--- a/frontend/app/src/router.test.tsx
+++ b/frontend/app/src/router.test.tsx
@@ -4,7 +4,12 @@ import { describe, expect, it } from "vitest";
 
 import { router } from "./router";
 
-function collectPaths(routes: readonly { path?: string; children?: readonly { path?: string; children?: readonly any[] }[] }[]): string[] {
+interface RouteNode {
+  path?: string;
+  children?: readonly RouteNode[];
+}
+
+function collectPaths(routes: readonly RouteNode[]): string[] {
   const paths: string[] = [];
   for (const route of routes) {
     if (route.path) paths.push(route.path);


### PR DESCRIPTION
## Summary
- replace background task SSE `any` cast with a narrow event-data guard
- type router test recursion without `any[]`
- move initial background task load out of direct set-state-in-effect pattern

## Test Plan
- cd frontend/app && npm test -- use-background-tasks.test.tsx router.test.tsx
- cd frontend/app && npx eslint src/hooks/use-background-tasks.ts src/hooks/use-background-tasks.test.tsx src/router.test.tsx
- cd frontend/app && npm run build