### PR TITLE
simplify: close frontend lint debt

### DIFF
--- a/frontend/app/src/components/chat-area/NoticeBubble.tsx
+++ b/frontend/app/src/components/chat-area/NoticeBubble.tsx
@@ -174,7 +174,7 @@ function normalizeStatus(raw: string): ParsedNotice["status"] {
   return "pending";
 }
 
-export function parseNoticeContent(raw: string, notificationType?: NotificationType): ParsedNotice {
+function parseNoticeContent(raw: string, notificationType?: NotificationType): ParsedNotice {
   switch (notificationType) {
     case "steer":
       return parseSteer(raw);

--- a/frontend/app/src/components/chat-area/ThinkingIndicator.tsx
+++ b/frontend/app/src/components/chat-area/ThinkingIndicator.tsx
@@ -23,20 +23,20 @@ interface ThinkingIndicatorProps {
 
 export function ThinkingIndicator({ runtimeStatus }: ThinkingIndicatorProps) {
   const isBooting = !runtimeStatus;
+  const phase = isBooting ? "boot" : "thinking";
   const messages = isBooting ? BOOT_MESSAGES : THINKING_MESSAGES;
-  const [msgIdx, setMsgIdx] = useState(0);
-
-  // Reset index when switching between boot and thinking phases
-  useEffect(() => {
-    setMsgIdx(0);
-  }, [isBooting]);
+  const [messageState, setMessageState] = useState({ phase, index: 0 });
+  const msgIdx = messageState.phase === phase ? messageState.index : 0;
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setMsgIdx((prev) => (prev + 1) % messages.length);
+      setMessageState((prev) => ({
+        phase,
+        index: prev.phase === phase ? (prev.index + 1) % messages.length : 1 % messages.length,
+      }));
     }, 1400);
     return () => clearInterval(interval);
-  }, [messages]);
+  }, [phase, messages.length]);
 
   const tool = runtimeStatus?.current_tool;
   const orbClass = isBooting ? "thinking-orb thinking-orb-boot" : "thinking-orb";
@@ -53,7 +53,7 @@ export function ThinkingIndicator({ runtimeStatus }: ThinkingIndicatorProps) {
           使用 {tool}
         </span>
       ) : (
-        <span key={`${isBooting ? "boot" : "think"}-${msgIdx}`} className="text-xs text-muted-foreground animate-fade-in">
+        <span key={`${phase}-${msgIdx}`} className="text-xs text-muted-foreground animate-fade-in">
           {messages[msgIdx]}
         </span>
       )}

--- a/frontend/app/src/components/ui/button.tsx
+++ b/frontend/app/src/components/ui/button.tsx
@@ -59,4 +59,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { ArrowLeft, Zap, Users, RefreshCw } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
@@ -12,32 +12,53 @@ export default function LibraryItemDetailPage() {
   const fetchLibrary = useAppStore((s) => s.fetchLibrary);
   const fetchResourceContent = useAppStore((s) => s.fetchResourceContent);
 
-  const [item, setItem] = useState<ResourceItem | null>(null);
-  const [content, setContent] = useState("");
-  const [loading, setLoading] = useState(true);
+  const contentKey = type && id ? `${type}:${id}` : "";
+  const [contentState, setContentState] = useState<{ key: string; content: string; error: string | null }>({
+    key: "",
+    content: "",
+    error: null,
+  });
 
   useEffect(() => {
     if (!type || !id) return;
     fetchLibrary(type === "skill" ? "skill" : "agent");
   }, [type, id, fetchLibrary]);
 
-  useEffect(() => {
-    if (!type || !id) return;
+  const item = useMemo<ResourceItem | null>(() => {
+    if (!type || !id) return null;
     const list = type === "skill" ? librarySkills : libraryAgents;
-    const found = list.find((i) => i.id === id);
-    if (found) setItem(found);
+    return list.find((i) => i.id === id) ?? null;
   }, [librarySkills, libraryAgents, type, id]);
 
   useEffect(() => {
     if (!type || !id) return;
-    setLoading(true);
+    const key = `${type}:${id}`;
+    let cancelled = false;
     fetchResourceContent(type, id)
-      .then(setContent)
-      .finally(() => setLoading(false));
+      .then((content) => {
+        if (!cancelled) {
+          setContentState({ key, content, error: null });
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setContentState({
+            key,
+            content: "",
+            error: err instanceof Error ? err.message : "加载失败",
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [type, id, fetchResourceContent]);
 
   const isSkill = type === "skill";
   const filename = isSkill ? "SKILL.md" : "agent.md";
+  const loading = !!contentKey && contentState.key !== contentKey;
+  const content = contentState.key === contentKey ? contentState.content : "";
+  const error = contentState.key === contentKey ? contentState.error : null;
 
   if (!item && !loading) {
     return (
@@ -90,6 +111,8 @@ export default function LibraryItemDetailPage() {
             <div className="flex items-center justify-center py-8">
               <RefreshCw className="w-4 h-4 animate-spin text-muted-foreground" />
             </div>
+          ) : error ? (
+            <p className="text-sm text-destructive text-center py-6">{error}</p>
           ) : content ? (
             <pre className="text-xs text-foreground whitespace-pre-wrap font-mono leading-relaxed max-h-[600px] overflow-y-auto">
               {content}


### PR DESCRIPTION
## Summary\n- make notice parsing internal and stop exporting unused button variants\n- remove synchronous setState-in-effect patterns from ThinkingIndicator and library detail loading\n- make npm run lint pass locally without suppressions\n\n## Verification\n- npm run lint\n- npm test -- ChatArea.test.tsx agent-shell-contract.test.tsx\n- npm run build