### PR TITLE
fix: guard sandbox file read payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -282,6 +282,17 @@ describe("thread api client contract", () => {
     await expect(api.listSandboxFiles("thread-1")).rejects.toThrow("Malformed sandbox file list");
   });
 
+  it("readSandboxFile rejects malformed file content payloads", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      path: "/workspace/app.py",
+      content: { text: "print(1)" },
+      size: "8",
+    }));
+
+    await expect(api.readSandboxFile("thread-1", "/workspace/app.py")).rejects.toThrow("Malformed sandbox file read");
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -572,7 +572,19 @@ function parseSandboxFileEntry(value: unknown): SandboxFileEntry {
 }
 
 export async function readSandboxFile(threadId: string, path: string): Promise<SandboxFileResult> {
-  return request(`${sandboxFilesBase(threadId)}/read?path=${encodeURIComponent(path)}`);
+  return parseSandboxFileRead(await request(`${sandboxFilesBase(threadId)}/read?path=${encodeURIComponent(path)}`));
+}
+
+function parseSandboxFileRead(value: unknown): SandboxFileResult {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const path = payload ? recordString(payload, "path") : undefined;
+  const content = payload ? recordString(payload, "content") : undefined;
+  const size = payload?.size;
+  if (!payload || !thread_id || !path || content === undefined || typeof size !== "number") {
+    throw new Error("Malformed sandbox file read");
+  }
+  return { thread_id, path, content, size };
 }
 
 export async function uploadSandboxFile(


### PR DESCRIPTION
## Summary
- reject malformed sandbox file read payloads at the frontend API boundary
- require thread/path/content strings and numeric size before file preview state receives content
- add regression coverage for malformed file read payloads

## Verification
- npm test -- client.test.ts
- npm test -- client.test.ts use-directory-browser.test.tsx
- npx eslint src/api/client.ts src/api/client.test.ts src/components/computer-panel/use-file-explorer.ts src/hooks/use-directory-browser.test.tsx
- npm run build
- npm run lint