### PR TITLE
simplify: fail loudly after agent user create

### DIFF
--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -273,7 +273,10 @@ def create_agent_user(
             updated_at=now_ms,
         )
 
-    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)  # type: ignore
+    created = get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
+    if created is None:
+        raise RuntimeError(f"Created agent user {agent_user_id} was not readable")
+    return created
 
 
 def _require_repo_backed_agent_ops(user_repo: Any = None, agent_config_repo: Any = None) -> None:

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -351,6 +351,34 @@ def test_library_service_get_resource_used_by_scopes_to_owner(monkeypatch: pytes
     assert seen == [("user-1", "repo-1", "cfg-repo")]
 
 
+def test_create_agent_user_fails_loudly_when_created_row_is_not_readable():
+    created_rows: list[UserRow] = []
+    saved_configs: list[tuple[str, dict[str, object]]] = []
+
+    class _UserRepo:
+        def create(self, row: UserRow) -> None:
+            created_rows.append(row)
+
+        def get_by_id(self, _user_id: str):
+            return None
+
+    class _AgentConfigRepo:
+        def save_config(self, agent_config_id: str, data: dict[str, object]) -> None:
+            saved_configs.append((agent_config_id, data))
+
+    with pytest.raises(RuntimeError, match="Created agent user .* was not readable"):
+        agent_user_service.create_agent_user(
+            "Toad",
+            "probe",
+            owner_user_id="user-1",
+            user_repo=_UserRepo(),
+            agent_config_repo=_AgentConfigRepo(),
+        )
+
+    assert len(created_rows) == 1
+    assert len(saved_configs) == 1
+
+
 @pytest.mark.asyncio
 async def test_panel_library_used_by_route_uses_user_scope(monkeypatch: pytest.MonkeyPatch):
     seen: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- remove the type-ignore from agent user creation
- make create_agent_user fail loudly if read-after-write cannot find the created agent user
- add a focused regression test for the broken storage invariant

## Verification
- uv run pytest tests/Integration/test_panel_auth_shell_coherence.py -q
- uv run ruff check backend/web/services/agent_user_service.py tests/Integration/test_panel_auth_shell_coherence.py
- uv run ruff format --check backend/web/services/agent_user_service.py tests/Integration/test_panel_auth_shell_coherence.py
- uv run pyright backend/web/services/agent_user_service.py