### PR TITLE
refactor(db): add agent schedule storage surface

### DIFF
--- a/backend/web/services/schedule_service.py
+++ b/backend/web/services/schedule_service.py
@@ -1,0 +1,164 @@
+"""Agent schedule CRUD service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from storage.runtime import build_schedule_repo as make_schedule_repo
+
+_RUN_TRIGGERS = {"scheduler", "manual"}
+_RUN_STATUSES = {"queued", "running", "succeeded", "failed", "cancelled"}
+
+
+def _require_non_empty(name: str, value: str) -> None:
+    if not value or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+
+
+def _validate_schedule_target(target_thread_id: str | None, create_thread_on_run: bool) -> None:
+    if not target_thread_id and not create_thread_on_run:
+        raise ValueError("schedule target must set target_thread_id or create_thread_on_run")
+
+
+def list_schedules(owner_user_id: str) -> list[dict[str, Any]]:
+    _require_non_empty("owner_user_id", owner_user_id)
+    repo = make_schedule_repo()
+    try:
+        return repo.list_by_owner(owner_user_id)
+    finally:
+        repo.close()
+
+
+def get_schedule(schedule_id: str) -> dict[str, Any] | None:
+    _require_non_empty("schedule_id", schedule_id)
+    repo = make_schedule_repo()
+    try:
+        return repo.get(schedule_id)
+    finally:
+        repo.close()
+
+
+def create_schedule(
+    *,
+    owner_user_id: str,
+    agent_user_id: str,
+    cron_expression: str,
+    instruction_template: str,
+    target_thread_id: str | None = None,
+    create_thread_on_run: bool = False,
+    enabled: bool = True,
+    timezone: str = "UTC",
+    next_run_at: str | None = None,
+) -> dict[str, Any]:
+    _require_non_empty("owner_user_id", owner_user_id)
+    _require_non_empty("agent_user_id", agent_user_id)
+    _require_non_empty("cron_expression", cron_expression)
+    _require_non_empty("instruction_template", instruction_template)
+    _require_non_empty("timezone", timezone)
+    _validate_schedule_target(target_thread_id, create_thread_on_run)
+    repo = make_schedule_repo()
+    try:
+        return repo.create(
+            owner_user_id=owner_user_id,
+            agent_user_id=agent_user_id,
+            cron_expression=cron_expression,
+            instruction_template=instruction_template,
+            target_thread_id=target_thread_id,
+            create_thread_on_run=create_thread_on_run,
+            enabled=enabled,
+            timezone=timezone,
+            next_run_at=next_run_at,
+        )
+    finally:
+        repo.close()
+
+
+def update_schedule(schedule_id: str, **fields: Any) -> dict[str, Any] | None:
+    _require_non_empty("schedule_id", schedule_id)
+    if "create_thread_on_run" in fields or "target_thread_id" in fields:
+        _validate_schedule_target(fields.get("target_thread_id"), bool(fields.get("create_thread_on_run")))
+    for key in ("agent_user_id", "cron_expression", "instruction_template", "timezone"):
+        if key in fields and fields[key] is not None:
+            _require_non_empty(key, fields[key])
+    repo = make_schedule_repo()
+    try:
+        return repo.update(schedule_id, **fields)
+    finally:
+        repo.close()
+
+
+def delete_schedule(schedule_id: str) -> bool:
+    _require_non_empty("schedule_id", schedule_id)
+    repo = make_schedule_repo()
+    try:
+        return repo.delete(schedule_id)
+    finally:
+        repo.close()
+
+
+def create_schedule_run(
+    *,
+    schedule_id: str,
+    owner_user_id: str,
+    agent_user_id: str,
+    triggered_by: str,
+    thread_id: str | None = None,
+    scheduled_for: str | None = None,
+    input_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    _require_non_empty("schedule_id", schedule_id)
+    _require_non_empty("owner_user_id", owner_user_id)
+    _require_non_empty("agent_user_id", agent_user_id)
+    if triggered_by not in _RUN_TRIGGERS:
+        raise ValueError("triggered_by must be scheduler or manual")
+    repo = make_schedule_repo()
+    try:
+        return repo.create_run(
+            schedule_id=schedule_id,
+            owner_user_id=owner_user_id,
+            agent_user_id=agent_user_id,
+            triggered_by=triggered_by,
+            thread_id=thread_id,
+            scheduled_for=scheduled_for,
+            input_json=input_json,
+        )
+    finally:
+        repo.close()
+
+
+def get_schedule_run(run_id: str) -> dict[str, Any] | None:
+    _require_non_empty("run_id", run_id)
+    repo = make_schedule_repo()
+    try:
+        return repo.get_run(run_id)
+    finally:
+        repo.close()
+
+
+def list_schedule_runs(schedule_id: str) -> list[dict[str, Any]]:
+    _require_non_empty("schedule_id", schedule_id)
+    repo = make_schedule_repo()
+    try:
+        return repo.list_runs(schedule_id)
+    finally:
+        repo.close()
+
+
+def update_schedule_run(run_id: str, **fields: Any) -> dict[str, Any] | None:
+    _require_non_empty("run_id", run_id)
+    if "status" in fields and fields["status"] not in _RUN_STATUSES:
+        raise ValueError("status must be queued, running, succeeded, failed, or cancelled")
+    repo = make_schedule_repo()
+    try:
+        return repo.update_run(run_id, **fields)
+    finally:
+        repo.close()
+
+
+def delete_schedule_run(run_id: str) -> bool:
+    _require_non_empty("run_id", run_id)
+    repo = make_schedule_repo()
+    try:
+        return repo.delete_run(run_id)
+    finally:
+        repo.close()

--- a/storage/container.py
+++ b/storage/container.py
@@ -36,6 +36,7 @@ from .contracts import (
 _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "checkpoint_repo": ("storage.providers.supabase.checkpoint_repo", "SupabaseCheckpointRepo"),
     "run_event_repo": ("storage.providers.supabase.run_event_repo", "SupabaseRunEventRepo"),
+    "schedule_repo": ("storage.providers.supabase.schedule_repo", "SupabaseScheduleRepo"),
     "file_operation_repo": ("storage.providers.supabase.file_operation_repo", "SupabaseFileOperationRepo"),
     "summary_repo": ("storage.providers.supabase.summary_repo", "SupabaseSummaryRepo"),
     "eval_repo": ("storage.providers.supabase.eval_repo", "SupabaseEvalRepo"),
@@ -81,6 +82,9 @@ class StorageContainer:
 
     def run_event_repo(self) -> RunEventRepo:
         return self._build("run_event_repo")
+
+    def schedule_repo(self) -> Any:
+        return self._build("schedule_repo")
 
     def file_operation_repo(self) -> FileOperationRepo:
         return self._build("file_operation_repo")

--- a/storage/providers/supabase/__init__.py
+++ b/storage/providers/supabase/__init__.py
@@ -15,9 +15,9 @@ from .queue_repo import SupabaseQueueRepo
 from .recipe_repo import SupabaseRecipeRepo
 from .resource_snapshot_repo import SupabaseResourceSnapshotRepo, list_snapshots_by_lease_ids, upsert_lease_resource_snapshot
 from .run_event_repo import SupabaseRunEventRepo
-from .schedule_repo import SupabaseScheduleRepo
 from .sandbox_monitor_repo import SupabaseSandboxMonitorRepo
 from .sandbox_volume_repo import SupabaseSandboxVolumeRepo
+from .schedule_repo import SupabaseScheduleRepo
 from .summary_repo import SupabaseSummaryRepo
 from .sync_file_repo import SupabaseSyncFileRepo
 from .terminal_repo import SupabaseTerminalRepo

--- a/storage/providers/supabase/__init__.py
+++ b/storage/providers/supabase/__init__.py
@@ -15,6 +15,7 @@ from .queue_repo import SupabaseQueueRepo
 from .recipe_repo import SupabaseRecipeRepo
 from .resource_snapshot_repo import SupabaseResourceSnapshotRepo, list_snapshots_by_lease_ids, upsert_lease_resource_snapshot
 from .run_event_repo import SupabaseRunEventRepo
+from .schedule_repo import SupabaseScheduleRepo
 from .sandbox_monitor_repo import SupabaseSandboxMonitorRepo
 from .sandbox_volume_repo import SupabaseSandboxVolumeRepo
 from .summary_repo import SupabaseSummaryRepo
@@ -42,6 +43,7 @@ __all__ = [
     "SupabaseRecipeRepo",
     "SupabaseResourceSnapshotRepo",
     "SupabaseRunEventRepo",
+    "SupabaseScheduleRepo",
     "SupabaseSandboxMonitorRepo",
     "SupabaseSandboxVolumeRepo",
     "SupabaseSummaryRepo",

--- a/storage/providers/supabase/schedule_repo.py
+++ b/storage/providers/supabase/schedule_repo.py
@@ -1,0 +1,173 @@
+"""Supabase repository for agent schedule records."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from storage.providers.supabase import _query as q
+
+_REPO = "schedule repo"
+_SCHEMA = "agent"
+_SCHEDULES_TABLE = "schedules"
+_RUNS_TABLE = "schedule_runs"
+
+
+class SupabaseScheduleRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def _schedules(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _SCHEDULES_TABLE, _REPO)
+
+    def _runs(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _RUNS_TABLE, _REPO)
+
+    def list_by_owner(self, owner_user_id: str) -> list[dict[str, Any]]:
+        return q.rows(
+            q.order(
+                self._schedules().select("*").eq("owner_user_id", owner_user_id),
+                "created_at",
+                desc=True,
+                repo=_REPO,
+                operation="list_by_owner",
+            ).execute(),
+            _REPO,
+            "list_by_owner",
+        )
+
+    def get(self, schedule_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            self._schedules().select("*").eq("id", schedule_id).execute(),
+            _REPO,
+            "get",
+        )
+        return rows[0] if rows else None
+
+    def create(
+        self,
+        *,
+        owner_user_id: str,
+        agent_user_id: str,
+        cron_expression: str,
+        instruction_template: str,
+        target_thread_id: str | None = None,
+        create_thread_on_run: bool = False,
+        enabled: bool = True,
+        timezone: str = "UTC",
+        next_run_at: str | None = None,
+    ) -> dict[str, Any]:
+        schedule_id = uuid.uuid4().hex
+        payload = {
+            "id": schedule_id,
+            "owner_user_id": owner_user_id,
+            "agent_user_id": agent_user_id,
+            "target_thread_id": target_thread_id,
+            "create_thread_on_run": create_thread_on_run,
+            "cron_expression": cron_expression,
+            "enabled": enabled,
+            "instruction_template": instruction_template,
+            "timezone": timezone,
+            "next_run_at": next_run_at,
+        }
+        rows = q.rows(self._schedules().insert(payload).execute(), _REPO, "create")
+        return rows[0] if rows else self.get(schedule_id) or {}
+
+    def update(self, schedule_id: str, **fields: Any) -> dict[str, Any] | None:
+        allowed = {
+            "agent_user_id",
+            "target_thread_id",
+            "create_thread_on_run",
+            "cron_expression",
+            "enabled",
+            "instruction_template",
+            "timezone",
+            "last_run_at",
+            "next_run_at",
+        }
+        updates = {key: value for key, value in fields.items() if key in allowed}
+        if not updates:
+            return self.get(schedule_id)
+        rows = q.rows(
+            self._schedules().update(updates).eq("id", schedule_id).execute(),
+            _REPO,
+            "update",
+        )
+        return rows[0] if rows else None
+
+    def delete(self, schedule_id: str) -> bool:
+        rows = q.rows(
+            self._schedules().delete().eq("id", schedule_id).execute(),
+            _REPO,
+            "delete",
+        )
+        return len(rows) > 0
+
+    def create_run(
+        self,
+        *,
+        schedule_id: str,
+        owner_user_id: str,
+        agent_user_id: str,
+        triggered_by: str,
+        thread_id: str | None = None,
+        scheduled_for: str | None = None,
+        input_json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        run_id = uuid.uuid4().hex
+        payload = {
+            "id": run_id,
+            "schedule_id": schedule_id,
+            "owner_user_id": owner_user_id,
+            "agent_user_id": agent_user_id,
+            "thread_id": thread_id,
+            "triggered_by": triggered_by,
+            "scheduled_for": scheduled_for,
+            "input_json": input_json or {},
+        }
+        rows = q.rows(self._runs().insert(payload).execute(), _REPO, "create_run")
+        return rows[0] if rows else self.get_run(run_id) or {}
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            self._runs().select("*").eq("id", run_id).execute(),
+            _REPO,
+            "get_run",
+        )
+        return rows[0] if rows else None
+
+    def list_runs(self, schedule_id: str) -> list[dict[str, Any]]:
+        return q.rows(
+            q.order(
+                self._runs().select("*").eq("schedule_id", schedule_id),
+                "created_at",
+                desc=True,
+                repo=_REPO,
+                operation="list_runs",
+            ).execute(),
+            _REPO,
+            "list_runs",
+        )
+
+    def update_run(self, run_id: str, **fields: Any) -> dict[str, Any] | None:
+        allowed = {"thread_id", "status", "started_at", "completed_at", "output_json", "error"}
+        updates = {key: value for key, value in fields.items() if key in allowed}
+        if not updates:
+            return self.get_run(run_id)
+        rows = q.rows(
+            self._runs().update(updates).eq("id", run_id).execute(),
+            _REPO,
+            "update_run",
+        )
+        return rows[0] if rows else None
+
+    def delete_run(self, run_id: str) -> bool:
+        rows = q.rows(
+            self._runs().delete().eq("id", run_id).execute(),
+            _REPO,
+            "delete_run",
+        )
+        return len(rows) > 0

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -69,6 +69,10 @@ def build_tool_task_repo(*, supabase_client: Any | None = None, supabase_client_
     return _build_storage_repo("tool_task_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
+def build_schedule_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo("schedule_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
+
+
 def build_lease_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
     return _build_storage_repo("lease_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 

--- a/tests/Unit/core/test_schedule_service_schema_contract.py
+++ b/tests/Unit/core/test_schedule_service_schema_contract.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.web.services import schedule_service
+
+
+class FakeScheduleRepo:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+        self.runs: list[dict] = []
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def list_by_owner(self, owner_user_id: str) -> list[dict]:
+        return [row for row in self.created if row["owner_user_id"] == owner_user_id]
+
+    def get(self, schedule_id: str) -> dict | None:
+        return next((row for row in self.created if row["id"] == schedule_id), None)
+
+    def create(self, **fields):
+        row = {"id": "schedule-1", **fields}
+        self.created.append(row)
+        return row
+
+    def update(self, schedule_id: str, **fields):
+        row = self.get(schedule_id)
+        if row is None:
+            return None
+        row.update(fields)
+        return row
+
+    def delete(self, schedule_id: str) -> bool:
+        before = len(self.created)
+        self.created = [row for row in self.created if row["id"] != schedule_id]
+        return len(self.created) < before
+
+    def create_run(self, **fields):
+        row = {"id": "run-1", **fields}
+        self.runs.append(row)
+        return row
+
+    def get_run(self, run_id: str) -> dict | None:
+        return next((row for row in self.runs if row["id"] == run_id), None)
+
+    def list_runs(self, schedule_id: str) -> list[dict]:
+        return [row for row in self.runs if row["schedule_id"] == schedule_id]
+
+    def update_run(self, run_id: str, **fields):
+        row = self.get_run(run_id)
+        if row is None:
+            return None
+        row.update(fields)
+        return row
+
+    def delete_run(self, run_id: str) -> bool:
+        before = len(self.runs)
+        self.runs = [row for row in self.runs if row["id"] != run_id]
+        return len(self.runs) < before
+
+
+def test_schedule_service_requires_target_thread_or_create_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", FakeScheduleRepo)
+
+    with pytest.raises(ValueError) as excinfo:
+        schedule_service.create_schedule(
+            owner_user_id="owner-1",
+            agent_user_id="agent-1",
+            cron_expression="*/15 * * * *",
+            instruction_template="work",
+        )
+
+    assert "target" in str(excinfo.value)
+
+
+def test_schedule_service_creates_valid_schedule(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = FakeScheduleRepo()
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", lambda: repo)
+
+    created = schedule_service.create_schedule(
+        owner_user_id="owner-1",
+        agent_user_id="agent-1",
+        cron_expression="*/15 * * * *",
+        instruction_template="work",
+        create_thread_on_run=True,
+    )
+
+    assert created["id"] == "schedule-1"
+    assert repo.created[0]["owner_user_id"] == "owner-1"
+    assert repo.closed
+
+
+def test_schedule_service_validates_run_trigger_and_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = FakeScheduleRepo()
+    monkeypatch.setattr(schedule_service, "make_schedule_repo", lambda: repo)
+
+    with pytest.raises(ValueError) as trigger_error:
+        schedule_service.create_schedule_run(
+            schedule_id="schedule-1",
+            owner_user_id="owner-1",
+            agent_user_id="agent-1",
+            triggered_by="button",
+        )
+
+    run = schedule_service.create_schedule_run(
+        schedule_id="schedule-1",
+        owner_user_id="owner-1",
+        agent_user_id="agent-1",
+        triggered_by="manual",
+    )
+
+    with pytest.raises(ValueError) as status_error:
+        schedule_service.update_schedule_run(run["id"], status="done")
+
+    assert "triggered_by" in str(trigger_error.value)
+    assert "status" in str(status_error.value)

--- a/tests/Unit/storage/test_schedule_runtime_wiring.py
+++ b/tests/Unit/storage/test_schedule_runtime_wiring.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from storage.container import StorageContainer
+from storage.runtime import build_schedule_repo, build_storage_container
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_storage_container_exposes_schedule_repo() -> None:
+    tables: dict[str, list[dict]] = {}
+    container = StorageContainer(supabase_client=FakeSupabaseClient(tables))
+
+    repo = container.schedule_repo()
+    repo.create(
+        owner_user_id="owner-1",
+        agent_user_id="agent-1",
+        cron_expression="0 * * * *",
+        instruction_template="work",
+        create_thread_on_run=True,
+    )
+
+    assert tables["agent.schedules"][0]["owner_user_id"] == "owner-1"
+
+
+def test_build_schedule_repo_uses_runtime_container() -> None:
+    tables: dict[str, list[dict]] = {}
+    repo = build_schedule_repo(supabase_client=FakeSupabaseClient(tables))
+
+    repo.create_run(
+        schedule_id="schedule-1",
+        owner_user_id="owner-1",
+        agent_user_id="agent-1",
+        triggered_by="manual",
+    )
+
+    assert tables["agent.schedule_runs"][0]["triggered_by"] == "manual"
+
+
+def test_build_storage_container_exposes_schedule_repo() -> None:
+    container = build_storage_container(supabase_client=FakeSupabaseClient())
+
+    assert container.schedule_repo().__class__.__name__ == "SupabaseScheduleRepo"

--- a/tests/Unit/storage/test_supabase_schedule_repo.py
+++ b/tests/Unit/storage/test_supabase_schedule_repo.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from storage.providers.supabase.schedule_repo import SupabaseScheduleRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_schedule_repo_writes_schedules_to_agent_schema() -> None:
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseScheduleRepo(FakeSupabaseClient(tables))
+
+    created = repo.create(
+        owner_user_id="owner-1",
+        agent_user_id="agent-1",
+        cron_expression="*/15 * * * *",
+        instruction_template="Summarize project state",
+        create_thread_on_run=True,
+    )
+
+    assert created["owner_user_id"] == "owner-1"
+    assert tables["agent.schedules"][0]["agent_user_id"] == "agent-1"
+    assert "staging.schedules" not in tables
+    assert "public.schedules" not in tables
+    assert "cron_jobs" not in tables
+
+
+def test_schedule_repo_manages_runs_under_agent_schedule_runs() -> None:
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseScheduleRepo(FakeSupabaseClient(tables))
+
+    run = repo.create_run(
+        schedule_id="schedule-1",
+        owner_user_id="owner-1",
+        agent_user_id="agent-1",
+        triggered_by="manual",
+        input_json={"source": "unit-test"},
+    )
+    updated = repo.update_run(run["id"], status="running", thread_id="thread-1")
+
+    assert tables["agent.schedule_runs"][0]["schedule_id"] == "schedule-1"
+    assert repo.list_runs("schedule-1")[0]["input_json"] == {"source": "unit-test"}
+    assert updated is not None
+    assert updated["status"] == "running"
+    assert updated["thread_id"] == "thread-1"


### PR DESCRIPTION
## Summary
- Add a Supabase schedule repo for `agent.schedules` and `agent.schedule_runs` using current `q.schema_table(..., 'agent', ...)` routing.
- Wire `schedule_repo` through `StorageContainer` and `storage.runtime.build_schedule_repo`.
- Add a thin schedule service plus focused storage/runtime/service tests.

## Stopline
- No API/router/frontend changes.
- No scheduler/runtime trigger execution.
- No live DB writes, live migration execution, migration-history edits, RLS/realtime, or legacy cron compatibility.
- No direct cherry-pick from old #507 storage wiring.

## Test Plan
- `uv run pytest tests/Unit/storage/test_supabase_schedule_repo.py tests/Unit/storage/test_schedule_runtime_wiring.py tests/Unit/core/test_schedule_service_schema_contract.py -q`
- `uv run ruff check storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py storage/container.py storage/runtime.py tests/Unit/storage/test_supabase_schedule_repo.py tests/Unit/storage/test_schedule_runtime_wiring.py tests/Unit/core/test_schedule_service_schema_contract.py`
- `uv run ruff format --check storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py storage/container.py storage/runtime.py tests/Unit/storage/test_supabase_schedule_repo.py tests/Unit/storage/test_schedule_runtime_wiring.py tests/Unit/core/test_schedule_service_schema_contract.py`
- `uv run pyright storage/providers/supabase/schedule_repo.py backend/web/services/schedule_service.py storage/container.py storage/runtime.py tests/Unit/storage/test_supabase_schedule_repo.py tests/Unit/storage/test_schedule_runtime_wiring.py tests/Unit/core/test_schedule_service_schema_contract.py`
- `uv run pytest tests/Unit/core tests/Unit/storage -q`