### PR TITLE
Route user settings through staging storage

### DIFF
--- a/storage/container.py
+++ b/storage/container.py
@@ -145,9 +145,7 @@ class StorageContainer:
         return self._build("invite_code_repo")
 
     def user_settings_repo(self) -> UserSettingsRepo:
-        # @@@user-settings-public-schema - user_settings is still a public-schema
-        # island, so authenticated settings routes must not inherit staging.
-        return self._build("user_settings_repo", client=self._public_supabase_client)
+        return self._build("user_settings_repo")
 
     def agent_config_repo(self) -> AgentConfigRepo:
         return self._build("agent_config_repo")

--- a/tests/Unit/storage/test_supabase_agent_registry_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_registry_repo.py
@@ -56,6 +56,18 @@ def test_storage_container_agent_registry_repo_uses_staging_client_not_public_cl
     assert public_client.table_names == []
 
 
+def test_storage_container_user_settings_repo_uses_staging_client_not_public_client() -> None:
+    staging_client = _FakeClient("staging")
+    public_client = _FakeClient("public")
+    container = StorageContainer(supabase_client=staging_client, public_supabase_client=public_client)
+
+    repo = container.user_settings_repo()
+    repo.get("user-1")
+
+    assert staging_client.table_names == ["user_settings"]
+    assert public_client.table_names == []
+
+
 def test_runtime_agent_registry_builder_does_not_resolve_public_client(monkeypatch) -> None:
     staging_client = _FakeClient("staging")
 


### PR DESCRIPTION
## Summary
- Route `StorageContainer.user_settings_repo()` through the runtime schema client instead of the public client.
- Add a storage wiring regression test proving `user_settings` uses the staging/runtime client while `sync_files` remains the explicit public-schema island.

## Ledger / ops evidence
- Checkpoint `public-schema-business-surface-purge-03-user-settings-staging-landing` closed `done/strict` in Ledger.
- Executed `/Users/lexicalmathical/share/ops/migrations/007_user_settings_staging_landing.sql` through the sanctioned pgl psql path before this PR.
- Post-psql DB proof: `public.user_settings` rows = 2, `staging.user_settings` rows = 2, no null or duplicate `user_id`, and expected columns/defaults.
- PostgREST proof: public and staging profiles both returned `206` with `content-range */2` for `user_settings?select=user_id&limit=0`.
- Backend API YATU: current-worktree backend on temporary `:8011` with `LEON_DB_SCHEMA=staging`; login 200, `GET /api/settings` 200, `GET /api/settings/account-resources` 200, default-model mutation to `leon:medium` and restore to `leon:large` verified, DB restore verified.

## Verification
- `uv run pytest tests/Unit/storage/test_supabase_agent_registry_repo.py tests/Unit/storage/test_supabase_settings_and_invites.py -q` -> 7 passed
- `uv run ruff check storage/container.py tests/Unit/storage/test_supabase_agent_registry_repo.py` -> All checks passed
- `git diff --check` on touched repo files -> no whitespace errors

## Out of scope
- Token usage accounting/enforcement.
- Model owner-vs-caller UX redesign.
- Settings UI redesign.
- `sync_files` staging migration.
- Public legacy table deletion.
