### PR TITLE
simplify: remove unused typing tracker logger

### DIFF
--- a/backend/web/services/typing_tracker.py
+++ b/backend/web/services/typing_tracker.py
@@ -6,14 +6,11 @@ streaming_service finally block calls stop(). Thread-safe (single event loop).
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from backend.web.services.chat_events import ChatEventBus
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- remove unused logging import and module logger from TypingTracker
- keep typing lifecycle behavior unchanged

## Verification
- uv run ruff check backend/web/services/typing_tracker.py backend/web/core/lifespan.py backend/web/services/streaming_service.py tests/Integration/test_messaging_social_handle_contract.py
- uv run pytest tests/Integration/test_messaging_social_handle_contract.py -q
- uv run pyright backend/web/services/typing_tracker.py

## Note
- A broader pyright run including streaming_service.py and test_messaging_social_handle_contract.py still has pre-existing unrelated type errors; this PR only changes typing_tracker.py.