### PR TITLE
simplify: validate backend pyright boundaries

### DIFF
--- a/backend/web/services/display_builder.py
+++ b/backend/web/services/display_builder.py
@@ -586,6 +586,8 @@ def _handle_tool_result(td: ThreadDisplay, data: dict) -> dict | None:
         return None
 
     tc_id = data.get("tool_call_id")
+    if not isinstance(tc_id, str) or not tc_id:
+        return None
     result = data.get("content", "")
     metadata = data.get("metadata") or {}
 

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -48,7 +48,10 @@ def _resolve_run_event_repo(agent: Any) -> RunEventRepo:
     run_event_repo = getattr(storage_container, "run_event_repo", None)
     if not callable(run_event_repo):
         raise RuntimeError("streaming_service requires agent.storage_container.run_event_repo()")
-    return run_event_repo()
+    repo = run_event_repo()
+    if not isinstance(repo, RunEventRepo):
+        raise RuntimeError("agent.storage_container.run_event_repo() returned an invalid repo")
+    return repo
 
 
 def _augment_system_prompt_for_terminal_followthrough(system_prompt: Any) -> Any:
@@ -143,6 +146,8 @@ async def write_cancellation_markers(
         if not callable(get_next_version):
             raise RuntimeError("Checkpointer missing get_next_version; cannot write cancellation markers honestly")
         next_message_version = get_next_version(current_versions.get("messages"), None)
+        if not isinstance(next_message_version, str | int | float):
+            raise RuntimeError("Checkpointer returned an invalid messages channel version")
         new_versions = {"messages": next_message_version}
         new_checkpoint["channel_versions"] = {**current_versions, **new_versions}
         new_checkpoint["updated_channels"] = list(new_versions)

--- a/backend/web/services/thread_runtime_convergence.py
+++ b/backend/web/services/thread_runtime_convergence.py
@@ -76,11 +76,15 @@ def summarize_owner_thread_runtime(app: Any, thread_ids: list[str]) -> dict[str,
         raise RuntimeError("terminal_repo must support summarize_threads for owner runtime convergence")
 
     summary = summarize_threads(thread_ids)
+    if not isinstance(summary, dict):
+        raise RuntimeError("terminal_repo.summarize_threads must return a dict")
     states: dict[str, str] = {}
     for thread_id in thread_ids:
         item = summary.get(thread_id)
         if item is None:
             continue
+        if not isinstance(item, dict):
+            raise RuntimeError("terminal_repo.summarize_threads returned an invalid summary item")
 
         active_terminal_id = str(item.get("active_terminal_id") or "").strip()
         latest_terminal_id = str(item.get("latest_terminal_id") or "").strip()

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -458,6 +458,7 @@ class CheckpointRepo(Protocol):
     def delete_checkpoints_by_ids(self, thread_id: str, checkpoint_ids: list[str]) -> None: ...
 
 
+@runtime_checkable
 class RunEventRepo(Protocol):
     def close(self) -> None: ...
     def append_event(

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -147,7 +147,18 @@ class _VersionedCheckpointSaver:
 
 
 def _fake_storage_container() -> SimpleNamespace:
-    return SimpleNamespace(run_event_repo=lambda: SimpleNamespace(close=lambda: None))
+    repo = SimpleNamespace(
+        close=lambda: None,
+        append_event=lambda _thread_id, _run_id, _event_type, _data, message_id=None: 0,
+        list_events=lambda _thread_id, _run_id, *, after=0, limit=200: [],
+        latest_seq=lambda _thread_id: 0,
+        latest_run_id=lambda _thread_id: None,
+        list_run_ids=lambda _thread_id: [],
+        run_start_seq=lambda _thread_id, _run_id: 0,
+        delete_runs=lambda _thread_id, _run_ids: 0,
+        delete_thread_events=lambda _thread_id: 0,
+    )
+    return SimpleNamespace(run_event_repo=lambda: repo)
 
 
 def _make_app() -> SimpleNamespace:


### PR DESCRIPTION
## Summary\n- validate injected run event repos against a runtime-checkable storage contract\n- validate checkpoint channel versions and terminal summary shapes at dynamic boundaries\n- avoid nullable tool_result ids flowing into display-builder helper code\n\n## Verification\n- uv run pyright backend/web storage/contracts.py\n- uv run ruff check backend/web/services/streaming_service.py backend/web/services/display_builder.py backend/web/services/thread_runtime_convergence.py storage/contracts.py tests/Unit/backend/web/services/test_streaming_eval_writer.py\n- uv run pytest tests/Unit/backend/web/services/test_thread_runtime_convergence.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q\n- uv run pytest tests/Integration/test_child_thread_live_bridge.py tests/Integration/test_query_loop_backend_bridge.py -q