### PR TITLE
fix: guard streaming post run payload

### DIFF
--- a/frontend/app/src/api/streaming.test.ts
+++ b/frontend/app/src/api/streaming.test.ts
@@ -44,6 +44,12 @@ describe("streaming api contract", () => {
     await expect(api.postRun("thread-1", "hello")).rejects.toThrow("Run cancelled");
   });
 
+  it("postRun rejects non-string run ids", async () => {
+    authFetch.mockResolvedValue(okJson({ run_id: { value: "run-1" }, thread_id: "thread-1" }));
+
+    await expect(api.postRun("thread-1", "hello")).rejects.toThrow("Run did not start");
+  });
+
   it("streams thread events through authenticated fetch without leaking token in the URL", async () => {
     const ac = new AbortController();
     const body = new ReadableStream({

--- a/frontend/app/src/api/streaming.ts
+++ b/frontend/app/src/api/streaming.ts
@@ -58,14 +58,16 @@ export async function postRun(
   signal?: AbortSignal,
   options?: { model?: string; enable_trajectory?: boolean; attachments?: string[] },
 ): Promise<{ run_id: string; thread_id: string }> {
-  const payload = await postJSON<{ run_id?: string; thread_id: string; status?: string }>(
+  const payload = asRecord(await postJSON(
     `/api/threads/${encodeURIComponent(threadId)}/messages`,
     { message, ...options },
     signal,
-  );
-  if (payload.status === "cancelled") throw new Error("Run cancelled");
-  if (!payload.run_id) throw new Error("Run did not start");
-  return { run_id: payload.run_id, thread_id: payload.thread_id };
+  ));
+  if (payload?.status === "cancelled") throw new Error("Run cancelled");
+  const runId = payload ? recordString(payload, "run_id") : undefined;
+  const responseThreadId = payload ? recordString(payload, "thread_id") : undefined;
+  if (!runId || !responseThreadId) throw new Error("Run did not start");
+  return { run_id: runId, thread_id: responseThreadId };
 }
 
 /** Persistent SSE connection to a thread's event stream. */


### PR DESCRIPTION
## Summary
- validate postRun payload shape before returning run identifiers
- require string run_id and thread_id for successful run start
- cover malformed run_id payloads

## Verification
- npm test -- streaming.test.ts
- npm test -- streaming.test.ts use-display-deltas.test.tsx
- npx eslint src/api/streaming.ts src/api/streaming.test.ts
- npm run build
- npm run lint