### PR TITLE
fix: guard send message payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -136,6 +136,16 @@ describe("thread api client contract", () => {
     expect(authFetch).toHaveBeenCalledWith("/api/threads/thread-1", { method: "DELETE" });
   });
 
+  it("sendMessage rejects malformed routing payload identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      status: "started",
+      routing: "direct",
+      thread_id: { value: "thread-1" },
+    }));
+
+    await expect(api.sendMessage("thread-1", "hello")).rejects.toThrow("Malformed send message result");
+  });
+
   it("getThreadLease rejects malformed lease identities", async () => {
     authFetch.mockResolvedValue(okJson({
       thread_id: "thread-1",

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -272,10 +272,22 @@ export async function getThreadRuntime(threadId: string): Promise<StreamStatus> 
 }
 
 export async function sendMessage(threadId: string, message: string): Promise<{ status: string; routing: string }> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}/messages`, {
+  return parseSendMessageResult(await request(`/api/threads/${encodeURIComponent(threadId)}/messages`, {
     method: "POST",
     body: JSON.stringify({ message }),
-  });
+  }));
+}
+
+function parseSendMessageResult(value: unknown): { status: string; routing: string; thread_id: string; run_id?: string } {
+  const payload = asRecord(value);
+  const status = payload ? recordString(payload, "status") : undefined;
+  const routing = payload ? recordString(payload, "routing") : undefined;
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const run_id = payload?.run_id;
+  if (!payload || !status || !routing || !thread_id || (run_id !== undefined && typeof run_id !== "string")) {
+    throw new Error("Malformed send message result");
+  }
+  return run_id === undefined ? { status, routing, thread_id } : { status, routing, thread_id, run_id };
 }
 
 // --- Sandbox API ---


### PR DESCRIPTION
## Summary
- reject malformed send-message routing payloads at the frontend API boundary
- require status, routing, and thread_id strings before the chat send path treats the route as accepted
- add regression coverage for malformed routing identities

## Verification
- npm test -- client.test.ts
- npx eslint src/api/client.ts src/api/client.test.ts src/hooks/use-app-actions.ts
- npm run build
- npm run lint