### PR TITLE
feat: create sandbox recipes by provider name

### DIFF
--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -47,6 +47,7 @@ class PublishAgentRequest(BaseModel):
 class CreateResourceRequest(BaseModel):
     name: str
     desc: str = ""
+    provider_name: str | None = None
     provider_type: str | None = None
     features: dict[str, bool] | None = None
 

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -214,16 +214,20 @@ async def create_resource(
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
     category = req.provider_type or ""
-    return await asyncio.to_thread(
-        library_service.create_resource,
-        resource_type,
-        req.name,
-        req.desc,
-        category,
-        req.features,
-        user_id,
-        request.app.state.recipe_repo,
-    )
+    try:
+        return await asyncio.to_thread(
+            library_service.create_resource,
+            resource_type,
+            req.name,
+            req.desc,
+            category,
+            req.features,
+            req.provider_name,
+            user_id,
+            request.app.state.recipe_repo,
+        )
+    except ValueError as error:
+        raise HTTPException(400, str(error)) from error
 
 
 @router.put("/library/{resource_type}/{resource_id}")

--- a/backend/web/services/library_service.py
+++ b/backend/web/services/library_service.py
@@ -182,12 +182,27 @@ def _recipe_row_needs_repair(row: dict[str, Any], *, provider_name: str, provide
     )
 
 
+def _resolve_recipe_provider(provider_name: str | None) -> tuple[str, str]:
+    name = str(provider_name or "").strip()
+    if not name:
+        raise ValueError("Recipe provider_name is required")
+    for sandbox in sandbox_service.available_sandbox_types():
+        if str(sandbox.get("name") or "").strip() != name:
+            continue
+        provider_type = str(sandbox.get("provider") or "").strip()
+        if not provider_type:
+            raise ValueError(f"Sandbox provider {name!r} is missing provider type")
+        return name, provider_type
+    raise ValueError(f"Unknown sandbox provider: {name}")
+
+
 def create_resource(
     resource_type: str,
     name: str,
     desc: str = "",
     category: str = "",
     features: dict[str, bool] | None = None,
+    provider_name: str | None = None,
     owner_user_id: str | None = None,
     recipe_repo: RecipeRepo | None = None,
 ) -> dict[str, Any]:
@@ -196,17 +211,16 @@ def create_resource(
     if resource_type == "recipe":
         owner_user_id = _require_recipe_owner(owner_user_id)
         recipe_repo = _require_recipe_repo(recipe_repo)
-        provider_type = cat.strip()
-        if not provider_type:
-            raise ValueError("Recipe provider_type is required")
+        provider_name, provider_type = _resolve_recipe_provider(provider_name)
         feature_source = features if isinstance(features, dict) else {}
         feature_values = {key: bool(feature_source.get(key, False)) for key in FEATURE_CATALOG}
-        recipe_id = f"{provider_type}:custom:{uuid.uuid4().hex[:8]}"
+        recipe_id = f"{provider_name}:custom:{uuid.uuid4().hex[:8]}"
         item = _normalize_recipe_item(
             {
                 "id": recipe_id,
                 "name": name,
                 "desc": desc,
+                "provider_name": provider_name,
                 "provider_type": provider_type,
                 "features": feature_values,
                 "created_at": now,

--- a/frontend/app/src/components/RecipeEditor.tsx
+++ b/frontend/app/src/components/RecipeEditor.tsx
@@ -10,48 +10,81 @@ import { useAppStore } from "@/store/app-store";
 import type { ResourceItem } from "@/store/types";
 
 interface RecipeEditorProps {
-  item: ResourceItem;
+  item: ResourceItem | null;
+  providerOptions?: ResourceItem[];
+  onCreated?: (item: ResourceItem) => void;
   onDeleted?: () => void;
 }
 
-function featureOptionsFor(item: ResourceItem): RecipeFeatureOption[] {
-  return item.feature_options ?? [];
+const EMPTY_PROVIDER_OPTIONS: ResourceItem[] = [];
+
+function featureOptionsFor(item: ResourceItem | null): RecipeFeatureOption[] {
+  return item?.feature_options ?? [];
 }
 
-export default function RecipeEditor({ item, onDeleted }: RecipeEditorProps) {
+function featureStateFor(options: RecipeFeatureOption[], item: ResourceItem | null): Record<string, boolean> {
+  return Object.fromEntries(options.map((option) => [option.key, Boolean(item?.features?.[option.key])]));
+}
+
+export default function RecipeEditor({ item, providerOptions = EMPTY_PROVIDER_OPTIONS, onCreated, onDeleted }: RecipeEditorProps) {
+  const addResource = useAppStore((s) => s.addResource);
   const updateResource = useAppStore((s) => s.updateResource);
   const deleteResource = useAppStore((s) => s.deleteResource);
-  const [name, setName] = useState(item.name);
-  const [desc, setDesc] = useState(item.desc);
-  const [features, setFeatures] = useState<Record<string, boolean>>(item.features ?? {});
+  const isCreate = item === null;
+  const initialProvider = providerOptions[0] ?? null;
+  const [name, setName] = useState(item?.name ?? "");
+  const [desc, setDesc] = useState(item?.desc ?? "");
+  const [providerName, setProviderName] = useState(item?.provider_name ?? initialProvider?.provider_name ?? "");
+  const activeProvider = providerOptions.find((option) => option.provider_name === providerName) ?? initialProvider;
+  const featureOptions = featureOptionsFor(item ?? activeProvider);
+  const [features, setFeatures] = useState<Record<string, boolean>>(featureStateFor(featureOptions, item));
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    setName(item.name);
-    setDesc(item.desc);
-    setFeatures(item.features ?? {});
-  }, [item]);
+    const nextProvider = item?.provider_name ?? providerOptions[0]?.provider_name ?? "";
+    const nextProviderItem = providerOptions.find((option) => option.provider_name === nextProvider) ?? providerOptions[0] ?? null;
+    const nextFeatureOptions = featureOptionsFor(item ?? nextProviderItem);
+    setName(item?.name ?? "");
+    setDesc(item?.desc ?? "");
+    setProviderName(nextProvider);
+    setFeatures(featureStateFor(nextFeatureOptions, item));
+  }, [item, providerOptions]);
+
+  useEffect(() => {
+    if (!isCreate) return;
+    setFeatures(featureStateFor(featureOptionsFor(activeProvider), null));
+  }, [activeProvider, isCreate]);
 
   const dirty = useMemo(() => {
+    if (isCreate) return name.trim().length > 0 || desc.trim().length > 0 || Object.values(features).some(Boolean);
+    if (!item) return false;
     if (name !== item.name || desc !== item.desc) return true;
     const base = item.features ?? {};
     const keys = new Set([...Object.keys(base), ...Object.keys(features)]);
     return [...keys].some((key) => Boolean(base[key]) !== Boolean(features[key]));
-  }, [desc, features, item, name]);
+  }, [desc, features, isCreate, item, name]);
 
   async function handleSave() {
     setSaving(true);
     try {
-      await updateResource("recipe", item.id, { name, desc, features });
-      toast.success("Sandbox recipe 已保存");
+      if (isCreate) {
+        if (!providerName) throw new Error("请选择 Sandbox provider");
+        const created = await addResource("recipe", name.trim(), desc.trim(), { provider_name: providerName, features });
+        toast.success("Sandbox recipe 已创建");
+        onCreated?.(created);
+      } else if (item) {
+        await updateResource("recipe", item.id, { name, desc, features });
+        toast.success("Sandbox recipe 已保存");
+      }
     } catch (error) {
-      toast.error(`保存失败: ${error instanceof Error ? error.message : String(error)}`);
+      toast.error(`${isCreate ? "创建" : "保存"}失败: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       setSaving(false);
     }
   }
 
   async function handleDeleteOrReset() {
+    if (!item) return;
     const action = item.builtin ? "重置" : "删除";
     if (!window.confirm(`${action} ${item.name}?`)) return;
     setSaving(true);
@@ -66,8 +99,7 @@ export default function RecipeEditor({ item, onDeleted }: RecipeEditorProps) {
     }
   }
 
-  const featureOptions = featureOptionsFor(item);
-  const providerLabel = item.provider_name || item.provider_type || "unknown";
+  const providerLabel = item?.provider_name || activeProvider?.provider_name || "unknown";
 
   return (
     <section className="rounded-2xl border border-border bg-card overflow-hidden">
@@ -76,9 +108,9 @@ export default function RecipeEditor({ item, onDeleted }: RecipeEditorProps) {
           <Box className="h-4 w-4 text-primary" />
         </div>
         <div className="min-w-0">
-          <h1 className="text-xl font-semibold text-foreground">{item.name}</h1>
+          <h1 className="text-xl font-semibold text-foreground">{isCreate ? "新建 Sandbox" : item?.name}</h1>
           <p className="mt-1 text-xs text-muted-foreground">
-            Sandbox · {providerLabel} · {item.builtin ? "默认模板" : "自定义模板"}
+            Sandbox · {providerLabel} · {item?.builtin ? "默认模板" : "自定义模板"}
           </p>
         </div>
       </div>
@@ -90,6 +122,26 @@ export default function RecipeEditor({ item, onDeleted }: RecipeEditorProps) {
           </label>
           <Input id="recipe-name" value={name} onChange={(event) => setName(event.target.value)} />
         </div>
+
+        {isCreate && (
+          <div className="space-y-2">
+            <label htmlFor="recipe-provider" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+              Provider
+            </label>
+            <select
+              id="recipe-provider"
+              value={providerName}
+              onChange={(event) => setProviderName(event.target.value)}
+              className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
+            >
+              {providerOptions.map((option) => (
+                <option key={option.provider_name} value={option.provider_name}>
+                  {option.provider_name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         <div className="space-y-2">
           <label htmlFor="recipe-desc" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
@@ -135,13 +187,15 @@ export default function RecipeEditor({ item, onDeleted }: RecipeEditorProps) {
       </div>
 
       <div className="flex items-center justify-between gap-3 border-t border-border px-5 py-4">
-        <Button variant="outline" size="sm" disabled={saving} onClick={() => void handleDeleteOrReset()}>
-          {item.builtin ? <RotateCcw className="mr-1.5 h-3.5 w-3.5" /> : <Trash2 className="mr-1.5 h-3.5 w-3.5" />}
-          {item.builtin ? "重置" : "删除"}
-        </Button>
-        <Button size="sm" disabled={saving || !dirty || !name.trim()} onClick={() => void handleSave()}>
+        {item ? (
+          <Button variant="outline" size="sm" disabled={saving} onClick={() => void handleDeleteOrReset()}>
+            {item.builtin ? <RotateCcw className="mr-1.5 h-3.5 w-3.5" /> : <Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+            {item.builtin ? "重置" : "删除"}
+          </Button>
+        ) : <div />}
+        <Button size="sm" disabled={saving || !dirty || !name.trim() || (isCreate && !providerName)} onClick={() => void handleSave()}>
           <Save className="mr-1.5 h-3.5 w-3.5" />
-          保存
+          {isCreate ? "创建" : "保存"}
         </Button>
       </div>
     </section>

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Box, Search, Store, Package, TrendingUp, Clock, Star, RefreshCw, Zap, Users, Trash2 } from "lucide-react";
+import { Box, Search, Store, Package, TrendingUp, Clock, Star, RefreshCw, Zap, Users, Trash2, Plus, X } from "lucide-react";
 import { useMarketplaceStore } from "@/store/marketplace-store";
 import { useAppStore } from "@/store/app-store";
 import { useIsMobile } from "@/hooks/use-mobile";
 import MarketplaceCard from "@/components/marketplace/MarketplaceCard";
 import UpdateDialog from "@/components/marketplace/UpdateDialog";
-import type { Agent } from "@/store/types";
+import RecipeEditor from "@/components/RecipeEditor";
+import type { Agent, ResourceItem } from "@/store/types";
 import type { UpdateAvailable } from "@/store/marketplace-store";
 
 type Tab = "explore" | "installed";
@@ -81,6 +82,7 @@ export default function MarketplacePage() {
   // Update dialog
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
   const [updateTarget, setUpdateTarget] = useState<{ agent: Agent; update: UpdateAvailable } | null>(null);
+  const [recipeCreateOpen, setRecipeCreateOpen] = useState(false);
 
 
   // Fetch explore items when filters change
@@ -114,6 +116,15 @@ export default function MarketplacePage() {
   const filteredRecipes = libraryRecipes.filter((recipe) =>
     !installedSearch || recipe.name.toLowerCase().includes(installedSearch.toLowerCase())
   );
+  const recipeProviderOptions = useMemo<ResourceItem[]>(() => {
+    const seen = new Set<string>();
+    return libraryRecipes.filter((recipe) => {
+      const providerName = recipe.provider_name;
+      if (!providerName || seen.has(providerName)) return false;
+      seen.add(providerName);
+      return true;
+    });
+  }, [libraryRecipes]);
 
   const installedSubTabs: { id: InstalledSubTab; label: string; icon: React.ElementType; count: number }[] = [
     { id: "member", label: "Agent", icon: Package, count: installedAgentUsers.length },
@@ -360,6 +371,24 @@ export default function MarketplacePage() {
                   ))}
                 </div>
 
+                {installedSubTabLoaded && installedSubTab === "recipe" && (
+                  <div className="mb-4 flex items-center justify-between rounded-xl border border-border bg-card px-3 py-2">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">Sandbox 模板</p>
+                      <p className="text-xs text-muted-foreground">为当前账号创建可复用的 sandbox recipe。</p>
+                    </div>
+                    <button
+                      type="button"
+                      disabled={recipeProviderOptions.length === 0}
+                      onClick={() => setRecipeCreateOpen(true)}
+                      className="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-3 py-1.5 text-xs font-medium text-background transition-colors hover:bg-foreground/90 disabled:opacity-50"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      新建 Sandbox
+                    </button>
+                  </div>
+                )}
+
                 {!installedSubTabLoaded && (
                   <div className="text-center py-12 text-sm text-muted-foreground">正在加载已安装内容...</div>
                 )}
@@ -528,6 +557,28 @@ export default function MarketplacePage() {
           update={updateTarget.update}
           agentName={updateTarget.agent.name}
         />
+      )}
+
+      {recipeCreateOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4" onClick={() => setRecipeCreateOpen(false)}>
+          <div className="w-full max-w-2xl" onClick={(event) => event.stopPropagation()}>
+            <div className="mb-2 flex justify-end">
+              <button
+                type="button"
+                aria-label="关闭"
+                onClick={() => setRecipeCreateOpen(false)}
+                className="rounded-full bg-card p-2 text-muted-foreground shadow-sm transition-colors hover:text-foreground"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <RecipeEditor
+              item={null}
+              providerOptions={recipeProviderOptions}
+              onCreated={() => setRecipeCreateOpen(false)}
+            />
+          </div>
+        </div>
       )}
 
     </div>

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,6 +35,7 @@ vi.mock("@/store/marketplace-store", () => ({
 
 const appStoreFetchLibrary = vi.fn();
 const appStoreDeleteResource = vi.fn();
+const appStoreAddResource = vi.fn();
 let appStoreState: Record<string, unknown>;
 
 vi.mock("@/store/app-store", () => ({
@@ -51,6 +52,18 @@ describe("MarketplacePage wording contract", () => {
     vi.restoreAllMocks();
     appStoreFetchLibrary.mockReset();
     appStoreDeleteResource.mockReset();
+    appStoreAddResource.mockReset();
+    appStoreAddResource.mockResolvedValue({
+      id: "daytona_selfhost:custom:probe",
+      name: "Selfhost Custom",
+      desc: "custom self-host sandbox",
+      type: "recipe",
+      provider_name: "daytona_selfhost",
+      provider_type: "daytona",
+      features: { lark_cli: false },
+      created_at: 1,
+      updated_at: 1,
+    });
     appStoreState = {
       agentList: [],
       agentsLoaded: true,
@@ -64,11 +77,18 @@ describe("MarketplacePage wording contract", () => {
           type: "recipe",
           provider_type: "daytona",
           provider_name: "daytona_selfhost",
+          features: { lark_cli: false },
+          feature_options: [{
+            key: "lark_cli",
+            name: "Lark CLI",
+            description: "Install lark-cli during sandbox bootstrap",
+          }],
         },
       ],
       librariesLoaded: { skill: true, mcp: true, agent: true, recipe: true },
       fetchLibrary: appStoreFetchLibrary,
       deleteResource: appStoreDeleteResource,
+      addResource: appStoreAddResource,
     };
   });
 
@@ -120,7 +140,7 @@ describe("MarketplacePage wording contract", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("button", { name: /Sandbox/ })).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /Sandbox/ }).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Recipe/ })).toBeNull();
     expect(screen.getByText("Self-host Daytona")).toBeTruthy();
     expect(screen.getByText("Sandbox · daytona_selfhost")).toBeTruthy();
@@ -143,6 +163,28 @@ describe("MarketplacePage wording contract", () => {
 
     expect(screen.queryByText("暂无已安装的 Sandbox")).toBeNull();
     expect(screen.getByText("正在加载已安装内容...")).toBeTruthy();
+  });
+
+  it("creates sandbox recipes with concrete provider_name from backend-loaded recipes", async () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=recipe"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "新建 Sandbox" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Selfhost Custom" } });
+    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "custom self-host sandbox" } });
+    fireEvent.click(screen.getByRole("button", { name: "创建" }));
+
+    await waitFor(() => {
+      expect(appStoreAddResource).toHaveBeenCalledWith("recipe", "Selfhost Custom", "custom self-host sandbox", {
+        provider_name: "daytona_selfhost",
+        features: { lark_cli: false },
+      });
+    });
   });
 
   it("uses Agent wording for marketplace member resources", () => {

--- a/frontend/app/src/store/app-store.ts
+++ b/frontend/app/src/store/app-store.ts
@@ -44,7 +44,7 @@ interface AppState {
     type: string,
     name: string,
     desc?: string,
-    extra?: { provider_type?: string; features?: Record<string, boolean> },
+    extra?: { provider_name?: string; provider_type?: string; features?: Record<string, boolean> },
   ) => Promise<ResourceItem>;
   updateResource: (type: string, id: string, fields: Partial<ResourceItem>) => Promise<void>;
   deleteResource: (type: string, id: string) => Promise<void>;

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -393,6 +393,42 @@ def test_library_service_get_resource_used_by_scopes_to_owner(monkeypatch: pytes
     assert seen == [("user-1", "repo-1", "cfg-repo")]
 
 
+def test_library_service_create_recipe_uses_provider_name_identity(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        library_service.sandbox_service,
+        "available_sandbox_types",
+        lambda: [
+            {"name": "daytona", "provider": "daytona", "available": True},
+            {"name": "daytona_selfhost", "provider": "daytona", "available": True},
+        ],
+    )
+
+    rows: dict[tuple[str, str], dict[str, object]] = {}
+
+    class _RecipeRepo:
+        def get(self, owner_user_id: str, recipe_id: str):
+            return rows.get((owner_user_id, recipe_id))
+
+        def upsert(self, **payload: object):
+            rows[(str(payload["owner_user_id"]), str(payload["recipe_id"]))] = {"data": payload["data"], **payload}
+
+    item = library_service.create_resource(
+        "recipe",
+        "Selfhost Custom",
+        "custom self-host sandbox",
+        features={"lark_cli": True},
+        provider_name="daytona_selfhost",
+        owner_user_id="user-1",
+        recipe_repo=_RecipeRepo(),
+    )
+
+    assert item["id"].startswith("daytona_selfhost:custom:")
+    assert item["provider_name"] == "daytona_selfhost"
+    assert item["provider_type"] == "daytona"
+    assert rows[("user-1", item["id"])]["provider_type"] == "daytona"
+    assert rows[("user-1", item["id"])]["data"]["provider_name"] == "daytona_selfhost"
+
+
 def test_create_agent_user_fails_loudly_when_created_row_is_not_readable():
     created_rows: list[UserRow] = []
     saved_configs: list[tuple[str, dict[str, object]]] = []


### PR DESCRIPTION
## Summary
- Create sandbox recipes by concrete `provider_name`, with `provider_type` kept only as classification.
- Add Marketplace Installed -> Sandbox `新建 Sandbox` flow backed by backend-loaded provider facts, not frontend hardcoding.
- Add regression coverage for self-host Daytona identity preservation.

## Verification
- `uv run pytest tests/Integration/test_panel_auth_shell_coherence.py tests/Unit/backend/test_auth_service_token_verification.py tests/Integration/test_thread_launch_config_contract.py -q`
- `uv run ruff check backend/web/models/panel.py backend/web/routers/panel.py backend/web/services/library_service.py tests/Integration/test_panel_auth_shell_coherence.py`
- `uv run pyright backend/web/services/library_service.py backend/web/routers/panel.py backend/web/models/panel.py`
- `npm test -- MarketplacePage.wording.test.tsx LibraryItemDetailPage.test.tsx NewChatPage.test.tsx`
- `npm run lint -- src/pages/MarketplacePage.tsx src/pages/MarketplacePage.wording.test.tsx src/components/RecipeEditor.tsx src/store/app-store.ts`
- `npm run build` in `frontend/app`
- Real API proof on temporary backend `8019`: create/read/delete `daytona_selfhost` recipe.
- Playwright CLI proof on temporary frontend `5190`: Marketplace Sandbox 6 -> create self-host custom -> Sandbox 7 -> delete -> Sandbox 6.