### PR TITLE
simplify: narrow supabase parse errors

### DIFF
--- a/storage/providers/supabase/invite_code_repo.py
+++ b/storage/providers/supabase/invite_code_repo.py
@@ -25,7 +25,7 @@ def _is_expired(row: dict) -> bool:
     try:
         exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
         return datetime.now(UTC) > exp
-    except Exception:
+    except ValueError:
         return False
 
 

--- a/storage/providers/supabase/user_settings_repo.py
+++ b/storage/providers/supabase/user_settings_repo.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
+from json import JSONDecodeError
 from typing import Any
 
 from storage.providers.supabase import _query as q
@@ -31,11 +33,9 @@ class SupabaseUserSettingsRepo:
             return {"user_id": user_id, "default_workspace": None, "recent_workspaces": [], "default_model": "leon:large"}
         row = dict(rows[0])
         if isinstance(row.get("recent_workspaces"), str):
-            import json
-
             try:
                 row["recent_workspaces"] = json.loads(row["recent_workspaces"])
-            except Exception:
+            except JSONDecodeError:
                 row["recent_workspaces"] = []
         if row.get("recent_workspaces") is None:
             row["recent_workspaces"] = []

--- a/tests/Unit/storage/test_supabase_settings_and_invites.py
+++ b/tests/Unit/storage/test_supabase_settings_and_invites.py
@@ -1,0 +1,46 @@
+import json
+
+import pytest
+
+from storage.providers.supabase.invite_code_repo import SupabaseInviteCodeRepo
+from storage.providers.supabase.user_settings_repo import SupabaseUserSettingsRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_user_settings_recent_workspace_parser_does_not_hide_unexpected_json_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    tables = {
+        "user_settings": [
+            {
+                "user_id": "user-1",
+                "recent_workspaces": '["/workspace"]',
+            }
+        ]
+    }
+    repo = SupabaseUserSettingsRepo(FakeSupabaseClient(tables=tables))
+
+    def _raise_runtime_error(_value: str) -> list[str]:
+        raise RuntimeError("json loader unavailable")
+
+    monkeypatch.setattr(json, "loads", _raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="json loader unavailable"):
+        repo.get("user-1")
+
+
+def test_invite_code_expiry_does_not_hide_non_string_expires_at() -> None:
+    repo = SupabaseInviteCodeRepo(
+        FakeSupabaseClient(
+            tables={
+                "invite_codes": [
+                    {
+                        "code": "BAD-DATE",
+                        "used_by": None,
+                        "expires_at": 123,
+                    }
+                ]
+            }
+        )
+    )
+
+    with pytest.raises(AttributeError):
+        repo.is_valid("BAD-DATE")


### PR DESCRIPTION
## Summary
- narrow user settings recent workspace JSON parsing to JSONDecodeError
- narrow invite-code expiry parsing to ValueError
- add storage tests proving unexpected parser/schema failures are no longer swallowed

## Verification
- uv run pytest tests/Unit/storage/test_supabase_settings_and_invites.py -q
- uv run pytest tests/Unit/storage/test_supabase_settings_and_invites.py tests/Unit/storage/test_supabase_thread_launch_pref_repo.py tests/Unit/storage/test_supabase_user_repo.py -q
- uv run ruff check storage/providers/supabase tests/Unit/storage
- uv run pyright storage/providers/supabase