### PR TITLE
simplify: guard app store library keys

### DIFF
--- a/frontend/app/src/store/app-store.ts
+++ b/frontend/app/src/store/app-store.ts
@@ -64,10 +64,13 @@ const LIBRARY_STATE_KEYS: Record<LibraryType, LibraryStateKey> = {
   recipe: "libraryRecipes",
 };
 
+function isLibraryType(type: string): type is LibraryType {
+  return type in LIBRARY_STATE_KEYS;
+}
+
 function getLibraryStateKey(type: string): LibraryStateKey {
-  const key = LIBRARY_STATE_KEYS[type as LibraryType];
-  if (!key) throw new Error(`Unsupported library type: ${type}`);
-  return key;
+  if (!isLibraryType(type)) throw new Error(`Unsupported library type: ${type}`);
+  return LIBRARY_STATE_KEYS[type];
 }
 
 function emptySessionState() {


### PR DESCRIPTION
## Summary
- replace app-store library key union assertion with a small runtime key guard
- preserve existing unsupported library type error behavior
- keep library state update flow unchanged

## Verification
- npm test -- app-store.test.ts agent-shell-contract.test.tsx
- npx eslint src/store/app-store.ts src/store/app-store.test.ts src/components/agent-shell-contract.test.tsx
- npm run build
- npm run lint