### PR TITLE
fix: guard workspace settings error detail

### DIFF
--- a/frontend/app/src/hooks/use-workspace-settings.test.tsx
+++ b/frontend/app/src/hooks/use-workspace-settings.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useWorkspaceSettings } from "./use-workspace-settings";
@@ -28,5 +28,33 @@ describe("useWorkspaceSettings", () => {
     await waitFor(() => {
       expect(consoleError).not.toHaveBeenCalled();
     });
+  });
+
+  it("ignores non-string workspace error details", async () => {
+    window.history.replaceState({}, "", "/chat/hire/agent-1");
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          default_workspace: null,
+          recent_workspaces: [],
+          default_model: "leon:large",
+          enabled_models: ["leon:large"],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ detail: { message: "not a string" } }),
+      } as Response);
+
+    const view = renderHook(() => useWorkspaceSettings());
+
+    await waitFor(() => {
+      expect(view.result.current.loading).toBe(false);
+    });
+
+    await expect(act(async () => {
+      await view.result.current.setDefaultWorkspace("/workspace");
+    })).rejects.toThrow("Failed to set workspace");
   });
 });

--- a/frontend/app/src/hooks/use-workspace-settings.ts
+++ b/frontend/app/src/hooks/use-workspace-settings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { asRecord, recordString } from "@/lib/records";
 import { authFetch } from "../store/auth-store";
 
 interface UserSettings {
@@ -11,6 +12,11 @@ interface UserSettings {
 function isActiveNewChatRoute(): boolean {
   const path = window.location.pathname.replace(/\/+$/, "");
   return path.startsWith("/chat/hire");
+}
+
+function errorDetail(value: unknown): string | undefined {
+  const payload = asRecord(value);
+  return payload ? recordString(payload, "detail") : undefined;
 }
 
 export function useWorkspaceSettings() {
@@ -47,7 +53,7 @@ export function useWorkspaceSettings() {
 
     if (!response.ok) {
       const data = await response.json();
-      throw new Error(data.detail || "Failed to set workspace");
+      throw new Error(errorDetail(data) || "Failed to set workspace");
     }
 
     await loadSettings();


### PR DESCRIPTION
## Summary
- read workspace settings error detail through string guards
- avoid surfacing non-string detail payloads as [object Object]
- add regression coverage for failed workspace setting responses

## Verification
- npm test -- use-workspace-settings.test.tsx
- npm test -- use-workspace-settings.test.tsx SettingsPage.test.tsx NewChatPage.test.tsx
- npx eslint src/hooks/use-workspace-settings.ts src/hooks/use-workspace-settings.test.tsx
- npm run build
- npm run lint