### PR TITLE
fix: guard observation field values

### DIFF
--- a/frontend/app/src/components/ObservationSection.test.tsx
+++ b/frontend/app/src/components/ObservationSection.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ObservationSection from "./ObservationSection";
+
+vi.mock("../api", () => ({
+  saveObservationConfig: vi.fn(async () => undefined),
+  verifyObservation: vi.fn(async () => ({ success: true, traces: [] })),
+}));
+
+describe("ObservationSection", () => {
+  it("does not render non-string provider field values", () => {
+    render(
+      <ObservationSection
+        config={{
+          active: "langfuse",
+          langfuse: {
+            secret_key: "sk-secret",
+            public_key: "pk-public",
+            host: { value: "https://langfuse.local" },
+          },
+        }}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByDisplayValue("[object Object]")).toBeNull();
+  });
+});

--- a/frontend/app/src/components/ObservationSection.tsx
+++ b/frontend/app/src/components/ObservationSection.tsx
@@ -1,7 +1,7 @@
 import { Eye, EyeOff, Check, X, Loader2, ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { saveObservationConfig, verifyObservation } from "../api";
-import { asRecord } from "../lib/records";
+import { asRecord, recordString } from "../lib/records";
 import { FEEDBACK_BRIEF } from "@/styles/ux-timing";
 
 interface ObservationSectionProps {
@@ -72,7 +72,7 @@ const PROVIDERS: ProviderDef[] = [
 
 function getNestedValue(config: Record<string, unknown>, field: FieldDef): string {
   const nested = asRecord(config[field.nested]);
-  return String(nested?.[field.key] ?? "");
+  return nested ? recordString(nested, field.key) ?? "" : "";
 }
 
 function setNestedValue(config: Record<string, unknown>, field: FieldDef, value: string): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- read observation provider field values through recordString
- avoid rendering non-string config fields as [object Object]
- add component coverage for malformed observation config values

## Verification
- npm test -- ObservationSection.test.tsx
- npm test -- ObservationSection.test.tsx SettingsPage.test.tsx
- npx eslint src/components/ObservationSection.tsx src/components/ObservationSection.test.tsx
- npm run build
- npm run lint