### PR TITLE
Move tool tasks to staging agent_thread_tasks

### DIFF
--- a/storage/providers/supabase/tool_task_repo.py
+++ b/storage/providers/supabase/tool_task_repo.py
@@ -9,7 +9,7 @@ from core.tools.task.types import Task, TaskStatus
 from storage.providers.supabase import _query as q
 
 _REPO = "tool_task repo"
-_TABLE = "tool_tasks"
+_TABLE = "agent_thread_tasks"
 
 
 class SupabaseToolTaskRepo:

--- a/tests/Unit/storage/test_supabase_tool_task_repo.py
+++ b/tests/Unit/storage/test_supabase_tool_task_repo.py
@@ -20,19 +20,29 @@ class _FakeTable:
 class _FakeClient:
     def __init__(self, rows):
         self.table_obj = _FakeTable(rows)
+        self.table_names: list[str] = []
 
-    def table(self, _name):
+    def table(self, name):
+        self.table_names.append(name)
         return self.table_obj
 
 
 def test_supabase_tool_task_repo_next_id_uses_max_existing_id_not_row_count():
-    repo = SupabaseToolTaskRepo(
-        _FakeClient(
-            [
-                {"task_id": "1"},
-                {"task_id": "3"},
-            ]
-        )
+    client = _FakeClient(
+        [
+            {"task_id": "1"},
+            {"task_id": "3"},
+        ]
     )
+    repo = SupabaseToolTaskRepo(client)
 
     assert repo.next_id("thread-gap") == "4"
+
+
+def test_supabase_tool_task_repo_uses_agent_thread_tasks_table():
+    client = _FakeClient([])
+    repo = SupabaseToolTaskRepo(client)
+
+    repo.next_id("thread-empty")
+
+    assert client.table_names == ["agent_thread_tasks"]


### PR DESCRIPTION
## Summary
- bind Supabase ToolTaskRepo to staging agent_thread_tasks
- add a narrow table-name regression test
- migration executed separately via ops path and verified in Ledger

## Verification
- uv run ruff format --check storage/providers/supabase/tool_task_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py
- uv run ruff check storage/providers/supabase/tool_task_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py
- uv run pytest tests/Unit/storage/test_supabase_tool_task_repo.py
- post-psql read-only verification: public.tool_tasks=274, staging.agent_thread_tasks=274
- PostgREST staging count probe: content-range */274
- ToolRunner/ToolSearch TaskCreate/List/Get/Update proof against real Supabase staging with cleanup