### PR TITLE
fix: guard observation verify result

### DIFF
--- a/frontend/app/src/components/ObservationSection.test.tsx
+++ b/frontend/app/src/components/ObservationSection.test.tsx
@@ -1,14 +1,32 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import ObservationSection from "./ObservationSection";
 
+const { verifyObservation } = vi.hoisted(() => ({
+  verifyObservation: vi.fn(),
+}));
+
 vi.mock("../api", () => ({
   saveObservationConfig: vi.fn(async () => undefined),
-  verifyObservation: vi.fn(async () => ({ success: true, traces: [] })),
+  verifyObservation,
 }));
+
+afterEach(() => {
+  cleanup();
+  verifyObservation.mockReset();
+});
+
+function renderActiveLangfuse() {
+  render(
+    <ObservationSection
+      config={{ active: "langfuse", langfuse: {} }}
+      onUpdate={vi.fn()}
+    />,
+  );
+}
 
 describe("ObservationSection", () => {
   it("does not render non-string provider field values", () => {
@@ -27,5 +45,35 @@ describe("ObservationSection", () => {
     );
 
     expect(screen.queryByDisplayValue("[object Object]")).toBeNull();
+  });
+
+  it("ignores non-string verify errors", async () => {
+    verifyObservation.mockResolvedValue({
+      success: false,
+      error: { message: "not a string" },
+    });
+
+    renderActiveLangfuse();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "测试连接" })[0]);
+
+    expect((await screen.findAllByText("连接失败：验证失败")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("[object Object]")).toBeNull();
+  });
+
+  it("does not treat non-boolean verify success as connected", async () => {
+    verifyObservation.mockResolvedValue({
+      success: "yes",
+      traces: [],
+    });
+
+    renderActiveLangfuse();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "测试连接" })[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("连接失败：验证失败").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/已连接/)).toBeNull();
   });
 });

--- a/frontend/app/src/components/ObservationSection.tsx
+++ b/frontend/app/src/components/ObservationSection.tsx
@@ -27,6 +27,12 @@ interface ProviderDef {
   fields: FieldDef[];
 }
 
+interface VerifyResult {
+  success: boolean;
+  error: string;
+  traces: unknown[];
+}
+
 function LangfuseIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -83,6 +89,22 @@ function setNestedValue(config: Record<string, unknown>, field: FieldDef, value:
   return updated;
 }
 
+function parseVerifyResult(result: unknown): VerifyResult {
+  const data = asRecord(result);
+  if (data?.success === true) {
+    return {
+      success: true,
+      error: "",
+      traces: Array.isArray(data.traces) ? data.traces : [],
+    };
+  }
+  return {
+    success: false,
+    error: data ? recordString(data, "error") || "验证失败" : "验证失败",
+    traces: [],
+  };
+}
+
 function maskValue(val: string) {
   if (!val || val.length <= 8) return "•".repeat(val?.length || 0);
   return val.slice(0, 4) + "•".repeat(Math.min(val.length - 8, 20)) + val.slice(-4);
@@ -93,7 +115,7 @@ export default function ObservationSection({ config, onUpdate }: ObservationSect
   const [savedFields, setSavedFields] = useState<Record<string, boolean>>({});
   const [advancedOpen, setAdvancedOpen] = useState<Record<string, boolean>>({});
   const [verifying, setVerifying] = useState(false);
-  const [verifyResult, setVerifyResult] = useState<{ success: boolean; error?: string; traces?: unknown[] } | null>(null);
+  const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
 
   const active = (config.active as string | null) ?? null;
 
@@ -130,9 +152,9 @@ export default function ObservationSection({ config, onUpdate }: ObservationSect
     setVerifyResult(null);
     try {
       const result = await verifyObservation();
-      setVerifyResult(result);
+      setVerifyResult(parseVerifyResult(result));
     } catch (err) {
-      setVerifyResult({ success: false, error: err instanceof Error ? err.message : "验证失败" });
+      setVerifyResult({ success: false, error: err instanceof Error ? err.message : "验证失败", traces: [] });
     } finally {
       setVerifying(false);
     }
@@ -270,7 +292,7 @@ export default function ObservationSection({ config, onUpdate }: ObservationSect
                         : "bg-destructive/10 border border-destructive/20 text-destructive"
                     }`}>
                       {verifyResult.success
-                        ? <><span className="w-1.5 h-1.5 rounded-full bg-success shrink-0" /> 已连接 · {(verifyResult.traces as unknown[])?.length ?? 0} 条近期追踪</>
+                        ? <><span className="w-1.5 h-1.5 rounded-full bg-success shrink-0" /> 已连接 · {verifyResult.traces.length} 条近期追踪</>
                         : <><X className="w-3.5 h-3.5 shrink-0" /> 连接失败：{verifyResult.error}</>
                       }
                     </div>


### PR DESCRIPTION
## Summary
- validate observation verify results before rendering status
- avoid rendering non-string verify errors
- require success === true before showing connected status

## Verification
- npm test -- ObservationSection.test.tsx
- npm test -- ObservationSection.test.tsx SettingsPage.test.tsx
- npx eslint src/components/ObservationSection.tsx src/components/ObservationSection.test.tsx
- npm run build
- npm run lint