### PR TITLE
simplify: share frontend record guard

### DIFF
--- a/frontend/app/src/components/chat-area/utils.ts
+++ b/frontend/app/src/components/chat-area/utils.ts
@@ -1,4 +1,5 @@
 import type { ToolStep } from "../../api";
+import { asRecord } from "../../lib/records";
 
 export function formatTime(ts?: number): string {
   if (!ts) return "";
@@ -7,7 +8,7 @@ export function formatTime(ts?: number): string {
 }
 
 export function getStepSummary(step: ToolStep): string {
-  const args = step.args as Record<string, unknown> | null;
+  const args = asRecord(step.args);
   if (!args) return step.name;
 
   // Agent tool: show description (PascalCase from backend)
@@ -57,7 +58,7 @@ export function getStepSummary(step: ToolStep): string {
 export function getStepResultSummary(step: ToolStep): string | null {
   if (!step.result) return null;
 
-  const args = step.args as Record<string, unknown> | null;
+  const args = asRecord(step.args);
   const result = step.result.trim();
 
   // Read: count lines

--- a/frontend/app/src/components/computer-panel/utils.ts
+++ b/frontend/app/src/components/computer-panel/utils.ts
@@ -1,4 +1,5 @@
 import type { ChatEntry, ToolStep, SandboxFileEntry } from "../../api";
+import { asRecord } from "../../lib/records";
 import type { TreeNode } from "./types";
 
 /* ── Flow types for message-flow panel ── */
@@ -40,27 +41,23 @@ export function extractAgentSteps(entries: ChatEntry[]): ToolStep[] {
 }
 
 export function parseCommandArgs(args: unknown): { command?: string; cwd?: string; description?: string } {
-  if (args && typeof args === "object") {
-    const a = args as Record<string, unknown>;
-    return {
-      command: a.command as string | undefined,
-      cwd: a.cwd as string | undefined,
-      description: a.description as string | undefined,
-    };
-  }
-  return {};
+  const a = asRecord(args);
+  if (!a) return {};
+  return {
+    command: a.command as string | undefined,
+    cwd: a.cwd as string | undefined,
+    description: a.description as string | undefined,
+  };
 }
 
 export function parseAgentArgs(args: unknown): { description?: string; prompt?: string; subagent_type?: string } {
-  if (args && typeof args === "object") {
-    const a = args as Record<string, unknown>;
-    return {
-      description: (a.Description ?? a.description) as string | undefined,
-      prompt: (a.Prompt ?? a.prompt) as string | undefined,
-      subagent_type: (a.SubagentType ?? a.subagent_type) as string | undefined,
-    };
-  }
-  return {};
+  const a = asRecord(args);
+  if (!a) return {};
+  return {
+    description: (a.Description ?? a.description) as string | undefined,
+    prompt: (a.Prompt ?? a.prompt) as string | undefined,
+    subagent_type: (a.SubagentType ?? a.subagent_type) as string | undefined,
+  };
 }
 
 export function buildTreeNodes(entries: SandboxFileEntry[], parentPath: string): TreeNode[] {

--- a/frontend/app/src/components/tool-renderers/BashRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/BashRenderer.tsx
@@ -1,17 +1,16 @@
 import { Check, Copy } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import type { ToolRendererProps } from "./types";
+import { asRecord } from "@/lib/records";
 import { FEEDBACK_BRIEF } from "@/styles/ux-timing";
 
 function parseArgs(args: unknown): { command?: string; description?: string } {
-  if (args && typeof args === "object") {
-    const a = args as Record<string, unknown>;
-    return {
-      command: a.command as string | undefined,
-      description: a.description as string | undefined,
-    };
-  }
-  return {};
+  const a = asRecord(args);
+  if (!a) return {};
+  return {
+    command: a.command as string | undefined,
+    description: a.description as string | undefined,
+  };
 }
 
 function CopyInline({ text }: { text: string }) {

--- a/frontend/app/src/components/tool-renderers/DefaultRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/DefaultRenderer.tsx
@@ -1,11 +1,12 @@
 import { memo } from "react";
 import type { ToolRendererProps } from "./types";
+import { asRecord } from "@/lib/records";
 
 function summarizeArgs(args: unknown): string {
   if (!args) return "";
   if (typeof args === "string") return args.slice(0, 80);
-  if (typeof args === "object") {
-    const obj = args as Record<string, unknown>;
+  const obj = asRecord(args);
+  if (obj) {
     const keys = Object.keys(obj);
     if (keys.length === 0) return "";
     // Show first meaningful value

--- a/frontend/app/src/components/tool-renderers/TaskRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/TaskRenderer.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from "react";
 import { useParams } from "react-router-dom";
 import type { ToolRendererProps } from "./types";
+import { asRecord } from "@/lib/records";
 
 function parseArgs(args: unknown): {
   description?: string;
@@ -10,18 +11,16 @@ function parseArgs(args: unknown): {
   status?: string;
   subagent_type?: string;
 } {
-  if (args && typeof args === "object") {
-    const a = args as Record<string, unknown>;
-    return {
-      description: (a.Description ?? a.description) as string | undefined,
-      prompt: (a.Prompt ?? a.prompt) as string | undefined,
-      subject: (a.subject ?? a.Subject) as string | undefined,
-      taskId: (a.taskId ?? a.TaskId) as string | undefined,
-      status: (a.status ?? a.Status) as string | undefined,
-      subagent_type: (a.SubagentType ?? a.subagent_type) as string | undefined,
-    };
-  }
-  return {};
+  const a = asRecord(args);
+  if (!a) return {};
+  return {
+    description: (a.Description ?? a.description) as string | undefined,
+    prompt: (a.Prompt ?? a.prompt) as string | undefined,
+    subject: (a.subject ?? a.Subject) as string | undefined,
+    taskId: (a.taskId ?? a.TaskId) as string | undefined,
+    status: (a.status ?? a.Status) as string | undefined,
+    subagent_type: (a.SubagentType ?? a.subagent_type) as string | undefined,
+  };
 }
 
 function getTaskLabel(name: string, args: ReturnType<typeof parseArgs>): string {

--- a/frontend/app/src/hooks/use-background-tasks.ts
+++ b/frontend/app/src/hooks/use-background-tasks.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { UseThreadStreamResult } from './use-thread-stream';
 import type { StreamEvent } from '../api/types';
+import { asRecord } from '../lib/records';
 
 export interface BackgroundTask {
   task_id: string;
@@ -28,8 +29,8 @@ interface BackgroundTaskEventData {
 const threadTasksInflight = new Map<string, Promise<BackgroundTask[]>>();
 
 function isBackgroundTaskEventData(data: unknown): data is BackgroundTaskEventData {
-  if (!data || typeof data !== "object") return false;
-  const value = data as Record<string, unknown>;
+  const value = asRecord(data);
+  if (!value) return false;
   return value.background === true && typeof value.task_id === "string";
 }
 

--- a/frontend/app/src/lib/records.ts
+++ b/frontend/app/src/lib/records.ts
@@ -1,0 +1,3 @@
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" ? value as Record<string, unknown> : null;
+}


### PR DESCRIPTION
## Summary
- add a small shared asRecord guard for unknown object reads
- replace repeated local unknown-to-record casts in chat/tool/computer display utilities
- keep behavior unchanged and avoid adding new test files

## Verification
- npm test -- ChatArea.test.tsx agent-shell-contract.test.tsx use-display-deltas.test.tsx
- npx eslint src/lib/records.ts src/hooks/use-background-tasks.ts src/components/tool-renderers/BashRenderer.tsx src/components/tool-renderers/TaskRenderer.tsx src/components/tool-renderers/DefaultRenderer.tsx src/components/computer-panel/utils.ts src/components/chat-area/utils.ts
- npm run build
- npm run lint