### PR TITLE
fix: guard thread permissions payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -140,6 +140,17 @@ describe("thread api client contract", () => {
     await expect(api.getThreadLease("thread-1")).rejects.toThrow("Malformed lease status");
   });
 
+  it("getThreadPermissions rejects malformed permission payload identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: { value: "thread-1" },
+      requests: [],
+      session_rules: { allow: [], deny: [], ask: [] },
+      managed_only: true,
+    }));
+
+    await expect(api.getThreadPermissions("thread-1")).rejects.toThrow("Malformed thread permissions");
+  });
+
   it("listSandboxSessions rejects malformed session identities", async () => {
     authFetch.mockResolvedValue(okJson({
       sessions: [{

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -130,7 +130,32 @@ function parseThreadDetail(value: unknown): ThreadDetail {
 }
 
 export async function getThreadPermissions(threadId: string, signal?: AbortSignal): Promise<ThreadPermissions> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}/permissions`, { signal });
+  return parseThreadPermissions(await request(`/api/threads/${encodeURIComponent(threadId)}/permissions`, { signal }));
+}
+
+function stringArray(value: unknown): string[] | null {
+  return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : null;
+}
+
+function parseThreadPermissionRules(value: unknown): ThreadPermissionRules | null {
+  const payload = asRecord(value);
+  const allow = payload ? stringArray(payload.allow) : null;
+  const deny = payload ? stringArray(payload.deny) : null;
+  const ask = payload ? stringArray(payload.ask) : null;
+  if (!payload || !allow || !deny || !ask) return null;
+  return { allow, deny, ask };
+}
+
+function parseThreadPermissions(value: unknown): ThreadPermissions {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const requests = payload?.requests;
+  const session_rules = parseThreadPermissionRules(payload?.session_rules);
+  const managed_only = payload?.managed_only;
+  if (!payload || !thread_id || !Array.isArray(requests) || !session_rules || typeof managed_only !== "boolean") {
+    throw new Error("Malformed thread permissions");
+  }
+  return { ...payload, thread_id, requests, session_rules, managed_only } as ThreadPermissions;
 }
 
 export async function resolveThreadPermission(


### PR DESCRIPTION
## Summary
- reject malformed thread permissions payloads at the frontend API boundary
- validate permission rule arrays before they reach the chat permission UI
- add regression coverage for malformed permission identities

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts use-thread-permissions.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts src/hooks/use-thread-permissions.ts src/hooks/use-thread-permissions.test.tsx
- npm run build
- npm run lint