### PR TITLE
fix: keep sandbox provider availability honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,7 @@ uv sync
 cd frontend/app && npm install && cd ../..
 ```
 
-**Sandbox providers** require extra dependencies — install only what you need:
-
-```bash
-uv sync --extra sandbox     # AgentBay
-uv sync --extra e2b         # E2B
-uv sync --extra daytona     # Daytona
-```
-
-Docker sandbox works out of the box (just needs Docker installed). See [Sandbox docs](docs/en/sandbox.mdx) for provider setup.
+Sandbox provider SDKs are installed by default. Docker still requires Docker installed locally. See [Sandbox docs](docs/en/sandbox.mdx) for provider setup.
 
 ### 3. Start the services
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,15 +51,7 @@ uv sync
 cd frontend/app && npm install && cd ../..
 ```
 
-**沙箱提供商**需要额外依赖——按需安装：
-
-```bash
-uv sync --extra sandbox     # AgentBay
-uv sync --extra e2b         # E2B
-uv sync --extra daytona     # Daytona
-```
-
-Docker 沙箱开箱即用（只需安装 Docker）。详见[沙箱文档](docs/zh/sandbox.mdx)。
+沙箱 Provider SDK 默认随 `uv sync` 安装。Docker 仍需要本机安装 Docker。详见[沙箱文档](docs/zh/sandbox.mdx)。
 
 ### 3. 启动服务
 

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -543,4 +543,68 @@ describe("NewChatPage", () => {
     expect(await screen.findByText("Self-host Daytona 已达上限")).toBeTruthy();
     expect((screen.getByRole("button", { name: "下一步" }) as HTMLButtonElement).disabled).toBe(true);
   });
+
+  it("shows unavailable configured sandbox providers instead of hiding their quota state", async () => {
+    sandboxTypesForTest = [{
+      name: "daytona_selfhost",
+      provider: "daytona",
+      available: false,
+      reason: "Provider daytona_selfhost is configured but unavailable in the current process",
+    }];
+    clientMocks.fetchAccountResourceLimits.mockResolvedValue([
+      {
+        resource: "sandbox",
+        provider_name: "daytona_selfhost",
+        label: "Self-host Daytona",
+        limit: 2,
+        used: 0,
+        remaining: 2,
+        can_create: true,
+      },
+    ]);
+    clientMocks.getDefaultThreadConfig.mockResolvedValue({
+      source: "derived",
+      config: {
+        create_mode: "new",
+        provider_config: "daytona_selfhost",
+        recipe: {
+          id: "daytona-recipe",
+          name: "Self-host Daytona",
+          provider_type: "daytona",
+          features: {},
+          configurable_features: {},
+          feature_options: [],
+        },
+        lease_id: null,
+        model: "leon:large",
+        workspace: null,
+      },
+    });
+    useAppStore.setState({
+      libraryRecipes: [{
+        id: "daytona-recipe",
+        type: "recipe",
+        name: "Self-host Daytona",
+        desc: "",
+        provider_type: "daytona",
+        available: true,
+        created_at: 0,
+        updated_at: 0,
+      }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Self-host Daytona 当前不可用")).toBeTruthy();
+    expect(screen.getByText("Provider daytona_selfhost is configured but unavailable in the current process")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "下一步" }) as HTMLButtonElement).disabled).toBe(true);
+  });
 });

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -279,12 +279,13 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   const providerConfigOptions = useMemo(
     () =>
       sandboxTypes
-        .filter((item) => item.available)
         .map((item) => ({
           value: item.name,
-          label: providerConfigLabel(item.name),
+          label: sandboxResourceByProvider.get(item.name)?.label ?? providerConfigLabel(item.name),
           providerType: item.provider || providerTypeFromName(item.name),
           resource: sandboxResourceByProvider.get(item.name),
+          available: item.available,
+          reason: item.reason,
         })),
     [sandboxResourceByProvider, sandboxTypes],
   );
@@ -535,7 +536,11 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   const selectedProviderResource = selectedProviderConfig
     ? sandboxResourceByProvider.get(selectedProviderConfig)
     : undefined;
+  const selectedProviderOption = selectedProviderConfig
+    ? providerConfigOptions.find((item) => item.value === selectedProviderConfig)
+    : undefined;
   const newSandboxQuotaBlocked = createMode === "new" && selectedProviderResource?.can_create === false;
+  const newSandboxProviderUnavailable = createMode === "new" && selectedProviderOption?.available === false;
   const stepSummary = createMode === "existing"
     ? `复用 ${providerSummaryLabel} 的现有沙盒`
     : `新建 ${providerSummaryLabel} 沙盒 · ${recipeSummaryLabel}`;
@@ -590,7 +595,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
           environmentControl={{
             panelClassName: "max-h-[calc(100vh-4rem)]",
             applyLabel: configStep === 3 ? "确认" : (configStep === 1 ? "下一步" : (localRecipeSelected ? "下一步" : "确认")),
-            applyDisabled: (configStep === 1 && newSandboxQuotaBlocked)
+            applyDisabled: (configStep === 1 && (newSandboxQuotaBlocked || newSandboxProviderUnavailable))
               || (configStep === 2 && createMode === "existing" && !selectedLeaseId),
             showBack: configStep > 1,
             backLabel: "返回上一步",
@@ -714,7 +719,9 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                           <SelectContent>
                             {providerConfigOptions.map((item) => (
                               <SelectItem key={item.value} value={item.value}>
-                                {item.resource?.can_create === false ? `${item.label} · 已达上限` : item.label}
+                                {!item.available
+                                  ? `${item.label} · 当前不可用`
+                                  : item.resource?.can_create === false ? `${item.label} · 已达上限` : item.label}
                               </SelectItem>
                             ))}
                           </SelectContent>
@@ -725,7 +732,13 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                         {accountResourcesError && (
                           <p className="mt-2 text-xs text-destructive">{accountResourcesError}</p>
                         )}
-                        {!accountResourcesLoading && selectedProviderResource && (
+                        {newSandboxProviderUnavailable && selectedProviderOption && (
+                          <div className="mt-2 space-y-1 text-xs text-destructive">
+                            <p>{selectedProviderOption.label} 当前不可用</p>
+                            {selectedProviderOption.reason && <p>{selectedProviderOption.reason}</p>}
+                          </div>
+                        )}
+                        {!newSandboxProviderUnavailable && !accountResourcesLoading && selectedProviderResource && (
                           <p className={cn(
                             "mt-2 text-xs",
                             selectedProviderResource.can_create ? "text-muted-foreground" : "text-destructive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,20 +50,21 @@ dependencies = [
     "fastapi>=0.118.0",
     "langgraph-checkpoint-postgres>=3.0.5",
     "psycopg[binary]>=3.3.3",
+    "wuying-agentbay-sdk>=0.10.0",
+    "e2b>=2.13.0",
+    "daytona-sdk>=0.139.0,<0.140.0",
+    "python-socks>=2.7.0",
 ]
 
 [project.optional-dependencies]
 pdf = ["pymupdf>=1.24.0"]
 pptx = ["python-pptx>=1.0.0"]
 docs = ["pymupdf>=1.24.0", "python-pptx>=1.0.0"]
-sandbox = ["wuying-agentbay-sdk>=0.10.0"]
-e2b = ["e2b>=2.13.0"]
-daytona = ["daytona-sdk>=0.139.0,<0.140.0", "python-socks>=2.7.0"]
 eval = ["httpx-sse>=0.4.0"]
 langfuse = ["langfuse>=3.0.0"]
 langsmith = ["langsmith>=0.1.0"]
 otel = ["opentelemetry-api>=1.20.0", "opentelemetry-sdk>=1.20.0", "opentelemetry-exporter-otlp>=1.20.0"]
-all = ["pymupdf>=1.24.0", "python-pptx>=1.0.0", "wuying-agentbay-sdk>=0.10.0", "e2b>=2.13.0", "daytona-sdk>=0.139.0,<0.140.0", "python-socks>=2.7.0", "httpx-sse>=0.4.0", "langfuse>=3.0.0", "langsmith>=0.1.0"]
+all = ["pymupdf>=1.24.0", "python-pptx>=1.0.0", "httpx-sse>=0.4.0", "langfuse>=3.0.0", "langsmith>=0.1.0"]
 
 [project.urls]
 Homepage = "https://github.com/Ju-Yi-AI-Lab/leonai"

--- a/uv.lock
+++ b/uv.lock
@@ -1466,7 +1466,9 @@ source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
     { name = "croniter" },
+    { name = "daytona-sdk" },
     { name = "duckduckgo-search" },
+    { name = "e2b" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "langchain" },
@@ -1482,35 +1484,26 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "pyright" },
+    { name = "python-socks" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sse-starlette" },
     { name = "supabase" },
     { name = "uvicorn" },
+    { name = "wuying-agentbay-sdk" },
 ]
 
 [package.optional-dependencies]
 all = [
-    { name = "daytona-sdk" },
-    { name = "e2b" },
     { name = "httpx-sse" },
     { name = "langfuse" },
     { name = "langsmith" },
     { name = "pymupdf" },
     { name = "python-pptx" },
-    { name = "python-socks" },
-    { name = "wuying-agentbay-sdk" },
-]
-daytona = [
-    { name = "daytona-sdk" },
-    { name = "python-socks" },
 ]
 docs = [
     { name = "pymupdf" },
     { name = "python-pptx" },
-]
-e2b = [
-    { name = "e2b" },
 ]
 eval = [
     { name = "httpx-sse" },
@@ -1532,9 +1525,6 @@ pdf = [
 pptx = [
     { name = "python-pptx" },
 ]
-sandbox = [
-    { name = "wuying-agentbay-sdk" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -1549,11 +1539,9 @@ dev = [
 requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "croniter", specifier = ">=6.0.0" },
-    { name = "daytona-sdk", marker = "extra == 'all'", specifier = ">=0.139.0,<0.140.0" },
-    { name = "daytona-sdk", marker = "extra == 'daytona'", specifier = ">=0.139.0,<0.140.0" },
+    { name = "daytona-sdk", specifier = ">=0.139.0,<0.140.0" },
     { name = "duckduckgo-search", specifier = ">=8.1.1" },
-    { name = "e2b", marker = "extra == 'all'", specifier = ">=2.13.0" },
-    { name = "e2b", marker = "extra == 'e2b'", specifier = ">=2.13.0" },
+    { name = "e2b", specifier = ">=2.13.0" },
     { name = "fastapi", specifier = ">=0.118.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-sse", marker = "extra == 'all'", specifier = ">=0.4.0" },
@@ -1584,17 +1572,15 @@ requires-dist = [
     { name = "python-pptx", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "python-pptx", marker = "extra == 'docs'", specifier = ">=1.0.0" },
     { name = "python-pptx", marker = "extra == 'pptx'", specifier = ">=1.0.0" },
-    { name = "python-socks", marker = "extra == 'all'", specifier = ">=2.7.0" },
-    { name = "python-socks", marker = "extra == 'daytona'", specifier = ">=2.7.0" },
+    { name = "python-socks", specifier = ">=2.7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sse-starlette", specifier = ">=1.6.0" },
     { name = "supabase", specifier = ">=2.28.3" },
     { name = "uvicorn", specifier = ">=0.30.0" },
-    { name = "wuying-agentbay-sdk", marker = "extra == 'all'", specifier = ">=0.10.0" },
-    { name = "wuying-agentbay-sdk", marker = "extra == 'sandbox'", specifier = ">=0.10.0" },
+    { name = "wuying-agentbay-sdk", specifier = ">=0.10.0" },
 ]
-provides-extras = ["pdf", "pptx", "docs", "sandbox", "e2b", "daytona", "eval", "langfuse", "langsmith", "otel", "all"]
+provides-extras = ["pdf", "pptx", "docs", "eval", "langfuse", "langsmith", "otel", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Keep configured sandbox providers visible in the new chat provider picker even when the backend marks them unavailable.
- Show unavailable provider reason text and block advancing while keeping available providers usable.
- Install AgentBay/E2B/Daytona provider SDKs by default and update README install guidance.

## Test Plan
- `uv run pytest tests/Unit/backend/test_auth_service_token_verification.py::test_create_initial_agents_persists_default_agent_avatars tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_users_avatar_auth_shell.py -q`
- `cd frontend/app && npm test -- NewChatPage.test.tsx`
- `cd frontend/app && npm run lint`
- `cd frontend/app && npm run build`
- `uv run ruff check backend/web/services/auth_service.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_users_avatar_auth_shell.py`
- `uv run ruff format --check backend/web/services/auth_service.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_users_avatar_auth_shell.py`
- `uv lock --check`

## YATU Evidence
- Playwright CLI against real frontend/backend proved unavailable configured providers stay visible, show `当前不可用` plus backend reason text, and disable `下一步` when selected.
- The same dialog showed Local quota text and left `下一步` enabled for an available provider.
- Runtime proof imported `agentbay`, `e2b`, `daytona_sdk`, and `python_socks`; `/api/sandbox/types` on the real backend reported configured providers available without SDK-missing reasons.

## Notes
- This PR is intentionally based on current `dev` with a single cherry-picked commit, separate from PR #507 Database Refactor and the already-merged PR #501 history.