### PR TITLE
fix: guard model selector responses

### DIFF
--- a/frontend/app/src/components/ModelSelector.test.tsx
+++ b/frontend/app/src/components/ModelSelector.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ModelSelector from "./ModelSelector";
+
+const { authFetch } = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/store/auth-store", () => ({
+  authFetch,
+}));
+
+function response(body: unknown, ok = true) {
+  return {
+    ok,
+    json: async () => body,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  authFetch.mockReset();
+});
+
+describe("ModelSelector", () => {
+  it("ignores non-string error details", async () => {
+    authFetch.mockImplementation(async (url: string) => {
+      if (url === "/api/settings") return response({ enabled_models: [] });
+      return response({ detail: { message: "not a string" } }, false);
+    });
+
+    render(<ModelSelector currentModel="leon:medium" threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Medium/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Mini" }));
+
+    expect(await screen.findByText("更新模型失败")).toBeTruthy();
+    expect(screen.queryByText("[object Object]")).toBeNull();
+  });
+
+  it("falls back to the requested model when the saved model is not a string", async () => {
+    const onModelChange = vi.fn();
+    authFetch.mockImplementation(async (url: string) => {
+      if (url === "/api/settings") return response({ enabled_models: [] });
+      return response({ model: { id: "leon:max" } });
+    });
+
+    render(
+      <ModelSelector
+        currentModel="leon:medium"
+        threadId="thread-1"
+        onModelChange={onModelChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Medium/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Max" }));
+
+    await waitFor(() => {
+      expect(onModelChange).toHaveBeenCalledWith("leon:max");
+    });
+  });
+
+  it("ignores malformed enabled model lists", async () => {
+    authFetch.mockResolvedValue(response({ enabled_models: { bad: true } }));
+
+    render(<ModelSelector currentModel="custom:model" threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /custom:model/ }));
+
+    await waitFor(() => {
+      expect(authFetch).toHaveBeenCalledWith("/api/settings");
+    });
+    expect(screen.queryByText("[object Object]")).toBeNull();
+  });
+});

--- a/frontend/app/src/components/ModelSelector.tsx
+++ b/frontend/app/src/components/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronDown, Cpu, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { asRecord, recordString } from "@/lib/records";
 import { authFetch } from "@/store/auth-store";
 
 interface ModelOption {
@@ -16,6 +17,25 @@ const VIRTUAL_MODELS: ModelOption[] = [
   { id: "leon:large", name: "Large", description: "复杂推理，困难任务" },
   { id: "leon:max", name: "Max", description: "极限性能，最难任务" },
 ];
+
+function parseEnabledModels(value: unknown): string[] {
+  const data = asRecord(value);
+  const models = data?.enabled_models;
+  if (!Array.isArray(models)) {
+    throw new Error("加载模型失败");
+  }
+  return models.filter((item): item is string => typeof item === "string");
+}
+
+function errorDetail(value: unknown): string | undefined {
+  const data = asRecord(value);
+  return data ? recordString(data, "detail") : undefined;
+}
+
+function savedModel(value: unknown, requestedModel: string): string {
+  const data = asRecord(value);
+  return data ? recordString(data, "model") || requestedModel : requestedModel;
+}
 
 interface ModelSelectorProps {
   currentModel: string;
@@ -41,8 +61,10 @@ export default function ModelSelector({
     if (!isOpen) return;
     authFetch("/api/settings")
       .then((r) => r.json())
-      .then((d) => setEnabledModels(d.enabled_models || []))
-      .catch(() => {});
+      .then((d) => setEnabledModels(parseEnabledModels(d)))
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "加载模型失败");
+      });
   }, [isOpen]);
 
   async function handleModelSelect(model: string) {
@@ -57,12 +79,11 @@ export default function ModelSelector({
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.detail || "更新模型失败");
+        throw new Error(errorDetail(await response.json()) || "更新模型失败");
       }
 
       const result = await response.json();
-      onModelChange?.(result.model || model);
+      onModelChange?.(savedModel(result, model));
       setIsOpen(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "更新模型失败");


### PR DESCRIPTION
## Summary
- validate enabled model settings payloads before rendering custom model options
- avoid rendering non-string model update error details
- keep model-change callbacks string-only when save responses contain malformed model values

## Verification
- npm test -- ModelSelector.test.tsx
- npm test -- ModelSelector.test.tsx SettingsPage.test.tsx NewChatPage.test.tsx
- npx eslint src/components/ModelSelector.tsx src/components/ModelSelector.test.tsx
- npm run build
- npm run lint