### PR TITLE
fix: guard settings custom model results

### DIFF
--- a/frontend/app/src/pages/SettingsPage.test.tsx
+++ b/frontend/app/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -19,7 +19,20 @@ vi.mock("../hooks/use-mobile", () => ({
 }));
 
 vi.mock("../components/ModelMappingSection", () => ({ default: () => null }));
-vi.mock("../components/ModelPoolSection", () => ({ default: () => null }));
+vi.mock("../components/ModelPoolSection", () => ({
+  default: ({
+    onAddCustomModel,
+    onRemoveCustomModel,
+  }: {
+    onAddCustomModel: (modelId: string, provider: string) => Promise<void>;
+    onRemoveCustomModel: (modelId: string) => Promise<void>;
+  }) => (
+    <div>
+      <button onClick={() => void onAddCustomModel("custom:model", "openai")}>add-custom-model</button>
+      <button onClick={() => void onRemoveCustomModel("custom:model")}>remove-custom-model</button>
+    </div>
+  ),
+}));
 vi.mock("../components/ObservationSection", () => ({ default: () => null }));
 vi.mock("../components/ProvidersSection", () => ({ default: () => null }));
 vi.mock("../components/SandboxSection", () => ({ default: () => null }));
@@ -43,6 +56,42 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+
+function settingsResponse() {
+  return {
+    model_mapping: {},
+    enabled_models: [],
+    custom_config: {},
+    providers: {},
+    default_workspace: null,
+    default_model: "leon:medium",
+  };
+}
+
+function mockSettingsRuntime(
+  handleMutation: (url: string) => { ok: boolean; json: () => Promise<unknown> } | undefined,
+) {
+  const counters = {
+    availableModelsFetches: 0,
+    settingsFetches: 0,
+  };
+  authFetch.mockImplementation(async (url: string) => {
+    if (url === "/api/settings/available-models") {
+      counters.availableModelsFetches += 1;
+      return { ok: true, json: async () => ({ models: [], virtual_models: [] }) };
+    }
+    if (url === "/api/settings") {
+      counters.settingsFetches += 1;
+      return { ok: true, json: async () => settingsResponse() };
+    }
+    if (url === "/api/settings/sandboxes") return { ok: true, json: async () => ({ sandboxes: {} }) };
+    if (url === "/api/settings/observation") return { ok: true, json: async () => ({}) };
+    const mutation = handleMutation(url);
+    if (mutation) return mutation;
+    throw new Error(`unexpected url: ${url}`);
+  });
+  return counters;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -99,5 +148,63 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(consoleError).not.toHaveBeenCalled();
     });
+  });
+
+  it("does not treat non-boolean custom model add success as successful", async () => {
+    window.history.replaceState({}, "", "/settings");
+    let customModelAdds = 0;
+    const counters = mockSettingsRuntime((url) => {
+      if (url === "/api/settings/models/custom") {
+        customModelAdds += 1;
+        return { ok: true, json: async () => ({ success: "yes" }) };
+      }
+      return undefined;
+    });
+
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="/settings" element={<SettingsPage />} />
+        </Routes>
+      </BrowserRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "add-custom-model" }));
+
+    await waitFor(() => {
+      expect(customModelAdds).toBe(1);
+    });
+    await Promise.resolve();
+    expect(counters.availableModelsFetches).toBe(1);
+    expect(counters.settingsFetches).toBe(1);
+  });
+
+  it("does not treat non-boolean custom model remove success as successful", async () => {
+    window.history.replaceState({}, "", "/settings");
+    let customModelRemoves = 0;
+    const counters = mockSettingsRuntime((url) => {
+      if (url.startsWith("/api/settings/models/custom?")) {
+        customModelRemoves += 1;
+        return { ok: true, json: async () => ({ success: "yes" }) };
+      }
+      return undefined;
+    });
+
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="/settings" element={<SettingsPage />} />
+        </Routes>
+      </BrowserRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "remove-custom-model" }));
+
+    await waitFor(() => {
+      expect(customModelRemoves).toBe(1);
+    });
+    await Promise.resolve();
+    expect(counters.availableModelsFetches).toBe(1);
+    expect(counters.settingsFetches).toBe(1);
   });
 });

--- a/frontend/app/src/pages/SettingsPage.tsx
+++ b/frontend/app/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import type { InviteCode } from "@/api/client";
 import { toast } from "sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { authFetch } from "../store/auth-store";
+import { asRecord } from "@/lib/records";
 
 interface AvailableModelsData {
   models: Array<{
@@ -80,6 +81,10 @@ function InviteStatusBadge({ code }: { code: InviteCode }) {
       未使用
     </span>
   );
+}
+
+function isSuccessResponse(value: unknown): boolean {
+  return asRecord(value)?.success === true;
 }
 
 function InviteCopyButton({ text }: { text: string }) {
@@ -334,7 +339,7 @@ export default function SettingsPage() {
       body: JSON.stringify({ model_id: modelId, provider, based_on: basedOn || null, context_limit: contextLimit || null }),
     });
     const data = await res.json();
-    if (data.success) {
+    if (isSuccessResponse(data)) {
       const [modelsRes, settingsRes] = await Promise.all([
         authFetch("/api/settings/available-models"),
         authFetch("/api/settings"),
@@ -430,7 +435,7 @@ export default function SettingsPage() {
                 method: "DELETE",
               });
               const data = await res.json();
-              if (data.success) {
+              if (isSuccessResponse(data)) {
                 const [modelsRes, settingsRes] = await Promise.all([
                   authFetch("/api/settings/available-models"),
                   authFetch("/api/settings"),


### PR DESCRIPTION
## Summary
- require custom model add/remove responses to report success === true before reloading settings
- avoid treating truthy non-boolean success payloads as successful mutations
- add SettingsPage regression coverage for malformed custom model mutation results

## Verification
- npm test -- SettingsPage.test.tsx
- npm test -- SettingsPage.test.tsx ModelPoolSection.test.tsx ModelSelector.test.tsx
- npx eslint src/pages/SettingsPage.tsx src/pages/SettingsPage.test.tsx
- npm run build
- npm run lint