### PR TITLE
simplify: narrow metric freshness parse errors

### DIFF
--- a/backend/web/services/resource_common.py
+++ b/backend/web/services/resource_common.py
@@ -112,7 +112,7 @@ def _to_metric_freshness(collected_at: str | None) -> str:
         return "stale"
     try:
         parsed = datetime.fromisoformat(raw)
-    except Exception:
+    except ValueError:
         return "stale"
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)


### PR DESCRIPTION
## Summary
- narrow metric timestamp parsing from broad Exception to ValueError
- keep invalid timestamps mapped to stale while letting unrelated errors surface

## Verification
- uv run ruff check backend/web/services/resource_common.py tests/Unit/backend/web/services/test_resource_common.py
- uv run pytest tests/Unit/backend/web/services/test_resource_common.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -q
- uv run pyright backend/web/services/resource_common.py
- uv run ruff check backend/web
- uv run pyright backend/web storage/contracts.py