### PR TITLE
fix: guard task renderer output

### DIFF
--- a/frontend/app/src/components/tool-renderers/TaskRenderer.test.tsx
+++ b/frontend/app/src/components/tool-renderers/TaskRenderer.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ToolStep } from "../../api";
 import TaskRenderer from "./TaskRenderer";
 
@@ -13,6 +13,21 @@ function renderTaskRenderer(step: ToolStep) {
     </MemoryRouter>,
   );
 }
+
+function renderExpandedTaskRenderer(step: ToolStep) {
+  return render(
+    <MemoryRouter initialEntries={["/threads/thread-1"]}>
+      <Routes>
+        <Route path="/threads/:threadId" element={<TaskRenderer step={step} expanded />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("TaskRenderer", () => {
   it("ignores non-string task arg fields instead of treating them as labels", () => {
@@ -25,5 +40,33 @@ describe("TaskRenderer", () => {
     });
 
     expect(screen.getByText("子任务")).toBeTruthy();
+  });
+
+  it("stringifies non-string task output payloads", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: async () => ({ result: { answer: "42" } }),
+    } as Response);
+
+    renderExpandedTaskRenderer({
+      id: "tool-1",
+      name: "Task",
+      args: { description: "solve" },
+      status: "done",
+      timestamp: 1,
+      subagent_stream: {
+        task_id: "task-1",
+        thread_id: "thread-1",
+        description: "solve",
+        status: "completed",
+        text: "",
+        tool_calls: [],
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "查看详情" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/"answer": "42"/)).toBeTruthy();
+    });
   });
 });

--- a/frontend/app/src/components/tool-renderers/TaskRenderer.tsx
+++ b/frontend/app/src/components/tool-renderers/TaskRenderer.tsx
@@ -40,6 +40,15 @@ function getTaskLabel(name: string, args: ReturnType<typeof parseArgs>): string 
   }
 }
 
+function taskOutputText(value: unknown): string {
+  const data = asRecord(value);
+  if (!data) return JSON.stringify(value, null, 2);
+  const result = data.result;
+  if (typeof result === "string") return result;
+  if (result !== undefined && result !== null) return JSON.stringify(result, null, 2);
+  return recordString(data, "text") ?? JSON.stringify(value, null, 2);
+}
+
 export default memo(function TaskRenderer({ step, expanded }: ToolRendererProps) {
   const { threadId } = useParams<{ threadId?: string }>();
   const args = parseArgs(step.args);
@@ -53,8 +62,7 @@ export default memo(function TaskRenderer({ step, expanded }: ToolRendererProps)
     setLoadingOutput(true);
     try {
       const res = await fetch(`/api/threads/${threadId}/tasks/${stream.task_id}`);
-      const data = await res.json();
-      setTaskOutput(data.result ?? data.text ?? JSON.stringify(data, null, 2));
+      setTaskOutput(taskOutputText(await res.json()));
     } catch {
       setTaskOutput("加载失败");
     } finally {


### PR DESCRIPTION
## Summary
- stringify non-string task detail outputs before rendering
- preserve task detail result-over-text ordering for string payloads
- add TaskRenderer regression coverage for object task result payloads

## Verification
- npm test -- TaskRenderer.test.tsx
- npm test -- TaskRenderer.test.tsx ChatArea.test.tsx
- npx eslint src/components/tool-renderers/TaskRenderer.tsx src/components/tool-renderers/TaskRenderer.test.tsx
- npm run build
- npm run lint