### PR TITLE
fix(db): serialize agent thread timestamps

### DIFF
--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from storage.providers.supabase import _query as q
@@ -44,6 +45,14 @@ def _to_dict(row: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _to_timestamptz(value: float | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return datetime.fromtimestamp(value, UTC).isoformat()
+
+
 class SupabaseThreadRepo:
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
@@ -69,6 +78,8 @@ class SupabaseThreadRepo:
     ) -> None:
         _validate_thread_identity(is_main=is_main, branch_index=branch_index)
         resolved_owner_user_id = owner_user_id or self._resolve_owner_user_id(agent_user_id)
+        created_at_value = _to_timestamptz(created_at)
+        updated_at_value = _to_timestamptz(updated_at) if updated_at is not None else created_at_value
         self._t().insert(
             {
                 "id": thread_id,
@@ -80,9 +91,9 @@ class SupabaseThreadRepo:
                 "status": status,
                 "is_main": int(is_main),
                 "branch_index": branch_index,
-                "created_at": created_at,
-                "updated_at": updated_at,
-                "last_active_at": last_active_at,
+                "created_at": created_at_value,
+                "updated_at": updated_at_value,
+                "last_active_at": _to_timestamptz(last_active_at),
             }
         ).execute()
 

--- a/tests/Unit/storage/test_supabase_thread_repo.py
+++ b/tests/Unit/storage/test_supabase_thread_repo.py
@@ -100,6 +100,48 @@ def test_supabase_thread_repo_create_defaults_active_status():
     assert client.table_obj.insert_payload["status"] == "active"
 
 
+def test_supabase_thread_repo_create_serializes_epoch_timestamps_for_agent_schema():
+    client = _FakeClient()
+    repo = SupabaseThreadRepo(client)
+
+    repo.create(
+        thread_id="thread-1",
+        agent_user_id="agent-1",
+        sandbox_type="local",
+        created_at=1.25,
+        updated_at=2.5,
+        last_active_at=3.75,
+        is_main=True,
+        branch_index=0,
+        owner_user_id="owner-1",
+    )
+
+    assert client.table_obj.insert_payload is not None
+    assert client.table_obj.insert_payload["created_at"] == "1970-01-01T00:00:01.250000+00:00"
+    assert client.table_obj.insert_payload["updated_at"] == "1970-01-01T00:00:02.500000+00:00"
+    assert client.table_obj.insert_payload["last_active_at"] == "1970-01-01T00:00:03.750000+00:00"
+
+
+def test_supabase_thread_repo_create_defaults_updated_at_to_created_at_for_agent_schema():
+    client = _FakeClient()
+    repo = SupabaseThreadRepo(client)
+
+    repo.create(
+        thread_id="thread-1",
+        agent_user_id="agent-1",
+        sandbox_type="local",
+        created_at=1.25,
+        is_main=True,
+        branch_index=0,
+        owner_user_id="owner-1",
+    )
+
+    assert client.table_obj.insert_payload is not None
+    assert client.table_obj.insert_payload["created_at"] == "1970-01-01T00:00:01.250000+00:00"
+    assert client.table_obj.insert_payload["updated_at"] == "1970-01-01T00:00:01.250000+00:00"
+    assert client.table_obj.insert_payload["last_active_at"] is None
+
+
 def test_supabase_thread_repo_create_uses_agent_user_id_not_member_id() -> None:
     client = _FakeClient()
     repo = SupabaseThreadRepo(client)


### PR DESCRIPTION
## Summary
- serialize Supabase agent thread timestamp payloads to UTC ISO strings for TIMESTAMPTZ columns
- default omitted updated_at to created_at during agent thread creation
- add regression tests for timestamp serialization and updated_at defaulting

## Verification
- uv run pytest tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py tests/Unit/core/test_agent_service.py -q
- uv run ruff check storage/providers/supabase/thread_repo.py tests/Unit/storage/test_supabase_thread_repo.py
- uv run ruff format --check storage/providers/supabase/thread_repo.py tests/Unit/storage/test_supabase_thread_repo.py && git diff --check
- Backend API YATU: real local backend :8010 POST /api/threads wrote agent.threads only; TaskCreate wrote agent.thread_tasks only; proof resources cleaned and guarded state restored

Scope: no migrations, no schedule work, no broader runtime routing.