### PR TITLE
refactor(db): start database refactor schema routing

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -92,6 +92,49 @@ def _seed_dev_user(app: FastAPI) -> None:
                 log.warning("DEV: avatar copy failed for %s: %s", agent_def["name"], e)
 
 
+def _wire_supabase_runtime(app: FastAPI, *, storage_client: Any, auth_client: Any) -> None:
+    """Wire Supabase repos without sharing the auth-mutated client into storage."""
+    from backend.web.services.auth_service import AuthService
+    from storage.container import StorageContainer
+    from storage.providers.supabase import (
+        SupabaseAccountRepo,
+        SupabaseChatEntityRepo,
+        SupabaseChatMessageRepo,
+        SupabaseChatRepo,
+        SupabaseContactRepo,
+        SupabaseEntityRepo,
+        SupabaseInviteCodeRepo,
+        SupabaseMemberRepo,
+        SupabaseRecipeRepo,
+        SupabaseThreadLaunchPrefRepo,
+        SupabaseThreadRepo,
+        SupabaseUserSettingsRepo,
+    )
+
+    app.state.member_repo = SupabaseMemberRepo(storage_client)
+    app.state.account_repo = SupabaseAccountRepo(storage_client)
+    app.state.entity_repo = SupabaseEntityRepo(storage_client)
+    app.state.thread_repo = SupabaseThreadRepo(storage_client)
+    app.state.thread_launch_pref_repo = SupabaseThreadLaunchPrefRepo(storage_client)
+    app.state.recipe_repo = SupabaseRecipeRepo(storage_client)
+    app.state.chat_repo = SupabaseChatRepo(storage_client)
+    app.state.chat_entity_repo = SupabaseChatEntityRepo(storage_client)
+    app.state.chat_message_repo = SupabaseChatMessageRepo(storage_client)
+    app.state.invite_code_repo = SupabaseInviteCodeRepo(storage_client)
+    app.state.user_settings_repo = SupabaseUserSettingsRepo(storage_client)
+    app.state.contact_repo = SupabaseContactRepo(storage_client)
+    app.state._supabase_client = storage_client
+    app.state._supabase_auth_client = auth_client
+    app.state._storage_container = StorageContainer(strategy="supabase", supabase_client=storage_client)
+    app.state.auth_service = AuthService(
+        members=app.state.member_repo,
+        accounts=app.state.account_repo,
+        entities=app.state.entity_repo,
+        supabase_client=auth_client,
+        invite_codes=app.state.invite_code_repo,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI lifespan context manager for startup and shutdown."""
@@ -115,36 +158,11 @@ async def lifespan(app: FastAPI):
 
     if _storage_strategy == "supabase":
         from backend.web.core.supabase_factory import create_supabase_client
-        from storage.container import StorageContainer
-        from storage.providers.supabase import (
-            SupabaseAccountRepo,
-            SupabaseChatEntityRepo,
-            SupabaseChatMessageRepo,
-            SupabaseChatRepo,
-            SupabaseContactRepo,
-            SupabaseEntityRepo,
-            SupabaseInviteCodeRepo,
-            SupabaseMemberRepo,
-            SupabaseRecipeRepo,
-            SupabaseThreadLaunchPrefRepo,
-            SupabaseThreadRepo,
-            SupabaseUserSettingsRepo,
-        )
 
+        # @@@supabase-client-boundary - auth calls mutate client auth headers; storage repos must keep service-role identity.
         _supabase_client = create_supabase_client()
-        app.state.member_repo = SupabaseMemberRepo(_supabase_client)
-        app.state.account_repo = SupabaseAccountRepo(_supabase_client)
-        app.state.entity_repo = SupabaseEntityRepo(_supabase_client)
-        app.state.thread_repo = SupabaseThreadRepo(_supabase_client)
-        app.state.thread_launch_pref_repo = SupabaseThreadLaunchPrefRepo(_supabase_client)
-        app.state.recipe_repo = SupabaseRecipeRepo(_supabase_client)
-        app.state.chat_repo = SupabaseChatRepo(_supabase_client)
-        app.state.chat_entity_repo = SupabaseChatEntityRepo(_supabase_client)
-        app.state.chat_message_repo = SupabaseChatMessageRepo(_supabase_client)
-        app.state.invite_code_repo = SupabaseInviteCodeRepo(_supabase_client)
-        app.state.user_settings_repo = SupabaseUserSettingsRepo(_supabase_client)
-        app.state._supabase_client = _supabase_client
-        app.state._storage_container = StorageContainer(strategy="supabase", supabase_client=_supabase_client)
+        _supabase_auth_client = create_supabase_client()
+        _wire_supabase_runtime(app, storage_client=_supabase_client, auth_client=_supabase_auth_client)
     else:
         from storage.providers.sqlite.chat_repo import SQLiteChatEntityRepo, SQLiteChatMessageRepo, SQLiteChatRepo
         from storage.providers.sqlite.entity_repo import SQLiteEntityRepo
@@ -167,17 +185,9 @@ async def lifespan(app: FastAPI):
         app.state.chat_entity_repo = SQLiteChatEntityRepo(chat_db)
         app.state.chat_message_repo = SQLiteChatMessageRepo(chat_db)
 
-    from backend.web.services.auth_service import AuthService
+    if _storage_strategy != "supabase":
+        from backend.web.services.auth_service import AuthService
 
-    if _storage_strategy == "supabase":
-        app.state.auth_service = AuthService(
-            members=app.state.member_repo,
-            accounts=app.state.account_repo,
-            entities=app.state.entity_repo,
-            supabase_client=_supabase_client,
-            invite_codes=app.state.invite_code_repo,
-        )
-    else:
         app.state.auth_service = AuthService(
             members=app.state.member_repo,
             accounts=app.state.account_repo,
@@ -199,9 +209,7 @@ async def lifespan(app: FastAPI):
 
     from backend.web.services.delivery_resolver import DefaultDeliveryResolver
 
-    if _storage_strategy == "supabase":
-        app.state.contact_repo = SupabaseContactRepo(_supabase_client)
-    else:
+    if _storage_strategy != "supabase":
         from storage.providers.sqlite.contact_repo import SQLiteContactRepo
 
         app.state.contact_repo = SQLiteContactRepo(chat_db)

--- a/backend/web/core/storage_factory.py
+++ b/backend/web/core/storage_factory.py
@@ -44,6 +44,14 @@ def make_cron_job_repo() -> Any:
     return SQLiteCronJobRepo(db_path=DB_PATH)
 
 
+def make_schedule_repo() -> Any:
+    if _strategy() == "supabase":
+        from storage.providers.supabase.schedule_repo import SupabaseScheduleRepo
+
+        return SupabaseScheduleRepo(_supabase_client())
+    raise RuntimeError("schedule repo requires LEON_STORAGE_STRATEGY=supabase")
+
+
 def make_sandbox_monitor_repo() -> Any:
     if _strategy() == "supabase":
         from storage.providers.supabase.sandbox_monitor_repo import SupabaseSandboxMonitorRepo

--- a/backend/web/core/supabase_factory.py
+++ b/backend/web/core/supabase_factory.py
@@ -7,6 +7,8 @@ import os
 import httpx
 from supabase import ClientOptions, create_client
 
+from storage.providers.supabase.schema import resolve_runtime_schema
+
 
 def create_supabase_client():
     """Build a supabase-py client from runtime environment.
@@ -22,7 +24,7 @@ def create_supabase_client():
         raise RuntimeError("SUPABASE_INTERNAL_URL or SUPABASE_PUBLIC_URL is required.")
     if not key:
         raise RuntimeError("LEON_SUPABASE_SERVICE_ROLE_KEY is required for Supabase storage runtime.")
-    schema = os.getenv("LEON_DB_SCHEMA", "public")
+    schema = resolve_runtime_schema()
     timeout = httpx.Timeout(30.0, connect=10.0)
     http_client = httpx.Client(timeout=timeout, trust_env=False)
     return create_client(url, key, options=ClientOptions(httpx_client=http_client, schema=schema))

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -91,6 +91,7 @@ from backend.web.routers import (  # noqa: E402
     monitor,
     panel,
     sandbox,
+    schedules,
     settings,
     thread_files,
     threads,
@@ -124,6 +125,7 @@ app.include_router(thread_files._public)
 app.include_router(settings.router)
 app.include_router(debug.router)
 app.include_router(panel.router)
+app.include_router(schedules.router)
 app.include_router(monitor.router)
 app.include_router(marketplace.router)
 

--- a/backend/web/routers/chats.py
+++ b/backend/web/routers/chats.py
@@ -47,9 +47,9 @@ async def create_chat(
     chat_service = app.state.chat_service
     try:
         if len(body.user_ids) >= 3:
-            chat = chat_service.create_group_chat(body.user_ids, body.title)
+            chat = chat_service.create_group_chat(body.user_ids, body.title, created_by_user_id=user_id)
         else:
-            chat = chat_service.find_or_create_chat(body.user_ids, body.title)
+            chat = chat_service.find_or_create_chat(body.user_ids, body.title, created_by_user_id=user_id)
         return {"id": chat.id, "title": chat.title, "status": chat.status, "created_at": chat.created_at}
     except ValueError as e:
         raise HTTPException(400, str(e))

--- a/backend/web/routers/schedules.py
+++ b/backend/web/routers/schedules.py
@@ -1,0 +1,29 @@
+"""Agent schedule runtime API."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.web.core.dependencies import get_current_user_id
+from backend.web.services import schedule_runtime_service
+
+router = APIRouter(prefix="/api/schedules", tags=["schedules"])
+
+
+@router.post("/{schedule_id}/run")
+async def run_schedule(
+    schedule_id: str,
+    request: Request,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+) -> dict[str, Any]:
+    try:
+        item = await schedule_runtime_service.trigger_schedule(request.app, schedule_id, owner_user_id=user_id, triggered_by="manual")
+    except PermissionError as exc:
+        raise HTTPException(403, str(exc)) from exc
+    except ValueError as exc:
+        message = str(exc)
+        status_code = 404 if "not found" in message else 400
+        raise HTTPException(status_code, message) from exc
+    return {"item": item}

--- a/backend/web/routers/schedules.py
+++ b/backend/web/routers/schedules.py
@@ -20,6 +20,8 @@ async def run_schedule(
 ) -> dict[str, Any]:
     try:
         item = await schedule_runtime_service.trigger_schedule(request.app, schedule_id, owner_user_id=user_id, triggered_by="manual")
+    except schedule_runtime_service.TargetThreadBusyError as exc:
+        raise HTTPException(409, str(exc)) from exc
     except PermissionError as exc:
         raise HTTPException(403, str(exc)) from exc
     except ValueError as exc:

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -355,6 +355,7 @@ def _create_owned_thread(
         sandbox_type=sandbox_type,
         cwd=payload.cwd,
         created_at=time.time(),
+        owner_user_id=owner_user_id,
         model=payload.model,
         is_main=resolved_is_main,
         branch_index=branch_index,

--- a/backend/web/services/chat_service.py
+++ b/backend/web/services/chat_service.py
@@ -52,7 +52,7 @@ class ChatService:
         m = self._members.get_by_id(user_id) if self._members else None
         return m.name if m else "unknown"
 
-    def find_or_create_chat(self, user_ids: list[str], title: str | None = None) -> ChatRow:
+    def find_or_create_chat(self, user_ids: list[str], title: str | None = None, *, created_by_user_id: str | None = None) -> ChatRow:
         """Find existing 1:1 chat between two social identities, or create one."""
         if len(user_ids) != 2:
             raise ValueError("Use create_group_chat() for 3+ participants")
@@ -63,18 +63,18 @@ class ChatService:
 
         now = time.time()
         chat_id = str(uuid.uuid4())
-        self._chats.create(ChatRow(id=chat_id, title=title, created_at=now))
+        self._chats.create(ChatRow(id=chat_id, title=title, type="direct", created_by_user_id=created_by_user_id, created_at=now))
         for uid in user_ids:
             self._chat_entities.add_participant(chat_id, uid, now)
         return self._chats.get_by_id(chat_id)
 
-    def create_group_chat(self, user_ids: list[str], title: str | None = None) -> ChatRow:
+    def create_group_chat(self, user_ids: list[str], title: str | None = None, *, created_by_user_id: str | None = None) -> ChatRow:
         """Create a group chat with 3+ participants."""
         if len(user_ids) < 3:
             raise ValueError("Group chat requires 3+ participants")
         now = time.time()
         chat_id = str(uuid.uuid4())
-        self._chats.create(ChatRow(id=chat_id, title=title, created_at=now))
+        self._chats.create(ChatRow(id=chat_id, title=title, type="group", created_by_user_id=created_by_user_id, created_at=now))
         for uid in user_ids:
             self._chat_entities.add_participant(chat_id, uid, now)
         return self._chats.get_by_id(chat_id)

--- a/backend/web/services/message_routing.py
+++ b/backend/web/services/message_routing.py
@@ -11,6 +11,10 @@ from core.runtime.middleware.monitor import AgentState
 logger = logging.getLogger(__name__)
 
 
+class TargetThreadActiveError(RuntimeError):
+    """Raised when the caller requires a fresh run but the target is already active."""
+
+
 async def route_message_to_brain(
     app: Any,
     thread_id: str,
@@ -19,6 +23,8 @@ async def route_message_to_brain(
     sender_name: str | None = None,
     sender_avatar_url: str | None = None,
     attachments: list[str] | None = None,
+    require_new_run: bool = False,
+    extra_message_metadata: dict[str, Any] | None = None,
 ) -> dict:
     """Route message to agent brain thread.
 
@@ -40,6 +46,8 @@ async def route_message_to_brain(
     run_content = content
 
     if hasattr(agent, "runtime") and agent.runtime.current_state == AgentState.ACTIVE:
+        if require_new_run:
+            raise TargetThreadActiveError(f"target thread {thread_id} is already active")
         qm.enqueue(
             steer_content,
             thread_id,
@@ -58,6 +66,8 @@ async def route_message_to_brain(
         lock = locks.setdefault(thread_id, asyncio.Lock())
     async with lock:
         if hasattr(agent, "runtime") and not agent.runtime.transition(AgentState.ACTIVE):
+            if require_new_run:
+                raise TargetThreadActiveError(f"target thread {thread_id} is already active")
             qm.enqueue(
                 steer_content,
                 thread_id,
@@ -71,6 +81,8 @@ async def route_message_to_brain(
             return {"status": "injected", "routing": "steer", "thread_id": thread_id}
         logger.debug("[route] → START RUN (idle→active)")
         meta = {"source": source, "sender_name": sender_name, "sender_avatar_url": sender_avatar_url}
+        if extra_message_metadata:
+            meta.update(extra_message_metadata)
         if attachments:
             meta["attachments"] = attachments
         run_id = start_agent_run(agent, thread_id, run_content, app, message_metadata=meta)

--- a/backend/web/services/schedule_run_completion_service.py
+++ b/backend/web/services/schedule_run_completion_service.py
@@ -1,0 +1,46 @@
+"""Schedule run finalization from real runtime boundaries."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from backend.web.services import schedule_service
+
+TerminalScheduleStatus = Literal["succeeded", "failed", "cancelled"]
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+def complete_schedule_run_from_runtime(
+    schedule_run_id: str | None,
+    *,
+    source: str | None,
+    status: TerminalScheduleStatus,
+    runtime_run_id: str,
+    thread_id: str,
+    error: str | None = None,
+) -> None:
+    if not schedule_run_id:
+        if source == "schedule":
+            raise RuntimeError("schedule source runtime run is missing schedule_run_id metadata")
+        return
+
+    existing = schedule_service.get_schedule_run(schedule_run_id)
+    if existing is None:
+        raise RuntimeError(f"schedule run {schedule_run_id} not found")
+    output_json = dict(existing.get("output_json") or {})
+    output_json["runtime"] = {
+        "run_id": runtime_run_id,
+        "thread_id": thread_id,
+        "status": status,
+    }
+    schedule_service.update_schedule_run(
+        schedule_run_id,
+        status=status,
+        completed_at=_now_iso(),
+        output_json=output_json,
+        error=error,
+    )

--- a/backend/web/services/schedule_runtime_service.py
+++ b/backend/web/services/schedule_runtime_service.py
@@ -6,7 +6,12 @@ from datetime import UTC, datetime
 from typing import Any
 
 from backend.web.services import schedule_service
-from backend.web.services.message_routing import route_message_to_brain
+from backend.web.services.message_routing import TargetThreadActiveError, route_message_to_brain
+from core.runtime.middleware.monitor import AgentState
+
+
+class TargetThreadBusyError(RuntimeError):
+    """Raised when a schedule trigger needs a fresh run but the target is active."""
 
 
 def _now_iso() -> str:
@@ -34,6 +39,14 @@ def _validate_thread(app: Any, schedule: dict[str, Any], thread_id: str, owner_u
         raise ValueError("target thread agent does not match schedule agent")
 
 
+def _thread_is_active(app: Any, thread_id: str) -> bool:
+    thread = app.state.thread_repo.get_by_id(thread_id)
+    sandbox_type = (thread or {}).get("sandbox_type", "local")
+    agent = getattr(app.state, "agent_pool", {}).get(f"{thread_id}:{sandbox_type}")
+    runtime = getattr(agent, "runtime", None)
+    return bool(runtime and getattr(runtime, "current_state", None) == AgentState.ACTIVE)
+
+
 def _validate_schedule(schedule: dict[str, Any] | None, owner_user_id: str) -> dict[str, Any]:
     if schedule is None:
         raise ValueError("schedule not found")
@@ -54,6 +67,8 @@ async def trigger_schedule(
     schedule = _validate_schedule(schedule_service.get_schedule(schedule_id), owner_user_id)
     thread_id = _target_thread(schedule)
     _validate_thread(app, schedule, thread_id, owner_user_id)
+    if _thread_is_active(app, thread_id):
+        raise TargetThreadBusyError("target thread is already active")
 
     run = schedule_service.create_schedule_run(
         schedule_id=schedule["id"],
@@ -69,7 +84,17 @@ async def trigger_schedule(
             thread_id,
             _schedule_instruction(schedule, run["id"]),
             source="schedule",
+            require_new_run=True,
+            extra_message_metadata={"schedule_run_id": run["id"]},
         )
+    except TargetThreadActiveError as exc:
+        schedule_service.update_schedule_run(
+            run["id"],
+            status="cancelled",
+            completed_at=_now_iso(),
+            error=str(exc),
+        )
+        raise TargetThreadBusyError(str(exc)) from exc
     except Exception as exc:
         schedule_service.update_schedule_run(
             run["id"],

--- a/backend/web/services/schedule_runtime_service.py
+++ b/backend/web/services/schedule_runtime_service.py
@@ -1,0 +1,90 @@
+"""Runtime trigger path for agent schedules."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from backend.web.services import schedule_service
+from backend.web.services.message_routing import route_message_to_brain
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+def _schedule_instruction(schedule: dict[str, Any], run_id: str) -> str:
+    return f"[Scheduled instruction]\nSchedule ID: {schedule['id']}\nSchedule Run ID: {run_id}\n\n{schedule['instruction_template']}"
+
+
+def _target_thread(schedule: dict[str, Any]) -> str:
+    thread_id = schedule.get("target_thread_id")
+    if not thread_id:
+        raise ValueError("schedule trigger requires target_thread_id in 02I")
+    return str(thread_id)
+
+
+def _validate_thread(app: Any, schedule: dict[str, Any], thread_id: str, owner_user_id: str) -> None:
+    thread = app.state.thread_repo.get_by_id(thread_id)
+    if thread is None:
+        raise ValueError(f"target thread {thread_id} not found")
+    if thread.get("owner_user_id") != owner_user_id:
+        raise PermissionError("target thread is not owned by schedule owner")
+    if thread.get("member_id") != schedule.get("agent_user_id"):
+        raise ValueError("target thread agent does not match schedule agent")
+
+
+def _validate_schedule(schedule: dict[str, Any] | None, owner_user_id: str) -> dict[str, Any]:
+    if schedule is None:
+        raise ValueError("schedule not found")
+    if schedule.get("owner_user_id") != owner_user_id:
+        raise PermissionError("schedule is not owned by current user")
+    if not schedule.get("enabled", True):
+        raise ValueError("schedule is disabled")
+    return schedule
+
+
+async def trigger_schedule(
+    app: Any,
+    schedule_id: str,
+    *,
+    owner_user_id: str,
+    triggered_by: str = "manual",
+) -> dict[str, Any]:
+    schedule = _validate_schedule(schedule_service.get_schedule(schedule_id), owner_user_id)
+    thread_id = _target_thread(schedule)
+    _validate_thread(app, schedule, thread_id, owner_user_id)
+
+    run = schedule_service.create_schedule_run(
+        schedule_id=schedule["id"],
+        owner_user_id=owner_user_id,
+        agent_user_id=schedule["agent_user_id"],
+        triggered_by=triggered_by,
+        thread_id=thread_id,
+        input_json={"instruction_template": schedule["instruction_template"]},
+    )
+    try:
+        routing = await route_message_to_brain(
+            app,
+            thread_id,
+            _schedule_instruction(schedule, run["id"]),
+            source="schedule",
+        )
+    except Exception as exc:
+        schedule_service.update_schedule_run(
+            run["id"],
+            status="failed",
+            completed_at=_now_iso(),
+            error=str(exc),
+        )
+        raise
+
+    updated_run = schedule_service.update_schedule_run(
+        run["id"],
+        status="running",
+        thread_id=thread_id,
+        started_at=_now_iso(),
+        output_json={"routing": routing},
+    )
+    schedule_service.update_schedule(schedule["id"], last_run_at=_now_iso())
+    return {"schedule_run": updated_run or run, "routing": routing}

--- a/backend/web/services/schedule_service.py
+++ b/backend/web/services/schedule_service.py
@@ -1,0 +1,155 @@
+"""Agent schedule CRUD service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.web.core.storage_factory import make_schedule_repo
+
+_RUN_TRIGGERS = {"scheduler", "manual"}
+_RUN_STATUSES = {"queued", "running", "succeeded", "failed", "cancelled"}
+
+
+def _repo() -> Any:
+    return make_schedule_repo()
+
+
+def _require_non_empty(name: str, value: str) -> None:
+    if not value or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+
+
+def _validate_schedule_target(target_thread_id: str | None, create_thread_on_run: bool) -> None:
+    if not target_thread_id and not create_thread_on_run:
+        raise ValueError("schedule target must set target_thread_id or create_thread_on_run")
+
+
+def list_schedules(owner_user_id: str) -> list[dict[str, Any]]:
+    _require_non_empty("owner_user_id", owner_user_id)
+    repo = _repo()
+    try:
+        return repo.list_by_owner(owner_user_id)
+    finally:
+        repo.close()
+
+
+def get_schedule(schedule_id: str) -> dict[str, Any] | None:
+    repo = _repo()
+    try:
+        return repo.get(schedule_id)
+    finally:
+        repo.close()
+
+
+def create_schedule(
+    *,
+    owner_user_id: str,
+    agent_user_id: str,
+    cron_expression: str,
+    instruction_template: str,
+    target_thread_id: str | None = None,
+    create_thread_on_run: bool = False,
+    enabled: bool = True,
+    timezone: str = "UTC",
+    next_run_at: str | None = None,
+) -> dict[str, Any]:
+    _require_non_empty("owner_user_id", owner_user_id)
+    _require_non_empty("agent_user_id", agent_user_id)
+    _require_non_empty("cron_expression", cron_expression)
+    _require_non_empty("instruction_template", instruction_template)
+    _require_non_empty("timezone", timezone)
+    _validate_schedule_target(target_thread_id, create_thread_on_run)
+    repo = _repo()
+    try:
+        return repo.create(
+            owner_user_id=owner_user_id,
+            agent_user_id=agent_user_id,
+            cron_expression=cron_expression,
+            instruction_template=instruction_template,
+            target_thread_id=target_thread_id,
+            create_thread_on_run=create_thread_on_run,
+            enabled=enabled,
+            timezone=timezone,
+            next_run_at=next_run_at,
+        )
+    finally:
+        repo.close()
+
+
+def update_schedule(schedule_id: str, **fields: Any) -> dict[str, Any] | None:
+    target_thread_id = fields.get("target_thread_id")
+    if "create_thread_on_run" in fields or "target_thread_id" in fields:
+        _validate_schedule_target(target_thread_id, bool(fields.get("create_thread_on_run")))
+    for key in ("agent_user_id", "cron_expression", "instruction_template", "timezone"):
+        if key in fields and fields[key] is not None:
+            _require_non_empty(key, fields[key])
+    repo = _repo()
+    try:
+        return repo.update(schedule_id, **fields)
+    finally:
+        repo.close()
+
+
+def delete_schedule(schedule_id: str) -> bool:
+    repo = _repo()
+    try:
+        return repo.delete(schedule_id)
+    finally:
+        repo.close()
+
+
+def create_schedule_run(
+    *,
+    schedule_id: str,
+    owner_user_id: str,
+    agent_user_id: str,
+    triggered_by: str,
+    thread_id: str | None = None,
+    scheduled_for: str | None = None,
+    input_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    _require_non_empty("schedule_id", schedule_id)
+    _require_non_empty("owner_user_id", owner_user_id)
+    _require_non_empty("agent_user_id", agent_user_id)
+    if triggered_by not in _RUN_TRIGGERS:
+        raise ValueError("triggered_by must be scheduler or manual")
+    repo = _repo()
+    try:
+        return repo.create_run(
+            schedule_id=schedule_id,
+            owner_user_id=owner_user_id,
+            agent_user_id=agent_user_id,
+            triggered_by=triggered_by,
+            thread_id=thread_id,
+            scheduled_for=scheduled_for,
+            input_json=input_json,
+        )
+    finally:
+        repo.close()
+
+
+def list_schedule_runs(schedule_id: str) -> list[dict[str, Any]]:
+    _require_non_empty("schedule_id", schedule_id)
+    repo = _repo()
+    try:
+        return repo.list_runs(schedule_id)
+    finally:
+        repo.close()
+
+
+def update_schedule_run(run_id: str, **fields: Any) -> dict[str, Any] | None:
+    if "status" in fields and fields["status"] not in _RUN_STATUSES:
+        raise ValueError("status must be queued, running, succeeded, failed, or cancelled")
+    repo = _repo()
+    try:
+        return repo.update_run(run_id, **fields)
+    finally:
+        repo.close()
+
+
+def delete_schedule_run(run_id: str) -> bool:
+    repo = _repo()
+    try:
+        return repo.delete_run(run_id)
+    finally:
+        repo.close()

--- a/backend/web/services/schedule_service.py
+++ b/backend/web/services/schedule_service.py
@@ -137,6 +137,15 @@ def list_schedule_runs(schedule_id: str) -> list[dict[str, Any]]:
         repo.close()
 
 
+def get_schedule_run(run_id: str) -> dict[str, Any] | None:
+    _require_non_empty("run_id", run_id)
+    repo = _repo()
+    try:
+        return repo.get_run(run_id)
+    finally:
+        repo.close()
+
+
 def update_schedule_run(run_id: str, **fields: Any) -> dict[str, Any] | None:
     if "status" in fields and fields["status"] not in _RUN_STATUSES:
         raise ValueError("status must be queued, running, succeeded, failed, or cancelled")

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -9,6 +9,7 @@ import uuid as _uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from backend.web.services import schedule_run_completion_service
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
 from backend.web.utils.serializers import extract_text_content
@@ -444,6 +445,8 @@ async def _run_agent_to_buffer(
     task = None
     stream_gen = None
     pending_tool_calls: dict[str, dict] = {}
+    terminal_status = "succeeded"
+    terminal_error: str | None = None
     try:
         config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
         if hasattr(agent, "_current_model_config"):
@@ -920,6 +923,8 @@ async def _run_agent_to_buffer(
                 await stream_gen.aclose()
                 await asyncio.sleep(wait)
             else:
+                terminal_status = "failed"
+                terminal_error = str(stream_err)
                 traceback.print_exc()
                 await emit({"event": "error", "data": json.dumps({"error": str(stream_err)}, ensure_ascii=False)})
                 break
@@ -955,6 +960,8 @@ async def _run_agent_to_buffer(
         # A5: emit run_done instead of done (persistent buffer — no mark_done)
         await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
     except asyncio.CancelledError:
+        terminal_status = "cancelled"
+        terminal_error = "Run cancelled by user"
         cancelled_tool_call_ids = await write_cancellation_markers(agent, config, pending_tool_calls)
         await emit(
             {
@@ -970,6 +977,8 @@ async def _run_agent_to_buffer(
         # Also emit run_done so frontend knows the run ended
         await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
     except Exception as e:
+        terminal_status = "failed"
+        terminal_error = str(e)
         traceback.print_exc()
         await emit({"event": "error", "data": json.dumps({"error": str(e)}, ensure_ascii=False)})
         await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
@@ -1018,6 +1027,16 @@ async def _run_agent_to_buffer(
             logger.warning("Failed to cleanup old runs for thread %s", thread_id, exc_info=True)
         if run_event_repo is not None:
             run_event_repo.close()
+
+        meta = message_metadata or {}
+        schedule_run_completion_service.complete_schedule_run_from_runtime(
+            meta.get("schedule_run_id"),
+            source=meta.get("source"),
+            status=terminal_status,
+            runtime_run_id=run_id,
+            thread_id=thread_id,
+            error=terminal_error,
+        )
 
         # Consume followup queue: if messages are pending, start a new run
         await _consume_followup_queue(agent, thread_id, app)

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -1,4 +1,4 @@
-"""TaskService - SQLite-backed task management tools.
+"""TaskService - storage-backed thread task tools.
 
 Provides TaskCreate/TaskGet/TaskList/TaskUpdate as DEFERRED tools.
 Tasks are partitioned by thread_id so all agents in the same thread share
@@ -129,8 +129,8 @@ TASK_UPDATE_SCHEMA = {
 class TaskService:
     """Task management service providing DEFERRED tools.
 
-    Tasks are stored in SQLite and partitioned by thread_id so all agents
-    in the same thread/team share the same task list.
+    Tasks are stored through the active storage strategy and partitioned by
+    thread_id so all agents in the same thread/team share the same task list.
 
     thread_id is resolved at call time from sandbox.thread_context;
     falls back to a fixed thread_id if provided at construction (for tests).

--- a/database/migrations/20260414_01_agent_threads_thread_tasks.sql
+++ b/database/migrations/20260414_01_agent_threads_thread_tasks.sql
@@ -1,0 +1,246 @@
+-- Database Refactor 02A: land agent.threads and agent.thread_tasks.
+--
+-- Scope:
+-- - Create agent schema.
+-- - Copy staging.threads into agent.threads.
+-- - Copy staging.agent_thread_tasks into agent.thread_tasks.
+--
+-- Non-goals:
+-- - No mutation or deletion of public.* / staging.*.
+-- - No schedules / cron_jobs / panel_tasks migration.
+-- - No hard FK from agent.thread_tasks to agent.threads because current source
+--   agent_thread_tasks rows are known orphaned against staging.threads.
+-- - No RLS/realtime in this migration. Add them only after policy/publication
+--   behavior is proved in a separate checkpoint.
+-- - First-run-only: fail if the agent schema already exists. This avoids
+--   hiding partial landing state behind IF NOT EXISTS / ON CONFLICT behavior.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_agent_schema_count integer;
+    v_missing_owner_count integer;
+    v_duplicate_branch_count integer;
+    v_bad_status_count integer;
+    v_negative_timestamp_count integer;
+    v_bad_task_status_count integer;
+    v_task_required_null_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_agent_schema_count
+    FROM information_schema.schemata
+    WHERE schema_name = 'agent';
+
+    IF v_agent_schema_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate 02A: schema agent already exists';
+    END IF;
+
+    SELECT count(*)
+    INTO v_missing_owner_count
+    FROM staging.threads t
+    LEFT JOIN staging.users u ON u.id = t.agent_user_id
+    WHERE u.id IS NULL OR u.owner_user_id IS NULL;
+
+    IF v_missing_owner_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % staging.threads rows lack owner_user_id derivation', v_missing_owner_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_duplicate_branch_count
+    FROM (
+        SELECT agent_user_id, branch_index
+        FROM staging.threads
+        GROUP BY agent_user_id, branch_index
+        HAVING count(*) > 1
+    ) duplicates;
+
+    IF v_duplicate_branch_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % duplicate (agent_user_id, branch_index) pairs', v_duplicate_branch_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_bad_status_count
+    FROM staging.threads
+    WHERE status NOT IN ('active', 'archived');
+
+    IF v_bad_status_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % rows have unsupported status', v_bad_status_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_negative_timestamp_count
+    FROM staging.threads
+    WHERE created_at < 0 OR updated_at < 0 OR last_active_at < 0;
+
+    IF v_negative_timestamp_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % rows have negative timestamps', v_negative_timestamp_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_bad_task_status_count
+    FROM staging.agent_thread_tasks
+    WHERE status NOT IN ('pending', 'in_progress', 'completed');
+
+    IF v_bad_task_status_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.thread_tasks: % rows have unsupported status', v_bad_task_status_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_task_required_null_count
+    FROM staging.agent_thread_tasks
+    WHERE thread_id IS NULL
+       OR task_id IS NULL
+       OR subject IS NULL
+       OR description IS NULL
+       OR status IS NULL
+       OR blocks IS NULL
+       OR blocked_by IS NULL
+       OR metadata IS NULL;
+
+    IF v_task_required_null_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.thread_tasks: % rows have required nulls', v_task_required_null_count;
+    END IF;
+END $$;
+
+CREATE SCHEMA agent;
+
+CREATE TABLE agent.threads (
+    id                   TEXT        PRIMARY KEY,
+    agent_user_id        TEXT        NOT NULL,
+    owner_user_id        TEXT        NOT NULL,
+    current_workspace_id TEXT,
+    model                TEXT,
+    cwd                  TEXT,
+    status               TEXT        NOT NULL DEFAULT 'active',
+    run_status           TEXT        NOT NULL DEFAULT 'idle',
+    is_main              BOOLEAN     NOT NULL DEFAULT false,
+    branch_index         INTEGER     NOT NULL DEFAULT 0,
+    last_active_at       TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT threads_status_chk
+        CHECK (status IN ('active', 'archived')),
+    CONSTRAINT threads_run_status_chk
+        CHECK (run_status IN ('idle', 'running', 'paused', 'error')),
+    CONSTRAINT threads_agent_branch_uq UNIQUE (agent_user_id, branch_index)
+);
+
+CREATE INDEX idx_threads_owner_active
+    ON agent.threads(owner_user_id, last_active_at DESC)
+    WHERE status = 'active';
+
+CREATE INDEX idx_threads_agent_active
+    ON agent.threads(agent_user_id)
+    WHERE status = 'active';
+
+CREATE TABLE agent.thread_tasks (
+    thread_id    TEXT  NOT NULL,
+    task_id      TEXT  NOT NULL,
+    subject      TEXT  NOT NULL,
+    description  TEXT  NOT NULL,
+    status       TEXT  NOT NULL DEFAULT 'pending',
+    active_form  TEXT,
+    owner        TEXT,
+    blocks       JSONB NOT NULL DEFAULT '[]',
+    blocked_by   JSONB NOT NULL DEFAULT '[]',
+    metadata     JSONB NOT NULL DEFAULT '{}',
+
+    PRIMARY KEY (thread_id, task_id),
+    CONSTRAINT thread_tasks_status_chk
+        CHECK (status IN ('pending', 'in_progress', 'completed'))
+);
+
+CREATE INDEX idx_thread_tasks_thread
+    ON agent.thread_tasks(thread_id);
+
+GRANT USAGE ON SCHEMA agent TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.threads TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.thread_tasks TO service_role;
+
+INSERT INTO agent.threads (
+    id,
+    agent_user_id,
+    owner_user_id,
+    model,
+    cwd,
+    status,
+    run_status,
+    is_main,
+    branch_index,
+    last_active_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    t.agent_user_id,
+    u.owner_user_id,
+    t.model,
+    t.cwd,
+    t.status,
+    'idle',
+    (t.is_main <> 0),
+    t.branch_index,
+    CASE WHEN t.last_active_at IS NULL THEN NULL ELSE to_timestamp(t.last_active_at) END,
+    to_timestamp(t.created_at),
+    CASE WHEN t.updated_at IS NULL THEN to_timestamp(t.created_at) ELSE to_timestamp(t.updated_at) END
+FROM staging.threads t
+JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.owner_user_id IS NOT NULL;
+
+INSERT INTO agent.thread_tasks (
+    thread_id,
+    task_id,
+    subject,
+    description,
+    status,
+    active_form,
+    owner,
+    blocks,
+    blocked_by,
+    metadata
+)
+SELECT
+    thread_id,
+    task_id,
+    subject,
+    description,
+    status,
+    active_form,
+    owner,
+    blocks,
+    blocked_by,
+    metadata
+FROM staging.agent_thread_tasks
+;
+
+DO $$
+DECLARE
+    v_source_threads integer;
+    v_target_threads integer;
+    v_source_tasks integer;
+    v_target_tasks integer;
+BEGIN
+    SELECT count(*)
+    INTO v_source_threads
+    FROM staging.threads t
+    JOIN staging.users u ON u.id = t.agent_user_id
+    WHERE u.owner_user_id IS NOT NULL;
+
+    SELECT count(*) INTO v_target_threads FROM agent.threads;
+
+    IF v_target_threads <> v_source_threads THEN
+        RAISE EXCEPTION 'agent.threads parity failed: source %, target %', v_source_threads, v_target_threads;
+    END IF;
+
+    SELECT count(*) INTO v_source_tasks FROM staging.agent_thread_tasks;
+    SELECT count(*) INTO v_target_tasks FROM agent.thread_tasks;
+
+    IF v_target_tasks <> v_source_tasks THEN
+        RAISE EXCEPTION 'agent.thread_tasks parity failed: source %, target %', v_source_tasks, v_target_tasks;
+    END IF;
+END $$;
+
+COMMIT;

--- a/database/migrations/20260414_02_agent_threads_sandbox_type.sql
+++ b/database/migrations/20260414_02_agent_threads_sandbox_type.sql
@@ -1,0 +1,94 @@
+-- Database Refactor 02A corrective migration: add agent.threads.sandbox_type.
+--
+-- Scope:
+-- - Add the current runtime-required sandbox_type column to agent.threads.
+-- - Backfill values from staging.threads by thread id.
+-- - Prove every target row was backfilled before enforcing NOT NULL.
+--
+-- Non-goals:
+-- - No runtime repository routing.
+-- - No mutation or deletion of public.* / staging.*.
+-- - No default value and no application fallback. Future writes must provide
+--   sandbox_type explicitly through the current thread creation contract.
+-- - No container/workspace ontology expansion in this corrective slice.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_agent_threads_count integer;
+    v_existing_column_count integer;
+    v_missing_source_count integer;
+    v_reverse_missing_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_agent_threads_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'threads';
+
+    IF v_agent_threads_count <> 1 THEN
+        RAISE EXCEPTION 'Cannot correct 02A: agent.threads does not exist';
+    END IF;
+
+    SELECT count(*)
+    INTO v_existing_column_count
+    FROM information_schema.columns
+    WHERE table_schema = 'agent'
+      AND table_name = 'threads'
+      AND column_name = 'sandbox_type';
+
+    IF v_existing_column_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot correct 02A: agent.threads.sandbox_type already exists';
+    END IF;
+
+    SELECT count(*)
+    INTO v_missing_source_count
+    FROM agent.threads a
+    LEFT JOIN staging.threads s ON s.id = a.id
+    WHERE s.id IS NULL
+       OR s.sandbox_type IS NULL
+       OR btrim(s.sandbox_type) = '';
+
+    IF v_missing_source_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot correct agent.threads.sandbox_type: % target rows lack source sandbox_type', v_missing_source_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_reverse_missing_count
+    FROM staging.threads s
+    LEFT JOIN agent.threads a ON a.id = s.id
+    WHERE a.id IS NULL;
+
+    IF v_reverse_missing_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot correct agent.threads.sandbox_type: % staging rows lack agent target row', v_reverse_missing_count;
+    END IF;
+END $$;
+
+ALTER TABLE agent.threads
+    ADD COLUMN sandbox_type TEXT;
+
+UPDATE agent.threads a
+SET sandbox_type = s.sandbox_type
+FROM staging.threads s
+WHERE s.id = a.id;
+
+DO $$
+DECLARE
+    v_null_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_null_count
+    FROM agent.threads
+    WHERE sandbox_type IS NULL
+       OR btrim(sandbox_type) = '';
+
+    IF v_null_count <> 0 THEN
+        RAISE EXCEPTION 'agent.threads.sandbox_type backfill failed: % rows remain blank', v_null_count;
+    END IF;
+END $$;
+
+ALTER TABLE agent.threads
+    ALTER COLUMN sandbox_type SET NOT NULL;
+
+COMMIT;

--- a/database/migrations/20260414_03_agent_schedules.sql
+++ b/database/migrations/20260414_03_agent_schedules.sql
@@ -1,0 +1,171 @@
+-- Database Refactor 02G: land agent.schedules and agent.schedule_runs.
+--
+-- Scope:
+-- - Create agent.schedules.
+-- - Create agent.schedule_runs.
+-- - Grant service_role access.
+--
+-- Non-goals:
+-- - No mutation or deletion of public.* / staging.*.
+-- - No migration from cron_jobs because live public/staging cron_jobs are empty.
+-- - No panel_tasks migration. Panel tasks are explicitly not target schedule ontology.
+-- - No runtime repository routing.
+-- - No /cron-jobs API behavior change.
+-- - No frontend behavior change.
+-- - No RLS/realtime policy in this migration. Add only after behavior is proved
+--   in a separate checkpoint.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_agent_schema_count integer;
+    v_agent_threads_count integer;
+    v_schedules_count integer;
+    v_schedule_runs_count integer;
+    v_public_cron_jobs_count integer;
+    v_staging_cron_jobs_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_agent_schema_count
+    FROM information_schema.schemata
+    WHERE schema_name = 'agent';
+
+    IF v_agent_schema_count <> 1 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent schema must exist exactly once, found %', v_agent_schema_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_agent_threads_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'threads';
+
+    IF v_agent_threads_count <> 1 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent.threads must exist exactly once, found %', v_agent_threads_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_schedules_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedules';
+
+    IF v_schedules_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent.schedules already exists';
+    END IF;
+
+    SELECT count(*)
+    INTO v_schedule_runs_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedule_runs';
+
+    IF v_schedule_runs_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent.schedule_runs already exists';
+    END IF;
+
+    SELECT count(*) INTO v_public_cron_jobs_count FROM public.cron_jobs;
+    SELECT count(*) INTO v_staging_cron_jobs_count FROM staging.cron_jobs;
+
+    IF v_public_cron_jobs_count <> 0 OR v_staging_cron_jobs_count <> 0 THEN
+        RAISE EXCEPTION
+            'Cannot migrate 02G without a cron_jobs data ruling: public %, staging %',
+            v_public_cron_jobs_count,
+            v_staging_cron_jobs_count;
+    END IF;
+END $$;
+
+CREATE TABLE agent.schedules (
+    id                   TEXT        PRIMARY KEY,
+    owner_user_id        TEXT        NOT NULL,
+    agent_user_id        TEXT        NOT NULL,
+    target_thread_id     TEXT,
+    create_thread_on_run BOOLEAN     NOT NULL DEFAULT false,
+    cron_expression      TEXT        NOT NULL,
+    enabled              BOOLEAN     NOT NULL DEFAULT true,
+    instruction_template TEXT        NOT NULL,
+    timezone             TEXT        NOT NULL DEFAULT 'UTC',
+    last_run_at          TIMESTAMPTZ,
+    next_run_at          TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT schedules_target_chk
+        CHECK (target_thread_id IS NOT NULL OR create_thread_on_run),
+    CONSTRAINT schedules_instruction_template_chk
+        CHECK (btrim(instruction_template) <> ''),
+    CONSTRAINT schedules_cron_expression_chk
+        CHECK (btrim(cron_expression) <> ''),
+    CONSTRAINT schedules_timezone_chk
+        CHECK (btrim(timezone) <> '')
+);
+
+CREATE INDEX idx_schedules_owner_enabled_next_run
+    ON agent.schedules(owner_user_id, next_run_at)
+    WHERE enabled = true;
+
+CREATE INDEX idx_schedules_agent
+    ON agent.schedules(agent_user_id);
+
+CREATE INDEX idx_schedules_target_thread
+    ON agent.schedules(target_thread_id)
+    WHERE target_thread_id IS NOT NULL;
+
+CREATE TABLE agent.schedule_runs (
+    id            TEXT        PRIMARY KEY,
+    schedule_id   TEXT        NOT NULL,
+    owner_user_id TEXT        NOT NULL,
+    agent_user_id TEXT        NOT NULL,
+    thread_id     TEXT,
+    status        TEXT        NOT NULL DEFAULT 'queued',
+    triggered_by  TEXT        NOT NULL,
+    scheduled_for TIMESTAMPTZ,
+    started_at    TIMESTAMPTZ,
+    completed_at  TIMESTAMPTZ,
+    input_json    JSONB       NOT NULL DEFAULT '{}',
+    output_json   JSONB       NOT NULL DEFAULT '{}',
+    error         TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT schedule_runs_status_chk
+        CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+    CONSTRAINT schedule_runs_triggered_by_chk
+        CHECK (triggered_by IN ('scheduler', 'manual'))
+);
+
+CREATE INDEX idx_schedule_runs_schedule_created
+    ON agent.schedule_runs(schedule_id, created_at DESC);
+
+CREATE INDEX idx_schedule_runs_owner_created
+    ON agent.schedule_runs(owner_user_id, created_at DESC);
+
+CREATE INDEX idx_schedule_runs_status_scheduled
+    ON agent.schedule_runs(status, scheduled_for);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.schedules TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.schedule_runs TO service_role;
+
+DO $$
+DECLARE
+    v_schedules_count integer;
+    v_schedule_runs_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_schedules_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedules';
+
+    SELECT count(*)
+    INTO v_schedule_runs_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedule_runs';
+
+    IF v_schedules_count <> 1 OR v_schedule_runs_count <> 1 THEN
+        RAISE EXCEPTION '02G table creation parity failed: schedules %, schedule_runs %', v_schedules_count, v_schedule_runs_count;
+    END IF;
+END $$;
+
+COMMIT;

--- a/database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql
+++ b/database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql
@@ -1,0 +1,75 @@
+-- Database Refactor 02A read-only prechecks.
+-- Run before executing database/migrations/20260414_01_agent_threads_thread_tasks.sql.
+-- This file must not mutate the database.
+
+-- 1. Every staging thread must resolve to an owner_user_id through staging.users.
+SELECT count(*) AS owner_derivation_missing
+FROM staging.threads t
+LEFT JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.id IS NULL OR u.owner_user_id IS NULL;
+
+-- 2. agent.threads target uniqueness must be safe.
+SELECT agent_user_id, branch_index, count(*) AS duplicate_count
+FROM staging.threads
+GROUP BY agent_user_id, branch_index
+HAVING count(*) > 1
+ORDER BY duplicate_count DESC, agent_user_id, branch_index;
+
+-- 3. staging thread statuses must fit the target check constraint.
+SELECT status, count(*) AS count
+FROM staging.threads
+WHERE status NOT IN ('active', 'archived')
+GROUP BY status
+ORDER BY status;
+
+-- 4. Unix epoch timestamps must be safe for to_timestamp().
+SELECT count(*) AS negative_thread_timestamps
+FROM staging.threads
+WHERE created_at < 0 OR updated_at < 0 OR last_active_at < 0;
+
+-- 5. Prove the source column types expected by the migration.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'staging'
+  AND table_name = 'threads'
+  AND column_name IN ('is_main', 'created_at', 'updated_at', 'last_active_at')
+ORDER BY column_name;
+
+-- 6. thread_tasks statuses must fit the target check constraint.
+SELECT status, count(*) AS count
+FROM staging.agent_thread_tasks
+WHERE status NOT IN ('pending', 'in_progress', 'completed')
+GROUP BY status
+ORDER BY status;
+
+-- 7. thread_tasks required fields and JSONB fields must not contain nulls.
+SELECT count(*) AS thread_task_required_nulls
+FROM staging.agent_thread_tasks
+WHERE thread_id IS NULL
+   OR task_id IS NULL
+   OR subject IS NULL
+   OR description IS NULL
+   OR status IS NULL
+   OR blocks IS NULL
+   OR blocked_by IS NULL
+   OR metadata IS NULL;
+
+-- 8. Expected source row counts.
+SELECT count(*) AS source_threads_for_agent_threads
+FROM staging.threads t
+JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.owner_user_id IS NOT NULL;
+
+SELECT count(*) AS source_thread_tasks
+FROM staging.agent_thread_tasks;
+
+-- 9. Known orphan source tasks. These are preserved without a hard FK in 02A.
+SELECT count(*) AS orphan_thread_tasks_against_staging_threads
+FROM staging.agent_thread_tasks tt
+LEFT JOIN staging.threads t ON t.id = tt.thread_id
+WHERE t.id IS NULL;
+
+-- 10. This migration is first-run-only: the target schema must not exist yet.
+SELECT count(*) AS agent_schema_exists
+FROM information_schema.schemata
+WHERE schema_name = 'agent';

--- a/database/prechecks/20260414_02_agent_threads_sandbox_type_readonly.sql
+++ b/database/prechecks/20260414_02_agent_threads_sandbox_type_readonly.sql
@@ -1,0 +1,48 @@
+-- Database Refactor 02A corrective read-only prechecks.
+-- Run before executing database/migrations/20260414_02_agent_threads_sandbox_type.sql.
+-- This file must not mutate the database.
+
+-- 1. The target table from 02A must already exist.
+SELECT count(*) AS agent_threads_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'threads';
+
+-- 2. The correction must not have already been applied.
+SELECT count(*) AS agent_threads_sandbox_type_exists
+FROM information_schema.columns
+WHERE table_schema = 'agent'
+  AND table_name = 'threads'
+  AND column_name = 'sandbox_type';
+
+-- 3. The source column must exist and be text-compatible.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'staging'
+  AND table_name = 'threads'
+  AND column_name = 'sandbox_type';
+
+-- 4. Source values must be present for every migrated target row.
+SELECT count(*) AS missing_source_sandbox_type
+FROM agent.threads a
+LEFT JOIN staging.threads s ON s.id = a.id
+WHERE s.id IS NULL
+   OR s.sandbox_type IS NULL
+   OR btrim(s.sandbox_type) = '';
+
+-- 5. Source and target row sets must still match before the correction.
+SELECT count(*) AS agent_threads_without_staging_source
+FROM agent.threads a
+LEFT JOIN staging.threads s ON s.id = a.id
+WHERE s.id IS NULL;
+
+SELECT count(*) AS staging_threads_without_agent_target
+FROM staging.threads s
+LEFT JOIN agent.threads a ON a.id = s.id
+WHERE a.id IS NULL;
+
+-- 6. Show the distinct source values being copied into agent.threads.
+SELECT sandbox_type, count(*) AS count
+FROM staging.threads
+GROUP BY sandbox_type
+ORDER BY count DESC, sandbox_type;

--- a/database/prechecks/20260414_03_agent_schedules_readonly.sql
+++ b/database/prechecks/20260414_03_agent_schedules_readonly.sql
@@ -1,0 +1,46 @@
+-- Database Refactor 02G read-only prechecks.
+-- Run before executing database/migrations/20260414_03_agent_schedules.sql.
+-- This file must not mutate the database.
+
+-- 1. The agent schema and agent.threads foundation from 02A must already exist.
+SELECT count(*) AS agent_schema_exists
+FROM information_schema.schemata
+WHERE schema_name = 'agent';
+
+SELECT count(*) AS agent_threads_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'threads';
+
+-- 2. The schedule target tables must not already exist.
+SELECT count(*) AS agent_schedules_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'schedules';
+
+SELECT count(*) AS agent_schedule_runs_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'schedule_runs';
+
+-- 3. Required agent.threads identity columns must exist.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'agent'
+  AND table_name = 'threads'
+  AND column_name IN ('id', 'agent_user_id', 'owner_user_id')
+ORDER BY ordinal_position;
+
+-- 4. Existing legacy schedule rows must be empty because 02G does not migrate cron_jobs.
+SELECT count(*) AS public_cron_jobs
+FROM public.cron_jobs;
+
+SELECT count(*) AS staging_cron_jobs
+FROM staging.cron_jobs;
+
+-- 5. Panel tasks are explicitly rejected as schedule source data; show their count only.
+SELECT count(*) AS public_panel_tasks_not_migrated
+FROM public.panel_tasks;
+
+-- 6. Service role must already have agent schema usage from 02A.
+SELECT has_schema_privilege('service_role', 'agent', 'USAGE') AS service_role_has_agent_usage;

--- a/database/rollbacks/20260414_01_agent_threads_thread_tasks.sql
+++ b/database/rollbacks/20260414_01_agent_threads_thread_tasks.sql
@@ -1,0 +1,13 @@
+-- Roll back Database Refactor 02A.
+--
+-- This rollback only removes the target landing tables created by
+-- database/migrations/20260414_01_agent_threads_thread_tasks.sql.
+-- It does not mutate public.* or staging.*.
+
+BEGIN;
+
+DROP TABLE IF EXISTS agent.thread_tasks;
+DROP TABLE IF EXISTS agent.threads;
+DROP SCHEMA IF EXISTS agent;
+
+COMMIT;

--- a/database/rollbacks/20260414_02_agent_threads_sandbox_type.sql
+++ b/database/rollbacks/20260414_02_agent_threads_sandbox_type.sql
@@ -1,0 +1,12 @@
+-- Roll back Database Refactor 02A sandbox_type correction.
+--
+-- This rollback only removes the corrective column added by
+-- database/migrations/20260414_02_agent_threads_sandbox_type.sql.
+-- It does not mutate public.* or staging.*.
+
+BEGIN;
+
+ALTER TABLE agent.threads
+    DROP COLUMN IF EXISTS sandbox_type;
+
+COMMIT;

--- a/database/rollbacks/20260414_03_agent_schedules.sql
+++ b/database/rollbacks/20260414_03_agent_schedules.sql
@@ -1,0 +1,12 @@
+-- Roll back Database Refactor 02G.
+--
+-- This rollback only removes the target schedule tables created by
+-- database/migrations/20260414_03_agent_schedules.sql.
+-- It does not mutate public.* or staging.*.
+
+BEGIN;
+
+DROP TABLE IF EXISTS agent.schedule_runs;
+DROP TABLE IF EXISTS agent.schedules;
+
+COMMIT;

--- a/docs/database-refactor/02-thread-tasks-schedules-preflight.md
+++ b/docs/database-refactor/02-thread-tasks-schedules-preflight.md
@@ -1,0 +1,423 @@
+# Database Refactor 02 Preflight: Thread Tasks And Schedules
+
+Date: 2026-04-14
+
+Status: design/preflight only. No DDL, no DB writes, no runtime route change.
+
+Ledger boundary: this packet exists to request a checkpoint ruling before any Database Refactor 02 implementation.
+
+## Recommendation
+
+Split the originally suggested `thread_tasks/schedules` slice.
+
+The first implementation slice should be:
+
+1. Create the `agent` schema foundation needed for runtime ownership.
+2. Land `agent.threads` from the current `staging.threads`.
+3. Land `agent.thread_tasks` from the current `staging.agent_thread_tasks`.
+4. Route the Supabase thread/task repos to explicit domain schemas.
+
+Do not migrate schedules in the same slice.
+
+Reason: `thread_tasks` depends on thread ownership and can be closed with a narrow backend API YATU. `schedules` currently comes from legacy `cron_jobs`, whose runtime behavior creates `panel_tasks`. The design target says panel tasks should be removed, and `schedule_runs` introduces new execution semantics. Combining those with `thread_tasks` would turn one database migration into a product behavior redesign.
+
+## Source Inputs
+
+- Upstream design comment: `https://github.com/nmhjklnm/mycel-db-design/issues/1#issuecomment-4237192274`
+- Design repo: `/Users/lexicalmathical/Codebase/mycel-db-design` at `9422bd8`
+- Current Mycel PR: `https://github.com/OpenDCAI/Mycel/pull/507`
+- Current contract matrix: `docs/database-refactor/target-contract-matrix.md`
+- Live DB queried through the existing staging backend `LEON_POSTGRES_URL`; secrets were not printed.
+
+## Design Conflict To Resolve
+
+The upstream design repo still says `agent.tool_tasks`, but the accepted Mycel ruling is `agent.thread_tasks`.
+
+More importantly, upstream `agent.tool_tasks` DDL models long-running tool execution progress:
+
+- `id`
+- `run_id`
+- `tool_name`
+- `input_json`
+- `output_json`
+- `progress_json`
+- `expires_at`
+
+Current Mycel `tool_tasks` / `agent_thread_tasks` model is different. It is the thread-scoped task-list state used by `core.tools.task`:
+
+- `thread_id`
+- `task_id`
+- `subject`
+- `description`
+- `status`
+- `active_form`
+- `owner`
+- `blocks`
+- `blocked_by`
+- `metadata`
+
+Therefore Database Refactor 02 must not copy the upstream `agent.tool_tasks` DDL as-is. For Mycel, the target table should be `agent.thread_tasks` with the current thread task contract. If Mycel later needs long-running tool execution progress, that should be a separate table and checkpoint, not this migration.
+
+## Live DB Facts
+
+### Thread tasks
+
+`public.tool_tasks`:
+
+- rows: 274
+- primary key: `(thread_id, task_id)`
+- statuses: `pending = 274`
+- distinct `thread_id`: 1
+- orphaned against `public.threads`: 274 rows
+
+`staging.agent_thread_tasks`:
+
+- rows: 274
+- primary key: `(thread_id, task_id)`
+- statuses: `pending = 274`
+- distinct `thread_id`: 1
+- orphaned against `staging.threads`: 274 rows
+
+The two current task tables have the same logical columns. `staging.agent_thread_tasks` is the better source because this refactor is moving from the staging runtime surface toward domain schemas.
+
+### Threads
+
+`staging.threads`:
+
+- rows: 81
+- columns: `id`, `agent_user_id`, `sandbox_type`, `model`, `cwd`, `status`, `created_at`, `updated_at`, `last_active_at`, `is_main`, `branch_index`
+- missing target `owner_user_id`, but it can be derived by joining `staging.users.id = staging.threads.agent_user_id`
+
+`public.threads`:
+
+- rows: 62
+- legacy `member_id`, `user_id`, `observation_provider`, `agent`
+
+Use `staging.threads` as the source for `agent.threads`.
+
+### Schedules
+
+`public.cron_jobs`:
+
+- rows: 0
+- legacy bigint timestamps
+- has `owner_user_id`
+
+`staging.cron_jobs`:
+
+- rows: 0
+- legacy bigint timestamps
+- has FK to `staging.users(id)`
+
+There is no schedule data to migrate right now. The work is product/API semantics, not data preservation.
+
+### Panel tasks
+
+`public.panel_tasks`:
+
+- rows: 2
+- statuses: `pending = 1`, `completed = 1`
+- sources: `agent = 1`, `manual = 1`
+
+`staging.panel_tasks`:
+
+- absent
+
+Panel tasks are not part of the target schema. They should not be migrated into `agent.thread_tasks` or `agent.schedules`.
+
+## Code Surfaces
+
+### Thread tasks
+
+- `core/tools/task/service.py`
+- `core/tools/task/types.py`
+- `storage/providers/supabase/tool_task_repo.py`
+- `storage/providers/sqlite/tool_task_repo.py`
+- `backend/web/core/storage_factory.py::make_tool_task_repo`
+- Tests:
+  - add Supabase schema route tests for the renamed table
+  - keep existing SQLite task service tests passing
+
+### Threads
+
+- `storage/providers/supabase/thread_repo.py`
+- `tests/test_supabase_thread_repo_schema.py`
+- Backend API surfaces already smoke-tested in PR #507:
+  - `POST /api/auth/login`
+  - `GET /api/members`
+  - `GET /api/threads`
+
+### Schedules / legacy cron
+
+- `storage/providers/supabase/cron_job_repo.py`
+- `storage/providers/sqlite/cron_job_repo.py`
+- `backend/web/services/cron_job_service.py`
+- `backend/web/services/cron_service.py`
+- `backend/web/routers/panel.py` `/cron-jobs`
+- `frontend/app/src/pages/TasksPage.tsx`
+- `frontend/app/src/components/cron-editor.tsx`
+- `frontend/app/src/components/task-modal.tsx`
+- `frontend/app/src/store/app-store.ts`
+
+This is too broad to mix with the first domain table migration.
+
+## Target Contract For Database Refactor 02A
+
+### `agent.threads`
+
+This table is required because `agent.thread_tasks` ownership, RLS, and future realtime visibility need a domain-thread source of truth.
+
+Minimum target columns:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS agent;
+
+CREATE TABLE agent.threads (
+    id                   TEXT        PRIMARY KEY,
+    agent_user_id        TEXT        NOT NULL,
+    owner_user_id        TEXT        NOT NULL,
+    current_workspace_id TEXT,
+    model                TEXT,
+    cwd                  TEXT,
+    status               TEXT        NOT NULL DEFAULT 'active',
+    run_status           TEXT        NOT NULL DEFAULT 'idle',
+    is_main              BOOLEAN     NOT NULL DEFAULT false,
+    branch_index         INTEGER     NOT NULL DEFAULT 0,
+    last_active_at       TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT threads_status_chk
+        CHECK (status IN ('active', 'archived')),
+    CONSTRAINT threads_run_status_chk
+        CHECK (run_status IN ('idle', 'running', 'paused', 'error')),
+    CONSTRAINT threads_agent_branch_uq UNIQUE (agent_user_id, branch_index)
+);
+
+CREATE INDEX idx_threads_owner_active
+    ON agent.threads(owner_user_id, last_active_at DESC)
+    WHERE status = 'active';
+
+CREATE INDEX idx_threads_agent_active
+    ON agent.threads(agent_user_id)
+    WHERE status = 'active';
+```
+
+Migration source:
+
+```sql
+INSERT INTO agent.threads (
+    id,
+    agent_user_id,
+    owner_user_id,
+    model,
+    cwd,
+    status,
+    run_status,
+    is_main,
+    branch_index,
+    last_active_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    t.agent_user_id,
+    u.owner_user_id,
+    t.model,
+    t.cwd,
+    t.status,
+    'idle',
+    (t.is_main <> 0),
+    t.branch_index,
+    CASE WHEN t.last_active_at IS NULL THEN NULL ELSE to_timestamp(t.last_active_at) END,
+    to_timestamp(t.created_at),
+    CASE WHEN t.updated_at IS NULL THEN to_timestamp(t.created_at) ELSE to_timestamp(t.updated_at) END
+FROM staging.threads t
+JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.owner_user_id IS NOT NULL;
+```
+
+Pre-migration check:
+
+```sql
+SELECT count(*) FROM staging.threads t
+LEFT JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.id IS NULL OR u.owner_user_id IS NULL;
+```
+
+This must be zero or explicitly waived before implementation.
+
+### `agent.thread_tasks`
+
+Use the current Mycel thread task contract, not upstream `agent.tool_tasks` progress DDL.
+
+```sql
+CREATE TABLE agent.thread_tasks (
+    thread_id    TEXT  NOT NULL,
+    task_id      TEXT  NOT NULL,
+    subject      TEXT  NOT NULL,
+    description  TEXT  NOT NULL,
+    status       TEXT  NOT NULL DEFAULT 'pending',
+    active_form  TEXT,
+    owner        TEXT,
+    blocks       JSONB NOT NULL DEFAULT '[]',
+    blocked_by   JSONB NOT NULL DEFAULT '[]',
+    metadata     JSONB NOT NULL DEFAULT '{}',
+
+    PRIMARY KEY (thread_id, task_id),
+    CONSTRAINT thread_tasks_status_chk
+        CHECK (status IN ('pending', 'in_progress', 'completed'))
+);
+
+CREATE INDEX idx_thread_tasks_thread
+    ON agent.thread_tasks(thread_id);
+```
+
+Migration source:
+
+```sql
+INSERT INTO agent.thread_tasks (
+    thread_id,
+    task_id,
+    subject,
+    description,
+    status,
+    active_form,
+    owner,
+    blocks,
+    blocked_by,
+    metadata
+)
+SELECT
+    thread_id,
+    task_id,
+    subject,
+    description,
+    status,
+    active_form,
+    owner,
+    blocks,
+    blocked_by,
+    metadata
+FROM staging.agent_thread_tasks;
+```
+
+Pre-migration issue: current 274 rows are orphaned against `staging.threads`. That means the insert above will preserve rows, but if `agent.thread_tasks` later adds a hard FK to `agent.threads`, these rows will fail. For this slice, do not add a hard FK. Ownership/RLS can still use `EXISTS(agent.threads...)`; orphan rows will simply be invisible to authenticated users until cleaned.
+
+## Supabase Client Contract
+
+PR #507 made `LEON_DB_SCHEMA` explicit for the current `public/staging` runtime. The target multi-schema design cannot keep relying on one global PostgREST default schema.
+
+Supabase-py supports:
+
+```python
+client.schema("agent").table("thread_tasks")
+```
+
+Database Refactor 02A should add a tiny domain table helper rather than broad compatibility branches. Expected shape:
+
+```python
+def table_in_schema(client: Any, schema: str, table: str) -> Any:
+    return client.schema(schema).table(table)
+```
+
+Then `SupabaseToolTaskRepo` should become either:
+
+- `SupabaseThreadTaskRepo`, or
+- a backward-compatible class name that targets `agent.thread_tasks` while the Python symbol rename happens in a follow-up.
+
+The table name must become `thread_tasks`. Do not keep a permanent `tool_tasks` fallback.
+
+## Migration Artifact Shape
+
+Create a versioned SQL artifact under a repo-owned path, for example:
+
+```text
+database/migrations/20260414_01_agent_threads_thread_tasks.sql
+```
+
+The artifact should be one transaction:
+
+1. `CREATE SCHEMA IF NOT EXISTS agent`
+2. create `agent.threads`
+3. create `agent.thread_tasks`
+4. copy from `staging.threads`
+5. copy from `staging.agent_thread_tasks`
+6. create indexes
+7. enable RLS only if policies can be proved against the migrated `agent.threads`
+8. add realtime publication for `agent.threads` and `agent.thread_tasks`
+9. run parity assertions at the end
+
+Suggested parity assertions:
+
+```sql
+SELECT
+    (SELECT count(*) FROM staging.threads t JOIN staging.users u ON u.id = t.agent_user_id WHERE u.owner_user_id IS NOT NULL) AS source_threads,
+    (SELECT count(*) FROM agent.threads) AS target_threads;
+
+SELECT
+    (SELECT count(*) FROM staging.agent_thread_tasks) AS source_tasks,
+    (SELECT count(*) FROM agent.thread_tasks) AS target_tasks;
+```
+
+## Rollback Plan
+
+Because this is a landing migration, rollback should be simple:
+
+```sql
+DROP TABLE IF EXISTS agent.thread_tasks;
+DROP TABLE IF EXISTS agent.threads;
+DROP SCHEMA IF EXISTS agent;
+```
+
+Do not delete or mutate `staging.*` or `public.*` in this slice. Old tables remain intact until a later purge checkpoint.
+
+## Backend/API YATU Closure Path
+
+Run against real Supabase with `LEON_STORAGE_STRATEGY=supabase`.
+
+Minimum backend API YATU:
+
+1. Login with a real test user.
+2. `GET /api/threads` returns 200 and still lists the same visible threads as before the route switch.
+3. Exercise the Task tool through a real thread path or a high-level backend API that writes through `core.tools.task.service`.
+4. Verify `agent.thread_tasks` row count changes when a thread task is created.
+5. Verify `GET /api/threads` still returns 200 after task creation.
+
+Source/test auxiliary evidence:
+
+- RED/GREEN repo tests for `SupabaseThreadTaskRepo` table route.
+- RED/GREEN tests proving no permanent `tool_tasks` table route remains in Supabase mode.
+- Storage runtime wiring tests.
+- `ruff check` and `ruff format --check`.
+
+## Schedules Follow-Up Packet
+
+Schedules should be a separate checkpoint after 02A.
+
+Reasoning:
+
+- `cron_jobs` has zero rows, so there is no urgent data migration.
+- Current `CronService.trigger_job()` creates `panel_tasks`.
+- Target `agent.schedules.task_template` should steer or create agent threads, not create legacy panel board rows.
+- `agent.schedule_runs` changes runtime observability and needs new service behavior.
+- The frontend Tasks/Cron UI is tied to legacy panel semantics.
+
+The follow-up checkpoint should decide one of these product directions before DDL:
+
+1. Remove legacy Tasks/Cron UI and replace it with agent schedule UI.
+2. Keep a compatibility UI label but route it to agent schedules.
+3. Park schedules until a real product loop exists.
+
+Do not silently migrate `panel_tasks` into schedules or thread tasks.
+
+## Stopline
+
+Stop and return to Ledger if any of these happen:
+
+- `thread_tasks` implementation starts adding permanent `tool_tasks` fallback.
+- The migration needs to mutate or delete `public.*` / `staging.*`.
+- The code starts mixing legacy `panel_tasks` into `agent.thread_tasks`.
+- The work requires frontend Tasks/Cron redesign.
+- Supabase domain schema routing becomes broad repo-specific branching instead of a small explicit helper.

--- a/docs/database-refactor/02a-execution-proof.md
+++ b/docs/database-refactor/02a-execution-proof.md
@@ -1,0 +1,271 @@
+# Database Refactor 02A Execution Proof
+
+Date: 2026-04-14
+
+Scope executed:
+
+- `database/migrations/20260414_01_agent_threads_thread_tasks.sql`
+- PostgREST exposed schemas update: add `agent`
+- `supabase-rest` restart only
+- service-role REST visibility proof
+
+Not executed:
+
+- no runtime repo route to `agent.*`
+- no RLS
+- no realtime
+- no schedules / cron_jobs / panel_tasks migration
+- no mutation or deletion of `public.*` or `staging.*`
+
+## Precheck Before Execution
+
+Read-only precheck was run immediately before migration.
+
+Results:
+
+- statement count: 11
+- owner derivation missing: 0
+- duplicate `(agent_user_id, branch_index)` pairs: 0 rows
+- unsupported thread statuses: 0 rows
+- negative thread timestamps: 0
+- source column types:
+  - `created_at`: `double precision`, not null
+  - `is_main`: `integer`, not null
+  - `last_active_at`: `double precision`, nullable
+  - `updated_at`: `double precision`, nullable
+- bad thread task statuses: 0 rows
+- thread task required nulls: 0
+- source threads for `agent.threads`: 81
+- source thread tasks: 274
+- orphan thread tasks against `staging.threads`: 274
+- `agent` schema exists before migration: 0
+
+## Migration Result
+
+The migration executed successfully.
+
+Post-execution row/parity checks:
+
+- `agent` schema exists: 1
+- `agent.threads`: 81
+- `agent.thread_tasks`: 274
+- `staging.threads`: 81
+- `staging.agent_thread_tasks`: 274
+- `public.tool_tasks`: 274
+
+Privilege checks:
+
+- `service_role` has `USAGE` on schema `agent`: true
+- `service_role` can `SELECT` `agent.threads`: true
+- `service_role` can `SELECT` `agent.thread_tasks`: true
+- `anon` has `USAGE` on schema `agent`: false
+- `authenticated` has `USAGE` on schema `agent`: false
+
+## PostgREST Exposure
+
+Remote self-hosted Supabase config was updated from:
+
+```text
+PGRST_DB_SCHEMAS=public,storage,graphql_public,staging
+```
+
+to:
+
+```text
+PGRST_DB_SCHEMAS=public,storage,graphql_public,staging,agent
+```
+
+Only `supabase-rest` was recreated/restarted through docker compose.
+
+Container proof after restart:
+
+```text
+PGRST_DB_SCHEMAS=public,storage,graphql_public,staging,agent
+supabase-rest Up
+```
+
+## Service-Role REST Proof
+
+Using the app Supabase service-role environment:
+
+```python
+client = create_supabase_client()
+threads = client.schema("agent").table("threads").select("id").limit(1).execute()
+tasks = client.schema("agent").table("thread_tasks").select("thread_id,task_id").limit(1).execute()
+```
+
+Result:
+
+- first attempt succeeded
+- `agent_threads_data_is_list`: true, length 1
+- `agent_thread_tasks_data_is_list`: true, length 1
+
+## Existing Staging Surface Smoke
+
+Against the already-running backend on port 8010:
+
+- `POST /api/auth/login`: 200, token present
+- `GET /api/threads`: 200
+
+`GET /api/members` returned 404 on this backend version, which appears to be a route/version mismatch rather than a DB failure. It did not return a 5xx. Do not use that endpoint as closure evidence for this execution slice.
+
+## Current Stopline
+
+Do not route runtime repos to `agent.*` until Ledger reviews this proof.
+
+Do not add RLS/realtime/anon/authenticated grants in this checkpoint.
+
+## Sandbox Type Correction
+
+Ledger authorized a narrow corrective migration after the initial execution proof found a runtime contract mismatch:
+
+- `agent.threads` had landed without `sandbox_type`
+- current `SupabaseThreadRepo` reads `sandbox_type`
+- current `/api/threads` derives the response `sandbox` field from `sandbox_type`
+- current runtime pool keys use `thread_id:sandbox_type`
+
+Local `psql` was not installed, so the exact SQL files were executed through the project Python environment with `psycopg`. Secrets were not printed.
+
+Corrective artifacts:
+
+- precheck: `database/prechecks/20260414_02_agent_threads_sandbox_type_readonly.sql`
+- migration: `database/migrations/20260414_02_agent_threads_sandbox_type.sql`
+- rollback: `database/rollbacks/20260414_02_agent_threads_sandbox_type.sql`
+
+Read-only precheck immediately before execution:
+
+- statement count: 7
+- `agent_threads_exists`: 1
+- `agent_threads_sandbox_type_exists`: 0
+- source `staging.threads.sandbox_type`: `text`, not null
+- `missing_source_sandbox_type`: 0
+- `agent_threads_without_staging_source`: 0
+- `staging_threads_without_agent_target`: 0
+- source distribution:
+  - `local`: 56
+  - `daytona_selfhost`: 25
+
+Migration result:
+
+- `database/migrations/20260414_02_agent_threads_sandbox_type.sql` executed successfully
+- no default value was added
+- no application fallback was added
+- no runtime routing was performed
+- no `public.*` or `staging.*` mutation was performed
+
+Post-execution DB proof:
+
+- `agent.threads.sandbox_type`: `text`, not null, no default
+- blank/null `agent.threads.sandbox_type` rows: 0
+- `agent.threads`: 81
+- `staging.threads`: 81
+- `agent.thread_tasks`: 274
+- `staging.agent_thread_tasks`: 274
+- `public.tool_tasks`: 274
+- target distribution:
+  - `local`: 56
+  - `daytona_selfhost`: 25
+
+Service-role REST proof:
+
+```python
+client = create_supabase_client()
+result = client.schema("agent").table("threads").select("id,sandbox_type").limit(3).execute()
+```
+
+Result:
+
+- `agent_threads_data_is_list`: true
+- `agent_threads_len`: 3
+- returned fields: `id`, `sandbox_type`
+- sample returned sandbox types: `local`
+
+Note: the first REST proof attempt hit local SOCKS proxy bleed because inherited `ALL_PROXY` made `httpx` require `socksio`. The proof was rerun with `ALL_PROXY/all_proxy` unset, matching the repo playbook.
+
+## Runtime Routing Service-Role Boundary
+
+Fresh backend proof on port `18010` found a real permission stopline:
+
+- `POST /api/auth/login`: 200
+- `GET /api/threads`: 500 before the runtime wiring fix
+- backend traceback: `SupabaseThreadRepo.list_by_owner_user_id` selected `agent.threads` with a user-authenticated PostgREST identity
+- PostgREST returned SQLSTATE `42501`, `permission denied for schema agent`
+
+Ledger ruling:
+
+- do not grant `anon` or `authenticated` access to `agent.*` in 02A
+- do not add RLS policies in 02A just to make direct authenticated PostgREST work
+- keep `LEON_DB_SCHEMA=staging` globally for auth/account/member/entity surfaces
+- keep migrated `agent.threads` and `agent.thread_tasks` behind the backend service-role repository boundary
+
+Code correction:
+
+- `backend.web.core.lifespan` now creates two Supabase clients in Supabase mode:
+  - storage client for repos and `StorageContainer`
+  - auth client for `AuthService`
+- reason: Supabase auth calls mutate the client's auth headers; storage repos must keep service-role identity
+- no grants, RLS, default schema fallback, or global `LEON_DB_SCHEMA=agent` path were added
+
+Regression test:
+
+```text
+uv run pytest tests/test_lifespan_supabase_wiring.py tests/test_supabase_tool_task_repo_schema.py tests/test_supabase_thread_repo_schema.py tests/test_supabase_factory.py tests/test_threads_router_agent_schema_contract.py tests/test_supabase_member_repo_schema.py -q
+15 passed
+```
+
+Lint/format:
+
+```text
+uv run ruff check backend/web/core/lifespan.py tests/test_lifespan_supabase_wiring.py
+All checks passed!
+
+uv run ruff format --check backend/web/core/lifespan.py tests/test_lifespan_supabase_wiring.py
+2 files already formatted
+```
+
+Fresh backend API YATU after the fix:
+
+- backend env: `LEON_STORAGE_STRATEGY=supabase`, `LEON_DB_SCHEMA=staging`
+- `POST /api/auth/login`: 200
+- `GET /api/threads`: 200
+- response for a temporary fresh user: `{"threads": []}`
+- temporary auth/user rows were cleaned up
+
+Task tool storage proof through `agent.thread_tasks`:
+
+- `TaskCreate`: created task id `1`
+- `TaskList`: total `1`
+- `TaskGet`: status `pending`
+- `TaskUpdate`: status `completed`
+- direct service-role read from `agent.thread_tasks`: 1 matching row
+- proof row was deleted after the check
+
+High-level ToolRunner proof through the registered task tools:
+
+- `ToolRunner.wrap_tool_call(TaskCreate)`: created task id `1`
+- `ToolRunner.wrap_tool_call(TaskList)`: total `1`
+- `ToolRunner.wrap_tool_call(TaskGet)`: status `pending`
+- `ToolRunner.wrap_tool_call(TaskUpdate)`: status `completed`
+- upstream fallback handler calls: 0
+- direct service-role read from `agent.thread_tasks`: 1 matching row
+- proof row was deleted after the check
+
+Direct PostgREST access remains denied:
+
+- anon REST request to `agent.threads`: HTTP 401, code `42501`
+- authenticated REST request to `agent.threads`: HTTP 403, code `42501`
+
+## Follow-Up Non-02A Blocker
+
+`POST /api/threads` still failed during an expanded proof attempt, but the failure is outside the `agent.*` repo-routing fix:
+
+- `POST /api/threads`: 500
+- traceback: `SupabaseEntityRepo.get_by_id` tried to read `staging.entities`
+- PostgREST returned `PGRST205`, table `staging.entities` not found in schema cache
+
+This should be tracked as a separate entity/thread-create checkpoint. It should not be patched inside 02A by adding fallback routing or inventing `staging.entities` without a target-contract decision.
+
+Resolution:
+
+- handled by `database-refactor-02b-supabase-actor-read-model-adapter`
+- proof: `docs/database-refactor/02b-actor-read-model-proof.md`

--- a/docs/database-refactor/02a-postgrest-exposure-runbook.md
+++ b/docs/database-refactor/02a-postgrest-exposure-runbook.md
@@ -1,0 +1,78 @@
+# Database Refactor 02A PostgREST Exposure Runbook
+
+Status: runbook only. Do not execute without Ledger authorization.
+
+## Current Proof
+
+Remote Supabase self-host config on ZGCA currently exposes:
+
+```text
+PGRST_DB_SCHEMAS=public,storage,graphql_public,staging
+```
+
+`agent` is not exposed today.
+
+Source:
+
+- server path: `/opt/supabase/repo/docker/.env`
+- container: `supabase-rest`
+- compose key: `PGRST_DB_SCHEMAS`
+
+Supabase-py confirms `client.schema("agent")` requires the schema to be in Supabase's exposed schema list.
+
+## Required Config Change
+
+After the DB migration creates `agent.threads` and `agent.thread_tasks`, update the self-hosted Supabase docker env:
+
+```dotenv
+PGRST_DB_SCHEMAS=public,storage,graphql_public,staging,agent
+```
+
+Then restart or recreate only the PostgREST container from `/opt/supabase/repo/docker`:
+
+```bash
+cd /opt/supabase/repo/docker
+docker compose up -d rest
+```
+
+If the env is already updated and only the schema cache needs reload, use:
+
+```sql
+NOTIFY pgrst, 'reload schema';
+```
+
+For this first `agent` exposure, prefer the container restart because the exposed schema list itself changes.
+
+## Required Grants
+
+The 02A migration grants only backend service-role access:
+
+```sql
+GRANT USAGE ON SCHEMA agent TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.threads TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.thread_tasks TO service_role;
+```
+
+Do not grant `anon` or `authenticated` in 02A. Direct frontend/PostgREST access, RLS, and realtime require a separate proof checkpoint.
+
+## Post-Migration REST Proof
+
+After migration and PostgREST exposure, prove service-role REST visibility from the app environment:
+
+```python
+from backend.web.core.supabase_factory import create_supabase_client
+
+client = create_supabase_client()
+threads = client.schema("agent").table("threads").select("id").limit(1).execute()
+tasks = client.schema("agent").table("thread_tasks").select("thread_id,task_id").limit(1).execute()
+print(len(threads.data), len(tasks.data))
+```
+
+Expected:
+
+- no `PGRST106` / schema-not-exposed error
+- no permission error
+- `threads.data` is a list
+- `tasks.data` is a list
+
+Only after this proof should runtime repos route to `agent.*`.

--- a/docs/database-refactor/02a-sandbox-type-correction-packet.md
+++ b/docs/database-refactor/02a-sandbox-type-correction-packet.md
@@ -1,0 +1,61 @@
+# Database Refactor 02A Sandbox Type Correction Packet
+
+Date: 2026-04-14
+
+## Why This Exists
+
+`agent.threads` was landed in 02A without `sandbox_type`.
+
+That is a schema/runtime contract mismatch, not a UI issue:
+
+- current `SupabaseThreadRepo` reads `sandbox_type` as part of the thread row contract
+- current `/api/threads` returns a `sandbox` field derived from `sandbox_type`
+- current runtime pool keys use `thread_id:sandbox_type`
+
+Routing runtime repos to `agent.threads` without this column would force an application fallback/default shim. That is explicitly disallowed for this checkpoint.
+
+## Narrow Decision
+
+Add `agent.threads.sandbox_type` as a corrective column copied from `staging.threads.sandbox_type`.
+
+This packet does not decide the final sandbox/container ontology. The meeting summary makes clear that `workspace` is only a thin working-directory context; the core runtime relation is thread to sandbox/container execution. `sandbox_type` may later be replaced by that stronger relation, but current 02A runtime routing still needs the current explicit field.
+
+## Artifacts
+
+- Precheck: `database/prechecks/20260414_02_agent_threads_sandbox_type_readonly.sql`
+- Migration: `database/migrations/20260414_02_agent_threads_sandbox_type.sql`
+- Rollback: `database/rollbacks/20260414_02_agent_threads_sandbox_type.sql`
+
+## Preconditions
+
+The read-only precheck must show:
+
+- `agent.threads` exists exactly once
+- `agent.threads.sandbox_type` does not already exist
+- `staging.threads.sandbox_type` exists and is text-compatible
+- every `agent.threads` row has a matching `staging.threads.sandbox_type`
+- row sets still match between `agent.threads` and `staging.threads`
+
+## Execution Plan
+
+1. Run the read-only precheck.
+2. Execute `database/migrations/20260414_02_agent_threads_sandbox_type.sql`.
+3. Verify `agent.threads.sandbox_type` exists, is `NOT NULL`, and row count remains unchanged.
+4. Verify service-role REST can select `id,sandbox_type` from `agent.threads`.
+
+## Stoplines
+
+- If any target row lacks a source `sandbox_type`, stop. Do not invent a default.
+- If `agent.threads.sandbox_type` already exists, stop. Do not make the migration idempotent.
+- If source/target row sets differ, stop. Do not route runtime repos.
+- Do not add runtime fallbacks, defaults, or schema routing in this packet.
+
+## Post-Execution Proof Required
+
+After Ledger authorizes execution and the migration runs, append proof to `docs/database-refactor/02a-execution-proof.md`:
+
+- precheck result summary
+- migration result
+- `information_schema.columns` proof for `agent.threads.sandbox_type`
+- source/target row parity
+- service-role REST proof selecting `id,sandbox_type`

--- a/docs/database-refactor/02b-actor-read-model-proof.md
+++ b/docs/database-refactor/02b-actor-read-model-proof.md
@@ -1,0 +1,127 @@
+# Database Refactor 02B Actor Read-Model Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02b-supabase-actor-read-model-adapter`
+
+Scope executed:
+
+- Remove Supabase runtime dependency on a nonexistent `entities` table.
+- Derive actor/entity read model from canonical sources:
+  - human and agent rows from `staging.users`
+  - agent main thread linkage from `agent.threads`
+- Fix the expanded thread-create path that writes `thread_launch_prefs` under staging:
+  - application contract still uses `member_id`
+  - staging database column is `agent_user_id`
+
+Not executed:
+
+- no DDL
+- no `public.entities`, `staging.entities`, or `agent.entities`
+- no fallback routing
+- no frontend redesign
+- no identity/chat schema migration
+
+## Root Cause
+
+The first expanded backend API proof after 02A failed at `POST /api/threads`:
+
+- `SupabaseEntityRepo.get_by_id` queried `staging.entities`
+- live staging has no `entities` table
+- PostgREST returned `PGRST205`
+
+After replacing `SupabaseEntityRepo` with a read-model adapter, the next real runtime blocker surfaced:
+
+- `SupabaseThreadLaunchPrefRepo.save_successful` wrote `member_id`
+- live `staging.thread_launch_prefs` has `agent_user_id`, not `member_id`
+- PostgREST returned `PGRST204`
+
+The correction is explicit schema mapping, not fallback:
+
+- `public.thread_launch_prefs`: `member_id`
+- `staging.thread_launch_prefs`: `agent_user_id`
+
+## Code Correction
+
+`SupabaseEntityRepo` is now a no-table read-model adapter:
+
+- `get_by_id(id)` loads the member row from `staging.users`
+- human actors become `EntityRow(type="human")`
+- agent actors become `EntityRow(type="agent")`
+- agent `thread_id` is derived from `SupabaseThreadRepo.get_main_thread(member.id)`
+- create/update/delete are no-ops because there is no Supabase entity table to mutate in this checkpoint
+
+`SupabaseThreadLaunchPrefRepo` now routes its agent identity column through `LEON_DB_SCHEMA`:
+
+- application input/output remains `member_id`
+- staging reads/writes `agent_user_id`
+- unknown runtime schemas fail loudly
+
+## Test Evidence
+
+RED was observed before implementation:
+
+- `tests/test_supabase_entity_repo_schema.py`: 4 failures because the old repo queried `entities`
+- `tests/test_supabase_thread_launch_pref_repo_schema.py`: 3 failures because the old repo queried/wrote `member_id` under staging and did not reject unknown schemas
+
+GREEN after implementation:
+
+```text
+uv run pytest tests/test_supabase_thread_launch_pref_repo_schema.py tests/test_supabase_entity_repo_schema.py tests/test_lifespan_supabase_wiring.py tests/test_supabase_tool_task_repo_schema.py tests/test_supabase_thread_repo_schema.py tests/test_supabase_factory.py tests/test_threads_router_agent_schema_contract.py tests/test_supabase_member_repo_schema.py -q
+22 passed
+```
+
+Lint/format:
+
+```text
+uv run ruff check storage/providers/supabase/thread_launch_pref_repo.py tests/test_supabase_thread_launch_pref_repo_schema.py storage/providers/supabase/entity_repo.py tests/test_supabase_entity_repo_schema.py
+All checks passed!
+
+uv run ruff format --check storage/providers/supabase/thread_launch_pref_repo.py tests/test_supabase_thread_launch_pref_repo_schema.py storage/providers/supabase/entity_repo.py tests/test_supabase_entity_repo_schema.py
+4 files already formatted
+```
+
+## Backend API YATU
+
+Fresh backend was launched on validation port `18010` with:
+
+- `LEON_STORAGE_STRATEGY=supabase`
+- `LEON_DB_SCHEMA=staging`
+- public Supabase REST/auth target
+- private Postgres/Supavisor runtime via the existing ops startup script
+
+Known non-blocking startup notes:
+
+- local provider was available
+- Daytona/AgentBay SDK imports still failed because optional SDK packages are not installed in this venv
+- those provider-load warnings did not affect the local-provider thread-create proof
+
+Real product-path proof used a temporary Supabase auth user plus temporary `staging.users` human/agent rows. Secrets and password were not recorded.
+
+Results:
+
+- `POST /api/auth/login`: 200
+- `GET /api/threads` before create: 200, count 0
+- `POST /api/threads`: 200
+- created thread id: `agent_yatu_wy14scan-1`
+- `GET /api/threads` after create: 200
+- created thread present in response: true
+- `GET /api/entities`: 200
+- temporary agent present with created thread id: true
+- `staging.thread_launch_prefs` row for `(owner_user_id, agent_user_id)`: 1
+
+Cleanup completed:
+
+- deleted temporary `agent.threads` row
+- deleted temporary `staging.thread_launch_prefs` row
+- deleted temporary `staging.users` agent row
+- deleted temporary `staging.users` human row
+- deleted temporary Supabase auth user
+
+## Stopline
+
+02B does not authorize adding an `entities` table back into Supabase.
+
+If later product design needs a durable actor projection table, that must be a new checkpoint with a target-schema decision. For this checkpoint, actor discovery is a read model derived from canonical user/thread state.

--- a/docs/database-refactor/02c-chat-actor-read-model-proof.md
+++ b/docs/database-refactor/02c-chat-actor-read-model-proof.md
@@ -1,0 +1,126 @@
+# Database Refactor 02C Chat Actor Read-Model Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02c-chat-actor-read-model-strict-proof`
+
+Scope:
+
+- proof-first backend API YATU
+- no DDL
+- no frontend work
+- no fallback routing
+- no RLS/grant/PostgREST exposure change
+- no service-role boundary change
+- no LLM delivery work
+
+Goal:
+
+- decide whether the 02B Supabase actor read-model is strict enough for chat participant and message-display surfaces
+
+## Setup
+
+Fresh backend was launched on validation port `18010` with the existing Supabase local runtime startup script.
+
+Known non-blocking startup notes:
+
+- local sandbox provider was available
+- Daytona/AgentBay SDK imports still failed because optional SDK packages are not installed in this venv
+- the proof did not rely on those providers
+
+Temporary fixture:
+
+- one temporary Supabase auth human
+- one temporary `staging.users` human row
+- one temporary `staging.users` agent row owned by that human
+- one temporary main thread created through `POST /api/threads`
+
+Secrets and temporary password were not recorded.
+
+## Backend API YATU Result
+
+API sequence:
+
+```text
+POST /api/auth/login
+POST /api/threads
+POST /api/chats
+```
+
+Observed result:
+
+- `POST /api/auth/login`: 200
+- `POST /api/threads`: 200
+- created thread id: `agent_02c_w589u2gv-1`
+- `POST /api/chats`: 500
+
+The proof stopped at the first failing product API surface as required by the 02C stopline.
+
+`POST /api/chats` response body:
+
+```text
+Internal Server Error
+```
+
+Backend traceback root:
+
+```text
+storage/providers/supabase/chat_repo.py:105
+SupabaseChatEntityRepo.find_chat_between(...)
+self._t().select("chat_id").eq("user_id", user_a).execute()
+
+postgrest.exceptions.APIError:
+{
+  "message": "Could not find the table 'staging.chat_entities' in the schema cache",
+  "code": "PGRST205",
+  "hint": "Perhaps you meant the table 'staging.chat_sessions'",
+  "details": null
+}
+```
+
+## Cleanup
+
+Cleanup completed for the fixture rows created before the failure:
+
+- deleted temporary `agent.threads` row
+- deleted temporary `staging.thread_launch_prefs` row
+- deleted temporary `staging.users` agent row
+- deleted temporary `staging.users` human row
+- deleted temporary Supabase auth user
+
+No chat row/message rows were created because `POST /api/chats` failed before insertion.
+
+## Classification
+
+This is not a narrow 02B actor read-model mismatch.
+
+The first failing surface is the chat storage schema boundary:
+
+- current `SupabaseChatEntityRepo` still targets `staging.chat_entities`
+- live target schema does not expose `staging.chat_entities`
+- canonical/current design direction is `chats / chat_members / messages`, not `chat_entities / chat_messages`
+
+Therefore 02C cannot upgrade 02B to strict yet.
+
+Recommended next checkpoint:
+
+- a dedicated chat schema/read-model migration or adapter checkpoint
+- likely target surfaces:
+  - `SupabaseChatRepo`
+  - `SupabaseChatEntityRepo`
+  - `SupabaseChatMessageRepo`
+  - `/api/chats`
+  - `/api/chats/{chat_id}`
+  - `/api/chats/{chat_id}/messages`
+- expected DB contract should be decided before code:
+  - `chat_members`, not legacy `chat_entities`
+  - `messages`, not legacy `chat_messages`
+  - unread should be based on `chat_members.last_read_seq` when this slice reaches unread/read proof
+
+Stopline remains:
+
+- do not recreate `chat_entities` just to satisfy old code
+- do not add fallback table probing
+- do not patch this inside 02C without a new Ledger ruling

--- a/docs/database-refactor/02d-chat-schema-read-model-adapter-proof.md
+++ b/docs/database-refactor/02d-chat-schema-read-model-adapter-proof.md
@@ -1,0 +1,162 @@
+# Database Refactor 02D Chat Schema Read-Model Adapter Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02d-chat-schema-read-model-adapter`
+
+Scope:
+
+- runtime adapter correction for Supabase `staging`
+- no DDL
+- no legacy `chat_entities` / `chat_messages` recreation
+- no fallback table probing
+- no frontend work
+- no LLM delivery work
+- no PostgREST, RLS, grant, or service-role boundary change
+
+## Contract
+
+Live `staging` chat storage uses:
+
+- `staging.chats`
+- `staging.chat_members`
+- `staging.messages`
+- `staging.increment_chat_message_seq(p_chat_id text) -> bigint`
+
+Runtime mapping:
+
+- `ChatRow.type` maps to `staging.chats.type`.
+- `ChatRow.created_by_user_id` maps to `staging.chats.created_by_user_id`.
+- `ChatEntityRow` is backed by `staging.chat_members`.
+- `ChatMessageRow.sender_id` maps to `staging.messages.sender_user_id`.
+- `ChatMessageRow.mentioned_ids` maps to `staging.messages.mentions_json`.
+- unread and mention state uses `staging.chat_members.last_read_seq`, not timestamp watermarks.
+
+The `public` runtime mapping remains on the legacy tables so this staging slice does not widen into public compatibility migration:
+
+- `public.chat_entities`
+- `public.chat_messages`
+
+## Source / Test Evidence
+
+Regression tests:
+
+```text
+uv run pytest tests/test_supabase_chat_repo_schema.py::test_chat_repos_keep_public_legacy_tables -q
+```
+
+Red result before implementation:
+
+```text
+FAILED tests/test_supabase_chat_repo_schema.py::test_chat_repos_keep_public_legacy_tables
+AssertionError: assert [] == ['chat_1']
+```
+
+Green result after implementation:
+
+```text
+1 passed
+```
+
+Focused package verification:
+
+```text
+uv run pytest tests/test_chat_service_schema_contract.py tests/test_supabase_chat_repo_schema.py -q
+```
+
+Result:
+
+```text
+7 passed
+```
+
+Wider schema routing regression pack:
+
+```text
+uv run pytest tests/test_chat_service_schema_contract.py tests/test_supabase_chat_repo_schema.py tests/test_supabase_thread_launch_pref_repo_schema.py tests/test_supabase_entity_repo_schema.py tests/test_lifespan_supabase_wiring.py tests/test_supabase_tool_task_repo_schema.py tests/test_supabase_thread_repo_schema.py tests/test_supabase_factory.py tests/test_threads_router_agent_schema_contract.py tests/test_supabase_member_repo_schema.py -q
+```
+
+Result:
+
+```text
+29 passed
+```
+
+## Backend API YATU
+
+Fresh backend was running on validation port `18010` with:
+
+- `LEON_STORAGE_STRATEGY=supabase`
+- `LEON_DB_SCHEMA=staging`
+- public Supabase REST/auth target
+- private Postgres/Supavisor via existing ops startup script
+
+Known non-blocking startup notes:
+
+- local provider was available
+- Daytona/AgentBay SDK imports still failed because optional SDK packages are not installed in this venv
+- the proof did not rely on those providers
+
+Temporary fixture:
+
+- one temporary Supabase auth human
+- one temporary `staging.users` human row
+- one temporary `staging.users` agent row owned by that human
+- one temporary local-provider main thread created through `POST /api/threads`
+- one temporary direct chat
+- one temporary message sent by the agent to the human with a human mention
+
+Secrets, bearer tokens, and temporary password were not recorded.
+
+API sequence and observed result:
+
+```text
+02D backend API YATU rerun start
+POST /api/auth/login 200
+POST /api/threads 200
+POST /api/chats 200
+POST /api/chats/{chat_id}/messages 200
+GET /api/chats/{chat_id} 200
+GET /api/chats/{chat_id}/messages 200
+GET /api/chats before read 200
+POST /api/chats/{chat_id}/read 200
+GET /api/chats after read 200
+02D backend API YATU RERUN PASS
+```
+
+Verified product behavior:
+
+- `POST /api/chats` creates a chat against `staging.chats`.
+- `POST /api/chats/{chat_id}/messages` writes to `staging.messages` through the sequence RPC.
+- `GET /api/chats/{chat_id}` derives both human and agent participants from `staging.users`.
+- `GET /api/chats/{chat_id}/messages` derives `sender_name` from `staging.users`.
+- `GET /api/chats` before read returns the created chat with `unread_count = 1`.
+- `GET /api/chats` before read returns `has_mention = true`.
+- `POST /api/chats/{chat_id}/read` updates `chat_members.last_read_seq` to the latest message sequence.
+- `GET /api/chats` after read returns `unread_count = 0`.
+- `GET /api/chats` after read returns `has_mention = false`.
+
+Cleanup completed / attempted:
+
+- deleted temporary `staging.messages` rows by chat id
+- deleted temporary `staging.chat_members` rows by chat id
+- deleted temporary `staging.chats` row
+- deleted temporary `agent.threads` row
+- deleted temporary `staging.thread_launch_prefs` rows for the owner
+- deleted temporary `staging.users` agent row
+- deleted temporary `staging.users` human row
+- deleted temporary Supabase auth user
+
+## Stopline
+
+02D closes the chat schema adapter mismatch exposed by 02C. It does not claim the whole chat product is complete.
+
+Remaining separate concerns must stay as separate checkpoints:
+
+- chat UX polish
+- chat contact/sidebar cleanup
+- token accounting
+- model ownership/defaulting semantics
+- full database ontology rewrite beyond current `staging` runtime adapter

--- a/docs/database-refactor/02e-thread-task-tool-surface-proof.md
+++ b/docs/database-refactor/02e-thread-task-tool-surface-proof.md
@@ -1,0 +1,144 @@
+# Database Refactor 02E Thread Task Tool Surface Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02e-thread-task-tool-surface-strict-proof`
+
+Scope:
+
+- `agent.thread_tasks` only
+- proof-first validation through ToolRegistry / ToolRunner
+- no DDL
+- no schedule / cron work
+- no panel task migration
+- no background-run API change
+- no route rename
+- no frontend work
+- no LLM delivery
+- no fallback table probing
+- no `public.tool_tasks` compatibility work
+- no run-history table design
+
+## Boundary
+
+`agent.thread_tasks` is the Mycel thread-scoped task/checkpoint-style work list used by:
+
+- `TaskCreate`
+- `TaskList`
+- `TaskGet`
+- `TaskUpdate`
+
+It is not:
+
+- background bash/agent run history
+- long-running tool execution progress
+- `panel_tasks`
+- schedules or `schedule_runs`
+- the stale upstream `agent.tool_tasks` design
+
+Important route note:
+
+- `/api/threads/{thread_id}/tasks` is not a proof surface for this checkpoint.
+- Current code uses that route for background bash/agent runs, not `agent.thread_tasks` records.
+
+## RED / GREEN
+
+Added a strict integration test that registers `TaskService` into `ToolRegistry`, calls task tools through `ToolRunner.wrap_tool_call()`, and verifies the write/read path reaches `agent.thread_tasks`.
+
+RED command:
+
+```text
+uv run pytest tests/test_thread_task_tool_surface_schema.py -q
+```
+
+RED result:
+
+```text
+FAILED tests/test_thread_task_tool_surface_schema.py::test_task_tools_persist_to_agent_thread_tasks_through_tool_runner
+<tool_use_error>FakeSupabaseQuery.select() got an unexpected keyword argument 'count'</tool_use_error>
+```
+
+This was the correct failure: the test reached `ToolRunner -> TaskService -> SupabaseToolTaskRepo.next_id`, and the fake Supabase test client did not support the `select(..., count="exact")` call shape used by the real repo.
+
+Minimal implementation:
+
+- allow the fake Supabase `select()` helper to accept keyword arguments used by supabase-py
+
+GREEN result:
+
+```text
+uv run pytest tests/test_thread_task_tool_surface_schema.py -q
+1 passed
+```
+
+## Live Supabase Proof
+
+A live proof harness ran with:
+
+- `LEON_STORAGE_STRATEGY=supabase`
+- `LEON_DB_SCHEMA=staging`
+- public Supabase REST target
+- service-role storage client
+- a temporary thread id
+
+The proof used the real tool execution surface:
+
+```text
+ToolRegistry
+TaskService
+ToolRunner.wrap_tool_call
+TaskCreate -> TaskList -> TaskGet -> TaskUpdate
+SupabaseToolTaskRepo
+agent.thread_tasks
+```
+
+Observed result:
+
+```text
+02E ToolRunner live Supabase proof start
+TaskCreate created 1
+agent.thread_tasks rows after create 1
+TaskList total 1
+TaskGet metadata checkpoint 02e
+TaskUpdate status completed
+02E ToolRunner live Supabase proof PASS
+02E cleanup deleted rows 1
+```
+
+Secrets and service-role keys were not printed.
+
+## Cleanup
+
+The live proof deleted the temporary `agent.thread_tasks` row by its temporary thread id.
+
+Observed cleanup:
+
+```text
+02E cleanup deleted rows 1
+```
+
+## Classification
+
+Closure evidence is mechanism-layer, not backend API YATU.
+
+Reason:
+
+- there is no true product HTTP task-card API for `agent.thread_tasks` in the current code
+- `/api/threads/{thread_id}/tasks` is a background-run API and is explicitly out of scope
+
+This proof is still stronger than repo-only evidence because it exercises the real tool dispatch path through `ToolRegistry` and `ToolRunner`, not direct repository calls or private `TaskService` helper calls.
+
+## Stopline
+
+02E proves the current `agent.thread_tasks` tool surface is wired through the target domain table.
+
+It does not claim:
+
+- task UX is complete
+- background run tasks are renamed or refactored
+- schedules are migrated
+- panel tasks are migrated
+- tool run history is modeled
+- PR #507 is ready to undraft or merge

--- a/docs/database-refactor/02f-agent-schedules-product-contract.md
+++ b/docs/database-refactor/02f-agent-schedules-product-contract.md
@@ -1,0 +1,329 @@
+# Database Refactor 02F Agent Schedules Product Contract
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02f-agent-schedules-product-contract-ruling`
+
+Status:
+
+- design/preflight only
+- no implementation
+- no DDL
+- no runtime behavior change
+
+## Boundary
+
+02F covers only the future product/schema contract for:
+
+- `agent.schedules`
+- `agent.schedule_runs`
+
+It does not cover:
+
+- `panel_tasks`
+- `agent.thread_tasks`
+- background bash/agent runs
+- long-running tool execution progress
+- frontend Tasks page redesign
+- cron UI polish
+- legacy `public.cron_jobs` compatibility migration
+
+## Live Metadata
+
+Verified against the live Supabase REST surface using service-role credentials. Secrets were not printed.
+
+Observed on 2026-04-14:
+
+```text
+public.cron_jobs: rows=0
+staging.cron_jobs: rows=0
+public.panel_tasks: rows=2
+staging.panel_tasks: missing
+```
+
+Meaning:
+
+- there is no schedule data that needs urgent preservation
+- legacy panel task data exists, but panel tasks are not part of the target schedule ontology
+- schedule migration is primarily a product/runtime contract decision, not a data-copy operation
+
+## Current Runtime Shape
+
+Current code is cron/panel-task-shaped:
+
+- `storage/providers/supabase/cron_job_repo.py`
+  - targets `cron_jobs`
+  - CRUD shape: `name`, `description`, `cron_expression`, `task_template`, `enabled`, `last_run_at`, `next_run_at`, `created_at`
+- `backend/web/services/cron_job_service.py`
+  - thin CRUD wrapper around cron job repo
+- `backend/web/services/cron_service.py`
+  - parses cron expressions with `croniter`
+  - `trigger_job()` loads a cron job and creates a legacy panel task through `backend.web.services.task_service`
+  - updates `last_run_at`
+- `backend/web/routers/panel.py`
+  - exposes `/cron-jobs` CRUD and `/cron-jobs/{job_id}/run`
+- `frontend/app/src/store/types.ts`
+  - has legacy `CronJob` and panel `Task` types
+- `tests/test_cron_service.py`
+  - currently asserts that triggering a cron job creates a panel task
+
+This runtime shape is not compatible with directly creating `agent.schedules` DDL, because doing so would either preserve panel tasks by inertia or introduce `schedule_runs` without a clear execution lifecycle.
+
+## Option Comparison
+
+### Option A: Agent Schedule Steers Or Creates Agent Thread
+
+Contract:
+
+- a schedule belongs to an owner user
+- a schedule targets an agent user
+- a schedule either creates a new agent thread or steers an existing configured thread
+- every firing creates an `agent.schedule_runs` row
+- run outcome is visible through schedule run history
+
+Advantages:
+
+- aligns with the database refactor target: schedules are agent runtime primitives
+- avoids legacy panel task preservation
+- gives `schedule_runs` a real lifecycle
+- supports future Mycel-agent self-development loops
+
+Costs:
+
+- requires a precise target for thread selection and message/steer payload
+- requires a new schedule run lifecycle
+- requires backend runtime behavior changes
+- frontend legacy Tasks/Cron UI cannot be treated as semantically correct without redesign or compatibility translation
+
+Verdict:
+
+- chosen target direction
+- not authorized for implementation in 02F
+
+### Option B: Compatibility UI Label, Backend Reroutes To Agent Schedule
+
+Contract:
+
+- keep `/cron-jobs` and UI labels temporarily
+- backend stores target records in `agent.schedules`
+- `/cron-jobs/{id}/run` triggers agent schedule execution instead of panel task creation
+
+Advantages:
+
+- minimizes immediate frontend churn
+- can keep user-facing affordance while backend ontology changes
+
+Costs:
+
+- high risk of semantic confusion
+- API name says cron job while storage/runtime says agent schedule
+- easy to hide a compatibility fallback behind old names
+
+Verdict:
+
+- allowed only as a future compatibility shim if explicitly designed
+- should not be the core ontology
+
+### Option C: Park Schedule Runtime
+
+Contract:
+
+- do not create schedule tables yet
+- remove or hide schedule runtime until a real product loop exists
+
+Advantages:
+
+- lowest risk
+- avoids half-designed scheduler semantics
+
+Costs:
+
+- does not advance schedule capability
+- leaves legacy `/cron-jobs` code in place
+
+Verdict:
+
+- acceptable if Option A cannot be made precise
+- not the preferred direction because schedules are part of the target schema plan
+
+## Chosen Contract
+
+Choose Option A as the target contract:
+
+```text
+agent.schedule -> agent thread execution -> agent.schedule_run
+```
+
+Minimum schedule relation:
+
+- `owner_user_id`
+- `agent_user_id`
+- `target_thread_id` nullable
+- `create_thread_on_run` boolean
+- `cron_expression`
+- `enabled`
+- `instruction_template`
+- `timezone`
+- `last_run_at`
+- `next_run_at`
+- `created_at`
+- `updated_at`
+
+Thread targeting rule:
+
+- if `target_thread_id` is set, a run steers that thread
+- if `target_thread_id` is not set and `create_thread_on_run` is true, a run creates a new thread for `agent_user_id`
+- if neither is true, the schedule is invalid and must fail loudly before execution
+
+Instruction template rule:
+
+- the schedule payload is an instruction to the agent, not a panel-task template
+- old panel task fields such as `priority`, `assignee_id`, `deadline`, and panel tags are not target schedule fields
+- if a compatibility UI submits old task-template JSON, a future compatibility layer must translate it explicitly or reject it
+
+## Schedule Run Lifecycle
+
+Minimum `agent.schedule_runs` states:
+
+```text
+queued
+running
+succeeded
+failed
+cancelled
+```
+
+Minimum run fields:
+
+- `id`
+- `schedule_id`
+- `owner_user_id`
+- `agent_user_id`
+- `thread_id`
+- `status`
+- `triggered_by`
+- `scheduled_for`
+- `started_at`
+- `completed_at`
+- `input_json`
+- `output_json`
+- `error`
+- `created_at`
+
+`triggered_by` values:
+
+- `scheduler`
+- `manual`
+
+Retry/cancel stance:
+
+- no retry semantics in the first implementation slice
+- no durable cancel semantics in the first implementation slice unless the execution path already exposes one cleanly
+- failed runs record `error` and stop
+
+## Rejected Legacy Concepts
+
+Do not migrate or preserve these into the target schedule model:
+
+- `panel_tasks`
+- panel task `priority`
+- panel task `assignee_id`
+- panel task `deadline`
+- panel task progress
+- old panel task result fields
+- `cron_job_id` as a panel task linkage
+
+Do not treat `agent.thread_tasks` as schedule output.
+
+`agent.thread_tasks` remains the thread-scoped Task tool work list. A schedule run may cause an agent to use Task tools later, but that is agent behavior, not the schedule storage contract.
+
+## Future Implementation Slices
+
+### 02G: Agent Schedule DDL Precheck And Migration
+
+Scope:
+
+- create `agent.schedules`
+- create `agent.schedule_runs`
+- grant service-role access
+- no deletion/mutation of `public.*` or `staging.*`
+- no runtime route change yet
+
+Verification:
+
+- live metadata precheck
+- migration execution proof
+- information_schema proof
+- service-role REST proof
+
+### 02H: Schedule Repo Routing
+
+Scope:
+
+- route Supabase schedule repo to `agent.schedules`
+- introduce explicit schedule repo naming if needed
+- preserve old `/cron-jobs` route only if compatibility is explicitly accepted
+
+Verification:
+
+- RED/GREEN repo schema tests
+- no fallback to `cron_jobs`
+- real service-role CRUD proof with cleanup
+
+### 02I: Schedule Trigger Runtime
+
+Scope:
+
+- make manual/scheduler trigger create `agent.schedule_runs`
+- steer existing thread or create a thread according to the contract
+- stop creating panel tasks
+
+Verification:
+
+- backend API or strongest available runtime proof
+- schedule run state transition proof
+- no panel task row creation
+
+### Later: Frontend Schedule UX
+
+Scope:
+
+- redesign UI language from cron/panel task to agent schedule
+- or explicitly define compatibility UI behavior
+
+Verification:
+
+- Playwright CLI frontend YATU only
+
+## Risk / Size
+
+Expected future implementation size:
+
+- DDL slice: small-to-medium
+- repo routing slice: small
+- runtime trigger slice: medium-to-high
+- frontend UX slice: high if done properly
+
+Primary risks:
+
+- preserving panel tasks by inertia
+- creating `schedule_runs` without a run lifecycle
+- pretending `/cron-jobs` is already semantically correct
+- mixing schedule output with `agent.thread_tasks`
+- adding compatibility fallback instead of a clear translation boundary
+
+## 02F Closure Evidence
+
+02F only closes the product contract ruling.
+
+Evidence:
+
+- source inspection of current cron repo/service/router/frontend/tests
+- live metadata count proof for `cron_jobs` and `panel_tasks`
+- explicit option comparison
+- selected target contract
+- future implementation slice boundaries
+
+No code, DDL, runtime behavior, frontend, or database state changed for 02F.

--- a/docs/database-refactor/02g-agent-schedules-ddl-execution-proof.md
+++ b/docs/database-refactor/02g-agent-schedules-ddl-execution-proof.md
@@ -1,0 +1,199 @@
+# Database Refactor 02G Agent Schedules DDL Execution Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02g-agent-schedules-ddl-precheck-and-migration`
+
+Status:
+
+- live DDL executed
+- service-role REST proof passed
+- no runtime behavior change
+
+## Authorized Scope
+
+Ledger authorized executing only:
+
+- `database/migrations/20260414_03_agent_schedules.sql`
+
+The authorized migration scope was:
+
+- create `agent.schedules`
+- create `agent.schedule_runs`
+- grant service-role table access
+- run service-role REST insert/select/delete proof
+
+Not authorized and not done:
+
+- no `public.*` mutation
+- no `staging.*` mutation
+- no `cron_jobs` migration
+- no `panel_tasks` migration
+- no runtime route change
+- no `/cron-jobs` API behavior change
+- no frontend change
+- no RLS/realtime change
+- no schedule trigger implementation
+
+## Pre-Execution Check
+
+Immediately before migration execution:
+
+```text
+precheck:
+  agent_schema_exists: 1
+  agent_threads_exists: 1
+  agent_schedules_exists: 0
+  agent_schedule_runs_exists: 0
+  public_cron_jobs: 0
+  staging_cron_jobs: 0
+  public_panel_tasks_not_migrated: 2
+```
+
+## Migration Execution
+
+Executed path:
+
+```text
+database/migrations/20260414_03_agent_schedules.sql
+```
+
+Migration output:
+
+```text
+migration_executed: database/migrations/20260414_03_agent_schedules.sql
+```
+
+## Metadata Proof
+
+Tables:
+
+```text
+agent | schedule_runs
+agent | schedules
+```
+
+Columns:
+
+```text
+schedule_runs | id | text | NO |
+schedule_runs | schedule_id | text | NO |
+schedule_runs | owner_user_id | text | NO |
+schedule_runs | agent_user_id | text | NO |
+schedule_runs | thread_id | text | YES |
+schedule_runs | status | text | NO | 'queued'::text
+schedule_runs | triggered_by | text | NO |
+schedule_runs | scheduled_for | timestamp with time zone | YES |
+schedule_runs | started_at | timestamp with time zone | YES |
+schedule_runs | completed_at | timestamp with time zone | YES |
+schedule_runs | input_json | jsonb | NO | '{}'::jsonb
+schedule_runs | output_json | jsonb | NO | '{}'::jsonb
+schedule_runs | error | text | YES |
+schedule_runs | created_at | timestamp with time zone | NO | now()
+schedules | id | text | NO |
+schedules | owner_user_id | text | NO |
+schedules | agent_user_id | text | NO |
+schedules | target_thread_id | text | YES |
+schedules | create_thread_on_run | boolean | NO | false
+schedules | cron_expression | text | NO |
+schedules | enabled | boolean | NO | true
+schedules | instruction_template | text | NO |
+schedules | timezone | text | NO | 'UTC'::text
+schedules | last_run_at | timestamp with time zone | YES |
+schedules | next_run_at | timestamp with time zone | YES |
+schedules | created_at | timestamp with time zone | NO | now()
+schedules | updated_at | timestamp with time zone | NO | now()
+```
+
+Constraints:
+
+```text
+agent.schedule_runs | schedule_runs_pkey | p
+agent.schedule_runs | schedule_runs_status_chk | c
+agent.schedule_runs | schedule_runs_triggered_by_chk | c
+agent.schedules | schedules_cron_expression_chk | c
+agent.schedules | schedules_instruction_template_chk | c
+agent.schedules | schedules_pkey | p
+agent.schedules | schedules_target_chk | c
+agent.schedules | schedules_timezone_chk | c
+```
+
+Indexes:
+
+```text
+schedule_runs | idx_schedule_runs_owner_created
+schedule_runs | idx_schedule_runs_schedule_created
+schedule_runs | idx_schedule_runs_status_scheduled
+schedule_runs | schedule_runs_pkey
+schedules | idx_schedules_agent
+schedules | idx_schedules_owner_enabled_next_run
+schedules | idx_schedules_target_thread
+schedules | schedules_pkey
+```
+
+Service-role grants:
+
+```text
+schedule_runs | DELETE
+schedule_runs | INSERT
+schedule_runs | SELECT
+schedule_runs | UPDATE
+schedules | DELETE
+schedules | INSERT
+schedules | SELECT
+schedules | UPDATE
+```
+
+Legacy table counts after migration:
+
+```text
+public_cron_jobs | staging_cron_jobs | public_panel_tasks
+0 | 0 | 2
+```
+
+This confirms the migration did not mutate `cron_jobs` or `panel_tasks`.
+
+## Service-Role REST Proof
+
+Proof shape:
+
+- inserted one temporary row into `agent.schedules`
+- inserted one temporary row into `agent.schedule_runs`
+- selected both rows back through service-role REST
+- deleted the temporary run row
+- deleted the temporary schedule row
+- confirmed cleanup returned zero rows for both temporary ids
+
+Output:
+
+```text
+inserted_schedule_rows: 1
+inserted_run_rows: 1
+selected_schedule_rows: 1
+selected_run_rows: 1
+deleted_run_rows: 1
+deleted_schedule_rows: 1
+remaining_run_rows: 0
+remaining_schedule_rows: 0
+```
+
+PostgREST schema cache reload was not required.
+
+## Claim Boundary
+
+02G proves only:
+
+- live DDL exists for `agent.schedules` and `agent.schedule_runs`
+- service-role can access both tables through Supabase REST
+- temporary proof data can be cleaned up
+- legacy `cron_jobs` and `panel_tasks` counts were preserved
+
+02G does not prove:
+
+- scheduler runtime behavior
+- agent thread execution from schedules
+- `/cron-jobs` compatibility behavior
+- frontend schedule UX
+- authenticated-user/RLS policy behavior

--- a/docs/database-refactor/02g-agent-schedules-ddl-packet.md
+++ b/docs/database-refactor/02g-agent-schedules-ddl-packet.md
@@ -1,0 +1,178 @@
+# Database Refactor 02G Agent Schedules DDL Packet
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02g-agent-schedules-ddl-precheck-and-migration`
+
+Status:
+
+- packet accepted by Ledger
+- live DDL executed after Ledger authorization
+- post-execution proof: `docs/database-refactor/02g-agent-schedules-ddl-execution-proof.md`
+
+## Stopline
+
+02G may only touch the target schedule tables:
+
+- `agent.schedules`
+- `agent.schedule_runs`
+
+02G must not:
+
+- mutate or delete `public.*`
+- mutate or delete `staging.*`
+- migrate `panel_tasks`
+- migrate `cron_jobs`
+- change runtime repository routing
+- change `/cron-jobs` API behavior
+- change frontend behavior
+- add RLS/realtime policies
+
+## Artifacts
+
+Read-only precheck:
+
+- `database/prechecks/20260414_03_agent_schedules_readonly.sql`
+
+Migration:
+
+- `database/migrations/20260414_03_agent_schedules.sql`
+
+Rollback:
+
+- `database/rollbacks/20260414_03_agent_schedules.sql`
+
+## Read-Only Live Precheck Output
+
+Executed against the live Supabase Postgres target through the private local tunnel. Secrets were not printed.
+
+```text
+agent_schema_exists:
+  1
+agent_threads_exists:
+  1
+agent_schedules_exists:
+  0
+agent_schedule_runs_exists:
+  0
+agent_threads_key_columns:
+  id | text | NO
+  agent_user_id | text | NO
+  owner_user_id | text | NO
+public_cron_jobs:
+  0
+staging_cron_jobs:
+  0
+public_panel_tasks_not_migrated:
+  2
+service_role_has_agent_usage:
+  True
+```
+
+Interpretation:
+
+- `agent` schema foundation from 02A exists.
+- `agent.threads` exists and has the required identity columns.
+- `agent.schedules` and `agent.schedule_runs` do not already exist.
+- live `public.cron_jobs` and `staging.cron_jobs` are empty, so 02G does not need a cron data migration.
+- `public.panel_tasks` has rows, but panel tasks are explicitly rejected as schedule source data and are not touched.
+- `service_role` already has `agent` schema usage.
+
+## DDL Shape
+
+`agent.schedules` stores the schedule contract:
+
+- owner user
+- agent user
+- optional target thread
+- explicit `create_thread_on_run`
+- cron expression
+- enabled flag
+- instruction template
+- timezone
+- last/next run timestamps
+
+The key validity constraint is:
+
+```text
+target_thread_id IS NOT NULL OR create_thread_on_run
+```
+
+This fails loudly if a schedule has no execution target.
+
+`agent.schedule_runs` stores execution history:
+
+- schedule id
+- owner user
+- agent user
+- optional thread id
+- status
+- trigger source
+- scheduled/started/completed timestamps
+- input/output JSON
+- error text
+
+Initial run states:
+
+```text
+queued
+running
+succeeded
+failed
+cancelled
+```
+
+Initial trigger sources:
+
+```text
+scheduler
+manual
+```
+
+## Grants, PostgREST, And RLS Stance
+
+Grants:
+
+- grant `SELECT, INSERT, UPDATE, DELETE` on both new tables to `service_role`
+- rely on 02A's existing `GRANT USAGE ON SCHEMA agent TO service_role`
+
+PostgREST:
+
+- `agent` is already expected to be exposed from the 02A runbook.
+- If service-role REST visibility fails because the PostgREST schema cache is stale, reload the schema cache as an operational step, not a schema fallback.
+
+RLS/realtime:
+
+- no RLS policy in 02G
+- no realtime publication in 02G
+- direct frontend access and authenticated-user policy design require a separate checkpoint
+
+## Service-Role REST Proof Plan
+
+After Ledger authorizes and the migration executes:
+
+1. Query `agent.schedules` and `agent.schedule_runs` through the service-role Supabase REST client.
+2. Insert one temporary schedule row with `create_thread_on_run = true`.
+3. Insert one temporary schedule run row referencing the temporary schedule id.
+4. Select both rows back through service-role REST.
+5. Delete the temporary run row, then delete the temporary schedule row.
+6. Confirm cleanup returns zero rows for the temporary ids.
+
+This proof only validates DDL visibility and service-role access. It does not claim scheduler runtime behavior.
+
+## Rollback Scope
+
+Rollback drops only:
+
+- `agent.schedule_runs`
+- `agent.schedules`
+
+It does not mutate `public.*` or `staging.*`.
+
+## Execution Gate
+
+Ledger accepted this packet and authorized executing only `database/migrations/20260414_03_agent_schedules.sql`.
+
+No further runtime route, frontend, RLS, realtime, cron compatibility, or panel-task work is authorized by this packet.

--- a/docs/database-refactor/02h-schedule-repo-routing-preflight.md
+++ b/docs/database-refactor/02h-schedule-repo-routing-preflight.md
@@ -1,0 +1,337 @@
+# Database Refactor 02H Schedule Repo Routing Preflight
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02h-schedule-repo-routing-preflight`
+
+Status:
+
+- preflight accepted by Ledger
+- implementation complete
+- closure proof: `docs/database-refactor/02h-schedule-repo-routing-proof.md`
+
+## Goal
+
+Create the first runtime-facing repository/service surface for the 02G tables:
+
+- `agent.schedules`
+- `agent.schedule_runs`
+
+This must be a clean schedule ontology surface, not a hidden rewrite of legacy `cron_jobs`.
+
+## Current Facts
+
+Existing legacy runtime is cron/panel-task-shaped:
+
+- `storage/providers/supabase/cron_job_repo.py`
+  - stores in `cron_jobs`
+  - fields: `name`, `description`, `cron_expression`, `task_template`, `enabled`, `last_run_at`, `next_run_at`, `created_at`
+- `backend/web/services/cron_job_service.py`
+  - thin CRUD wrapper over `make_cron_job_repo`
+- `backend/web/services/cron_service.py`
+  - reads cron jobs
+  - creates legacy panel tasks through `task_service.create_task`
+  - writes `cron_job_id` into panel task data
+- `backend/web/routers/panel.py`
+  - exposes `/api/panel/cron-jobs`
+  - create/update/list/delete/run endpoints are still named cron jobs
+- `frontend/app/src/store/types.ts`
+  - still has `CronJob`
+- `frontend/app/src/pages/TasksPage.tsx`
+  - still drives cron job UI
+
+The new 02G table requires fields that legacy `/cron-jobs` does not provide:
+
+- `owner_user_id`
+- `agent_user_id`
+- `target_thread_id` or `create_thread_on_run`
+- `instruction_template`
+
+Therefore, directly rerouting legacy `/cron-jobs` create/update calls into `agent.schedules` would require invented defaults or request-context guesswork. That would violate the no-fallback/no-patch stance.
+
+## Recommended 02H Contract
+
+02H should introduce an explicit schedule repository/service surface and prove it routes to `agent.*`.
+
+Do this:
+
+- create `storage/providers/supabase/schedule_repo.py`
+- expose `SupabaseScheduleRepo`
+- add `make_schedule_repo()` in `backend/web/core/storage_factory.py`
+- create `backend/web/services/schedule_service.py`
+- add focused tests for repo/service routing
+- run a service-role CRUD proof against live Supabase
+
+Do not do this in 02H:
+
+- do not change `/api/panel/cron-jobs`
+- do not change `CronService`
+- do not create panel tasks
+- do not add schedule trigger execution
+- do not change frontend
+- do not add RLS/realtime
+- do not add compatibility fallback from old cron fields to schedule fields
+
+## Exact Repository Surface
+
+`SupabaseScheduleRepo` should provide schedule CRUD:
+
+```python
+class SupabaseScheduleRepo:
+    def list_by_owner(self, owner_user_id: str) -> list[dict]: ...
+    def get(self, schedule_id: str) -> dict | None: ...
+    def create(
+        self,
+        *,
+        owner_user_id: str,
+        agent_user_id: str,
+        cron_expression: str,
+        instruction_template: str,
+        target_thread_id: str | None = None,
+        create_thread_on_run: bool = False,
+        enabled: bool = True,
+        timezone: str = "UTC",
+        next_run_at: str | None = None,
+    ) -> dict: ...
+    def update(self, schedule_id: str, **fields: Any) -> dict | None: ...
+    def delete(self, schedule_id: str) -> bool: ...
+```
+
+It should provide minimal run-history methods:
+
+```python
+class SupabaseScheduleRepo:
+    def create_run(
+        self,
+        *,
+        schedule_id: str,
+        owner_user_id: str,
+        agent_user_id: str,
+        triggered_by: str,
+        thread_id: str | None = None,
+        scheduled_for: str | None = None,
+        input_json: dict | None = None,
+    ) -> dict: ...
+    def list_runs(self, schedule_id: str) -> list[dict]: ...
+    def update_run(self, run_id: str, **fields: Any) -> dict | None: ...
+    def delete_run(self, run_id: str) -> bool: ...
+```
+
+Reason to keep one repo class in 02H:
+
+- both tables are part of the same schedule storage aggregate
+- no runtime trigger lifecycle exists yet
+- splitting schedule and run repos now adds ceremony without behavior
+
+## Service Surface
+
+`backend/web/services/schedule_service.py` should be a thin validation/wrapper layer:
+
+- `list_schedules(owner_user_id: str)`
+- `get_schedule(schedule_id: str)`
+- `create_schedule(...)`
+- `update_schedule(schedule_id: str, **fields)`
+- `delete_schedule(schedule_id: str)`
+- `create_schedule_run(...)`
+- `list_schedule_runs(schedule_id: str)`
+- `update_schedule_run(run_id: str, **fields)`
+- `delete_schedule_run(run_id: str)`
+
+Validation should be minimal and aligned with table constraints:
+
+- `owner_user_id` must be non-empty
+- `agent_user_id` must be non-empty
+- `cron_expression` must be non-empty
+- `instruction_template` must be non-empty
+- at least one of `target_thread_id` or `create_thread_on_run` must be true
+- `triggered_by` must be `scheduler` or `manual`
+- `status`, if updated, must be one of `queued`, `running`, `succeeded`, `failed`, `cancelled`
+
+Do not validate cron syntax in 02H unless an existing helper is directly reused without broadening scope. The DB only requires non-empty cron expression; trigger semantics belong to a later runtime checkpoint.
+
+## Schema Mapping
+
+For Supabase runtime:
+
+- when `LEON_DB_SCHEMA=staging`, schedule storage uses `client.schema("agent").table("schedules")`
+- when `LEON_DB_SCHEMA=staging`, schedule run storage uses `client.schema("agent").table("schedule_runs")`
+- `public` must not route to `agent.*` by accident
+- unknown runtime schemas must fail loudly
+
+Recommended stance:
+
+```text
+staging -> agent.schedules / agent.schedule_runs
+public  -> unsupported for new schedule repo
+other   -> unsupported
+```
+
+Reason:
+
+- `public.cron_jobs` is legacy
+- 02G created the new schedule ontology under `agent`
+- a new schedule repo should not preserve public legacy behavior
+
+## Rejected Approaches
+
+### Rejected: Rewrite SupabaseCronJobRepo To Use agent.schedules
+
+Problem:
+
+- `/cron-jobs` create does not pass `owner_user_id`
+- `/cron-jobs` create does not pass `agent_user_id`
+- legacy `task_template` is not the same as `instruction_template`
+- legacy run endpoint returns a panel task, not a schedule run
+
+This would require invented defaults and hidden translation. That is exactly the fallback-shaped compatibility layer 02F warned against.
+
+### Rejected: Route CronService Trigger To Schedule Runs In 02H
+
+Problem:
+
+- schedule run lifecycle has not been designed at product/API level
+- agent thread execution from a schedule has not been proven
+- panel task creation must not be silently preserved
+
+This belongs to a later checkpoint.
+
+### Rejected: Add Frontend Schedule UX In 02H
+
+Problem:
+
+- current UI is task/cron/panel shaped
+- schedule creation needs agent/thread targeting
+- frontend changes would widen scope beyond repo routing
+
+This belongs after backend schedule API semantics are clear.
+
+## RED/GREEN Plan
+
+### RED 1: Supabase schedule repo routes staging to agent tables
+
+Create `tests/test_supabase_schedule_repo_schema.py`.
+
+Test shape:
+
+```python
+def test_schedule_repo_uses_agent_tables_under_staging_runtime(monkeypatch):
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables = {}
+    repo = SupabaseScheduleRepo(FakeSupabaseClient(tables))
+
+    created = repo.create(
+        owner_user_id="owner_1",
+        agent_user_id="agent_1",
+        cron_expression="*/15 * * * *",
+        instruction_template="Summarize project state",
+        create_thread_on_run=True,
+    )
+
+    assert created["owner_user_id"] == "owner_1"
+    assert tables["agent.schedules"][0]["agent_user_id"] == "agent_1"
+    assert "cron_jobs" not in tables
+```
+
+Expected RED:
+
+- import fails because `SupabaseScheduleRepo` does not exist
+
+### RED 2: Unknown/public schema fails loudly
+
+Test shape:
+
+```python
+def test_schedule_repo_rejects_public_runtime_schema(monkeypatch):
+    monkeypatch.setenv("LEON_DB_SCHEMA", "public")
+
+    with pytest.raises(RuntimeError):
+        SupabaseScheduleRepo(FakeSupabaseClient()).list_by_owner("owner_1")
+```
+
+Expected RED:
+
+- import fails before implementation
+
+### RED 3: Schedule service refuses invalid target
+
+Create `tests/test_schedule_service_schema_contract.py`.
+
+Test shape:
+
+```python
+def test_schedule_service_requires_target_thread_or_create_thread(monkeypatch):
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", lambda: FakeScheduleRepo())
+
+    with pytest.raises(ValueError, match="target"):
+        schedule_service.create_schedule(
+            owner_user_id="owner_1",
+            agent_user_id="agent_1",
+            cron_expression="*/15 * * * *",
+            instruction_template="work",
+        )
+```
+
+Expected RED:
+
+- import fails because `schedule_service` does not exist
+
+### GREEN
+
+Implement only enough to pass these tests:
+
+- `storage/providers/supabase/schedule_repo.py`
+- `backend/web/core/storage_factory.py::make_schedule_repo`
+- `backend/web/services/schedule_service.py`
+- exports in `storage/providers/supabase/__init__.py`
+
+No router, frontend, scheduler, or panel task changes.
+
+## Verification Plan
+
+Local source/test proof:
+
+```bash
+uv run pytest tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py -q
+uv run pytest tests/test_supabase_tool_task_repo_schema.py tests/test_thread_task_tool_surface_schema.py tests/test_supabase_chat_repo_schema.py -q
+uv run ruff check storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py backend/web/core/storage_factory.py tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py
+uv run ruff format --check storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py backend/web/core/storage_factory.py tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py
+```
+
+Live service-role CRUD proof:
+
+- set `LEON_STORAGE_STRATEGY=supabase`
+- set `LEON_DB_SCHEMA=staging`
+- use service-role Supabase runtime
+- call `schedule_service.create_schedule(...)`
+- call `schedule_service.get_schedule(...)`
+- call `schedule_service.list_schedules(owner_user_id)`
+- call `schedule_service.update_schedule(...)`
+- call `schedule_service.create_schedule_run(...)`
+- call `schedule_service.list_schedule_runs(schedule_id)`
+- call `schedule_service.update_schedule_run(...)`
+- delete temporary rows
+- prove cleanup returns zero rows
+
+This proof is mechanism-level storage/service proof, not YATU product closure. Product-level YATU waits until there is an authenticated backend API or frontend surface.
+
+## Stopline
+
+Stop immediately and return to Ledger if implementation appears to require any of these:
+
+- adding request fields to `/api/panel/cron-jobs`
+- changing `/api/panel/cron-jobs`
+- changing `CronService`
+- creating panel tasks
+- implementing agent thread execution from schedule runs
+- adding frontend schedule UI
+- granting authenticated/anon direct table access
+- adding RLS/realtime
+- mapping `public.cron_jobs` or `staging.cron_jobs` into `agent.schedules`
+
+The acceptable 02H closure is narrow:
+
+```text
+New explicit schedule repo/service surface routes to agent.schedules and agent.schedule_runs under staging Supabase runtime, with no legacy cron fallback and no trigger behavior.
+```

--- a/docs/database-refactor/02h-schedule-repo-routing-proof.md
+++ b/docs/database-refactor/02h-schedule-repo-routing-proof.md
@@ -1,0 +1,173 @@
+# Database Refactor 02H Schedule Repo Routing Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02h-schedule-repo-routing-preflight`
+
+Status:
+
+- implementation complete
+- mechanism-level repo/service proof passed
+- no product YATU claimed
+
+## Scope Implemented
+
+Created an explicit schedule repo/service surface for:
+
+- `agent.schedules`
+- `agent.schedule_runs`
+
+Files changed:
+
+- `storage/providers/supabase/schedule_repo.py`
+- `backend/web/services/schedule_service.py`
+- `backend/web/core/storage_factory.py`
+- `storage/providers/supabase/__init__.py`
+- `tests/test_supabase_schedule_repo_schema.py`
+- `tests/test_schedule_service_schema_contract.py`
+- `docs/database-refactor/02h-schedule-repo-routing-preflight.md`
+
+## Stopline Held
+
+Not changed:
+
+- no `/api/panel/cron-jobs` route changes
+- no `CronService` changes
+- no panel task creation
+- no schedule trigger runtime
+- no frontend work
+- no RLS/realtime
+- no public/staging cron_jobs mapping
+- no cron_jobs or panel_tasks migration
+- no authenticated/anon table grants
+
+## Implementation Shape
+
+`SupabaseScheduleRepo` is one storage aggregate over both schedule tables.
+
+Under `LEON_DB_SCHEMA=staging`:
+
+- schedules route to `client.schema("agent").table("schedules")`
+- schedule runs route to `client.schema("agent").table("schedule_runs")`
+
+`public` and unknown schemas fail loudly through the explicit schema router. This avoids silently preserving legacy `public.cron_jobs`.
+
+`schedule_service` is a thin validation wrapper:
+
+- validates non-empty owner/agent/cron/instruction/timezone fields
+- requires `target_thread_id` or `create_thread_on_run`
+- validates run trigger source
+- validates run status updates
+- delegates storage to `make_schedule_repo`
+
+The implementation includes `delete_schedule_run` because the live CRUD proof needs to clean temporary run rows. This is cleanup CRUD, not trigger/runtime behavior.
+
+## RED Evidence
+
+Initial focused test run before implementation:
+
+```text
+ERROR tests/test_supabase_schedule_repo_schema.py
+ModuleNotFoundError: No module named 'storage.providers.supabase.schedule_repo'
+
+ERROR tests/test_schedule_service_schema_contract.py
+ImportError: cannot import name 'schedule_service' from 'backend.web.services'
+```
+
+This was the expected RED state: the new repo/service surface did not exist.
+
+## GREEN Evidence
+
+Focused tests:
+
+```text
+uv run pytest tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py -q
+......                                                                   [100%]
+6 passed in 0.02s
+```
+
+Wider schema regression pack:
+
+```text
+uv run pytest tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py tests/test_supabase_tool_task_repo_schema.py tests/test_thread_task_tool_surface_schema.py tests/test_supabase_chat_repo_schema.py tests/test_supabase_thread_repo_schema.py tests/test_supabase_entity_repo_schema.py tests/test_supabase_member_repo_schema.py tests/test_supabase_thread_launch_pref_repo_schema.py tests/test_threads_router_agent_schema_contract.py -q
+.............................                                            [100%]
+29 passed in 0.37s
+```
+
+Ruff:
+
+```text
+uv run ruff check storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py backend/web/core/storage_factory.py storage/providers/supabase/__init__.py tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py
+All checks passed!
+```
+
+Format:
+
+```text
+uv run ruff format --check storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py backend/web/core/storage_factory.py storage/providers/supabase/__init__.py tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py
+6 files already formatted
+```
+
+## Live Service-Role CRUD Proof
+
+Proof used `schedule_service`, not direct table-only calls.
+
+Runtime shape:
+
+- `LEON_STORAGE_STRATEGY=supabase`
+- `LEON_DB_SCHEMA=staging`
+- service-role Supabase runtime
+- command run with `ALL_PROXY` / `all_proxy` unset to avoid known SOCKS proxy bleed
+
+First attempt without unsetting proxy failed at supabase-py `.schema()` with the known SOCKS proxy import error. This was an environment issue, not schedule logic. The successful proof used the repo-local runtime rule: unset proxy env for Supabase service proof.
+
+Successful proof output:
+
+```text
+created_schedule_id_prefix: 7af6e1fc
+fetched_schedule_rows: 1
+listed_owner_schedule_rows: 1
+updated_schedule_enabled: False
+created_run_id_prefix: b0ea9f92
+listed_run_rows: 1
+updated_run_status: running
+updated_run_thread_id_prefix: thread_0
+deleted_run: True
+deleted_schedule: True
+remaining_run_rows: 0
+remaining_schedule_rows: 0
+remaining_owner_schedule_rows: 0
+```
+
+This proves:
+
+- `schedule_service.create_schedule` writes `agent.schedules`
+- `schedule_service.get_schedule` reads the row
+- `schedule_service.list_schedules` filters by owner
+- `schedule_service.update_schedule` updates the row
+- `schedule_service.create_schedule_run` writes `agent.schedule_runs`
+- `schedule_service.list_schedule_runs` reads run history
+- `schedule_service.update_schedule_run` updates run status/thread metadata
+- `schedule_service.delete_schedule_run` cleans up the run
+- `schedule_service.delete_schedule` cleans up the schedule
+- cleanup left zero temporary rows
+
+## Claim Boundary
+
+02H proves mechanism-level routing only:
+
+- explicit schedule repo/service exists
+- staging Supabase runtime routes to `agent.schedules` and `agent.schedule_runs`
+- public/unknown schedule repo schemas fail loudly
+- service-role CRUD works through `schedule_service`
+
+02H does not prove product-level behavior:
+
+- no authenticated schedule API
+- no frontend schedule UX
+- no scheduler loop
+- no agent thread execution from schedules
+- no `/cron-jobs` compatibility behavior
+- no RLS/authenticated-user policy

--- a/docs/database-refactor/02i-schedule-trigger-runtime-preflight.md
+++ b/docs/database-refactor/02i-schedule-trigger-runtime-preflight.md
@@ -1,0 +1,400 @@
+# Database Refactor 02I Schedule Trigger Runtime Preflight
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02i-schedule-trigger-runtime-preflight`
+
+Status:
+
+- implemented
+- proof: `docs/database-refactor/02i-schedule-trigger-runtime-proof.md`
+
+## Goal
+
+Add the first honest runtime path for schedule execution:
+
+```text
+agent.schedules row -> schedule_run row -> route instruction into an agent thread
+```
+
+This must not resurrect the old `cron_jobs -> panel_tasks` behavior.
+
+## Current Usable Surfaces
+
+From existing runtime:
+
+- `backend.web.services.schedule_service`
+  - schedule CRUD over `agent.schedules`
+  - run CRUD over `agent.schedule_runs`
+- `backend.web.services.message_routing.route_message_to_brain`
+  - if thread agent is idle: starts an agent run
+  - if thread agent is active: enqueues a steer message
+  - returns routing status, run id when a new run starts, and thread id
+- `backend.web.routers.threads._create_owned_thread`
+  - private router helper that creates thread + sandbox resources
+  - currently too coupled to reuse from schedule runtime without extraction
+- `backend.web.services.cron_service.CronService`
+  - legacy service that reads `cron_jobs` and creates panel tasks
+  - not a valid extension point for new schedule runtime
+
+## Product And Scope Decision
+
+02I should be a manual trigger runtime slice, not a full scheduler.
+
+Recommended scope:
+
+- add explicit schedule runtime service
+- add explicit authenticated schedule trigger API
+- support only schedules with `target_thread_id`
+- create `agent.schedule_runs` before routing
+- route `instruction_template` into the target thread through `route_message_to_brain`
+- update run status to `running` when routing is accepted
+- update run status to `failed` when validation/routing fails
+- prove no `panel_tasks` rows are created
+
+Not in 02I:
+
+- no cron loop
+- no due schedule polling
+- no `/api/panel/cron-jobs`
+- no `CronService` edits
+- no frontend
+- no RLS/realtime
+- no create-thread-on-run implementation
+- no completion hook from agent run events to schedule_runs `succeeded`
+
+## Approach Options
+
+### Option A: Explicit Schedule Runtime Service + Manual Trigger API
+
+New service:
+
+- `backend/web/services/schedule_runtime_service.py`
+
+New router:
+
+- `backend/web/routers/schedules.py`
+- `POST /api/schedules/{schedule_id}/run`
+
+Flow:
+
+1. Load schedule by id.
+2. Verify schedule exists, is enabled, and belongs to the authenticated user.
+3. Require `target_thread_id`.
+4. Verify target thread exists and belongs to the schedule owner and schedule agent.
+5. Create schedule run with status `queued`.
+6. Route `instruction_template` into the target thread through `route_message_to_brain`.
+7. Update schedule run to `running`, storing thread id and route output.
+8. Update schedule `last_run_at`.
+9. Return the schedule run and route result.
+
+Failure flow:
+
+1. If schedule is invalid or disabled, fail loudly before creating a run.
+2. If target resolution/routing fails after run creation, mark run `failed`, set `completed_at`, and store `error`.
+
+Verdict:
+
+- recommended
+- small enough to verify
+- explicit new ontology
+- no hidden cron compatibility
+
+### Option B: Rewrite CronService To Trigger agent.schedule_runs
+
+Rejected.
+
+Problems:
+
+- old service name and API still say cron job
+- old data source is `cron_jobs`
+- old effect is panel task creation
+- this would encourage compatibility glue instead of schedule ontology
+
+### Option C: Full Scheduler Runtime With create_thread_on_run
+
+Rejected for 02I.
+
+Problems:
+
+- needs thread creation service extraction from router helper
+- needs due polling and concurrency/locking policy
+- needs run completion semantics
+- too large for one bounded checkpoint
+
+This should become later checkpoints after manual trigger proves the execution path.
+
+## 02I Runtime/API Surface
+
+### Service API
+
+`backend.web.services.schedule_runtime_service`:
+
+```python
+async def trigger_schedule(
+    app: Any,
+    schedule_id: str,
+    *,
+    owner_user_id: str,
+    triggered_by: str = "manual",
+) -> dict[str, Any]:
+    ...
+```
+
+Return shape:
+
+```python
+{
+    "schedule_run": {...},
+    "routing": {...},
+}
+```
+
+### HTTP API
+
+`backend.web.routers.schedules`:
+
+```text
+POST /api/schedules/{schedule_id}/run
+```
+
+Auth:
+
+- `get_current_user_id`
+
+Request body:
+
+- no required fields in 02I
+
+Response:
+
+```python
+{
+    "item": {
+        "schedule_run": {...},
+        "routing": {...},
+    }
+}
+```
+
+Not added in 02I:
+
+- schedule CRUD HTTP API
+- list runs HTTP API
+- frontend UI
+
+Reason:
+
+- 02H already proves repo/service CRUD
+- 02I only needs an authenticated surface to prove trigger runtime
+
+## Thread Steering Rule
+
+For 02I, only this target shape is executable:
+
+```text
+target_thread_id is set
+```
+
+Validation:
+
+- schedule owner must match authenticated user
+- schedule must be enabled
+- thread must exist
+- thread owner must match schedule owner
+- thread member/agent id must match schedule agent id
+
+If `target_thread_id` is missing and `create_thread_on_run` is true:
+
+- return an explicit unsupported-target error
+- do not invent a thread
+- do not call `_create_owned_thread`
+- do not fallback to main thread
+
+Reason:
+
+- thread creation is currently buried in `backend.web.routers.threads._create_owned_thread`
+- reusing that private router helper from runtime service would deepen coupling
+- extracting thread creation into a service is a separate checkpoint
+
+## Schedule Run Lifecycle In 02I
+
+Supported transitions:
+
+```text
+queued -> running
+queued -> failed
+```
+
+`queued`:
+
+- created before routing
+- contains schedule id, owner id, agent id, trigger source, scheduled_for/input_json
+
+`running`:
+
+- set after `route_message_to_brain` accepts the instruction
+- includes `thread_id`
+- `output_json` stores route result, such as direct start or steer injection
+
+`failed`:
+
+- set if target validation or routing fails after the run row exists
+- sets `completed_at`
+- stores error string
+
+Not supported in 02I:
+
+- `succeeded`
+- `cancelled`
+- retry
+- completion based on actual LLM run outcome
+
+Reason:
+
+- `route_message_to_brain` starts or queues work but does not synchronously represent final LLM completion
+- marking `succeeded` at route acceptance would be false evidence
+- completion hook needs a later event integration checkpoint
+
+## Instruction Payload
+
+The message sent to the agent should be the schedule `instruction_template` plus minimal schedule context.
+
+Proposed text:
+
+```text
+[Scheduled instruction]
+Schedule ID: <schedule_id>
+Schedule Run ID: <run_id>
+
+<instruction_template>
+```
+
+Reason:
+
+- gives the agent durable ids for logs/follow-up
+- avoids legacy task-template JSON
+- does not add new prompt framework
+
+## RED/GREEN Plan
+
+### RED 1: Runtime creates run and routes target-thread schedule
+
+Create `tests/test_schedule_runtime_service.py`.
+
+Fake app state:
+
+- schedule service repo returns one schedule with `target_thread_id`
+- thread repo returns matching owner/agent thread
+- route function is monkeypatched to capture call and return `{"status": "started", ...}`
+
+Expected RED:
+
+- import fails because `schedule_runtime_service` does not exist
+
+### RED 2: Runtime rejects create_thread_on_run without target
+
+Test schedule:
+
+- `target_thread_id = None`
+- `create_thread_on_run = True`
+
+Expected behavior:
+
+- no call to `route_message_to_brain`
+- run is not created, or if created after target resolution is moved earlier, run is marked failed
+- recommended: fail before run creation because no execution target exists in 02I
+
+### RED 3: HTTP API calls runtime with authenticated user
+
+Create `tests/test_schedules_router.py`.
+
+Test shape:
+
+- include schedules router in a small FastAPI app
+- override auth dependency to return `owner_1`
+- monkeypatch runtime trigger function
+- POST `/api/schedules/schedule_1/run`
+- assert runtime receives `owner_user_id="owner_1"`
+
+Expected RED:
+
+- router does not exist
+
+### GREEN
+
+Implement only:
+
+- `backend/web/services/schedule_runtime_service.py`
+- `backend/web/routers/schedules.py`
+- `backend/web/main.py` router registration
+- focused tests
+
+Do not touch:
+
+- `backend/web/services/cron_service.py`
+- `backend/web/routers/panel.py`
+- frontend files
+- schedule DDL
+
+## Verification Plan
+
+Focused tests:
+
+```bash
+uv run pytest tests/test_schedule_runtime_service.py tests/test_schedules_router.py -q
+```
+
+Regression pack:
+
+```bash
+uv run pytest tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py tests/test_supabase_tool_task_repo_schema.py tests/test_thread_task_tool_surface_schema.py tests/test_supabase_chat_repo_schema.py -q
+```
+
+Lint/format:
+
+```bash
+uv run ruff check backend/web/services/schedule_runtime_service.py backend/web/routers/schedules.py backend/web/main.py tests/test_schedule_runtime_service.py tests/test_schedules_router.py
+uv run ruff format --check backend/web/services/schedule_runtime_service.py backend/web/routers/schedules.py backend/web/main.py tests/test_schedule_runtime_service.py tests/test_schedules_router.py
+```
+
+Backend API YATU target:
+
+1. Start real backend with Supabase runtime and real LLM API key environment.
+2. Authenticate as a real test user.
+3. Create or select an owned agent thread.
+4. Insert a temporary schedule for that user/agent/thread through `schedule_service`.
+5. Call authenticated `POST /api/schedules/{schedule_id}/run`.
+6. Assert response contains a schedule run with status `running`.
+7. Assert no new `public.panel_tasks` row was created.
+8. Assert run row exists in `agent.schedule_runs` with route output.
+9. Cleanup temporary schedule/run rows.
+
+LLM/agent evidence bar:
+
+- If route result is `started`, verify a real agent run was started with a real LLM key configured.
+- If route result is `injected` because the agent was already active, treat it as routing proof only, not completion proof.
+- Do not claim schedule execution succeeded unless a later checkpoint observes final assistant output or run event completion.
+
+## Stopline
+
+Stop and return to Ledger if implementation requires any of these:
+
+- editing `/api/panel/cron-jobs`
+- editing `CronService`
+- creating panel tasks
+- mapping `cron_jobs` to schedules
+- adding frontend schedule UI
+- implementing cron polling loop
+- implementing create-thread-on-run
+- calling private router helper `_create_owned_thread` from runtime service
+- marking schedule runs `succeeded` without real completion evidence
+- adding RLS/realtime/authenticated table grants
+
+The acceptable 02I closure is:
+
+```text
+Authenticated manual trigger for target-thread schedules creates schedule_run and routes instruction into the agent thread, with no panel_tasks creation and no false completion claim.
+```

--- a/docs/database-refactor/02i-schedule-trigger-runtime-proof.md
+++ b/docs/database-refactor/02i-schedule-trigger-runtime-proof.md
@@ -1,0 +1,241 @@
+# Database Refactor 02I Schedule Trigger Runtime Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02i-schedule-trigger-runtime-preflight`
+
+Status:
+
+- implementation proof
+- ready for Ledger closure review
+
+## Scope Landed
+
+02I adds the first explicit runtime path for target-thread schedules:
+
+```text
+agent.schedules -> agent.schedule_runs -> route_message_to_brain(target_thread_id)
+```
+
+Implemented surfaces:
+
+- `backend.web.services.schedule_runtime_service.trigger_schedule`
+- `backend.web.routers.schedules`
+- `POST /api/schedules/{schedule_id}/run`
+- `backend.web.main` router registration
+- `SupabaseThreadRepo` now projects `owner_user_id` from `agent.threads`, because schedule runtime owner validation needs the same field the target schema already stores.
+
+## Explicit Non-Scope
+
+Not implemented in 02I:
+
+- no cron loop
+- no due schedule polling
+- no `/api/panel/cron-jobs`
+- no `CronService` edits
+- no `panel_tasks` creation
+- no frontend
+- no RLS/realtime work
+- no `create_thread_on_run`
+- no private `_create_owned_thread` coupling
+- no `succeeded` schedule run completion hook
+
+The run lifecycle in this slice is intentionally:
+
+```text
+queued -> running
+queued -> failed
+```
+
+`running` means routing was accepted by `route_message_to_brain`; it does not mean the scheduled agent work has completed.
+
+## RED Evidence
+
+Initial tests were written before implementation:
+
+```text
+uv run pytest tests/test_schedule_runtime_service.py tests/test_schedules_router.py -q
+```
+
+Initial RED failures:
+
+```text
+ImportError: cannot import name 'schedule_runtime_service' from 'backend.web.services'
+ImportError: cannot import name 'schedules' from 'backend.web.routers'
+```
+
+Live backend YATU then exposed a real repo projection gap:
+
+```text
+trigger_status=403
+trigger_body={"detail": "target thread is not owned by schedule owner"}
+```
+
+Root cause:
+
+- live `agent.threads` contains `owner_user_id`
+- `SupabaseThreadRepo.get_by_id()` did not project `owner_user_id`
+- schedule runtime correctly refused to bypass owner validation
+
+Focused RED added:
+
+```text
+uv run pytest tests/test_supabase_thread_repo_schema.py -q
+```
+
+RED failures:
+
+```text
+test_thread_repo_lists_agent_threads_by_owner_under_staging_runtime
+test_thread_repo_get_by_id_exposes_owner_user_id_under_staging_runtime
+```
+
+## GREEN Evidence
+
+Focused schedule/runtime/thread repo pack:
+
+```text
+uv run pytest tests/test_supabase_thread_repo_schema.py tests/test_schedule_runtime_service.py tests/test_schedules_router.py -q
+```
+
+Result:
+
+```text
+9 passed in 0.33s
+```
+
+Earlier focused schedule pack:
+
+```text
+uv run pytest tests/test_schedule_runtime_service.py tests/test_schedules_router.py -q
+```
+
+Result:
+
+```text
+4 passed
+```
+
+Regression pack:
+
+```text
+uv run pytest tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py tests/test_supabase_tool_task_repo_schema.py tests/test_thread_task_tool_surface_schema.py tests/test_supabase_chat_repo_schema.py -q
+```
+
+Result:
+
+```text
+14 passed
+```
+
+## Backend API YATU
+
+Backend proof server:
+
+```text
+BACKEND_PORT=8013 /Users/lexicalmathical/Codebase/leonai/ops/dev/run_local_supabase_backend.sh /Users/lexicalmathical/worktrees/leonai--database-refactor
+```
+
+Runtime facts:
+
+- worktree: `/Users/lexicalmathical/worktrees/leonai--database-refactor`
+- backend: `http://127.0.0.1:8013`
+- storage strategy: Supabase
+- DB schema setting: `staging`, routed to target `agent.*` repos where applicable
+- proof account: existing fully registered OTP account from local ops note
+- no secrets printed in proof
+
+YATU flow:
+
+1. Login through `POST /api/auth/login`.
+2. Read owned threads through `GET /api/threads`.
+3. Insert a temporary `agent.schedules` row with service-role setup.
+4. Trigger through authenticated product API `POST /api/schedules/{schedule_id}/run`.
+5. Read `agent.schedule_runs` through service-role verification.
+6. Confirm `public.panel_tasks` count is unchanged.
+7. Confirm real thread received an assistant reply.
+8. Delete temporary schedule and run rows.
+
+Observed output:
+
+```text
+login_status=200
+user_id=15267c8a-a04a-40ab-b4b7-bba61cadda5b
+target_thread_id=m_dKjuBBLbR1bw-7
+target_agent_user_id=m_dKjuBBLbR1bw
+target_running_before=False
+panel_tasks_before=2
+schedule_created=ffddcff5ad9946d69706cab143ab08a4
+trigger_status=200
+schedule_run_id=af6bbf9d812742c582e832ff8fd8a449
+schedule_run_status=running
+routing_status=started
+routing_kind=direct
+routing_run_id_present=True
+persisted_run_count=1
+persisted_run_status=running
+persisted_run_thread_id=m_dKjuBBLbR1bw-7
+persisted_run_triggered_by=manual
+persisted_run_has_routing_output=True
+assistant_reply_seen=True
+assistant_reply_tail=收到，定时指令已到达这个线程。
+panel_tasks_after=2
+panel_tasks_delta=0
+cleanup_deleted_runs=1
+cleanup_deleted_schedules=1
+cleanup_remaining_runs=0
+cleanup_remaining_schedules=0
+```
+
+Follow-up runtime state check:
+
+```text
+poll 0 running False updated_at 2026-04-13T19:56:14.284777+00:00
+entry_count 1
+tail assistant 收到，定时指令已到达这个线程。已到达。
+```
+
+Backend runtime logs also showed real agent runtime entry:
+
+```text
+[LeonAgent] Initialized successfully
+[Memory] Context: ~89353 tokens, limit=1050000, threshold=735000, compact=no
+[Memory] Final: 236 msgs (~24829 tokens) sent to LLM
+```
+
+This proves the trigger reached the real runtime path. It does not prove schedule completion semantics, because 02I deliberately has no run completion hook.
+
+## Legacy Guard
+
+`public.panel_tasks` was checked before and after the authenticated trigger:
+
+```text
+panel_tasks_before=2
+panel_tasks_after=2
+panel_tasks_delta=0
+```
+
+No `CronService` or `/api/panel/cron-jobs` path was used.
+
+## Cleanup
+
+Temporary YATU rows were deleted:
+
+```text
+cleanup_deleted_runs=1
+cleanup_deleted_schedules=1
+cleanup_remaining_runs=0
+cleanup_remaining_schedules=0
+```
+
+## Residuals
+
+Remaining work belongs to later checkpoints:
+
+- scheduler loop / due polling
+- `create_thread_on_run`
+- completion hook from real agent run events to `agent.schedule_runs.succeeded/failed`
+- schedule CRUD HTTP API
+- frontend schedule UI

--- a/docs/database-refactor/02j-schedule-run-completion-preflight.md
+++ b/docs/database-refactor/02j-schedule-run-completion-preflight.md
@@ -1,0 +1,376 @@
+# Database Refactor 02J Schedule Run Completion Preflight
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02j-schedule-run-completion`
+
+Status:
+
+- implemented
+- proof: `docs/database-refactor/02j-schedule-run-completion-proof.md`
+
+## Goal
+
+Make accepted schedule triggers complete honestly:
+
+```text
+agent.schedule_runs.running -> agent.schedule_runs.succeeded | failed
+```
+
+02I proved schedule runtime entry. 02J should prove completion semantics for the only schedule trigger shape that has a clean ownership boundary:
+
+```text
+target-thread schedule -> newly-started runtime run_id -> _run_agent_to_buffer final boundary
+```
+
+## Source Proof
+
+### Direct Start Path
+
+`backend.web.services.message_routing.route_message_to_brain` currently has two routing outcomes:
+
+- IDLE target agent:
+  - transitions the agent runtime to `ACTIVE`
+  - calls `start_agent_run(...)`
+  - returns `{status: "started", routing: "direct", run_id, thread_id}`
+- ACTIVE target agent:
+  - enqueues a steer message
+  - returns `{status: "injected", routing: "steer", thread_id}`
+
+Only the direct-start path gives the schedule runtime a distinct runtime `run_id`.
+
+### Runtime Final Boundary
+
+`backend.web.services.streaming_service._run_agent_to_buffer(...)` is the real runtime run boundary:
+
+- emits `run_start`
+- streams LLM/tool events
+- emits `run_done` on normal completion
+- emits `cancelled` + `run_done` on cancellation
+- emits `error` + `run_done` on exception
+- transitions the runtime back to `IDLE` in `finally`
+- starts follow-up queue consumption after cleanup
+
+This is the right place to finalize `agent.schedule_runs`, because route acceptance is not completion.
+
+### Current Metadata Gap
+
+02I stores the schedule run id in the prompt text:
+
+```text
+Schedule Run ID: <run_id>
+```
+
+That is not a machine contract. 02J must carry `schedule_run_id` as structured metadata to `_run_agent_to_buffer`.
+
+`start_agent_run(...)` already accepts `message_metadata` and passes it into `_run_agent_to_buffer(...)`.
+
+So the intended metadata path is:
+
+```text
+schedule_runtime_service
+  -> route_message_to_brain(..., message_metadata={schedule_run_id})
+  -> start_agent_run(..., message_metadata=merged_metadata)
+  -> _run_agent_to_buffer(..., message_metadata)
+  -> schedule completion update
+```
+
+## Key Invariant
+
+Every accepted schedule trigger in 02J must map to exactly one newly-started runtime `run_id`.
+
+Therefore schedule triggers must be start-only in 02J:
+
+- if the target agent is idle and `route_message_to_brain` starts a run, accept and finalize later
+- if the target agent is active, reject with an explicit conflict before creating a durable `schedule_run`
+- do not inject schedule instructions into an already-running agent turn
+
+Reason:
+
+- active injection has no distinct runtime run ownership
+- expanding queue/message metadata to track injected schedule messages is a separate cross-cutting design
+- marking injected schedule runs as succeeded would be false completion
+
+## Recommended Scope
+
+### 1. Add Start-Only Routing
+
+Modify `route_message_to_brain` with an explicit option, for example:
+
+```python
+async def route_message_to_brain(
+    app: Any,
+    thread_id: str,
+    content: str,
+    source: str = "owner",
+    ...,
+    require_new_run: bool = False,
+    extra_message_metadata: dict[str, Any] | None = None,
+) -> dict:
+    ...
+```
+
+Behavior:
+
+- if `require_new_run=True` and the agent is already `ACTIVE`, return a loud structured conflict or raise a specific exception
+- do not enqueue
+- do not create a `schedule_run` before this condition is known
+
+Preferred implementation shape:
+
+- introduce a small exception class in `message_routing.py`, e.g. `TargetThreadActiveError`
+- schedule runtime maps it to HTTP `409 Conflict`
+
+### 2. Move Schedule Run Creation After Start-Only Eligibility
+
+02I currently creates the schedule run before calling `route_message_to_brain`.
+
+02J should first prove the target can accept a new direct run, then create the schedule run, then call the direct-start route.
+
+But this has a race: the target could become active between the eligibility check and `start_agent_run`.
+
+Better option:
+
+- `route_message_to_brain(require_new_run=True, prepare_metadata=...)` should own the active check and direct-start atomic transition.
+- schedule runtime still needs the schedule run id before `start_agent_run` so metadata can include it.
+
+Practical 02J solution:
+
+1. Validate schedule and target thread before creating a run.
+2. Create `agent.schedule_runs` as `queued`.
+3. Call `route_message_to_brain(... require_new_run=True, extra_message_metadata={"schedule_run_id": run["id"]})`.
+4. If route raises `TargetThreadActiveError`, delete or cancel the just-created schedule run?
+
+This is the tricky part. Deleting would hide the attempted trigger; cancelling would create a schedule run despite the desired no-run conflict proof.
+
+Recommended stricter solution:
+
+- add a schedule-runtime-local precheck for active target before run creation
+- call `route_message_to_brain(require_new_run=True)` to guard the race
+- if the race still loses after run creation, mark the newly-created run `cancelled` with an explicit error
+
+YATU proof should cover the common active-before-create path and assert no `schedule_run` is created. Race fallback exists only for correctness under concurrency and should not be treated as the normal product behavior.
+
+### 3. Carry Runtime Metadata
+
+`route_message_to_brain` should merge `extra_message_metadata` into the `meta` dict passed to `start_agent_run`.
+
+The resulting initial `HumanMessage` metadata should include:
+
+```python
+{
+    "source": "schedule",
+    "schedule_run_id": "<agent.schedule_runs.id>",
+}
+```
+
+The `schedule_run_id` must not be parsed from text.
+
+### 4. Finalize At Runtime Boundary
+
+Add a small schedule finalization helper, probably in a new file:
+
+- `backend/web/services/schedule_run_completion_service.py`
+
+Suggested API:
+
+```python
+def complete_schedule_run_from_runtime(
+    schedule_run_id: str | None,
+    *,
+    status: Literal["succeeded", "failed", "cancelled"],
+    runtime_run_id: str,
+    thread_id: str,
+    error: str | None = None,
+) -> None:
+    ...
+```
+
+Behavior:
+
+- if `schedule_run_id` is missing, no-op
+- if present, update `agent.schedule_runs`
+- on success:
+  - `status="succeeded"`
+  - `completed_at=now`
+  - merge `output_json.runtime_run_id`
+  - merge `output_json.thread_id`
+- on failure:
+  - `status="failed"` or `cancelled`
+  - `completed_at=now`
+  - `error=<runtime error or cancellation message>`
+  - merge runtime metadata into `output_json`
+
+This helper keeps schedule-specific persistence out of the main streaming loop body.
+
+### 5. Wire `_run_agent_to_buffer`
+
+Inside `_run_agent_to_buffer`:
+
+- maintain a local terminal status:
+  - success if the stream loop reaches normal `run_done`
+  - cancelled on `asyncio.CancelledError`
+  - failed on generic exception
+- after emitting terminal event, call the completion helper with `message_metadata.get("schedule_run_id")`
+- do not mark success before the agent stream actually reaches normal terminal path
+
+Important:
+
+- if the stream emits an `"error"` event from a non-retryable stream error and then breaks without raising, that must be treated as failed, not succeeded
+- this may require setting `terminal_error` when `stream_err` is non-retryable
+
+## Explicit Non-Scope
+
+Not in 02J:
+
+- no scheduler loop
+- no due polling
+- no cron compatibility
+- no `/api/panel/cron-jobs`
+- no `CronService`
+- no frontend
+- no schedule CRUD HTTP API
+- no `create_thread_on_run`
+- no active-injection completion attribution
+- no DDL unless source inspection proves `output_json.runtime_run_id` is inadequate
+
+## Proposed Write Set
+
+Likely files:
+
+- modify `backend/web/services/message_routing.py`
+- modify `backend/web/services/schedule_runtime_service.py`
+- create `backend/web/services/schedule_run_completion_service.py`
+- modify `backend/web/services/streaming_service.py`
+- modify `tests/test_schedule_runtime_service.py`
+- create `tests/test_schedule_run_completion_service.py`
+- modify or create focused tests for `message_routing` start-only behavior
+- modify focused streaming tests, likely `tests/test_storage_runtime_wiring.py` or a new `tests/test_schedule_run_completion_streaming.py`
+- create `docs/database-refactor/02j-schedule-run-completion-proof.md` after implementation
+
+Avoid touching:
+
+- `backend/web/services/cron_service.py`
+- panel task repos
+- frontend files
+- migrations
+
+## RED/GREEN Plan
+
+### RED 1: Start-Only Routing
+
+Test:
+
+- active target + `require_new_run=True` does not enqueue
+- raises/returns conflict
+
+Expected RED:
+
+- current `route_message_to_brain` enqueues and returns injected
+
+### RED 2: Schedule Runtime Rejects Active Target Before Run Creation
+
+Test:
+
+- fake app has active agent for the target thread
+- `trigger_schedule(...)` returns/raises conflict
+- `create_schedule_run` is not called
+
+Expected RED:
+
+- current 02I creates a run and routes injected/started based on router behavior
+
+### RED 3: Runtime Metadata Carries Schedule Run ID
+
+Test:
+
+- schedule runtime creates run
+- route call receives `extra_message_metadata={"schedule_run_id": run_id}`
+- direct route returns runtime `run_id`
+- schedule run output stores runtime run id
+
+Expected RED:
+
+- current route has no metadata parameter
+
+### RED 4: Completion Helper Updates Schedule Run
+
+Test:
+
+- `complete_schedule_run_from_runtime(schedule_run_id, status="succeeded", runtime_run_id=..., thread_id=...)`
+- calls `schedule_service.update_schedule_run` with `status="succeeded"`, `completed_at`, and merged output JSON
+
+Expected RED:
+
+- helper does not exist
+
+### RED 5: Streaming Final Boundary Calls Completion Helper
+
+Test:
+
+- run `_run_agent_to_buffer(...)` with `message_metadata={"schedule_run_id": "sr_1"}`
+- fake agent stream completes normally
+- completion helper receives `status="succeeded"` and runtime `run_id`
+
+Expected RED:
+
+- current streaming service never finalizes schedule runs
+
+## Backend API YATU Plan
+
+Use the same real proof shape as 02I:
+
+1. Start backend on a temporary port with Supabase runtime env.
+2. Login with existing full OTP test account.
+3. Pick a target owned thread that is idle.
+4. Insert temporary `agent.schedules`.
+5. Call authenticated `POST /api/schedules/{schedule_id}/run`.
+6. Confirm immediate response:
+   - `schedule_run.status` starts as `running`
+   - routing is `started/direct`
+   - routing has runtime `run_id`
+7. Poll `agent.schedule_runs` until:
+   - `status="succeeded"`
+   - `completed_at` non-null
+   - `output_json.routing.run_id` or `output_json.runtime_run_id` matches route runtime run id
+8. Confirm target thread has a real assistant reply.
+9. Confirm `public.panel_tasks` count does not change.
+10. Cleanup temporary schedule/run rows to zero.
+
+Active conflict YATU:
+
+1. Trigger a schedule against a target thread while its agent is active, or use a deterministic backend-level setup if real active timing is too brittle.
+2. Call authenticated `POST /api/schedules/{schedule_id}/run`.
+3. Expect HTTP `409 Conflict`.
+4. Confirm no new `agent.schedule_runs` row was created for that schedule.
+
+If real active timing is too brittle for product-level YATU, use focused mechanism-level proof for active conflict and say so. Do not fake it as YATU.
+
+## Acceptance Bar
+
+02J can close only if:
+
+- Ledger accepts this preflight before implementation
+- RED failures are captured first
+- focused tests pass
+- relevant regression pack passes
+- ruff and format pass
+- backend API YATU proves `running -> succeeded` after real runtime completion
+- active target conflict is proven without creating normal schedule_run rows
+- `public.panel_tasks` remains unchanged
+- temporary rows are cleaned to zero
+
+## Risk Notes
+
+The highest-risk part is `_run_agent_to_buffer` terminal status classification.
+
+The implementation must not mark a schedule run `succeeded` if:
+
+- the agent stream emitted a terminal error event
+- the run was cancelled
+- route only injected into an active run
+- no distinct runtime `run_id` exists
+
+If this cannot be done cleanly, the correct outcome is to stop and report a runtime architecture blocker.

--- a/docs/database-refactor/02j-schedule-run-completion-proof.md
+++ b/docs/database-refactor/02j-schedule-run-completion-proof.md
@@ -1,0 +1,234 @@
+# Database Refactor 02J Schedule Run Completion Proof
+
+Date: 2026-04-14
+
+Checkpoint:
+
+- `database-refactor-02j-schedule-run-completion`
+
+Status:
+
+- implementation proof
+- ready for Ledger closure review
+
+## Scope Landed
+
+02J adds honest completion semantics for schedule-triggered direct runtime runs:
+
+```text
+agent.schedule_runs.running -> succeeded | failed | cancelled
+```
+
+Implemented surfaces:
+
+- `backend.web.services.message_routing.TargetThreadActiveError`
+- `route_message_to_brain(... require_new_run=True, extra_message_metadata=...)`
+- `backend.web.services.schedule_runtime_service.TargetThreadBusyError`
+- direct-start-only schedule trigger behavior
+- `backend.web.services.schedule_run_completion_service`
+- `schedule_service.get_schedule_run`
+- `_run_agent_to_buffer` finalization of schedule runs at the real runtime terminal boundary
+- `POST /api/schedules/{schedule_id}/run` maps active target conflicts to HTTP `409`
+
+## Explicit Stopline Held
+
+Not implemented:
+
+- no scheduler loop
+- no due polling
+- no cron compatibility
+- no `/api/panel/cron-jobs`
+- no `CronService`
+- no frontend
+- no schedule CRUD HTTP API
+- no `create_thread_on_run`
+- no active-injection attribution
+- no DDL
+- no `panel_tasks` writes
+
+## Design Invariant
+
+Every accepted schedule trigger in 02J maps to exactly one newly-started runtime `run_id`.
+
+Therefore:
+
+- idle target: accepted, direct runtime run starts, schedule run is finalized later
+- active target: rejected with `409 Conflict`, no normal schedule run is created
+- race-lost-after-create path: the created run is marked `cancelled`, not hidden
+
+## RED Evidence
+
+Focused RED tests were added before implementation:
+
+```text
+uv run pytest tests/test_message_routing_schedule_start_only.py tests/test_schedule_runtime_service.py tests/test_schedule_run_completion_service.py tests/test_schedule_run_completion_streaming.py -q
+```
+
+First valid RED:
+
+```text
+ImportError: cannot import name 'schedule_run_completion_service' from 'backend.web.services'
+```
+
+Initial test self-check:
+
+- a nested-class `NameError` in `tests/test_schedule_run_completion_streaming.py` was corrected before accepting RED
+- after correction, RED was the missing production service, not a test typo
+
+## GREEN Evidence
+
+Focused 02J pack:
+
+```text
+uv run pytest tests/test_message_routing_schedule_start_only.py tests/test_schedule_runtime_service.py tests/test_schedule_run_completion_service.py tests/test_schedule_run_completion_streaming.py tests/test_schedules_router.py -q
+```
+
+Result:
+
+```text
+12 passed in 0.30s
+```
+
+Regression pack:
+
+```text
+uv run pytest tests/test_supabase_thread_repo_schema.py tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py tests/test_supabase_tool_task_repo_schema.py tests/test_thread_task_tool_surface_schema.py tests/test_supabase_chat_repo_schema.py -q
+```
+
+Result:
+
+```text
+19 passed in 0.12s
+```
+
+Lint:
+
+```text
+uv run ruff check backend/web/services/message_routing.py backend/web/services/schedule_runtime_service.py backend/web/services/schedule_run_completion_service.py backend/web/services/streaming_service.py backend/web/routers/schedules.py backend/web/services/schedule_service.py tests/test_message_routing_schedule_start_only.py tests/test_schedule_runtime_service.py tests/test_schedule_run_completion_service.py tests/test_schedule_run_completion_streaming.py tests/test_schedules_router.py
+```
+
+Result:
+
+```text
+All checks passed!
+```
+
+Format:
+
+```text
+uv run ruff format --check backend/web/services/message_routing.py backend/web/services/schedule_runtime_service.py backend/web/services/schedule_run_completion_service.py backend/web/services/streaming_service.py backend/web/routers/schedules.py backend/web/services/schedule_service.py tests/test_message_routing_schedule_start_only.py tests/test_schedule_runtime_service.py tests/test_schedule_run_completion_service.py tests/test_schedule_run_completion_streaming.py tests/test_schedules_router.py
+```
+
+Result:
+
+```text
+11 files already formatted
+```
+
+## Backend API YATU
+
+Backend proof server:
+
+```text
+BACKEND_PORT=8013 /Users/lexicalmathical/Codebase/leonai/ops/dev/run_local_supabase_backend.sh /Users/lexicalmathical/worktrees/leonai--database-refactor
+```
+
+Runtime facts:
+
+- backend: `http://127.0.0.1:8013`
+- storage: Supabase
+- proof account: existing fully registered OTP account from local ops note
+- proof target thread: `m_dKjuBBLbR1bw-7`
+- proof target agent: `m_dKjuBBLbR1bw`
+- no secrets printed
+
+YATU flow:
+
+1. Login through `POST /api/auth/login`.
+2. Read target thread through `GET /api/threads`.
+3. Create two temporary `agent.schedules` rows with service-role setup.
+4. Trigger schedule 1 through authenticated `POST /api/schedules/{schedule_id}/run`.
+5. Immediately trigger schedule 2 against the same target to prove active conflict.
+6. Poll `agent.schedule_runs` until schedule 1 reaches terminal state.
+7. Read thread detail to confirm real assistant reply.
+8. Verify `public.panel_tasks` count is unchanged.
+9. Cleanup temporary schedule/run rows.
+
+Observed output:
+
+```text
+login_status=200
+target_thread_id=m_dKjuBBLbR1bw-7
+target_agent_user_id=m_dKjuBBLbR1bw
+target_running_before=False
+panel_tasks_before=2
+schedule1_created=9c6377c59b5d4232b01e56be2dfef01b
+schedule2_created=0e5e24fc518a4a9ab851f6cc121e61be
+trigger1_status=200
+schedule_run1_id=349e970a52c24bc89537719e87a9ff2e
+route_runtime_run_id=b1c237af-8729-4e31-9348-9e40f29cdb9c
+trigger2_status=409
+trigger2_body={"detail": "target thread is already active"}
+schedule1_run_count=1
+schedule1_final={"completed_at_present": true, "error": null, "id": "349e970a52c24bc89537719e87a9ff2e", "routing": {"routing": "direct", "run_id": "b1c237af-8729-4e31-9348-9e40f29cdb9c", "status": "started", "thread_id": "m_dKjuBBLbR1bw-7"}, "runtime": {"run_id": "b1c237af-8729-4e31-9348-9e40f29cdb9c", "status": "succeeded", "thread_id": "m_dKjuBBLbR1bw-7"}, "status": "succeeded"}
+schedule2_run_count=0
+thread_entry_count=1
+thread_last_reply=收到，本次定时运行已完成。
+panel_tasks_after=2
+panel_tasks_delta=0
+cleanup_deleted_runs=1
+cleanup_deleted_schedules=2
+cleanup_remaining_runs=0
+cleanup_remaining_schedules=0
+```
+
+Backend runtime logs confirmed real runtime/LLM path:
+
+```text
+[LeonAgent] Initialized successfully
+[Memory] Context: ~89585 tokens (sys=0, msgs=89585), limit=1050000, threshold=735000, compact=no
+[Memory] Final: 240 msgs (~25062 tokens) sent to LLM (original: 1191 msgs)
+```
+
+## Active Conflict Proof
+
+The active conflict was proven through the real authenticated backend API, not only a mock:
+
+```text
+trigger2_status=409
+trigger2_body={"detail": "target thread is already active"}
+schedule2_run_count=0
+```
+
+This satisfies the 02J invariant: active target threads are not silently injected and do not create normal schedule run rows.
+
+## Legacy Guard
+
+`public.panel_tasks` did not change:
+
+```text
+panel_tasks_before=2
+panel_tasks_after=2
+panel_tasks_delta=0
+```
+
+## Cleanup
+
+Temporary proof rows were removed:
+
+```text
+cleanup_deleted_runs=1
+cleanup_deleted_schedules=2
+cleanup_remaining_runs=0
+cleanup_remaining_schedules=0
+```
+
+## Residuals
+
+Future checkpoints:
+
+- scheduler loop / due polling
+- `create_thread_on_run`
+- schedule CRUD HTTP API
+- frontend schedule UX
+- active-injection attribution if product later requires schedule instructions to enter already-running turns

--- a/docs/database-refactor/meeting-distilled-decisions.md
+++ b/docs/database-refactor/meeting-distilled-decisions.md
@@ -1,0 +1,115 @@
+# Database Refactor Meeting: Distilled Decisions
+
+Date: 2026-04-14
+
+Source transcript:
+
+- `/Users/lexicalmathical/Downloads/43876540-3be8-4c8a-b5c5-fa1e496057f0.txt`
+
+This file is the post-discussion summary. Prefer this over raw early transcript fragments when the discussion contradicts itself.
+
+## Refactor Shape
+
+This database refactor is an aggressive ontology rewrite, not a small compatibility migration.
+
+Checkpoint rule:
+
+- keep each schema move narrow
+- bring uncertain concepts back to Ledger before DDL or runtime routing
+- do not preserve old concepts only because current tables exist
+- do not hide mismatches with application fallbacks/defaults
+
+## Sandbox / Container / Workspace
+
+Terminology rule:
+
+- do not use `environment` as a product/schema concept
+- transcript references to environment should be interpreted as the later, clearer `sandbox` concept
+- use sandbox as the primary name unless a later checkpoint specifically needs a lower-level container implementation detail
+
+The core runtime relation is thread to sandbox/container execution.
+
+Do not model the core path as:
+
+```text
+thread -> workspace -> device
+```
+
+Correct interpretation:
+
+- thread needs a sandbox/container execution target directly
+- workspace is a thin working-directory or project context inside one sandbox
+- workspace is useful only when a real runtime/API needs cwd/project selection
+- workspace has no direct old-table mapping
+- device may also be a new identifier-like concept and should not be forced into the first agent thread slice
+
+`sandbox_type` is current runtime contract state. It may later be replaced by a stronger sandbox/container relation, but it should not be replaced by a fake default or hidden fallback.
+
+## Sandbox Template
+
+`recipe` is not a final target concept.
+
+Final interpretation:
+
+- the old recipe concept is deleted as a standalone name
+- the surviving product/schema concept is `Sandbox Template`
+- `Sandbox Template` belongs to sandbox creation
+- it should not be buried under workspace unless a later checkpoint proves workspace-specific configuration is needed
+
+Working direction:
+
+- sandbox template/config describes preinstalled CLI/SDK/tooling and resource shape
+- current naming should follow the target design once Ledger confirms the exact table name
+- avoid `library_recipes` as the final name
+
+## Terminal / Process
+
+Persistent terminal tables are not automatically justified.
+
+Working interpretation:
+
+- the old terminal layer is removed from the target path
+- chat session is also removed from the target path
+- execution should align with the Claude Code style: direct subprocess execution rather than persistent PTY modeling
+- running state can be owned by the sandbox/container runtime or backend memory
+- completed output/result should be stored in product records such as thread/message/run result surfaces
+- if a running process abstraction is needed, design it explicitly; do not keep old terminal tables by inertia
+
+## Mount / Volume / File Transfer
+
+Mount and volume are the same conceptual layer for this refactor. They should be removed together, not split into two concepts.
+
+File upload/download should become a unified sandbox upload/download interface.
+
+Working direction:
+
+- do not preserve `sandbox_volumes`
+- do not introduce a separate mount table as a replacement for volume
+- route file transfer through sandbox/container APIs
+- if shared storage becomes a paid/advanced product feature later, it needs a separate checkpoint and product justification
+
+## Session / Chat Session
+
+Session/chat_session is not part of the target base schema.
+
+If current code still depends on it, that is a cleanup checkpoint, not a reason to keep the table.
+
+## Schedules / Tasks
+
+`agent.thread_tasks` and schedules are separate work.
+
+Current 02A scope:
+
+- `agent.threads`
+- `agent.thread_tasks`
+
+Do not mix `cron_jobs`, `panel_tasks`, or schedule execution semantics into the 02A thread task landing.
+
+## Testing / Product Proof
+
+Backend API YATU can be used while DB work is in progress, but closure needs product-level proof after routing:
+
+- login
+- thread list
+- task create/list/get/update through high-level APIs or the real task tool surface
+- no direct helper-only proof as closure

--- a/docs/database-refactor/target-contract-matrix.md
+++ b/docs/database-refactor/target-contract-matrix.md
@@ -145,7 +145,7 @@ Current code surfaces:
 | `agent.agent_rules` | `public.agent_rules`, `staging.agent_rules` | migrate | Keep separate CRUD object. |
 | `agent.agent_skills` | `public.agent_skills`, `staging.agent_skills` | migrate | Keep separate CRUD object. |
 | `agent.agent_sub_agents` | `public.agent_sub_agents`, `staging.agent_sub_agents` | migrate | Config-time sub-agent definitions. |
-| `agent.threads` | `public.threads`, `staging.threads`, `staging.thread_config` | migrate | Thread runtime must eventually point at container workspace, not terminal. |
+| `agent.threads` | `public.threads`, `staging.threads`, `staging.thread_config` | migrate | Thread runtime must point at sandbox/container execution. Workspace is only a thin working-directory context, not the core runtime relation. |
 | `agent.thread_launch_prefs` | `public.thread_launch_prefs`, `staging.thread_launch_prefs` | migrate | Preserve if still product-visible launch preference. |
 | `agent.run_events` | `public.run_events`, `staging.run_events` | migrate | Runtime/event history belongs with agent execution. |
 | `agent.summaries` | `public.summaries`, `staging.summaries` | migrate | Keep if used by context compaction/summaries. |
@@ -175,11 +175,11 @@ Current code surfaces:
 | `container.devices` | sandbox provider/account resource config; no exact current table | migrate/add | Device is persistent compute endpoint. Need daemon/provider reality check before DDL. |
 | `container.sandbox_templates` | `public.library_recipes`, `staging.library_recipes`, SQLite `library_recipes` | rename + migrate | The issue reply says `sandbox_templates`, not `sandbox_recipes`. This supersedes earlier discussion naming. |
 | `container.sandboxes` | `public.sandbox_leases`, `public.sandbox_instances`, staging equivalents | migrate | Target combines persistent sandbox desired/observed state. |
-| `container.workspaces` | `sandbox_leases`, thread terminal/lease binding, file workspace paths | migrate | Must replace thread -> terminal -> lease assumptions with thread -> workspace. |
+| `container.workspaces` | cwd/project path state inside a sandbox/container | migrate/add only if needed | Workspace is a thin working-directory context. Do not model thread -> workspace -> device as the core relation. |
 | `container.resource_snapshots` | `lease_resource_snapshots` | migrate | Target commit reply says resource snapshots remain in container. |
 | `container.provider_events` | `public.provider_events`, `staging.provider_events` | migrate | Issue reply places provider events in container; observability boundary should be revisited later. |
 | terminals | `abstract_terminals`, `thread_terminal_pointers`, `terminal_commands`, `terminal_command_chunks` | route-out | Issue reply: terminal is stateless sandbox exec API, no PTY persistence. Current Mycel code still depends heavily on terminal repos, so this is a major implementation slice. |
-| volumes | `sandbox_volumes` | route-out | Issue reply: file upload/download uses Supabase Storage directly; volumes abstraction is invalid. |
+| mount/volumes | `sandbox_volumes`, mount-style file workspace abstractions | route-out/delete together | Mount and volume are the same wrong layer for this refactor. File upload/download should go through a unified sandbox upload/download interface. |
 | `sync_files` | `public.sync_files`, `staging.sync_files`, SQLite `sync_files` | route-out/delete candidate | No target model unless a future sync feature is explicitly designed. |
 
 Current code surfaces:
@@ -251,11 +251,13 @@ blind DDL dump. The safe sequence is:
    - Remove durable terminal/command/chunk pointer assumptions from the runtime
      path.
    - Replace thread -> terminal -> lease file path lookup with thread ->
-     workspace / sandbox exec API contract.
+     sandbox/container exec API contract. Keep workspace as a thin cwd/project
+     context only when a real API needs it.
 5. Later slices:
    - identity migration
    - chat migration
-   - container sandbox/workspace migration
+   - container sandbox migration, with workspace kept as a thin path/context
+     object only if the runtime still needs it
    - hub marketplace migration
    - observability schema
 

--- a/docs/database-refactor/target-contract-matrix.md
+++ b/docs/database-refactor/target-contract-matrix.md
@@ -1,0 +1,271 @@
+# Mycel Database Refactor Target Contract Matrix
+
+Date: 2026-04-14
+
+This document is the first Database Refactor PR artifact. It intentionally does
+not apply DDL yet. Its job is to turn the external design reply, the
+`mycel-db-design` repo, current Mycel storage code, and live Supabase metadata
+into an executable migration plan.
+
+## Sources
+
+- GitHub issue reply: <https://github.com/nmhjklnm/mycel-db-design/issues/1#issuecomment-4237192274>
+- Design repo checkout: `/Users/lexicalmathical/Codebase/mycel-db-design`
+- Design commit: `9422bd8` (`refactor(container): remove terminal layer and volumes abstraction`)
+- Mycel worktree: `/Users/lexicalmathical/worktrees/leonai--database-refactor`
+- Live DB metadata source: Supabase Postgres using `LEON_POSTGRES_URL` from the currently running local backend process
+
+## Current Live DB Facts
+
+Command shape, with secrets supplied by operator runtime:
+
+```bash
+LEON_POSTGRES_URL='<from running backend env or ops docs>' uv run python - <<'PY'
+import os
+import psycopg
+
+with psycopg.connect(os.environ["LEON_POSTGRES_URL"], connect_timeout=10) as conn:
+    with conn.cursor() as cur:
+        cur.execute("""
+            select table_schema, table_name
+            from information_schema.tables
+            where table_schema in (
+                'public','staging','identity','chat','agent',
+                'container','hub','observability','eval'
+            )
+              and table_type = 'BASE TABLE'
+            order by table_schema, table_name
+        """)
+        for schema, table in cur.fetchall():
+            print(f"{schema}.{table}")
+PY
+```
+
+Observed on 2026-04-14:
+
+- Existing product schemas: `public`, `staging`
+- Target domain schemas present: none of `identity`, `chat`, `agent`, `container`, `hub`, `observability`, `eval`
+- Base table count across `public` + `staging`: `101`
+- RLS policies in these schemas: `0`
+- Functions in these schemas: `6`
+- Realtime publication tables: `5`
+
+Current functions:
+
+```text
+public.count_unread_per_chat
+public.increment_member_thread_seq
+public.next_mycel_id
+staging.increment_chat_message_seq
+staging.increment_user_thread_seq
+staging.next_mycel_id
+```
+
+Current realtime publication:
+
+```text
+public.chat_members
+public.message_reads
+public.messages
+public.relationships
+public.threads
+```
+
+## Upstream Design Inconsistencies To Resolve Locally
+
+The issue reply is newer than parts of the design files and should be treated
+as the current human decision where it conflicts with the checked-out design
+repo.
+
+| Topic | Issue reply says | `mycel-db-design@9422bd8` actually says | Mycel PR ruling |
+|---|---|---|---|
+| Thread tasks | `tool_tasks` -> `thread_tasks` | `agent-schema.md` still defines `agent.tool_tasks` and realtime for `agent.tool_tasks` | Use `thread_tasks` as the Mycel target name; flag upstream design doc as stale |
+| Chat deliveries/reactions/pins | Keep as future extension only | `chat-schema.md`, `overview.md`, and `schema-decisions.md` still define them as base chat tables | Exclude from P0 Database Refactor; do not migrate/create them now |
+| Observability | Added `observability` schema | No `observability-schema.md` exists in commit `9422bd8`; eval tables are only discussed in the issue | Create an observability/eval target slice, but require a local Mycel schema contract before DDL |
+
+## Target Classification
+
+Classification meanings:
+
+- `keep`: target concept already matches and can be carried forward.
+- `rename`: same concept, better target name.
+- `migrate`: move data/code from current schema/table into target domain table.
+- `defer`: valid concept, but not in the first DDL slice.
+- `delete candidate`: legacy product table should not get a target home.
+- `route-out`: do not model as durable remote DB table; use runtime memory, provider API, Supabase Storage, or local runtime state.
+
+### Identity
+
+| Target | Current sources | Classification | Notes |
+|---|---|---|---|
+| `identity.users` | `staging.users`, `public.members`, `staging.agent_registry` | migrate | Human + agent unified actor table is the target. `members` and `agent_registry` should be migration sources only, not target concepts. |
+| `identity.accounts` | `public.accounts`, `staging.accounts` | migrate | Login credentials stay in identity. Need one canonical account source during migration. |
+| `identity.assets` | `staging.assets`; avatar repair code writes assets | migrate | Static user-managed assets belong here. Agent artifacts do not. |
+| `identity.user_settings` | `public.user_settings`, `staging.user_settings` | migrate | Convert toward scoped KV settings. Model/token config must not stay as opaque accidental blob forever. |
+| `identity.invite_codes` | `public.invite_codes`, `staging.invite_codes` | migrate | Registration control belongs to identity. |
+| `identity.model_providers` | `user_settings.models_config`, runtime model config | defer | Valid direction, but issue reply marks model/token as outside current design handling. Needs runtime contract audit first. |
+| `identity.model_mappings` | `user_settings.default_model`, `agent_configs.model` | defer | Same as above. Must settle caller-vs-owner-vs-agent model lookup semantics before DDL. |
+
+Current code surfaces:
+
+- `storage/providers/supabase/member_repo.py`
+- `storage/providers/supabase/user_settings_repo.py`
+- `storage/providers/supabase/invite_code_repo.py`
+- `backend/web/services/auth_service.py`
+
+### Chat
+
+| Target | Current sources | Classification | Notes |
+|---|---|---|---|
+| `chat.chats` | `public.chats`, `staging.chats` | migrate | Keep target seq/preview/list behavior, but validate current frontend expectations first. |
+| `chat.messages` | `public.messages`, `staging.messages`; SQLite `chat_messages` | migrate | Message order should use `messages.seq`. |
+| `chat.chat_members` | `public.chat_members`, `staging.chat_members` | migrate | Unread source of truth is `chat_members.last_read_seq`. |
+| `chat.contacts` | `public.contacts`, `staging.contacts` | migrate | Need preserve contact state semantics. |
+| `chat.relationships` | `public.relationships`, `staging.relationships` | migrate | Must include initiator semantics if absent in current code/data. |
+| `chat.message_attachments` | current attachment/files behavior | defer | Add only when file/message attachment path is contract-ready. |
+| `chat.message_deliveries` | `public.message_deliveries` | delete candidate / defer | Not part of base chat schema per issue reply. Current delivery resolver is routing strategy, not per-device delivery state. |
+| `chat.message_reactions` | none | defer | Future extension only. If quality feedback is needed, route to observability/feedback, not base chat. |
+| `chat.message_pins` | none | defer | Future extension only. Conversation pinning is not message pinning. |
+| `message_reads` | `public.message_reads` | delete candidate | Not target unread model. |
+| `chat_sessions` | `public.chat_sessions`, `staging.chat_sessions` | route-out | Removed from target. Runtime/session state should not be base chat DB. |
+
+Current code surfaces:
+
+- `storage/providers/supabase/chat_repo.py`
+- `storage/providers/supabase/contact_repo.py`
+- `storage/providers/supabase/chat_session_repo.py`
+- `backend/web/routers/conversations.py`
+- `backend/web/routers/threads.py`
+
+### Agent
+
+| Target | Current sources | Classification | Notes |
+|---|---|---|---|
+| `agent.agent_configs` | `public.agent_configs`, `staging.agent_configs` | migrate | Agent behavior definition belongs here. |
+| `agent.agent_rules` | `public.agent_rules`, `staging.agent_rules` | migrate | Keep separate CRUD object. |
+| `agent.agent_skills` | `public.agent_skills`, `staging.agent_skills` | migrate | Keep separate CRUD object. |
+| `agent.agent_sub_agents` | `public.agent_sub_agents`, `staging.agent_sub_agents` | migrate | Config-time sub-agent definitions. |
+| `agent.threads` | `public.threads`, `staging.threads`, `staging.thread_config` | migrate | Thread runtime must eventually point at container workspace, not terminal. |
+| `agent.thread_launch_prefs` | `public.thread_launch_prefs`, `staging.thread_launch_prefs` | migrate | Preserve if still product-visible launch preference. |
+| `agent.run_events` | `public.run_events`, `staging.run_events` | migrate | Runtime/event history belongs with agent execution. |
+| `agent.summaries` | `public.summaries`, `staging.summaries` | migrate | Keep if used by context compaction/summaries. |
+| `agent.message_queue` | `public.message_queue`, `staging.message_queue` | migrate | Queue is agent runtime infra. |
+| `agent.file_operations` | `public.file_operations`, `staging.file_operations` | migrate | File/sync default follows design; `sync_files` is not target. |
+| `agent.thread_tasks` | `public.tool_tasks`, `staging.agent_thread_tasks`, SQLite `tasks` | rename + migrate | Use `thread_tasks`, not `tool_tasks`. `agent_thread_tasks` is closer but still transitional. |
+| `agent.schedules` | `public.cron_jobs`, `staging.cron_jobs` | rename + migrate | Old `cron_jobs` should not survive. |
+| `agent.schedule_runs` | none or implicit run/events | migrate/add | Required for schedule-level observability; `run_events` does not replace it. |
+| LangGraph checkpoint tables | `public.checkpoints`, `public.checkpoint_*`, `staging.checkpoint_*`, `staging.writes` | migrate | Keep exact LangGraph structure; schema move should not alter framework contract. |
+| `agent_registry` | `public.agent_registry`, `staging.agent_registry`, SQLite `agents` | delete candidate | Replaced by unified identity + agent configs. |
+| `panel_tasks` | `public.panel_tasks`, SQLite `panel_tasks` | delete candidate | Do not give a new product target table. |
+
+Current code surfaces:
+
+- `storage/providers/supabase/tool_task_repo.py`
+- `storage/providers/supabase/cron_job_repo.py`
+- `storage/providers/supabase/agent_registry_repo.py`
+- `storage/providers/supabase/panel_task_repo.py`
+- `storage/providers/supabase/thread_repo.py`
+- `backend/web/services/cron_service.py`
+- `backend/web/services/task_service.py`
+
+### Container / Runtime
+
+| Target | Current sources | Classification | Notes |
+|---|---|---|---|
+| `container.devices` | sandbox provider/account resource config; no exact current table | migrate/add | Device is persistent compute endpoint. Need daemon/provider reality check before DDL. |
+| `container.sandbox_templates` | `public.library_recipes`, `staging.library_recipes`, SQLite `library_recipes` | rename + migrate | The issue reply says `sandbox_templates`, not `sandbox_recipes`. This supersedes earlier discussion naming. |
+| `container.sandboxes` | `public.sandbox_leases`, `public.sandbox_instances`, staging equivalents | migrate | Target combines persistent sandbox desired/observed state. |
+| `container.workspaces` | `sandbox_leases`, thread terminal/lease binding, file workspace paths | migrate | Must replace thread -> terminal -> lease assumptions with thread -> workspace. |
+| `container.resource_snapshots` | `lease_resource_snapshots` | migrate | Target commit reply says resource snapshots remain in container. |
+| `container.provider_events` | `public.provider_events`, `staging.provider_events` | migrate | Issue reply places provider events in container; observability boundary should be revisited later. |
+| terminals | `abstract_terminals`, `thread_terminal_pointers`, `terminal_commands`, `terminal_command_chunks` | route-out | Issue reply: terminal is stateless sandbox exec API, no PTY persistence. Current Mycel code still depends heavily on terminal repos, so this is a major implementation slice. |
+| volumes | `sandbox_volumes` | route-out | Issue reply: file upload/download uses Supabase Storage directly; volumes abstraction is invalid. |
+| `sync_files` | `public.sync_files`, `staging.sync_files`, SQLite `sync_files` | route-out/delete candidate | No target model unless a future sync feature is explicitly designed. |
+
+Current code surfaces:
+
+- `storage/providers/supabase/lease_repo.py`
+- `storage/providers/supabase/terminal_repo.py`
+- `storage/providers/supabase/chat_session_repo.py`
+- `storage/providers/supabase/sandbox_volume_repo.py`
+- `storage/providers/supabase/sync_file_repo.py`
+- `storage/providers/supabase/resource_snapshot_repo.py`
+- `storage/providers/supabase/provider_event_repo.py`
+- `backend/web/services/file_channel_service.py`
+- `backend/web/services/thread_state_service.py`
+- `backend/web/routers/threads.py`
+- `sandbox/lease.py`
+- `sandbox/terminal.py`
+
+### Hub / Marketplace
+
+| Target | Current sources | Classification | Notes |
+|---|---|---|---|
+| `hub.marketplace_publishers` | `public.marketplace_publishers`, `staging.marketplace_publishers` | migrate | Use `public.marketplace_*` as source because it has real data; staging is empty per issue. |
+| `hub.marketplace_items` | `public.marketplace_items`, `staging.marketplace_items` | migrate | Same source rule. |
+| `hub.marketplace_versions` | `public.marketplace_versions`, `staging.marketplace_versions` | migrate | Same source rule. |
+
+Current code surfaces:
+
+- `backend/web/models/marketplace.py`
+- `backend/web/routers/marketplace.py`
+- `frontend/app/src/pages/MarketplacePage.tsx`
+
+### Observability / Eval
+
+| Target | Current sources | Classification | Notes |
+|---|---|---|---|
+| `observability.eval_runs` or `eval.eval_runs` | `public.eval_runs`, `staging.eval_runs`, `eval/repo.py` | migrate | Required for Mycel agents developing Mycel. Need local schema contract because upstream commit has no observability DDL file. |
+| `observability.eval_metrics` | `public.eval_metrics`, `staging.eval_metrics` | migrate | Keep. |
+| `observability.eval_llm_calls` | `public.eval_llm_calls`, `staging.eval_llm_calls` | migrate | Keep. |
+| `observability.eval_tool_calls` | `public.eval_tool_calls`, `staging.eval_tool_calls` | migrate | Keep. |
+| `observability.evaluation_batches` | `public.evaluation_batches`, `staging.evaluation_batches` | migrate | Keep if current eval harness uses batches. |
+| `observability.evaluation_batch_runs` | `public.evaluation_batch_runs`, `staging.evaluation_batch_runs` | migrate | Keep if current eval harness uses batches. |
+| `provider_events` | `public.provider_events`, `staging.provider_events` | split decision needed | Issue body suggested eval/observability; issue reply says container retains provider_events. Treat as container P0, maybe mirror/aggregate later. |
+| `audit_logs` | `public.audit_logs` | delete candidate | Not current core product schema. |
+
+Current code surfaces:
+
+- `eval/repo.py`
+- `storage/providers/supabase/eval_repo.py`
+- `storage/providers/supabase/provider_event_repo.py`
+- `backend/web/routers/webhooks.py`
+
+## Proposed PR Shape
+
+This PR should start as a major Database Refactor branch, but not as a single
+blind DDL dump. The safe sequence is:
+
+1. `database-refactor-00-target-contract-and-migration-slicing`
+   - Land this matrix.
+   - Get Ledger acceptance on the first implementation slice.
+2. `database-refactor-01-schema-loader-and-search-path`
+   - Introduce an explicit schema-addressing layer for Supabase repos so table
+     access is not hard-coded to whatever `LEON_DB_SCHEMA` points at.
+   - No product table rename yet.
+3. `database-refactor-02-thread-tasks-schedules`
+   - Rename `tool_tasks` / `agent_thread_tasks` concept to `agent.thread_tasks`.
+   - Rename `cron_jobs` concept to `agent.schedules`.
+   - Add `agent.schedule_runs`.
+4. `database-refactor-03-terminal-volume-route-out`
+   - Remove durable terminal/command/chunk pointer assumptions from the runtime
+     path.
+   - Replace thread -> terminal -> lease file path lookup with thread ->
+     workspace / sandbox exec API contract.
+5. Later slices:
+   - identity migration
+   - chat migration
+   - container sandbox/workspace migration
+   - hub marketplace migration
+   - observability schema
+
+## Stopline
+
+Do not write destructive migrations or drop legacy tables until:
+
+- target table inventory is accepted by Ledger;
+- source table row counts and owner/key relationships are captured;
+- each slice has a rollback or route-out story;
+- backend API YATU exists for the affected product path;
+- frontend Playwright CLI YATU exists for affected UI paths;
+- public/staging compatibility shims are not added as a new permanent layer.

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -150,6 +150,8 @@ class ChatRow(BaseModel):
     status: str = "active"
     created_at: float
     updated_at: float | None = None
+    type: str = "direct"
+    created_by_user_id: str | None = None
 
 
 class ChatEntityRow(BaseModel):

--- a/storage/providers/supabase/__init__.py
+++ b/storage/providers/supabase/__init__.py
@@ -20,6 +20,7 @@ from .resource_snapshot_repo import list_snapshots_by_lease_ids, upsert_lease_re
 from .run_event_repo import SupabaseRunEventRepo
 from .sandbox_monitor_repo import SupabaseSandboxMonitorRepo
 from .sandbox_volume_repo import SupabaseSandboxVolumeRepo
+from .schedule_repo import SupabaseScheduleRepo
 from .summary_repo import SupabaseSummaryRepo
 from .sync_file_repo import SupabaseSyncFileRepo
 from .terminal_repo import SupabaseTerminalRepo
@@ -49,6 +50,7 @@ __all__ = [
     "SupabaseQueueRepo",
     "SupabaseRecipeRepo",
     "SupabaseRunEventRepo",
+    "SupabaseScheduleRepo",
     "SupabaseSandboxMonitorRepo",
     "SupabaseSandboxVolumeRepo",
     "SupabaseSummaryRepo",

--- a/storage/providers/supabase/chat_repo.py
+++ b/storage/providers/supabase/chat_repo.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from storage.contracts import ChatEntityRow, ChatMessageRow, ChatRow
 from storage.providers.supabase import _query as q
+from storage.providers.supabase.schema import resolve_runtime_schema, route_for_schema
 
 _REPO_CHAT = "chat repo"
 _TABLE_CHATS = "chats"
@@ -16,27 +17,40 @@ _TABLE_CHAT_ENTITIES = "chat_entities"
 
 _REPO_MSG = "chat message repo"
 _TABLE_CHAT_MESSAGES = "chat_messages"
+_CHAT_MEMBER_TABLES = {
+    "public": _TABLE_CHAT_ENTITIES,
+    "staging": "chat_members",
+}
+_MESSAGE_TABLES = {
+    "public": _TABLE_CHAT_MESSAGES,
+    "staging": "messages",
+}
 
 
 class SupabaseChatRepo:
     """Chat CRUD backed by Supabase."""
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _REPO_CHAT)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
 
     def create(self, row: ChatRow) -> None:
-        self._t().insert(
-            {
-                "id": row.id,
-                "title": row.title,
-                "status": row.status,
-                "created_at": row.created_at,
-                "updated_at": row.updated_at,
-            }
-        ).execute()
+        payload = {
+            "id": row.id,
+            "title": row.title,
+            "status": row.status,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+        }
+        if self._schema == "staging":
+            if not row.created_by_user_id:
+                raise ValueError("created_by_user_id is required for staging.chats")
+            payload["type"] = row.type
+            payload["created_by_user_id"] = row.created_by_user_id
+        self._t().insert(payload).execute()
 
     def get_by_id(self, chat_id: str) -> ChatRow | None:
         response = self._t().select("*").eq("id", chat_id).execute()
@@ -50,6 +64,8 @@ class SupabaseChatRepo:
             status=r.get("status", "active"),
             created_at=float(r["created_at"]),
             updated_at=float(r["updated_at"]) if r.get("updated_at") is not None else None,
+            type=r.get("type", "direct"),
+            created_by_user_id=r.get("created_by_user_id"),
         )
 
     def delete(self, chat_id: str) -> None:
@@ -62,8 +78,9 @@ class SupabaseChatRepo:
 class SupabaseChatEntityRepo:
     """Chat entity membership backed by Supabase."""
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _REPO_ENTITY)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
@@ -95,6 +112,11 @@ class SupabaseChatEntityRepo:
         return len(raw) > 0
 
     def update_last_read(self, chat_id: str, user_id: str, last_read_at: float) -> None:
+        if self._schema == "staging":
+            # @@@seq-read-watermark - the API still says "mark read now"; staging stores the latest message seq instead of a timestamp.
+            latest_seq = self._latest_message_seq(chat_id)
+            self._t().update({"last_read_seq": latest_seq}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
+            return
         self._t().update({"last_read_at": last_read_at}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
 
     def update_mute(self, chat_id: str, user_id: str, muted: bool, mute_until: float | None = None) -> None:
@@ -123,40 +145,69 @@ class SupabaseChatEntityRepo:
         return None
 
     def _to_entity_row(self, r: dict[str, Any]) -> ChatEntityRow:
+        last_read = r.get("last_read_seq") if self._schema == "staging" else r.get("last_read_at")
         return ChatEntityRow(
             chat_id=r["chat_id"],
             user_id=r["user_id"],
             joined_at=float(r["joined_at"]),
-            last_read_at=float(r["last_read_at"]) if r.get("last_read_at") is not None else None,
+            last_read_at=float(last_read) if last_read is not None else None,
             muted=bool(r.get("muted", False)),
             mute_until=float(r["mute_until"]) if r.get("mute_until") is not None else None,
         )
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE_CHAT_ENTITIES)
+        return self._client.table(route_for_schema(_REPO_ENTITY, _CHAT_MEMBER_TABLES, self._schema))
+
+    def _latest_message_seq(self, chat_id: str) -> int:
+        response = (
+            q.order(
+                self._client.table(route_for_schema(_REPO_MSG, _MESSAGE_TABLES, self._schema)).select("seq").eq("chat_id", chat_id),
+                "seq",
+                desc=True,
+                repo=_REPO_ENTITY,
+                operation="latest_message_seq",
+            )
+            .limit(1)
+            .execute()
+        )
+        rows = q.rows(response, _REPO_ENTITY, "latest_message_seq")
+        if not rows:
+            return 0
+        return int(rows[0].get("seq") or 0)
 
 
 class SupabaseChatMessageRepo:
     """Chat message persistence backed by Supabase."""
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _REPO_MSG)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
 
     def create(self, row: ChatMessageRow) -> None:
-        mentions_json = json.dumps(row.mentioned_ids) if row.mentioned_ids else json.dumps([])
-        self._t().insert(
-            {
+        if self._schema == "staging":
+            seq = self._next_seq(row.chat_id)
+            payload = {
+                "id": row.id,
+                "chat_id": row.chat_id,
+                "seq": seq,
+                "sender_user_id": row.sender_id,
+                "content": row.content,
+                "mentions_json": row.mentioned_ids or [],
+                "created_at": row.created_at,
+            }
+        else:
+            payload = {
                 "id": row.id,
                 "chat_id": row.chat_id,
                 "sender_id": row.sender_id,
                 "content": row.content,
-                "mentions": mentions_json,
+                "mentions": json.dumps(row.mentioned_ids) if row.mentioned_ids else json.dumps([]),
                 "created_at": row.created_at,
             }
-        ).execute()
+        self._t().insert(payload).execute()
 
     def list_by_chat(
         self,
@@ -176,6 +227,14 @@ class SupabaseChatMessageRepo:
 
     def list_unread(self, chat_id: str, user_id: str) -> list[ChatMessageRow]:
         """Return unread messages (after last_read_at, excluding own) in chronological order."""
+        if self._schema == "staging":
+            last_read = self._last_read_seq(chat_id, user_id)
+            query = self._t().select("*").eq("chat_id", chat_id).neq("sender_user_id", user_id)
+            query = q.gt(query, "seq", last_read, _REPO_MSG, "list_unread")
+            query = q.order(query, "seq", desc=False, repo=_REPO_MSG, operation="list_unread")
+            raw = q.rows(query.execute(), _REPO_MSG, "list_unread")
+            return [self._to_msg(r) for r in raw]
+
         # Fetch last_read_at for this user in this chat.
         resp_ce = self._client.table(_TABLE_CHAT_ENTITIES).select("last_read_at").eq("chat_id", chat_id).eq("user_id", user_id).execute()
         ce_rows = q.rows(resp_ce, _REPO_MSG, "list_unread(last_read_at)")
@@ -192,6 +251,9 @@ class SupabaseChatMessageRepo:
         return [self._to_msg(r) for r in raw]
 
     def count_unread(self, chat_id: str, user_id: str) -> int:
+        if self._schema == "staging":
+            return len(self.list_unread(chat_id, user_id))
+
         # Fetch last_read_at for this user in this chat.
         resp_ce = self._client.table(_TABLE_CHAT_ENTITIES).select("last_read_at").eq("chat_id", chat_id).eq("user_id", user_id).execute()
         ce_rows = q.rows(resp_ce, _REPO_MSG, "count_unread(last_read_at)")
@@ -211,6 +273,12 @@ class SupabaseChatMessageRepo:
         # Fallback: count from data list.
         raw = q.rows(response, _REPO_MSG, "count_unread")
         return len(raw)
+
+    def has_unread_mention(self, chat_id: str, user_id: str) -> bool:
+        for message in self.list_unread(chat_id, user_id):
+            if user_id in message.mentioned_ids:
+                return True
+        return False
 
     def list_by_time_range(
         self,
@@ -241,7 +309,8 @@ class SupabaseChatMessageRepo:
         return [self._to_msg(r) for r in raw]
 
     def _to_msg(self, r: dict[str, Any]) -> ChatMessageRow:
-        mentions_raw = r.get("mentions")
+        sender_id = r.get("sender_user_id") if self._schema == "staging" else r.get("sender_id")
+        mentions_raw = r.get("mentions_json") if self._schema == "staging" else r.get("mentions")
         if mentions_raw is None or mentions_raw == "":
             mentioned: list[str] = []
         elif isinstance(mentions_raw, list):
@@ -255,11 +324,36 @@ class SupabaseChatMessageRepo:
         return ChatMessageRow(
             id=r["id"],
             chat_id=r["chat_id"],
-            sender_id=r["sender_id"],
+            sender_id=sender_id,
             content=r["content"],
             mentioned_ids=mentioned,
             created_at=float(r["created_at"]),
         )
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE_CHAT_MESSAGES)
+        return self._client.table(route_for_schema(_REPO_MSG, _MESSAGE_TABLES, self._schema))
+
+    def _next_seq(self, chat_id: str) -> int:
+        response = self._client.rpc("increment_chat_message_seq", {"p_chat_id": chat_id}).execute()
+        data = getattr(response, "data", None)
+        if isinstance(data, int):
+            return data
+        if isinstance(data, list) and data:
+            first = data[0]
+            if isinstance(first, dict):
+                return int(first.get("value") or first.get("increment_chat_message_seq") or 0)
+            return int(first)
+        raise RuntimeError("Supabase chat message repo expected increment_chat_message_seq RPC data.")
+
+    def _last_read_seq(self, chat_id: str, user_id: str) -> int:
+        response = (
+            self._client.table(route_for_schema(_REPO_ENTITY, _CHAT_MEMBER_TABLES, self._schema))
+            .select("last_read_seq")
+            .eq("chat_id", chat_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+        rows = q.rows(response, _REPO_MSG, "last_read_seq")
+        if not rows:
+            return 0
+        return int(rows[0].get("last_read_seq") or 0)

--- a/storage/providers/supabase/entity_repo.py
+++ b/storage/providers/supabase/entity_repo.py
@@ -4,70 +4,60 @@ from __future__ import annotations
 
 from typing import Any
 
-from storage.contracts import EntityRow
-from storage.providers.supabase import _query as q
+from storage.contracts import EntityRow, MemberRow, MemberType
+from storage.providers.supabase.member_repo import SupabaseMemberRepo
+from storage.providers.supabase.thread_repo import SupabaseThreadRepo
 
 _REPO = "entity repo"
-_TABLE = "entities"
 
 
 class SupabaseEntityRepo:
-    def __init__(self, client: Any) -> None:
-        self._client = q.validate_client(client, _REPO)
+    def __init__(self, client: Any, *, member_repo: Any | None = None, thread_repo: Any | None = None) -> None:
+        self._client = client
+        self._member_repo = member_repo or SupabaseMemberRepo(client)
+        self._thread_repo = thread_repo or SupabaseThreadRepo(client)
 
     def close(self) -> None:
         return None
 
     def create(self, row: EntityRow) -> None:
-        self._t().insert(
-            {
-                "id": row.id,
-                "type": row.type,
-                "member_id": row.member_id,
-                "name": row.name,
-                "avatar": row.avatar,
-                "thread_id": row.thread_id,
-                "created_at": row.created_at,
-            }
-        ).execute()
+        # @@@entity-read-model - Supabase has no entities table; agent thread_id is derived from agent.threads.
+        return None
 
     def get_by_id(self, id: str) -> EntityRow | None:
-        response = self._t().select("*").eq("id", id).execute()
-        rows = q.rows(response, _REPO, "get_by_id")
-        if not rows:
+        member = self._member_repo.get_by_id(id)
+        if member is None:
             return None
-        return EntityRow.model_validate(rows[0])
+        return self._row_from_member(member)
 
     def get_by_member_id(self, member_id: str) -> list[EntityRow]:
-        response = self._t().select("*").eq("member_id", member_id).execute()
-        rows = q.rows(response, _REPO, "get_by_member_id")
-        return [EntityRow.model_validate(r) for r in rows]
+        row = self.get_by_id(member_id)
+        return [row] if row is not None else []
 
     def list_all(self) -> list[EntityRow]:
-        query = q.order(self._t().select("*"), "created_at", desc=False, repo=_REPO, operation="list_all")
-        rows = q.rows(query.execute(), _REPO, "list_all")
-        return [EntityRow.model_validate(r) for r in rows]
+        return [self._row_from_member(member) for member in self._member_repo.list_all()]
 
     def list_by_type(self, entity_type: str) -> list[EntityRow]:
-        query = q.order(
-            self._t().select("*").eq("type", entity_type),
-            "created_at",
-            desc=False,
-            repo=_REPO,
-            operation="list_by_type",
-        )
-        rows = q.rows(query.execute(), _REPO, "list_by_type")
-        return [EntityRow.model_validate(r) for r in rows]
+        return [row for row in self.list_all() if row.type == entity_type]
 
     def update(self, id: str, **fields: Any) -> None:
-        allowed = {"name", "avatar", "thread_id"}
-        updates = {k: v for k, v in fields.items() if k in allowed}
-        if not updates:
-            return
-        self._t().update(updates).eq("id", id).execute()
+        return None
 
     def delete(self, id: str) -> None:
-        self._t().delete().eq("id", id).execute()
+        return None
 
-    def _t(self) -> Any:
-        return self._client.table(_TABLE)
+    def _row_from_member(self, member: MemberRow) -> EntityRow:
+        entity_type = "agent" if member.type is MemberType.MYCEL_AGENT else "human"
+        thread_id = None
+        if entity_type == "agent":
+            main_thread = self._thread_repo.get_main_thread(member.id)
+            thread_id = main_thread["id"] if main_thread is not None else None
+        return EntityRow(
+            id=member.id,
+            type=entity_type,
+            member_id=member.id,
+            name=member.name,
+            avatar=member.avatar,
+            thread_id=thread_id,
+            created_at=member.created_at,
+        )

--- a/storage/providers/supabase/member_repo.py
+++ b/storage/providers/supabase/member_repo.py
@@ -6,37 +6,63 @@ from typing import Any
 
 from storage.contracts import AccountRow, MemberRow
 from storage.providers.supabase import _query as q
+from storage.providers.supabase.schema import resolve_runtime_schema, route_for_schema
 
 _MEMBER_REPO = "member repo"
-_MEMBER_TABLE = "members"
+_MEMBER_TABLES = {
+    "public": "members",
+    "staging": "users",
+}
+_NAME_COLUMNS = {
+    "public": "name",
+    "staging": "display_name",
+}
+_DESCRIPTION_COLUMNS = {
+    "public": "description",
+    "staging": "bio",
+}
+_CONFIG_COLUMNS = {
+    "public": "config_dir",
+    "staging": "agent_config_id",
+}
+_SEQ_COLUMNS = {
+    "public": "next_thread_seq",
+    "staging": "next_thread_seq",
+}
+_SEQ_RPCS = {
+    "public": ("increment_member_thread_seq", "p_member_id"),
+    "staging": ("increment_user_thread_seq", "p_user_id"),
+}
 
 _ACCOUNT_REPO = "account repo"
 _ACCOUNT_TABLE = "accounts"
 
 
 class SupabaseMemberRepo:
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _MEMBER_REPO)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
 
     def create(self, row: MemberRow) -> None:
+        payload = {
+            "id": row.id,
+            "type": row.type.value,
+            "avatar": row.avatar,
+            "owner_user_id": row.owner_user_id,
+            self._seq_column: row.next_entity_seq,
+            "email": row.email,
+            "mycel_id": row.mycel_id,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+            self._name_column: row.name,
+            self._description_column: row.description,
+            self._config_column: row.config_dir,
+        }
         self._t().insert(
-            {
-                "id": row.id,
-                "name": row.name,
-                "type": row.type.value,
-                "avatar": row.avatar,
-                "description": row.description,
-                "config_dir": row.config_dir,
-                "owner_user_id": row.owner_user_id,
-                "next_entity_seq": row.next_entity_seq,
-                "email": row.email,
-                "mycel_id": row.mycel_id,
-                "created_at": row.created_at,
-                "updated_at": row.updated_at,
-            }
+            {k: v for k, v in payload.items() if v is not None}
         ).execute()
 
     def get_by_id(self, member_id: str) -> MemberRow | None:
@@ -47,7 +73,7 @@ class SupabaseMemberRepo:
         return MemberRow.model_validate(self._normalize(rows[0]))
 
     def get_by_name(self, name: str) -> MemberRow | None:
-        response = self._t().select("*").eq("name", name).execute()
+        response = self._t().select("*").eq(self._name_column, name).execute()
         rows = q.rows(response, _MEMBER_REPO, "get_by_name")
         if not rows:
             return None
@@ -85,16 +111,17 @@ class SupabaseMemberRepo:
 
     def update(self, member_id: str, **fields: Any) -> None:
         allowed = {"name", "avatar", "description", "config_dir", "owner_user_id", "updated_at"}
-        updates = {k: v for k, v in fields.items() if k in allowed}
+        updates = {self._column_for_field(k): v for k, v in fields.items() if k in allowed}
         if not updates:
             return
         self._t().update(updates).eq("id", member_id).execute()
 
     def increment_entity_seq(self, member_id: str) -> int:
         """Atomically increment next_entity_seq and return the new value via RPC."""
+        rpc_name, param_name = _SEQ_RPCS[self._schema]
         response = self._client.rpc(
-            "increment_member_entity_seq",
-            {"p_member_id": member_id},
+            rpc_name,
+            {param_name: member_id},
         ).execute()
         # RPC returns scalar; supabase-py wraps it in data
         if isinstance(response, dict):
@@ -103,7 +130,7 @@ class SupabaseMemberRepo:
             data = getattr(response, "data", None)
         if data is None:
             raise RuntimeError(
-                f"Supabase {_MEMBER_REPO} expected data from increment_member_entity_seq RPC. "
+                f"Supabase {_MEMBER_REPO} expected data from {rpc_name} RPC. "
                 "Check the function exists and member_id is valid."
             )
         # data may be a list with one element (scalar), or an int directly
@@ -117,11 +144,46 @@ class SupabaseMemberRepo:
         self._t().delete().eq("id", member_id).execute()
 
     def _normalize(self, row: dict[str, Any]) -> dict[str, Any]:
-        """Ensure type is a MemberType-compatible value."""
-        return row
+        normalized = dict(row)
+        normalized["name"] = row.get(self._name_column)
+        normalized["type"] = self._member_type(row.get("type"))
+        normalized["description"] = row.get(self._description_column)
+        normalized["config_dir"] = row.get(self._config_column)
+        normalized["next_entity_seq"] = row.get(self._seq_column, 0)
+        return normalized
 
     def _t(self) -> Any:
-        return self._client.table(_MEMBER_TABLE)
+        return self._client.table(route_for_schema(_MEMBER_REPO, _MEMBER_TABLES, self._schema))
+
+    @property
+    def _name_column(self) -> str:
+        return route_for_schema(_MEMBER_REPO, _NAME_COLUMNS, self._schema)
+
+    @property
+    def _description_column(self) -> str:
+        return route_for_schema(_MEMBER_REPO, _DESCRIPTION_COLUMNS, self._schema)
+
+    @property
+    def _config_column(self) -> str:
+        return route_for_schema(_MEMBER_REPO, _CONFIG_COLUMNS, self._schema)
+
+    @property
+    def _seq_column(self) -> str:
+        return route_for_schema(_MEMBER_REPO, _SEQ_COLUMNS, self._schema)
+
+    def _column_for_field(self, field: str) -> str:
+        if field == "name":
+            return self._name_column
+        if field == "description":
+            return self._description_column
+        if field == "config_dir":
+            return self._config_column
+        return field
+
+    def _member_type(self, value: Any) -> Any:
+        if self._schema == "staging" and value == "agent":
+            return "mycel_agent"
+        return value
 
 
 class SupabaseAccountRepo:

--- a/storage/providers/supabase/member_repo.py
+++ b/storage/providers/supabase/member_repo.py
@@ -61,9 +61,7 @@ class SupabaseMemberRepo:
             self._description_column: row.description,
             self._config_column: row.config_dir,
         }
-        self._t().insert(
-            {k: v for k, v in payload.items() if v is not None}
-        ).execute()
+        self._t().insert({k: v for k, v in payload.items() if v is not None}).execute()
 
     def get_by_id(self, member_id: str) -> MemberRow | None:
         response = self._t().select("*").eq("id", member_id).execute()
@@ -130,8 +128,7 @@ class SupabaseMemberRepo:
             data = getattr(response, "data", None)
         if data is None:
             raise RuntimeError(
-                f"Supabase {_MEMBER_REPO} expected data from {rpc_name} RPC. "
-                "Check the function exists and member_id is valid."
+                f"Supabase {_MEMBER_REPO} expected data from {rpc_name} RPC. Check the function exists and member_id is valid."
             )
         # data may be a list with one element (scalar), or an int directly
         if isinstance(data, list):

--- a/storage/providers/supabase/schedule_repo.py
+++ b/storage/providers/supabase/schedule_repo.py
@@ -1,0 +1,180 @@
+"""Supabase repository for agent schedule records."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from storage.providers.supabase import _query as q
+from storage.providers.supabase.schema import route_for_schema
+
+_REPO = "schedule repo"
+_SCHEMA = "agent"
+_SCHEDULES_TABLE = "schedules"
+_RUNS_TABLE = "schedule_runs"
+_ROUTES = {"staging": _SCHEMA}
+
+
+class SupabaseScheduleRepo:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
+        self._client = q.validate_client(client, _REPO)
+        self._schema = schema
+
+    def close(self) -> None:
+        return None
+
+    def _agent_table(self, table_name: str) -> Any:
+        schema = route_for_schema(_REPO, _ROUTES, self._schema)
+        return self._client.schema(schema).table(table_name)
+
+    def _schedules(self) -> Any:
+        return self._agent_table(_SCHEDULES_TABLE)
+
+    def _runs(self) -> Any:
+        return self._agent_table(_RUNS_TABLE)
+
+    def list_by_owner(self, owner_user_id: str) -> list[dict[str, Any]]:
+        return q.rows(
+            q.order(
+                self._schedules().select("*").eq("owner_user_id", owner_user_id),
+                "created_at",
+                desc=True,
+                repo=_REPO,
+                operation="list_by_owner",
+            ).execute(),
+            _REPO,
+            "list_by_owner",
+        )
+
+    def get(self, schedule_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            self._schedules().select("*").eq("id", schedule_id).execute(),
+            _REPO,
+            "get",
+        )
+        return rows[0] if rows else None
+
+    def create(
+        self,
+        *,
+        owner_user_id: str,
+        agent_user_id: str,
+        cron_expression: str,
+        instruction_template: str,
+        target_thread_id: str | None = None,
+        create_thread_on_run: bool = False,
+        enabled: bool = True,
+        timezone: str = "UTC",
+        next_run_at: str | None = None,
+    ) -> dict[str, Any]:
+        schedule_id = uuid.uuid4().hex
+        payload = {
+            "id": schedule_id,
+            "owner_user_id": owner_user_id,
+            "agent_user_id": agent_user_id,
+            "target_thread_id": target_thread_id,
+            "create_thread_on_run": create_thread_on_run,
+            "cron_expression": cron_expression,
+            "enabled": enabled,
+            "instruction_template": instruction_template,
+            "timezone": timezone,
+            "next_run_at": next_run_at,
+        }
+        rows = q.rows(self._schedules().insert(payload).execute(), _REPO, "create")
+        return rows[0] if rows else self.get(schedule_id) or {}
+
+    def update(self, schedule_id: str, **fields: Any) -> dict[str, Any] | None:
+        allowed = {
+            "agent_user_id",
+            "target_thread_id",
+            "create_thread_on_run",
+            "cron_expression",
+            "enabled",
+            "instruction_template",
+            "timezone",
+            "last_run_at",
+            "next_run_at",
+        }
+        updates = {key: value for key, value in fields.items() if key in allowed and value is not None}
+        if not updates:
+            return self.get(schedule_id)
+        rows = q.rows(
+            self._schedules().update(updates).eq("id", schedule_id).execute(),
+            _REPO,
+            "update",
+        )
+        return rows[0] if rows else None
+
+    def delete(self, schedule_id: str) -> bool:
+        rows = q.rows(
+            self._schedules().delete().eq("id", schedule_id).execute(),
+            _REPO,
+            "delete",
+        )
+        return len(rows) > 0
+
+    def create_run(
+        self,
+        *,
+        schedule_id: str,
+        owner_user_id: str,
+        agent_user_id: str,
+        triggered_by: str,
+        thread_id: str | None = None,
+        scheduled_for: str | None = None,
+        input_json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        run_id = uuid.uuid4().hex
+        payload = {
+            "id": run_id,
+            "schedule_id": schedule_id,
+            "owner_user_id": owner_user_id,
+            "agent_user_id": agent_user_id,
+            "thread_id": thread_id,
+            "triggered_by": triggered_by,
+            "scheduled_for": scheduled_for,
+            "input_json": input_json or {},
+        }
+        rows = q.rows(self._runs().insert(payload).execute(), _REPO, "create_run")
+        return rows[0] if rows else self.get_run(run_id) or {}
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            self._runs().select("*").eq("id", run_id).execute(),
+            _REPO,
+            "get_run",
+        )
+        return rows[0] if rows else None
+
+    def list_runs(self, schedule_id: str) -> list[dict[str, Any]]:
+        return q.rows(
+            q.order(
+                self._runs().select("*").eq("schedule_id", schedule_id),
+                "created_at",
+                desc=True,
+                repo=_REPO,
+                operation="list_runs",
+            ).execute(),
+            _REPO,
+            "list_runs",
+        )
+
+    def update_run(self, run_id: str, **fields: Any) -> dict[str, Any] | None:
+        allowed = {"thread_id", "status", "started_at", "completed_at", "output_json", "error"}
+        updates = {key: value for key, value in fields.items() if key in allowed and value is not None}
+        if not updates:
+            return self.get_run(run_id)
+        rows = q.rows(
+            self._runs().update(updates).eq("id", run_id).execute(),
+            _REPO,
+            "update_run",
+        )
+        return rows[0] if rows else None
+
+    def delete_run(self, run_id: str) -> bool:
+        rows = q.rows(
+            self._runs().delete().eq("id", run_id).execute(),
+            _REPO,
+            "delete_run",
+        )
+        return len(rows) > 0

--- a/storage/providers/supabase/schema.py
+++ b/storage/providers/supabase/schema.py
@@ -1,0 +1,26 @@
+"""Explicit runtime schema routing for Supabase storage repos."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+SUPPORTED_RUNTIME_SCHEMAS = frozenset({"public", "staging"})
+
+
+def resolve_runtime_schema(schema: str | None = None) -> str:
+    resolved = schema or os.getenv("LEON_DB_SCHEMA")
+    if not resolved:
+        raise RuntimeError("LEON_DB_SCHEMA is required for Supabase storage runtime.")
+    if resolved not in SUPPORTED_RUNTIME_SCHEMAS:
+        allowed = ", ".join(sorted(SUPPORTED_RUNTIME_SCHEMAS))
+        raise RuntimeError(f"Unsupported LEON_DB_SCHEMA={resolved!r}. Supported runtime schemas: {allowed}.")
+    return resolved
+
+
+def route_for_schema(repo: str, mapping: Mapping[str, str], schema: str | None = None) -> str:
+    resolved = resolve_runtime_schema(schema)
+    if resolved not in mapping:
+        allowed = ", ".join(sorted(mapping))
+        raise RuntimeError(f"Supabase {repo} has no route for LEON_DB_SCHEMA={resolved!r}. Routed schemas: {allowed}.")
+    return mapping[resolved]

--- a/storage/providers/supabase/thread_launch_pref_repo.py
+++ b/storage/providers/supabase/thread_launch_pref_repo.py
@@ -7,28 +7,37 @@ import time
 from typing import Any
 
 from storage.providers.supabase import _query as q
+from storage.providers.supabase.schema import resolve_runtime_schema, route_for_schema
 
 _REPO = "thread launch pref repo"
 _TABLE = "thread_launch_prefs"
+_AGENT_COLUMNS = {
+    "public": "member_id",
+    "staging": "agent_user_id",
+}
+_BASE_SELECT_COLUMNS = (
+    "owner_user_id",
+    "last_confirmed_json",
+    "last_successful_json",
+    "last_confirmed_at",
+    "last_successful_at",
+)
 
 
 class SupabaseThreadLaunchPrefRepo:
     """Persist per-user/member last confirmed + successful new-thread config."""
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _REPO)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
 
     def get(self, owner_user_id: str, member_id: str) -> dict[str, Any] | None:
-        response = (
-            self._t()
-            .select("owner_user_id, member_id, last_confirmed_json, last_successful_json, last_confirmed_at, last_successful_at")
-            .eq("owner_user_id", owner_user_id)
-            .eq("member_id", member_id)
-            .execute()
-        )
+        agent_column = self._agent_column
+        select = ", ".join(("owner_user_id", agent_column, *_BASE_SELECT_COLUMNS[1:]))
+        response = self._t().select(select).eq("owner_user_id", owner_user_id).eq(agent_column, member_id).execute()
         rows = q.rows(response, _REPO, "get")
         if not rows:
             return None
@@ -37,7 +46,7 @@ class SupabaseThreadLaunchPrefRepo:
         successful_raw = row.get("last_successful_json")
         return {
             "owner_user_id": row["owner_user_id"],
-            "member_id": row["member_id"],
+            "member_id": row[agent_column],
             "last_confirmed": json.loads(confirmed_raw) if confirmed_raw else None,
             "last_successful": json.loads(successful_raw) if successful_raw else None,
             "last_confirmed_at": row.get("last_confirmed_at"),
@@ -60,17 +69,21 @@ class SupabaseThreadLaunchPrefRepo:
     ) -> None:
         payload = json.dumps(config, ensure_ascii=False)
         now = time.time()
-        # Upsert: insert a bare row if not exists, then update the specific column.
-        # supabase-py supports upsert with on_conflict.
+        agent_column = self._agent_column
+        # @@@thread-launch-pref-schema - application still says member_id; staging DB stores the same identity as agent_user_id.
         self._t().upsert(
             {
                 "owner_user_id": owner_user_id,
-                "member_id": member_id,
+                agent_column: member_id,
                 json_col: payload,
                 ts_col: now,
             },
-            on_conflict="owner_user_id,member_id",
+            on_conflict=f"owner_user_id,{agent_column}",
         ).execute()
 
     def _t(self) -> Any:
         return self._client.table(_TABLE)
+
+    @property
+    def _agent_column(self) -> str:
+        return route_for_schema(_REPO, _AGENT_COLUMNS, self._schema)

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -5,21 +5,36 @@ from __future__ import annotations
 from typing import Any
 
 from storage.providers.supabase import _query as q
+from storage.providers.supabase.schema import resolve_runtime_schema, route_for_schema
 
 _REPO = "thread repo"
 _TABLE = "threads"
 
-_COLS = (
+_THREAD_MEMBER_COLUMNS = {
+    "public": "member_id",
+    "staging": "agent_user_id",
+}
+_OWNER_TABLES = {
+    "public": "members",
+    "staging": "users",
+}
+_OWNER_NAME_COLUMNS = {
+    "public": "name",
+    "staging": "display_name",
+}
+_BASE_COLS = (
     "id",
-    "member_id",
     "sandbox_type",
     "model",
     "cwd",
-    "observation_provider",
     "is_main",
     "branch_index",
     "created_at",
 )
+_OPTIONAL_COLS_BY_SCHEMA = {
+    "public": ("observation_provider",),
+    "staging": (),
+}
 
 
 def _validate_thread_identity(*, is_main: bool, branch_index: int) -> None:
@@ -31,16 +46,27 @@ def _validate_thread_identity(*, is_main: bool, branch_index: int) -> None:
         raise ValueError("Child thread must have branch_index>0")
 
 
-def _to_dict(row: dict[str, Any]) -> dict[str, Any]:
-    result = {c: row.get(c) for c in _COLS}
+def _select_cols(schema: str) -> tuple[str, ...]:
+    return (_thread_member_column(schema), *_BASE_COLS, *_OPTIONAL_COLS_BY_SCHEMA[schema])
+
+
+def _to_dict(row: dict[str, Any], schema: str) -> dict[str, Any]:
+    result = {c: row.get(c) for c in _BASE_COLS}
+    result["member_id"] = row.get(_thread_member_column(schema))
+    result["observation_provider"] = row.get("observation_provider")
     result["is_main"] = bool(result["is_main"])
     result["branch_index"] = int(result["branch_index"]) if result["branch_index"] is not None else 0
     return result
 
 
+def _thread_member_column(schema: str) -> str:
+    return route_for_schema(_REPO, _THREAD_MEMBER_COLUMNS, schema)
+
+
 class SupabaseThreadRepo:
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _REPO)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
@@ -57,38 +83,38 @@ class SupabaseThreadRepo:
         is_main = bool(extra.get("is_main", False))
         branch_index = int(extra["branch_index"])
         _validate_thread_identity(is_main=is_main, branch_index=branch_index)
-        self._t().insert(
-            {
-                "id": thread_id,
-                "member_id": member_id,
-                "sandbox_type": sandbox_type,
-                "cwd": cwd,
-                "model": extra.get("model"),
-                "observation_provider": extra.get("observation_provider"),
-                "is_main": int(is_main),
-                "branch_index": branch_index,
-                "created_at": created_at,
-            }
-        ).execute()
+        payload = {
+            "id": thread_id,
+            self._thread_member_column: member_id,
+            "sandbox_type": sandbox_type,
+            "cwd": cwd,
+            "model": extra.get("model"),
+            "is_main": int(is_main),
+            "branch_index": branch_index,
+            "created_at": created_at,
+        }
+        if self._schema == "public":
+            payload["observation_provider"] = extra.get("observation_provider")
+        self._t().insert(payload).execute()
 
     def get_by_id(self, thread_id: str) -> dict[str, Any] | None:
-        select = ", ".join(_COLS)
+        select = ", ".join(_select_cols(self._schema))
         response = self._t().select(select).eq("id", thread_id).execute()
         rows = q.rows(response, _REPO, "get_by_id")
         if not rows:
             return None
-        return _to_dict(rows[0])
+        return _to_dict(rows[0], self._schema)
 
     def get_main_thread(self, member_id: str) -> dict[str, Any] | None:
-        select = ", ".join(_COLS)
-        response = self._t().select(select).eq("member_id", member_id).eq("is_main", 1).execute()
+        select = ", ".join(_select_cols(self._schema))
+        response = self._t().select(select).eq(self._thread_member_column, member_id).eq("is_main", 1).execute()
         rows = q.rows(response, _REPO, "get_main_thread")
         if not rows:
             return None
-        return _to_dict(rows[0])
+        return _to_dict(rows[0], self._schema)
 
     def get_next_branch_index(self, member_id: str) -> int:
-        response = self._t().select("branch_index").eq("member_id", member_id).execute()
+        response = self._t().select("branch_index").eq(self._thread_member_column, member_id).execute()
         rows = q.rows(response, _REPO, "get_next_branch_index")
         if not rows:
             return 1
@@ -96,10 +122,10 @@ class SupabaseThreadRepo:
         return max_idx + 1
 
     def list_by_member(self, member_id: str) -> list[dict[str, Any]]:
-        select = ", ".join(_COLS)
+        select = ", ".join(_select_cols(self._schema))
         query = q.order(
             q.order(
-                self._t().select(select).eq("member_id", member_id),
+                self._t().select(select).eq(self._thread_member_column, member_id),
                 "branch_index",
                 desc=False,
                 repo=_REPO,
@@ -111,7 +137,7 @@ class SupabaseThreadRepo:
             operation="list_by_member",
         )
         rows = q.rows(query.execute(), _REPO, "list_by_member")
-        return [_to_dict(r) for r in rows]
+        return [_to_dict(r, self._schema) for r in rows]
 
     def list_by_owner_user_id(self, owner_user_id: str) -> list[dict[str, Any]]:
         """Return all threads owned by this user via a two-step query (members JOIN threads).
@@ -119,9 +145,10 @@ class SupabaseThreadRepo:
         Supabase PostgREST foreign-table embed syntax is used to avoid raw SQL.
         We query members for the owner, then fetch threads for those member IDs.
         """
-        # Step 1: get member IDs for this owner
-        mem_response = self._client.table("members").select("id, name, avatar").eq("owner_user_id", owner_user_id).execute()
-        member_rows = q.rows(mem_response, _REPO, "list_by_owner_user_id:members")
+        owner_table = route_for_schema(_REPO, _OWNER_TABLES, self._schema)
+        owner_name_col = route_for_schema(_REPO, _OWNER_NAME_COLUMNS, self._schema)
+        mem_response = self._client.table(owner_table).select(f"id, {owner_name_col}, avatar").eq("owner_user_id", owner_user_id).execute()
+        member_rows = q.rows(mem_response, _REPO, f"list_by_owner_user_id:{owner_table}")
         if not member_rows:
             return []
 
@@ -129,10 +156,10 @@ class SupabaseThreadRepo:
         member_ids = list(member_map.keys())
 
         # Step 2: get threads for those members
-        thread_cols = ", ".join(_COLS)
+        thread_cols = ", ".join(_select_cols(self._schema))
         query = q.order(
             q.order(
-                q.in_(self._t().select(thread_cols), "member_id", member_ids, _REPO, "list_by_owner_user_id"),
+                q.in_(self._t().select(thread_cols), self._thread_member_column, member_ids, _REPO, "list_by_owner_user_id"),
                 "is_main",
                 desc=True,
                 repo=_REPO,
@@ -145,31 +172,14 @@ class SupabaseThreadRepo:
         )
         thread_rows = q.rows(query.execute(), _REPO, "list_by_owner_user_id:threads")
 
-        # Step 3: enrich with member_name, member_avatar; entity_name via entities table
-        # Entity id = member_id in the new model, so look up entities by member_id
-        member_ids = list({r["member_id"] for r in thread_rows if r.get("member_id")})
-        entity_map: dict[str, str] = {}
-        if member_ids:
-            ent_response = q.in_(
-                self._client.table("entities").select("id, name"),
-                "id",
-                member_ids,
-                _REPO,
-                "list_by_owner_user_id:entities",
-            ).execute()
-            ent_rows = q.rows(ent_response, _REPO, "list_by_owner_user_id:entities")
-            for er in ent_rows:
-                if er.get("id"):
-                    entity_map[er["id"]] = er.get("name", "")
-
         result: list[dict[str, Any]] = []
         for raw in thread_rows:
-            d = _to_dict(raw)
+            d = _to_dict(raw, self._schema)
             mid = d["member_id"]
             member_info = member_map.get(mid, {})
-            d["member_name"] = member_info.get("name")
+            d["member_name"] = member_info.get(owner_name_col)
             d["member_avatar"] = member_info.get("avatar")
-            d["entity_name"] = entity_map.get(mid)
+            d["entity_name"] = None
             result.append(d)
         return result
 
@@ -197,3 +207,7 @@ class SupabaseThreadRepo:
 
     def _t(self) -> Any:
         return self._client.table(_TABLE)
+
+    @property
+    def _thread_member_column(self) -> str:
+        return _thread_member_column(self._schema)

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -2,26 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from storage.providers.supabase import _query as q
-from storage.providers.supabase.schema import resolve_runtime_schema, route_for_schema
+from storage.providers.supabase.schema import resolve_runtime_schema
 
 _REPO = "thread repo"
+_SCHEMA = "agent"
 _TABLE = "threads"
-
-_THREAD_MEMBER_COLUMNS = {
-    "public": "member_id",
-    "staging": "agent_user_id",
-}
-_OWNER_TABLES = {
-    "public": "members",
-    "staging": "users",
-}
-_OWNER_NAME_COLUMNS = {
-    "public": "name",
-    "staging": "display_name",
-}
+_THREAD_MEMBER_COLUMN = "agent_user_id"
 _BASE_COLS = (
     "id",
     "sandbox_type",
@@ -31,10 +21,6 @@ _BASE_COLS = (
     "branch_index",
     "created_at",
 )
-_OPTIONAL_COLS_BY_SCHEMA = {
-    "public": ("observation_provider",),
-    "staging": (),
-}
 
 
 def _validate_thread_identity(*, is_main: bool, branch_index: int) -> None:
@@ -47,20 +33,28 @@ def _validate_thread_identity(*, is_main: bool, branch_index: int) -> None:
 
 
 def _select_cols(schema: str) -> tuple[str, ...]:
-    return (_thread_member_column(schema), *_BASE_COLS, *_OPTIONAL_COLS_BY_SCHEMA[schema])
+    resolve_runtime_schema(schema)
+    return (_THREAD_MEMBER_COLUMN, *_BASE_COLS)
 
 
 def _to_dict(row: dict[str, Any], schema: str) -> dict[str, Any]:
     result = {c: row.get(c) for c in _BASE_COLS}
-    result["member_id"] = row.get(_thread_member_column(schema))
+    resolve_runtime_schema(schema)
+    result["member_id"] = row.get(_THREAD_MEMBER_COLUMN)
     result["observation_provider"] = row.get("observation_provider")
     result["is_main"] = bool(result["is_main"])
     result["branch_index"] = int(result["branch_index"]) if result["branch_index"] is not None else 0
     return result
 
 
-def _thread_member_column(schema: str) -> str:
-    return route_for_schema(_REPO, _THREAD_MEMBER_COLUMNS, schema)
+def _created_at_payload(schema: str, created_at: float) -> float | str:
+    resolve_runtime_schema(schema)
+    return datetime.fromtimestamp(created_at, tz=UTC).isoformat()
+
+
+def _is_main_payload(schema: str, is_main: bool) -> bool | int:
+    resolve_runtime_schema(schema)
+    return is_main
 
 
 class SupabaseThreadRepo:
@@ -83,18 +77,20 @@ class SupabaseThreadRepo:
         is_main = bool(extra.get("is_main", False))
         branch_index = int(extra["branch_index"])
         _validate_thread_identity(is_main=is_main, branch_index=branch_index)
+        owner_user_id = extra.get("owner_user_id")
+        if not owner_user_id:
+            raise ValueError("owner_user_id is required when creating agent.threads rows")
         payload = {
             "id": thread_id,
             self._thread_member_column: member_id,
+            "owner_user_id": owner_user_id,
             "sandbox_type": sandbox_type,
             "cwd": cwd,
             "model": extra.get("model"),
-            "is_main": int(is_main),
+            "is_main": _is_main_payload(self._schema, is_main),
             "branch_index": branch_index,
-            "created_at": created_at,
+            "created_at": _created_at_payload(self._schema, created_at),
         }
-        if self._schema == "public":
-            payload["observation_provider"] = extra.get("observation_provider")
         self._t().insert(payload).execute()
 
     def get_by_id(self, thread_id: str) -> dict[str, Any] | None:
@@ -107,7 +103,9 @@ class SupabaseThreadRepo:
 
     def get_main_thread(self, member_id: str) -> dict[str, Any] | None:
         select = ", ".join(_select_cols(self._schema))
-        response = self._t().select(select).eq(self._thread_member_column, member_id).eq("is_main", 1).execute()
+        response = (
+            self._t().select(select).eq(self._thread_member_column, member_id).eq("is_main", _is_main_payload(self._schema, True)).execute()
+        )
         rows = q.rows(response, _REPO, "get_main_thread")
         if not rows:
             return None
@@ -142,24 +140,12 @@ class SupabaseThreadRepo:
     def list_by_owner_user_id(self, owner_user_id: str) -> list[dict[str, Any]]:
         """Return all threads owned by this user via a two-step query (members JOIN threads).
 
-        Supabase PostgREST foreign-table embed syntax is used to avoid raw SQL.
-        We query members for the owner, then fetch threads for those member IDs.
+        Thread rows already carry owner_user_id in the migrated agent schema.
         """
-        owner_table = route_for_schema(_REPO, _OWNER_TABLES, self._schema)
-        owner_name_col = route_for_schema(_REPO, _OWNER_NAME_COLUMNS, self._schema)
-        mem_response = self._client.table(owner_table).select(f"id, {owner_name_col}, avatar").eq("owner_user_id", owner_user_id).execute()
-        member_rows = q.rows(mem_response, _REPO, f"list_by_owner_user_id:{owner_table}")
-        if not member_rows:
-            return []
-
-        member_map: dict[str, dict[str, Any]] = {r["id"]: r for r in member_rows}
-        member_ids = list(member_map.keys())
-
-        # Step 2: get threads for those members
         thread_cols = ", ".join(_select_cols(self._schema))
         query = q.order(
             q.order(
-                q.in_(self._t().select(thread_cols), self._thread_member_column, member_ids, _REPO, "list_by_owner_user_id"),
+                self._t().select(thread_cols).eq("owner_user_id", owner_user_id),
                 "is_main",
                 desc=True,
                 repo=_REPO,
@@ -170,21 +156,19 @@ class SupabaseThreadRepo:
             repo=_REPO,
             operation="list_by_owner_user_id",
         )
-        thread_rows = q.rows(query.execute(), _REPO, "list_by_owner_user_id:threads")
+        thread_rows = q.rows(query.execute(), _REPO, "list_by_owner_user_id:agent_threads")
 
         result: list[dict[str, Any]] = []
         for raw in thread_rows:
             d = _to_dict(raw, self._schema)
-            mid = d["member_id"]
-            member_info = member_map.get(mid, {})
-            d["member_name"] = member_info.get(owner_name_col)
-            d["member_avatar"] = member_info.get("avatar")
+            d["member_name"] = None
+            d["member_avatar"] = None
             d["entity_name"] = None
             result.append(d)
         return result
 
     def update(self, thread_id: str, **fields: Any) -> None:
-        allowed = {"sandbox_type", "model", "cwd", "observation_provider", "is_main", "branch_index"}
+        allowed = {"sandbox_type", "model", "cwd", "is_main", "branch_index"}
         updates = {k: v for k, v in fields.items() if k in allowed}
         if not updates:
             return
@@ -199,15 +183,16 @@ class SupabaseThreadRepo:
                 branch_index=next_branch_index if next_branch_index is not None else int(current["branch_index"]),
             )
         if "is_main" in updates:
-            updates["is_main"] = int(bool(updates["is_main"]))
+            updates["is_main"] = _is_main_payload(self._schema, bool(updates["is_main"]))
         self._t().update(updates).eq("id", thread_id).execute()
 
     def delete(self, thread_id: str) -> None:
         self._t().delete().eq("id", thread_id).execute()
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return self._client.schema(_SCHEMA).table(_TABLE)
 
     @property
     def _thread_member_column(self) -> str:
-        return _thread_member_column(self._schema)
+        resolve_runtime_schema(self._schema)
+        return _THREAD_MEMBER_COLUMN

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -14,6 +14,7 @@ _TABLE = "threads"
 _THREAD_MEMBER_COLUMN = "agent_user_id"
 _BASE_COLS = (
     "id",
+    "owner_user_id",
     "sandbox_type",
     "model",
     "cwd",

--- a/storage/providers/supabase/tool_task_repo.py
+++ b/storage/providers/supabase/tool_task_repo.py
@@ -7,20 +7,23 @@ from typing import Any
 
 from core.tools.task.types import Task, TaskStatus
 from storage.providers.supabase import _query as q
+from storage.providers.supabase.schema import resolve_runtime_schema
 
 _REPO = "tool_task repo"
-_TABLE = "tool_tasks"
+_SCHEMA = "agent"
+_TABLE = "thread_tasks"
 
 
 class SupabaseToolTaskRepo:
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, *, schema: str | None = None) -> None:
         self._client = q.validate_client(client, _REPO)
+        self._schema = resolve_runtime_schema(schema)
 
     def close(self) -> None:
         return None
 
     def _table(self) -> Any:
-        return self._client.table(_TABLE)
+        return self._client.schema(_SCHEMA).table(_TABLE)
 
     def next_id(self, thread_id: str) -> str:
         rows = q.rows(

--- a/tests/fakes/supabase.py
+++ b/tests/fakes/supabase.py
@@ -170,3 +170,20 @@ class FakeSupabaseClient:
         if table_name in self._auto_seq_tables:
             query._auto_seq = True
         return query
+
+    def schema(self, schema_name: str) -> FakeSupabaseSchemaClient:
+        return FakeSupabaseSchemaClient(schema_name, self._tables, self._auto_seq_tables)
+
+
+class FakeSupabaseSchemaClient:
+    def __init__(self, schema_name: str, tables: dict[str, list[dict]], auto_seq_tables: set[str]):
+        self._schema_name = schema_name
+        self._tables = tables
+        self._auto_seq_tables = auto_seq_tables
+
+    def table(self, table_name: str) -> FakeSupabaseQuery:
+        qualified = f"{self._schema_name}.{table_name}"
+        query = FakeSupabaseQuery(qualified, self._tables)
+        if qualified in self._auto_seq_tables:
+            query._auto_seq = True
+        return query

--- a/tests/fakes/supabase.py
+++ b/tests/fakes/supabase.py
@@ -26,7 +26,7 @@ class FakeSupabaseQuery:
         self._delete_requested = False
         self._auto_seq = False
 
-    def select(self, _columns: str):
+    def select(self, _columns: str, **_kwargs: object):
         return self
 
     def insert(self, payload: dict | list[dict]):

--- a/tests/fakes/supabase.py
+++ b/tests/fakes/supabase.py
@@ -33,7 +33,7 @@ class FakeSupabaseQuery:
         self._insert_payload = payload if isinstance(payload, list) else dict(payload)
         return self
 
-    def upsert(self, payload: dict, *, on_conflict: str = ""):
+    def upsert(self, payload: dict, *, on_conflict: str = "", ignore_duplicates: bool = False):
         self._upsert_payload = dict(payload)
         self._upsert_conflict = on_conflict
         return self
@@ -109,9 +109,8 @@ class FakeSupabaseQuery:
 
         # UPSERT
         if self._upsert_payload is not None:
-            conflict_col = self._upsert_conflict or "id"
-            conflict_val = self._upsert_payload.get(conflict_col)
-            existing = [r for r in table if r.get(conflict_col) == conflict_val]
+            conflict_cols = [col.strip() for col in (self._upsert_conflict or "id").split(",") if col.strip()]
+            existing = [r for r in table if all(r.get(col) == self._upsert_payload.get(col) for col in conflict_cols)]
             if existing:
                 existing[0].update(self._upsert_payload)
                 return FakeSupabaseResponse([dict(existing[0])])

--- a/tests/test_chat_service_schema_contract.py
+++ b/tests/test_chat_service_schema_contract.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from backend.web.services.chat_service import ChatService
+from storage.contracts import ChatRow
+
+
+class CapturingChatRepo:
+    def __init__(self) -> None:
+        self.created: list[ChatRow] = []
+
+    def create(self, row: ChatRow) -> None:
+        self.created.append(row)
+
+    def get_by_id(self, chat_id: str) -> ChatRow | None:
+        return next((row for row in self.created if row.id == chat_id), None)
+
+
+class EmptyChatEntityRepo:
+    def __init__(self) -> None:
+        self.participants: list[tuple[str, str]] = []
+
+    def find_chat_between(self, user_a: str, user_b: str) -> str | None:
+        return None
+
+    def add_participant(self, chat_id: str, user_id: str, joined_at: float) -> None:
+        self.participants.append((chat_id, user_id))
+
+
+class EmptyMessageRepo:
+    pass
+
+
+class EmptyEntityRepo:
+    pass
+
+
+class EmptyMemberRepo:
+    pass
+
+
+def test_chat_service_sets_direct_chat_type_and_creator() -> None:
+    chats = CapturingChatRepo()
+    service = ChatService(chats, EmptyChatEntityRepo(), EmptyMessageRepo(), EmptyEntityRepo(), EmptyMemberRepo())
+
+    service.find_or_create_chat(["human_1", "agent_1"], created_by_user_id="human_1")
+
+    assert chats.created[0].type == "direct"
+    assert chats.created[0].created_by_user_id == "human_1"
+
+
+def test_chat_service_sets_group_chat_type_and_creator() -> None:
+    chats = CapturingChatRepo()
+    service = ChatService(chats, EmptyChatEntityRepo(), EmptyMessageRepo(), EmptyEntityRepo(), EmptyMemberRepo())
+
+    service.create_group_chat(["human_1", "agent_1", "agent_2"], "group", created_by_user_id="human_1")
+
+    assert chats.created[0].type == "group"
+    assert chats.created[0].created_by_user_id == "human_1"

--- a/tests/test_lifespan_supabase_wiring.py
+++ b/tests/test_lifespan_supabase_wiring.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.web.core.lifespan import _wire_supabase_runtime
+
+
+class _FakeSupabaseClient:
+    def table(self, table_name: str):
+        raise AssertionError(f"table() should not be called in wiring test: {table_name}")
+
+    def schema(self, schema_name: str):
+        raise AssertionError(f"schema() should not be called in wiring test: {schema_name}")
+
+
+def test_supabase_storage_repos_do_not_share_auth_client(monkeypatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    storage_client = _FakeSupabaseClient()
+    auth_client = _FakeSupabaseClient()
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    _wire_supabase_runtime(app, storage_client=storage_client, auth_client=auth_client)
+
+    assert app.state.thread_repo._client is storage_client
+    assert app.state.member_repo._client is storage_client
+    assert app.state.auth_service._sb is auth_client
+    assert app.state.auth_service._sb is not app.state.thread_repo._client

--- a/tests/test_message_routing_schedule_start_only.py
+++ b/tests/test_message_routing_schedule_start_only.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from backend.web.services import agent_pool, message_routing, streaming_service
+from core.runtime.middleware.monitor import AgentState
+
+
+class FakeRuntime:
+    def __init__(self, state=AgentState.ACTIVE) -> None:
+        self.current_state = state
+
+    def transition(self, state) -> bool:
+        if self.current_state == AgentState.ACTIVE:
+            return False
+        self.current_state = state
+        return True
+
+
+class FakeQueueManager:
+    def __init__(self) -> None:
+        self.enqueued: list[dict] = []
+
+    def enqueue(self, content: str, thread_id: str, notification_type: str, **fields) -> None:
+        self.enqueued.append({"content": content, "thread_id": thread_id, "notification_type": notification_type, **fields})
+
+
+@pytest.mark.asyncio
+async def test_require_new_run_rejects_active_thread_without_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = SimpleNamespace(state=SimpleNamespace(queue_manager=FakeQueueManager()))
+    agent = SimpleNamespace(runtime=FakeRuntime())
+
+    async def fake_get_or_create_agent(_app, _sandbox_type, *, thread_id: str):
+        assert thread_id == "thread_1"
+        return agent
+
+    monkeypatch.setattr(agent_pool, "resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr(agent_pool, "get_or_create_agent", fake_get_or_create_agent)
+
+    with pytest.raises(message_routing.TargetThreadActiveError):
+        await message_routing.route_message_to_brain(
+            app,
+            "thread_1",
+            "scheduled work",
+            source="schedule",
+            require_new_run=True,
+        )
+
+    assert app.state.queue_manager.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_direct_start_merges_extra_message_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            queue_manager=FakeQueueManager(),
+            thread_locks={},
+            thread_locks_guard=asyncio.Lock(),
+        )
+    )
+    agent = SimpleNamespace(runtime=FakeRuntime(AgentState.IDLE))
+    started: dict = {}
+
+    async def fake_get_or_create_agent(_app, _sandbox_type, *, thread_id: str):
+        assert thread_id == "thread_1"
+        return agent
+
+    def fake_start_agent_run(_agent, thread_id: str, content: str, _app, message_metadata: dict):
+        started.update({"thread_id": thread_id, "content": content, "message_metadata": message_metadata})
+        return "runtime_run_1"
+
+    monkeypatch.setattr(agent_pool, "resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr(agent_pool, "get_or_create_agent", fake_get_or_create_agent)
+    monkeypatch.setattr(streaming_service, "start_agent_run", fake_start_agent_run)
+
+    result = await message_routing.route_message_to_brain(
+        app,
+        "thread_1",
+        "scheduled work",
+        source="schedule",
+        require_new_run=True,
+        extra_message_metadata={"schedule_run_id": "schedule_run_1"},
+    )
+
+    assert result == {"status": "started", "routing": "direct", "run_id": "runtime_run_1", "thread_id": "thread_1"}
+    assert started["message_metadata"] == {
+        "source": "schedule",
+        "sender_name": None,
+        "sender_avatar_url": None,
+        "schedule_run_id": "schedule_run_1",
+    }

--- a/tests/test_schedule_run_completion_service.py
+++ b/tests/test_schedule_run_completion_service.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.web.services import schedule_run_completion_service
+
+
+class FakeScheduleService:
+    def __init__(self) -> None:
+        self.runs = {
+            "schedule_run_1": {
+                "id": "schedule_run_1",
+                "status": "running",
+                "output_json": {"routing": {"run_id": "runtime_run_1"}},
+            }
+        }
+        self.updates: list[tuple[str, dict]] = []
+
+    def get_schedule_run(self, run_id: str) -> dict | None:
+        return self.runs.get(run_id)
+
+    def update_schedule_run(self, run_id: str, **fields) -> dict | None:
+        self.updates.append((run_id, fields))
+        self.runs[run_id].update(fields)
+        return self.runs[run_id]
+
+
+def test_complete_schedule_run_marks_success_and_preserves_routing_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = FakeScheduleService()
+    monkeypatch.setattr(schedule_run_completion_service, "schedule_service", service)
+
+    schedule_run_completion_service.complete_schedule_run_from_runtime(
+        "schedule_run_1",
+        source="schedule",
+        status="succeeded",
+        runtime_run_id="runtime_run_1",
+        thread_id="thread_1",
+    )
+
+    assert service.updates[0][0] == "schedule_run_1"
+    fields = service.updates[0][1]
+    assert fields["status"] == "succeeded"
+    assert "completed_at" in fields
+    assert fields["error"] is None
+    assert fields["output_json"] == {
+        "routing": {"run_id": "runtime_run_1"},
+        "runtime": {"run_id": "runtime_run_1", "thread_id": "thread_1", "status": "succeeded"},
+    }
+
+
+def test_schedule_source_without_schedule_run_id_fails_loudly() -> None:
+    with pytest.raises(RuntimeError, match="schedule_run_id"):
+        schedule_run_completion_service.complete_schedule_run_from_runtime(
+            None,
+            source="schedule",
+            status="succeeded",
+            runtime_run_id="runtime_run_1",
+            thread_id="thread_1",
+        )
+
+
+def test_non_schedule_run_without_schedule_run_id_noops(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = FakeScheduleService()
+    monkeypatch.setattr(schedule_run_completion_service, "schedule_service", service)
+
+    schedule_run_completion_service.complete_schedule_run_from_runtime(
+        None,
+        source="owner",
+        status="succeeded",
+        runtime_run_id="runtime_run_1",
+        thread_id="thread_1",
+    )
+
+    assert service.updates == []

--- a/tests/test_schedule_run_completion_streaming.py
+++ b/tests/test_schedule_run_completion_streaming.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from backend.web.services import streaming_service
+from backend.web.services.event_buffer import ThreadEventBuffer
+from core.runtime.middleware.monitor import AgentState
+
+
+class FakeGraphAgent:
+    checkpointer = None
+
+    async def aget_state(self, _config):
+        return SimpleNamespace(values={})
+
+    async def astream(self, *_args, **_kwargs):
+        if False:  # pragma: no cover
+            yield None
+
+
+class FakeRuntime:
+    current_state = AgentState.ACTIVE
+
+    state = SimpleNamespace(flags=SimpleNamespace(is_compacting=False))
+
+    def set_event_callback(self, _callback) -> None:
+        return None
+
+    def get_status_dict(self) -> dict[str, Any]:
+        return {}
+
+    def transition(self, state) -> bool:
+        self.current_state = state
+        return True
+
+
+class FakeAgent:
+    def __init__(self) -> None:
+        self.agent = FakeGraphAgent()
+        self.runtime = FakeRuntime()
+        self.storage_container = None
+
+
+class FakeQueueManager:
+    def dequeue(self, _thread_id: str):
+        return None
+
+
+class FakeDisplayBuilder:
+    def apply_event(self, *_args, **_kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_boundary_marks_schedule_run_succeeded(monkeypatch: pytest.MonkeyPatch) -> None:
+    completions: list[dict] = []
+
+    def fake_complete_schedule_run_from_runtime(schedule_run_id: str | None, **fields) -> None:
+        completions.append({"schedule_run_id": schedule_run_id, **fields})
+
+    async def fake_cleanup_old_runs(*_args, **_kwargs) -> int:
+        return 0
+
+    monkeypatch.setattr(
+        streaming_service.schedule_run_completion_service, "complete_schedule_run_from_runtime", fake_complete_schedule_run_from_runtime
+    )
+    monkeypatch.setattr(streaming_service, "cleanup_old_runs", fake_cleanup_old_runs)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            display_builder=FakeDisplayBuilder(),
+            thread_last_active={},
+            thread_tasks={},
+            queue_manager=FakeQueueManager(),
+        )
+    )
+
+    await streaming_service._run_agent_to_buffer(
+        FakeAgent(),
+        "thread_1",
+        "scheduled work",
+        app,
+        False,
+        ThreadEventBuffer(),
+        "runtime_run_1",
+        {"source": "schedule", "schedule_run_id": "schedule_run_1"},
+    )
+
+    assert completions == [
+        {
+            "schedule_run_id": "schedule_run_1",
+            "source": "schedule",
+            "status": "succeeded",
+            "runtime_run_id": "runtime_run_1",
+            "thread_id": "thread_1",
+            "error": None,
+        }
+    ]

--- a/tests/test_schedule_runtime_service.py
+++ b/tests/test_schedule_runtime_service.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.web.services import schedule_runtime_service
+
+
+class FakeThreadRepo:
+    def __init__(self, rows: dict[str, dict]) -> None:
+        self._rows = rows
+
+    def get_by_id(self, thread_id: str) -> dict | None:
+        return self._rows.get(thread_id)
+
+
+class FakeScheduleStore:
+    def __init__(self, schedule: dict) -> None:
+        self.schedule = schedule
+        self.runs: list[dict] = []
+        self.updated_runs: list[tuple[str, dict]] = []
+        self.updated_schedules: list[tuple[str, dict]] = []
+
+    def get_schedule(self, schedule_id: str) -> dict | None:
+        return self.schedule if self.schedule["id"] == schedule_id else None
+
+    def create_schedule_run(self, **fields) -> dict:
+        run = {"id": "run_1", "status": "queued", **fields}
+        self.runs.append(run)
+        return run
+
+    def update_schedule_run(self, run_id: str, **fields) -> dict | None:
+        self.updated_runs.append((run_id, fields))
+        run = next((item for item in self.runs if item["id"] == run_id), None)
+        if run is None:
+            return None
+        run.update(fields)
+        return run
+
+    def update_schedule(self, schedule_id: str, **fields) -> dict | None:
+        self.updated_schedules.append((schedule_id, fields))
+        self.schedule.update(fields)
+        return self.schedule
+
+
+@pytest.mark.asyncio
+async def test_trigger_schedule_routes_target_thread_and_marks_run_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = FakeScheduleStore(
+        {
+            "id": "schedule_1",
+            "owner_user_id": "owner_1",
+            "agent_user_id": "agent_1",
+            "target_thread_id": "thread_1",
+            "create_thread_on_run": False,
+            "enabled": True,
+            "instruction_template": "Summarize today.",
+        }
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(thread_repo=FakeThreadRepo({"thread_1": {"owner_user_id": "owner_1", "member_id": "agent_1"}}))
+    )
+    routed: dict[str, str] = {}
+
+    async def fake_route_message_to_brain(_app, thread_id: str, content: str, source: str):
+        routed.update({"thread_id": thread_id, "content": content, "source": source})
+        return {"status": "started", "routing": "direct", "run_id": "agent_run_1", "thread_id": thread_id}
+
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "get_schedule", store.get_schedule)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "create_schedule_run", store.create_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "update_schedule_run", store.update_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "update_schedule", store.update_schedule)
+    monkeypatch.setattr(schedule_runtime_service, "route_message_to_brain", fake_route_message_to_brain)
+
+    result = await schedule_runtime_service.trigger_schedule(app, "schedule_1", owner_user_id="owner_1")
+
+    assert routed["thread_id"] == "thread_1"
+    assert routed["source"] == "schedule"
+    assert "Schedule ID: schedule_1" in routed["content"]
+    assert "Schedule Run ID: run_1" in routed["content"]
+    assert "Summarize today." in routed["content"]
+    assert result["schedule_run"]["status"] == "running"
+    assert result["routing"]["status"] == "started"
+    assert store.runs[0]["status"] == "running"
+    assert store.updated_runs[-1][1]["status"] == "running"
+    assert store.updated_runs[-1][1]["thread_id"] == "thread_1"
+    assert store.updated_schedules[-1][0] == "schedule_1"
+    assert "last_run_at" in store.updated_schedules[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_trigger_schedule_rejects_create_thread_on_run_without_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = FakeScheduleStore(
+        {
+            "id": "schedule_1",
+            "owner_user_id": "owner_1",
+            "agent_user_id": "agent_1",
+            "target_thread_id": None,
+            "create_thread_on_run": True,
+            "enabled": True,
+            "instruction_template": "Work.",
+        }
+    )
+    app = SimpleNamespace(state=SimpleNamespace(thread_repo=FakeThreadRepo({})))
+    route_called = False
+
+    async def fake_route_message_to_brain(*_args, **_kwargs):
+        nonlocal route_called
+        route_called = True
+        return {}
+
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "get_schedule", store.get_schedule)
+    monkeypatch.setattr(schedule_runtime_service, "route_message_to_brain", fake_route_message_to_brain)
+
+    with pytest.raises(ValueError, match="target_thread_id"):
+        await schedule_runtime_service.trigger_schedule(app, "schedule_1", owner_user_id="owner_1")
+
+    assert route_called is False
+    assert store.runs == []
+
+
+@pytest.mark.asyncio
+async def test_trigger_schedule_marks_run_failed_when_routing_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = FakeScheduleStore(
+        {
+            "id": "schedule_1",
+            "owner_user_id": "owner_1",
+            "agent_user_id": "agent_1",
+            "target_thread_id": "thread_1",
+            "create_thread_on_run": False,
+            "enabled": True,
+            "instruction_template": "Work.",
+        }
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(thread_repo=FakeThreadRepo({"thread_1": {"owner_user_id": "owner_1", "member_id": "agent_1"}}))
+    )
+
+    async def fake_route_message_to_brain(*_args, **_kwargs):
+        raise RuntimeError("route failed")
+
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "get_schedule", store.get_schedule)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "create_schedule_run", store.create_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "update_schedule_run", store.update_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service, "route_message_to_brain", fake_route_message_to_brain)
+
+    with pytest.raises(RuntimeError, match="route failed"):
+        await schedule_runtime_service.trigger_schedule(app, "schedule_1", owner_user_id="owner_1")
+
+    assert store.updated_runs[-1][1]["status"] == "failed"
+    assert store.updated_runs[-1][1]["error"] == "route failed"
+    assert "completed_at" in store.updated_runs[-1][1]

--- a/tests/test_schedule_runtime_service.py
+++ b/tests/test_schedule_runtime_service.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from backend.web.services import schedule_runtime_service
+from core.runtime.middleware.monitor import AgentState
 
 
 class FakeThreadRepo:
@@ -62,8 +63,8 @@ async def test_trigger_schedule_routes_target_thread_and_marks_run_running(monke
     )
     routed: dict[str, str] = {}
 
-    async def fake_route_message_to_brain(_app, thread_id: str, content: str, source: str):
-        routed.update({"thread_id": thread_id, "content": content, "source": source})
+    async def fake_route_message_to_brain(_app, thread_id: str, content: str, source: str, **kwargs):
+        routed.update({"thread_id": thread_id, "content": content, "source": source, **kwargs})
         return {"status": "started", "routing": "direct", "run_id": "agent_run_1", "thread_id": thread_id}
 
     monkeypatch.setattr(schedule_runtime_service.schedule_service, "get_schedule", store.get_schedule)
@@ -76,6 +77,8 @@ async def test_trigger_schedule_routes_target_thread_and_marks_run_running(monke
 
     assert routed["thread_id"] == "thread_1"
     assert routed["source"] == "schedule"
+    assert routed["require_new_run"] is True
+    assert routed["extra_message_metadata"] == {"schedule_run_id": "run_1"}
     assert "Schedule ID: schedule_1" in routed["content"]
     assert "Schedule Run ID: run_1" in routed["content"]
     assert "Summarize today." in routed["content"]
@@ -150,3 +153,94 @@ async def test_trigger_schedule_marks_run_failed_when_routing_fails(monkeypatch:
     assert store.updated_runs[-1][1]["status"] == "failed"
     assert store.updated_runs[-1][1]["error"] == "route failed"
     assert "completed_at" in store.updated_runs[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_trigger_schedule_rejects_active_target_before_creating_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = FakeScheduleStore(
+        {
+            "id": "schedule_1",
+            "owner_user_id": "owner_1",
+            "agent_user_id": "agent_1",
+            "target_thread_id": "thread_1",
+            "create_thread_on_run": False,
+            "enabled": True,
+            "instruction_template": "Work.",
+        }
+    )
+    active_runtime = SimpleNamespace(current_state=AgentState.ACTIVE)
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=FakeThreadRepo(
+                {
+                    "thread_1": {
+                        "owner_user_id": "owner_1",
+                        "member_id": "agent_1",
+                        "sandbox_type": "local",
+                    }
+                }
+            ),
+            agent_pool={"thread_1:local": SimpleNamespace(runtime=active_runtime)},
+        )
+    )
+    route_called = False
+
+    async def fake_route_message_to_brain(*_args, **_kwargs):
+        nonlocal route_called
+        route_called = True
+        return {}
+
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "get_schedule", store.get_schedule)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "create_schedule_run", store.create_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service, "route_message_to_brain", fake_route_message_to_brain)
+
+    with pytest.raises(schedule_runtime_service.TargetThreadBusyError):
+        await schedule_runtime_service.trigger_schedule(app, "schedule_1", owner_user_id="owner_1")
+
+    assert route_called is False
+    assert store.runs == []
+
+
+@pytest.mark.asyncio
+async def test_trigger_schedule_passes_schedule_run_id_as_structured_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = FakeScheduleStore(
+        {
+            "id": "schedule_1",
+            "owner_user_id": "owner_1",
+            "agent_user_id": "agent_1",
+            "target_thread_id": "thread_1",
+            "create_thread_on_run": False,
+            "enabled": True,
+            "instruction_template": "Work.",
+        }
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=FakeThreadRepo(
+                {
+                    "thread_1": {
+                        "owner_user_id": "owner_1",
+                        "member_id": "agent_1",
+                        "sandbox_type": "local",
+                    }
+                }
+            ),
+            agent_pool={},
+        )
+    )
+    route_kwargs: dict = {}
+
+    async def fake_route_message_to_brain(*_args, **kwargs):
+        route_kwargs.update(kwargs)
+        return {"status": "started", "routing": "direct", "run_id": "runtime_run_1", "thread_id": "thread_1"}
+
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "get_schedule", store.get_schedule)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "create_schedule_run", store.create_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "update_schedule_run", store.update_schedule_run)
+    monkeypatch.setattr(schedule_runtime_service.schedule_service, "update_schedule", store.update_schedule)
+    monkeypatch.setattr(schedule_runtime_service, "route_message_to_brain", fake_route_message_to_brain)
+
+    await schedule_runtime_service.trigger_schedule(app, "schedule_1", owner_user_id="owner_1")
+
+    assert route_kwargs["require_new_run"] is True
+    assert route_kwargs["extra_message_metadata"] == {"schedule_run_id": "run_1"}

--- a/tests/test_schedule_service_schema_contract.py
+++ b/tests/test_schedule_service_schema_contract.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.web.services import schedule_service
+
+
+class FakeScheduleRepo:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+        self.runs: list[dict] = []
+
+    def close(self) -> None:
+        return None
+
+    def list_by_owner(self, owner_user_id: str) -> list[dict]:
+        return [row for row in self.created if row["owner_user_id"] == owner_user_id]
+
+    def get(self, schedule_id: str) -> dict | None:
+        return next((row for row in self.created if row["id"] == schedule_id), None)
+
+    def create(self, **fields):
+        row = {"id": "schedule_1", **fields}
+        self.created.append(row)
+        return row
+
+    def update(self, schedule_id: str, **fields):
+        row = self.get(schedule_id)
+        if row is None:
+            return None
+        row.update(fields)
+        return row
+
+    def delete(self, schedule_id: str) -> bool:
+        before = len(self.created)
+        self.created = [row for row in self.created if row["id"] != schedule_id]
+        return len(self.created) < before
+
+    def create_run(self, **fields):
+        row = {"id": "run_1", **fields}
+        self.runs.append(row)
+        return row
+
+    def list_runs(self, schedule_id: str) -> list[dict]:
+        return [row for row in self.runs if row["schedule_id"] == schedule_id]
+
+    def update_run(self, run_id: str, **fields):
+        row = next((item for item in self.runs if item["id"] == run_id), None)
+        if row is None:
+            return None
+        row.update(fields)
+        return row
+
+
+def test_schedule_service_requires_target_thread_or_create_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", lambda: FakeScheduleRepo())
+
+    with pytest.raises(ValueError, match="target"):
+        schedule_service.create_schedule(
+            owner_user_id="owner_1",
+            agent_user_id="agent_1",
+            cron_expression="*/15 * * * *",
+            instruction_template="work",
+        )
+
+
+def test_schedule_service_creates_valid_schedule(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = FakeScheduleRepo()
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", lambda: repo)
+
+    created = schedule_service.create_schedule(
+        owner_user_id="owner_1",
+        agent_user_id="agent_1",
+        cron_expression="*/15 * * * *",
+        instruction_template="work",
+        create_thread_on_run=True,
+    )
+
+    assert created["id"] == "schedule_1"
+    assert repo.created[0]["owner_user_id"] == "owner_1"
+
+
+def test_schedule_service_validates_run_trigger_and_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = FakeScheduleRepo()
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", lambda: repo)
+
+    with pytest.raises(ValueError, match="triggered_by"):
+        schedule_service.create_schedule_run(
+            schedule_id="schedule_1",
+            owner_user_id="owner_1",
+            agent_user_id="agent_1",
+            triggered_by="button",
+        )
+
+    run = schedule_service.create_schedule_run(
+        schedule_id="schedule_1",
+        owner_user_id="owner_1",
+        agent_user_id="agent_1",
+        triggered_by="manual",
+    )
+
+    with pytest.raises(ValueError, match="status"):
+        schedule_service.update_schedule_run(run["id"], status="done")

--- a/tests/test_schedules_router.py
+++ b/tests/test_schedules_router.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.web.core.dependencies import get_current_user_id
+from backend.web.routers import schedules
+
+
+def test_run_schedule_endpoint_calls_runtime_with_authenticated_user(monkeypatch) -> None:
+    app = FastAPI()
+    app.state.marker = "app-state"
+    app.include_router(schedules.router)
+    app.dependency_overrides[get_current_user_id] = lambda: "owner_1"
+    calls: list[dict] = []
+
+    async def fake_trigger_schedule(app_obj, schedule_id: str, *, owner_user_id: str, triggered_by: str):
+        calls.append(
+            {
+                "app_marker": app_obj.state.marker,
+                "schedule_id": schedule_id,
+                "owner_user_id": owner_user_id,
+                "triggered_by": triggered_by,
+            }
+        )
+        return {"schedule_run": {"id": "run_1", "status": "running"}, "routing": {"status": "started"}}
+
+    monkeypatch.setattr(schedules.schedule_runtime_service, "trigger_schedule", fake_trigger_schedule)
+
+    response = TestClient(app).post("/api/schedules/schedule_1/run")
+
+    assert response.status_code == 200
+    assert response.json()["item"]["schedule_run"]["id"] == "run_1"
+    assert calls == [
+        {
+            "app_marker": "app-state",
+            "schedule_id": "schedule_1",
+            "owner_user_id": "owner_1",
+            "triggered_by": "manual",
+        }
+    ]

--- a/tests/test_supabase_chat_repo_schema.py
+++ b/tests/test_supabase_chat_repo_schema.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from storage.contracts import ChatMessageRow, ChatRow
+from storage.providers.supabase.chat_repo import SupabaseChatEntityRepo, SupabaseChatMessageRepo, SupabaseChatRepo
+from tests.fakes.supabase import FakeSupabaseClient, FakeSupabaseResponse
+
+
+class FakeRpc:
+    def __init__(self, value: int):
+        self._value = value
+
+    def execute(self) -> FakeSupabaseResponse:
+        return FakeSupabaseResponse([{"value": self._value}])
+
+
+class ChatFakeSupabaseClient(FakeSupabaseClient):
+    def __init__(self, tables: dict[str, list[dict]] | None = None):
+        super().__init__(tables=tables)
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def rpc(self, name: str, params: dict):
+        self.rpc_calls.append((name, dict(params)))
+        chat_id = params["p_chat_id"]
+        messages = self._tables.setdefault("messages", [])
+        next_seq = 1 + max((int(row.get("seq", 0)) for row in messages if row.get("chat_id") == chat_id), default=0)
+        return FakeRpc(next_seq)
+
+
+def test_chat_repo_creates_staging_chat_with_type_and_creator(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseChatRepo(ChatFakeSupabaseClient(tables))
+
+    repo.create(
+        ChatRow(
+            id="chat_1",
+            title="direct",
+            type="direct",
+            created_by_user_id="owner_1",
+            created_at=1.0,
+        )
+    )
+
+    assert tables["chats"] == [
+        {
+            "id": "chat_1",
+            "type": "direct",
+            "title": "direct",
+            "status": "active",
+            "created_by_user_id": "owner_1",
+            "created_at": 1.0,
+            "updated_at": None,
+        }
+    ]
+
+
+def test_chat_member_repo_uses_staging_chat_members(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {
+        "messages": [
+            {"chat_id": "chat_1", "seq": 7},
+        ]
+    }
+    repo = SupabaseChatEntityRepo(ChatFakeSupabaseClient(tables))
+
+    repo.add_participant("chat_1", "user_1", 1.0)
+    repo.update_last_read("chat_1", "user_1", 9999999999.0)
+
+    assert tables["chat_members"] == [
+        {
+            "chat_id": "chat_1",
+            "user_id": "user_1",
+            "joined_at": 1.0,
+            "last_read_seq": 7,
+        }
+    ]
+    assert repo.list_chats_for_user("user_1") == ["chat_1"]
+    assert repo.is_participant_in_chat("chat_1", "user_1") is True
+
+
+def test_chat_repos_keep_public_legacy_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "public")
+    tables: dict[str, list[dict]] = {
+        "chat_entities": [
+            {
+                "chat_id": "chat_1",
+                "user_id": "user_1",
+                "joined_at": 1.0,
+            }
+        ],
+        "chat_messages": [
+            {
+                "id": "msg_1",
+                "chat_id": "chat_1",
+                "sender_id": "agent_1",
+                "content": "hello",
+                "mentions": json.dumps(["user_1"]),
+                "created_at": 2.0,
+            }
+        ],
+    }
+    client = ChatFakeSupabaseClient(tables)
+
+    assert SupabaseChatEntityRepo(client).list_chats_for_user("user_1") == ["chat_1"]
+    assert [message.id for message in SupabaseChatMessageRepo(client).list_by_chat("chat_1")] == ["msg_1"]
+
+
+def test_chat_message_repo_uses_staging_messages_and_seq_rpc(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    client = ChatFakeSupabaseClient(tables)
+    repo = SupabaseChatMessageRepo(client)
+
+    repo.create(
+        ChatMessageRow(
+            id="msg_1",
+            chat_id="chat_1",
+            sender_id="agent_1",
+            content="hello",
+            mentioned_ids=["human_1"],
+            created_at=2.0,
+        )
+    )
+
+    assert client.rpc_calls == [("increment_chat_message_seq", {"p_chat_id": "chat_1"})]
+    assert tables["messages"] == [
+        {
+            "id": "msg_1",
+            "chat_id": "chat_1",
+            "seq": 1,
+            "sender_user_id": "agent_1",
+            "content": "hello",
+            "mentions_json": ["human_1"],
+            "created_at": 2.0,
+        }
+    ]
+
+    messages = repo.list_by_chat("chat_1")
+    assert [(message.sender_id, message.mentioned_ids) for message in messages] == [("agent_1", ["human_1"])]
+
+
+def test_chat_message_repo_counts_unread_by_last_read_seq(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    repo = SupabaseChatMessageRepo(
+        ChatFakeSupabaseClient(
+            {
+                "chat_members": [
+                    {
+                        "chat_id": "chat_1",
+                        "user_id": "human_1",
+                        "last_read_seq": 1,
+                    }
+                ],
+                "messages": [
+                    {
+                        "id": "msg_1",
+                        "chat_id": "chat_1",
+                        "seq": 1,
+                        "sender_user_id": "agent_1",
+                        "content": "old",
+                        "mentions_json": json.dumps(["human_1"]),
+                        "created_at": 1.0,
+                    },
+                    {
+                        "id": "msg_2",
+                        "chat_id": "chat_1",
+                        "seq": 2,
+                        "sender_user_id": "agent_1",
+                        "content": "new mention",
+                        "mentions_json": json.dumps(["human_1"]),
+                        "created_at": 2.0,
+                    },
+                    {
+                        "id": "msg_3",
+                        "chat_id": "chat_1",
+                        "seq": 3,
+                        "sender_user_id": "human_1",
+                        "content": "own",
+                        "mentions_json": json.dumps([]),
+                        "created_at": 3.0,
+                    },
+                ],
+            }
+        )
+    )
+
+    assert repo.count_unread("chat_1", "human_1") == 1
+    assert [message.id for message in repo.list_unread("chat_1", "human_1")] == ["msg_2"]
+    assert repo.has_unread_mention("chat_1", "human_1") is True

--- a/tests/test_supabase_entity_repo_schema.py
+++ b/tests/test_supabase_entity_repo_schema.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from storage.providers.supabase.entity_repo import SupabaseEntityRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+class NoEntitiesFakeSupabaseClient(FakeSupabaseClient):
+    def table(self, table_name: str):
+        if table_name == "entities":
+            raise AssertionError("SupabaseEntityRepo must not query a missing entities table")
+        return super().table(table_name)
+
+
+def test_entity_repo_derives_human_actor_from_staging_users(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = NoEntitiesFakeSupabaseClient(
+        tables={
+            "users": [
+                {
+                    "id": "human_1",
+                    "type": "human",
+                    "display_name": "Ada",
+                    "avatar": "avatar.png",
+                    "created_at": 1.0,
+                    "next_thread_seq": 0,
+                }
+            ]
+        }
+    )
+
+    row = SupabaseEntityRepo(client).get_by_id("human_1")
+
+    assert row is not None
+    assert row.id == "human_1"
+    assert row.type == "human"
+    assert row.member_id == "human_1"
+    assert row.name == "Ada"
+    assert row.avatar == "avatar.png"
+    assert row.thread_id is None
+
+
+def test_entity_repo_derives_agent_actor_with_main_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = NoEntitiesFakeSupabaseClient(
+        tables={
+            "users": [
+                {
+                    "id": "agent_1",
+                    "type": "agent",
+                    "display_name": "Builder",
+                    "owner_user_id": "human_1",
+                    "created_at": 1.0,
+                    "next_thread_seq": 0,
+                }
+            ],
+            "agent.threads": [
+                {
+                    "id": "thread_main",
+                    "agent_user_id": "agent_1",
+                    "owner_user_id": "human_1",
+                    "sandbox_type": "local",
+                    "model": "large",
+                    "cwd": "/work",
+                    "is_main": True,
+                    "branch_index": 0,
+                    "created_at": "2026-04-14T00:00:00+00:00",
+                }
+            ],
+        }
+    )
+
+    row = SupabaseEntityRepo(client).get_by_id("agent_1")
+
+    assert row is not None
+    assert row.id == "agent_1"
+    assert row.type == "agent"
+    assert row.member_id == "agent_1"
+    assert row.name == "Builder"
+    assert row.thread_id == "thread_main"
+
+
+def test_entity_repo_lists_agent_actors_without_entities_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = NoEntitiesFakeSupabaseClient(
+        tables={
+            "users": [
+                {
+                    "id": "human_1",
+                    "type": "human",
+                    "display_name": "Ada",
+                    "created_at": 1.0,
+                    "next_thread_seq": 0,
+                },
+                {
+                    "id": "agent_1",
+                    "type": "agent",
+                    "display_name": "Builder",
+                    "owner_user_id": "human_1",
+                    "created_at": 2.0,
+                    "next_thread_seq": 0,
+                },
+            ],
+            "agent.threads": [],
+        }
+    )
+
+    rows = SupabaseEntityRepo(client).list_by_type("agent")
+
+    assert [(row.id, row.type, row.name, row.thread_id) for row in rows] == [("agent_1", "agent", "Builder", None)]
+
+
+def test_entity_repo_writes_are_read_model_noops(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables = {
+        "users": [
+            {
+                "id": "agent_1",
+                "type": "agent",
+                "display_name": "Builder",
+                "owner_user_id": "human_1",
+                "created_at": 1.0,
+                "next_thread_seq": 0,
+            }
+        ],
+        "agent.threads": [],
+    }
+    repo = SupabaseEntityRepo(NoEntitiesFakeSupabaseClient(tables=tables))
+    row = repo.get_by_id("agent_1")
+    assert row is not None
+
+    repo.create(row)
+    repo.update("agent_1", thread_id="thread_main", name="Builder")
+    repo.delete("agent_1")
+
+    assert "entities" not in tables

--- a/tests/test_supabase_factory.py
+++ b/tests/test_supabase_factory.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.web.core import supabase_factory
+
+
+def _set_required_supabase_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUPABASE_INTERNAL_URL", "https://supabase.example.test")
+    monkeypatch.setenv("LEON_SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
+
+
+def test_create_supabase_client_requires_explicit_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_required_supabase_env(monkeypatch)
+    monkeypatch.delenv("LEON_DB_SCHEMA", raising=False)
+
+    with pytest.raises(RuntimeError, match="LEON_DB_SCHEMA"):
+        supabase_factory.create_supabase_client()
+
+
+def test_create_supabase_client_rejects_unknown_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_required_supabase_env(monkeypatch)
+    monkeypatch.setenv("LEON_DB_SCHEMA", "identity")
+
+    with pytest.raises(RuntimeError, match="Unsupported LEON_DB_SCHEMA"):
+        supabase_factory.create_supabase_client()
+
+
+def test_create_supabase_client_passes_explicit_staging_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_required_supabase_env(monkeypatch)
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    captured: dict[str, object] = {}
+
+    def fake_create_client(url: str, key: str, *, options: object):
+        captured["url"] = url
+        captured["key"] = key
+        captured["schema"] = getattr(options, "schema", None)
+        return "client"
+
+    monkeypatch.setattr(supabase_factory, "create_client", fake_create_client)
+
+    assert supabase_factory.create_supabase_client() == "client"
+    assert captured == {
+        "url": "https://supabase.example.test",
+        "key": "service-role-key",
+        "schema": "staging",
+    }

--- a/tests/test_supabase_factory.py
+++ b/tests/test_supabase_factory.py
@@ -45,3 +45,11 @@ def test_create_supabase_client_passes_explicit_staging_schema(monkeypatch: pyte
         "key": "service-role-key",
         "schema": "staging",
     }
+
+
+def test_create_supabase_client_rejects_agent_as_global_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_required_supabase_env(monkeypatch)
+    monkeypatch.setenv("LEON_DB_SCHEMA", "agent")
+
+    with pytest.raises(RuntimeError, match="Unsupported LEON_DB_SCHEMA"):
+        supabase_factory.create_supabase_client()

--- a/tests/test_supabase_member_repo_schema.py
+++ b/tests/test_supabase_member_repo_schema.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from storage.contracts import MemberType
+from storage.providers.supabase.member_repo import SupabaseMemberRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_member_repo_uses_staging_users_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = FakeSupabaseClient(
+        tables={
+            "users": [
+                {
+                    "id": "u_1",
+                    "type": "human",
+                    "display_name": "Ada",
+                    "avatar": "avatar.png",
+                    "bio": "operator",
+                    "owner_user_id": None,
+                    "next_thread_seq": 7,
+                    "created_at": 1.0,
+                    "updated_at": 2.0,
+                    "email": "ada@example.test",
+                    "mycel_id": 42,
+                }
+            ],
+        }
+    )
+
+    row = SupabaseMemberRepo(client).get_by_id("u_1")
+
+    assert row is not None
+    assert row.id == "u_1"
+    assert row.name == "Ada"
+    assert row.type is MemberType.HUMAN
+    assert row.description == "operator"
+    assert row.next_entity_seq == 7
+
+
+def test_member_repo_maps_staging_agent_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = FakeSupabaseClient(
+        tables={
+            "users": [
+                {
+                    "id": "agent_1",
+                    "type": "agent",
+                    "display_name": "Builder",
+                    "created_at": 1.0,
+                    "next_thread_seq": 0,
+                }
+            ],
+        }
+    )
+
+    row = SupabaseMemberRepo(client).get_by_id("agent_1")
+
+    assert row is not None
+    assert row.type is MemberType.MYCEL_AGENT
+
+
+def test_member_repo_rejects_unknown_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "identity")
+
+    with pytest.raises(RuntimeError):
+        SupabaseMemberRepo(FakeSupabaseClient()).get_by_id("u_1")

--- a/tests/test_supabase_schedule_repo_schema.py
+++ b/tests/test_supabase_schedule_repo_schema.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from storage.providers.supabase.schedule_repo import SupabaseScheduleRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_schedule_repo_uses_agent_tables_under_staging_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseScheduleRepo(FakeSupabaseClient(tables))
+
+    created = repo.create(
+        owner_user_id="owner_1",
+        agent_user_id="agent_1",
+        cron_expression="*/15 * * * *",
+        instruction_template="Summarize project state",
+        create_thread_on_run=True,
+    )
+
+    assert created["owner_user_id"] == "owner_1"
+    assert created["agent_user_id"] == "agent_1"
+    assert tables["agent.schedules"][0]["agent_user_id"] == "agent_1"
+    assert "cron_jobs" not in tables
+
+
+def test_schedule_repo_manages_runs_under_agent_schedule_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseScheduleRepo(FakeSupabaseClient(tables))
+
+    run = repo.create_run(
+        schedule_id="schedule_1",
+        owner_user_id="owner_1",
+        agent_user_id="agent_1",
+        triggered_by="manual",
+        input_json={"source": "test"},
+    )
+    updated = repo.update_run(run["id"], status="running", thread_id="thread_1")
+
+    assert tables["agent.schedule_runs"][0]["schedule_id"] == "schedule_1"
+    assert repo.list_runs("schedule_1")[0]["input_json"] == {"source": "test"}
+    assert updated is not None
+    assert updated["status"] == "running"
+    assert updated["thread_id"] == "thread_1"
+
+
+def test_schedule_repo_rejects_public_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "public")
+
+    with pytest.raises(RuntimeError, match="no route"):
+        SupabaseScheduleRepo(FakeSupabaseClient()).list_by_owner("owner_1")

--- a/tests/test_supabase_thread_launch_pref_repo_schema.py
+++ b/tests/test_supabase_thread_launch_pref_repo_schema.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from storage.providers.supabase.thread_launch_pref_repo import SupabaseThreadLaunchPrefRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_thread_launch_pref_repo_reads_staging_agent_user_id_as_member_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = FakeSupabaseClient(
+        tables={
+            "thread_launch_prefs": [
+                {
+                    "owner_user_id": "owner_1",
+                    "agent_user_id": "agent_1",
+                    "last_confirmed_json": '{"model":"large"}',
+                    "last_successful_json": '{"provider":"local"}',
+                    "last_confirmed_at": 1.0,
+                    "last_successful_at": 2.0,
+                }
+            ],
+        }
+    )
+
+    row = SupabaseThreadLaunchPrefRepo(client).get("owner_1", "agent_1")
+
+    assert row == {
+        "owner_user_id": "owner_1",
+        "member_id": "agent_1",
+        "last_confirmed": {"model": "large"},
+        "last_successful": {"provider": "local"},
+        "last_confirmed_at": 1.0,
+        "last_successful_at": 2.0,
+    }
+
+
+def test_thread_launch_pref_repo_writes_staging_agent_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseThreadLaunchPrefRepo(FakeSupabaseClient(tables=tables))
+
+    repo.save_successful("owner_1", "agent_1", {"model": "large"})
+
+    assert tables["thread_launch_prefs"][0]["owner_user_id"] == "owner_1"
+    assert tables["thread_launch_prefs"][0]["agent_user_id"] == "agent_1"
+    assert "member_id" not in tables["thread_launch_prefs"][0]
+
+
+def test_thread_launch_pref_repo_rejects_unknown_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "identity")
+
+    with pytest.raises(RuntimeError):
+        SupabaseThreadLaunchPrefRepo(FakeSupabaseClient()).get("owner_1", "agent_1")

--- a/tests/test_supabase_thread_repo_schema.py
+++ b/tests/test_supabase_thread_repo_schema.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from storage.providers.supabase.thread_repo import SupabaseThreadRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_thread_repo_lists_staging_threads_by_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = FakeSupabaseClient(
+        tables={
+            "users": [
+                {
+                    "id": "agent_1",
+                    "owner_user_id": "owner_1",
+                    "display_name": "Builder",
+                    "avatar": "avatar.png",
+                }
+            ],
+            "threads": [
+                {
+                    "id": "thread_1",
+                    "agent_user_id": "agent_1",
+                    "sandbox_type": "local",
+                    "model": "large",
+                    "cwd": "/work",
+                    "is_main": 1,
+                    "branch_index": 0,
+                    "created_at": 1.0,
+                }
+            ],
+        }
+    )
+
+    rows = SupabaseThreadRepo(client).list_by_owner_user_id("owner_1")
+
+    assert rows == [
+        {
+            "id": "thread_1",
+            "member_id": "agent_1",
+            "sandbox_type": "local",
+            "model": "large",
+            "cwd": "/work",
+            "observation_provider": None,
+            "is_main": True,
+            "branch_index": 0,
+            "created_at": 1.0,
+            "member_name": "Builder",
+            "member_avatar": "avatar.png",
+            "entity_name": None,
+        }
+    ]
+
+
+def test_thread_repo_rejects_unknown_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "identity")
+
+    with pytest.raises(RuntimeError):
+        SupabaseThreadRepo(FakeSupabaseClient()).list_by_owner_user_id("owner_1")

--- a/tests/test_supabase_thread_repo_schema.py
+++ b/tests/test_supabase_thread_repo_schema.py
@@ -6,28 +6,21 @@ from storage.providers.supabase.thread_repo import SupabaseThreadRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
 
-def test_thread_repo_lists_staging_threads_by_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_thread_repo_lists_agent_threads_by_owner_under_staging_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
     client = FakeSupabaseClient(
         tables={
-            "users": [
-                {
-                    "id": "agent_1",
-                    "owner_user_id": "owner_1",
-                    "display_name": "Builder",
-                    "avatar": "avatar.png",
-                }
-            ],
-            "threads": [
+            "agent.threads": [
                 {
                     "id": "thread_1",
                     "agent_user_id": "agent_1",
+                    "owner_user_id": "owner_1",
                     "sandbox_type": "local",
                     "model": "large",
                     "cwd": "/work",
-                    "is_main": 1,
+                    "is_main": True,
                     "branch_index": 0,
-                    "created_at": 1.0,
+                    "created_at": "2026-04-14T00:00:00+00:00",
                 }
             ],
         }
@@ -45,12 +38,58 @@ def test_thread_repo_lists_staging_threads_by_owner(monkeypatch: pytest.MonkeyPa
             "observation_provider": None,
             "is_main": True,
             "branch_index": 0,
-            "created_at": 1.0,
-            "member_name": "Builder",
-            "member_avatar": "avatar.png",
+            "created_at": "2026-04-14T00:00:00+00:00",
+            "member_name": None,
+            "member_avatar": None,
             "entity_name": None,
         }
     ]
+
+
+def test_thread_repo_creates_agent_thread_with_owner_and_timestamptz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseThreadRepo(FakeSupabaseClient(tables=tables))
+
+    repo.create(
+        thread_id="thread_1",
+        member_id="agent_1",
+        sandbox_type="local",
+        cwd="/work",
+        created_at=1710000000.0,
+        owner_user_id="owner_1",
+        model="large",
+        is_main=True,
+        branch_index=0,
+    )
+
+    assert tables["agent.threads"] == [
+        {
+            "id": "thread_1",
+            "agent_user_id": "agent_1",
+            "owner_user_id": "owner_1",
+            "sandbox_type": "local",
+            "cwd": "/work",
+            "model": "large",
+            "is_main": True,
+            "branch_index": 0,
+            "created_at": "2024-03-09T16:00:00+00:00",
+        }
+    ]
+
+
+def test_thread_repo_requires_owner_when_creating_agent_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    repo = SupabaseThreadRepo(FakeSupabaseClient())
+
+    with pytest.raises(ValueError, match="owner_user_id"):
+        repo.create(
+            thread_id="thread_1",
+            member_id="agent_1",
+            sandbox_type="local",
+            branch_index=0,
+            is_main=True,
+        )
 
 
 def test_thread_repo_rejects_unknown_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_supabase_thread_repo_schema.py
+++ b/tests/test_supabase_thread_repo_schema.py
@@ -35,6 +35,7 @@ def test_thread_repo_lists_agent_threads_by_owner_under_staging_runtime(monkeypa
             "sandbox_type": "local",
             "model": "large",
             "cwd": "/work",
+            "owner_user_id": "owner_1",
             "observation_provider": None,
             "is_main": True,
             "branch_index": 0,
@@ -44,6 +45,33 @@ def test_thread_repo_lists_agent_threads_by_owner_under_staging_runtime(monkeypa
             "entity_name": None,
         }
     ]
+
+
+def test_thread_repo_get_by_id_exposes_owner_user_id_under_staging_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = FakeSupabaseClient(
+        tables={
+            "agent.threads": [
+                {
+                    "id": "thread_1",
+                    "agent_user_id": "agent_1",
+                    "owner_user_id": "owner_1",
+                    "sandbox_type": "local",
+                    "model": "large",
+                    "cwd": "/work",
+                    "is_main": True,
+                    "branch_index": 0,
+                    "created_at": "2026-04-14T00:00:00+00:00",
+                }
+            ],
+        }
+    )
+
+    row = SupabaseThreadRepo(client).get_by_id("thread_1")
+
+    assert row is not None
+    assert row["owner_user_id"] == "owner_1"
+    assert row["member_id"] == "agent_1"
 
 
 def test_thread_repo_creates_agent_thread_with_owner_and_timestamptz(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_supabase_tool_task_repo_schema.py
+++ b/tests/test_supabase_tool_task_repo_schema.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from core.tools.task.types import Task, TaskStatus
+from storage.providers.supabase.tool_task_repo import SupabaseToolTaskRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_tool_task_repo_uses_agent_thread_tasks_under_staging_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    client = FakeSupabaseClient(
+        tables={
+            "agent.thread_tasks": [
+                {
+                    "thread_id": "thread_1",
+                    "task_id": "1",
+                    "subject": "Route runtime",
+                    "description": "Use domain table",
+                    "status": "pending",
+                    "active_form": None,
+                    "owner": "agent",
+                    "blocks": [],
+                    "blocked_by": [],
+                    "metadata": {},
+                }
+            ],
+        }
+    )
+
+    tasks = SupabaseToolTaskRepo(client).list_all("thread_1")
+
+    assert tasks == [
+        Task(
+            id="1",
+            subject="Route runtime",
+            description="Use domain table",
+            status=TaskStatus.PENDING,
+            owner="agent",
+        )
+    ]
+
+
+def test_tool_task_repo_rejects_unknown_runtime_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_DB_SCHEMA", "identity")
+
+    with pytest.raises(RuntimeError):
+        SupabaseToolTaskRepo(FakeSupabaseClient()).list_all("thread_1")

--- a/tests/test_thread_task_tool_surface_schema.py
+++ b/tests/test_thread_task_tool_surface_schema.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from backend.web.core import storage_factory
+from core.runtime.registry import ToolRegistry
+from core.runtime.runner import ToolRunner
+from core.tools.task.service import TaskService
+from sandbox.thread_context import set_current_thread_id
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def _call_tool(runner: ToolRunner, name: str, args: dict, call_id: str) -> dict:
+    request = SimpleNamespace(tool_call={"name": name, "args": args, "id": call_id})
+
+    def unexpected_upstream(_request):
+        raise AssertionError(f"{name} must be handled by ToolRunner registry dispatch")
+
+    message = runner.wrap_tool_call(request, unexpected_upstream)
+    assert isinstance(message, ToolMessage)
+    return json.loads(message.content)
+
+
+def test_task_tools_persist_to_agent_thread_tasks_through_tool_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setenv("LEON_DB_SCHEMA", "staging")
+    tables: dict[str, list[dict]] = {}
+    monkeypatch.setattr(storage_factory, "_supabase_client", lambda: FakeSupabaseClient(tables))
+    set_current_thread_id("thread_02e")
+
+    registry = ToolRegistry()
+    TaskService(registry=registry)
+    runner = ToolRunner(registry)
+
+    created = _call_tool(
+        runner,
+        "TaskCreate",
+        {
+            "subject": "Prove task tool surface",
+            "description": "Persist through ToolRunner into agent.thread_tasks",
+            "active_form": "Proving task tool surface",
+            "metadata": {"checkpoint": "02e"},
+        },
+        "call-create",
+    )
+    assert created["id"] == "1"
+    assert tables["agent.thread_tasks"] == [
+        {
+            "thread_id": "thread_02e",
+            "task_id": "1",
+            "subject": "Prove task tool surface",
+            "description": "Persist through ToolRunner into agent.thread_tasks",
+            "status": "pending",
+            "active_form": "Proving task tool surface",
+            "owner": None,
+            "blocks": [],
+            "blocked_by": [],
+            "metadata": {"checkpoint": "02e"},
+        }
+    ]
+
+    listed = _call_tool(runner, "TaskList", {}, "call-list")
+    assert listed["total"] == 1
+    assert listed["tasks"][0]["subject"] == "Prove task tool surface"
+
+    detail = _call_tool(runner, "TaskGet", {"task_id": "1"}, "call-get")
+    assert detail["metadata"] == {"checkpoint": "02e"}
+
+    updated = _call_tool(
+        runner,
+        "TaskUpdate",
+        {"task_id": "1", "status": "in_progress", "owner": "agent_02e", "metadata": {"verified": True}},
+        "call-update",
+    )
+    assert updated["task"]["status"] == "in_progress"
+    assert tables["agent.thread_tasks"][0]["status"] == "in_progress"
+    assert tables["agent.thread_tasks"][0]["owner"] == "agent_02e"
+    assert tables["agent.thread_tasks"][0]["metadata"] == {"checkpoint": "02e", "verified": True}

--- a/tests/test_threads_router_agent_schema_contract.py
+++ b/tests/test_threads_router_agent_schema_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.web.models.requests import CreateThreadRequest
+from backend.web.routers import threads as threads_router
+
+
+class _MemberRepo:
+    def __init__(self) -> None:
+        self._seq = 0
+
+    def get_by_id(self, member_id: str):
+        if member_id != "agent_1":
+            return None
+        return SimpleNamespace(id="agent_1", owner_user_id="owner_1", name="Builder", avatar=None)
+
+    def increment_entity_seq(self, member_id: str) -> int:
+        assert member_id == "agent_1"
+        self._seq += 1
+        return self._seq
+
+
+class _ThreadRepo:
+    def __init__(self) -> None:
+        self.created: dict | None = None
+
+    def get_main_thread(self, member_id: str):
+        assert member_id == "agent_1"
+        return None
+
+    def get_next_branch_index(self, member_id: str) -> int:
+        assert member_id == "agent_1"
+        return 1
+
+    def create(self, **kwargs):
+        self.created = dict(kwargs)
+
+
+class _EntityRepo:
+    def __init__(self) -> None:
+        self.created = None
+
+    def get_by_id(self, entity_id: str):
+        assert entity_id == "agent_1"
+        return None
+
+    def create(self, row) -> None:
+        self.created = row
+
+
+class _ThreadLaunchPrefRepo:
+    def save_successful(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def test_create_owned_thread_passes_owner_user_id_to_thread_repo() -> None:
+    thread_repo = _ThreadRepo()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            member_repo=_MemberRepo(),
+            entity_repo=_EntityRepo(),
+            thread_repo=thread_repo,
+            thread_launch_pref_repo=_ThreadLaunchPrefRepo(),
+            thread_sandbox={},
+            thread_cwd={},
+        )
+    )
+
+    threads_router._create_owned_thread(
+        app,
+        "owner_1",
+        CreateThreadRequest(member_id="agent_1", sandbox="local"),
+        is_main=False,
+    )
+
+    assert thread_repo.created is not None
+    assert thread_repo.created["owner_user_id"] == "owner_1"


### PR DESCRIPTION
## Summary

Database Refactor PR #507 lands the first reviewable foundation slice of the target schema work through checkpoint `02J`.

This PR intentionally stops at a coherent foundation boundary instead of continuing to widen the draft by inertia.

## Scope

- Establishes the database refactor target contract, explicit schema addressing, and search-path safety.
- Lands `agent.threads` and `agent.thread_tasks` routing, including migration/precheck/rollback coverage.
- Routes Supabase actor/chat/thread/task read surfaces toward explicit schema-owned repositories.
- Defines and lands `agent.schedules` and `agent.schedule_runs` as the schedule domain storage surface.
- Adds schedule repository/service routing, authenticated manual schedule trigger API, start-only busy protection, and schedule run finalization from runtime completion.
- Preserves known residual work as follow-up checkpoints rather than expanding this PR further.

## Database / Migration Facts

Included database artifacts:

- `database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql`
- `database/migrations/20260414_01_agent_threads_thread_tasks.sql`
- `database/rollbacks/20260414_01_agent_threads_thread_tasks.sql`
- `database/prechecks/20260414_02_agent_threads_sandbox_type_readonly.sql`
- `database/migrations/20260414_02_agent_threads_sandbox_type.sql`
- `database/rollbacks/20260414_02_agent_threads_sandbox_type.sql`
- `database/prechecks/20260414_03_agent_schedules_readonly.sql`
- `database/migrations/20260414_03_agent_schedules.sql`
- `database/rollbacks/20260414_03_agent_schedules.sql`

Live proof has already created `agent.schedules` and `agent.schedule_runs` during checkpoint `02G`.

## Verification

GitHub CI at head `9d50918bdf8abb5796ee7af112b85679b181da56` is green:

- Python lint/type check passed.
- Frontend lint/type/build passed.
- Unit tests passed on Ubuntu, macOS, and Windows.
- Mintlify deployment check passed.

Local focused verification:

```bash
uv run pytest tests/test_message_routing_schedule_start_only.py tests/test_schedule_runtime_service.py tests/test_schedule_run_completion_service.py tests/test_schedule_run_completion_streaming.py tests/test_schedules_router.py -q
```

Result: `12 passed`.

Local schema regression verification:

```bash
uv run pytest tests/test_supabase_thread_repo_schema.py tests/test_supabase_schedule_repo_schema.py tests/test_schedule_service_schema_contract.py tests/test_supabase_tool_task_repo_schema.py tests/test_thread_task_tool_surface_schema.py tests/test_supabase_chat_repo_schema.py -q
```

Result: `19 passed`.

Formatting/lint verification:

```bash
uv run ruff check <touched python files>
uv run ruff format --check <touched python files>
```

Result: passed.

Backend API YATU proof for `02J`:

- Ran a temporary local backend on port `8013` with real Supabase/auth/LLM path.
- Authenticated through the real OTP/login path.
- Triggered `POST /api/schedules/{schedule_id}/run`.
- Observed persisted `agent.schedule_runs` row completing to `succeeded`.
- Verified `output_json.runtime.run_id` matched the routed runtime run id.
- Observed assistant completion in the target thread.
- Verified a second immediate trigger while target thread was active returned `409`.
- Verified `public.panel_tasks` count did not change.
- Cleaned temporary proof rows.

Proof docs are under `docs/database-refactor/`, including:

- `02g-agent-schedules-ddl-execution-proof.md`
- `02h-schedule-repo-routing-proof.md`
- `02i-schedule-trigger-runtime-proof.md`
- `02j-schedule-run-completion-proof.md`

## Known Residuals

These are intentionally not solved in this PR:

- Scheduler due polling loop.
- `create_thread_on_run` service extraction.
- Schedule CRUD API.
- Frontend schedule UX.
- Active-injection attribution design.
- Separate public schema purge blocker: `public-schema-business-surface-purge-07`.
- Prior blocked checkpoint: `database-refactor-02c-chat-actor-read-model-strict-proof`.

## Ledger Ruling

The Mycel ledger authorized preparing this PR for review and undrafting now.

This is not merge authorization. Merge still requires a separate review/merge authorization packet after review state and head SHA are stable.
