### PR TITLE
fix: derive launch config defaults from thread bridge

### DIFF
--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -167,13 +167,11 @@ def _derive_default_config(
     providers: list[dict[str, Any]],
     recipes: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    agent_thread_ids = {str(item.get("id") or "").strip() for item in agent_threads if item.get("id")}
-    agent_leases = [
-        lease for lease in leases if any(str(thread_id or "").strip() in agent_thread_ids for thread_id in lease.get("thread_ids") or [])
-    ]
-    if agent_leases:
-        lease = agent_leases[0]
-        return _existing_config_from_lease(lease, model=None, workspace=lease.get("cwd"))
+    leases_by_id = {str(lease.get("lease_id") or "").strip(): lease for lease in leases if str(lease.get("lease_id") or "").strip()}
+    for thread in _iter_default_bridge_threads(agent_threads):
+        lease = leases_by_id.get(thread["current_workspace_id"])
+        if lease is not None:
+            return _existing_config_from_lease(lease, model=None, workspace=lease.get("cwd"))
 
     provider_names = [str(item["name"]) for item in providers]
     provider_config = "local" if "local" in provider_names else (provider_names[0] if provider_names else "local")
@@ -195,6 +193,21 @@ def _derive_default_config(
         "model": None,
         "workspace": None,
     }
+
+
+def _iter_default_bridge_threads(agent_threads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    threads_with_bridge = []
+    for thread in agent_threads:
+        current_workspace_id = str(thread.get("current_workspace_id") or "").strip()
+        if current_workspace_id:
+            threads_with_bridge.append({**thread, "current_workspace_id": current_workspace_id})
+
+    # @@@launch-config-thread-bridge-authority - replay-15 makes thread-owned
+    # current_workspace_id the discovery authority for derived existing-mode
+    # defaults; live lease lookup only materializes that bridge.
+    if threads_with_bridge and all(item.get("created_at") is not None for item in threads_with_bridge):
+        return sorted(threads_with_bridge, key=lambda item: item["created_at"], reverse=True)
+    return threads_with_bridge
 
 
 def _recipe_matches_provider(recipe: dict[str, Any], provider_config: str) -> bool:

--- a/docs/database-refactor/dev-replay-14-launch-config-backend-truth-preflight.md
+++ b/docs/database-refactor/dev-replay-14-launch-config-backend-truth-preflight.md
@@ -1,0 +1,264 @@
+# Database Refactor Dev Replay 14: Launch Config Backend Truth Preflight
+
+## Goal
+
+Define the minimal truthful backend contract for launch-config persistence and
+default resolution after replay-13 landed create-time
+`thread.current_workspace_id`.
+
+This checkpoint is doc/ruling only. It does not implement backend behavior
+changes, frontend changes, request-shell redesign, runtime cutover,
+file-channel/monitor/schedule work, SQL/migrations, live DB writes, or legacy
+deletion.
+
+## Linkage
+
+- replay-12 declared launch-config persistence as explicit residue after the
+  thread write contract was clarified
+- replay-13 made supported thread-create paths write a concrete bridge into
+  `thread.current_workspace_id`
+- current mismatch: backend launch-config persistence and default derivation are
+  still lease-centric, even though thread creation truth now lands on
+  `current_workspace_id`
+
+## Architectural Frame
+
+The product/runtime concept remains:
+
+```text
+thread -> sandbox
+workspace = a thin workdir inside that sandbox
+```
+
+The currently persisted bridge remains:
+
+```text
+thread.current_workspace_id -> workspace -> sandbox
+```
+
+Replay-14 is not about changing that architecture. It is about deciding how the
+backend launch-config layer should speak truthfully now that replay-13 has
+already landed the thread-side bridge.
+
+## Sources
+
+- `docs/database-refactor/dev-replay-12-thread-create-write-contract-preflight.md`
+- `backend/web/services/thread_launch_config_service.py`
+- `backend/web/models/requests.py`
+- `backend/web/routers/threads.py`
+- `storage/contracts.py`
+- `storage/providers/supabase/thread_repo.py`
+- `frontend/app/src/api/client.ts`
+- `frontend/app/src/pages/NewChatPage.tsx`
+
+## Current Code Facts
+
+### 1. Persisted launch-config payload is still lease-shaped
+
+`backend/web/services/thread_launch_config_service.py:12-20` normalizes stored
+payload into:
+
+- `create_mode`
+- `provider_config`
+- `recipe_id`
+- `lease_id`
+- `model`
+- `workspace`
+
+There is no persisted `current_workspace_id`, sandbox binding id, or other
+thread-aligned runtime pointer in this payload shape.
+
+`backend/web/models/requests.py:27-34` matches that lease-shaped persistence
+surface:
+
+- `SaveThreadLaunchConfigRequest.lease_id` still exists
+- no workspace-id field exists
+
+### 2. Saved "existing" config is validated by live lease lookup
+
+`backend/web/services/thread_launch_config_service.py:100-121` treats an
+`existing` config as valid only if:
+
+- `lease_id` is present
+- `lease_id` resolves inside `sandbox_service.list_user_leases(...)`
+
+If the lease disappears, the saved config is discarded.
+
+This means backend launch-config persistence currently treats the lease list as
+its authority surface for `"existing"`, not thread rows and not
+`current_workspace_id`.
+
+### 3. Derived default config is still agent-lease-first
+
+`backend/web/services/thread_launch_config_service.py:162-176` derives default
+config by:
+
+- collecting all agent thread ids from `thread_repo.list_by_agent_user(...)`
+- scanning live user leases
+- picking the first lease whose `thread_ids` intersects those agent thread ids
+- returning `_existing_config_from_lease(...)`
+
+So the current derived-default rule is:
+
+```text
+agent threads -> intersect live leases -> choose lease -> emit existing config
+```
+
+Not:
+
+```text
+agent threads -> inspect thread.current_workspace_id -> resolve binding -> emit config
+```
+
+### 4. Thread create success persistence still writes lease semantics on existing path
+
+`backend/web/routers/threads.py:651-699` now writes
+`current_workspace_id` during thread creation, but it still persists
+last-successful launch config as:
+
+- existing path: `build_existing_launch_config(lease=owned_lease, ...)`
+- new path: `build_new_launch_config(...)`
+
+So replay-13 corrected thread-row write truth, but not launch-config persistence
+truth.
+
+### 5. Frontend shell is still lease-centric, but replay-14 does not touch it
+
+Frontend still sends and restores `lease_id`:
+
+- `frontend/app/src/api/client.ts`
+- `frontend/app/src/pages/NewChatPage.tsx`
+
+This matters because it constrains what the backend may reject today. But it is
+not authorization to keep backend internals dual-authority forever.
+
+## Contract Mismatch
+
+After replay-13, the backend now has two different truth surfaces:
+
+1. **Thread creation truth**
+   - supported create paths write `thread.current_workspace_id`
+
+2. **Launch-config truth**
+   - saved config persistence still keys `"existing"` off `lease_id`
+   - derived defaults still scan live leases first
+
+That duality is the residue replay-14 must name precisely.
+
+## Ruling
+
+### 1. Launch-config persistence is metadata, not authority
+
+The backend launch-config layer must not define runtime truth on its own.
+
+Its role is:
+
+- remember recent user/operator choices
+- validate whether those choices are still actionable
+- provide a default draft for the create UI
+
+Its role is **not**:
+
+- declare the authoritative thread binding model
+- outvote thread-row write truth
+- keep lease-first semantics alive after thread-side truth has changed
+
+### 2. `lease_id` remains tolerated only as ingress metadata for the current shell
+
+Explicit temporary treatment:
+
+- tolerated:
+  - `CreateThreadRequest.lease_id`
+  - `SaveThreadLaunchConfigRequest.lease_id`
+  - stored `last_confirmed` / `last_successful` payloads that still carry
+    `lease_id`
+  - backend validation of that saved shell payload against live leases
+
+- not tolerated:
+  - any new storage/thread binding seam using `lease_id` as authoritative truth
+  - any claim that saved launch-config persistence is the system-of-record for
+    runtime binding
+  - any widening of `lease_id` deeper into thread repo/runtime contracts
+
+This is ingress tolerance only. It is not architectural endorsement.
+
+### 3. Derived backend defaults should stop being lease-first in the next implementation slice
+
+The first replay-14 implementation slice should target backend default
+resolution, not frontend payload cleanup.
+
+Required direction:
+
+- backend default resolution should prefer thread-aligned truth
+- specifically, it should stop deriving `"existing"` defaults purely by
+  intersecting agent threads with live leases
+- if `"existing"` remains supported, its backend derivation must be justified by
+  thread-owned binding truth, not lease-list coincidence
+
+This does **not** force a request-shell cut in replay-14. It only says the
+backend read/persistence layer must stop treating lease-first derivation as its
+native truth.
+
+### 4. Saved launch-config payload may remain lease-shaped for one narrow follow-up slice
+
+Replay-14 does not require immediate removal of `lease_id` from saved payloads.
+
+But the only legal reason to keep it temporarily is:
+
+- the current frontend shell still submits `"existing"` choices in lease terms
+- the backend still needs to round-trip that draft faithfully during the
+  cleanup transition
+
+That temporary legality ends where backend truth begins:
+
+- thread creation truth already moved
+- next backend launch-config slice must follow it
+
+No vague "transition period" language is allowed beyond this explicit residue.
+
+### 5. Replay-14 does not authorize frontend or runtime cutover
+
+This preflight does **not** authorize:
+
+- removing `lease_id` from frontend payloads
+- redesigning `NewChatPage`
+- changing runtime binding readers/managers
+- changing file-channel/monitor/schedule semantics
+- migrations or live DB writes
+
+Those are separate checkpoints.
+
+## Proposed First Implementation Checkpoint After Replay-14
+
+`database-refactor-dev-replay-15-launch-config-backend-default-resolution`
+
+Target boundary:
+
+- keep request shell unchanged
+- keep frontend unchanged
+- keep thread create contract unchanged
+- change backend launch-config resolution so derived defaults no longer use
+  lease-first coincidence as native truth
+- explicitly document whether saved `lease_id` remains round-trip metadata or is
+  replaced by a thread-aligned backend representation
+
+## Stopline
+
+Replay-14 does **not** authorize:
+
+- frontend product changes
+- request model redesign
+- runtime cutover
+- monitor/file-channel/schedule work
+- SQL/migrations/live DB writes
+- legacy deletion outside the narrow backend launch-config slice
+
+## Honest Residuals
+
+- saved launch-config payloads are still lease-shaped
+- backend validates `"existing"` configs through live lease lookup
+- backend derived defaults are still agent-lease-first
+- frontend shell is still lease-centric
+
+Those residuals are now explicit. The next slice must reduce backend
+dual-authority, not bury it under more lease-aware glue.

--- a/docs/database-refactor/dev-replay-15-launch-config-backend-default-resolution-preflight.md
+++ b/docs/database-refactor/dev-replay-15-launch-config-backend-default-resolution-preflight.md
@@ -1,0 +1,170 @@
+# Database Refactor Dev Replay 15: Launch Config Backend Default Resolution Preflight
+
+## Goal
+
+Define the exact implementation boundary for the first backend-only cleanup
+slice after replay-14:
+
+- stop derived launch-config defaults from using lease-first coincidence as
+  their native truth
+- keep the current request shell, frontend payload shape, and runtime cutover
+  out of scope
+
+This checkpoint is preflight only. It does not implement the cleanup.
+
+## Linkage
+
+- replay-13 made supported thread-create paths write a concrete bridge into
+  `thread.current_workspace_id`
+- replay-14 closed the contract debate:
+  - launch-config persistence is metadata, not authority
+  - `lease_id` is tolerated only as ingress / round-trip residue
+  - the next implementation slice should be backend-only default-resolution
+    cleanup
+
+## Current Truth
+
+Today `backend/web/services/thread_launch_config_service.py` resolves defaults
+in this order:
+
+1. validate `last_successful`
+2. validate `last_confirmed`
+3. derive a fresh config by:
+   - listing agent threads
+   - listing live user leases
+   - picking the first lease whose `thread_ids` intersects those thread ids
+
+That third step is the remaining mismatch. It still treats lease-thread
+association as the backend's native authority, even though replay-13 already
+moved create-time thread truth to `current_workspace_id`.
+
+## Required Direction
+
+Replay-15 should change only the backend default-resolution logic.
+
+The target rule is:
+
+```text
+agent threads -> thread-owned current_workspace_id -> matching live bridge ->
+existing config
+```
+
+Not:
+
+```text
+agent threads -> intersect thread_ids inside live leases -> existing config
+```
+
+This still allows a narrow temporary residue:
+
+- the returned `"existing"` config may continue to carry `lease_id`
+- saved launch-config payloads may remain lease-shaped
+
+But that `lease_id` must now be downstream metadata derived from the
+thread-owned bridge, not the source of truth used to discover the bridge.
+
+## Exact Write Set
+
+### Authorized code
+
+- `backend/web/services/thread_launch_config_service.py`
+
+### Authorized tests
+
+- `tests/Integration/test_thread_launch_config_contract.py`
+
+### Explicitly out of scope
+
+- `backend/web/models/requests.py`
+- `backend/web/routers/threads.py`
+- `frontend/app/src/api/client.ts`
+- `frontend/app/src/pages/NewChatPage.tsx`
+- `storage/contracts.py`
+- `storage/providers/supabase/thread_launch_pref_repo.py`
+- any runtime/monitor/file-channel/schedule code
+- any SQL or live DB write
+
+## Planned Mechanism
+
+Replay-15 should keep the outer API shape unchanged and only tighten
+`resolve_default_config(...)` / `_derive_default_config(...)`.
+
+The intended mechanism is:
+
+1. read `agent_threads = thread_repo.list_by_agent_user(agent_user_id)`
+2. identify candidate thread rows that already carry a non-blank
+   `current_workspace_id`
+3. choose the most defensible candidate from thread truth rather than from
+   lease coincidence
+4. look up the matching live lease using that thread-owned bridge id
+5. if the live bridge is still resolvable, emit `"existing"` config from that
+   bound resource
+6. otherwise fall back to the existing provider/recipe-based `"new"` default
+
+This means replay-15 still tolerates live-lease lookup as a materialization
+step, but no longer as the discovery authority.
+
+## Candidate Selection Rule
+
+Replay-15 should keep candidate selection simple.
+
+The preferred rule is:
+
+- scan agent threads in descending recency if timestamps are available
+- otherwise preserve current repo return order
+- pick the first thread row whose `current_workspace_id` is non-blank and can
+  still be materialized to a live lease
+
+Do not invent scoring, ranking, or multi-thread heuristics in this slice.
+
+## Test Plan
+
+Replay-15 should be driven by focused contract tests in
+`tests/Integration/test_thread_launch_config_contract.py`.
+
+Required RED/GREEN coverage:
+
+1. when saved configs are absent/invalid, derived default should use
+   `thread.current_workspace_id` rather than `lease.thread_ids` intersection
+2. a lease with matching `thread_ids` but no matching
+   `current_workspace_id` bridge must not win
+3. if a thread-owned bridge points to a missing live lease, derivation should
+   fall back cleanly to the existing `"new"` provider/recipe default
+4. saved `last_successful` / `last_confirmed` precedence should remain intact
+
+No product-level YATU is required for replay-15 preflight itself. This is a
+mechanism-layer slice.
+
+## Stopline
+
+Replay-15 must not:
+
+- redesign request payloads
+- remove `lease_id` from the create/config shell
+- change `save_last_confirmed_config(...)` or `save_last_successful_config(...)`
+  payload shape unless strictly required by the backend-only default-resolution
+  cleanup
+- modify thread creation flow
+- touch frontend behavior
+- cut runtime over to a new binding reader
+- add migrations, schema work, or live DB writes
+- add fallback-heavy heuristics
+
+## Expected Artifact
+
+If replay-15 is authorized, the result should be a narrow backend PR whose
+effect is easy to state:
+
+- derived default resolution now follows thread-owned bridge truth
+- saved shell payloads remain temporarily lease-shaped
+- no outward shell/runtime contract was widened
+
+## Open Question To Resolve In The Ruling
+
+Is replay-15 allowed to keep emitted `"existing"` defaults carrying `lease_id`
+as frontend-facing residue while switching backend discovery authority to
+`current_workspace_id`?
+
+The intended answer is yes, because replay-14 already allowed `lease_id` as
+ingress / round-trip residue. Replay-15 just must not continue to use it as the
+native backend discovery key.

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -350,6 +350,137 @@ def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() ->
     }
 
 
+def test_resolve_default_config_derives_existing_from_thread_current_workspace_id_not_lease_thread_ids() -> None:
+    thread_repo = _FakeThreadRepo()
+    thread_repo.rows["agent-user-1-1"] = {
+        "thread_id": "agent-user-1-1",
+        "agent_user_id": "agent-user-1",
+        "current_workspace_id": "lease-2",
+        "is_main": True,
+        "branch_index": 0,
+    }
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_launch_pref_repo=SimpleNamespace(get=lambda _owner_user_id, _agent_user_id: {}),
+            thread_repo=thread_repo,
+            user_repo=SimpleNamespace(),
+            recipe_repo=object(),
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "list_user_leases",
+            return_value=[
+                {
+                    "lease_id": "lease-1",
+                    "provider_name": "local",
+                    "recipe": default_recipe_snapshot("local"),
+                    "cwd": "/workspace/wrong",
+                    "thread_ids": ["agent-user-1-1"],
+                },
+                {
+                    "lease_id": "lease-2",
+                    "provider_name": "daytona_selfhost",
+                    "recipe": default_recipe_snapshot("daytona"),
+                    "cwd": "/workspace/right",
+                    "thread_ids": [],
+                },
+            ],
+        ),
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "available_sandbox_types",
+            return_value=[
+                {"name": "local", "available": True},
+                {"name": "daytona_selfhost", "available": True},
+            ],
+        ),
+        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+    ):
+        result = thread_launch_config_service.resolve_default_config(
+            app=app,
+            owner_user_id="owner-1",
+            agent_user_id="agent-user-1",
+        )
+
+    assert result == {
+        "source": "derived",
+        "config": {
+            "create_mode": "existing",
+            "provider_config": "daytona_selfhost",
+            "recipe": default_recipe_snapshot("daytona"),
+            "lease_id": "lease-2",
+            "model": None,
+            "workspace": "/workspace/right",
+        },
+    }
+
+
+def test_resolve_default_config_falls_back_to_new_default_when_thread_workspace_bridge_is_missing() -> None:
+    thread_repo = _FakeThreadRepo()
+    thread_repo.rows["agent-user-1-1"] = {
+        "thread_id": "agent-user-1-1",
+        "agent_user_id": "agent-user-1",
+        "current_workspace_id": "missing-lease",
+        "is_main": True,
+        "branch_index": 0,
+    }
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_launch_pref_repo=SimpleNamespace(get=lambda _owner_user_id, _agent_user_id: {}),
+            thread_repo=thread_repo,
+            user_repo=SimpleNamespace(),
+            recipe_repo=object(),
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "list_user_leases",
+            return_value=[
+                {
+                    "lease_id": "lease-1",
+                    "provider_name": "daytona_selfhost",
+                    "recipe": default_recipe_snapshot("daytona"),
+                    "cwd": "/workspace/wrong",
+                    "thread_ids": ["agent-user-1-1"],
+                }
+            ],
+        ),
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "available_sandbox_types",
+            return_value=[{"name": "local", "available": True}],
+        ),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
+    ):
+        result = thread_launch_config_service.resolve_default_config(
+            app=app,
+            owner_user_id="owner-1",
+            agent_user_id="agent-user-1",
+        )
+
+    assert result == {
+        "source": "derived",
+        "config": {
+            "create_mode": "new",
+            "provider_config": "local",
+            "recipe_id": "local:default",
+            "recipe": default_recipe_snapshot("local"),
+            "lease_id": None,
+            "model": None,
+            "workspace": None,
+        },
+    }
+
+
 def test_find_owned_agent_returns_none_for_foreign_agent() -> None:
     app = _make_threads_app()
 


### PR DESCRIPTION
## Summary
- add replay-14 and replay-15 database-refactor preflight docs for launch-config backend truth and default-resolution boundary
- change `thread_launch_config_service` so derived existing-mode defaults follow thread-owned `current_workspace_id` instead of lease `thread_ids` coincidence
- add focused integration coverage for bridge-first default discovery and fallback-to-new when the thread-owned bridge cannot be materialized

## Test Plan
- `uv run pytest tests/Integration/test_thread_launch_config_contract.py -q`
- `uv run ruff check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py`
- `uv run ruff format --check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py`
- `git diff --check`
