### PR TITLE
Database refactor: live agent schema cleanup preflight

### DIFF
--- a/database/prechecks/20260414_02_live_agent_schema_residue_readonly.sql
+++ b/database/prechecks/20260414_02_live_agent_schema_residue_readonly.sql
@@ -1,0 +1,184 @@
+-- Database Refactor dev replay 02 read-only live residue probes.
+--
+-- Scope:
+-- - Classify current live agent schema state after historical/manual DDL work.
+-- - Classify target-only agent.threads rows.
+-- - Classify orphan thread-task residue.
+-- - Inspect migration-state representation.
+--
+-- This file must not mutate the database.
+
+BEGIN READ ONLY;
+
+SELECT 'agent.threads' AS table_name, count(*) AS row_count FROM agent.threads
+UNION ALL SELECT 'agent.thread_tasks', count(*) FROM agent.thread_tasks
+UNION ALL SELECT 'agent.schedules', count(*) FROM agent.schedules
+UNION ALL SELECT 'agent.schedule_runs', count(*) FROM agent.schedule_runs
+ORDER BY table_name;
+
+SELECT 'agent_not_staging' AS kind, count(*) AS row_count
+FROM agent.threads a
+LEFT JOIN staging.threads s ON s.id = a.id
+WHERE s.id IS NULL
+UNION ALL
+SELECT 'staging_not_agent' AS kind, count(*) AS row_count
+FROM staging.threads s
+LEFT JOIN agent.threads a ON a.id = s.id
+WHERE a.id IS NULL
+ORDER BY kind;
+
+SELECT
+    a.id,
+    a.agent_user_id,
+    agent_user.type AS agent_type,
+    agent_user.display_name AS agent_display_name,
+    a.owner_user_id,
+    owner_user.type AS owner_type,
+    owner_user.display_name AS owner_display_name,
+    a.sandbox_type,
+    a.model,
+    a.cwd,
+    a.status,
+    a.run_status,
+    a.is_main,
+    a.branch_index,
+    a.created_at,
+    a.updated_at,
+    a.last_active_at
+FROM agent.threads a
+LEFT JOIN staging.threads s ON s.id = a.id
+LEFT JOIN staging.users agent_user ON agent_user.id = a.agent_user_id
+LEFT JOIN staging.users owner_user ON owner_user.id = a.owner_user_id
+WHERE s.id IS NULL
+ORDER BY a.created_at;
+
+WITH target_only AS (
+    SELECT a.*
+    FROM agent.threads a
+    LEFT JOIN staging.threads s ON s.id = a.id
+    WHERE s.id IS NULL
+)
+SELECT
+    count(*) AS target_only_threads,
+    count(*) FILTER (WHERE su_agent.id IS NULL) AS missing_agent_user_in_staging_users,
+    count(*) FILTER (WHERE su_owner.id IS NULL) AS missing_owner_user_in_staging_users,
+    count(*) FILTER (WHERE au_agent.id IS NULL) AS missing_agent_user_in_auth_users,
+    count(*) FILTER (WHERE au_owner.id IS NULL) AS missing_owner_user_in_auth_users
+FROM target_only t
+LEFT JOIN staging.users su_agent ON su_agent.id = t.agent_user_id
+LEFT JOIN staging.users su_owner ON su_owner.id = t.owner_user_id
+LEFT JOIN auth.users au_agent ON au_agent.id::text = t.agent_user_id
+LEFT JOIN auth.users au_owner ON au_owner.id::text = t.owner_user_id;
+
+WITH target_only AS (
+    SELECT a.id
+    FROM agent.threads a
+    LEFT JOIN staging.threads s ON s.id = a.id
+    WHERE s.id IS NULL
+)
+SELECT 'agent.thread_tasks' AS source, count(*) AS row_count
+FROM agent.thread_tasks tt
+JOIN target_only t ON t.id = tt.thread_id
+UNION ALL
+SELECT 'staging.agent_thread_tasks' AS source, count(*) AS row_count
+FROM staging.agent_thread_tasks tt
+JOIN target_only t ON t.id = tt.thread_id;
+
+SELECT
+    thread_id,
+    status,
+    owner,
+    active_form,
+    count(*) AS row_count,
+    count(DISTINCT task_id) AS distinct_task_ids,
+    count(DISTINCT subject) AS distinct_subjects
+FROM agent.thread_tasks
+GROUP BY thread_id, status, owner, active_form
+ORDER BY row_count DESC, thread_id, status;
+
+SELECT
+    min(task_id) AS lexicographic_min_task_id,
+    max(task_id) AS lexicographic_max_task_id,
+    count(*) AS row_count,
+    bool_and(task_id ~ '^[0-9]+$') AS all_numeric_task_ids,
+    min(task_id::integer) FILTER (WHERE task_id ~ '^[0-9]+$') AS min_numeric_task_id,
+    max(task_id::integer) FILTER (WHERE task_id ~ '^[0-9]+$') AS max_numeric_task_id
+FROM agent.thread_tasks
+WHERE thread_id = 'test-deferred-execution';
+
+SELECT subject, description, status, count(*) AS row_count
+FROM agent.thread_tasks
+GROUP BY subject, description, status
+ORDER BY row_count DESC, subject;
+
+SELECT 'agent_not_staging' AS kind, count(*) AS row_count
+FROM agent.thread_tasks a
+LEFT JOIN staging.agent_thread_tasks s
+    ON s.thread_id = a.thread_id
+   AND s.task_id = a.task_id
+WHERE s.task_id IS NULL
+UNION ALL
+SELECT 'staging_not_agent' AS kind, count(*) AS row_count
+FROM staging.agent_thread_tasks s
+LEFT JOIN agent.thread_tasks a
+    ON a.thread_id = s.thread_id
+   AND a.task_id = s.task_id
+WHERE a.task_id IS NULL
+ORDER BY kind;
+
+SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE position('migration' IN lower(table_name)) > 0
+   OR position('migration' IN lower(table_schema)) > 0
+ORDER BY table_schema, table_name;
+
+SELECT version, name
+FROM supabase_migrations.schema_migrations
+WHERE starts_with(version, '20260414')
+ORDER BY version;
+
+SELECT table_schema, table_name, column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE (table_schema, table_name) IN (
+    ('public', 'checkpoint_migrations'),
+    ('staging', 'checkpoint_migrations'),
+    ('supabase_migrations', 'schema_migrations')
+)
+ORDER BY table_schema, table_name, ordinal_position;
+
+SELECT 'public.checkpoint_migrations' AS table_name, count(*) AS row_count
+FROM public.checkpoint_migrations
+UNION ALL
+SELECT 'staging.checkpoint_migrations', count(*)
+FROM staging.checkpoint_migrations
+ORDER BY table_name;
+
+SELECT c.relname AS table_name, con.conname, con.contype, pg_get_constraintdef(con.oid)
+FROM pg_constraint con
+JOIN pg_class c ON c.oid = con.conrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'agent'
+ORDER BY c.relname, con.conname;
+
+SELECT n.nspname AS schema_name, c.relname AS table_name, c.relrowsecurity, c.relforcerowsecurity
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'agent'
+  AND c.relkind = 'r'
+ORDER BY c.relname;
+
+SELECT p.pubname, n.nspname AS schema_name, c.relname AS table_name
+FROM pg_publication p
+JOIN pg_publication_rel pr ON pr.prpubid = p.oid
+JOIN pg_class c ON c.oid = pr.prrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'agent'
+ORDER BY p.pubname, c.relname;
+
+SELECT table_name, grantee, privilege_type
+FROM information_schema.table_privileges
+WHERE table_schema = 'agent'
+  AND grantee IN ('service_role', 'authenticated', 'anon')
+ORDER BY table_name, grantee, privilege_type;
+
+COMMIT;

--- a/docs/database-refactor/dev-replay-02-live-agent-schema-validation-cleanup-preflight.md
+++ b/docs/database-refactor/dev-replay-02-live-agent-schema-validation-cleanup-preflight.md
@@ -1,0 +1,194 @@
+# Database Refactor Dev Replay 02: Live Agent Schema Cleanup Preflight
+
+## Goal
+
+Classify the current live `agent` schema state after historical/manual database-refactor work, then decide a cleanup and migration-state policy before any live DB writes.
+
+This checkpoint is read-only. It does not merge PR #509, execute migrations, delete proof residue, route runtime repositories, or change schedules.
+
+## Read-Only Probes
+
+Probe file:
+
+- `database/prechecks/20260414_02_live_agent_schema_residue_readonly.sql`
+
+The probes were also run manually on 2026-04-14 through the private Supavisor session tunnel using the ops-recorded tenant-user connection shape. No secrets were printed or stored in this repo.
+
+## Live Facts
+
+Current `agent` table counts:
+
+- `agent.threads`: 83
+- `agent.thread_tasks`: 274
+- `agent.schedules`: 0
+- `agent.schedule_runs`: 0
+
+Thread source/target parity:
+
+- `staging_not_agent`: 0
+- `agent_not_staging`: 2
+
+The two target-only `agent.threads` rows are:
+
+- `agent_yatu_17761029419594-1`
+- `agent_yatu_02b_17761036443327-1`
+
+Both rows have:
+
+- `sandbox_type = 'local'`
+- `model = 'large'`
+- `status = 'active'`
+- `run_status = 'idle'`
+- `is_main = true`
+- `branch_index = 0`
+- no `cwd`
+- no `last_active_at`
+- no matching `staging.threads` row
+- no matching agent or owner row in `staging.users`
+- no matching agent or owner row in `auth.users`
+- no referencing row in `agent.thread_tasks` or `staging.agent_thread_tasks`
+
+Classification: these are standalone YATU/proof residue rows, not live product state.
+
+Thread-task facts:
+
+- All 274 `agent.thread_tasks` rows use `thread_id = 'test-deferred-execution'`.
+- All 274 rows are `status = 'pending'`.
+- All 274 rows share `subject = 'PT02_EXEC'`.
+- All 274 rows share `description = 'created after discovery'`.
+- All 274 rows have null `owner`, null `active_form`, empty `blocks`, empty `blocked_by`, and empty `metadata`.
+- Task ids are numeric 1 through 274.
+- `agent.thread_tasks` and `staging.agent_thread_tasks` are in exact parity: no source-only or target-only task rows.
+- The same 274 rows also exist in `public.tool_tasks`.
+- The residue is referenced only by:
+  - `agent.thread_tasks.thread_id`: 274
+  - `staging.agent_thread_tasks.thread_id`: 274
+  - `public.tool_tasks.thread_id`: 274
+
+Classification: this is legacy test residue copied through all task tables, not live thread-attached work.
+
+Migration-state facts:
+
+- `supabase_migrations.schema_migrations` has no `20260414%` rows.
+- `agent.threads`, `agent.thread_tasks`, `agent.schedules`, and `agent.schedule_runs` therefore appear to have been created manually or through unrecorded scripts, not through Supabase migration state.
+- `public.checkpoint_migrations` has 10 rows and only a single integer column `v`.
+- `staging.checkpoint_migrations` has 0 rows and only a single integer column `v`.
+- Those checkpoint tables are not an adequate durable schema-migration record for the `agent` schema replay.
+
+Current `agent` exposure:
+
+- Grants exist only for `service_role` on `agent.threads`, `agent.thread_tasks`, `agent.schedules`, and `agent.schedule_runs`.
+- RLS is disabled for all four `agent` tables.
+- No `agent` tables are in a publication.
+
+Schema drift versus PR #509 fresh DDL:
+
+- Current live `agent.threads.sandbox_type` is `NOT NULL`.
+- Current live does not have the stricter `threads_sandbox_type_chk` check constraint from PR #509.
+- Schedule tables exist even though PR #509 deliberately excludes schedule work.
+
+## Policy Recommendation
+
+Separate three actions. Do not combine them into one migration.
+
+1. Merge PR #509 independently if desired.
+2. Create an explicit live cleanup checkpoint for proof/test residue.
+3. Create an explicit migration-state reconciliation checkpoint after cleanup policy is accepted.
+
+## Cleanup Candidate
+
+Candidate cleanup should be a write-only-after-approval packet, not run from this preflight:
+
+```sql
+BEGIN;
+
+CREATE SCHEMA maintenance;
+
+CREATE TABLE maintenance.agent_residue_cleanup_20260414 AS
+SELECT 'agent.threads' AS source_table, to_jsonb(t.*) AS row_data
+FROM agent.threads t
+LEFT JOIN staging.threads s ON s.id = t.id
+WHERE s.id IS NULL
+UNION ALL
+SELECT 'agent.thread_tasks' AS source_table, to_jsonb(tt.*) AS row_data
+FROM agent.thread_tasks tt
+WHERE tt.thread_id = 'test-deferred-execution'
+UNION ALL
+SELECT 'staging.agent_thread_tasks' AS source_table, to_jsonb(tt.*) AS row_data
+FROM staging.agent_thread_tasks tt
+WHERE tt.thread_id = 'test-deferred-execution'
+UNION ALL
+SELECT 'public.tool_tasks' AS source_table, to_jsonb(tt.*) AS row_data
+FROM public.tool_tasks tt
+WHERE tt.thread_id = 'test-deferred-execution';
+
+DELETE FROM agent.thread_tasks
+WHERE thread_id = 'test-deferred-execution';
+
+DELETE FROM staging.agent_thread_tasks
+WHERE thread_id = 'test-deferred-execution';
+
+DELETE FROM public.tool_tasks
+WHERE thread_id = 'test-deferred-execution';
+
+DELETE FROM agent.threads t
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM staging.threads s
+    WHERE s.id = t.id
+);
+
+COMMIT;
+```
+
+Expected backup rows if run against the observed state:
+
+- 2 rows from `agent.threads`
+- 274 rows from `agent.thread_tasks`
+- 274 rows from `staging.agent_thread_tasks`
+- 274 rows from `public.tool_tasks`
+- 824 total backup rows
+
+Expected post-cleanup counts if no concurrent writes happen:
+
+- `agent.threads`: 81
+- `agent.thread_tasks`: 0
+- `staging.agent_thread_tasks`: 0
+- `public.tool_tasks`: 0
+
+This candidate intentionally uses a `maintenance` schema. That is a live-write policy choice and needs explicit approval; it is not authorized by this preflight.
+
+## Migration-State Options
+
+Option A: do not fake migration history.
+
+- Keep Supabase migration state untouched.
+- Treat current live as manually advanced.
+- Use explicit validation docs plus cleanup proof.
+- This is honest but means future automated migration tooling will not know these `agent` objects are already present.
+
+Option B: create a reconciliation marker outside Supabase migrations.
+
+- Add a small `maintenance.schema_reconciliation_events` table and record that `agent` DDL was manually present before dev replay.
+- This avoids falsifying Supabase migration history.
+- It adds one maintenance table, so it needs explicit approval.
+
+Option C: insert synthetic rows into `supabase_migrations.schema_migrations`.
+
+- Not recommended.
+- It makes tooling believe migrations ran when they did not.
+- It also cannot honestly represent the schema drift: current live has schedule tables and lacks PR #509's sandbox-type check constraint.
+
+Recommendation: Option A for now. After cleanup, decide whether a maintenance reconciliation table is worth the extra surface area.
+
+## Stopline
+
+No write is authorized by this preflight.
+
+Before any cleanup:
+
+1. Re-run the read-only probe.
+2. Confirm counts still match the expected rows.
+3. Review exact cleanup SQL.
+4. Decide whether backup should live in a DB `maintenance` schema or be exported outside the DB.
+5. Get a separate Ledger and human authorization for the write.


### PR DESCRIPTION
## Summary

Adds a read-only preflight packet for the current live `agent` schema state after historical/manual database-refactor work.

This PR contains only:
- read-only residue classification SQL
- a cleanup/migration-state policy document

## Key live findings

- `agent.threads`: 83 rows
- `agent.thread_tasks`: 274 rows
- `agent.schedules`: 0 rows
- `agent.schedule_runs`: 0 rows
- `agent.threads` has 2 target-only YATU/proof rows not present in `staging.threads`
- all 274 task rows are `test-deferred-execution` / `PT02_EXEC` residue and are mirrored across `agent.thread_tasks`, `staging.agent_thread_tasks`, and `public.tool_tasks`
- `supabase_migrations.schema_migrations` has no `20260414` rows, so live appears manually advanced relative to the replay packet

## Verification

- `uv lock --check`
- `git diff --check HEAD~1..HEAD`
- static grep found no forbidden fallback/secret patterns
- live execution of the precheck SQL under `BEGIN READ ONLY` succeeded with writes false

## Stopline

This PR does not authorize DB writes, cleanup, migration execution, PR #509 merge, runtime routing, or schedule changes. Candidate cleanup SQL is documented only as a future write-authorization packet.