### PR TITLE
fix: guard sandbox type payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -190,6 +190,14 @@ describe("thread api client contract", () => {
     await expect(api.listSandboxSessions()).rejects.toThrow("Malformed sandbox sessions");
   });
 
+  it("listSandboxTypes rejects malformed sandbox type identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      types: [{ name: { value: "local" }, available: true }],
+    }));
+
+    await expect(api.listSandboxTypes()).rejects.toThrow("Malformed sandbox types");
+  });
+
   it("listMyLeases rejects malformed lease participant identities", async () => {
     authFetch.mockResolvedValue(okJson({
       leases: [{

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -237,8 +237,22 @@ export async function sendMessage(threadId: string, message: string): Promise<{ 
 // --- Sandbox API ---
 
 export async function listSandboxTypes(): Promise<SandboxType[]> {
-  const payload = await request<{ types: SandboxType[] }>("/api/sandbox/types");
-  return payload.types;
+  return parseSandboxTypes(await request("/api/sandbox/types"));
+}
+
+function parseSandboxTypes(value: unknown): SandboxType[] {
+  const payload = asRecord(value);
+  const types = payload?.types;
+  if (!Array.isArray(types)) throw new Error("Malformed sandbox types");
+  return types.map((type) => {
+    const data = asRecord(type);
+    const name = data ? recordString(data, "name") : undefined;
+    const available = data?.available;
+    if (!data || !name || typeof available !== "boolean") {
+      throw new Error("Malformed sandbox types");
+    }
+    return { ...data, name, available } as SandboxType;
+  });
 }
 
 export async function pickFolder(): Promise<string | null> {


### PR DESCRIPTION
## Summary
- reject malformed sandbox type catalog payloads at the frontend API boundary
- require each sandbox type to provide a string name and boolean availability before NewChat/resource selection uses it
- add regression coverage for malformed sandbox type identities

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts NewChatPage.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts src/pages/NewChatPage.test.tsx src/hooks/use-thread-manager.ts
- npm run build
- npm run lint