### PR TITLE
simplify: remove duplicate new chat bootstrap

### DIFF
--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Search, MessageSquare } from "lucide-react";
 import ActorAvatar from "./ActorAvatar";
@@ -14,12 +14,7 @@ interface NewChatDialogProps {
 export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps) {
   const navigate = useNavigate();
   const agentList = useAppStore(s => s.agentList);
-  const loadAll = useAppStore(s => s.loadAll);
   const [filter, setFilter] = useState("");
-
-  useEffect(() => {
-    if (open) loadAll();
-  }, [open, loadAll]);
 
   const filtered = useMemo(() => {
     if (!filter) return agentList;


### PR DESCRIPTION
## Summary
- remove NewChatDialog's duplicate loadAll effect
- keep panel bootstrap owned by RootLayout authenticated shell

## Verification
- cd frontend/app && npm test -- agent-shell-contract.test.tsx
- cd frontend/app && npx eslint src/components/NewChatDialog.tsx src/components/agent-shell-contract.test.tsx
- cd frontend/app && npm run build