### PR TITLE
refactor: rename shell lease contract to existing sandbox

### DIFF
--- a/backend/web/models/requests.py
+++ b/backend/web/models/requests.py
@@ -13,7 +13,7 @@ class CreateThreadRequest(BaseModel):
     agent_user_id: str
     sandbox: str = "local"
     recipe_id: str | None = None
-    lease_id: str | None = None
+    existing_sandbox_id: str | None = None
     cwd: str | None = None
     model: str | None = None
     agent: str | None = None
@@ -29,7 +29,7 @@ class SaveThreadLaunchConfigRequest(BaseModel):
     create_mode: Literal["new", "existing"]
     provider_config: str
     recipe_id: str | None = None
-    lease_id: str | None = None
+    existing_sandbox_id: str | None = None
     model: str | None = None
     workspace: str | None = None
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -105,13 +105,28 @@ def _resolve_default_config_for_owned_agent(app: Any, owner_user_id: str, agent_
     return resolve_default_config(app, owner_user_id, agent_user_id)
 
 
+def _serialize_outward_shell_config(config: dict[str, Any]) -> dict[str, Any]:
+    outward = dict(config)
+    outward["existing_sandbox_id"] = outward.pop("lease_id", None)
+    return outward
+
+
+def _serialize_internal_shell_config(config: dict[str, Any]) -> dict[str, Any]:
+    internal = dict(config)
+    # @@@shell-contract-translation - replay-23 only cleans the outward
+    # request/frontend contract. Backend helper truth still speaks lease_id, so
+    # the route boundary must translate without creating a long-lived dual shell.
+    internal["lease_id"] = internal.pop("existing_sandbox_id", None)
+    return internal
+
+
 def _save_default_config_for_owned_agent(
     app: Any,
     owner_user_id: str,
     payload: SaveThreadLaunchConfigRequest,
 ) -> dict[str, bool]:
     _require_owned_agent(app, payload.agent_user_id, owner_user_id)
-    config = payload.model_dump()
+    config = _serialize_internal_shell_config(payload.model_dump())
     if payload.create_mode == "new":
         _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.recipe_id)
     save_last_confirmed_config(app, owner_user_id, payload.agent_user_id, config)
@@ -297,10 +312,10 @@ def _serialize_permission_answers(payload: Any) -> list[dict[str, Any]] | None:
 
 def _validate_sandbox_provider_gate(app: Any, owner_user_id: str, payload: CreateThreadRequest) -> JSONResponse | None:
     sandbox_type = payload.sandbox or "local"
-    if payload.lease_id:
+    if payload.existing_sandbox_id:
         owned_lease = sandbox_service.resolve_owned_lease(
             owner_user_id,
-            payload.lease_id,
+            payload.existing_sandbox_id,
             thread_repo=app.state.thread_repo,
             user_repo=app.state.user_repo,
         )
@@ -315,7 +330,7 @@ def _validate_sandbox_provider_gate(app: Any, owner_user_id: str, payload: Creat
 
 
 def _validate_sandbox_quota_gate(app: Any, owner_user_id: str, payload: CreateThreadRequest) -> JSONResponse | None:
-    if payload.lease_id:
+    if payload.existing_sandbox_id:
         return None
     sandbox_type = payload.sandbox or "local"
     try:
@@ -622,7 +637,7 @@ def _create_owned_thread(
     if not agent_user or agent_user.owner_user_id != owner_user_id:
         raise HTTPException(403, "Not authorized")
 
-    selected_lease_id = payload.lease_id
+    selected_lease_id = payload.existing_sandbox_id
     owned_lease: dict[str, Any] | None = None
     if selected_lease_id:
         owned_lease = sandbox_service.resolve_owned_lease(
@@ -795,7 +810,11 @@ async def get_default_thread_config(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any]:
-    return await asyncio.to_thread(_resolve_default_config_for_owned_agent, app, user_id, agent_user_id)
+    config = await asyncio.to_thread(_resolve_default_config_for_owned_agent, app, user_id, agent_user_id)
+    return {
+        **config,
+        "config": _serialize_outward_shell_config(dict(config.get("config") or {})),
+    }
 
 
 @router.post("/default-config")

--- a/docs/database-refactor/dev-replay-22-request-and-frontend-launch-config-shell-contract-preflight.md
+++ b/docs/database-refactor/dev-replay-22-request-and-frontend-launch-config-shell-contract-preflight.md
@@ -1,0 +1,216 @@
+# Database Refactor Dev Replay 22: Request And Frontend Launch Config Shell Contract Preflight
+
+## Goal
+
+Decide the next narrow cleanup boundary for the remaining outward shell
+contract that still exposes thread-create / launch-config selection as
+`lease_id`.
+
+This checkpoint is doc/ruling only. It does not change request models,
+frontend behavior, backend behavior, runtime/resource surfaces, SQL/migrations,
+or live DB state.
+
+## Why This Comes Next
+
+Replay-20 and replay-21 finished the backend-shell truth cleanup:
+
+- shell-level `lease_id` was explicitly classified as residue, not backend
+  authority
+- backend launch-config normalization now drops effective `lease_id` for
+  `create_mode="new"`
+
+That means the next ambiguity is no longer inside backend helper truth. It is
+the outward shell contract:
+
+- request models still expose `lease_id`
+- frontend API/types still expose `lease_id`
+- `NewChatPage` still models existing-resource selection directly as
+  `selectedLeaseId`
+
+So replay-22 should decide how that outward shell should evolve now that the
+backend no longer treats `lease_id` as native truth.
+
+## Current Code Facts
+
+### 1. Backend request models still expose shell-level `lease_id`
+
+`backend/web/models/requests.py` still defines:
+
+- `CreateThreadRequest.lease_id`
+- `SaveThreadLaunchConfigRequest.lease_id`
+
+Those are the backend request-side shell entry points.
+
+### 2. Frontend API client/types still expose shell-level `lease_id`
+
+`frontend/app/src/api/client.ts` still includes:
+
+- `CreateThreadOptions.leaseId`
+- `createThread(...)` writing `body.lease_id`
+- `parseThreadLaunchConfig(...)` reading `payload.lease_id`
+
+`frontend/app/src/api/types.ts` still includes:
+
+- `ThreadLaunchConfig.lease_id?: string | null`
+
+These are the frontend API contract surfaces for the same shell concept.
+
+### 3. UI state in `NewChatPage` is still directly lease-shaped
+
+`frontend/app/src/pages/NewChatPage.tsx` still uses:
+
+- `selectedLeaseId`
+- `leaseOptions`
+- `config.lease_id`
+- create-mode branching that writes `lease_id` into outgoing config
+
+This means the UI is still naming the selector in lease-native terms.
+
+### 4. Not every `lease_id` in frontend is residue
+
+Replay-20 already established that these are **not** part of the shell cleanup:
+
+- `UserLeaseSummary.lease_id`
+- `TerminalStatus.lease_id`
+- `LeaseStatus.lease_id`
+- `parseUserLeases(...)`
+- `parseTerminalStatus(...)`
+- `parseLeaseStatus(...)`
+
+Those describe real runtime/resource identity, not thread-create shell
+selection.
+
+## The Actual Ambiguity
+
+There are at least three possible ways to move the outward shell next.
+
+### A. Keep the outward shell lease-shaped indefinitely
+
+This is easy, but now mismatched with backend truth. It risks preserving the
+wrong mental model for future work.
+
+### B. Rename the outward shell toward thread/bridge/workspace language
+
+This would align the shell better with backend truth, but may still need an
+existing-lease selector concept somewhere.
+
+### C. Keep the user-facing concept as "existing sandbox/session" selection,
+but stop presenting it as `lease_id` in the request/frontend contract
+
+This looks like the most honest direction:
+
+- preserve the user action: choose an existing runtime resource
+- stop exposing raw `lease_id` as the first-class shell field name
+
+## Recommended Ruling
+
+### 1. The next lane should target outward shell contract cleanup
+
+Replay-22 should explicitly say:
+
+- backend-shell truth is now clean enough
+- the next residue is outward shell naming/contract shape
+
+### 2. Bias toward request/frontend contract cleanup together, not separately
+
+Unlike replay-21, this lane probably should not split backend request models
+and frontend API/types into separate checkpoints.
+
+Reason:
+
+- request model names and frontend payload names are one contract boundary
+- changing only one side would mostly create temporary translation glue
+
+### 3. Keep runtime/resource identity completely out of lane
+
+Replay-22 must preserve the split:
+
+- shell selection residue is in lane
+- runtime/resource lease identity is out of lane
+
+### 4. Prefer semantic rename over patchy alias sprawl
+
+If replay-22 eventually renames outward fields, it should avoid a long-lived
+"both names everywhere" state unless a short compatibility bridge is truly
+required.
+
+The target should be a cleaner shell, not a permanent bilingual contract.
+
+## Proposed First Implementation Candidates
+
+Replay-22 should compare two candidate directions.
+
+### Candidate 1: API-contract-first cleanup
+
+Target:
+
+- rename/reshape request model fields and frontend API/types first
+- update `NewChatPage` state/serialization in the same slice
+- keep backend helper truth unchanged
+
+Pros:
+
+- aligns the outer shell with backend truth directly
+- avoids adding more backend translation glue
+
+Cons:
+
+- wider than replay-21
+- touches both backend request models and frontend app code
+
+### Candidate 2: UI wording/state cleanup only
+
+Target:
+
+- keep request payload shape for now
+- only rename frontend local state and presentation
+
+Pros:
+
+- narrower UI-only touch
+
+Cons:
+
+- likely fake progress
+- leaves the actual API contract still lease-shaped
+
+## Recommendation
+
+Prefer Candidate 1.
+
+Reason:
+
+- replay-22 is specifically about outward contract cleanup
+- cleaning only UI wording while keeping the API contract lease-shaped would
+  mostly be cosmetic
+
+## Proposed First Implementation Checkpoint After Replay-22
+
+`database-refactor-dev-replay-23-request-and-frontend-launch-config-shell-contract-cleanup`
+
+Likely boundary:
+
+- `backend/web/models/requests.py`
+- backend router/request serialization only as needed
+- `frontend/app/src/api/client.ts`
+- `frontend/app/src/api/types.ts`
+- `frontend/app/src/pages/NewChatPage.tsx`
+- focused frontend/API tests
+
+## Stopline
+
+Replay-22 does **not** authorize:
+
+- runtime/resource/monitor surface changes
+- storage contract changes
+- backend thread binding logic changes
+- SQL/migrations/live DB writes
+- historical row repair
+- broad product redesign outside launch-config/thread-create shell
+
+## Open Question For Ledger Ruling
+
+Is replay-22 the right checkpoint to classify the remaining outward shell
+contract as the next residue target, and should the next implementation slice
+prefer a combined request/frontend contract cleanup rather than a UI-only or
+backend-only half step?

--- a/docs/database-refactor/dev-replay-23-request-and-frontend-launch-config-shell-contract-cleanup-preflight.md
+++ b/docs/database-refactor/dev-replay-23-request-and-frontend-launch-config-shell-contract-cleanup-preflight.md
@@ -1,0 +1,247 @@
+# Database Refactor Dev Replay 23: Request And Frontend Launch Config Shell Contract Cleanup Preflight
+
+## Goal
+
+Define the first implementation slice that cleans the remaining outward shell
+contract for thread-create / launch-config selection by replacing shell-level
+`lease_id` naming with `existing_sandbox_id`.
+
+This checkpoint is preflight only. It does not implement the rename yet.
+
+## Why This Comes Next
+
+Replay-22 already closed the design question:
+
+- the remaining residue is outward shell naming and payload shape
+- backend-shell truth is already clean enough
+- runtime/resource `lease_id` identity must stay out of lane
+
+That means replay-23 should stop debating the direction and instead define the
+exact synchronized request/frontend cleanup slice.
+
+## Current Code Facts
+
+### 1. Backend request models still expose shell-level `lease_id`
+
+`backend/web/models/requests.py` still defines:
+
+- `CreateThreadRequest.lease_id`
+- `SaveThreadLaunchConfigRequest.lease_id`
+
+These are not runtime/resource identity fields. They are outward shell entry
+points for choosing an existing sandbox.
+
+### 2. Frontend API contract still exposes shell-level `lease_id`
+
+`frontend/app/src/api/client.ts` still includes:
+
+- `CreateThreadOptions.leaseId`
+- `createThread(...)` writing `body.lease_id`
+- `parseThreadLaunchConfig(...)` reading `payload.lease_id`
+
+`frontend/app/src/api/types.ts` still includes:
+
+- `ThreadLaunchConfig.lease_id?: string | null`
+
+These are the public frontend contract surfaces that still speak the old shell
+name.
+
+### 3. Frontend orchestration state is still lease-shaped
+
+`frontend/app/src/hooks/use-thread-manager.ts` still exposes:
+
+- `handleCreateThread(..., leaseId?: string, ...)`
+
+`frontend/app/src/pages/NewChatPage.tsx` still uses:
+
+- `selectedLeaseId`
+- `config.lease_id`
+- `saveDefaultThreadConfig(... lease_id: ...)`
+- existing-mode create path passing `selectedLease.lease_id`
+
+So the shell residue is not isolated to one component. It spans request model,
+API client/types, thread-manager helper, and page state.
+
+### 4. Not every `lease_id` is shell residue
+
+These remain legitimate runtime/resource identity and are out of lane:
+
+- `UserLeaseSummary.lease_id`
+- `TerminalStatus.lease_id`
+- `LeaseStatus.lease_id`
+- `parseUserLeases(...)`
+- `parseTerminalStatus(...)`
+- `parseLeaseStatus(...)`
+- backend monitor/runtime/resource surfaces that address real leases
+
+Replay-23 must not rename or reinterpret any of those.
+
+## Chosen Naming Direction
+
+Replay-23 should use:
+
+- `existing_sandbox_id`
+
+Reason:
+
+- it matches the user-facing shell action: choose an existing sandbox
+- it stops presenting the selector as native runtime lease truth
+- it is narrower and less misleading than generic names like `sandbox_id`
+- it keeps create-mode semantics explicit: this field belongs to the existing
+  branch of the launch shell
+
+## Exact Target
+
+Replay-23 should make the outward shell contract consistent around
+`existing_sandbox_id`:
+
+- backend request models accept `existing_sandbox_id`
+- frontend API client/types use `existingSandboxId` / `existing_sandbox_id`
+- frontend local state uses `selectedExistingSandboxId`
+- default launch-config serialization/parsing uses `existing_sandbox_id`
+
+The runtime/resource model beneath that contract does **not** change:
+
+- existing-mode create still resolves/binds the selected live lease row
+- saved canonical existing-mode config may still be rebuilt from the selected
+  lease row under current backend truth
+
+So this is a shell cleanup slice, not a runtime rewrite.
+
+## Exact Write Set
+
+### Authorized backend code
+
+- `backend/web/models/requests.py`
+- `backend/web/routers/threads.py`
+
+`threads.py` is in-lane because request parsing and route-level save/create
+payload handling need to move in lockstep with the request model rename.
+
+### Authorized frontend code
+
+- `frontend/app/src/api/client.ts`
+- `frontend/app/src/api/types.ts`
+- `frontend/app/src/hooks/use-thread-manager.ts`
+- `frontend/app/src/pages/NewChatPage.tsx`
+
+### Authorized focused tests
+
+- `tests/Integration/test_thread_launch_config_contract.py`
+- `tests/Integration/test_threads_router.py`
+- `frontend/app/src/api/client.test.ts`
+- `frontend/app/src/pages/NewChatPage.test.tsx`
+
+### Out of lane even if grep finds `lease_id`
+
+- monitor/resource/runtime routes and tests
+- sandbox lease list/detail types beyond shell launch-config parsing
+- terminal/lease status contracts
+- storage/runtime bindings
+- SQL/migrations/live DB writes
+
+## Planned Mechanism
+
+Replay-23 should prefer one synchronized rename slice instead of aliases.
+
+### Backend request side
+
+Rename:
+
+- `CreateThreadRequest.lease_id` -> `CreateThreadRequest.existing_sandbox_id`
+- `SaveThreadLaunchConfigRequest.lease_id` ->
+  `SaveThreadLaunchConfigRequest.existing_sandbox_id`
+
+Then update route code so request handling reads the new field name while still
+resolving/binding the same underlying owned lease row.
+
+### Frontend API/types side
+
+Rename:
+
+- `CreateThreadOptions.leaseId` -> `CreateThreadOptions.existingSandboxId`
+- `ThreadLaunchConfig.lease_id` -> `ThreadLaunchConfig.existing_sandbox_id`
+- serializer/parser payload keys to `existing_sandbox_id`
+
+### Frontend orchestration/page side
+
+Rename:
+
+- `handleCreateThread(... leaseId ...)` -> `handleCreateThread(... existingSandboxId ...)`
+- `selectedLeaseId` -> `selectedExistingSandboxId`
+
+Keep the actual selected object source as the existing lease list for now.
+Replay-23 is not required to rename `UserLeaseSummary` or the live lease list
+API because those still model real runtime/resource identity.
+
+## No Long-Lived Alias Rule
+
+Replay-23 should **not** introduce a long-lived bilingual shell contract like:
+
+- request accepts both `lease_id` and `existing_sandbox_id`
+- frontend sends one but reads both forever
+
+If a microscopic compatibility shim is required to keep one focused test or one
+route path honest during the same slice, it must be:
+
+- internal only
+- short-lived
+- removed before calling the checkpoint done
+
+The target state of replay-23 is one outward shell name, not two.
+
+## Test Plan
+
+Replay-23 should be driven by focused contract tests, not broad product work.
+
+Required proof:
+
+1. backend request models and route tests accept `existing_sandbox_id` and no
+   longer rely on shell-level `lease_id`
+2. create-thread existing-mode route path still binds the selected existing
+   sandbox correctly
+3. default-config route save/load paths serialize and parse
+   `existing_sandbox_id`
+4. frontend API client serializes `existingSandboxId` to
+   `existing_sandbox_id`
+5. frontend launch-config parsing returns `existing_sandbox_id`
+6. `NewChatPage` existing-mode flow still passes the selected existing sandbox
+   through the helper layer using the new shell name
+
+Not required in replay-23:
+
+- YATU frontend/browser proof
+- runtime/provider proof
+- migration proof
+
+## Stopline
+
+Replay-23 must not:
+
+- rename runtime/resource lease identity surfaces
+- change `UserLeaseSummary.lease_id`
+- change `TerminalStatus.lease_id`
+- change `LeaseStatus.lease_id`
+- change monitor/resource APIs
+- change backend thread binding truth
+- change storage contracts
+- add SQL/migrations/live DB writes
+- redesign the existing-sandbox chooser UX
+
+## Expected Artifact
+
+If replay-23 lands cleanly, the result should be simple to state:
+
+- outward shell contract now says `existing_sandbox_id`
+- runtime/resource surfaces still say `lease_id`
+- there is no permanent dual-name shell contract left behind
+
+## Open Question For Ledger Ruling
+
+Is this the right replay-23 implementation boundary:
+
+- use `existing_sandbox_id` as the single outward shell name
+- update backend request models, frontend API/types, `use-thread-manager`, and
+  `NewChatPage` together
+- keep runtime/resource `lease_id` surfaces untouched
+- avoid long-lived request/frontend alias sprawl?

--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -68,6 +68,24 @@ describe("thread api client contract", () => {
     );
   });
 
+  it("createThread sends existing_sandbox_id for existing sandbox selection", async () => {
+    authFetch.mockResolvedValue(okJson({ thread_id: "thread-1" }));
+
+    await api.createThread({
+      sandbox: "local",
+      agentUserId: "agent-1",
+      existingSandboxId: "lease-1",
+    });
+
+    expect(authFetch).toHaveBeenCalledWith(
+      "/api/threads",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ sandbox: "local", agent_user_id: "agent-1", existing_sandbox_id: "lease-1" }),
+      }),
+    );
+  });
+
   it("createThread surfaces backend error messages", async () => {
     authFetch.mockResolvedValue(errorJson(409, {
       error: "sandbox_quota_exceeded",
@@ -126,7 +144,7 @@ describe("thread api client contract", () => {
   it("getDefaultThreadConfig queries by agent_user_id", async () => {
     authFetch.mockResolvedValue(okJson({
       source: "derived",
-      config: { create_mode: "new", provider_config: "local", recipe: null, lease_id: null, model: null, workspace: null },
+      config: { create_mode: "new", provider_config: "local", recipe: null, existing_sandbox_id: null, model: null, workspace: null },
     }));
 
     await api.getDefaultThreadConfig("agent-1");
@@ -163,6 +181,33 @@ describe("thread api client contract", () => {
           provider_config: "local",
           recipe_id: "local:default",
           model: "gpt-5.4-mini",
+        }),
+      }),
+    );
+  });
+
+  it("saveDefaultThreadConfig posts existing_sandbox_id for existing-mode shell config", async () => {
+    authFetch.mockResolvedValue(okJson({ ok: true }));
+
+    await api.saveDefaultThreadConfig("agent-1", {
+      create_mode: "existing",
+      provider_config: "daytona_selfhost",
+      existing_sandbox_id: "lease-1",
+      model: "gpt-5.4",
+      workspace: "/workspace/reused",
+    });
+
+    expect(authFetch).toHaveBeenCalledWith(
+      "/api/threads/default-config",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          agent_user_id: "agent-1",
+          create_mode: "existing",
+          provider_config: "daytona_selfhost",
+          existing_sandbox_id: "lease-1",
+          model: "gpt-5.4",
+          workspace: "/workspace/reused",
         }),
       }),
     );

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -64,7 +64,7 @@ export async function listThreads(): Promise<ThreadSummary[]> {
 export interface CreateThreadOptions {
   sandbox: string;
   recipeId?: string;
-  leaseId?: string;
+  existingSandboxId?: string;
   cwd?: string;
   agentUserId: string;
   model?: string;
@@ -74,7 +74,7 @@ export interface CreateThreadOptions {
 export async function createThread(opts: CreateThreadOptions): Promise<ThreadSummary> {
   const body: Record<string, unknown> = { sandbox: opts.sandbox, agent_user_id: opts.agentUserId };
   if (opts.recipeId) body.recipe_id = opts.recipeId;
-  if (opts.leaseId) body.lease_id = opts.leaseId;
+  if (opts.existingSandboxId) body.existing_sandbox_id = opts.existingSandboxId;
   if (opts.cwd) body.cwd = opts.cwd;
   if (opts.model) body.model = opts.model;
   if (opts.agent) body.agent = opts.agent;
@@ -128,7 +128,7 @@ function parseThreadLaunchConfig(value: unknown): ThreadLaunchConfig | null {
   const create_mode = payload?.create_mode;
   const provider_config = payload ? recordString(payload, "provider_config") : undefined;
   const recipe = payload?.recipe;
-  const lease_id = payload?.lease_id;
+  const existing_sandbox_id = payload?.existing_sandbox_id;
   const model = payload?.model;
   const workspace = payload?.workspace;
   if (
@@ -136,13 +136,13 @@ function parseThreadLaunchConfig(value: unknown): ThreadLaunchConfig | null {
     !isLaunchCreateMode(create_mode) ||
     !provider_config ||
     (recipe !== undefined && recipe !== null && asRecord(recipe) === null) ||
-    !isStringOrNullish(lease_id) ||
+    !isStringOrNullish(existing_sandbox_id) ||
     !isStringOrNullish(model) ||
     !isStringOrNullish(workspace)
   ) {
     return null;
   }
-  return { ...payload, create_mode, provider_config, recipe, lease_id, model, workspace } as ThreadLaunchConfig;
+  return { ...payload, create_mode, provider_config, recipe, existing_sandbox_id, model, workspace } as ThreadLaunchConfig;
 }
 
 function parseDefaultThreadConfig(value: unknown): ThreadLaunchConfigResponse {

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -134,7 +134,7 @@ export interface ThreadLaunchConfig {
   provider_config: string;
   recipe_id?: string | null;
   recipe?: RecipeSnapshot | null;
-  lease_id?: string | null;
+  existing_sandbox_id?: string | null;
   model?: string | null;
   workspace?: string | null;
 }

--- a/frontend/app/src/hooks/use-thread-manager.ts
+++ b/frontend/app/src/hooks/use-thread-manager.ts
@@ -28,7 +28,7 @@ export interface ThreadManagerActions {
     cwd?: string,
     agentUserId?: string,
     model?: string,
-    leaseId?: string,
+    existingSandboxId?: string,
     recipeId?: string,
   ) => Promise<string>;
   handleGetDefaultThread: (agentUserId: string, signal?: AbortSignal) => Promise<ThreadSummary | null>;
@@ -98,11 +98,18 @@ export function useThreadManager(): ThreadManagerState & ThreadManagerActions {
     cwd?: string,
     agentUserId?: string,
     model?: string,
-    leaseId?: string,
+    existingSandboxId?: string,
     recipeId?: string,
   ): Promise<string> => {
     const type = sandbox ?? selectedSandbox;
-    const thread = await createThread({ sandbox: type, cwd, agentUserId: agentUserId ?? "", model, leaseId, recipeId });
+    const thread = await createThread({
+      sandbox: type,
+      cwd,
+      agentUserId: agentUserId ?? "",
+      model,
+      existingSandboxId,
+      recipeId,
+    });
     setThreads((prev) => upsertThread(prev, thread));
     setSelectedSandbox(type);
     return thread.thread_id;

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -6,13 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import NewChatPage from "./NewChatPage";
 import { useAuthStore } from "../store/auth-store";
 import { useAppStore } from "../store/app-store";
-import type { AccountResourceLimit, SandboxType } from "../api/types";
+import type { AccountResourceLimit, SandboxType, UserLeaseSummary } from "../api/types";
 
 const handleGetDefaultThread = vi.fn();
 const handleCreateThread = vi.fn();
 const clientMocks = vi.hoisted(() => ({
   getDefaultThreadConfig: vi.fn(() => new Promise(() => {})),
-  listMyLeases: vi.fn(async () => []),
+  listMyLeases: vi.fn<() => Promise<UserLeaseSummary[]>>(async () => []),
   saveDefaultThreadConfig: vi.fn(async () => undefined),
   fetchAccountResourceLimits: vi.fn<() => Promise<AccountResourceLimit[]>>(async () => []),
 }));
@@ -509,7 +509,6 @@ describe("NewChatPage", () => {
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-1",
         recipe_name: "Existing One",
-        recipe: null,
         observed_state: "running",
         desired_state: "running",
         cwd: "/workspace/reused-1",
@@ -521,7 +520,6 @@ describe("NewChatPage", () => {
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-2",
         recipe_name: "Existing Two",
-        recipe: null,
         observed_state: "running",
         desired_state: "running",
         cwd: "/workspace/reused-2",

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -12,6 +12,8 @@ const handleGetDefaultThread = vi.fn();
 const handleCreateThread = vi.fn();
 const clientMocks = vi.hoisted(() => ({
   getDefaultThreadConfig: vi.fn(() => new Promise(() => {})),
+  listMyLeases: vi.fn(async () => []),
+  saveDefaultThreadConfig: vi.fn(async () => undefined),
   fetchAccountResourceLimits: vi.fn<() => Promise<AccountResourceLimit[]>>(async () => []),
 }));
 
@@ -84,8 +86,8 @@ vi.mock("../api", () => ({
 
 vi.mock("../api/client", () => ({
   getDefaultThreadConfig: clientMocks.getDefaultThreadConfig,
-  listMyLeases: vi.fn(async () => []),
-  saveDefaultThreadConfig: vi.fn(async () => undefined),
+  listMyLeases: clientMocks.listMyLeases,
+  saveDefaultThreadConfig: clientMocks.saveDefaultThreadConfig,
 }));
 
 vi.mock("../api/settings", () => ({
@@ -129,6 +131,10 @@ describe("NewChatPage", () => {
     handleCreateThread.mockResolvedValue("thread-from-test");
     clientMocks.getDefaultThreadConfig.mockReset();
     clientMocks.getDefaultThreadConfig.mockImplementation(() => new Promise(() => {}));
+    clientMocks.listMyLeases.mockReset();
+    clientMocks.listMyLeases.mockResolvedValue([]);
+    clientMocks.saveDefaultThreadConfig.mockReset();
+    clientMocks.saveDefaultThreadConfig.mockResolvedValue(undefined);
     clientMocks.fetchAccountResourceLimits.mockReset();
     clientMocks.fetchAccountResourceLimits.mockResolvedValue([]);
     sandboxTypesForTest = [{ name: "local", available: true }];
@@ -482,6 +488,69 @@ describe("NewChatPage", () => {
         "leon:large",
         undefined,
         "local-recipe",
+      );
+    });
+  });
+
+  it("reuses the configured existing sandbox from existing_sandbox_id instead of falling back to the first lease", async () => {
+    clientMocks.getDefaultThreadConfig.mockResolvedValue({
+      source: "last_successful",
+      config: {
+        create_mode: "existing",
+        provider_config: "daytona_selfhost",
+        existing_sandbox_id: "lease-2",
+        model: "leon:large",
+        workspace: "/workspace/reused-2",
+      },
+    });
+    clientMocks.listMyLeases.mockResolvedValue([
+      {
+        lease_id: "lease-1",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-1",
+        recipe_name: "Existing One",
+        recipe: null,
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/reused-1",
+        thread_ids: [],
+        agents: [],
+      },
+      {
+        lease_id: "lease-2",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-2",
+        recipe_name: "Existing Two",
+        recipe: null,
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/reused-2",
+        thread_ids: [],
+        agents: [],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+            <Route path="/chat/hire/thread/:threadId" element={<ThreadRouteProbe />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("centered-input-box");
+    fireEvent.click(screen.getByRole("button", { name: "发送测试消息" }));
+
+    await waitFor(() => {
+      expect(handleCreateThread).toHaveBeenCalledWith(
+        "daytona_selfhost",
+        undefined,
+        "m_xVuNpKJNxblZ",
+        "leon:large",
+        "lease-2",
       );
     });
   });

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -64,7 +64,7 @@ const MODEL_OPTIONS = [
 
 type ConfigSnapshot = {
   createMode: "new" | "existing";
-  selectedLeaseId: string;
+  selectedExistingSandboxId: string;
   selectedRecipeId: string;
   selectedRecipeFeatures: Record<string, boolean>;
   selectedWorkspace: string;
@@ -130,7 +130,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   const [leaseOptions, setLeaseOptions] = useState<UserLeaseSummary[]>([]);
   const [leaseError, setLeaseError] = useState<string | null>(null);
   const [leaseLoading, setLeaseLoading] = useState(true);
-  const [selectedLeaseId, setSelectedLeaseId] = useState<string>("");
+  const [selectedExistingSandboxId, setSelectedExistingSandboxId] = useState<string>("");
   const [selectedRecipeId, setSelectedRecipeId] = useState<string>("");
   const [selectedRecipeFeatures, setSelectedRecipeFeatures] = useState<Record<string, boolean>>({});
   const [selectedProviderConfig, setSelectedProviderConfig] = useState<string>("");
@@ -233,7 +233,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         const leases = await listMyLeases(ac.signal);
         if (cancelled) return;
         setLeaseOptions(leases);
-        setSelectedLeaseId((current) => current || leases[0]?.lease_id || "");
+        setSelectedExistingSandboxId((current) => current || leases[0]?.lease_id || "");
       } catch (err) {
         if (cancelled) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
@@ -268,7 +268,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         } satisfies RecipeSnapshot,
       }))
   ), [libraryRecipes]);
-  const selectedLease = leaseOptions.find((lease) => lease.lease_id === selectedLeaseId) ?? null;
+  const selectedLease = leaseOptions.find((lease) => lease.lease_id === selectedExistingSandboxId) ?? null;
   const sandboxResourceByProvider = useMemo(() => {
     const map = new Map<string, AccountResourceLimit>();
     for (const item of accountResources) {
@@ -296,10 +296,10 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   }, [recipeOptions, selectedRecipeId]);
 
   useEffect(() => {
-    if (!selectedLeaseId && leaseOptions[0]?.lease_id) {
-      setSelectedLeaseId(leaseOptions[0].lease_id);
+    if (!selectedExistingSandboxId && leaseOptions[0]?.lease_id) {
+      setSelectedExistingSandboxId(leaseOptions[0].lease_id);
     }
-  }, [leaseOptions, selectedLeaseId]);
+  }, [leaseOptions, selectedExistingSandboxId]);
 
   useEffect(() => {
     if (createModeInitialized || leaseLoading) return;
@@ -418,7 +418,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   function applyResolvedConfig(config: ThreadLaunchConfig) {
     setCreateMode(config.create_mode);
     setSelectedProviderConfig(config.provider_config || "");
-    setSelectedLeaseId(config.lease_id || "");
+    setSelectedExistingSandboxId(config.existing_sandbox_id || "");
     setSelectedRecipeId(config.recipe_id || config.recipe?.id || "");
     setSelectedRecipeFeatures(config.recipe?.features ?? {});
     setSelectedWorkspace(config.workspace || "");
@@ -442,7 +442,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   function buildConfigSnapshot(): ConfigSnapshot {
     return {
       createMode,
-      selectedLeaseId: selectedLeaseId || leaseOptions[0]?.lease_id || "",
+      selectedExistingSandboxId: selectedExistingSandboxId || leaseOptions[0]?.lease_id || "",
       selectedRecipeId,
       selectedRecipeFeatures: { ...selectedRecipeFeatures },
       selectedWorkspace: activeWorkspace,
@@ -463,7 +463,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   function cancelConfigChanges() {
     if (!configSnapshot) return resetConfigPanel();
     setCreateMode(configSnapshot.createMode);
-    setSelectedLeaseId(configSnapshot.selectedLeaseId);
+    setSelectedExistingSandboxId(configSnapshot.selectedExistingSandboxId);
     setSelectedRecipeId(configSnapshot.selectedRecipeId);
     setSelectedRecipeFeatures(configSnapshot.selectedRecipeFeatures);
     setSelectedWorkspace(configSnapshot.selectedWorkspace);
@@ -477,7 +477,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
       create_mode: createMode,
       provider_config: selectedProviderConfig,
       recipe_id: selectedRecipeSnapshot?.id || null,
-      lease_id: createMode === "existing" ? selectedLeaseId || null : null,
+      existing_sandbox_id: createMode === "existing" ? selectedExistingSandboxId || null : null,
       model: draftModel,
       workspace,
     });
@@ -596,7 +596,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
             panelClassName: "max-h-[calc(100vh-4rem)]",
             applyLabel: configStep === 3 ? "确认" : (configStep === 1 ? "下一步" : (localRecipeSelected ? "下一步" : "确认")),
             applyDisabled: (configStep === 1 && (newSandboxQuotaBlocked || newSandboxProviderUnavailable))
-              || (configStep === 2 && createMode === "existing" && !selectedLeaseId),
+              || (configStep === 2 && createMode === "existing" && !selectedExistingSandboxId),
             showBack: configStep > 1,
             backLabel: "返回上一步",
             onBack: stepBack,
@@ -709,7 +709,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                             }
                             const nextLease = leaseOptions.find((lease) => lease.provider_name === nextProviderConfig);
                             if (createMode === "existing") {
-                              setSelectedLeaseId(nextLease?.lease_id || "");
+                              setSelectedExistingSandboxId(nextLease?.lease_id || "");
                             }
                           }}
                         >
@@ -846,13 +846,13 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                           </div>
                           <div className="max-h-[320px] space-y-2 overflow-y-auto pr-1">
                             {filteredLeaseOptions.map((lease) => {
-                              const isActive = selectedLeaseId === lease.lease_id;
+                              const isActive = selectedExistingSandboxId === lease.lease_id;
                               const stateMeta = leaseStateMeta(lease.observed_state);
                               return (
                                 <button
                                   key={lease.lease_id}
                                   type="button"
-                                  onClick={() => setSelectedLeaseId(lease.lease_id)}
+                                  onClick={() => setSelectedExistingSandboxId(lease.lease_id)}
                                   className={cn(
                                     "w-full rounded-2xl border p-3 text-left transition-colors",
                                     isActive ? "border-primary/40 bg-primary/5" : "border-border bg-background hover:bg-accent/40",

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -538,7 +538,7 @@ async def test_create_thread_persists_existing_lease_successful_config() -> None
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "lease_id": "lease-1",
+            "existing_sandbox_id": "lease-1",
             "model": "gpt-5.4",
             "cwd": "/workspace/requested",
         }
@@ -641,7 +641,14 @@ async def test_get_default_thread_config_runs_sync_repo_work_off_event_loop(monk
 
     result = await threads_router.get_default_thread_config("agent-user-1", "owner-1", app)
 
-    assert result == {"source": "last_successful", "config": {"create_mode": "existing", "provider_config": "local"}}
+    assert result == {
+        "source": "last_successful",
+        "config": {
+            "create_mode": "existing",
+            "provider_config": "local",
+            "existing_sandbox_id": None,
+        },
+    }
     assert to_thread_calls == [("_resolve_default_config_for_owned_agent", (app, "owner-1", "agent-user-1"))]
 
 
@@ -652,7 +659,7 @@ async def test_save_default_thread_config_uses_strict_agent_gate(monkeypatch: py
         agent_user_id="agent-user-2",
         create_mode="new",
         provider_config="local",
-        lease_id=None,
+        existing_sandbox_id=None,
         model="gpt-5.4-mini",
         workspace="/tmp/demo",
     )
@@ -680,7 +687,7 @@ async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(mon
         create_mode="new",
         provider_config="local",
         recipe_id="local:default",
-        lease_id=None,
+        existing_sandbox_id=None,
         model="gpt-5.4-mini",
         workspace="/tmp/demo",
     )
@@ -747,7 +754,14 @@ def test_get_default_thread_config_route_uses_owner_and_agent_user_contract(monk
         response = client.get("/api/threads/default-config", params={"agent_user_id": "agent-user-1"})
 
     assert response.status_code == 200
-    assert response.json() == {"source": "last_successful", "config": {"create_mode": "existing", "provider_config": "local"}}
+    assert response.json() == {
+        "source": "last_successful",
+        "config": {
+            "create_mode": "existing",
+            "provider_config": "local",
+            "existing_sandbox_id": None,
+        },
+    }
     assert calls == [(app, "owner-1", "agent-user-1")]
 
 
@@ -768,7 +782,7 @@ def test_save_default_thread_config_route_persists_confirmed_agent_user_payload(
                 "create_mode": "new",
                 "provider_config": "local",
                 "recipe_id": "local:default",
-                "lease_id": None,
+                "existing_sandbox_id": None,
                 "model": "gpt-5.4-mini",
                 "workspace": "/tmp/demo",
             },

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -431,7 +431,7 @@ async def test_create_thread_route_uses_canonical_existing_lease_binding_helper(
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "lease_id": "lease-1",
+            "existing_sandbox_id": "lease-1",
             "cwd": "/workspace/reused",
         }
     )
@@ -463,7 +463,7 @@ async def test_create_thread_route_persists_current_workspace_id_for_existing_le
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "lease_id": "lease-1",
+            "existing_sandbox_id": "lease-1",
             "cwd": "/workspace/reused",
         }
     )
@@ -790,7 +790,7 @@ async def test_create_thread_route_rejects_unavailable_provider_for_existing_lea
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "lease_id": "lease-1",
+            "existing_sandbox_id": "lease-1",
         }
     )
 


### PR DESCRIPTION
## Summary
- rename the outward thread-create and default-config shell contract from `lease_id` / `leaseId` to `existing_sandbox_id` / `existingSandboxId`
- keep backend helper truth and runtime/resource lease identity unchanged by translating only at the route boundary
- update focused backend/frontend contract tests to prove the synchronized rename and existing-sandbox selection behavior

## Test Plan
- [x] `uv run pytest tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q`
- [x] `cd frontend/app && pnpm vitest run src/api/client.test.ts src/pages/NewChatPage.test.tsx`
- [x] `uv run ruff check backend/web/models/requests.py backend/web/routers/threads.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py`
- [x] `uv run ruff format --check backend/web/models/requests.py backend/web/routers/threads.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py`
- [x] `cd frontend/app && pnpm exec eslint src/api/client.ts src/api/types.ts src/hooks/use-thread-manager.ts src/pages/NewChatPage.tsx src/api/client.test.ts src/pages/NewChatPage.test.tsx`
- [x] `cd frontend/app && pnpm exec tsc --noEmit`
- [x] `git diff --check`
