### PR TITLE
simplify: use assistant entry type guard

### DIFF
--- a/frontend/app/src/pages/ChatPage.tsx
+++ b/frontend/app/src/pages/ChatPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useOutletContext, useLocation } from "react-router-dom";
 import { Check, ShieldAlert, X } from "lucide-react";
 import { toast } from "sonner";
 import ChatArea from "../components/ChatArea";
-import type { AssistantTurn, AskUserAnswer, AskUserQuestionPrompt, PermissionRequest } from "../api";
+import type { AssistantTurn, AskUserAnswer, AskUserQuestionPrompt, ChatEntry, PermissionRequest } from "../api";
 import { uploadSandboxFile } from "../api";
 import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { Button } from "../components/ui/button";
@@ -38,6 +38,10 @@ function isAskUserQuestionRequest(
   request: PermissionRequest | null,
 ): request is PermissionRequest & { args: PermissionRequest["args"] & { questions: AskUserQuestionPrompt[] } } {
   return !!request && request.tool_name === "AskUserQuestion" && Array.isArray(request.args?.questions);
+}
+
+function isAssistantTurn(entry: ChatEntry): entry is AssistantTurn {
+  return entry.role === "assistant";
 }
 
 /** Thin wrapper: key={threadId} forces remount → all hook state resets naturally. */
@@ -129,8 +133,8 @@ function ChatPageInner({ threadId }: { threadId: string }) {
   const handleTaskNoticeClick = useCallback(
     (taskId: string) => {
       for (const entry of entries) {
-        if (entry.role !== "assistant") continue;
-        for (const seg of (entry as AssistantTurn).segments) {
+        if (!isAssistantTurn(entry)) continue;
+        for (const seg of entry.segments) {
           if (seg.type === "tool" && seg.step.name === "Agent" && seg.step.subagent_stream?.task_id === taskId) {
             handleFocusAgent(seg.step.id);
             return;


### PR DESCRIPTION
## Summary
- add a ChatEntry -> AssistantTurn type guard in ChatPage
- replace the task notice assistant cast with the discriminator guard

## Verification
- cd frontend/app && npm test -- ChatArea.test.tsx
- cd frontend/app && npx eslint src/pages/ChatPage.tsx src/components/ChatArea.test.tsx
- cd frontend/app && npm run build