### PR TITLE
simplify: remove duplicate contact page bootstrap

### DIFF
--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -42,11 +42,9 @@ export default function AgentDetail() {
   const agent = useAppStore(s => s.getAgentById(id || ""));
   const updateAgent = useAppStore(s => s.updateAgent);
   const updateAgentConfig = useAppStore(s => s.updateAgentConfig);
-  const loadAll = useAppStore(s => s.loadAll);
   const librarySkills = useAppStore(s => s.librarySkills);
   const libraryMcps = useAppStore(s => s.libraryMcps);
   const libraryAgents = useAppStore(s => s.libraryAgents);
-  useEffect(() => { loadAll(); }, [loadAll]);
 
   const [pickerType, setPickerType] = useState<"skill" | "mcp" | "agent" | null>(null);
   const [editingName, setEditingName] = useState(false);

--- a/frontend/app/src/pages/AgentsPage.tsx
+++ b/frontend/app/src/pages/AgentsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Search, Plus, Zap, Users, Wrench, Plug, SearchX, ArrowUpDown, AlertTriangle, RefreshCw, MessageSquare, Copy, Trash2, Bot, Camera } from "lucide-react";
 import ActorAvatar from "@/components/ActorAvatar";
 import { uploadUserAvatar } from "@/api/client";
@@ -58,14 +58,11 @@ export default function AgentsPage() {
   const [sortBy, setSortBy] = useState<SortKey>(null);
   const navigate = useNavigate();
   const agentList = useAppStore(s => s.agentList);
-  const loadAll = useAppStore(s => s.loadAll);
   const error = useAppStore(s => s.error);
   const retry = useAppStore(s => s.retry);
   const deleteAgent = useAppStore(s => s.deleteAgent);
   const addAgent = useAppStore(s => s.addAgent);
   const updateAgentConfig = useAppStore(s => s.updateAgentConfig);
-
-  useEffect(() => { loadAll(); }, [loadAll]);
 
   let filtered = agentList.filter((s) => {
     if (statusFilter !== "all" && s.status !== statusFilter) return false;


### PR DESCRIPTION
## Summary
- remove repeated contact-page loadAll effects now covered by RootLayout authenticated bootstrap
- keep contact pages as store consumers instead of secondary bootstrappers

## Verification
- cd frontend/app && npm test -- AgentDetailPage.wording.test.tsx agent-shell-contract.test.tsx
- cd frontend/app && npx eslint src/pages/AgentsPage.tsx src/pages/AgentDetailPage.tsx src/components/agent-shell-contract.test.tsx src/pages/AgentDetailPage.wording.test.tsx
- cd frontend/app && npm run build