### PR TITLE
fix: read bash renderer args as strings

### DIFF
--- a/frontend/app/src/components/tool-renderers/BashRenderer.test.tsx
+++ b/frontend/app/src/components/tool-renderers/BashRenderer.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ToolStep } from "../../api";
+import BashRenderer from "./BashRenderer";
+
+function renderBashRenderer(step: ToolStep) {
+  return render(<BashRenderer step={step} expanded={false} />);
+}
+
+describe("BashRenderer", () => {
+  it("ignores non-string command fields instead of rendering invalid labels", () => {
+    renderBashRenderer({
+      id: "tool-1",
+      name: "Bash",
+      args: { command: 123, description: "fallback description" },
+      status: "done",
+      timestamp: 1,
+    });
+
+    expect(screen.getByText("fallback description")).toBeTruthy();
+    expect(screen.queryByText("123")).toBeNull();
+  });
+});

--- a/frontend/app/src/components/tool-renderers/BashRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/BashRenderer.tsx
@@ -1,15 +1,15 @@
 import { Check, Copy } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import type { ToolRendererProps } from "./types";
-import { asRecord } from "@/lib/records";
+import { asRecord, recordString } from "@/lib/records";
 import { FEEDBACK_BRIEF } from "@/styles/ux-timing";
 
 function parseArgs(args: unknown): { command?: string; description?: string } {
   const a = asRecord(args);
   if (!a) return {};
   return {
-    command: a.command as string | undefined,
-    description: a.description as string | undefined,
+    command: recordString(a, "command"),
+    description: recordString(a, "description"),
   };
 }
 


### PR DESCRIPTION
## Summary
- replace BashRenderer command/description assertions with recordString reads
- ignore non-string command values instead of rendering invalid labels/copy actions
- add focused renderer coverage for malformed bash args

## Verification
- npm test -- BashRenderer.test.tsx
- npm test -- BashRenderer.test.tsx TaskRenderer.test.tsx ChatArea.test.tsx agent-shell-contract.test.tsx
- npx eslint src/components/tool-renderers/BashRenderer.tsx src/components/tool-renderers/BashRenderer.test.tsx src/lib/records.ts
- npm run build
- npm run lint