### PR TITLE
fix: guard workspace section save response

### DIFF
--- a/frontend/app/src/components/WorkspaceSection.test.tsx
+++ b/frontend/app/src/components/WorkspaceSection.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceSection from "./WorkspaceSection";
+
+const { authFetch } = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/store/auth-store", () => ({
+  authFetch,
+}));
+
+afterEach(() => {
+  cleanup();
+  authFetch.mockReset();
+});
+
+describe("WorkspaceSection", () => {
+  it("ignores non-string error details", async () => {
+    authFetch.mockResolvedValue({
+      json: async () => ({ success: false, detail: { message: "not a string" } }),
+    });
+
+    render(<WorkspaceSection defaultWorkspace="/workspace" onUpdate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(await screen.findByText("保存失败")).toBeTruthy();
+    expect(screen.queryByText("[object Object]")).toBeNull();
+  });
+
+  it("does not accept non-string saved workspace values", async () => {
+    const onUpdate = vi.fn();
+    authFetch.mockResolvedValue({
+      json: async () => ({ success: true, workspace: { path: "/workspace" } }),
+    });
+
+    render(<WorkspaceSection defaultWorkspace="/workspace" onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("保存失败")).toBeTruthy();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/components/WorkspaceSection.tsx
+++ b/frontend/app/src/components/WorkspaceSection.tsx
@@ -2,6 +2,7 @@ import { FolderOpen } from "lucide-react";
 import { useState } from "react";
 import { FEEDBACK_NORMAL } from "@/styles/ux-timing";
 import { authFetch } from "@/store/auth-store";
+import { asRecord, recordString } from "@/lib/records";
 
 interface WorkspaceSectionProps {
   defaultWorkspace: string | null;
@@ -13,6 +14,28 @@ export default function WorkspaceSection({ defaultWorkspace, onUpdate }: Workspa
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
+
+  function applySaveResponse(value: unknown): boolean {
+    const data = asRecord(value);
+    if (!data) {
+      setError("保存失败");
+      return false;
+    }
+    if (data.success === true) {
+      const workspace = recordString(data, "workspace");
+      if (!workspace) {
+        setError("保存失败");
+        return false;
+      }
+      onUpdate(workspace);
+      setPath(workspace);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), FEEDBACK_NORMAL);
+      return true;
+    }
+    setError(recordString(data, "detail") || "保存失败");
+    return false;
+  }
 
   const handleSave = async () => {
     if (!path.trim()) return;
@@ -26,14 +49,7 @@ export default function WorkspaceSection({ defaultWorkspace, onUpdate }: Workspa
         body: JSON.stringify({ workspace: path.trim() }),
       });
       const data = await res.json();
-      if (data.success) {
-        onUpdate(data.workspace);
-        setPath(data.workspace);
-        setSuccess(true);
-        setTimeout(() => setSuccess(false), FEEDBACK_NORMAL);
-      } else {
-        setError(data.detail || "保存失败");
-      }
+      applySaveResponse(data);
     } catch {
       setError("网络错误");
     } finally {


### PR DESCRIPTION
## Summary
- validate workspace save response before updating settings UI state
- avoid rendering non-string error details or storing non-string workspace values
- add WorkspaceSection regression coverage for malformed save responses

## Verification
- npm test -- WorkspaceSection.test.tsx
- npm test -- WorkspaceSection.test.tsx SettingsPage.test.tsx use-workspace-settings.test.tsx
- npx eslint src/components/WorkspaceSection.tsx src/components/WorkspaceSection.test.tsx
- npm run build
- npm run lint