### PR TITLE
fix: guard sandbox upload payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -293,6 +293,20 @@ describe("thread api client contract", () => {
     await expect(api.readSandboxFile("thread-1", "/workspace/app.py")).rejects.toThrow("Malformed sandbox file read");
   });
 
+  it("uploadSandboxFile rejects malformed upload results", async () => {
+    authFetch.mockResolvedValue(okJson({
+      thread_id: "thread-1",
+      relative_path: "avatar.png",
+      absolute_path: "/workspace/files/avatar.png",
+      size_bytes: "3",
+      sha256: "abc",
+    }));
+
+    await expect(api.uploadSandboxFile("thread-1", { file: new File(["png"], "avatar.png") })).rejects.toThrow(
+      "Malformed sandbox upload result",
+    );
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -604,7 +604,20 @@ export async function uploadSandboxFile(
     const body = await response.text();
     throw new Error(`API ${response.status}: ${body || response.statusText}`);
   }
-  return (await response.json()) as SandboxUploadResult;
+  return parseSandboxUploadResult(await response.json());
+}
+
+function parseSandboxUploadResult(value: unknown): SandboxUploadResult {
+  const payload = asRecord(value);
+  const thread_id = payload ? recordString(payload, "thread_id") : undefined;
+  const relative_path = payload ? recordString(payload, "relative_path") : undefined;
+  const absolute_path = payload ? recordString(payload, "absolute_path") : undefined;
+  const size_bytes = payload?.size_bytes;
+  const sha256 = payload ? recordString(payload, "sha256") : undefined;
+  if (!payload || !thread_id || !relative_path || !absolute_path || typeof size_bytes !== "number" || !sha256) {
+    throw new Error("Malformed sandbox upload result");
+  }
+  return { thread_id, relative_path, absolute_path, size_bytes, sha256 };
 }
 
 export function getSandboxDownloadUrl(


### PR DESCRIPTION
## Summary
- reject malformed sandbox upload results at the frontend API boundary
- require thread/path/hash strings and numeric size before ChatPage uses attachment upload output
- add regression coverage for malformed upload results

## Verification
- npm test -- client.test.ts
- npx eslint src/api/client.ts src/api/client.test.ts src/pages/ChatPage.tsx
- npm run build
- npm run lint