### PR TITLE
simplify: make sandbox status load honest

### DIFF
--- a/frontend/app/src/hooks/use-thread-data.test.tsx
+++ b/frontend/app/src/hooks/use-thread-data.test.tsx
@@ -22,8 +22,8 @@ afterEach(() => {
   window.history.replaceState({}, "", "/");
 });
 
-function Harness({ threadId }: { threadId?: string }) {
-  const state = useThreadData(threadId);
+function Harness({ threadId, skipInitialLoad = false }: { threadId?: string; skipInitialLoad?: boolean }) {
+  const state = useThreadData(threadId, skipInitialLoad);
   useEffect(() => {
     void state.loading;
   }, [state.loading]);
@@ -48,6 +48,22 @@ describe("useThreadData", () => {
     await Promise.resolve();
 
     expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("logs skipped initial sandbox load failures while still on the thread route", async () => {
+    window.history.replaceState({}, "", "/chat/hire/thread/thread-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    getThread.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    render(<Harness threadId="thread-1" skipInitialLoad />);
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[useThreadData] Failed to load sandbox status:",
+        expect.any(TypeError),
+      );
+    });
     consoleError.mockRestore();
   });
 });

--- a/frontend/app/src/hooks/use-thread-data.ts
+++ b/frontend/app/src/hooks/use-thread-data.ts
@@ -82,10 +82,14 @@ export function useThreadData(threadId: string | undefined, skipInitialLoad = fa
       // @@@skip-entries-not-sandbox — skipInitialLoad skips ENTRIES (to avoid
       // overwriting optimistic entries), but we still need sandbox status so
       // TaskProgress shows the correct indicator from the start.
-      loadThreadDetail(threadId).then(thread => {
-        const sandbox = thread.sandbox;
-        setActiveSandbox(sandbox && typeof sandbox === "object" ? (sandbox as SandboxInfo) : null);
-      }).catch(() => {});
+      loadThreadDetail(threadId)
+        .then((thread) => {
+          setActiveSandbox(thread.sandbox);
+        })
+        .catch((err: unknown) => {
+          if (!isActiveThreadRoute(threadId)) return;
+          console.error("[useThreadData] Failed to load sandbox status:", err);
+        });
       return;
     }
     void loadThread(threadId);


### PR DESCRIPTION
## Summary\n- remove redundant SandboxInfo cast from useThreadData\n- replace empty skipInitialLoad sandbox-status catch with route-aware error logging\n- add a focused hook test for the failure path\n\n## Verification\n- npm test -- use-thread-data.test.tsx\n- npx eslint src/hooks/use-thread-data.ts src/hooks/use-thread-data.test.tsx\n- npm run build\n- npm run lint