### PR TITLE
Database refactor: write current workspace during thread create

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -519,7 +519,7 @@ def _create_thread_sandbox_resources(
     sandbox_type: str,
     recipe: dict[str, Any] | None,
     cwd: str | None = None,
-) -> None:
+) -> str:
     """Create volume, lease, and terminal eagerly so volume exists before file uploads."""
     from datetime import datetime
 
@@ -576,6 +576,7 @@ def _create_thread_sandbox_resources(
         )
     finally:
         terminal_repo.close()
+    return lease_id
 
 
 def _resolve_owned_recipe_snapshot(
@@ -647,6 +648,25 @@ def _create_owned_thread(
     resolved_is_main = is_main or not has_main
     branch_index = 0 if resolved_is_main else app.state.thread_repo.get_next_branch_index(agent_user_id)
 
+    if selected_lease_id:
+        current_workspace_id = selected_lease_id
+        bound_cwd = bind_thread_to_existing_lease(
+            new_thread_id,
+            selected_lease_id,
+            cwd=payload.cwd,
+        )
+    else:
+        # @@@create-write-bridge-first - replay-13 requires supported create paths
+        # to persist the concrete workspace bridge at thread-row creation time,
+        # not bind runtime truth after a workspace-blind row already exists.
+        current_workspace_id = _create_thread_sandbox_resources(
+            new_thread_id,
+            sandbox_type,
+            selected_recipe,
+            payload.cwd,
+        )
+        bound_cwd = None
+
     app.state.thread_repo.create(
         thread_id=new_thread_id,
         agent_user_id=agent_user_id,
@@ -656,6 +676,8 @@ def _create_owned_thread(
         model=payload.model,
         is_main=resolved_is_main,
         branch_index=branch_index,
+        owner_user_id=owner_user_id,
+        current_workspace_id=current_workspace_id,
     )
 
     # Set thread state
@@ -664,22 +686,7 @@ def _create_owned_thread(
         app.state.thread_cwd[new_thread_id] = payload.cwd
 
     if selected_lease_id:
-        # @@@reuse-lease-binding - Reuse an existing lease by attaching a fresh terminal for the new thread.
-        bound_cwd = bind_thread_to_existing_lease(
-            new_thread_id,
-            selected_lease_id,
-            cwd=payload.cwd,
-        )
         app.state.thread_cwd[new_thread_id] = bound_cwd
-    else:
-        # @@@lease-early-creation - Create volume + lease + terminal at thread creation
-        # so volume exists BEFORE any file uploads.
-        _create_thread_sandbox_resources(
-            new_thread_id,
-            sandbox_type,
-            selected_recipe,
-            payload.cwd,
-        )
 
     if selected_lease_id and owned_lease is not None:
         successful_config = build_existing_launch_config(

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -584,6 +584,8 @@ class AgentService:
             model=model_name or parent_thread.get("model"),
             is_main=False,
             branch_index=branch_index,
+            owner_user_id=str(parent_thread.get("owner_user_id") or ""),
+            current_workspace_id=parent_thread.get("current_workspace_id"),
         )
 
     async def _handle_agent(

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -276,10 +276,14 @@ class AgentSubAgentRow(BaseModel):
 class ThreadRow(BaseModel):
     id: str
     agent_user_id: str
+    owner_user_id: str | None = None
+    current_workspace_id: str | None = None
     sandbox_type: str
     model: str | None = None
     cwd: str | None = None
     status: str = "active"
+    is_main: bool = False
+    branch_index: int = 0
     created_at: float
     updated_at: float | None = None
     last_active_at: float | None = None
@@ -780,9 +784,11 @@ class ThreadRepo(Protocol):
         model: str | None = None,
         is_main: bool,
         branch_index: int,
+        owner_user_id: str,
         status: str = "active",
         updated_at: float | None = None,
         last_active_at: float | None = None,
+        current_workspace_id: str | None = None,
     ) -> None: ...
     def list_by_ids(self, thread_ids: list[str]) -> list[dict[str, Any]]: ...
     def get_by_id(self, thread_id: str) -> dict[str, Any] | None: ...

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -71,20 +71,23 @@ class SupabaseThreadRepo:
         model: str | None = None,
         is_main: bool,
         branch_index: int,
+        owner_user_id: str,
         status: str = "active",
         updated_at: float | None = None,
         last_active_at: float | None = None,
-        owner_user_id: str | None = None,
+        current_workspace_id: str | None = None,
     ) -> None:
         _validate_thread_identity(is_main=is_main, branch_index=branch_index)
-        resolved_owner_user_id = owner_user_id or self._resolve_owner_user_id(agent_user_id)
+        if not owner_user_id.strip():
+            raise ValueError("owner_user_id is required for agent.threads create")
         created_at_value = _to_timestamptz(created_at)
         updated_at_value = _to_timestamptz(updated_at) if updated_at is not None else created_at_value
         self._t().insert(
             {
                 "id": thread_id,
                 "agent_user_id": agent_user_id,
-                "owner_user_id": resolved_owner_user_id,
+                "owner_user_id": owner_user_id,
+                "current_workspace_id": current_workspace_id,
                 "sandbox_type": sandbox_type,
                 "cwd": cwd,
                 "model": model,
@@ -239,13 +242,3 @@ class SupabaseThreadRepo:
 
     def _t(self) -> Any:
         return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
-
-    def _resolve_owner_user_id(self, agent_user_id: str) -> str:
-        response = self._client.table("users").select("owner_user_id").eq("id", agent_user_id).execute()
-        rows = q.rows(response, _REPO, "resolve_owner_user_id")
-        if not rows:
-            raise ValueError(f"agent user {agent_user_id!r} not found while creating agent.threads row")
-        owner_user_id = rows[0].get("owner_user_id")
-        if not isinstance(owner_user_id, str) or not owner_user_id.strip():
-            raise ValueError(f"agent user {agent_user_id!r} has no owner_user_id for agent.threads row")
-        return owner_user_id

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -458,6 +458,34 @@ async def test_create_thread_route_uses_canonical_existing_lease_binding_helper(
 
 
 @pytest.mark.asyncio
+async def test_create_thread_route_persists_current_workspace_id_for_existing_lease() -> None:
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={})
+    payload = CreateThreadRequest.model_validate(
+        {
+            "agent_user_id": "agent-user-1",
+            "lease_id": "lease-1",
+            "cwd": "/workspace/reused",
+        }
+    )
+
+    with (
+        patch.object(
+            threads_router.sandbox_service,
+            "resolve_owned_lease",
+            return_value={"lease_id": "lease-1", "provider_name": "local", "recipe": None},
+        ),
+        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
+        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", return_value=None),
+    ):
+        created = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    row = app.state.thread_repo.rows[created["thread_id"]]
+    assert row["current_workspace_id"] == "lease-1"
+
+
+@pytest.mark.asyncio
 async def test_create_thread_route_passes_local_cwd_into_sandbox_bootstrap():
     app = _make_threads_app(thread_sandbox={}, thread_cwd={})
     payload = CreateThreadRequest.model_validate(
@@ -476,6 +504,36 @@ async def test_create_thread_route_passes_local_cwd_into_sandbox_bootstrap():
         default_recipe_snapshot("local"),
         "/tmp/fresh-local-thread",
     )
+
+
+@pytest.mark.asyncio
+async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox_bridge() -> None:
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={})
+    payload = CreateThreadRequest.model_validate(
+        {
+            "agent_user_id": "agent-user-1",
+            "cwd": "/tmp/fresh-local-thread",
+        }
+    )
+
+    with (
+        patch.object(threads_router, "_validate_sandbox_provider_gate", return_value=None),
+        patch.object(threads_router, "_validate_sandbox_quota_gate", return_value=None),
+        patch.object(threads_router, "_validate_mount_capability_gate", return_value=None),
+        patch.object(threads_router, "_create_thread_sandbox_resources", return_value="lease-new") as create_resources,
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", return_value=None),
+    ):
+        created = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    create_resources.assert_called_once_with(
+        created["thread_id"],
+        "local",
+        default_recipe_snapshot("local"),
+        "/tmp/fresh-local-thread",
+    )
+    row = app.state.thread_repo.rows[created["thread_id"]]
+    assert row["current_workspace_id"] == "lease-new"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -79,10 +79,14 @@ class _FakeThreadRepo:
         model: str | None,
         is_main: bool,
         branch_index: int,
+        owner_user_id: str,
+        current_workspace_id: str | None = None,
     ):
         row = {
             "id": thread_id,
             "agent_user_id": agent_user_id,
+            "owner_user_id": owner_user_id,
+            "current_workspace_id": current_workspace_id,
             "sandbox_type": sandbox_type,
             "cwd": cwd,
             "model": model,
@@ -1141,6 +1145,8 @@ async def test_handle_agent_registers_subagent_thread_metadata_before_return(mon
             "parent-thread": {
                 "id": "parent-thread",
                 "agent_user_id": "agent-user-1",
+                "owner_user_id": "owner-1",
+                "current_workspace_id": "lease-parent",
                 "sandbox_type": "daytona_selfhost",
                 "cwd": "/home/daytona",
                 "model": "gpt-parent",
@@ -1171,6 +1177,8 @@ async def test_handle_agent_registers_subagent_thread_metadata_before_return(mon
 
         assert child_thread is not None
         assert child_thread["agent_user_id"] == "agent-user-1"
+        assert child_thread["owner_user_id"] == "owner-1"
+        assert child_thread["current_workspace_id"] == "lease-parent"
         assert child_thread["sandbox_type"] == "daytona_selfhost"
         assert child_thread["cwd"] == "/home/daytona"
         assert child_thread["is_main"] is False

--- a/tests/Unit/storage/test_supabase_thread_repo.py
+++ b/tests/Unit/storage/test_supabase_thread_repo.py
@@ -1,3 +1,5 @@
+import pytest
+
 from storage.providers.supabase.thread_repo import SupabaseThreadRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
@@ -159,6 +161,41 @@ def test_supabase_thread_repo_create_uses_agent_user_id_not_member_id() -> None:
     assert client.table_obj.insert_payload is not None
     assert client.table_obj.insert_payload["agent_user_id"] == "agent-1"
     assert "member_id" not in client.table_obj.insert_payload
+
+
+def test_supabase_thread_repo_create_writes_current_workspace_id() -> None:
+    client = _FakeClient()
+    repo = SupabaseThreadRepo(client)
+
+    repo.create(
+        thread_id="thread-1",
+        agent_user_id="agent-1",
+        sandbox_type="local",
+        created_at=1.0,
+        is_main=True,
+        branch_index=0,
+        owner_user_id="owner-1",
+        current_workspace_id="lease-1",
+    )
+
+    assert client.table_obj.insert_payload is not None
+    assert client.table_obj.insert_payload["current_workspace_id"] == "lease-1"
+
+
+def test_supabase_thread_repo_create_requires_explicit_owner_user_id() -> None:
+    client = _FakeClient()
+    repo = SupabaseThreadRepo(client)
+
+    with pytest.raises(TypeError):
+        repo.create(
+            thread_id="thread-1",
+            agent_user_id="agent-1",
+            sandbox_type="local",
+            created_at=1.0,
+            is_main=True,
+            branch_index=0,
+            current_workspace_id="lease-1",
+        )
 
 
 def test_supabase_thread_repo_update_writes_model_only():


### PR DESCRIPTION
## Summary
- persist `current_workspace_id` at thread-row creation time for the supported create paths
- remove storage-layer `owner_user_id` fallback and require explicit write-seam ownership fields
- update the subagent metadata create callsite and focused tests to match the explicit contract

## Test Plan
- `uv run pytest tests/Unit/storage/test_supabase_thread_repo.py tests/Integration/test_threads_router.py tests/Unit/core/test_agent_service.py -k "registers_subagent_thread_metadata_before_return or reuses_existing_completed_child_thread_for_same_parent_and_name or not registers_subagent_thread_metadata_before_return and not reuses_existing_completed_child_thread_for_same_parent_and_name" -q`
- `uv run ruff check storage/contracts.py storage/providers/supabase/thread_repo.py backend/web/routers/threads.py core/agents/service.py tests/Unit/storage/test_supabase_thread_repo.py tests/Integration/test_threads_router.py tests/Unit/core/test_agent_service.py`
- `uv run ruff format --check storage/contracts.py storage/providers/supabase/thread_repo.py backend/web/routers/threads.py core/agents/service.py tests/Unit/storage/test_supabase_thread_repo.py tests/Integration/test_threads_router.py tests/Unit/core/test_agent_service.py`
- `git diff --check`
