### PR TITLE
fix: tighten launch config shell lease residue

### DIFF
--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -10,11 +10,15 @@ from sandbox.recipes import normalize_recipe_snapshot, provider_type_from_name
 
 
 def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    create_mode = "existing" if payload.get("create_mode") == "existing" else "new"
+    lease_id = str(payload.get("lease_id") or "").strip() or None
+    if create_mode != "existing":
+        lease_id = None
     return {
-        "create_mode": "existing" if payload.get("create_mode") == "existing" else "new",
+        "create_mode": create_mode,
         "provider_config": str(payload.get("provider_config") or "").strip(),
         "recipe_id": str(payload.get("recipe_id") or "").strip() or None,
-        "lease_id": str(payload.get("lease_id") or "").strip() or None,
+        "lease_id": lease_id,
         "model": str(payload.get("model") or "").strip() or None,
         "workspace": str(payload.get("workspace") or "").strip() or None,
     }

--- a/docs/database-refactor/dev-replay-20-launch-config-and-thread-shell-lease-residue-preflight.md
+++ b/docs/database-refactor/dev-replay-20-launch-config-and-thread-shell-lease-residue-preflight.md
@@ -1,0 +1,263 @@
+# Database Refactor Dev Replay 20: Launch Config And Thread Shell Lease Residue Preflight
+
+## Goal
+
+Decide the next narrow cleanup boundary for the remaining `lease_id` residue in
+the thread-create / launch-config shell.
+
+This checkpoint is doc/ruling only. It does not change request models,
+frontend payloads, backend behavior, runtime managers, SQL/migrations, or live
+DB state.
+
+## Why This Comes Next
+
+Replay-18 and replay-19 finished the current-workspace null-fencing line:
+
+- explicit historical/read-compat null rows are fenced as legacy residue
+- helper/test-only create looseness has been tightened
+
+That leaves a different residue family:
+
+- `lease_id` still appears in thread-create request shells and launch-config
+  payloads even though backend truth for thread binding has already shifted to
+  thread-owned `current_workspace_id`
+
+The next ambiguity is no longer about nullability. It is about whether the
+shell still exposes `lease_id` as if it were native truth, or whether it is
+now just a temporary ingress/round-trip field around a different backend
+authority.
+
+## Linkage
+
+- replay-13 made owner-facing thread create write `current_workspace_id`
+- replay-14 and replay-15 established that launch-config persistence is
+  metadata and that backend default resolution should derive from thread-owned
+  bridge truth rather than lease-first coincidence
+- replay-18 and replay-19 fenced the remaining nullable current-workspace
+  residue without widening into shell cleanup
+
+So replay-20 should return to the launch-config / thread shell residue that was
+intentionally deferred earlier.
+
+## Current Code Facts
+
+### 1. Request models still expose `lease_id`
+
+`backend/web/models/requests.py` still carries `lease_id` in thread-related
+request models.
+
+That means the owner-facing shell still speaks lease-shaped input directly.
+
+### 2. Thread router still treats `payload.lease_id` as the existing-resource selector
+
+`backend/web/routers/threads.py` still branches on `payload.lease_id` for the
+"existing lease" path and maps it to `current_workspace_id`.
+
+This may still be acceptable as ingress residue, but it should now be named
+and fenced honestly.
+
+### 3. Launch-config service still stores and round-trips `lease_id`
+
+`backend/web/services/thread_launch_config_service.py` still normalizes,
+persists, and returns `lease_id`.
+
+After replay-15, this no longer means lease-first is backend truth. But the
+shell still looks lease-shaped.
+
+### 4. Frontend API contract still models launch-config as lease-shaped
+
+`frontend/app/src/api/client.ts` and `frontend/app/src/api/types.ts` still
+encode/decode launch-config payloads with `lease_id`.
+
+This is a shell contract question, not a runtime/monitor question.
+
+## Explicit Frontend Classification
+
+Replay-20 must classify the frontend `lease_id` surfaces explicitly instead of
+talking about "frontend residue" as one blob.
+
+### Thread shell / launch-config residue
+
+These frontend surfaces are in replay-20 scope because they are part of the
+owner-facing thread-create or launch-config shell:
+
+1. `frontend/app/src/api/client.ts`
+
+- `CreateThreadOptions.leaseId`
+- `createThread(...)` writing `body.lease_id`
+- `parseThreadLaunchConfig(...)` reading `payload.lease_id`
+- `saveDefaultThreadConfig(...)` round-tripping `ThreadLaunchConfig`
+
+2. `frontend/app/src/api/types.ts`
+
+- `ThreadLaunchConfig.lease_id?: string | null`
+
+These are the places where shell-level lease selection still appears in the
+API/UI contract even though backend thread-binding truth has moved elsewhere.
+
+### Legitimate runtime/resource identity
+
+These frontend/API surfaces are **not** replay-20 residue just because they
+contain `lease_id`. They describe real resource/runtime identity:
+
+1. `frontend/app/src/api/types.ts`
+
+- `UserLeaseSummary.lease_id`
+- `TerminalStatus.lease_id`
+- `LeaseStatus.lease_id`
+
+2. `frontend/app/src/api/client.ts`
+
+- `parseUserLeases(...)`
+- `parseTerminalStatus(...)`
+- `parseLeaseStatus(...)`
+
+These should stay out of replay-20. They are reporting or parsing real lease
+objects, not modeling the thread-create / launch-config shell.
+
+## Important Non-Goal
+
+Replay-20 must not confuse two different categories of `lease_id`.
+
+### Legitimate runtime/resource identity
+
+These are not replay-20 targets:
+
+- monitor/resource overview/detail surfaces
+- sandbox/lease status surfaces
+- runtime/session/terminal/lease records where `lease_id` is the real resource
+  identity
+
+Those uses are not residue just because they mention leases.
+
+### Thread shell / launch-config residue
+
+This **is** replay-20 territory:
+
+- owner-facing create-thread shell
+- launch-config persistence / payload shape
+- frontend thread-create config UI/API contract
+
+The question here is whether lease-shaped shell fields are still the right
+temporary ingress, or whether they now obscure the real authority too much.
+
+## The Actual Ambiguity
+
+There are three possible interpretations of today's shell-level `lease_id`:
+
+### A. It is still native truth for thread binding
+
+This is likely false now, because thread binding truth has already moved to
+thread-owned `current_workspace_id`.
+
+### B. It is tolerated only as an ingress/round-trip shell field
+
+This means:
+
+- users can still pick an existing lease by `lease_id`
+- backend may still echo/save that field for shell continuity
+- but it is no longer the backend authority for thread binding
+
+### C. It is already harmful enough that the next slice should remove or rename it
+
+This may eventually be true, but replay-20 should first decide whether the next
+slice belongs in backend shell semantics only, or whether it must widen into
+frontend/request contract cleanup.
+
+## Recommended Ruling
+
+### 1. Treat shell-level `lease_id` as residue, not backend authority
+
+Replay-20 should explicitly state:
+
+- thread binding truth is not `lease_id`
+- shell-level `lease_id` is, at most, a temporary selector / round-trip field
+  around thread-owned bridge truth
+
+### 2. Separate backend-shell cleanup from frontend/request-contract cleanup
+
+The next implementation checkpoint should prefer the smallest honest slice.
+
+The first question is not "remove `lease_id` everywhere".
+The first question is:
+
+- can backend shell semantics be tightened further while request/frontend shape
+  stays temporarily stable?
+
+### 3. Keep monitor/runtime lease identity out of lane
+
+Replay-20 should explicitly reject any attempt to clean up monitor/runtime
+`lease_id` references under the same banner. Those are separate concepts.
+
+## Proposed Next Implementation Candidates
+
+Replay-20 should evaluate these two candidate directions and choose one in the
+ruling.
+
+### Candidate 1: backend-shell-only tightening
+
+Target:
+
+- keep request/frontend payload shape unchanged for now
+- tighten backend launch-config / router semantics so `lease_id` is treated
+  explicitly as ingress/round-trip residue, not native truth
+
+Pros:
+
+- narrower
+- aligns with replay-15 style
+- less likely to widen into frontend churn
+
+### Candidate 2: request/frontend shell contract cleanup
+
+Target:
+
+- start renaming/remapping request and frontend payloads away from `lease_id`
+
+Pros:
+
+- cleaner long-term surface
+
+Cons:
+
+- wider
+- couples backend truth cleanup with UI/API contract movement
+- more likely to spill into unrelated shell churn
+
+## Recommendation
+
+Prefer Candidate 1 first.
+
+Reason:
+
+- backend authority has already moved
+- the next minimal step is to make backend shell semantics more honest before
+  forcing a frontend/request contract rewrite
+
+## Proposed First Implementation Checkpoint After Replay-20
+
+`database-refactor-dev-replay-21-launch-config-backend-shell-residue-tightening`
+
+Intended boundary:
+
+- backend shell semantics only
+- no frontend/request payload redesign yet
+- no runtime/monitor work
+
+## Stopline
+
+Replay-20 does **not** authorize:
+
+- changing request model fields yet
+- changing frontend payload/types yet
+- changing monitor/runtime/resource surfaces
+- changing storage contracts or runtime binding readers
+- SQL/migrations/live DB writes
+- historical row repair
+
+## Open Question For Ledger Ruling
+
+Is replay-20 the right checkpoint to formally classify shell-level `lease_id`
+as temporary ingress/round-trip residue and to bias the next implementation
+slice toward backend-shell-only tightening rather than frontend/request contract
+cleanup?

--- a/docs/database-refactor/dev-replay-21-launch-config-backend-shell-residue-tightening-preflight.md
+++ b/docs/database-refactor/dev-replay-21-launch-config-backend-shell-residue-tightening-preflight.md
@@ -1,0 +1,186 @@
+# Database Refactor Dev Replay 21: Launch Config Backend Shell Residue Tightening Preflight
+
+## Goal
+
+Define the first backend-only implementation slice that tightens launch-config
+shell residue without changing request/frontend payload shape.
+
+This checkpoint is preflight only. It does not implement the tightening yet.
+
+## Why This Comes Next
+
+Replay-20 closed the classification question:
+
+- shell-level `lease_id` in thread-create / launch-config surfaces is residue,
+  not backend authority
+- runtime/resource `lease_id` identity is a separate category and out of lane
+
+That means the next slice should not yet rename request fields or rewrite the
+frontend shell. It should first make backend shell semantics more honest while
+the payload shape remains temporarily stable.
+
+## Current Code Facts
+
+### 1. Backend normalization still allows `lease_id` to survive independent of `create_mode`
+
+`backend/web/services/thread_launch_config_service.py`
+`normalize_launch_config_payload(...)` currently returns:
+
+- normalized `create_mode`
+- normalized `lease_id`
+
+But it does not enforce the shell truth that:
+
+- `"new"` config should not carry an effective existing-lease selector
+
+So a `"new"` payload can still persist a trimmed `lease_id` through the generic
+normalization path.
+
+### 2. Existing-mode truth is already materialized from live lease lookup
+
+The same service already does something more honest in other paths:
+
+- `_validate_saved_config(...)` resolves `"existing"` configs through live
+  lease lookup
+- `_existing_config_from_lease(...)` rebuilds canonical existing config from
+  the actual lease row
+- `_derive_default_config(...)` derives existing-mode defaults from thread-owned
+  `current_workspace_id`
+
+So replay-21 is not inventing a new principle. It is tightening the remaining
+backend shell path to match what the rest of the service already implies.
+
+### 3. Existing route save path already uses backend helpers
+
+`backend/web/routers/threads.py` uses:
+
+- `build_existing_launch_config(...)`
+- `build_new_launch_config(...)`
+- `save_last_successful_config(...)`
+
+That means a backend-only service tightening may be enough if it stays inside
+the helper layer. Router changes should be avoided unless the tests prove they
+are required.
+
+## Exact Target
+
+Replay-21 should tighten backend shell semantics so that:
+
+- `"new"` launch-config state cannot carry an effective `lease_id`
+- `"existing"` launch-config state still uses `lease_id` only as shell-level
+  selector / round-trip field
+- canonical existing-mode config continues to be rebuilt from the resolved
+  lease row, not trusted raw payload
+
+## Exact Write Set
+
+### Authorized code
+
+- `backend/web/services/thread_launch_config_service.py`
+
+### Authorized focused tests
+
+- `tests/Integration/test_thread_launch_config_contract.py`
+
+### Allowed only if RED proves strictly necessary
+
+- `backend/web/routers/threads.py`
+
+Reason:
+
+- the tightening should ideally land in backend helper/service semantics only
+- router widening should happen only if helper-level tightening exposes a real
+  mismatch in the current save/create path
+
+## Planned Mechanism
+
+Replay-21 should prefer the smallest honest change:
+
+1. make normalization and/or save-path semantics enforce:
+   - if `create_mode == "new"`, persisted/canonical config has `lease_id = None`
+2. preserve existing-mode shell shape for now:
+   - `lease_id` may still exist as selector/round-trip field
+3. keep derived existing-mode defaults sourced from thread-owned bridge truth
+4. do not change request models or frontend payloads yet
+
+## Candidate Tightening Points
+
+The likely narrowest landing is one of:
+
+### Option A: tighten `normalize_launch_config_payload(...)`
+
+If `create_mode` normalizes to `"new"`, force:
+
+- `lease_id = None`
+
+Pros:
+
+- smallest single-point rule
+- directly expresses backend shell truth
+
+### Option B: tighten save/validate paths only
+
+Leave raw normalization generic, but force `"new"` configs to lose `lease_id`
+before persistence and canonicalization.
+
+Pros:
+
+- narrower effect surface
+
+Cons:
+
+- easier to leave duplicate shell looseness elsewhere
+
+## Recommendation
+
+Prefer Option A unless RED proves it breaks an intentional backend caller.
+
+Reason:
+
+- replay-21 is about making backend shell semantics explicit
+- the cleanest place to express that rule is the normalization helper itself
+
+## Test Plan
+
+Replay-21 should be driven by focused tests in
+`tests/Integration/test_thread_launch_config_contract.py`.
+
+Required coverage:
+
+1. a `"new"` payload with a stray `lease_id` is normalized/persisted/canonicalized
+   with `lease_id = None`
+2. existing-mode canonical shape still carries `lease_id` from the resolved
+   lease row
+3. replay-15 existing-mode derivation from thread-owned bridge still passes
+4. route-level successful-config persistence still stays correct for existing
+   and new paths
+
+## Stopline
+
+Replay-21 must not:
+
+- rename request model fields
+- change frontend payload/types
+- change monitor/runtime/resource surfaces
+- change storage contracts
+- change runtime binding readers
+- add SQL/migrations/live DB writes
+- remove existing-mode shell support entirely
+
+## Expected Artifact
+
+If replay-21 lands cleanly, the result should be easy to state:
+
+- backend shell semantics no longer let `"new"` configs carry an effective
+  `lease_id`
+- existing-mode shell support still works
+- request/frontend contract remains temporarily unchanged
+
+## Open Question For Ledger Ruling
+
+Is this the right narrow replay-21 boundary:
+
+- helper/service-only by default
+- `thread_launch_config_service.py` plus focused integration proof
+- backend-shell tightening first, while request/frontend payload shape stays
+  stable for now?

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -173,6 +173,39 @@ def test_save_last_confirmed_config_normalizes_payload() -> None:
     ]
 
 
+def test_save_last_confirmed_config_drops_stray_lease_id_for_new_mode() -> None:
+    app = _make_threads_app()
+
+    thread_launch_config_service.save_last_confirmed_config(
+        app=app,
+        owner_user_id="owner-1",
+        agent_user_id="agent-user-1",
+        payload={
+            "create_mode": "new",
+            "provider_config": "local",
+            "recipe_id": "local:default",
+            "lease_id": "lease-stray",
+            "model": "gpt-5.4-mini",
+            "workspace": "/tmp/demo",
+        },
+    )
+
+    assert app.state.thread_launch_pref_repo.confirmed == [
+        (
+            "owner-1",
+            "agent-user-1",
+            {
+                "create_mode": "new",
+                "provider_config": "local",
+                "recipe_id": "local:default",
+                "lease_id": None,
+                "model": "gpt-5.4-mini",
+                "workspace": "/tmp/demo",
+            },
+        )
+    ]
+
+
 def test_build_existing_launch_config_uses_canonical_shape() -> None:
     config = thread_launch_config_service.build_existing_launch_config(
         lease={


### PR DESCRIPTION
## Summary
- add replay-20 doc-only preflight that classifies shell-level lease residue vs real runtime/resource lease identity
- tighten backend launch-config normalization so new-mode configs cannot carry an effective lease_id
- add replay-21 preflight doc and focused integration proof for the tightened backend-shell semantics

## Test Plan
- [x] uv run pytest tests/Integration/test_thread_launch_config_contract.py -k 'drops_stray_lease_id_for_new_mode or save_last_confirmed_config_normalizes_payload or build_existing_launch_config_uses_canonical_shape or build_new_launch_config_uses_recipe_id or derives_existing_from_thread_current_workspace_id_not_lease_thread_ids or create_thread_persists_existing_lease_successful_config' -q
- [x] uv run ruff check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py
- [x] uv run ruff format --check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py
- [x] git diff --check