### PR TITLE
fix: guard thread permission mutations

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -151,6 +151,32 @@ describe("thread api client contract", () => {
     await expect(api.getThreadPermissions("thread-1")).rejects.toThrow("Malformed thread permissions");
   });
 
+  it("resolveThreadPermission rejects malformed permission mutation identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      ok: true,
+      thread_id: "thread-1",
+      request_id: { value: "request-1" },
+    }));
+
+    await expect(api.resolveThreadPermission("thread-1", "request-1", "allow")).rejects.toThrow(
+      "Malformed permission mutation",
+    );
+  });
+
+  it("addThreadPermissionRule rejects malformed rule mutation payloads", async () => {
+    authFetch.mockResolvedValue(okJson({
+      ok: true,
+      thread_id: "thread-1",
+      scope: "session",
+      rules: { allow: "bash", deny: [], ask: [] },
+      managed_only: true,
+    }));
+
+    await expect(api.addThreadPermissionRule("thread-1", "allow", "bash")).rejects.toThrow(
+      "Malformed permission rules mutation",
+    );
+  });
+
   it("listSandboxSessions rejects malformed session identities", async () => {
     authFetch.mockResolvedValue(okJson({
       sessions: [{

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -166,10 +166,24 @@ export async function resolveThreadPermission(
   answers?: AskUserAnswer[],
   annotations?: Record<string, unknown>,
 ): Promise<{ ok: boolean; thread_id: string; request_id: string }> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}/permissions/${encodeURIComponent(requestId)}/resolve`, {
-    method: "POST",
-    body: JSON.stringify({ decision, message, answers, annotations }),
-  });
+  return parsePermissionMutation(await request(
+    `/api/threads/${encodeURIComponent(threadId)}/permissions/${encodeURIComponent(requestId)}/resolve`,
+    {
+      method: "POST",
+      body: JSON.stringify({ decision, message, answers, annotations }),
+    },
+  ));
+}
+
+function parsePermissionMutation(value: unknown): { ok: boolean; thread_id: string; request_id: string } {
+  const payload = asRecord(value);
+  const ok = payload?.ok;
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const request_id = payload ? recordString(payload, "request_id") : undefined;
+  if (!payload || typeof ok !== "boolean" || !thread_id || !request_id) {
+    throw new Error("Malformed permission mutation");
+  }
+  return { ok, thread_id, request_id };
 }
 
 export async function addThreadPermissionRule(
@@ -177,10 +191,10 @@ export async function addThreadPermissionRule(
   behavior: PermissionRuleBehavior,
   toolName: string,
 ): Promise<{ ok: boolean; thread_id: string; scope: string; rules: ThreadPermissionRules; managed_only: boolean }> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}/permissions/rules`, {
+  return parsePermissionRulesMutation(await request(`/api/threads/${encodeURIComponent(threadId)}/permissions/rules`, {
     method: "POST",
     body: JSON.stringify({ behavior, tool_name: toolName }),
-  });
+  }));
 }
 
 export async function removeThreadPermissionRule(
@@ -188,10 +202,25 @@ export async function removeThreadPermissionRule(
   behavior: PermissionRuleBehavior,
   toolName: string,
 ): Promise<{ ok: boolean; thread_id: string; scope: string; rules: ThreadPermissionRules; managed_only: boolean }> {
-  return request(
+  return parsePermissionRulesMutation(await request(
     `/api/threads/${encodeURIComponent(threadId)}/permissions/rules/${encodeURIComponent(behavior)}/${encodeURIComponent(toolName)}`,
     { method: "DELETE" },
-  );
+  ));
+}
+
+function parsePermissionRulesMutation(
+  value: unknown,
+): { ok: boolean; thread_id: string; scope: string; rules: ThreadPermissionRules; managed_only: boolean } {
+  const payload = asRecord(value);
+  const ok = payload?.ok;
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const scope = payload ? recordString(payload, "scope") : undefined;
+  const rules = parseThreadPermissionRules(payload?.rules);
+  const managed_only = payload?.managed_only;
+  if (!payload || typeof ok !== "boolean" || !thread_id || !scope || !rules || typeof managed_only !== "boolean") {
+    throw new Error("Malformed permission rules mutation");
+  }
+  return { ok, thread_id, scope, rules, managed_only };
 }
 
 export async function getThreadRuntime(threadId: string): Promise<StreamStatus> {

--- a/frontend/app/src/hooks/use-thread-permissions.ts
+++ b/frontend/app/src/hooks/use-thread-permissions.ts
@@ -63,9 +63,9 @@ export function useThreadPermissions(threadId: string | undefined): ThreadPermis
     try {
       const payload = await getThreadPermissions(threadId, controller.signal);
       if (refreshGenerationRef.current !== generation) return;
-      setRequests(payload.requests ?? []);
-      setSessionRules(payload.session_rules ?? { allow: [], deny: [], ask: [] });
-      setManagedOnly(payload.managed_only ?? false);
+      setRequests(payload.requests);
+      setSessionRules(payload.session_rules);
+      setManagedOnly(payload.managed_only);
     } catch (err) {
       if (controller.signal.aborted) return;
       if (refreshGenerationRef.current !== generation) return;


### PR DESCRIPTION
## Summary
- reject malformed permission resolve mutation payloads
- reject malformed permission rule mutation payloads for add/remove
- remove duplicate fallback defaults from the permissions hook now that the API boundary admits the shape

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts use-thread-permissions.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts src/hooks/use-thread-permissions.ts src/hooks/use-thread-permissions.test.tsx
- npm run build
- npm run lint