### PR TITLE
fix: guard thread session payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -159,6 +159,20 @@ describe("thread api client contract", () => {
     await expect(api.getThreadLease("thread-1")).rejects.toThrow("Malformed lease status");
   });
 
+  it("getThreadSession rejects malformed session identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      session_id: "session-1",
+      terminal_id: { value: "terminal-1" },
+      status: "active",
+      started_at: "2026-04-12T00:00:00",
+      last_active_at: "2026-04-12T00:01:00",
+      expires_at: "2026-04-12T01:00:00",
+    }));
+
+    await expect(api.getThreadSession("thread-1")).rejects.toThrow("Malformed session status");
+  });
+
   it("getThreadPermissions rejects malformed permission payload identities", async () => {
     authFetch.mockResolvedValue(okJson({
       thread_id: { value: "thread-1" },

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -407,7 +407,22 @@ export async function destroySandboxSession(sessionId: string, provider: string)
 // --- Session/Terminal/Lease API ---
 
 export async function getThreadSession(threadId: string): Promise<SessionStatus> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}/session`);
+  return parseSessionStatus(await request(`/api/threads/${encodeURIComponent(threadId)}/session`));
+}
+
+function parseSessionStatus(value: unknown): SessionStatus {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const session_id = payload ? recordString(payload, "session_id") : undefined;
+  const terminal_id = payload ? recordString(payload, "terminal_id") : undefined;
+  const status = payload ? recordString(payload, "status") : undefined;
+  const started_at = payload ? recordString(payload, "started_at") : undefined;
+  const last_active_at = payload ? recordString(payload, "last_active_at") : undefined;
+  const expires_at = payload ? recordString(payload, "expires_at") : undefined;
+  if (!payload || !thread_id || !session_id || !terminal_id || !status || !started_at || !last_active_at || !expires_at) {
+    throw new Error("Malformed session status");
+  }
+  return { ...payload, thread_id, session_id, terminal_id, status, started_at, last_active_at, expires_at } as SessionStatus;
 }
 
 export async function getThreadTerminal(threadId: string): Promise<TerminalStatus> {


### PR DESCRIPTION
## Summary
- reject malformed thread session status payloads at the frontend API boundary
- require the session, terminal, thread, status, and timestamp strings before Computer Panel receives session state
- add regression coverage for malformed session identities

## Verification
- npm test -- client.test.ts
- npx eslint src/api/client.ts src/api/client.test.ts src/components/computer-panel/use-sandbox-status.ts
- npm run build
- npm run lint