### PR TITLE
refactor: return launch recipe selector explicitly

### DIFF
--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -133,6 +133,7 @@ def _validate_saved_config(
     return {
         "create_mode": "new",
         "provider_config": provider_config,
+        "recipe_id": recipe_id,
         "recipe": recipe_snapshot,
         "lease_id": None,
         "model": config.get("model"),
@@ -188,6 +189,7 @@ def _derive_default_config(
     return {
         "create_mode": "new",
         "provider_config": provider_config,
+        "recipe_id": str(recipe["id"]) if recipe is not None else None,
         "recipe": recipe_snapshot,
         "lease_id": None,
         "model": None,

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -424,8 +424,9 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "new",
         provider_config: "local",
+        recipe_id: "local-recipe",
         recipe: {
-          id: "local-recipe",
+          id: "stale-display-snapshot",
           name: "Local",
           provider_type: "local",
           features: { lark_cli: false },
@@ -439,6 +440,18 @@ describe("NewChatPage", () => {
     });
     useAppStore.setState({
       libraryRecipes: [{
+        id: "other-recipe",
+        type: "recipe",
+        name: "Other Local",
+        desc: "",
+        provider_type: "local",
+        features: {},
+        configurable_features: {},
+        feature_options: [],
+        available: true,
+        created_at: 0,
+        updated_at: 0,
+      }, {
         id: "local-recipe",
         type: "recipe",
         name: "Local",

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -421,7 +421,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     setCreateMode(config.create_mode);
     setSelectedProviderConfig(config.provider_config || "");
     setSelectedLeaseId(config.lease_id || "");
-    setSelectedRecipeId(config.recipe?.id || "");
+    setSelectedRecipeId(config.recipe_id || config.recipe?.id || "");
     setSelectedRecipeFeatures(config.recipe?.features ?? {});
     setSelectedWorkspace(config.workspace || "");
     setSelectedModel(config.model || settings?.default_model || "leon:large");

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -341,6 +341,7 @@ def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() ->
         "config": {
             "create_mode": "new",
             "provider_config": "local",
+            "recipe_id": "local:default",
             "recipe": default_recipe_snapshot("local"),
             "lease_id": None,
             "model": "gpt-4.1",


### PR DESCRIPTION
## Summary
- Return `recipe_id` explicitly in new-sandbox default launch configs.
- Make New Chat apply `config.recipe_id` before falling back to display snapshot `recipe.id`.
- Add red/green coverage so selector and display snapshot are no longer conflated.

## Verification
- `uv run pytest tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_panel_auth_shell_coherence.py -q`
- `uv run ruff check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py`
- `uv run pyright backend/web/services/thread_launch_config_service.py`
- `npm test -- NewChatPage.test.tsx client.test.ts MarketplacePage.wording.test.tsx`
- `npm run lint -- src/pages/NewChatPage.tsx src/pages/NewChatPage.test.tsx src/api/types.ts`
- `git diff --check`