### PR TITLE
simplify: normalize auth fetch headers

### DIFF
--- a/frontend/app/src/store/auth-store.test.ts
+++ b/frontend/app/src/store/auth-store.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("authFetch header contract", () => {
+  let authFetch: typeof import("./auth-store").authFetch;
+  let useAuthStore: typeof import("./auth-store").useAuthStore;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    vi.stubGlobal("localStorage", storage);
+    vi.stubGlobal("window", { __MYCEL_CONFIG__: {}, localStorage: storage });
+
+    ({ authFetch, useAuthStore } = await import("./auth-store"));
+    useAuthStore.setState({
+      token: "token-1",
+      user: null,
+      agent: null,
+      userId: null,
+      setupInfo: null,
+      login: vi.fn(),
+      sendOtp: vi.fn(),
+      verifyOtp: vi.fn(),
+      completeRegister: vi.fn(),
+      clearSetupInfo: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
+  it("preserves HeadersInit while adding auth and JSON defaults", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authFetch("/api/settings", {
+      headers: new Headers([["X-Trace-Id", "trace-1"]]),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+    expect(headers.get("X-Trace-Id")).toBe("trace-1");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Authorization")).toBe("Bearer token-1");
+  });
+
+  it("does not force JSON content type for FormData uploads", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authFetch("/api/upload", {
+      method: "POST",
+      body: new FormData(),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+    expect(headers.get("Content-Type")).toBeNull();
+    expect(headers.get("Authorization")).toBe("Bearer token-1");
+  });
+});

--- a/frontend/app/src/store/auth-store.ts
+++ b/frontend/app/src/store/auth-store.ts
@@ -116,14 +116,18 @@ export const useAuthStore = create<AuthState>()(
 /**
  * Fetch with Bearer token. On 401, clears auth.
  */
+function buildAuthHeaders(init: RequestInit | undefined, token: string | null): Headers {
+  const headers = new Headers(init?.headers);
+  if (!(init?.body instanceof FormData) && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  return headers;
+}
+
 export async function authFetch(url: string, init?: RequestInit): Promise<Response> {
   const token = useAuthStore.getState().token;
-  const isFormData = init?.body instanceof FormData;
-  const headers: Record<string, string> = {
-    ...(isFormData ? {} : { "Content-Type": "application/json" }),
-    ...(init?.headers as Record<string, string> ?? {}),
-  };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const headers = buildAuthHeaders(init, token);
 
   // Prepend API_BASE for relative URLs when configured
   const resolvedUrl = API_BASE && url.startsWith("/") ? `${API_BASE}${url}` : url;


### PR DESCRIPTION
## Summary
- replace authFetch HeadersInit record cast with native Headers normalization
- preserve caller headers across Headers/tuple/object shapes
- keep JSON default off for FormData uploads and cover the contract

## Verification
- npm test -- auth-store.test.ts app-store.test.ts client.test.ts
- npx eslint src/store/auth-store.ts src/store/auth-store.test.ts
- npm run build
- npm run lint