### PR TITLE
fix: guard streaming cancel message

### DIFF
--- a/frontend/app/src/api/streaming.test.ts
+++ b/frontend/app/src/api/streaming.test.ts
@@ -32,6 +32,12 @@ describe("streaming api contract", () => {
     await expect(api.cancelRun("thread-1")).rejects.toThrow("No active run found");
   });
 
+  it("cancelRun ignores non-string backend messages", async () => {
+    authFetch.mockResolvedValue(okJson({ ok: false, message: { text: "No active run found" } }));
+
+    await expect(api.cancelRun("thread-1")).rejects.toThrow(/^Cancel failed$/);
+  });
+
   it("postRun reports startup cancellation as a cancelled run", async () => {
     authFetch.mockResolvedValue(okJson({ status: "cancelled", routing: "cancelled", thread_id: "thread-1" }));
 

--- a/frontend/app/src/api/streaming.ts
+++ b/frontend/app/src/api/streaming.ts
@@ -1,6 +1,7 @@
 import type { StreamEvent } from "./types";
 import { processChunk } from "./sse-processor";
 import { authFetch } from "../store/auth-store";
+import { asRecord, recordString } from "../lib/records";
 
 /** Read an SSE response body, dispatch events, return { lastSeq, runEnded }. */
 async function consumeSSEStream(
@@ -121,6 +122,6 @@ export async function streamThreadEvents(
 export async function cancelRun(threadId: string): Promise<void> {
   const res = await authFetch(`/api/threads/${encodeURIComponent(threadId)}/runs/cancel`, { method: "POST" });
   if (!res.ok) throw new Error(`Cancel failed: ${res.statusText}`);
-  const payload = await res.json();
-  if (payload?.ok === false) throw new Error(payload.message || "Cancel failed");
+  const payload = asRecord(await res.json());
+  if (payload?.ok === false) throw new Error(recordString(payload, "message") || "Cancel failed");
 }


### PR DESCRIPTION
## Summary
- parse cancel-run responses before reading backend messages
- keep string backend cancel messages, fall back for malformed messages
- cover non-string cancel message payloads

## Verification
- npm test -- streaming.test.ts
- npm test -- streaming.test.ts use-display-deltas.test.tsx
- npx eslint src/api/streaming.ts src/api/streaming.test.ts
- npm run build
- npm run lint