### PR TITLE
fix: ignore unknown display delta types

### DIFF
--- a/frontend/app/src/hooks/use-display-deltas.test.tsx
+++ b/frontend/app/src/hooks/use-display-deltas.test.tsx
@@ -116,6 +116,36 @@ describe("useDisplayDeltas", () => {
     expect(entries[0].segments[0].step.status).toBe("done");
   });
 
+  it("ignores display deltas with unknown protocol types", () => {
+    const initialEntries: ChatEntry[] = [
+      {
+        id: "user-1",
+        role: "user",
+        content: "hello",
+        timestamp: Date.now(),
+      },
+    ];
+
+    render(<Harness initialEntries={initialEntries} />);
+
+    act(() => {
+      latestHandler?.({
+        type: "display_delta",
+        data: {
+          type: "unknown_delta_type",
+          entry: {
+            id: "turn-1",
+            role: "assistant",
+            timestamp: Date.now(),
+            segments: [],
+          },
+        },
+      });
+    });
+
+    expect(JSON.parse(screen.getByTestId("entries").textContent || "[]")).toEqual(initialEntries);
+  });
+
   it("stops reporting running after the assistant turn finalizes", () => {
     render(<Harness initialEntries={[]} />);
 

--- a/frontend/app/src/hooks/use-display-deltas.ts
+++ b/frontend/app/src/hooks/use-display-deltas.ts
@@ -21,6 +21,7 @@ import {
 } from "../api";
 import type { UseThreadStreamResult } from "./use-thread-stream";
 import { makeId } from "./utils";
+import { asRecord } from "../lib/records";
 
 // --- Delta types from backend ---
 
@@ -65,6 +66,14 @@ type DisplayDelta =
 
 type SequencedDisplayDelta = DisplayDelta & { _display_seq?: number };
 
+const DISPLAY_DELTA_TYPES = new Set<string>([
+  "append_entry",
+  "append_segment",
+  "update_segment",
+  "finalize_turn",
+  "full_state",
+]);
+
 // --- Helpers ---
 
 function updateLastTurn(
@@ -80,6 +89,11 @@ function updateLastTurn(
     }
   }
   return entries;
+}
+
+function isSequencedDisplayDelta(value: unknown): value is SequencedDisplayDelta {
+  const delta = asRecord(value);
+  return typeof delta?.type === "string" && DISPLAY_DELTA_TYPES.has(delta.type);
 }
 
 // --- Delta reducer ---
@@ -214,8 +228,8 @@ export function useDisplayDeltas(
   useEffect(() => {
     return subscribe((event) => {
       if (event.type !== "display_delta") return;
-      const delta = event.data as SequencedDisplayDelta | undefined;
-      if (!delta || !delta.type) return;
+      if (!isSequencedDisplayDelta(event.data)) return;
+      const delta = event.data;
 
       // @@@display-seq-dedup — skip stale deltas replayed from ring buffer
       const deltaSeq = delta._display_seq;


### PR DESCRIPTION
## Summary
- guard display_delta SSE payloads by known protocol type before applying them
- prevent unknown delta types from writing undefined into chat entries
- add a focused regression test for the invalid protocol event

## Verification
- npm test -- use-display-deltas.test.tsx
- npx eslint src/hooks/use-display-deltas.ts src/hooks/use-display-deltas.test.tsx
- npm run build
- npm run lint