### PR TITLE
simplify: share assistant turn guard

### DIFF
--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -266,6 +266,10 @@ export interface NoticeMessage {
 
 export type ChatEntry = UserMessage | AssistantTurn | NoticeMessage;
 
+export function isAssistantTurn(entry: ChatEntry): entry is AssistantTurn {
+  return entry.role === "assistant";
+}
+
 export interface StreamStatus {
   state: { state: string; flags: Record<string, boolean> };
   tokens: { total_tokens: number; input_tokens: number; output_tokens: number; cost: number };

--- a/frontend/app/src/components/ChatArea.tsx
+++ b/frontend/app/src/components/ChatArea.tsx
@@ -1,4 +1,4 @@
-import type { AssistantTurn, ChatEntry, NoticeMessage, StreamStatus } from "../api";
+import { isAssistantTurn, type AssistantTurn, type ChatEntry, type StreamStatus } from "../api";
 import { useStickyScroll } from "../hooks/use-sticky-scroll";
 import type { AskUserQuestionPendingState } from "../pages/ask-user-question";
 import { parseAskUserQuestionAnswerPayload } from "../pages/ask-user-question";
@@ -37,7 +37,7 @@ export default function ChatArea({ entries, runtimeStatus, loading, onFocusAgent
 
   let lastAskAssistantId: string | null = null;
   for (const entry of entries) {
-    if (entry.role === "assistant" && hasAskUserQuestionTool(entry as AssistantTurn)) {
+    if (isAssistantTurn(entry) && hasAskUserQuestionTool(entry)) {
       lastAskAssistantId = entry.id;
       continue;
     }
@@ -53,7 +53,7 @@ export default function ChatArea({ entries, runtimeStatus, loading, onFocusAgent
   if (askUserQuestion) {
     const pendingAssistant = [...entries]
       .reverse()
-      .find((entry): entry is AssistantTurn => entry.role === "assistant" && hasAskUserQuestionTool(entry as AssistantTurn));
+      .find((entry): entry is AssistantTurn => isAssistantTurn(entry) && hasAskUserQuestionTool(entry));
     if (pendingAssistant) {
       askUserQuestionDisplays.set(pendingAssistant.id, { mode: "pending", pending: askUserQuestion });
     }
@@ -69,7 +69,7 @@ export default function ChatArea({ entries, runtimeStatus, loading, onFocusAgent
             const isHidden = "showing" in entry && entry.showing === false;
             if (isHidden) return null;
             if (entry.role === "notice") {
-              return <NoticeBubble key={entry.id} entry={entry as NoticeMessage} onTaskNoticeClick={onTaskNoticeClick} />;
+              return <NoticeBubble key={entry.id} entry={entry} onTaskNoticeClick={onTaskNoticeClick} />;
             }
             if (entry.role === "user") {
               return (
@@ -78,18 +78,17 @@ export default function ChatArea({ entries, runtimeStatus, loading, onFocusAgent
                 </div>
               );
             }
-            const assistantEntry = entry as AssistantTurn;
-            const isStreamingThis = assistantEntry.streaming === true;
+            const isStreamingThis = entry.streaming === true;
             return (
               <div key={entry.id}>
                 <AssistantBlock
-                  entry={assistantEntry}
+                  entry={entry}
                   isStreamingThis={isStreamingThis}
                   runtimeStatus={isStreamingThis ? runtimeStatus : null}
                   onFocusAgent={onFocusAgent}
                   agentName={agentName}
                   agentAvatarUrl={agentAvatarUrl}
-                  askUserQuestion={askUserQuestionDisplays.get(assistantEntry.id)}
+                  askUserQuestion={askUserQuestionDisplays.get(entry.id)}
                 />
               </div>
             );

--- a/frontend/app/src/components/computer-panel/AgentsView.tsx
+++ b/frontend/app/src/components/computer-panel/AgentsView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
-import type { AssistantTurn, ToolStep } from "../../api";
+import { isAssistantTurn, type ToolStep } from "../../api";
 import { useThreadData } from "../../hooks/use-thread-data";
 import { useDisplayDeltas } from "../../hooks/use-display-deltas";
 import { useThreadStream } from "../../hooks/use-thread-stream";
@@ -73,8 +73,8 @@ export function AgentsView({ steps }: AgentsViewProps) {
   const flowItems = useMemo<FlowItem[]>(() => {
     const items: FlowItem[] = [];
     for (const entry of entries) {
-      if (entry.role !== "assistant") continue;
-      for (const seg of (entry as AssistantTurn).segments) {
+      if (!isAssistantTurn(entry)) continue;
+      for (const seg of entry.segments) {
         if (seg.type === "tool") {
           items.push({ type: "tool", step: seg.step, turnId: entry.id });
         } else if (seg.type === "text" && seg.content.trim()) {

--- a/frontend/app/src/hooks/use-display-deltas.ts
+++ b/frontend/app/src/hooks/use-display-deltas.ts
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import {
   cancelRun,
+  isAssistantTurn,
   postRun,
   type AssistantTurn,
   type ChatEntry,
@@ -71,9 +72,10 @@ function updateLastTurn(
   updater: (turn: AssistantTurn) => AssistantTurn,
 ): ChatEntry[] {
   for (let i = entries.length - 1; i >= 0; i--) {
-    if (entries[i].role === "assistant") {
+    const entry = entries[i];
+    if (isAssistantTurn(entry)) {
       const updated = [...entries];
-      updated[i] = updater(entries[i] as AssistantTurn);
+      updated[i] = updater(entry);
       return updated;
     }
   }

--- a/frontend/app/src/pages/ChatPage.tsx
+++ b/frontend/app/src/pages/ChatPage.tsx
@@ -3,8 +3,8 @@ import { useParams, useOutletContext, useLocation } from "react-router-dom";
 import { Check, ShieldAlert, X } from "lucide-react";
 import { toast } from "sonner";
 import ChatArea from "../components/ChatArea";
-import type { AssistantTurn, AskUserAnswer, AskUserQuestionPrompt, ChatEntry, PermissionRequest } from "../api";
-import { uploadSandboxFile } from "../api";
+import type { AskUserAnswer, AskUserQuestionPrompt, PermissionRequest } from "../api";
+import { isAssistantTurn, uploadSandboxFile } from "../api";
 import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { Button } from "../components/ui/button";
 import ComputerPanel from "../components/computer-panel";
@@ -38,10 +38,6 @@ function isAskUserQuestionRequest(
   request: PermissionRequest | null,
 ): request is PermissionRequest & { args: PermissionRequest["args"] & { questions: AskUserQuestionPrompt[] } } {
   return !!request && request.tool_name === "AskUserQuestion" && Array.isArray(request.args?.questions);
-}
-
-function isAssistantTurn(entry: ChatEntry): entry is AssistantTurn {
-  return entry.role === "assistant";
 }
 
 /** Thin wrapper: key={threadId} forces remount → all hook state resets naturally. */


### PR DESCRIPTION
## Summary\n- add one shared isAssistantTurn guard at the ChatEntry type boundary\n- reuse it in chat rendering, child-agent flow rendering, and display delta updates\n- remove duplicate/local assistant narrowing and casts\n\n## Verification\n- npm test -- ChatArea.test.tsx agent-shell-contract.test.tsx\n- npx eslint src/api/types.ts src/pages/ChatPage.tsx src/components/ChatArea.tsx src/components/computer-panel/AgentsView.tsx src/hooks/use-display-deltas.ts\n- npm run build