### PR TITLE
Route sync file state through staging storage

### DIFF
--- a/storage/container.py
+++ b/storage/container.py
@@ -119,9 +119,7 @@ class StorageContainer:
         return self._build("tool_task_repo")
 
     def sync_file_repo(self) -> SyncFileRepo:
-        # @@@sync-file-public-schema - sync_files is still a public-schema island,
-        # so runtime cleanup must not silently inherit staging.
-        return self._build("sync_file_repo", client=self._public_supabase_client)
+        return self._build("sync_file_repo")
 
     def resource_snapshot_repo(self) -> ResourceSnapshotRepo:
         return self._build("resource_snapshot_repo")

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -10,7 +10,6 @@ from typing import Any
 from storage.container import StorageContainer
 
 _WEB_SUPABASE_CLIENT_FACTORY = "backend.web.core.supabase_factory:create_supabase_client"
-_PUBLIC_SUPABASE_CLIENT_FACTORY = "backend.web.core.supabase_factory:create_public_supabase_client"
 
 
 def uses_supabase_storage() -> bool:
@@ -91,7 +90,6 @@ def build_sync_file_repo(*, supabase_client: Any | None = None, supabase_client_
         "sync_file_repo",
         supabase_client=supabase_client,
         supabase_client_factory=supabase_client_factory,
-        public_supabase_client_factory=_PUBLIC_SUPABASE_CLIENT_FACTORY,
     )
 
 

--- a/tests/Unit/storage/test_supabase_agent_registry_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_registry_repo.py
@@ -68,6 +68,18 @@ def test_storage_container_user_settings_repo_uses_staging_client_not_public_cli
     assert public_client.table_names == []
 
 
+def test_storage_container_sync_file_repo_uses_staging_client_not_public_client() -> None:
+    staging_client = _FakeClient("staging")
+    public_client = _FakeClient("public")
+    container = StorageContainer(supabase_client=staging_client, public_supabase_client=public_client)
+
+    repo = container.sync_file_repo()
+    repo.track_file("thread-1", "notes/a.txt", "a" * 64, 123)
+
+    assert staging_client.table_names == ["sync_files"]
+    assert public_client.table_names == []
+
+
 def test_runtime_agent_registry_builder_does_not_resolve_public_client(monkeypatch) -> None:
     staging_client = _FakeClient("staging")
 
@@ -89,6 +101,22 @@ def test_runtime_agent_registry_builder_does_not_resolve_public_client(monkeypat
     )
 
     assert staging_client.table_names == ["agent_registry"]
+
+
+def test_runtime_sync_file_builder_does_not_resolve_public_client(monkeypatch) -> None:
+    staging_client = _FakeClient("staging")
+
+    def fake_resolve_supabase_client(supabase_client=None, factory_ref=None):
+        if factory_ref is not None:
+            raise AssertionError(f"unexpected public factory resolution: {factory_ref}")
+        return supabase_client
+
+    monkeypatch.setattr(storage_runtime, "_resolve_supabase_client", fake_resolve_supabase_client)
+
+    repo = storage_runtime.build_sync_file_repo(supabase_client=staging_client)
+    repo.track_file("thread-1", "notes/a.txt", "a" * 64, 123)
+
+    assert staging_client.table_names == ["sync_files"]
 
 
 def test_supabase_agent_registry_repo_lists_running_by_name() -> None:


### PR DESCRIPTION
## Summary
- Route `StorageContainer.sync_file_repo()` through the runtime schema client instead of the public client.
- Stop `storage.runtime.build_sync_file_repo()` from resolving the public Supabase factory.
- Add seam tests covering both storage/runtime sync file bindings.

## Ledger / ops evidence
- Checkpoint `public-schema-business-surface-purge-04-sync-files-staging-landing` closed `done/usable` in Ledger.
- Executed `/Users/lexicalmathical/share/ops/migrations/008_sync_files_staging_landing.sql` through the sanctioned pgl psql path before this PR.
- Post-psql DB proof: `public.sync_files` rows = 34, `staging.sync_files` rows = 34, no null key fields, no duplicate keys, no bad checksum lengths.
- PostgREST proof: public and staging profiles both returned `206` with `content-range */34` for `sync_files?select=thread_id&limit=0`.
- Mechanism proof: real staging `SyncState` / `SupabaseSyncFileRepo` track/get/batch/clear flow with a temporary thread row, then cleanup verified.
- Backend cleanup-path proof: `backend.web.utils.helpers.delete_thread_in_db(thread_id)` cleared a temporary staging sync row; follow-up DB proof showed row count back to 34 and no temp rows.

## Verification
- `uv run pytest tests/Unit/storage/test_supabase_agent_registry_repo.py tests/Unit/storage/test_supabase_settings_and_invites.py tests/Unit/backend/web/utils/test_helpers.py -q` -> 12 passed
- `uv run ruff check storage/container.py storage/runtime.py tests/Unit/storage/test_supabase_agent_registry_repo.py` -> All checks passed
- `git diff --check` on touched repo files -> no whitespace errors

## Out of scope
- Public `sync_files` deletion.
- Provider SDK/runtime repair.
- Sandbox upload/download strategy changes.
- Strict non-local provider upload/download YATU.
- Token usage/account-resource semantics.
