### PR TITLE
fix: validate background task payloads

### DIFF
--- a/frontend/app/src/hooks/use-background-tasks.test.tsx
+++ b/frontend/app/src/hooks/use-background-tasks.test.tsx
@@ -1,19 +1,20 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useBackgroundTasks } from "./use-background-tasks";
 import type { UseThreadStreamResult } from "./use-thread-stream";
 
 afterEach(() => {
+  cleanup();
   vi.restoreAllMocks();
   window.history.replaceState({}, "", "/");
 });
 
 function Harness() {
   const subscribe: UseThreadStreamResult["subscribe"] = () => () => {};
-  useBackgroundTasks({ threadId: "thread-1", subscribe });
-  return null;
+  const { tasks } = useBackgroundTasks({ threadId: "thread-1", subscribe });
+  return <pre data-testid="tasks">{JSON.stringify(tasks)}</pre>;
 }
 
 describe("useBackgroundTasks", () => {
@@ -33,5 +34,53 @@ describe("useBackgroundTasks", () => {
     await Promise.resolve();
 
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("reports malformed task list payloads instead of storing invalid task state", async () => {
+    window.history.replaceState({}, "", "/chat/hire/thread/thread-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: "not-a-task-list" }),
+    } as Response);
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[BackgroundTasks] Error fetching tasks:",
+        expect.objectContaining({
+          message: "Malformed background task payload: expected task array",
+        }),
+      );
+    });
+    expect(screen.getByTestId("tasks").textContent).toBe("[]");
+  });
+
+  it("accepts the backend cancelled task status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          task_id: "task-1",
+          task_type: "agent",
+          status: "cancelled",
+          description: "cancelled probe",
+        },
+      ],
+    } as Response);
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(JSON.parse(screen.getByTestId("tasks").textContent || "[]")).toEqual([
+        {
+          task_id: "task-1",
+          task_type: "agent",
+          status: "cancelled",
+          description: "cancelled probe",
+        },
+      ]);
+    });
   });
 });

--- a/frontend/app/src/hooks/use-background-tasks.ts
+++ b/frontend/app/src/hooks/use-background-tasks.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { UseThreadStreamResult } from './use-thread-stream';
 import type { StreamEvent } from '../api/types';
-import { asRecord } from '../lib/records';
+import { asRecord, recordNumber, recordString } from '../lib/records';
 
 export interface BackgroundTask {
   task_id: string;
   task_type: 'bash' | 'agent';
-  status: 'running' | 'completed' | 'error';
+  status: 'running' | 'completed' | 'error' | 'cancelled';
   command_line?: string;
   description?: string;
   exit_code?: number;
@@ -27,6 +27,37 @@ interface BackgroundTaskEventData {
 }
 
 const threadTasksInflight = new Map<string, Promise<BackgroundTask[]>>();
+
+function parseTaskType(value: unknown): BackgroundTask["task_type"] {
+  if (value === "bash" || value === "agent") return value;
+  throw new Error("Malformed background task payload: task_type");
+}
+
+function parseTaskStatus(value: unknown): BackgroundTask["status"] {
+  if (value === "running" || value === "completed" || value === "error" || value === "cancelled") return value;
+  throw new Error("Malformed background task payload: status");
+}
+
+function parseBackgroundTasks(value: unknown): BackgroundTask[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Malformed background task payload: expected task array");
+  }
+  return value.map((item, index) => {
+    const record = asRecord(item);
+    if (!record) throw new Error(`Malformed background task payload: task[${index}]`);
+    const taskId = recordString(record, "task_id");
+    if (!taskId) throw new Error(`Malformed background task payload: task[${index}].task_id`);
+    return {
+      task_id: taskId,
+      task_type: parseTaskType(record.task_type),
+      status: parseTaskStatus(record.status),
+      command_line: recordString(record, "command_line"),
+      description: recordString(record, "description"),
+      exit_code: recordNumber(record, "exit_code"),
+      error: recordString(record, "error"),
+    };
+  });
+}
 
 function isBackgroundTaskEventData(data: unknown): data is BackgroundTaskEventData {
   const value = asRecord(data);
@@ -50,7 +81,7 @@ function loadThreadTasks(threadId: string): Promise<BackgroundTask[]> {
       if (!response.ok) {
         throw new Error(response.statusText || `HTTP ${response.status}`);
       }
-      return response.json() as Promise<BackgroundTask[]>;
+      return parseBackgroundTasks(await response.json());
     })
     .finally(() => {
       threadTasksInflight.delete(threadId);


### PR DESCRIPTION
## Summary
- validate /threads/:id/tasks JSON before storing background task state
- include backend cancelled task status in the frontend BackgroundTask contract
- add hook regression coverage for malformed payloads and cancelled tasks

## Verification
- npm test -- use-background-tasks.test.tsx
- npx eslint src/hooks/use-background-tasks.ts src/hooks/use-background-tasks.test.tsx
- npm run build
- npm run lint