### PR TITLE
fix: guard sandbox section field values

### DIFF
--- a/frontend/app/src/components/SandboxSection.test.tsx
+++ b/frontend/app/src/components/SandboxSection.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import SandboxSection from "./SandboxSection";
+
+vi.mock("../api", () => ({
+  saveSandboxConfig: vi.fn(async () => undefined),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SandboxSection", () => {
+  it("does not render non-string field values", () => {
+    render(
+      <SandboxSection
+        sandboxes={{
+          daytona: {
+            provider: "daytona",
+            daytona: {
+              api_key: "sk-daytona",
+              api_url: { value: "https://daytona.local" },
+            },
+          },
+        }}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Daytona/ }));
+
+    expect(screen.queryByDisplayValue("[object Object]")).toBeNull();
+  });
+
+  it("falls back to the config name when provider is not a string", () => {
+    render(
+      <SandboxSection
+        sandboxes={{
+          daytona: {
+            provider: { type: "daytona" },
+            daytona: { api_url: "https://daytona.local" },
+          },
+        }}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Daytona/ }));
+
+    expect(screen.getByPlaceholderText("https://app.daytona.io/api")).toBeTruthy();
+  });
+});

--- a/frontend/app/src/components/SandboxSection.tsx
+++ b/frontend/app/src/components/SandboxSection.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, Eye, EyeOff } from "lucide-react";
 import { useState } from "react";
 import { saveSandboxConfig } from "../api";
-import { asRecord } from "../lib/records";
+import { asRecord, recordString } from "../lib/records";
 
 interface SandboxSectionProps {
   sandboxes: Record<string, Record<string, unknown>>;
@@ -49,16 +49,22 @@ const COMMON_FIELDS: FieldDef[] = [
   { key: "init_commands", label: "初始化命令", type: "text", placeholder: "逗号分隔的命令" },
 ];
 
+function fieldValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return "";
+}
+
 function getNestedValue(config: Record<string, unknown>, field: FieldDef): string {
   if (field.nested) {
     const nested = asRecord(config[field.nested]);
-    return String(nested?.[field.key] ?? "");
+    return fieldValue(nested?.[field.key]);
   }
   if (field.key === "init_commands") {
     const cmds = config[field.key];
     return Array.isArray(cmds) ? cmds.join(", ") : "";
   }
-  return String(config[field.key] ?? "");
+  return fieldValue(config[field.key]);
 }
 
 function setNestedValue(config: Record<string, unknown>, field: FieldDef, value: string): Record<string, unknown> {
@@ -167,7 +173,7 @@ export default function SandboxSection({ sandboxes, onUpdate }: SandboxSectionPr
 
       <div className="border border-border rounded-lg overflow-hidden divide-y divide-border">
         {entries.map(([configName, config]) => {
-          const providerType = String(config.provider ?? configName);
+          const providerType = recordString(config, "provider") ?? configName;
           const fields = PROVIDER_FIELDS[providerType] ?? [];
           const isExpanded = expanded === configName;
           const isSaving = saving === configName;


### PR DESCRIPTION
## Summary
- read sandbox settings fields through admitted string/number values
- fall back to config name when provider is not a string
- add SandboxSection coverage for malformed field and provider values

## Verification
- npm test -- SandboxSection.test.tsx
- npm test -- SandboxSection.test.tsx SettingsPage.test.tsx ProvidersSection.test.tsx
- npx eslint src/components/SandboxSection.tsx src/components/SandboxSection.test.tsx
- npm run build
- npm run lint