### PR TITLE
fix: guard default thread config payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -86,7 +86,10 @@ describe("thread api client contract", () => {
   });
 
   it("getDefaultThreadConfig queries by agent_user_id", async () => {
-    authFetch.mockResolvedValue(okJson({ source: "derived", config: {} }));
+    authFetch.mockResolvedValue(okJson({
+      source: "derived",
+      config: { create_mode: "new", provider_config: "local", recipe: null, lease_id: null, model: null, workspace: null },
+    }));
 
     await api.getDefaultThreadConfig("agent-1");
 
@@ -94,6 +97,12 @@ describe("thread api client contract", () => {
       "/api/threads/default-config?agent_user_id=agent-1",
       { signal: undefined },
     );
+  });
+
+  it("getDefaultThreadConfig rejects malformed launch config payloads", async () => {
+    authFetch.mockResolvedValue(okJson({ source: "derived", config: { provider_config: "local" } }));
+
+    await expect(api.getDefaultThreadConfig("agent-1")).rejects.toThrow("Malformed default thread config");
   });
 
   it("saveDefaultThreadConfig posts agent_user_id", async () => {

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -90,7 +90,51 @@ function parseThreadSummary(value: unknown): ThreadSummary {
 }
 
 export async function getDefaultThreadConfig(agentUserId: string, signal?: AbortSignal): Promise<ThreadLaunchConfigResponse> {
-  return request(`/api/threads/default-config?agent_user_id=${encodeURIComponent(agentUserId)}`, { signal });
+  return parseDefaultThreadConfig(await request(`/api/threads/default-config?agent_user_id=${encodeURIComponent(agentUserId)}`, { signal }));
+}
+
+function isDefaultConfigSource(value: unknown): value is ThreadLaunchConfigResponse["source"] {
+  return value === "last_successful" || value === "last_confirmed" || value === "derived";
+}
+
+function isLaunchCreateMode(value: unknown): value is ThreadLaunchConfig["create_mode"] {
+  return value === "new" || value === "existing";
+}
+
+function isStringOrNullish(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function parseThreadLaunchConfig(value: unknown): ThreadLaunchConfig | null {
+  const payload = asRecord(value);
+  const create_mode = payload?.create_mode;
+  const provider_config = payload ? recordString(payload, "provider_config") : undefined;
+  const recipe = payload?.recipe;
+  const lease_id = payload?.lease_id;
+  const model = payload?.model;
+  const workspace = payload?.workspace;
+  if (
+    !payload ||
+    !isLaunchCreateMode(create_mode) ||
+    !provider_config ||
+    (recipe !== undefined && recipe !== null && asRecord(recipe) === null) ||
+    !isStringOrNullish(lease_id) ||
+    !isStringOrNullish(model) ||
+    !isStringOrNullish(workspace)
+  ) {
+    return null;
+  }
+  return { ...payload, create_mode, provider_config, recipe, lease_id, model, workspace } as ThreadLaunchConfig;
+}
+
+function parseDefaultThreadConfig(value: unknown): ThreadLaunchConfigResponse {
+  const payload = asRecord(value);
+  const source = payload?.source;
+  const config = parseThreadLaunchConfig(payload?.config);
+  if (!payload || !isDefaultConfigSource(source) || !config) {
+    throw new Error("Malformed default thread config");
+  }
+  return { source, config };
 }
 
 export async function saveDefaultThreadConfig(


### PR DESCRIPTION
## Summary
- reject malformed default thread launch config payloads at the frontend API boundary
- require the backend-normalized launch config source, create mode, provider config, and string/null optional fields
- add regression coverage for malformed default launch configs

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts NewChatPage.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts src/pages/NewChatPage.test.tsx
- npm run build
- npm run lint