### PR TITLE
fix: guard model pool test responses

### DIFF
--- a/frontend/app/src/components/ModelPoolSection.test.tsx
+++ b/frontend/app/src/components/ModelPoolSection.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ModelPoolSection from "./ModelPoolSection";
+
+const { authFetch } = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/store/auth-store", () => ({
+  authFetch,
+}));
+
+function response(body: unknown) {
+  return {
+    json: async () => body,
+  };
+}
+
+function renderModelPool() {
+  return render(
+    <ModelPoolSection
+      models={[{ id: "custom:model", name: "Custom", custom: true }]}
+      enabledModels={["custom:model"]}
+      customConfig={{}}
+      providers={{ openai: { api_key: null, base_url: null } }}
+      onToggle={vi.fn()}
+      onAddCustomModel={vi.fn()}
+      onRemoveCustomModel={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  authFetch.mockReset();
+});
+
+describe("ModelPoolSection", () => {
+  it("ignores non-string model test errors", async () => {
+    authFetch.mockResolvedValue(response({
+      success: false,
+      error: { message: "not a string" },
+    }));
+
+    renderModelPool();
+
+    fireEvent.click(screen.getByRole("button", { name: "测试" }));
+
+    expect(await screen.findByText("测试失败")).toBeTruthy();
+    expect(screen.queryByText("[object Object]")).toBeNull();
+  });
+
+  it("does not accept non-boolean model test success values", async () => {
+    authFetch.mockResolvedValue(response({ success: "yes" }));
+
+    renderModelPool();
+
+    fireEvent.click(screen.getByRole("button", { name: "测试" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("测试失败")).toBeTruthy();
+    });
+    expect(screen.queryByText("✓")).toBeNull();
+  });
+});

--- a/frontend/app/src/components/ModelPoolSection.tsx
+++ b/frontend/app/src/components/ModelPoolSection.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import { asRecord, recordString } from "@/lib/records";
 import { FEEDBACK_NORMAL } from "@/styles/ux-timing";
 import { authFetch } from "@/store/auth-store";
 
@@ -18,6 +19,14 @@ interface ModelPoolSectionProps {
   onToggle: (modelId: string, enabled: boolean) => void;
   onAddCustomModel: (modelId: string, provider: string, basedOn?: string, contextLimit?: number) => Promise<void>;
   onRemoveCustomModel: (modelId: string) => Promise<void>;
+}
+
+function parseModelTestResult(value: unknown): { status: "ok" | "fail"; error: string } {
+  const data = asRecord(value);
+  if (data?.success === true) {
+    return { status: "ok", error: "" };
+  }
+  return { status: "fail", error: data ? recordString(data, "error") || "测试失败" : "测试失败" };
 }
 
 export default function ModelPoolSection({ models, enabledModels, customConfig, providers, onToggle, onAddCustomModel, onRemoveCustomModel }: ModelPoolSectionProps) {
@@ -61,9 +70,9 @@ export default function ModelPoolSection({ models, enabledModels, customConfig, 
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ model_id: modelId }),
       });
-      const data = await res.json();
-      setTestStatus((s) => ({ ...s, [modelId]: data.success ? "ok" : "fail" }));
-      if (!data.success) setTestError((s) => ({ ...s, [modelId]: data.error || "测试失败" }));
+      const result = parseModelTestResult(await res.json());
+      setTestStatus((s) => ({ ...s, [modelId]: result.status }));
+      if (result.status === "fail") setTestError((s) => ({ ...s, [modelId]: result.error }));
     } catch {
       setTestStatus((s) => ({ ...s, [modelId]: "fail" }));
       setTestError((s) => ({ ...s, [modelId]: "网络错误" }));


### PR DESCRIPTION
## Summary
- validate model test response success as a boolean true before showing success
- avoid rendering non-string model test errors
- add ModelPoolSection regression coverage for malformed test responses

## Verification
- npm test -- ModelPoolSection.test.tsx
- npm test -- ModelPoolSection.test.tsx SettingsPage.test.tsx ModelSelector.test.tsx
- npx eslint src/components/ModelPoolSection.tsx src/components/ModelPoolSection.test.tsx
- npm run build
- npm run lint