### PR TITLE
fix: read task renderer args as strings

### DIFF
--- a/frontend/app/src/components/tool-renderers/TaskRenderer.test.tsx
+++ b/frontend/app/src/components/tool-renderers/TaskRenderer.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { ToolStep } from "../../api";
+import TaskRenderer from "./TaskRenderer";
+
+function renderTaskRenderer(step: ToolStep) {
+  return render(
+    <MemoryRouter>
+      <TaskRenderer step={step} expanded={false} />
+    </MemoryRouter>,
+  );
+}
+
+describe("TaskRenderer", () => {
+  it("ignores non-string task arg fields instead of treating them as labels", () => {
+    renderTaskRenderer({
+      id: "tool-1",
+      name: "Task",
+      args: { description: 123 },
+      status: "done",
+      timestamp: 1,
+    });
+
+    expect(screen.getByText("子任务")).toBeTruthy();
+  });
+});

--- a/frontend/app/src/components/tool-renderers/TaskRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/TaskRenderer.tsx
@@ -1,7 +1,7 @@
 import { memo, useState } from "react";
 import { useParams } from "react-router-dom";
 import type { ToolRendererProps } from "./types";
-import { asRecord } from "@/lib/records";
+import { asRecord, recordString } from "@/lib/records";
 
 function parseArgs(args: unknown): {
   description?: string;
@@ -14,12 +14,12 @@ function parseArgs(args: unknown): {
   const a = asRecord(args);
   if (!a) return {};
   return {
-    description: (a.Description ?? a.description) as string | undefined,
-    prompt: (a.Prompt ?? a.prompt) as string | undefined,
-    subject: (a.subject ?? a.Subject) as string | undefined,
-    taskId: (a.taskId ?? a.TaskId) as string | undefined,
-    status: (a.status ?? a.Status) as string | undefined,
-    subagent_type: (a.SubagentType ?? a.subagent_type) as string | undefined,
+    description: recordString(a, "Description") ?? recordString(a, "description"),
+    prompt: recordString(a, "Prompt") ?? recordString(a, "prompt"),
+    subject: recordString(a, "subject") ?? recordString(a, "Subject"),
+    taskId: recordString(a, "taskId") ?? recordString(a, "TaskId"),
+    status: recordString(a, "status") ?? recordString(a, "Status"),
+    subagent_type: recordString(a, "SubagentType") ?? recordString(a, "subagent_type"),
   };
 }
 


### PR DESCRIPTION
## Summary
- replace TaskRenderer arg string assertions with recordString reads
- ignore non-string task arg fields instead of crashing label generation
- add focused renderer coverage for malformed task args

## Verification
- npm test -- TaskRenderer.test.tsx
- npm test -- TaskRenderer.test.tsx ChatArea.test.tsx agent-shell-contract.test.tsx
- npx eslint src/components/tool-renderers/TaskRenderer.tsx src/components/tool-renderers/TaskRenderer.test.tsx src/lib/records.ts
- npm run build
- npm run lint