### PR TITLE
fix: guard directory browser error detail

### DIFF
--- a/frontend/app/src/hooks/use-directory-browser.test.tsx
+++ b/frontend/app/src/hooks/use-directory-browser.test.tsx
@@ -28,4 +28,19 @@ describe("useDirectoryBrowser", () => {
     expect(view.result.current.items).toEqual([]);
     expect(view.result.current.error).toBe("Malformed directory browser payload: items must be an array");
   });
+
+  it("ignores non-string error details", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: { message: "not a string" } }),
+    } as Response);
+
+    const view = renderHook(() => useDirectoryBrowser((path) => `/browse?path=${path}`, "/workspace"));
+
+    await act(async () => {
+      await view.result.current.loadPath("/workspace");
+    });
+
+    expect(view.result.current.error).toBe("加载失败");
+  });
 });

--- a/frontend/app/src/hooks/use-directory-browser.ts
+++ b/frontend/app/src/hooks/use-directory-browser.ts
@@ -64,8 +64,9 @@ export function useDirectoryBrowser(buildUrl: (path: string) => string, initialP
     try {
       const res = await fetch(buildUrl(path));
       if (!res.ok) {
-        const d = await res.json().catch(() => ({}));
-        throw new Error((d as { detail?: string }).detail || "加载失败");
+        const errorPayload = asRecord(await res.json().catch(() => null));
+        const detail = errorPayload ? recordString(errorPayload, "detail") : undefined;
+        throw new Error(detail || "加载失败");
       }
       const data = parseBrowsePayload(await res.json(), path);
       setCurrentPath(data.currentPath);


### PR DESCRIPTION
## Summary
- read directory browser error detail through recordString
- avoid rendering non-string JSON details as [object Object]
- add regression coverage for malformed error detail payloads

## Verification
- npm test -- use-directory-browser.test.tsx
- npm test -- use-directory-browser.test.tsx use-background-tasks.test.tsx
- npx eslint src/hooks/use-directory-browser.ts src/hooks/use-directory-browser.test.tsx
- npm run build
- npm run lint