### PR TITLE
chore(db): add agent schedule DDL replay artifact

### DIFF
--- a/database/migrations/20260414_03_agent_schedules.sql
+++ b/database/migrations/20260414_03_agent_schedules.sql
@@ -1,0 +1,171 @@
+-- Database Refactor 02G: land agent.schedules and agent.schedule_runs.
+--
+-- Scope:
+-- - Create agent.schedules.
+-- - Create agent.schedule_runs.
+-- - Grant service_role access.
+--
+-- Non-goals:
+-- - No mutation or deletion of public.* / staging.*.
+-- - No migration from cron_jobs because live public/staging cron_jobs are empty.
+-- - No panel_tasks migration. Panel tasks are explicitly not target schedule ontology.
+-- - No runtime repository routing.
+-- - No /cron-jobs API behavior change.
+-- - No frontend behavior change.
+-- - No RLS/realtime policy in this migration. Add only after behavior is proved
+--   in a separate checkpoint.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_agent_schema_count integer;
+    v_agent_threads_count integer;
+    v_schedules_count integer;
+    v_schedule_runs_count integer;
+    v_public_cron_jobs_count integer;
+    v_staging_cron_jobs_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_agent_schema_count
+    FROM information_schema.schemata
+    WHERE schema_name = 'agent';
+
+    IF v_agent_schema_count <> 1 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent schema must exist exactly once, found %', v_agent_schema_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_agent_threads_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'threads';
+
+    IF v_agent_threads_count <> 1 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent.threads must exist exactly once, found %', v_agent_threads_count;
+    END IF;
+
+    SELECT count(*)
+    INTO v_schedules_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedules';
+
+    IF v_schedules_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent.schedules already exists';
+    END IF;
+
+    SELECT count(*)
+    INTO v_schedule_runs_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedule_runs';
+
+    IF v_schedule_runs_count <> 0 THEN
+        RAISE EXCEPTION 'Cannot migrate 02G: agent.schedule_runs already exists';
+    END IF;
+
+    SELECT count(*) INTO v_public_cron_jobs_count FROM public.cron_jobs;
+    SELECT count(*) INTO v_staging_cron_jobs_count FROM staging.cron_jobs;
+
+    IF v_public_cron_jobs_count <> 0 OR v_staging_cron_jobs_count <> 0 THEN
+        RAISE EXCEPTION
+            'Cannot migrate 02G without a cron_jobs data ruling: public %, staging %',
+            v_public_cron_jobs_count,
+            v_staging_cron_jobs_count;
+    END IF;
+END $$;
+
+CREATE TABLE agent.schedules (
+    id                   TEXT        PRIMARY KEY,
+    owner_user_id        TEXT        NOT NULL,
+    agent_user_id        TEXT        NOT NULL,
+    target_thread_id     TEXT,
+    create_thread_on_run BOOLEAN     NOT NULL DEFAULT false,
+    cron_expression      TEXT        NOT NULL,
+    enabled              BOOLEAN     NOT NULL DEFAULT true,
+    instruction_template TEXT        NOT NULL,
+    timezone             TEXT        NOT NULL DEFAULT 'UTC',
+    last_run_at          TIMESTAMPTZ,
+    next_run_at          TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT schedules_target_chk
+        CHECK (target_thread_id IS NOT NULL OR create_thread_on_run),
+    CONSTRAINT schedules_instruction_template_chk
+        CHECK (btrim(instruction_template) <> ''),
+    CONSTRAINT schedules_cron_expression_chk
+        CHECK (btrim(cron_expression) <> ''),
+    CONSTRAINT schedules_timezone_chk
+        CHECK (btrim(timezone) <> '')
+);
+
+CREATE INDEX idx_schedules_owner_enabled_next_run
+    ON agent.schedules(owner_user_id, next_run_at)
+    WHERE enabled = true;
+
+CREATE INDEX idx_schedules_agent
+    ON agent.schedules(agent_user_id);
+
+CREATE INDEX idx_schedules_target_thread
+    ON agent.schedules(target_thread_id)
+    WHERE target_thread_id IS NOT NULL;
+
+CREATE TABLE agent.schedule_runs (
+    id            TEXT        PRIMARY KEY,
+    schedule_id   TEXT        NOT NULL,
+    owner_user_id TEXT        NOT NULL,
+    agent_user_id TEXT        NOT NULL,
+    thread_id     TEXT,
+    status        TEXT        NOT NULL DEFAULT 'queued',
+    triggered_by  TEXT        NOT NULL,
+    scheduled_for TIMESTAMPTZ,
+    started_at    TIMESTAMPTZ,
+    completed_at  TIMESTAMPTZ,
+    input_json    JSONB       NOT NULL DEFAULT '{}',
+    output_json   JSONB       NOT NULL DEFAULT '{}',
+    error         TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT schedule_runs_status_chk
+        CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+    CONSTRAINT schedule_runs_triggered_by_chk
+        CHECK (triggered_by IN ('scheduler', 'manual'))
+);
+
+CREATE INDEX idx_schedule_runs_schedule_created
+    ON agent.schedule_runs(schedule_id, created_at DESC);
+
+CREATE INDEX idx_schedule_runs_owner_created
+    ON agent.schedule_runs(owner_user_id, created_at DESC);
+
+CREATE INDEX idx_schedule_runs_status_scheduled
+    ON agent.schedule_runs(status, scheduled_for);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.schedules TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON agent.schedule_runs TO service_role;
+
+DO $$
+DECLARE
+    v_schedules_count integer;
+    v_schedule_runs_count integer;
+BEGIN
+    SELECT count(*)
+    INTO v_schedules_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedules';
+
+    SELECT count(*)
+    INTO v_schedule_runs_count
+    FROM information_schema.tables
+    WHERE table_schema = 'agent'
+      AND table_name = 'schedule_runs';
+
+    IF v_schedules_count <> 1 OR v_schedule_runs_count <> 1 THEN
+        RAISE EXCEPTION '02G table creation parity failed: schedules %, schedule_runs %', v_schedules_count, v_schedule_runs_count;
+    END IF;
+END $$;
+
+COMMIT;

--- a/database/prechecks/20260414_03_agent_schedules_readonly.sql
+++ b/database/prechecks/20260414_03_agent_schedules_readonly.sql
@@ -1,0 +1,46 @@
+-- Database Refactor 02G read-only prechecks.
+-- Run before executing database/migrations/20260414_03_agent_schedules.sql.
+-- This file must not mutate the database.
+
+-- 1. The agent schema and agent.threads foundation from 02A must already exist.
+SELECT count(*) AS agent_schema_exists
+FROM information_schema.schemata
+WHERE schema_name = 'agent';
+
+SELECT count(*) AS agent_threads_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'threads';
+
+-- 2. The schedule target tables must not already exist.
+SELECT count(*) AS agent_schedules_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'schedules';
+
+SELECT count(*) AS agent_schedule_runs_exists
+FROM information_schema.tables
+WHERE table_schema = 'agent'
+  AND table_name = 'schedule_runs';
+
+-- 3. Required agent.threads identity columns must exist.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'agent'
+  AND table_name = 'threads'
+  AND column_name IN ('id', 'agent_user_id', 'owner_user_id')
+ORDER BY ordinal_position;
+
+-- 4. Existing legacy schedule rows must be empty because 02G does not migrate cron_jobs.
+SELECT count(*) AS public_cron_jobs
+FROM public.cron_jobs;
+
+SELECT count(*) AS staging_cron_jobs
+FROM staging.cron_jobs;
+
+-- 5. Panel tasks are explicitly rejected as schedule source data; show their count only.
+SELECT count(*) AS public_panel_tasks_not_migrated
+FROM public.panel_tasks;
+
+-- 6. Service role must already have agent schema usage from 02A.
+SELECT has_schema_privilege('service_role', 'agent', 'USAGE') AS service_role_has_agent_usage;

--- a/database/rollbacks/20260414_03_agent_schedules.sql
+++ b/database/rollbacks/20260414_03_agent_schedules.sql
@@ -1,0 +1,12 @@
+-- Roll back Database Refactor 02G.
+--
+-- This rollback only removes the target schedule tables created by
+-- database/migrations/20260414_03_agent_schedules.sql.
+-- It does not mutate public.* or staging.*.
+
+BEGIN;
+
+DROP TABLE IF EXISTS agent.schedule_runs;
+DROP TABLE IF EXISTS agent.schedules;
+
+COMMIT;

--- a/docs/database-refactor/dev-replay-07-agent-schedules-ddl-artifact-replay.md
+++ b/docs/database-refactor/dev-replay-07-agent-schedules-ddl-artifact-replay.md
@@ -1,0 +1,124 @@
+# Database Refactor Dev Replay 07: Agent Schedules DDL Artifact Replay
+
+## Goal
+
+Restore the replayable fresh-environment DDL artifact for `agent.schedules` and
+`agent.schedule_runs` on current `dev`, without replaying the old PR #507 runtime
+work.
+
+This checkpoint is SQL/docs only. It does not execute migrations against current
+live, route schedule repositories, change APIs, change frontend behavior, add
+RLS/realtime, migrate legacy cron rows, or edit migration history.
+
+## Source Lineage
+
+The schedule DDL comes from historical PR #507 commit:
+
+- `8161f835` — `refactor(db): land agent schedules schema`
+
+Only the 02G DDL artifact was replayed:
+
+- `database/prechecks/20260414_03_agent_schedules_readonly.sql`
+- `database/migrations/20260414_03_agent_schedules.sql`
+- `database/rollbacks/20260414_03_agent_schedules.sql`
+
+The later PR #507 commits are intentionally excluded from this replay:
+
+- `5a1dde35` — schedule repo/service surface
+- `84d29c2d` — schedule trigger runtime
+- `9d50918b` — schedule run completion
+
+Those are runtime/product behavior slices, not DDL artifact replay.
+
+## Current Dev Gap
+
+Current `dev` has the `agent.threads` / `agent.thread_tasks` replay artifact,
+but no schedule DDL artifact. The existing thread/task migration explicitly says
+schedules and schedule runs are not in that slice.
+
+That means a fresh environment can replay the first agent-schema slice but cannot
+replay the schedule target tables that already exist on current live.
+
+## Live Metadata Comparison
+
+Read-only live inspection found all four relevant tables exist and are empty:
+
+- `agent.schedules`: 0 rows
+- `agent.schedule_runs`: 0 rows
+- `public.cron_jobs`: 0 rows
+- `staging.cron_jobs`: 0 rows
+
+Observed live `agent.schedules` columns:
+
+- `id`
+- `owner_user_id`
+- `agent_user_id`
+- `target_thread_id`
+- `create_thread_on_run`
+- `cron_expression`
+- `enabled`
+- `instruction_template`
+- `timezone`
+- `last_run_at`
+- `next_run_at`
+- `created_at`
+- `updated_at`
+
+Observed live `agent.schedule_runs` columns:
+
+- `id`
+- `schedule_id`
+- `owner_user_id`
+- `agent_user_id`
+- `thread_id`
+- `status`
+- `triggered_by`
+- `scheduled_for`
+- `started_at`
+- `completed_at`
+- `input_json`
+- `output_json`
+- `error`
+- `created_at`
+
+The replayed DDL matches this live shape:
+
+- schedule targeting is explicit through `target_thread_id` or
+  `create_thread_on_run`
+- schedule execution belongs to both `owner_user_id` and `agent_user_id`
+- run status values are `queued`, `running`, `succeeded`, `failed`,
+  `cancelled`
+- trigger sources are `scheduler` and `manual`
+- access is service-role only
+- RLS is not enabled
+- realtime publication is not added
+
+## Migration Stance
+
+The migration is for fresh environments where:
+
+- schema `agent` already exists
+- `agent.threads` already exists
+- `agent.schedules` does not exist
+- `agent.schedule_runs` does not exist
+- `public.cron_jobs` and `staging.cron_jobs` are empty
+
+It fails loudly if either legacy cron table contains rows. A cron data migration
+would require a separate ruling, because `cron_jobs` is a legacy name and not the
+target schedule ontology.
+
+Current live already has the target schedule tables and has no rows in either
+target or legacy schedule tables. Therefore this migration must not be executed
+on current live under this checkpoint.
+
+## Stopline
+
+No write is authorized by this checkpoint.
+
+Before any schedule runtime work:
+
+1. Land the DDL artifact independently.
+2. Decide whether to replay the old 02H schedule repo/service surface or redesign
+   it against current `dev`.
+3. Keep manual trigger runtime, run completion, due polling, frontend schedule UX,
+   RLS/realtime, and legacy cron deletion as separate checkpoints.


### PR DESCRIPTION
## Summary
- add the fresh-environment DDL artifact for agent.schedules and agent.schedule_runs
- add matching read-only precheck and rollback SQL from historical PR #507 / 8161f835
- document the dev-replay-07 boundary: no current-live execution, no runtime/API/frontend work

## Validation
- SQL files compared byte-for-byte against historical 8161f835 artifact
- git diff --cached --check passed before commit
- static SQL checks confirmed no IF NOT EXISTS, no ON CONFLICT, and no data INSERT/UPDATE/DELETE
- read-only live metadata comparison confirmed current live schedule table columns match the artifact and all schedule/cron tables are empty

## Scope Boundary
This PR is DDL/docs only. It does not execute migrations on live, edit migration history, add schedule runtime/repo/API/frontend code, add RLS/realtime, or migrate cron_jobs/panel_tasks.