### PR TITLE
fix: guard thread lease payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -108,6 +108,19 @@ describe("thread api client contract", () => {
     expect(authFetch).toHaveBeenCalledWith("/api/threads/thread-1", { method: "DELETE" });
   });
 
+  it("getThreadLease rejects malformed lease identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      lease_id: { value: "lease-1" },
+      provider_name: "local",
+      instance: null,
+      created_at: "2026-04-12T00:00:00Z",
+      updated_at: "2026-04-12T00:00:00Z",
+    }));
+
+    await expect(api.getThreadLease("thread-1")).rejects.toThrow("Malformed lease status");
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -21,6 +21,7 @@ import type {
 } from "./types";
 
 import { authFetch } from "../store/auth-store";
+import { asRecord, recordString } from "../lib/records";
 
 async function checkedResponse(url: string, init?: RequestInit): Promise<Response> {
   const response = await authFetch(url, init);
@@ -220,7 +221,20 @@ export async function getThreadLease(threadId: string): Promise<LeaseStatus | nu
     const body = await response.text();
     throw new Error(`API ${response.status}: ${body || response.statusText}`);
   }
-  return (await response.json()) as LeaseStatus;
+  return parseLeaseStatus(await response.json());
+}
+
+function parseLeaseStatus(value: unknown): LeaseStatus {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const lease_id = payload ? recordString(payload, "lease_id") : undefined;
+  const provider_name = payload ? recordString(payload, "provider_name") : undefined;
+  const created_at = payload ? recordString(payload, "created_at") : undefined;
+  const updated_at = payload ? recordString(payload, "updated_at") : undefined;
+  if (!payload || !thread_id || !lease_id || !provider_name || !created_at || !updated_at) {
+    throw new Error("Malformed lease status");
+  }
+  return { ...payload, thread_id, lease_id, provider_name, created_at, updated_at } as LeaseStatus;
 }
 
 // --- Sandbox Files API ---


### PR DESCRIPTION
## Summary
- validate thread lease payload identity fields before returning lease status
- fail loudly on malformed lease status responses
- cover malformed lease_id payloads

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts computer-panel/utils.test.ts
- npx eslint src/api/client.ts src/api/client.test.ts
- npm run build
- npm run lint