### PR TITLE
Move agent registry storage to staging

### DIFF
--- a/storage/container.py
+++ b/storage/container.py
@@ -113,9 +113,7 @@ class StorageContainer:
         return self._build("chat_session_repo")
 
     def agent_registry_repo(self) -> AgentRegistryRepo:
-        # @@@agent-registry-public-schema - agent_registry is still a public-schema
-        # island, so subagent persistence must not silently inherit staging.
-        return self._build("agent_registry_repo", client=self._public_supabase_client)
+        return self._build("agent_registry_repo")
 
     def tool_task_repo(self) -> ToolTaskRepo:
         return self._build("tool_task_repo")

--- a/storage/providers/supabase/agent_registry_repo.py
+++ b/storage/providers/supabase/agent_registry_repo.py
@@ -52,6 +52,18 @@ class SupabaseAgentRegistryRepo:
         r = rows[0]
         return (r["agent_id"], r["name"], r["thread_id"], r["status"], r.get("parent_agent_id"), r.get("subagent_type"))
 
+    def list_running_by_name(self, name: str) -> list[tuple]:
+        rows = q.rows(
+            self._table()
+            .select("agent_id,name,thread_id,status,parent_agent_id,subagent_type")
+            .eq("name", name)
+            .eq("status", "running")
+            .execute(),
+            _REPO,
+            "list_running_by_name",
+        )
+        return [(r["agent_id"], r["name"], r["thread_id"], r["status"], r.get("parent_agent_id"), r.get("subagent_type")) for r in rows]
+
     def update_status(self, agent_id: str, status: str) -> None:
         self._table().update({"status": status}).eq("agent_id", agent_id).execute()
 

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -83,12 +83,7 @@ def build_terminal_repo(*, supabase_client: Any | None = None, supabase_client_f
 
 
 def build_agent_registry_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
-    return _build_storage_repo(
-        "agent_registry_repo",
-        supabase_client=supabase_client,
-        supabase_client_factory=supabase_client_factory,
-        public_supabase_client_factory=_PUBLIC_SUPABASE_CLIENT_FACTORY,
-    )
+    return _build_storage_repo("agent_registry_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
 def build_sync_file_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):

--- a/tests/Unit/storage/test_supabase_agent_registry_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_registry_repo.py
@@ -1,0 +1,100 @@
+import storage.runtime as storage_runtime
+from storage.container import StorageContainer
+from storage.providers.supabase.agent_registry_repo import SupabaseAgentRegistryRepo
+
+
+class _FakeTable:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.eq_calls: list[tuple[str, object]] = []
+        self.select_calls: list[str] = []
+        self.upsert_payload = None
+
+    def select(self, cols):
+        self.select_calls.append(cols)
+        return self
+
+    def eq(self, key, value):
+        self.eq_calls.append((key, value))
+        return self
+
+    def upsert(self, payload):
+        self.upsert_payload = payload
+        return self
+
+    def execute(self):
+        return type("Resp", (), {"data": self.rows})()
+
+
+class _FakeClient:
+    def __init__(self, label: str, rows=None):
+        self.label = label
+        self.table_obj = _FakeTable(rows)
+        self.table_names: list[str] = []
+
+    def table(self, name):
+        self.table_names.append(name)
+        return self.table_obj
+
+
+def test_storage_container_agent_registry_repo_uses_staging_client_not_public_client() -> None:
+    staging_client = _FakeClient("staging")
+    public_client = _FakeClient("public")
+    container = StorageContainer(supabase_client=staging_client, public_supabase_client=public_client)
+
+    repo = container.agent_registry_repo()
+    repo.register(
+        agent_id="agent-1",
+        name="Scout",
+        thread_id="thread-1",
+        status="running",
+        parent_agent_id=None,
+        subagent_type="General",
+    )
+
+    assert staging_client.table_names == ["agent_registry"]
+    assert public_client.table_names == []
+
+
+def test_runtime_agent_registry_builder_does_not_resolve_public_client(monkeypatch) -> None:
+    staging_client = _FakeClient("staging")
+
+    def fake_resolve_supabase_client(supabase_client=None, factory_ref=None):
+        if factory_ref is not None:
+            raise AssertionError(f"unexpected public factory resolution: {factory_ref}")
+        return supabase_client
+
+    monkeypatch.setattr(storage_runtime, "_resolve_supabase_client", fake_resolve_supabase_client)
+
+    repo = storage_runtime.build_agent_registry_repo(supabase_client=staging_client)
+    repo.register(
+        agent_id="agent-1",
+        name="Scout",
+        thread_id="thread-1",
+        status="running",
+        parent_agent_id=None,
+        subagent_type="General",
+    )
+
+    assert staging_client.table_names == ["agent_registry"]
+
+
+def test_supabase_agent_registry_repo_lists_running_by_name() -> None:
+    rows = [
+        {
+            "agent_id": "agent-1",
+            "name": "Scout",
+            "thread_id": "thread-1",
+            "status": "running",
+            "parent_agent_id": "parent-1",
+            "subagent_type": "General",
+        }
+    ]
+    client = _FakeClient("staging", rows)
+    repo = SupabaseAgentRegistryRepo(client)
+
+    result = repo.list_running_by_name("Scout")
+
+    assert result == [("agent-1", "Scout", "thread-1", "running", "parent-1", "General")]
+    assert client.table_names == ["agent_registry"]
+    assert client.table_obj.eq_calls == [("name", "Scout"), ("status", "running")]


### PR DESCRIPTION
## Summary
- move the Supabase agent registry repo off the public-schema client and onto the normal runtime schema client
- implement the missing SupabaseAgentRegistryRepo.list_running_by_name contract used by AgentRegistry/SendMessage
- add focused storage tests for staging binding and list_running_by_name

## Verification
- uv run ruff format --check storage/container.py storage/runtime.py storage/providers/supabase/agent_registry_repo.py tests/Unit/storage/test_supabase_agent_registry_repo.py
- uv run ruff check storage/container.py storage/runtime.py storage/providers/supabase/agent_registry_repo.py tests/Unit/storage/test_supabase_agent_registry_repo.py
- uv run pytest tests/Unit/storage/test_supabase_agent_registry_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py
- executed approved ops migration 006_agent_registry_staging_landing.sql outside this repo; staging.agent_registry count 38, PostgREST staging count */38
- runtime proof via core.agents.registry.AgentRegistry against real Supabase staging covered register/get/list/list_running_by_name/latest/update_status and cleanup back to 38 rows