### PR TITLE
fix: guard sandbox file list payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -272,6 +272,16 @@ describe("thread api client contract", () => {
     await expect(api.listMyLeases()).rejects.toThrow("Malformed user leases");
   });
 
+  it("listSandboxFiles rejects malformed file entries", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      path: "/workspace",
+      entries: [{ name: "src", is_dir: "true", size: 0 }],
+    }));
+
+    await expect(api.listSandboxFiles("thread-1")).rejects.toThrow("Malformed sandbox file list");
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   ThreadPermissionRules,
   PermissionRuleBehavior,
   AskUserAnswer,
+  SandboxFileEntry,
   SandboxFileResult,
   SandboxFilesListResult,
   SandboxUploadResult,
@@ -538,7 +539,36 @@ function sandboxFilesBase(threadId: string): string {
 
 export async function listSandboxFiles(threadId: string, path?: string): Promise<SandboxFilesListResult> {
   const q = path ? `?path=${encodeURIComponent(path)}` : "";
-  return request(`${sandboxFilesBase(threadId)}/list${q}`);
+  return parseSandboxFilesList(await request(`${sandboxFilesBase(threadId)}/list${q}`));
+}
+
+function parseSandboxFilesList(value: unknown): SandboxFilesListResult {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const path = payload ? recordString(payload, "path") : undefined;
+  const entries = payload?.entries;
+  if (!payload || !thread_id || !path || !Array.isArray(entries)) {
+    throw new Error("Malformed sandbox file list");
+  }
+  return { thread_id, path, entries: entries.map(parseSandboxFileEntry) };
+}
+
+function parseSandboxFileEntry(value: unknown): SandboxFileEntry {
+  const payload = asRecord(value);
+  const name = payload ? recordString(payload, "name") : undefined;
+  const is_dir = payload?.is_dir;
+  const size = payload?.size;
+  const children_count = payload?.children_count;
+  if (
+    !payload ||
+    !name ||
+    typeof is_dir !== "boolean" ||
+    typeof size !== "number" ||
+    (children_count !== undefined && children_count !== null && typeof children_count !== "number")
+  ) {
+    throw new Error("Malformed sandbox file list");
+  }
+  return children_count === undefined ? { name, is_dir, size } : { name, is_dir, size, children_count };
 }
 
 export async function readSandboxFile(threadId: string, path: string): Promise<SandboxFileResult> {


### PR DESCRIPTION
## Summary
- reject malformed sandbox file list payloads at the frontend API boundary
- require thread/path strings and typed file entry fields before the file explorer builds a tree
- add regression coverage for malformed file entries

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts use-directory-browser.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts src/components/computer-panel/use-file-explorer.ts src/hooks/use-directory-browser.test.tsx
- npm run build
- npm run lint