### PR TITLE
simplify: guard chat event payloads

### DIFF
--- a/frontend/app/src/api/chat-events.test.ts
+++ b/frontend/app/src/api/chat-events.test.ts
@@ -50,4 +50,36 @@ describe("chat event stream", () => {
       { type: "typing_start", data: { user_id: "agent-1" } },
     ]);
   });
+
+  it("parses chat message and typing event data at the API boundary", () => {
+    expect(api.parseChatMessageEventData({
+      id: "msg-1",
+      chat_id: "chat-1",
+      sender_id: "agent-1",
+      sender_name: "Toad",
+      content: "hello",
+      mentioned_ids: ["user-1"],
+      created_at: 1,
+    })).toEqual({
+      id: "msg-1",
+      chat_id: "chat-1",
+      sender_id: "agent-1",
+      sender_name: "Toad",
+      content: "hello",
+      mentioned_ids: ["user-1"],
+      created_at: 1,
+    });
+    expect(api.parseChatTypingUserId({ user_id: "agent-1" })).toBe("agent-1");
+    expect(api.parseChatTypingUserId({})).toBeNull();
+    expect(() => api.parseChatMessageEventData({ id: "msg-1" })).toThrow("chat_id must be a string");
+    expect(() => api.parseChatMessageEventData({
+      id: "msg-1",
+      chat_id: "chat-1",
+      sender_id: "agent-1",
+      sender_name: "Toad",
+      content: "hello",
+      mentioned_ids: ["user-1", 7],
+      created_at: 1,
+    })).toThrow("mentioned_ids must be a string array");
+  });
 });

--- a/frontend/app/src/api/chat-events.ts
+++ b/frontend/app/src/api/chat-events.ts
@@ -1,8 +1,54 @@
 import { authFetch } from "../store/auth-store";
+import { asRecord } from "../lib/records";
+import type { ChatMessage } from "./types";
 
 export interface ChatStreamEvent {
   type: string;
   data: unknown;
+}
+
+function requiredString(value: Record<string, unknown>, key: string): string {
+  const field = value[key];
+  if (typeof field !== "string") {
+    throw new Error(`Malformed chat message event: ${key} must be a string`);
+  }
+  return field;
+}
+
+function requiredNumber(value: Record<string, unknown>, key: string): number {
+  const field = value[key];
+  if (typeof field !== "number") {
+    throw new Error(`Malformed chat message event: ${key} must be a number`);
+  }
+  return field;
+}
+
+function requiredStringArray(value: Record<string, unknown>, key: string): string[] {
+  const field = value[key];
+  if (!Array.isArray(field) || field.some((item) => typeof item !== "string")) {
+    throw new Error(`Malformed chat message event: ${key} must be a string array`);
+  }
+  return field;
+}
+
+export function parseChatMessageEventData(data: unknown): ChatMessage {
+  const value = asRecord(data);
+  if (!value) throw new Error("Malformed chat message event: data must be an object");
+  return {
+    id: requiredString(value, "id"),
+    chat_id: requiredString(value, "chat_id"),
+    sender_id: requiredString(value, "sender_id"),
+    sender_name: requiredString(value, "sender_name"),
+    content: requiredString(value, "content"),
+    mentioned_ids: requiredStringArray(value, "mentioned_ids"),
+    created_at: requiredNumber(value, "created_at"),
+  };
+}
+
+export function parseChatTypingUserId(data: unknown): string | null {
+  const value = asRecord(data);
+  const userId = value?.user_id;
+  return typeof userId === "string" && userId ? userId : null;
 }
 
 function parseEvent(raw: string): ChatStreamEvent | null {

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router-dom";
 import { PanelLeft, Send } from "lucide-react";
 import { authFetch, useAuthStore } from "../store/auth-store";
-import { streamChatEvents } from "../api/chat-events";
+import { parseChatMessageEventData, parseChatTypingUserId, streamChatEvents } from "../api/chat-events";
 import { UserBubble } from "../components/chat-area/UserBubble";
 import { ChatBubble } from "../components/chat-area/ChatBubble";
 import type { ChatMember, ChatMessage, ChatDetail } from "../api/types";
@@ -122,7 +122,7 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
       chatId,
       (event) => {
         if (event.type === "message") {
-          const msg = event.data as ChatMessage;
+          const msg = parseChatMessageEventData(event.data);
           setMessages(prev => {
             // Skip if we already have this exact message id
             if (prev.some(m => m.id === msg.id)) return prev;
@@ -146,14 +146,12 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
           return;
         }
         if (event.type === "typing_start") {
-          const data = event.data as { user_id?: string };
-          const userId = data.user_id;
+          const userId = parseChatTypingUserId(event.data);
           if (userId) setTypingEntities(prev => new Set([...prev, userId]));
           return;
         }
         if (event.type === "typing_stop") {
-          const data = event.data as { user_id?: string };
-          const userId = data.user_id;
+          const userId = parseChatTypingUserId(event.data);
           if (!userId) return;
           setTypingEntities(prev => {
             const next = new Set(prev);


### PR DESCRIPTION
## Summary
- move chat SSE message/typing payload parsing into api/chat-events
- remove ChatConversationPage event.data casts
- fail loudly on malformed chat message payloads

## Verification
- npm test -- chat-events.test.ts
- npx eslint src/api/chat-events.ts src/api/chat-events.test.ts src/pages/ChatConversationPage.tsx src/lib/records.ts
- npm run build
- npm run lint