### PR TITLE
fix: guard thread terminal payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -173,6 +173,21 @@ describe("thread api client contract", () => {
     await expect(api.getThreadSession("thread-1")).rejects.toThrow("Malformed session status");
   });
 
+  it("getThreadTerminal rejects malformed terminal state", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      terminal_id: "terminal-1",
+      lease_id: "lease-1",
+      cwd: "/workspace",
+      env_delta: { PATH: 123 },
+      version: "1",
+      created_at: "2026-04-12T00:00:00",
+      updated_at: "2026-04-12T00:01:00",
+    }));
+
+    await expect(api.getThreadTerminal("thread-1")).rejects.toThrow("Malformed terminal status");
+  });
+
   it("getThreadPermissions rejects malformed permission payload identities", async () => {
     authFetch.mockResolvedValue(okJson({
       thread_id: { value: "thread-1" },

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -426,7 +426,29 @@ function parseSessionStatus(value: unknown): SessionStatus {
 }
 
 export async function getThreadTerminal(threadId: string): Promise<TerminalStatus> {
-  return request(`/api/threads/${encodeURIComponent(threadId)}/terminal`);
+  return parseTerminalStatus(await request(`/api/threads/${encodeURIComponent(threadId)}/terminal`));
+}
+
+function stringMap(value: unknown): Record<string, string> | null {
+  const payload = asRecord(value);
+  if (!payload) return null;
+  return Object.values(payload).every((item) => typeof item === "string") ? payload as Record<string, string> : null;
+}
+
+function parseTerminalStatus(value: unknown): TerminalStatus {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const terminal_id = payload ? recordString(payload, "terminal_id") : undefined;
+  const lease_id = payload ? recordString(payload, "lease_id") : undefined;
+  const cwd = payload ? recordString(payload, "cwd") : undefined;
+  const env_delta = stringMap(payload?.env_delta);
+  const version = payload?.version;
+  const created_at = payload ? recordString(payload, "created_at") : undefined;
+  const updated_at = payload ? recordString(payload, "updated_at") : undefined;
+  if (!payload || !thread_id || !terminal_id || !lease_id || !cwd || !env_delta || typeof version !== "number" || !created_at || !updated_at) {
+    throw new Error("Malformed terminal status");
+  }
+  return { ...payload, thread_id, terminal_id, lease_id, cwd, env_delta, version, created_at, updated_at } as TerminalStatus;
 }
 
 export async function getThreadLease(threadId: string): Promise<LeaseStatus | null> {


### PR DESCRIPTION
## Summary
- reject malformed thread terminal status payloads at the frontend API boundary
- require terminal/thread/lease/cwd/timestamp strings, numeric version, and string-only env_delta before Computer Panel receives terminal state
- add regression coverage for malformed terminal state

## Verification
- npm test -- client.test.ts
- npx eslint src/api/client.ts src/api/client.test.ts src/components/computer-panel/use-sandbox-status.ts
- npm run build
- npm run lint