### PR TITLE
fix: guard workspace setup modal response

### DIFF
--- a/frontend/app/src/components/WorkspaceSetupModal.test.tsx
+++ b/frontend/app/src/components/WorkspaceSetupModal.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceSetupModal from "./WorkspaceSetupModal";
+
+const { authFetch } = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/store/auth-store", () => ({
+  authFetch,
+}));
+
+vi.mock("./FilesystemBrowser", () => ({
+  default: () => <div>filesystem-browser</div>,
+}));
+
+afterEach(() => {
+  authFetch.mockReset();
+});
+
+describe("WorkspaceSetupModal", () => {
+  it("ignores non-string error details", async () => {
+    authFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: { message: "not a string" } }),
+    });
+
+    render(<WorkspaceSetupModal open onClose={vi.fn()} onWorkspaceSet={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(await screen.findByText("保存失败")).toBeTruthy();
+    expect(screen.queryByText("[object Object]")).toBeNull();
+  });
+
+  it("does not accept non-string saved workspace values", async () => {
+    const onWorkspaceSet = vi.fn();
+    const onClose = vi.fn();
+    authFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ workspace: { path: "/workspace" } }),
+    });
+
+    render(<WorkspaceSetupModal open onClose={onClose} onWorkspaceSet={onWorkspaceSet} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("保存失败")).toBeTruthy();
+    });
+    expect(onWorkspaceSet).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/components/WorkspaceSetupModal.tsx
+++ b/frontend/app/src/components/WorkspaceSetupModal.tsx
@@ -13,6 +13,7 @@ import { Label } from "./ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import FilesystemBrowser from "./FilesystemBrowser";
 import { authFetch } from "@/store/auth-store";
+import { asRecord, recordString } from "@/lib/records";
 
 interface WorkspaceSetupModalProps {
   open: boolean;
@@ -58,12 +59,16 @@ export default function WorkspaceSetupModal({
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.detail || "保存失败");
+        const data = asRecord(await response.json());
+        throw new Error(data ? recordString(data, "detail") || "保存失败" : "保存失败");
       }
 
-      const data = await response.json();
-      onWorkspaceSet(data.workspace);
+      const data = asRecord(await response.json());
+      const savedWorkspace = data ? recordString(data, "workspace") : undefined;
+      if (!savedWorkspace) {
+        throw new Error("保存失败");
+      }
+      onWorkspaceSet(savedWorkspace);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "保存失败");


### PR DESCRIPTION
## Summary
- validate workspace setup modal save responses before calling callbacks
- avoid rendering non-string error details or accepting non-string workspace values
- add WorkspaceSetupModal regression coverage for malformed save responses

## Verification
- npm test -- WorkspaceSetupModal.test.tsx
- npm test -- WorkspaceSetupModal.test.tsx WorkspaceSection.test.tsx use-workspace-settings.test.tsx
- npx eslint src/components/WorkspaceSetupModal.tsx src/components/WorkspaceSetupModal.test.tsx
- npm run build
- npm run lint