### PR TITLE
fix: guard observation verify payload

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -335,6 +335,18 @@ describe("thread api client contract", () => {
     await expect(api.generateInviteCode()).rejects.toThrow("Malformed invite code");
   });
 
+  it("verifyObservation rejects malformed success fields", async () => {
+    authFetch.mockResolvedValue(okJson({ success: "yes", traces: [] }));
+
+    await expect(api.verifyObservation()).rejects.toThrow("Malformed observation verify result");
+  });
+
+  it("verifyObservation rejects malformed error fields", async () => {
+    authFetch.mockResolvedValue(okJson({ success: false, error: { message: "not a string" } }));
+
+    await expect(api.verifyObservation()).rejects.toThrow("Malformed observation verify result");
+  });
+
   it("uploadUserAvatar sends user avatar path instead of members path", async () => {
     authFetch.mockResolvedValue(okJson({ ok: true }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -646,13 +646,33 @@ export async function saveObservationConfig(
   });
 }
 
-export async function verifyObservation(): Promise<{
+export interface ObservationVerifyResult {
   success: boolean;
   provider?: string;
-  traces?: unknown[];
+  traces: unknown[];
   error?: string;
-}> {
-  return request("/api/settings/observation/verify");
+}
+
+function parseObservationVerifyResult(value: unknown): ObservationVerifyResult {
+  const payload = asRecord(value);
+  const success = payload?.success;
+  const provider = payload?.provider;
+  const traces = payload?.traces;
+  const error = payload?.error;
+  if (!payload || typeof success !== "boolean" || !isStringOrNullish(provider)) {
+    throw new Error("Malformed observation verify result");
+  }
+  const admittedProvider = provider ?? undefined;
+  if (success) {
+    if (!Array.isArray(traces)) throw new Error("Malformed observation verify result");
+    return { success, provider: admittedProvider, traces };
+  }
+  if (typeof error !== "string") throw new Error("Malformed observation verify result");
+  return { success, provider: admittedProvider, traces: [], error };
+}
+
+export async function verifyObservation(): Promise<ObservationVerifyResult> {
+  return parseObservationVerifyResult(await request("/api/settings/observation/verify"));
 }
 
 // --- Invite Code API ---

--- a/frontend/app/src/components/ObservationSection.test.tsx
+++ b/frontend/app/src/components/ObservationSection.test.tsx
@@ -47,23 +47,20 @@ describe("ObservationSection", () => {
     expect(screen.queryByDisplayValue("[object Object]")).toBeNull();
   });
 
-  it("ignores non-string verify errors", async () => {
-    verifyObservation.mockResolvedValue({
-      success: false,
-      error: { message: "not a string" },
-    });
+  it("shows verify API errors", async () => {
+    verifyObservation.mockRejectedValue(new Error("Malformed observation verify result"));
 
     renderActiveLangfuse();
 
     fireEvent.click(screen.getAllByRole("button", { name: "测试连接" })[0]);
 
-    expect((await screen.findAllByText("连接失败：验证失败")).length).toBeGreaterThan(0);
-    expect(screen.queryByText("[object Object]")).toBeNull();
+    expect((await screen.findAllByText("连接失败：Malformed observation verify result")).length).toBeGreaterThan(0);
   });
 
-  it("does not treat non-boolean verify success as connected", async () => {
+  it("shows failed verification results", async () => {
     verifyObservation.mockResolvedValue({
-      success: "yes",
+      success: false,
+      error: "Langfuse keys not configured",
       traces: [],
     });
 
@@ -72,7 +69,7 @@ describe("ObservationSection", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "测试连接" })[0]);
 
     await waitFor(() => {
-      expect(screen.getAllByText("连接失败：验证失败").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("连接失败：Langfuse keys not configured").length).toBeGreaterThan(0);
     });
     expect(screen.queryByText(/已连接/)).toBeNull();
   });

--- a/frontend/app/src/components/ObservationSection.tsx
+++ b/frontend/app/src/components/ObservationSection.tsx
@@ -29,7 +29,7 @@ interface ProviderDef {
 
 interface VerifyResult {
   success: boolean;
-  error: string;
+  error?: string;
   traces: unknown[];
 }
 
@@ -89,22 +89,6 @@ function setNestedValue(config: Record<string, unknown>, field: FieldDef, value:
   return updated;
 }
 
-function parseVerifyResult(result: unknown): VerifyResult {
-  const data = asRecord(result);
-  if (data?.success === true) {
-    return {
-      success: true,
-      error: "",
-      traces: Array.isArray(data.traces) ? data.traces : [],
-    };
-  }
-  return {
-    success: false,
-    error: data ? recordString(data, "error") || "验证失败" : "验证失败",
-    traces: [],
-  };
-}
-
 function maskValue(val: string) {
   if (!val || val.length <= 8) return "•".repeat(val?.length || 0);
   return val.slice(0, 4) + "•".repeat(Math.min(val.length - 8, 20)) + val.slice(-4);
@@ -152,7 +136,7 @@ export default function ObservationSection({ config, onUpdate }: ObservationSect
     setVerifyResult(null);
     try {
       const result = await verifyObservation();
-      setVerifyResult(parseVerifyResult(result));
+      setVerifyResult(result);
     } catch (err) {
       setVerifyResult({ success: false, error: err instanceof Error ? err.message : "验证失败", traces: [] });
     } finally {


### PR DESCRIPTION
## Summary
- parse observation verify responses at the API client boundary
- remove duplicate verify-result parsing from ObservationSection
- keep the component focused on rendering admitted results or API errors

## Verification
- npm test -- client.test.ts
- npm test -- ObservationSection.test.tsx
- npm test -- client.test.ts ObservationSection.test.tsx
- npm run lint -- src/api/client.ts src/api/client.test.ts src/components/ObservationSection.tsx src/components/ObservationSection.test.tsx
- npm run build