### PR TITLE
Database refactor: add thread runtime binding read model

### DIFF
--- a/backend/web/services/thread_runtime_binding_service.py
+++ b/backend/web/services/thread_runtime_binding_service.py
@@ -3,11 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
-
-
-BindingPurpose = Literal["run", "file_channel", "monitor", "launch_default"]
-_VALID_PURPOSES = {"run", "file_channel", "monitor", "launch_default"}
+from typing import Any
 
 
 class ThreadRuntimeBindingError(RuntimeError):
@@ -44,11 +40,7 @@ def resolve_thread_runtime_binding(
     sandbox_repo: Any,
     thread_id: str,
     owner_user_id: str | None = None,
-    purpose: BindingPurpose = "run",
 ) -> ThreadRuntimeBinding:
-    if purpose not in _VALID_PURPOSES:
-        raise ValueError(f"Unknown thread runtime binding purpose: {purpose}")
-
     thread = _load_row(thread_repo, thread_id, "thread")
     thread_owner_user_id = _required_text(thread, "owner_user_id", "thread")
     if owner_user_id is not None and owner_user_id != thread_owner_user_id:

--- a/backend/web/services/thread_runtime_binding_service.py
+++ b/backend/web/services/thread_runtime_binding_service.py
@@ -1,0 +1,135 @@
+"""Target-style thread runtime binding read model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+BindingPurpose = Literal["run", "file_channel", "monitor", "launch_default"]
+_VALID_PURPOSES = {"run", "file_channel", "monitor", "launch_default"}
+
+
+class ThreadRuntimeBindingError(RuntimeError):
+    """Raised when a thread cannot satisfy the target runtime binding contract."""
+
+
+@dataclass(frozen=True)
+class ThreadRuntimeBinding:
+    thread_id: str
+    owner_user_id: str
+    agent_user_id: str
+    workspace_id: str
+    workspace_path: str
+    workspace_status: str | None
+    workspace_desired_state: str | None
+    workspace_observed_state: str | None
+    sandbox_id: str
+    device_id: str | None
+    provider_name: str
+    provider_env_id: str | None
+    sandbox_status: str | None
+    sandbox_desired_state: str | None
+    sandbox_observed_state: str | None
+    sandbox_template_id: str | None
+    sandbox_config: dict[str, Any] = field(default_factory=dict)
+    model: str | None = None
+    legacy_cwd: str | None = None
+
+
+def resolve_thread_runtime_binding(
+    *,
+    thread_repo: Any,
+    workspace_repo: Any,
+    sandbox_repo: Any,
+    thread_id: str,
+    owner_user_id: str | None = None,
+    purpose: BindingPurpose = "run",
+) -> ThreadRuntimeBinding:
+    if purpose not in _VALID_PURPOSES:
+        raise ValueError(f"Unknown thread runtime binding purpose: {purpose}")
+
+    thread = _load_row(thread_repo, thread_id, "thread")
+    thread_owner_user_id = _required_text(thread, "owner_user_id", "thread")
+    if owner_user_id is not None and owner_user_id != thread_owner_user_id:
+        raise PermissionError(f"thread owner mismatch: expected {owner_user_id}, got {thread_owner_user_id}")
+
+    workspace_id = _required_text(thread, "current_workspace_id", "thread")
+    workspace = _load_row(workspace_repo, workspace_id, "workspace")
+    _require_same_owner(workspace, thread_owner_user_id, "workspace")
+
+    sandbox_id = _required_text(workspace, "sandbox_id", "workspace")
+    sandbox = _load_row(sandbox_repo, sandbox_id, "sandbox")
+    _require_same_owner(sandbox, thread_owner_user_id, "sandbox")
+
+    return ThreadRuntimeBinding(
+        thread_id=thread_id,
+        owner_user_id=thread_owner_user_id,
+        agent_user_id=_required_text(thread, "agent_user_id", "thread"),
+        workspace_id=workspace_id,
+        workspace_path=_required_text(workspace, "workspace_path", "workspace"),
+        workspace_status=_optional_text(workspace, "status"),
+        workspace_desired_state=_optional_text(workspace, "desired_state"),
+        workspace_observed_state=_optional_text(workspace, "observed_state"),
+        sandbox_id=sandbox_id,
+        device_id=_optional_text(sandbox, "device_id"),
+        provider_name=_required_text(sandbox, "provider_name", "sandbox"),
+        provider_env_id=_optional_text(sandbox, "provider_env_id"),
+        sandbox_status=_optional_text(sandbox, "status"),
+        sandbox_desired_state=_optional_text(sandbox, "desired_state"),
+        sandbox_observed_state=_optional_text(sandbox, "observed_state"),
+        sandbox_template_id=_optional_text(sandbox, "template_id"),
+        sandbox_config=_config_dict(sandbox),
+        model=_optional_text(thread, "model"),
+        legacy_cwd=_optional_text(thread, "cwd"),
+    )
+
+
+def _load_row(repo: Any, row_id: str, label: str) -> Any:
+    get_by_id = getattr(repo, "get_by_id", None)
+    if not callable(get_by_id):
+        raise ThreadRuntimeBindingError(f"{label}_repo must support get_by_id")
+    row = get_by_id(row_id)
+    if row is None:
+        raise ThreadRuntimeBindingError(f"{label} not found: {row_id}")
+    return row
+
+
+def _require_same_owner(row: Any, owner_user_id: str, label: str) -> None:
+    row_owner_user_id = _required_text(row, "owner_user_id", label)
+    if row_owner_user_id != owner_user_id:
+        raise PermissionError(f"{label} owner mismatch: expected {owner_user_id}, got {row_owner_user_id}")
+
+
+def _required_text(row: Any, key: str, label: str) -> str:
+    value = _value(row, key)
+    if isinstance(value, str):
+        value = value.strip()
+    if value is None or value == "":
+        raise ThreadRuntimeBindingError(f"{label}.{key} is required")
+    return str(value)
+
+
+def _optional_text(row: Any, key: str) -> str | None:
+    value = _value(row, key)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return str(value)
+
+
+def _config_dict(sandbox: Any) -> dict[str, Any]:
+    config = _value(sandbox, "config")
+    if config is None:
+        return {}
+    if not isinstance(config, dict):
+        raise ThreadRuntimeBindingError("sandbox.config must be an object")
+    return dict(config)
+
+
+def _value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    return getattr(row, key, None)

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from pathlib import Path
+from inspect import signature
 
 import pytest
 
@@ -78,7 +79,6 @@ def test_resolves_thread_workspace_sandbox_binding_without_legacy_runtime_ids() 
         **_repos(thread=_thread(), workspace=_workspace(), sandbox=_sandbox()),
         thread_id="thread-1",
         owner_user_id="owner-1",
-        purpose="run",
     )
 
     assert binding.thread_id == "thread-1"
@@ -115,7 +115,6 @@ def test_missing_workspace_pointer_fails_loudly() -> None:
             **_repos(thread=_thread(current_workspace_id=None), workspace=_workspace(), sandbox=_sandbox()),
             thread_id="thread-1",
             owner_user_id="owner-1",
-            purpose="run",
         )
 
     assert "current_workspace_id" in str(excinfo.value)
@@ -127,7 +126,6 @@ def test_owner_mismatch_fails_loudly() -> None:
             **_repos(thread=_thread(), workspace=_workspace(), sandbox=_sandbox()),
             thread_id="thread-1",
             owner_user_id="other-owner",
-            purpose="run",
         )
 
     assert "owner mismatch" in str(excinfo.value)
@@ -139,7 +137,6 @@ def test_missing_workspace_row_fails_loudly() -> None:
             **_repos(thread=_thread(), workspace=None, sandbox=_sandbox()),
             thread_id="thread-1",
             owner_user_id="owner-1",
-            purpose="run",
         )
 
     assert "workspace-1" in str(excinfo.value)
@@ -151,10 +148,13 @@ def test_workspace_without_sandbox_fails_loudly() -> None:
             **_repos(thread=_thread(), workspace=_workspace(sandbox_id=None), sandbox=_sandbox()),
             thread_id="thread-1",
             owner_user_id="owner-1",
-            purpose="run",
         )
 
     assert "sandbox_id" in str(excinfo.value)
+
+
+def test_service_signature_does_not_expose_unused_purpose_dimension() -> None:
+    assert "purpose" not in signature(resolve_thread_runtime_binding).parameters
 
 
 def test_service_does_not_import_legacy_runtime_glue() -> None:

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from backend.web.services.thread_runtime_binding_service import (
+    ThreadRuntimeBindingError,
+    resolve_thread_runtime_binding,
+)
+
+
+class _Repo:
+    def __init__(self, rows: dict[str, dict]) -> None:
+        self.rows = rows
+
+    def get_by_id(self, row_id: str):
+        return self.rows.get(row_id)
+
+
+def _repos(
+    *,
+    thread: dict | None = None,
+    workspace: dict | None = None,
+    sandbox: dict | None = None,
+):
+    return {
+        "thread_repo": _Repo({"thread-1": thread} if thread is not None else {}),
+        "workspace_repo": _Repo({"workspace-1": workspace} if workspace is not None else {}),
+        "sandbox_repo": _Repo({"sandbox-1": sandbox} if sandbox is not None else {}),
+    }
+
+
+def _thread(**overrides):
+    return {
+        "id": "thread-1",
+        "owner_user_id": "owner-1",
+        "agent_user_id": "agent-1",
+        "current_workspace_id": "workspace-1",
+        "model": "large",
+        "cwd": "/legacy-cwd",
+        **overrides,
+    }
+
+
+def _workspace(**overrides):
+    return {
+        "id": "workspace-1",
+        "owner_user_id": "owner-1",
+        "sandbox_id": "sandbox-1",
+        "workspace_path": "/workspace",
+        "status": "ready",
+        "desired_state": "running",
+        "observed_state": "running",
+        **overrides,
+    }
+
+
+def _sandbox(**overrides):
+    return {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "device_id": "device-1",
+        "provider_name": "daytona",
+        "provider_env_id": "provider-env-1",
+        "status": "ready",
+        "desired_state": "running",
+        "observed_state": "running",
+        "template_id": "template-1",
+        "config": {"sdk": "preinstalled"},
+        **overrides,
+    }
+
+
+def test_resolves_thread_workspace_sandbox_binding_without_legacy_runtime_ids() -> None:
+    binding = resolve_thread_runtime_binding(
+        **_repos(thread=_thread(), workspace=_workspace(), sandbox=_sandbox()),
+        thread_id="thread-1",
+        owner_user_id="owner-1",
+        purpose="run",
+    )
+
+    assert binding.thread_id == "thread-1"
+    assert binding.owner_user_id == "owner-1"
+    assert binding.agent_user_id == "agent-1"
+    assert binding.workspace_id == "workspace-1"
+    assert binding.workspace_path == "/workspace"
+    assert binding.workspace_status == "ready"
+    assert binding.workspace_desired_state == "running"
+    assert binding.workspace_observed_state == "running"
+    assert binding.sandbox_id == "sandbox-1"
+    assert binding.device_id == "device-1"
+    assert binding.provider_name == "daytona"
+    assert binding.provider_env_id == "provider-env-1"
+    assert binding.sandbox_status == "ready"
+    assert binding.sandbox_desired_state == "running"
+    assert binding.sandbox_observed_state == "running"
+    assert binding.sandbox_template_id == "template-1"
+    assert binding.sandbox_config == {"sdk": "preinstalled"}
+    assert binding.model == "large"
+    assert binding.legacy_cwd == "/legacy-cwd"
+
+    payload = asdict(binding)
+    assert "terminal_id" not in payload
+    assert "active_terminal_id" not in payload
+    assert "chat_session_id" not in payload
+    assert "lease_id" not in payload
+    assert "volume_id" not in payload
+
+
+def test_missing_workspace_pointer_fails_loudly() -> None:
+    with pytest.raises(ThreadRuntimeBindingError) as excinfo:
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(current_workspace_id=None), workspace=_workspace(), sandbox=_sandbox()),
+            thread_id="thread-1",
+            owner_user_id="owner-1",
+            purpose="run",
+        )
+
+    assert "current_workspace_id" in str(excinfo.value)
+
+
+def test_owner_mismatch_fails_loudly() -> None:
+    with pytest.raises(PermissionError) as excinfo:
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(), workspace=_workspace(), sandbox=_sandbox()),
+            thread_id="thread-1",
+            owner_user_id="other-owner",
+            purpose="run",
+        )
+
+    assert "owner mismatch" in str(excinfo.value)
+
+
+def test_missing_workspace_row_fails_loudly() -> None:
+    with pytest.raises(ThreadRuntimeBindingError) as excinfo:
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(), workspace=None, sandbox=_sandbox()),
+            thread_id="thread-1",
+            owner_user_id="owner-1",
+            purpose="run",
+        )
+
+    assert "workspace-1" in str(excinfo.value)
+
+
+def test_workspace_without_sandbox_fails_loudly() -> None:
+    with pytest.raises(ThreadRuntimeBindingError) as excinfo:
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(), workspace=_workspace(sandbox_id=None), sandbox=_sandbox()),
+            thread_id="thread-1",
+            owner_user_id="owner-1",
+            purpose="run",
+        )
+
+    assert "sandbox_id" in str(excinfo.value)
+
+
+def test_service_does_not_import_legacy_runtime_glue() -> None:
+    source = Path("backend/web/services/thread_runtime_binding_service.py").read_text()
+
+    assert "terminal_repo" not in source
+    assert "lease_repo" not in source
+    assert "chat_session" not in source
+    assert "sandbox_volume" not in source
+    assert "sync_file" not in source

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from pathlib import Path
 from inspect import signature
+from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## Summary
- add a narrow `ThreadRuntimeBinding` read-model service for the target thread/workspace/sandbox contract
- keep the slice mechanism-only: no runtime/API/storage wiring, no SQL or migration changes
- remove the unused `purpose` dimension so the seam is intentionally strict and always workspace-required

## Test Plan
- uv run pytest tests/Unit/backend/web/services/test_thread_runtime_binding_service.py tests/Unit/backend/web/services/test_thread_runtime_convergence.py -q
- git diff --check