### PR TITLE
fix: guard default thread payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -85,6 +85,12 @@ describe("thread api client contract", () => {
     );
   });
 
+  it("getDefaultThread rejects malformed default-thread envelopes", async () => {
+    authFetch.mockResolvedValue(okJson({ thread: false }));
+
+    await expect(api.getDefaultThread("agent-1")).rejects.toThrow("Malformed default thread");
+  });
+
   it("getDefaultThreadConfig queries by agent_user_id", async () => {
     authFetch.mockResolvedValue(okJson({
       source: "derived",

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -75,12 +75,19 @@ export async function getDefaultThread(agentUserId: string, signal?: AbortSignal
   // @@@default-thread-wire-main-route - frontend now treats this as a template ->
   // default-thread resolver, but the backend endpoint name stays `/threads/main`
   // until the route contract is renamed in a later slice.
-  const payload = await request<{ thread: ThreadSummary | null }>("/api/threads/main", {
+  return parseDefaultThread(await request("/api/threads/main", {
     method: "POST",
     body: JSON.stringify({ agent_user_id: agentUserId }),
     signal,
-  });
-  return payload.thread ? parseThreadSummary(payload.thread) : null;
+  }));
+}
+
+function parseDefaultThread(value: unknown): ThreadSummary | null {
+  const payload = asRecord(value);
+  if (!payload || !("thread" in payload)) throw new Error("Malformed default thread");
+  if (payload.thread === null) return null;
+  if (asRecord(payload.thread) === null) throw new Error("Malformed default thread");
+  return parseThreadSummary(payload.thread);
 }
 
 function parseThreadSummary(value: unknown): ThreadSummary {


### PR DESCRIPTION
## Summary
- reject malformed default-thread envelopes instead of treating them as no thread
- keep null default-thread responses unchanged
- add API client regression coverage

## Verification
- npm test -- client.test.ts
- npm run lint -- src/api/client.ts src/api/client.test.ts src/hooks/use-thread-manager.ts
- npm run build