### PR TITLE
simplify: read tool renderer args through helpers

### DIFF
--- a/frontend/app/src/components/tool-renderers/EditFileRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/EditFileRenderer.tsx
@@ -1,10 +1,16 @@
 import { memo } from "react";
 import type { ToolRendererProps } from "./types";
 import { DiffBlock } from "../shared/DiffBlock";
+import { asRecord, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): { file_path?: string; old_string?: string; new_string?: string } {
-  if (args && typeof args === "object") return args as { file_path?: string; old_string?: string; new_string?: string };
-  return {};
+  const record = asRecord(args);
+  if (!record) return {};
+  return {
+    file_path: recordString(record, "file_path"),
+    old_string: recordString(record, "old_string"),
+    new_string: recordString(record, "new_string"),
+  };
 }
 
 export default memo(function EditFileRenderer({ step, expanded }: ToolRendererProps) {

--- a/frontend/app/src/components/tool-renderers/ListDirRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/ListDirRenderer.tsx
@@ -1,10 +1,15 @@
 import { memo } from "react";
 import type { ToolRendererProps } from "./types";
 import { CodeBlock } from "../shared/CodeBlock";
+import { asRecord, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): { path?: string; dir_path?: string } {
-  if (args && typeof args === "object") return args as { path?: string; dir_path?: string };
-  return {};
+  const record = asRecord(args);
+  if (!record) return {};
+  return {
+    path: recordString(record, "path"),
+    dir_path: recordString(record, "dir_path"),
+  };
 }
 
 export default memo(function ListDirRenderer({ step, expanded }: ToolRendererProps) {

--- a/frontend/app/src/components/tool-renderers/ReadFileRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/ReadFileRenderer.tsx
@@ -2,10 +2,16 @@ import { memo } from "react";
 import type { ToolRendererProps } from "./types";
 import { CodeBlock } from "../shared/CodeBlock";
 import { inferLanguage } from "../shared/utils";
+import { asRecord, recordNumber, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): { file_path?: string; limit?: number; offset?: number } {
-  if (args && typeof args === "object") return args as { file_path?: string; limit?: number; offset?: number };
-  return {};
+  const record = asRecord(args);
+  if (!record) return {};
+  return {
+    file_path: recordString(record, "file_path"),
+    limit: recordNumber(record, "limit"),
+    offset: recordNumber(record, "offset"),
+  };
 }
 
 export default memo(function ReadFileRenderer({ step, expanded }: ToolRendererProps) {

--- a/frontend/app/src/components/tool-renderers/SearchRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/SearchRenderer.tsx
@@ -1,10 +1,16 @@
 import { memo } from "react";
 import type { ToolRendererProps } from "./types";
 import { CodeBlock } from "../shared/CodeBlock";
+import { asRecord, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): { pattern?: string; path?: string; glob?: string } {
-  if (args && typeof args === "object") return args as { pattern?: string; path?: string; glob?: string };
-  return {};
+  const record = asRecord(args);
+  if (!record) return {};
+  return {
+    pattern: recordString(record, "pattern"),
+    path: recordString(record, "path"),
+    glob: recordString(record, "glob"),
+  };
 }
 
 // Parse search result lines to find which display lines are actual matches.

--- a/frontend/app/src/components/tool-renderers/WebRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/WebRenderer.tsx
@@ -1,10 +1,16 @@
 import { memo } from "react";
 import type { ToolRendererProps } from "./types";
 import { CodeBlock } from "../shared/CodeBlock";
+import { asRecord, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): { url?: string; query?: string; prompt?: string } {
-  if (args && typeof args === "object") return args as { url?: string; query?: string; prompt?: string };
-  return {};
+  const record = asRecord(args);
+  if (!record) return {};
+  return {
+    url: recordString(record, "url"),
+    query: recordString(record, "query"),
+    prompt: recordString(record, "prompt"),
+  };
 }
 
 export default memo(function WebRenderer({ step, expanded }: ToolRendererProps) {

--- a/frontend/app/src/components/tool-renderers/WriteFileRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/WriteFileRenderer.tsx
@@ -2,10 +2,15 @@ import { memo } from "react";
 import type { ToolRendererProps } from "./types";
 import { CodeBlock } from "../shared/CodeBlock";
 import { inferLanguage } from "../shared/utils";
+import { asRecord, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): { file_path?: string; content?: string } {
-  if (args && typeof args === "object") return args as { file_path?: string; content?: string };
-  return {};
+  const record = asRecord(args);
+  if (!record) return {};
+  return {
+    file_path: recordString(record, "file_path"),
+    content: recordString(record, "content"),
+  };
 }
 
 export default memo(function WriteFileRenderer({ step, expanded }: ToolRendererProps) {

--- a/frontend/app/src/lib/records.ts
+++ b/frontend/app/src/lib/records.ts
@@ -1,3 +1,13 @@
 export function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" ? value as Record<string, unknown> : null;
 }
+
+export function recordString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function recordNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}


### PR DESCRIPTION
## Summary
- add tiny shared record field readers for primitive tool args
- replace repeated unsafe renderer arg object assertions in read/write/edit/search/list/web renderers
- keep renderer layout and labels unchanged

## Verification
- npm test -- ChatArea.test.tsx agent-shell-contract.test.tsx
- npx eslint src/lib/records.ts src/components/tool-renderers/WriteFileRenderer.tsx src/components/tool-renderers/EditFileRenderer.tsx src/components/tool-renderers/SearchRenderer.tsx src/components/tool-renderers/ListDirRenderer.tsx src/components/tool-renderers/WebRenderer.tsx src/components/tool-renderers/ReadFileRenderer.tsx
- npm run build
- npm run lint