### PR TITLE
fix: guard thread detail payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -60,6 +60,17 @@ describe("thread api client contract", () => {
     await expect(api.listThreads()).rejects.toThrow("Malformed thread summaries");
   });
 
+  it("getThread rejects malformed thread detail display data", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      entries: {},
+      display_seq: "3",
+      sandbox: null,
+    }));
+
+    await expect(api.getThread("thread-1")).rejects.toThrow("Malformed thread detail");
+  });
+
   it("getDefaultThread resolves through agent_user_id", async () => {
     authFetch.mockResolvedValue(okJson({ thread: null }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -108,7 +108,25 @@ export async function deleteThread(threadId: string): Promise<void> {
 }
 
 export async function getThread(threadId: string): Promise<ThreadDetail> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}`);
+  return parseThreadDetail(await request(`/api/threads/${encodeURIComponent(threadId)}`));
+}
+
+function parseThreadDetail(value: unknown): ThreadDetail {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const entries = payload?.entries;
+  const display_seq = payload?.display_seq;
+  const sandbox = payload?.sandbox;
+  if (
+    !payload ||
+    !thread_id ||
+    !Array.isArray(entries) ||
+    typeof display_seq !== "number" ||
+    (sandbox !== null && asRecord(sandbox) === null)
+  ) {
+    throw new Error("Malformed thread detail");
+  }
+  return { ...payload, thread_id, entries, display_seq, sandbox } as ThreadDetail;
 }
 
 export async function getThreadPermissions(threadId: string, signal?: AbortSignal): Promise<ThreadPermissions> {


### PR DESCRIPTION
## Summary
- validate thread detail payload before returning display state
- require string thread_id, entries array, numeric display_seq, and object-or-null sandbox
- cover malformed thread detail display payloads

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts use-thread-data.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts
- npm run build
- npm run lint