### PR TITLE
simplify: guard frontend input params

### DIFF
--- a/frontend/app/src/pages/ChatPage.tsx
+++ b/frontend/app/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ import { useDisplayDeltas } from "../hooks/use-display-deltas";
 import { useThreadData } from "../hooks/use-thread-data";
 import { useThreadPermissions } from "../hooks/use-thread-permissions";
 import { useThreadStream } from "../hooks/use-thread-stream";
+import { asRecord } from "../lib/records";
 import type { PermissionRuleBehavior } from "../api";
 import type { ThreadManagerState, ThreadManagerActions } from "../hooks/use-thread-manager";
 
@@ -217,9 +218,7 @@ function ChatPageInner({ threadId }: { threadId: string }) {
         "allow",
         undefined,
         answers,
-        typeof currentPermissionRequest.args.annotations === "object" && currentPermissionRequest.args.annotations !== null
-          ? currentPermissionRequest.args.annotations as Record<string, unknown>
-          : undefined,
+        asRecord(currentPermissionRequest.args.annotations) ?? undefined,
       );
       await refreshThread();
       toast.success("已提交回答，Leon 会继续当前任务");

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -19,6 +19,14 @@ type InstalledAgentUser = Agent & {
   };
 };
 
+function isTab(value: string | null): value is Tab {
+  return value === "explore" || value === "installed";
+}
+
+function isInstalledSubTab(value: string | null): value is InstalledSubTab {
+  return value === "member" || value === "skill" || value === "agent";
+}
+
 const typeFilters: { id: TypeFilter; label: string }[] = [
   { id: "all", label: "All" },
   { id: "member", label: "Member" },
@@ -38,8 +46,10 @@ export default function MarketplacePage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const tab = (searchParams.get("tab") as Tab) || "explore";
-  const installedSubTab = (searchParams.get("sub") as InstalledSubTab) || "member";
+  const rawTab = searchParams.get("tab");
+  const rawInstalledSubTab = searchParams.get("sub");
+  const tab = isTab(rawTab) ? rawTab : "explore";
+  const installedSubTab = isInstalledSubTab(rawInstalledSubTab) ? rawInstalledSubTab : "member";
 
   const setTab = (t: Tab) => setSearchParams((p) => { p.set("tab", t); p.delete("sub"); return p; }, { replace: true });
   const setInstalledSubTab = (s: InstalledSubTab) => setSearchParams((p) => { p.set("sub", s); return p; }, { replace: true });

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -65,4 +65,16 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.getAllByRole("button", { name: /Agent/ }).length).toBeGreaterThan(0);
     expect(screen.getByText("暂无已安装的 Agent")).toBeTruthy();
   });
+
+  it("falls back to explore for invalid tab params", () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=unknown&sub=ghost"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Explore" })).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- reuse asRecord for AskUserQuestion annotations in ChatPage
- replace Marketplace tab query casts with explicit guards
- add a focused invalid query param contract test

## Verification
- npm test -- MarketplacePage.wording.test.tsx
- npx eslint src/pages/ChatPage.tsx src/pages/MarketplacePage.tsx src/pages/MarketplacePage.wording.test.tsx src/lib/records.ts
- npm run build
- npm run lint