### PR TITLE
Database refactor dev replay: thread task DDL packet

### DIFF
--- a/database/migrations/20260414_01_agent_threads_thread_tasks.sql
+++ b/database/migrations/20260414_01_agent_threads_thread_tasks.sql
@@ -1,0 +1,276 @@
+-- Database Refactor dev replay 01: land agent.threads and agent.thread_tasks.
+--
+-- Scope:
+-- - Create agent schema.
+-- - Copy staging.threads into agent.threads.
+-- - Copy staging.agent_thread_tasks into agent.thread_tasks.
+--
+-- Non-goals:
+-- - No mutation or deletion of public.* / staging.*.
+-- - No schedules / schedule_runs migration in this slice.
+-- - No runtime repository routing.
+-- - No hard FK from agent.thread_tasks to agent.threads because current source
+--   agent_thread_tasks rows are known orphaned against staging.threads.
+-- - No RLS/realtime. Add policy/publication behavior only after it is proved in
+--   a separate checkpoint.
+-- - First-run-only: fail if agent schema already exists. Do not hide partial
+--   landing state behind IF NOT EXISTS / ON CONFLICT behavior.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_agent_schema_count integer;
+    v_missing_owner_count integer;
+    v_duplicate_branch_count integer;
+    v_bad_status_count integer;
+    v_negative_timestamp_count integer;
+    v_blank_sandbox_type_count integer;
+    v_bad_task_status_count integer;
+    v_task_required_null_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_agent_schema_count
+    FROM information_schema.schemata
+    WHERE schema_name = 'agent';
+
+    IF v_agent_schema_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate dev replay 01: schema agent already exists';
+    END IF;
+
+    SELECT count(*)
+    INTO v_missing_owner_count
+    FROM staging.threads t
+    LEFT JOIN staging.users u ON u.id = t.agent_user_id
+    WHERE u.id IS NULL
+       OR u.owner_user_id IS NULL;
+
+    IF v_missing_owner_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % staging.threads rows lack owner_user_id derivation', v_missing_owner_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_duplicate_branch_count
+    FROM (
+        SELECT agent_user_id, branch_index
+        FROM staging.threads
+        GROUP BY agent_user_id, branch_index
+        HAVING count(*) > 1
+    ) duplicates;
+
+    IF v_duplicate_branch_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % duplicate (agent_user_id, branch_index) pairs', v_duplicate_branch_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_bad_status_count
+    FROM staging.threads
+    WHERE status NOT IN ('active', 'archived');
+
+    IF v_bad_status_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % rows have unsupported status', v_bad_status_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_negative_timestamp_count
+    FROM staging.threads
+    WHERE created_at < 0
+       OR updated_at < 0
+       OR last_active_at < 0;
+
+    IF v_negative_timestamp_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % rows have negative timestamps', v_negative_timestamp_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_blank_sandbox_type_count
+    FROM staging.threads
+    WHERE sandbox_type IS NULL
+       OR btrim(sandbox_type) = '';
+
+    IF v_blank_sandbox_type_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.threads: % rows lack sandbox_type', v_blank_sandbox_type_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_bad_task_status_count
+    FROM staging.agent_thread_tasks
+    WHERE status NOT IN ('pending', 'in_progress', 'completed');
+
+    IF v_bad_task_status_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.thread_tasks: % rows have unsupported status', v_bad_task_status_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_task_required_null_count
+    FROM staging.agent_thread_tasks
+    WHERE thread_id IS NULL
+       OR task_id IS NULL
+       OR subject IS NULL
+       OR description IS NULL
+       OR status IS NULL
+       OR blocks IS NULL
+       OR blocked_by IS NULL
+       OR metadata IS NULL;
+
+    IF v_task_required_null_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate agent.thread_tasks: % rows have required nulls', v_task_required_null_count;
+    END IF;
+END $$;
+
+CREATE SCHEMA agent;
+
+CREATE TABLE agent.threads (
+    id                   TEXT        PRIMARY KEY,
+    agent_user_id        TEXT        NOT NULL,
+    owner_user_id        TEXT        NOT NULL,
+    current_workspace_id TEXT,
+    sandbox_type         TEXT        NOT NULL,
+    model                TEXT,
+    cwd                  TEXT,
+    status               TEXT        NOT NULL DEFAULT 'active',
+    run_status           TEXT        NOT NULL DEFAULT 'idle',
+    is_main              BOOLEAN     NOT NULL DEFAULT false,
+    branch_index         INTEGER     NOT NULL DEFAULT 0,
+    last_active_at       TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT threads_status_chk
+        CHECK (status IN ('active', 'archived')),
+    CONSTRAINT threads_run_status_chk
+        CHECK (run_status IN ('idle', 'running', 'paused', 'error')),
+    CONSTRAINT threads_sandbox_type_chk
+        CHECK (btrim(sandbox_type) <> ''),
+    CONSTRAINT threads_agent_branch_uq UNIQUE (agent_user_id, branch_index)
+);
+
+CREATE INDEX idx_threads_owner_active
+    ON agent.threads(owner_user_id, last_active_at DESC)
+    WHERE status = 'active';
+
+CREATE INDEX idx_threads_agent_active
+    ON agent.threads(agent_user_id)
+    WHERE status = 'active';
+
+CREATE TABLE agent.thread_tasks (
+    thread_id    TEXT  NOT NULL,
+    task_id      TEXT  NOT NULL,
+    subject      TEXT  NOT NULL,
+    description  TEXT  NOT NULL,
+    status       TEXT  NOT NULL DEFAULT 'pending',
+    active_form  TEXT,
+    owner        TEXT,
+    blocks       JSONB NOT NULL DEFAULT '[]',
+    blocked_by   JSONB NOT NULL DEFAULT '[]',
+    metadata     JSONB NOT NULL DEFAULT '{}',
+
+    PRIMARY KEY (thread_id, task_id),
+    CONSTRAINT thread_tasks_status_chk
+        CHECK (status IN ('pending', 'in_progress', 'completed'))
+);
+
+CREATE INDEX idx_thread_tasks_thread
+    ON agent.thread_tasks(thread_id);
+
+GRANT USAGE ON SCHEMA agent TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.threads TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.thread_tasks TO service_role;
+
+INSERT INTO agent.threads (
+    id,
+    agent_user_id,
+    owner_user_id,
+    sandbox_type,
+    model,
+    cwd,
+    status,
+    run_status,
+    is_main,
+    branch_index,
+    last_active_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    t.agent_user_id,
+    u.owner_user_id,
+    t.sandbox_type,
+    t.model,
+    t.cwd,
+    t.status,
+    'idle',
+    (t.is_main <> 0),
+    t.branch_index,
+    CASE WHEN t.last_active_at IS NULL THEN NULL ELSE to_timestamp(t.last_active_at) END,
+    to_timestamp(t.created_at),
+    CASE WHEN t.updated_at IS NULL THEN to_timestamp(t.created_at) ELSE to_timestamp(t.updated_at) END
+FROM staging.threads t
+JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.owner_user_id IS NOT NULL;
+
+INSERT INTO agent.thread_tasks (
+    thread_id,
+    task_id,
+    subject,
+    description,
+    status,
+    active_form,
+    owner,
+    blocks,
+    blocked_by,
+    metadata
+)
+SELECT
+    thread_id,
+    task_id,
+    subject,
+    description,
+    status,
+    active_form,
+    owner,
+    blocks,
+    blocked_by,
+    metadata
+FROM staging.agent_thread_tasks;
+
+DO $$
+DECLARE
+    v_source_threads integer;
+    v_target_threads integer;
+    v_source_tasks integer;
+    v_target_tasks integer;
+    v_blank_sandbox_type_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_source_threads
+    FROM staging.threads t
+    JOIN staging.users u ON u.id = t.agent_user_id
+    WHERE u.owner_user_id IS NOT NULL;
+
+    SELECT count(*) INTO v_target_threads FROM agent.threads;
+
+    IF v_target_threads <> v_source_threads THEN
+        RAISE EXCEPTION 'agent.threads parity failed: source %, target %', v_source_threads, v_target_threads;
+    END IF;
+
+    SELECT count(*) INTO v_source_tasks FROM staging.agent_thread_tasks;
+    SELECT count(*) INTO v_target_tasks FROM agent.thread_tasks;
+
+    IF v_target_tasks <> v_source_tasks THEN
+        RAISE EXCEPTION 'agent.thread_tasks parity failed: source %, target %', v_source_tasks, v_target_tasks;
+    END IF;
+
+    SELECT count(*)
+    INTO v_blank_sandbox_type_count
+    FROM agent.threads
+    WHERE sandbox_type IS NULL
+       OR btrim(sandbox_type) = '';
+
+    IF v_blank_sandbox_type_count <> 0 THEN
+        RAISE EXCEPTION 'agent.threads sandbox_type parity failed: % blank target rows', v_blank_sandbox_type_count;
+    END IF;
+END $$;
+
+COMMIT;

--- a/database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql
+++ b/database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql
@@ -1,0 +1,122 @@
+-- Database Refactor dev replay 01 read-only precheck.
+--
+-- Scope:
+-- - Inspect the current staging source shape for agent.threads and agent.thread_tasks.
+-- - Inspect whether target agent tables already exist.
+-- - Do not mutate data, schemas, grants, or publications.
+--
+-- Run before considering database/migrations/20260414_01_agent_threads_thread_tasks.sql.
+
+BEGIN READ ONLY;
+
+-- Source table presence.
+SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE (table_schema, table_name) IN (
+    ('staging', 'threads'),
+    ('staging', 'agent_thread_tasks'),
+    ('staging', 'users'),
+    ('agent', 'threads'),
+    ('agent', 'thread_tasks')
+)
+ORDER BY table_schema, table_name;
+
+-- Source column contracts expected by the migration.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'staging'
+  AND table_name = 'threads'
+ORDER BY ordinal_position;
+
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'staging'
+  AND table_name = 'agent_thread_tasks'
+ORDER BY ordinal_position;
+
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'staging'
+  AND table_name = 'users'
+ORDER BY ordinal_position;
+
+-- Every staging thread must resolve to an owner_user_id through staging.users.
+SELECT count(*) AS owner_derivation_missing
+FROM staging.threads t
+LEFT JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.id IS NULL
+   OR u.owner_user_id IS NULL;
+
+-- agent.threads target uniqueness must be safe.
+SELECT agent_user_id, branch_index, count(*) AS duplicate_count
+FROM staging.threads
+GROUP BY agent_user_id, branch_index
+HAVING count(*) > 1
+ORDER BY duplicate_count DESC, agent_user_id, branch_index;
+
+-- staging thread statuses must fit the target check constraint.
+SELECT status, count(*) AS count
+FROM staging.threads
+WHERE status NOT IN ('active', 'archived')
+GROUP BY status
+ORDER BY status;
+
+-- Unix epoch timestamps must be safe for to_timestamp().
+SELECT count(*) AS negative_thread_timestamps
+FROM staging.threads
+WHERE created_at < 0
+   OR updated_at < 0
+   OR last_active_at < 0;
+
+-- sandbox_type is required in the current dev runtime contract.
+SELECT count(*) AS blank_sandbox_type
+FROM staging.threads
+WHERE sandbox_type IS NULL
+   OR btrim(sandbox_type) = '';
+
+-- thread_tasks statuses must fit the target check constraint.
+SELECT status, count(*) AS count
+FROM staging.agent_thread_tasks
+WHERE status NOT IN ('pending', 'in_progress', 'completed')
+GROUP BY status
+ORDER BY status;
+
+-- thread_tasks required fields and JSONB fields must not contain nulls.
+SELECT count(*) AS thread_task_required_nulls
+FROM staging.agent_thread_tasks
+WHERE thread_id IS NULL
+   OR task_id IS NULL
+   OR subject IS NULL
+   OR description IS NULL
+   OR status IS NULL
+   OR blocks IS NULL
+   OR blocked_by IS NULL
+   OR metadata IS NULL;
+
+-- Source row counts.
+SELECT count(*) AS source_threads_for_agent_threads
+FROM staging.threads t
+JOIN staging.users u ON u.id = t.agent_user_id
+WHERE u.owner_user_id IS NOT NULL;
+
+SELECT count(*) AS source_thread_tasks
+FROM staging.agent_thread_tasks;
+
+-- Known source-task integrity gap. This slice preserves tasks without a hard FK.
+SELECT count(*) AS orphan_thread_tasks_against_staging_threads
+FROM staging.agent_thread_tasks tt
+LEFT JOIN staging.threads t ON t.id = tt.thread_id
+WHERE t.id IS NULL;
+
+-- This migration is first-run-only. Existing target objects mean current live
+-- has already been advanced and needs validation/cleanup, not this migration.
+SELECT schema_name
+FROM information_schema.schemata
+WHERE schema_name = 'agent';
+
+SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+ORDER BY table_name;
+
+COMMIT;

--- a/database/rollbacks/20260414_01_agent_threads_thread_tasks.sql
+++ b/database/rollbacks/20260414_01_agent_threads_thread_tasks.sql
@@ -1,0 +1,18 @@
+-- Roll back Database Refactor dev replay 01.
+--
+-- Scope:
+-- - Remove only the target landing objects created by
+--   database/migrations/20260414_01_agent_threads_thread_tasks.sql.
+--
+-- Non-goals:
+-- - No mutation of public.* or staging.*.
+-- - No schedule rollback. If later agent.* tables exist, roll them back first;
+--   DROP SCHEMA agent should fail loudly instead of hiding extra objects.
+
+BEGIN;
+
+DROP TABLE agent.thread_tasks;
+DROP TABLE agent.threads;
+DROP SCHEMA agent;
+
+COMMIT;

--- a/docs/database-refactor/dev-replay-01-agent-threads-thread-tasks-ddl-precheck.md
+++ b/docs/database-refactor/dev-replay-01-agent-threads-thread-tasks-ddl-precheck.md
@@ -1,0 +1,83 @@
+# Database Refactor Dev Replay 01: Agent Threads And Thread Tasks
+
+## Goal
+
+Codify the first dev-based landing packet for `agent.threads` and `agent.thread_tasks` without replaying stale PR #507 runtime surfaces.
+
+This slice is deliberately DDL/precheck/rollback only. It does not route runtime repositories, add schedules, mutate existing `public.*` or `staging.*`, or create compatibility shims.
+
+## Current Live Proof
+
+Read-only proof was run on 2026-04-14 through the private Supavisor session tunnel using the ops-recorded tenant-user connection shape. No secrets were printed or stored in this repo.
+
+Observed schemas and tables:
+
+- schemas: `agent`, `public`, `staging`
+- target tables already present: `agent.threads`, `agent.thread_tasks`
+- later target tables already present: `agent.schedules`, `agent.schedule_runs`
+- legacy/source tables still present: `public.threads`, `public.tool_tasks`, `staging.threads`, `staging.agent_thread_tasks`, `staging.users`
+
+Observed row counts:
+
+- `staging.threads`: 81
+- `agent.threads`: 83
+- `staging.agent_thread_tasks`: 274
+- `agent.thread_tasks`: 274
+
+Source-shape checks:
+
+- owner derivation missing: 0
+- duplicate `(agent_user_id, branch_index)` pairs in `staging.threads`: 0
+- unsupported `staging.threads.status`: 0
+- blank `staging.threads.sandbox_type`: 0
+- unsupported `staging.agent_thread_tasks.status`: 0
+- required nulls in `staging.agent_thread_tasks`: 0
+
+Important mismatch:
+
+- `agent.threads` has 2 target-only rows that are not in `staging.threads`; both are YATU/proof rows.
+- Every current thread-task row uses `thread_id = 'test-deferred-execution'`, so all 274 rows are orphaned against both `staging.threads` and `agent.threads`.
+
+This means current live has already been advanced past the fresh first-run migration shape, likely by the historical PR #507 work. The migration in this packet is still useful as a clean replay artifact for fresh environments, but it must not be executed blindly against current live.
+
+## Files
+
+- `database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql`
+- `database/migrations/20260414_01_agent_threads_thread_tasks.sql`
+- `database/rollbacks/20260414_01_agent_threads_thread_tasks.sql`
+
+## Migration Stance
+
+The migration is first-run-only:
+
+- it fails if schema `agent` already exists
+- it creates `agent.threads` with `sandbox_type` from the start
+- it copies `staging.threads` through `staging.users.owner_user_id`
+- it copies `staging.agent_thread_tasks`
+- it intentionally does not add an FK from `agent.thread_tasks.thread_id` to `agent.threads.id`
+- it grants only `service_role`
+
+No `IF NOT EXISTS`, `ON CONFLICT`, or compatibility fallback is used.
+
+## Current Live Stopline
+
+Do not execute this migration on current live as-is. Current live already contains `agent.*` objects and extra schedule tables. The correct next live-facing checkpoint is a validation/cleanup checkpoint, not a first-run DDL execution.
+
+Candidate next checkpoint:
+
+- verify whether the two target-only YATU threads should be removed or preserved as proof residue
+- decide whether the 274 `test-deferred-execution` thread-task rows are legacy test residue and should be deleted
+- decide how migration state should be represented for a live DB that was manually advanced before this dev replay PR
+
+## Proof Plan
+
+Before any execution in a fresh environment:
+
+1. Run `database/prechecks/20260414_01_agent_threads_thread_tasks_readonly.sql`.
+2. Confirm source checks are zero except the known orphan thread-task count.
+3. Confirm `agent` schema is absent.
+4. Execute `database/migrations/20260414_01_agent_threads_thread_tasks.sql`.
+5. Verify service-role REST visibility for `agent.threads` and `agent.thread_tasks`.
+6. Do not claim product closure; this is metadata/SQL proof only.
+
+Backend API YATU and frontend Playwright CLI YATU belong to later runtime-routing checkpoints.


### PR DESCRIPTION
## Summary

Adds the first dev-based database-refactor replay packet for `agent.threads` and `agent.thread_tasks`.

This PR contains only:
- read-only precheck SQL
- fresh-environment first-run migration SQL
- rollback SQL
- documentation of current live DB source-shape proof and stopline

## Current live finding

Current live is already advanced: `agent.threads`, `agent.thread_tasks`, `agent.schedules`, and `agent.schedule_runs` already exist. The migration in this PR is therefore a clean replay artifact for fresh environments and must not be executed blindly on current live.

Known live residue documented in the packet:
- `agent.threads` has 2 target-only YATU/proof rows not present in `staging.threads`
- all 274 thread-task rows use `thread_id = 'test-deferred-execution'` and are orphaned against both `staging.threads` and `agent.threads`

## Verification

- `git diff --check`
- live execution of the precheck SQL under `BEGIN READ ONLY` succeeded with writes false
- static grep confirmed executable SQL has no `IF NOT EXISTS`, `ON CONFLICT`, `DROP TABLE IF EXISTS`, or `DROP SCHEMA IF EXISTS`

## Stopline

No live migration execution is authorized by this PR. The next live-facing checkpoint should handle validation/cleanup/migration-state for the already-advanced `agent` schema.