### PR TITLE
fix: guard user leases payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -134,6 +134,21 @@ describe("thread api client contract", () => {
     await expect(api.listSandboxSessions()).rejects.toThrow("Malformed sandbox sessions");
   });
 
+  it("listMyLeases rejects malformed lease participant identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      leases: [{
+        lease_id: "lease-1",
+        provider_name: "local",
+        recipe_id: "recipe-1",
+        recipe_name: "Local",
+        thread_ids: ["thread-1"],
+        agents: [{ thread_id: { value: "thread-1" }, agent_name: "Toad" }],
+      }],
+    }));
+
+    await expect(api.listMyLeases()).rejects.toThrow("Malformed user leases");
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -208,8 +208,42 @@ function parseSandboxSessions(value: unknown): SandboxSession[] {
 }
 
 export async function listMyLeases(signal?: AbortSignal): Promise<UserLeaseSummary[]> {
-  const payload = await request<{ leases: UserLeaseSummary[] }>("/api/sandbox/leases/mine", { signal });
-  return payload.leases;
+  return parseUserLeases(await request("/api/sandbox/leases/mine", { signal }));
+}
+
+function parseUserLeases(value: unknown): UserLeaseSummary[] {
+  const payload = asRecord(value);
+  const leases = payload?.leases;
+  if (!Array.isArray(leases)) throw new Error("Malformed user leases");
+  return leases.map((lease) => {
+    const data = asRecord(lease);
+    const lease_id = data ? recordString(data, "lease_id") : undefined;
+    const provider_name = data ? recordString(data, "provider_name") : undefined;
+    const recipe_id = data ? recordString(data, "recipe_id") : undefined;
+    const recipe_name = data ? recordString(data, "recipe_name") : undefined;
+    const thread_ids = data?.thread_ids;
+    const agents = data?.agents;
+    if (
+      !data ||
+      !lease_id ||
+      !provider_name ||
+      !recipe_id ||
+      !recipe_name ||
+      !Array.isArray(thread_ids) ||
+      !thread_ids.every((id) => typeof id === "string") ||
+      !Array.isArray(agents)
+    ) {
+      throw new Error("Malformed user leases");
+    }
+    const admittedAgents = agents.map((agent) => {
+      const agentData = asRecord(agent);
+      const thread_id = agentData ? recordString(agentData, "thread_id") : undefined;
+      const agent_name = agentData ? recordString(agentData, "agent_name") : undefined;
+      if (!agentData || !thread_id || !agent_name) throw new Error("Malformed user leases");
+      return { ...agentData, thread_id, agent_name };
+    });
+    return { ...data, lease_id, provider_name, recipe_id, recipe_name, thread_ids, agents: admittedAgents } as UserLeaseSummary;
+  });
 }
 
 export async function destroySandboxSession(sessionId: string, provider: string): Promise<void> {


### PR DESCRIPTION
## Summary
- validate current-user lease payloads before returning resource choices
- require string lease identity fields, string thread_ids, and string agent identities
- cover malformed lease participant payloads

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts NewChatPage.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts
- npm run build
- npm run lint