### PR TITLE
simplify: remove local folder picker route

### DIFF
--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -1,8 +1,6 @@
 """Sandbox management endpoints."""
 
 import asyncio
-import subprocess
-import sys
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -36,79 +34,6 @@ async def list_sandbox_types() -> dict[str, Any]:
     """List available sandbox types."""
     types = await asyncio.to_thread(sandbox_service.available_sandbox_types)
     return {"types": types}
-
-
-@router.get("/pick-folder")
-async def pick_folder() -> dict[str, Any]:
-    """Open system folder picker dialog and return selected path."""
-    try:
-        if sys.platform == "darwin":  # macOS
-            result = subprocess.run(
-                [
-                    "osascript",
-                    "-e",
-                    'POSIX path of (choose folder with prompt "选择工作目录")',
-                ],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if result.returncode == 0:
-                path = result.stdout.strip()
-                return {"path": path}
-            raise HTTPException(400, "User cancelled folder selection")
-        if sys.platform == "win32":  # Windows
-            # Use PowerShell folder browser
-            ps_script = """
-            Add-Type -AssemblyName System.Windows.Forms
-            $dialog = New-Object System.Windows.Forms.FolderBrowserDialog
-            $dialog.Description = "选择工作目录"
-            $dialog.ShowNewFolderButton = $true
-            if ($dialog.ShowDialog() -eq 'OK') {
-                Write-Output $dialog.SelectedPath
-            }
-            """
-            result = subprocess.run(
-                ["powershell", "-Command", ps_script],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                path = result.stdout.strip()
-                return {"path": path}
-            raise HTTPException(400, "User cancelled folder selection")
-        # Linux
-        # Try zenity first, fallback to kdialog
-        try:
-            result = subprocess.run(
-                ["zenity", "--file-selection", "--directory", "--title=选择工作目录"],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if result.returncode == 0:
-                path = result.stdout.strip()
-                return {"path": path}
-        except FileNotFoundError:
-            # Try kdialog
-            result = subprocess.run(
-                ["kdialog", "--getexistingdirectory", ".", "--title", "选择工作目录"],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if result.returncode == 0:
-                path = result.stdout.strip()
-                return {"path": path}
-        raise HTTPException(400, "User cancelled folder selection")
-    except subprocess.TimeoutExpired:
-        raise HTTPException(408, "Folder selection timed out")
-    # @@@http_passthrough - keep explicit business/status errors from selection branches intact
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(500, f"Failed to open folder picker: {str(e)}") from e
 
 
 @router.get("/sessions")

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -373,16 +373,6 @@ function parseSandboxTypes(value: unknown): SandboxType[] {
   });
 }
 
-export async function pickFolder(): Promise<string | null> {
-  try {
-    const payload = await request<{ path: string }>("/api/sandbox/pick-folder");
-    return payload.path;
-  } catch (err) {
-    console.log("Folder selection cancelled or failed:", err);
-    return null;
-  }
-}
-
 export async function listSandboxSessions(): Promise<SandboxSession[]> {
   const sessions = parseSandboxSessions(await request("/api/sandbox/sessions"));
   const toTs = (value?: string): number => {

--- a/tests/Integration/test_sandbox_router_user_shell.py
+++ b/tests/Integration/test_sandbox_router_user_shell.py
@@ -7,6 +7,12 @@ import pytest
 from backend.web.routers import sandbox as sandbox_router
 
 
+def test_sandbox_router_does_not_expose_local_folder_picker() -> None:
+    paths = {route.path for route in sandbox_router.router.routes}
+
+    assert "/api/sandbox/pick-folder" not in paths
+
+
 @pytest.mark.asyncio
 async def test_list_my_leases_uses_user_repo_not_member_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- remove unused frontend pickFolder API wrapper
- remove backend /api/sandbox/pick-folder local GUI route
- add router contract coverage that the web backend does not expose a local folder picker

## Verification
- uv run pytest tests/Integration/test_sandbox_router_user_shell.py
- npm test -- client.test.ts
- rg -n "pickFolder|pick-folder|osascript|zenity|kdialog|FolderBrowserDialog" frontend/app/src backend/web tests
- uv run ruff check backend/web/routers/sandbox.py tests/Integration/test_sandbox_router_user_shell.py
- npm run lint -- src/api/client.ts src/api/client.test.ts
- npm run build