### PR TITLE
refactor(db): route thread runtime to agent schema

### DIFF
--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -17,6 +17,18 @@ def validate_client(client: Any, repo: str) -> Any:
     return client
 
 
+def schema_table(client: Any, schema: str, table: str, repo: str) -> Any:
+    """Return a schema-qualified table query root, failing loudly if unsupported."""
+    schema_method = getattr(client, "schema", None)
+    if not callable(schema_method):
+        raise RuntimeError(f"Supabase {repo} requires client.schema({schema!r}) support for {schema}.{table}.")
+    scoped = schema_method(schema)
+    table_method = getattr(scoped, "table", None)
+    if not callable(table_method):
+        raise RuntimeError(f"Supabase {repo} schema({schema!r}) result must expose table(name).")
+    return table_method(table)
+
+
 def rows(response: Any, repo: str, operation: str) -> list[dict[str, Any]]:
     """Extract and validate the `.data` list from a supabase-py response."""
     if isinstance(response, dict):

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -7,15 +7,19 @@ from typing import Any
 from storage.providers.supabase import _query as q
 
 _REPO = "thread repo"
+_SCHEMA = "agent"
 _TABLE = "threads"
 
 _COLS = (
     "id",
     "agent_user_id",
+    "owner_user_id",
+    "current_workspace_id",
     "sandbox_type",
     "model",
     "cwd",
     "status",
+    "run_status",
     "is_main",
     "branch_index",
     "created_at",
@@ -61,12 +65,15 @@ class SupabaseThreadRepo:
         status: str = "active",
         updated_at: float | None = None,
         last_active_at: float | None = None,
+        owner_user_id: str | None = None,
     ) -> None:
         _validate_thread_identity(is_main=is_main, branch_index=branch_index)
+        resolved_owner_user_id = owner_user_id or self._resolve_owner_user_id(agent_user_id)
         self._t().insert(
             {
                 "id": thread_id,
                 "agent_user_id": agent_user_id,
+                "owner_user_id": resolved_owner_user_id,
                 "sandbox_type": sandbox_type,
                 "cwd": cwd,
                 "model": model,
@@ -220,4 +227,14 @@ class SupabaseThreadRepo:
         self._t().delete().eq("id", thread_id).execute()
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
+
+    def _resolve_owner_user_id(self, agent_user_id: str) -> str:
+        response = self._client.table("users").select("owner_user_id").eq("id", agent_user_id).execute()
+        rows = q.rows(response, _REPO, "resolve_owner_user_id")
+        if not rows:
+            raise ValueError(f"agent user {agent_user_id!r} not found while creating agent.threads row")
+        owner_user_id = rows[0].get("owner_user_id")
+        if not isinstance(owner_user_id, str) or not owner_user_id.strip():
+            raise ValueError(f"agent user {agent_user_id!r} has no owner_user_id for agent.threads row")
+        return owner_user_id

--- a/storage/providers/supabase/tool_task_repo.py
+++ b/storage/providers/supabase/tool_task_repo.py
@@ -9,7 +9,8 @@ from core.tools.task.types import Task, TaskStatus
 from storage.providers.supabase import _query as q
 
 _REPO = "tool_task repo"
-_TABLE = "agent_thread_tasks"
+_SCHEMA = "agent"
+_TABLE = "thread_tasks"
 
 
 class SupabaseToolTaskRepo:
@@ -20,7 +21,7 @@ class SupabaseToolTaskRepo:
         return None
 
     def _table(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
 
     def next_id(self, thread_id: str) -> str:
         rows = q.rows(

--- a/tests/Unit/core/test_task_service_agent_thread_tasks_routing.py
+++ b/tests/Unit/core/test_task_service_agent_thread_tasks_routing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from langchain_core.messages import ToolMessage
+
+from core.runtime.registry import ToolRegistry
+from core.runtime.runner import ToolRunner
+from core.tools.task.service import TaskService
+from sandbox.thread_context import set_current_thread_id
+from storage.runtime import build_tool_task_repo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def _call_tool(runner: ToolRunner, name: str, args: dict, call_id: str) -> dict:
+    request = SimpleNamespace(tool_call={"name": name, "args": args, "id": call_id})
+
+    def unexpected_upstream(_request):
+        raise AssertionError(f"{name} must be handled by ToolRunner registry dispatch")
+
+    message = runner.wrap_tool_call(request, unexpected_upstream)
+    assert isinstance(message, ToolMessage)
+    return json.loads(message.content)
+
+
+def test_task_service_persists_through_tool_runner_to_agent_thread_tasks() -> None:
+    tables: dict[str, list[dict]] = {}
+    repo = build_tool_task_repo(supabase_client=FakeSupabaseClient(tables=tables))
+    set_current_thread_id("thread-04")
+
+    registry = ToolRegistry()
+    TaskService(registry=registry, repo=repo)
+    runner = ToolRunner(registry)
+
+    created = _call_tool(
+        runner,
+        "TaskCreate",
+        {
+            "subject": "Route runtime",
+            "description": "Persist task through agent.thread_tasks",
+            "metadata": {"checkpoint": "04"},
+        },
+        "call-create",
+    )
+
+    assert created["id"] == "1"
+    assert tables["agent.thread_tasks"] == [
+        {
+            "thread_id": "thread-04",
+            "task_id": "1",
+            "subject": "Route runtime",
+            "description": "Persist task through agent.thread_tasks",
+            "status": "pending",
+            "active_form": None,
+            "owner": None,
+            "blocks": [],
+            "blocked_by": [],
+            "metadata": {"checkpoint": "04"},
+        }
+    ]
+
+    listed = _call_tool(runner, "TaskList", {}, "call-list")
+    assert listed["total"] == 1
+    assert listed["tasks"][0]["subject"] == "Route runtime"

--- a/tests/Unit/storage/test_supabase_thread_repo.py
+++ b/tests/Unit/storage/test_supabase_thread_repo.py
@@ -1,4 +1,5 @@
 from storage.providers.supabase.thread_repo import SupabaseThreadRepo
+from tests.fakes.supabase import FakeSupabaseClient
 
 
 class _FakeTable:
@@ -56,6 +57,9 @@ class _FakeClient:
     def __init__(self) -> None:
         self.table_obj = _FakeTable()
 
+    def schema(self, _name):
+        return self
+
     def table(self, _name):
         return self.table_obj
 
@@ -71,6 +75,7 @@ def test_supabase_thread_repo_create_writes_integer_main_flag():
         created_at=1.0,
         is_main=True,
         branch_index=0,
+        owner_user_id="owner-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -88,6 +93,7 @@ def test_supabase_thread_repo_create_defaults_active_status():
         created_at=1.0,
         is_main=True,
         branch_index=0,
+        owner_user_id="owner-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -105,6 +111,7 @@ def test_supabase_thread_repo_create_uses_agent_user_id_not_member_id() -> None:
         created_at=1.0,
         is_main=True,
         branch_index=0,
+        owner_user_id="owner-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -242,3 +249,36 @@ def test_supabase_thread_repo_list_by_ids_chunks_large_in_filters() -> None:
 
     assert [row["id"] for row in rows] == ["thread-0", "thread-80"]
     assert [len(values) for _key, values in client.table_obj.in_calls] == [80, 1]
+
+
+def test_supabase_thread_repo_reads_agent_threads_schema_table() -> None:
+    client = FakeSupabaseClient(
+        tables={
+            "agent.threads": [
+                {
+                    "id": "thread-1",
+                    "agent_user_id": "agent-1",
+                    "owner_user_id": "owner-1",
+                    "current_workspace_id": None,
+                    "sandbox_type": "local",
+                    "model": "large",
+                    "cwd": "/work",
+                    "status": "active",
+                    "run_status": "idle",
+                    "is_main": True,
+                    "branch_index": 0,
+                    "created_at": "2026-04-14T00:00:00+00:00",
+                    "updated_at": "2026-04-14T00:00:00+00:00",
+                    "last_active_at": None,
+                }
+            ]
+        }
+    )
+    repo = SupabaseThreadRepo(client)
+
+    row = repo.get_by_id("thread-1")
+
+    assert row is not None
+    assert row["id"] == "thread-1"
+    assert row["agent_user_id"] == "agent-1"
+    assert row["owner_user_id"] == "owner-1"

--- a/tests/Unit/storage/test_supabase_tool_task_repo.py
+++ b/tests/Unit/storage/test_supabase_tool_task_repo.py
@@ -1,4 +1,6 @@
+from core.tools.task.types import Task, TaskStatus
 from storage.providers.supabase.tool_task_repo import SupabaseToolTaskRepo
+from tests.fakes.supabase import FakeSupabaseClient
 
 
 class _FakeTable:
@@ -22,6 +24,10 @@ class _FakeClient:
         self.table_obj = _FakeTable(rows)
         self.table_names: list[str] = []
 
+    def schema(self, name):
+        self.table_names.append(f"schema:{name}")
+        return self
+
     def table(self, name):
         self.table_names.append(name)
         return self.table_obj
@@ -39,10 +45,41 @@ def test_supabase_tool_task_repo_next_id_uses_max_existing_id_not_row_count():
     assert repo.next_id("thread-gap") == "4"
 
 
-def test_supabase_tool_task_repo_uses_agent_thread_tasks_table():
+def test_supabase_tool_task_repo_uses_agent_schema_thread_tasks_table():
     client = _FakeClient([])
     repo = SupabaseToolTaskRepo(client)
 
     repo.next_id("thread-empty")
 
-    assert client.table_names == ["agent_thread_tasks"]
+    assert client.table_names == ["schema:agent", "thread_tasks"]
+
+
+def test_supabase_tool_task_repo_reads_agent_thread_tasks_schema_table() -> None:
+    client = FakeSupabaseClient(
+        tables={
+            "agent.thread_tasks": [
+                {
+                    "thread_id": "thread-1",
+                    "task_id": "1",
+                    "subject": "Route runtime",
+                    "description": "Read from target domain table",
+                    "status": "pending",
+                    "active_form": None,
+                    "owner": None,
+                    "blocks": [],
+                    "blocked_by": [],
+                    "metadata": {},
+                }
+            ]
+        }
+    )
+    repo = SupabaseToolTaskRepo(client)
+
+    assert repo.list_all("thread-1") == [
+        Task(
+            id="1",
+            subject="Route runtime",
+            description="Read from target domain table",
+            status=TaskStatus.PENDING,
+        )
+    ]

--- a/tests/fakes/supabase.py
+++ b/tests/fakes/supabase.py
@@ -26,7 +26,7 @@ class FakeSupabaseQuery:
         self._delete_requested = False
         self._auto_seq = False
 
-    def select(self, _columns: str):
+    def select(self, _columns: str, **_kwargs):
         return self
 
     def insert(self, payload: dict | list[dict]):
@@ -161,12 +161,18 @@ class FakeSupabaseClient:
         self,
         tables: dict[str, list[dict]] | None = None,
         auto_seq_tables: set[str] | None = None,
+        schema_name: str | None = None,
     ):
         self._tables = tables if tables is not None else {}
         self._auto_seq_tables = auto_seq_tables or set()
+        self._schema_name = schema_name
 
     def table(self, table_name: str) -> FakeSupabaseQuery:
-        query = FakeSupabaseQuery(table_name, self._tables)
-        if table_name in self._auto_seq_tables:
+        resolved_table = f"{self._schema_name}.{table_name}" if self._schema_name else table_name
+        query = FakeSupabaseQuery(resolved_table, self._tables)
+        if resolved_table in self._auto_seq_tables:
             query._auto_seq = True
         return query
+
+    def schema(self, schema_name: str) -> FakeSupabaseClient:
+        return FakeSupabaseClient(self._tables, self._auto_seq_tables, schema_name=schema_name)


### PR DESCRIPTION
## Summary
- Route Supabase thread runtime reads/writes to `agent.threads` via explicit schema-scoped table access.
- Route TaskService/tool task persistence to `agent.thread_tasks` while preserving max task id allocation.
- Add fail-loud schema table helper plus focused fake Supabase, repo, and ToolRunner mechanism tests.

## Test Plan
- `uv run pytest tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py tests/Unit/core/test_agent_service.py -q`
- `uv run ruff check storage/providers/supabase/_query.py storage/providers/supabase/thread_repo.py storage/providers/supabase/tool_task_repo.py tests/fakes/supabase.py tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py`
- `uv run ruff format --check storage/providers/supabase/_query.py storage/providers/supabase/thread_repo.py storage/providers/supabase/tool_task_repo.py tests/fakes/supabase.py tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py`
- `git diff --check`
- Read-only backend API YATU: existing worktree backend on `:8010`, `LEON_DB_SCHEMA=staging`, real auth login `200`, `GET /api/threads` `200` with `threads` count 3. No thread/task creation or live DB write performed.

## Scope Guard
- No schedule runtime work.
- No migration execution or migration-history edit.
- No stale PR #507 member/entity/chat/storage_factory replay.
- No compatibility double-write or fallback to staging.