### PR TITLE
simplify: remove unsafe frontend lint debt

### DIFF
--- a/frontend/app/src/hooks/use-thread-manager.ts
+++ b/frontend/app/src/hooks/use-thread-manager.ts
@@ -82,8 +82,9 @@ export function useThreadManager(): ThreadManagerState & ThreadManagerActions {
       } catch {
         // ignore bootstrap errors in UI; user can retry by action
       } finally {
-        if (cancelled) return;
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     })();
 

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         changeOrigin: true,
         configure: (proxy) => {
           // Disable buffering for SSE responses
-          proxy.on("proxyRes", (proxyRes, _req, _res) => {
+          proxy.on("proxyRes", (proxyRes) => {
             if (proxyRes.headers["content-type"]?.includes("text/event-stream")) {
               // Ensure no compression/buffering on the proxy side
               proxyRes.headers["cache-control"] = "no-cache";


### PR DESCRIPTION
## Summary\n- remove a return from use-thread-manager's finally block\n- drop unused Vite proxy callback parameters\n\n## Verification\n- npx eslint src/hooks/use-thread-manager.ts vite.config.ts\n- npm test -- NewChatPage.test.tsx\n- npm run build\n- npm run lint now reports 5 remaining existing errors, down from the prior 9