### PR TITLE
fix: guard sandbox sessions payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -121,6 +121,19 @@ describe("thread api client contract", () => {
     await expect(api.getThreadLease("thread-1")).rejects.toThrow("Malformed lease status");
   });
 
+  it("listSandboxSessions rejects malformed session identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      sessions: [{
+        session_id: "session-1",
+        thread_id: "thread-1",
+        provider: { name: "local" },
+        status: "running",
+      }],
+    }));
+
+    await expect(api.listSandboxSessions()).rejects.toThrow("Malformed sandbox sessions");
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -171,13 +171,13 @@ export async function pickFolder(): Promise<string | null> {
 }
 
 export async function listSandboxSessions(): Promise<SandboxSession[]> {
-  const payload = await request<{ sessions: SandboxSession[] }>("/api/sandbox/sessions");
+  const sessions = parseSandboxSessions(await request("/api/sandbox/sessions"));
   const toTs = (value?: string): number => {
     if (!value) return 0;
     const ts = Date.parse(value);
     return Number.isFinite(ts) ? ts : 0;
   };
-  return [...payload.sessions].sort((a, b) => {
+  return [...sessions].sort((a, b) => {
     const createdDiff = toTs(b.created_at) - toTs(a.created_at);
     if (createdDiff !== 0) return createdDiff;
     const activeDiff = toTs(b.last_active) - toTs(a.last_active);
@@ -187,6 +187,23 @@ export async function listSandboxSessions(): Promise<SandboxSession[]> {
     const threadDiff = a.thread_id.localeCompare(b.thread_id);
     if (threadDiff !== 0) return threadDiff;
     return a.session_id.localeCompare(b.session_id);
+  });
+}
+
+function parseSandboxSessions(value: unknown): SandboxSession[] {
+  const payload = asRecord(value);
+  const sessions = payload?.sessions;
+  if (!Array.isArray(sessions)) throw new Error("Malformed sandbox sessions");
+  return sessions.map((session) => {
+    const data = asRecord(session);
+    const session_id = data ? recordString(data, "session_id") : undefined;
+    const thread_id = data ? recordString(data, "thread_id") : undefined;
+    const provider = data ? recordString(data, "provider") : undefined;
+    const status = data ? recordString(data, "status") : undefined;
+    if (!data || !session_id || !thread_id || !provider || !status) {
+      throw new Error("Malformed sandbox sessions");
+    }
+    return { ...data, session_id, thread_id, provider, status } as SandboxSession;
   });
 }
 


### PR DESCRIPTION
## Summary
- validate sandbox sessions payload before sorting and returning sessions
- require string session_id, thread_id, provider, and status
- cover malformed provider payloads

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts computer-panel/utils.test.ts
- npx eslint src/api/client.ts src/api/client.test.ts
- npm run build
- npm run lint