### PR TITLE
simplify: guard sse event parsing

### DIFF
--- a/frontend/app/src/api/sse-processor.ts
+++ b/frontend/app/src/api/sse-processor.ts
@@ -1,10 +1,14 @@
 import type { StreamEvent, StreamEventType } from "./types";
 import { STREAM_EVENT_TYPES } from "./types";
 
-const VALID_EVENT_TYPES = new Set<string>(STREAM_EVENT_TYPES);
+const VALID_EVENT_TYPES: ReadonlySet<string> = new Set(STREAM_EVENT_TYPES);
+
+function isStreamEventType(raw: string): raw is StreamEventType {
+  return VALID_EVENT_TYPES.has(raw);
+}
 
 function normalizeStreamType(raw: string): StreamEventType {
-  if (VALID_EVENT_TYPES.has(raw)) return raw as StreamEventType;
+  if (isStreamEventType(raw)) return raw;
   console.warn(`[SSE] Unknown event type: "${raw}", falling back to "text"`);
   return "text";
 }
@@ -17,9 +21,13 @@ function tryParse(value: string): unknown {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function extractSeq(data: unknown): number | undefined {
-  if (typeof data === "object" && data !== null) {
-    const seq = (data as Record<string, unknown>)._seq;
+  if (isRecord(data)) {
+    const seq = data._seq;
     if (typeof seq === "number") return seq;
   }
   return undefined;

--- a/frontend/app/src/api/streaming.test.ts
+++ b/frontend/app/src/api/streaming.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StreamEvent } from "./types";
 
 const authFetch = vi.fn();
 
@@ -46,9 +47,14 @@ describe("streaming api contract", () => {
       },
     });
     authFetch.mockResolvedValue(new Response(body));
+    const events: StreamEvent[] = [];
 
-    await api.streamThreadEvents("thread-1", () => ac.abort(), ac.signal, 7);
+    await api.streamThreadEvents("thread-1", (event) => {
+      events.push(event);
+      ac.abort();
+    }, ac.signal, 7);
 
     expect(authFetch).toHaveBeenCalledWith("/api/threads/thread-1/events?after=7", { signal: ac.signal });
+    expect(events).toEqual([{ type: "status", data: { _seq: 8 } }]);
   });
 });


### PR DESCRIPTION
## Summary
- replace SSE event type and sequence casts with explicit type guards
- extend streaming contract test to assert parsed event dispatch

## Verification
- npm test -- streaming.test.ts
- npx eslint src/api/sse-processor.ts src/api/streaming.test.ts
- npm run build
- npm run lint