### PR TITLE
refactor: clean outward sandbox template contract

### DIFF
--- a/backend/web/models/requests.py
+++ b/backend/web/models/requests.py
@@ -12,7 +12,7 @@ class CreateThreadRequest(BaseModel):
 
     agent_user_id: str
     sandbox: str = "local"
-    recipe_id: str | None = None
+    sandbox_template_id: str | None = None
     existing_sandbox_id: str | None = None
     cwd: str | None = None
     model: str | None = None
@@ -28,7 +28,7 @@ class SaveThreadLaunchConfigRequest(BaseModel):
     agent_user_id: str
     create_mode: Literal["new", "existing"]
     provider_config: str
-    recipe_id: str | None = None
+    sandbox_template_id: str | None = None
     existing_sandbox_id: str | None = None
     model: str | None = None
     workspace: str | None = None

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -105,15 +105,29 @@ def _resolve_default_config_for_owned_agent(app: Any, owner_user_id: str, agent_
     return resolve_default_config(app, owner_user_id, agent_user_id)
 
 
+def _translate_internal_launch_config_to_outward(config: dict[str, Any]) -> dict[str, Any]:
+    translated = dict(config)
+    translated["sandbox_template_id"] = translated.pop("recipe_id", None)
+    translated["sandbox_template"] = translated.pop("recipe", None)
+    return translated
+
+
+def _translate_outward_launch_config_to_internal(config: dict[str, Any]) -> dict[str, Any]:
+    translated = dict(config)
+    translated["recipe_id"] = translated.pop("sandbox_template_id", None)
+    translated.pop("sandbox_template", None)
+    return translated
+
+
 def _save_default_config_for_owned_agent(
     app: Any,
     owner_user_id: str,
     payload: SaveThreadLaunchConfigRequest,
 ) -> dict[str, bool]:
     _require_owned_agent(app, payload.agent_user_id, owner_user_id)
-    config = payload.model_dump()
+    config = _translate_outward_launch_config_to_internal(payload.model_dump())
     if payload.create_mode == "new":
-        _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.recipe_id)
+        _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.sandbox_template_id)
     save_last_confirmed_config(app, owner_user_id, payload.agent_user_id, config)
     return {"ok": True}
 
@@ -636,7 +650,7 @@ def _create_owned_thread(
         sandbox_type = str(owned_lease["provider_name"] or sandbox_type)
     selected_recipe = None
     if not selected_lease_id:
-        selected_recipe = _resolve_owned_recipe_snapshot(app, owner_user_id, sandbox_type, payload.recipe_id)
+        selected_recipe = _resolve_owned_recipe_snapshot(app, owner_user_id, sandbox_type, payload.sandbox_template_id)
 
     # @@@non-atomic-create - these 3 steps (seq++, thread) are not atomic.
     # @@@user-owned-thread-seq - thread ids are now allocated from the unified
@@ -798,7 +812,7 @@ async def get_default_thread_config(
     config = await asyncio.to_thread(_resolve_default_config_for_owned_agent, app, user_id, agent_user_id)
     return {
         **config,
-        "config": dict(config.get("config") or {}),
+        "config": _translate_internal_launch_config_to_outward(dict(config.get("config") or {})),
     }
 
 

--- a/docs/database-refactor/dev-replay-25-recipe-to-sandbox-template-inventory-preflight.md
+++ b/docs/database-refactor/dev-replay-25-recipe-to-sandbox-template-inventory-preflight.md
@@ -1,0 +1,275 @@
+# Database Refactor Dev Replay 25: Recipe To Sandbox Template Inventory Preflight
+
+## Goal
+
+Classify the remaining `recipe` naming surface into clear layers before any
+rename lane starts.
+
+This checkpoint is doc/ruling only. It does not rename resource types, request
+fields, frontend routes, library APIs, storage contracts, runtime/provider
+behavior, SQL/migrations, or live DB state.
+
+## Why This Comes Next
+
+Replay-22 through replay-24 finished the launch-config shell cleanup around
+existing sandbox selection:
+
+- outward shell now says `existing_sandbox_id`
+- backend helper truth now also says `existing_sandbox_id`
+- runtime/resource surfaces still honestly keep `lease_id`
+
+That means the biggest remaining naming residue is no longer about existing
+sandbox selection. It is the older `recipe` term itself.
+
+Right now `recipe` simultaneously means:
+
+- the user-facing sandbox template concept
+- an owner-facing request/response contract field
+- a library resource type
+- a backend/storage internal identifier family
+
+Those are not one layer. Replay-25 exists to separate them before we rename
+anything.
+
+## Current Code Facts
+
+### 1. Owner-facing launch-config and thread-create contract still says `recipe`
+
+Examples:
+
+- `backend/web/models/requests.py`
+  - `CreateThreadRequest.recipe_id`
+  - `SaveThreadLaunchConfigRequest.recipe_id`
+- `backend/web/services/thread_launch_config_service.py`
+  - `recipe_id`
+  - `recipe`
+- `backend/web/routers/threads.py`
+  - `_resolve_owned_recipe_snapshot(...)`
+  - thread create path still resolves `payload.recipe_id`
+
+This is not just UI wording. It is part of the owner-facing backend contract.
+
+### 2. Frontend API/types/UI still model sandbox templates through `recipe`
+
+Examples:
+
+- `frontend/app/src/api/types.ts`
+  - `RecipeSnapshot`
+  - `ThreadLaunchConfig.recipe_id`
+  - `UserLeaseSummary.recipe_id`
+  - `UserLeaseSummary.recipe_name`
+- `frontend/app/src/api/client.ts`
+  - `CreateThreadOptions.recipeId`
+  - `createThread(...)` sending `recipe_id`
+- `frontend/app/src/pages/NewChatPage.tsx`
+  - `selectedRecipeId`
+  - `recipeOptions`
+  - `"选择沙盒模板"` UI built from `recipe`-shaped state
+- `frontend/app/src/components/RecipeEditor.tsx`
+
+This means the frontend still treats the user-visible sandbox template concept
+as `recipe` in both code and API contract.
+
+### 3. Library/store/router also still promote `recipe` as a first-class resource type
+
+Examples:
+
+- `backend/web/services/library_service.py`
+  - `list_library("recipe", ...)`
+  - `create_resource("recipe", ...)`
+  - `update/delete` paths keyed on `"recipe"`
+- `frontend/app/src/store/app-store.ts`
+  - `LibraryType = "skill" | "mcp" | "agent" | "recipe"`
+  - `libraryRecipes`
+- `frontend/app/src/pages/MarketplacePage.tsx`
+  - installed sub-tab `"recipe"`
+  - `/library/recipe/:id`
+- `frontend/app/src/pages/LibraryItemDetailPage.tsx`
+  - `DetailLibraryType = "skill" | "agent" | "recipe"`
+
+This is deeper than a local variable rename. `recipe` is currently a resource
+taxonomy decision.
+
+### 4. The target term already exists elsewhere as `sandbox template`
+
+There is already evidence that the repo is moving toward the new concept:
+
+- `backend/web/services/thread_runtime_binding_service.py`
+  - `sandbox_template_id`
+- UI wording already says `"Sandbox"` / `"沙盒模板"` in several places
+- user intent for this lane is explicit: `recipe` should become `sandbox template`
+
+So replay-25 is not inventing a new direction. It is inventorying an already
+declared direction that the codebase has not consistently applied.
+
+## The Actual Ambiguity
+
+There are three distinct rename scopes hiding inside the single phrase
+"rename recipe to sandbox template."
+
+### A. User-visible wording only
+
+Change:
+
+- labels
+- toasts
+- component titles
+- marketplace/detail wording
+
+But keep:
+
+- resource type `"recipe"`
+- backend request fields like `recipe_id`
+- frontend API/types like `RecipeSnapshot`
+
+This is the narrowest move, but it is mostly cosmetic.
+
+### B. Outward contract rename
+
+Change:
+
+- owner-facing backend request/response naming
+- frontend API/types naming
+- frontend page/component naming
+
+But keep:
+
+- library resource type `"recipe"`
+- storage/repo contracts
+- runtime/provider internals
+
+This is the first non-cosmetic candidate.
+
+### C. Full taxonomy + internal rename
+
+Change all of:
+
+- outward contract
+- library resource type
+- store keys / routes / editors
+- backend service/resource taxonomy
+- storage/repo naming
+
+This is the most honest end state, but it is much larger than the current lane
+size that replay-22 through replay-24 used.
+
+## Recommended Ruling
+
+### 1. Replay-25 should stay inventory-only
+
+This residue crosses:
+
+- backend outward contract
+- frontend API/types
+- library taxonomy
+- component naming
+- backend internal/service naming
+
+That is too wide to rename by inertia.
+
+### 2. The first implementation lane should likely target outward contract before taxonomy
+
+Recommended first cut after replay-25:
+
+- rename user-visible/frontend/API concept toward `sandbox template`
+- keep library resource type `"recipe"` temporarily internal
+
+Reason:
+
+- it makes product and owner-facing contract more truthful
+- it avoids mixing outward rename with library/storage taxonomy in one jump
+
+### 3. Library resource type rename should be a separate later lane
+
+Changing `"recipe"` as a resource type would also touch:
+
+- backend library CRUD dispatch
+- frontend store keys
+- router paths
+- detail/editor routing
+- test fixtures across marketplace/library surfaces
+
+That deserves its own checkpoint after the outward rename is settled.
+
+### 4. Runtime/resource lease truth remains completely out of lane
+
+Replay-25 must not mix this rename with:
+
+- `lease_id`
+- monitor/session/terminal surfaces
+- runtime provider snapshots
+- sandbox binding semantics
+
+Those are unrelated truths.
+
+## Proposed Classification Output
+
+Replay-25 should explicitly produce three buckets.
+
+### Bucket 1. Outward rename candidates
+
+Likely in-scope for the first implementation lane:
+
+- `CreateThreadRequest.recipe_id`
+- `SaveThreadLaunchConfigRequest.recipe_id`
+- `ThreadLaunchConfig.recipe_id`
+- `ThreadLaunchConfig.recipe`
+- `CreateThreadOptions.recipeId`
+- `RecipeSnapshot`
+- `RecipeEditor`
+- `selectedRecipeId`
+- outward UI copy that still says recipe
+
+### Bucket 2. Taxonomy/internal rename candidates
+
+Should likely wait for a later checkpoint:
+
+- `list_library("recipe", ...)`
+- `create_resource("recipe", ...)`
+- `update/delete_resource("recipe", ...)`
+- `LibraryType = ... | "recipe"`
+- `libraryRecipes`
+- `/library/recipe/:id`
+
+### Bucket 3. Protected truths / not in lane
+
+Must not be renamed by replay-25 or its first follow-up:
+
+- runtime/resource `lease_id`
+- provider/runtime payload shape not tied to sandbox-template naming
+- schema/migration/storage repair work
+- sandbox binding semantics
+
+## Proposed Next Checkpoint
+
+Recommended next implementation checkpoint after replay-25:
+
+`database-refactor-dev-replay-26-outward-sandbox-template-contract-cleanup`
+
+Target shape:
+
+- user-visible and owner-facing contract stops saying `recipe`
+- library resource taxonomy may still internally say `"recipe"` for one more lane
+- no long-lived alias sprawl unless focused RED proves a short bridge is truly
+  required
+
+## Stopline
+
+Replay-25 does **not** authorize:
+
+- resource type rename from `"recipe"` to another key
+- route migration from `/library/recipe/...`
+- storage/repo contract rename
+- runtime/provider payload redesign
+- SQL/migrations/live DB writes
+- schema changes
+- broad marketplace redesign
+- any implementation code change beyond doc/ruling
+
+## Open Question For Ruling
+
+Is replay-25 the right checkpoint to classify the current `recipe` residue into
+outward contract, taxonomy/internal, and protected-truth buckets, so that the
+next implementation lane can first clean the user-facing and owner-facing
+`sandbox template` contract without yet renaming the underlying library
+resource type?

--- a/docs/database-refactor/dev-replay-26-outward-sandbox-template-contract-cleanup-preflight.md
+++ b/docs/database-refactor/dev-replay-26-outward-sandbox-template-contract-cleanup-preflight.md
@@ -1,0 +1,243 @@
+# Database Refactor Dev Replay 26: Outward Sandbox Template Contract Cleanup Preflight
+
+## Goal
+
+Define the first implementation slice that renames the outward
+owner-facing/frontend-facing `recipe` contract toward `sandbox template`
+language without yet changing the underlying library resource taxonomy.
+
+This checkpoint is preflight only. It does not implement the rename yet.
+
+## Why This Comes Next
+
+Replay-25 already classified the current `recipe` residue into three buckets:
+
+- outward contract residue
+- taxonomy/internal residue
+- protected truths
+
+That means replay-26 should stop debating scope and instead define the first
+actual rename slice.
+
+The correct first slice is **not** a full `recipe` eradication pass. It is the
+outward contract cleanup:
+
+- user-visible naming
+- owner-facing request/response naming
+- frontend API/types/page naming
+
+While explicitly leaving the deeper library taxonomy alone for one more lane.
+
+## Current Code Facts
+
+### 1. Backend request models still expose outward `recipe` fields
+
+`backend/web/models/requests.py` still defines:
+
+- `CreateThreadRequest.recipe_id`
+- `SaveThreadLaunchConfigRequest.recipe_id`
+
+Those are owner-facing contract fields, not storage internals.
+
+### 2. Frontend API/types still expose outward `recipe` naming
+
+`frontend/app/src/api/client.ts` still uses:
+
+- `CreateThreadOptions.recipeId`
+- `createThread(...)` writing `recipe_id`
+- default-config save/load flows carrying `recipe_id`
+
+`frontend/app/src/api/types.ts` still defines:
+
+- `RecipeSnapshot`
+- `ThreadLaunchConfig.recipe_id`
+- `ThreadLaunchConfig.recipe`
+
+These are the clearest outward rename targets.
+
+### 3. Page-level orchestration is still recipe-shaped
+
+`frontend/app/src/pages/NewChatPage.tsx` still uses:
+
+- `selectedRecipeId`
+- `recipeOptions`
+- `selectedRecipeSnapshot`
+- save/create payloads built from `recipe_id` and `recipe`
+
+This means the outward rename is not finished unless page-state naming also
+moves.
+
+### 4. Library taxonomy is still recipe-shaped and intentionally out of lane
+
+Examples that must stay out of replay-26:
+
+- `list_library("recipe", ...)`
+- `create_resource("recipe", ...)`
+- `LibraryType = "skill" | "mcp" | "agent" | "recipe"`
+- `libraryRecipes`
+- `/library/recipe/:id`
+
+These belong to the later taxonomy lane, not the first outward contract lane.
+
+## Chosen Direction
+
+Replay-26 should rename the outward contract to sandbox-template language while
+keeping the internal library taxonomy temporarily stable.
+
+The intended end state after replay-26 is:
+
+- owner-facing/backend request fields say `sandbox_template_*`
+- frontend API/types/page state say `sandbox template`
+- internal library resource taxonomy may still say `"recipe"`
+
+This is an intentionally split state, but it is an honest one:
+
+- the product-facing concept becomes truthful first
+- taxonomy/internal cleanup comes later as a separate checkpoint
+
+## Exact Target Naming
+
+Replay-26 should bias toward the following outward naming:
+
+- `recipe_id` -> `sandbox_template_id`
+- `recipe` -> `sandbox_template`
+- `RecipeSnapshot` -> `SandboxTemplateSnapshot`
+- `recipeId` -> `sandboxTemplateId`
+- `selectedRecipeId` -> `selectedSandboxTemplateId`
+- `recipeOptions` -> `sandboxTemplateOptions`
+
+The rename should stay at the outward contract and page/component state layer.
+
+## Exact Write Set
+
+### Authorized backend code
+
+- `backend/web/models/requests.py`
+- `backend/web/routers/threads.py`
+
+`threads.py` is in-lane only for synchronized request/response payload handling
+that must move with the request model rename.
+
+### Authorized frontend code
+
+- `frontend/app/src/api/client.ts`
+- `frontend/app/src/api/types.ts`
+- `frontend/app/src/pages/NewChatPage.tsx`
+
+### Allowed if focused RED proves clearly necessary
+
+- `frontend/app/src/pages/NewChatPage.test.tsx`
+- `frontend/app/src/api/client.test.ts`
+- `tests/Integration/test_thread_launch_config_contract.py`
+- `tests/Integration/test_threads_router.py`
+
+### Explicitly out of lane
+
+- `backend/web/services/library_service.py`
+- `frontend/app/src/store/app-store.ts`
+- `frontend/app/src/pages/MarketplacePage.tsx`
+- `frontend/app/src/pages/LibraryItemDetailPage.tsx`
+- `frontend/app/src/components/RecipeEditor.tsx`
+- any repo/storage contract or runtime provider code
+
+## Planned Mechanism
+
+Replay-26 should be a synchronized outward rename, not a long-lived bilingual
+bridge.
+
+### Backend request side
+
+Rename outward request fields:
+
+- `CreateThreadRequest.recipe_id` -> `sandbox_template_id`
+- `SaveThreadLaunchConfigRequest.recipe_id` -> `sandbox_template_id`
+
+Route handling should consume the new outward fields while continuing to call
+internal helpers/library layers however they currently need to be called.
+
+### Frontend API/types side
+
+Rename outward API contract terms:
+
+- `CreateThreadOptions.recipeId` -> `CreateThreadOptions.sandboxTemplateId`
+- `ThreadLaunchConfig.recipe_id` -> `ThreadLaunchConfig.sandbox_template_id`
+- `ThreadLaunchConfig.recipe` -> `ThreadLaunchConfig.sandbox_template`
+- `RecipeSnapshot` -> `SandboxTemplateSnapshot`
+
+Serializer/parser behavior should follow those new names at the outward
+boundary.
+
+### Page orchestration side
+
+Rename local state and view-model terms in `NewChatPage.tsx` so the page no
+longer speaks `recipe` as the product concept.
+
+The page may still source its options from `libraryRecipes` for now. Replay-26
+is not required to rename store taxonomy.
+
+## No Long-Lived Alias Rule
+
+Replay-26 should avoid a permanent dual outward contract such as:
+
+- request accepts both `recipe_id` and `sandbox_template_id`
+- response emits both `recipe` and `sandbox_template`
+- frontend parser accepts both forever
+
+If one short internal bridge is temporarily required inside the same slice, it
+must be:
+
+- internal only
+- tightly scoped
+- removed before claiming replay-26 done
+
+The target state is one outward name, not two.
+
+## Test Plan
+
+Replay-26 should be driven by focused contract proof.
+
+Required proof:
+
+1. backend request models and route tests accept the new outward
+   `sandbox_template_*` fields
+2. thread-create new-mode path still resolves the selected template correctly
+3. default-config save/load paths serialize and parse `sandbox_template_id` and
+   `sandbox_template`
+4. frontend API client serializes/parses the new names correctly
+5. `NewChatPage` still constructs the same create/save behavior while using the
+   new outward naming
+
+Not required:
+
+- library taxonomy rename
+- runtime/provider proof
+- schema/migration proof
+- marketplace/library-page rename
+- Playwright YATU
+
+## Stopline
+
+Replay-26 must not:
+
+- rename the `"recipe"` library resource type
+- rename `libraryRecipes`
+- rename `/library/recipe/:id`
+- rewrite library CRUD dispatch
+- change storage/repo schema or contracts
+- change runtime/provider payload truth
+- change `lease_id` runtime/resource surfaces
+- widen into marketplace/library taxonomy cleanup
+
+## Expected Artifact
+
+If replay-26 lands cleanly, the result should be easy to state:
+
+- the outward product/API contract now says `sandbox template`
+- the internal library taxonomy may still say `recipe`
+- there is no permanent bilingual outward contract left behind
+
+## Open Question For Ruling
+
+Is replay-26 the right first implementation lane to rename the outward
+owner-facing/frontend-facing `recipe` contract to `sandbox template` language
+without yet renaming the underlying library resource taxonomy?

--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -50,20 +50,20 @@ describe("thread api client contract", () => {
     );
   });
 
-  it("createThread sends recipe_id instead of the recipe snapshot", async () => {
+  it("createThread sends sandbox_template_id instead of the template snapshot", async () => {
     authFetch.mockResolvedValue(okJson({ thread_id: "thread-1" }));
 
     await api.createThread({
       sandbox: "local",
       agentUserId: "agent-1",
-      recipeId: "local:default",
+      sandboxTemplateId: "local:default",
     });
 
     expect(authFetch).toHaveBeenCalledWith(
       "/api/threads",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ sandbox: "local", agent_user_id: "agent-1", recipe_id: "local:default" }),
+        body: JSON.stringify({ sandbox: "local", agent_user_id: "agent-1", sandbox_template_id: "local:default" }),
       }),
     );
   });
@@ -144,7 +144,7 @@ describe("thread api client contract", () => {
   it("getDefaultThreadConfig queries by agent_user_id", async () => {
     authFetch.mockResolvedValue(okJson({
       source: "derived",
-      config: { create_mode: "new", provider_config: "local", recipe: null, existing_sandbox_id: null, model: null, workspace: null },
+      config: { create_mode: "new", provider_config: "local", sandbox_template: null, existing_sandbox_id: null, model: null, workspace: null },
     }));
 
     await api.getDefaultThreadConfig("agent-1");
@@ -167,7 +167,7 @@ describe("thread api client contract", () => {
     await api.saveDefaultThreadConfig("agent-1", {
       create_mode: "new",
       provider_config: "local",
-      recipe_id: "local:default",
+      sandbox_template_id: "local:default",
       model: "gpt-5.4-mini",
     });
 
@@ -179,7 +179,7 @@ describe("thread api client contract", () => {
           agent_user_id: "agent-1",
           create_mode: "new",
           provider_config: "local",
-          recipe_id: "local:default",
+          sandbox_template_id: "local:default",
           model: "gpt-5.4-mini",
         }),
       }),

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -63,7 +63,7 @@ export async function listThreads(): Promise<ThreadSummary[]> {
 
 export interface CreateThreadOptions {
   sandbox: string;
-  recipeId?: string;
+  sandboxTemplateId?: string;
   existingSandboxId?: string;
   cwd?: string;
   agentUserId: string;
@@ -73,7 +73,7 @@ export interface CreateThreadOptions {
 
 export async function createThread(opts: CreateThreadOptions): Promise<ThreadSummary> {
   const body: Record<string, unknown> = { sandbox: opts.sandbox, agent_user_id: opts.agentUserId };
-  if (opts.recipeId) body.recipe_id = opts.recipeId;
+  if (opts.sandboxTemplateId) body.sandbox_template_id = opts.sandboxTemplateId;
   if (opts.existingSandboxId) body.existing_sandbox_id = opts.existingSandboxId;
   if (opts.cwd) body.cwd = opts.cwd;
   if (opts.model) body.model = opts.model;
@@ -127,7 +127,7 @@ function parseThreadLaunchConfig(value: unknown): ThreadLaunchConfig | null {
   const payload = asRecord(value);
   const create_mode = payload?.create_mode;
   const provider_config = payload ? recordString(payload, "provider_config") : undefined;
-  const recipe = payload?.recipe;
+  const sandbox_template = payload?.sandbox_template;
   const existing_sandbox_id = payload?.existing_sandbox_id;
   const model = payload?.model;
   const workspace = payload?.workspace;
@@ -135,14 +135,22 @@ function parseThreadLaunchConfig(value: unknown): ThreadLaunchConfig | null {
     !payload ||
     !isLaunchCreateMode(create_mode) ||
     !provider_config ||
-    (recipe !== undefined && recipe !== null && asRecord(recipe) === null) ||
+    (sandbox_template !== undefined && sandbox_template !== null && asRecord(sandbox_template) === null) ||
     !isStringOrNullish(existing_sandbox_id) ||
     !isStringOrNullish(model) ||
     !isStringOrNullish(workspace)
   ) {
     return null;
   }
-  return { ...payload, create_mode, provider_config, recipe, existing_sandbox_id, model, workspace } as ThreadLaunchConfig;
+  return {
+    ...payload,
+    create_mode,
+    provider_config,
+    sandbox_template,
+    existing_sandbox_id,
+    model,
+    workspace,
+  } as ThreadLaunchConfig;
 }
 
 function parseDefaultThreadConfig(value: unknown): ThreadLaunchConfigResponse {

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -118,7 +118,7 @@ export interface RecipeFeatureOption {
   icon?: string;
 }
 
-export interface RecipeSnapshot {
+export interface SandboxTemplateSnapshot {
   id: string;
   name: string;
   desc?: string;
@@ -132,8 +132,8 @@ export interface RecipeSnapshot {
 export interface ThreadLaunchConfig {
   create_mode: "new" | "existing";
   provider_config: string;
-  recipe_id?: string | null;
-  recipe?: RecipeSnapshot | null;
+  sandbox_template_id?: string | null;
+  sandbox_template?: SandboxTemplateSnapshot | null;
   existing_sandbox_id?: string | null;
   model?: string | null;
   workspace?: string | null;
@@ -161,7 +161,7 @@ export interface UserLeaseSummary {
   provider_name: string;
   recipe_id: string;
   recipe_name: string;
-  recipe?: RecipeSnapshot;
+  recipe?: SandboxTemplateSnapshot;
   observed_state?: string | null;
   desired_state?: string | null;
   cwd?: string | null;

--- a/frontend/app/src/hooks/use-thread-manager.ts
+++ b/frontend/app/src/hooks/use-thread-manager.ts
@@ -29,7 +29,7 @@ export interface ThreadManagerActions {
     agentUserId?: string,
     model?: string,
     existingSandboxId?: string,
-    recipeId?: string,
+    sandboxTemplateId?: string,
   ) => Promise<string>;
   handleGetDefaultThread: (agentUserId: string, signal?: AbortSignal) => Promise<ThreadSummary | null>;
 }
@@ -99,7 +99,7 @@ export function useThreadManager(): ThreadManagerState & ThreadManagerActions {
     agentUserId?: string,
     model?: string,
     existingSandboxId?: string,
-    recipeId?: string,
+    sandboxTemplateId?: string,
   ): Promise<string> => {
     const type = sandbox ?? selectedSandbox;
     const thread = await createThread({
@@ -108,7 +108,7 @@ export function useThreadManager(): ThreadManagerState & ThreadManagerActions {
       agentUserId: agentUserId ?? "",
       model,
       existingSandboxId,
-      recipeId,
+      sandboxTemplateId,
     });
     setThreads((prev) => upsertThread(prev, thread));
     setSelectedSandbox(type);

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -318,7 +318,7 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "new",
         provider_config: "local",
-        recipe: {
+        sandbox_template: {
           id: "local-recipe",
           name: "Local",
           provider_type: "local",
@@ -326,7 +326,7 @@ describe("NewChatPage", () => {
           configurable_features: {},
           feature_options: [],
         },
-        lease_id: null,
+        existing_sandbox_id: null,
         model: "leon:large",
         workspace: null,
       },
@@ -373,7 +373,7 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "new",
         provider_config: "local",
-        recipe: {
+        sandbox_template: {
           id: "local-recipe",
           name: "Local",
           provider_type: "local",
@@ -381,7 +381,7 @@ describe("NewChatPage", () => {
           configurable_features: {},
           feature_options: [],
         },
-        lease_id: null,
+        existing_sandbox_id: null,
         model: "leon:large",
         workspace: null,
       },
@@ -424,8 +424,8 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "new",
         provider_config: "local",
-        recipe_id: "local-recipe",
-        recipe: {
+        sandbox_template_id: "local-recipe",
+        sandbox_template: {
           id: "stale-display-snapshot",
           name: "Local",
           provider_type: "local",
@@ -433,7 +433,7 @@ describe("NewChatPage", () => {
           configurable_features: { lark_cli: true },
           feature_options: [{ key: "lark_cli", name: "Lark CLI", description: "Install Lark CLI" }],
         },
-        lease_id: null,
+        existing_sandbox_id: null,
         model: "leon:large",
         workspace: null,
       },
@@ -571,7 +571,7 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "new",
         provider_config: "daytona_selfhost",
-        recipe: {
+        sandbox_template: {
           id: "daytona-recipe",
           name: "Self-host Daytona",
           provider_type: "daytona",
@@ -579,7 +579,7 @@ describe("NewChatPage", () => {
           configurable_features: {},
           feature_options: [],
         },
-        lease_id: null,
+        existing_sandbox_id: null,
         model: "leon:large",
         workspace: null,
       },
@@ -634,7 +634,7 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "new",
         provider_config: "daytona_selfhost",
-        recipe: {
+        sandbox_template: {
           id: "daytona-recipe",
           name: "Self-host Daytona",
           provider_type: "daytona",
@@ -642,7 +642,7 @@ describe("NewChatPage", () => {
           configurable_features: {},
           feature_options: [],
         },
-        lease_id: null,
+        existing_sandbox_id: null,
         model: "leon:large",
         workspace: null,
       },

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -10,7 +10,7 @@ import ActorAvatar from "../components/ActorAvatar";
 import FilesystemBrowser from "../components/FilesystemBrowser";
 import { getDefaultThreadConfig, listMyLeases, saveDefaultThreadConfig } from "../api/client";
 import { fetchAccountResourceLimits } from "../api/settings";
-import type { AccountResourceLimit, RecipeFeatureOption, RecipeSnapshot, ThreadLaunchConfig, UserLeaseSummary } from "../api/types";
+import type { AccountResourceLimit, RecipeFeatureOption, SandboxTemplateSnapshot, ThreadLaunchConfig, UserLeaseSummary } from "../api/types";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
 import { Checkbox } from "../components/ui/checkbox";
 import { cn } from "../lib/utils";
@@ -65,8 +65,8 @@ const MODEL_OPTIONS = [
 type ConfigSnapshot = {
   createMode: "new" | "existing";
   selectedExistingSandboxId: string;
-  selectedRecipeId: string;
-  selectedRecipeFeatures: Record<string, boolean>;
+  selectedSandboxTemplateId: string;
+  selectedSandboxTemplateFeatures: Record<string, boolean>;
   selectedWorkspace: string;
   selectedProviderConfig: string;
 };
@@ -103,10 +103,10 @@ function leaseStateMeta(state?: string | null): { dot: string; label: string } {
   }
 }
 
-function enabledFeatureLabels(recipe: RecipeSnapshot | null): string[] {
-  if (!recipe?.feature_options?.length) return [];
-  return recipe.feature_options
-    .filter((item) => recipe.features?.[item.key])
+function enabledFeatureLabels(sandboxTemplate: SandboxTemplateSnapshot | null): string[] {
+  if (!sandboxTemplate?.feature_options?.length) return [];
+  return sandboxTemplate.feature_options
+    .filter((item) => sandboxTemplate.features?.[item.key])
     .map((item) => item.name);
 }
 
@@ -131,8 +131,8 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   const [leaseError, setLeaseError] = useState<string | null>(null);
   const [leaseLoading, setLeaseLoading] = useState(true);
   const [selectedExistingSandboxId, setSelectedExistingSandboxId] = useState<string>("");
-  const [selectedRecipeId, setSelectedRecipeId] = useState<string>("");
-  const [selectedRecipeFeatures, setSelectedRecipeFeatures] = useState<Record<string, boolean>>({});
+  const [selectedSandboxTemplateId, setSelectedSandboxTemplateId] = useState<string>("");
+  const [selectedSandboxTemplateFeatures, setSelectedSandboxTemplateFeatures] = useState<Record<string, boolean>>({});
   const [selectedProviderConfig, setSelectedProviderConfig] = useState<string>("");
   const [selectedWorkspace, setSelectedWorkspace] = useState<string>("");
   const [selectedModel, setSelectedModel] = useState<string>("");
@@ -250,13 +250,13 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     };
   }, []);
 
-  const recipeOptions = useMemo(() => (
+  const sandboxTemplateOptions = useMemo(() => (
     libraryRecipes
       .filter((item) => item.available !== false && item.provider_type)
       .map((item) => ({
         value: item.id,
         label: item.name,
-        recipe: {
+        sandboxTemplate: {
           id: item.id,
           name: item.name,
           desc: item.desc,
@@ -265,7 +265,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
           features: (item as { features?: Record<string, boolean> }).features ?? {},
           configurable_features: (item as { configurable_features?: Record<string, boolean> }).configurable_features ?? {},
           feature_options: (item as { feature_options?: RecipeFeatureOption[] }).feature_options ?? [],
-        } satisfies RecipeSnapshot,
+        } satisfies SandboxTemplateSnapshot,
       }))
   ), [libraryRecipes]);
   const selectedLease = leaseOptions.find((lease) => lease.lease_id === selectedExistingSandboxId) ?? null;
@@ -290,10 +290,10 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     [sandboxResourceByProvider, sandboxTypes],
   );
   useEffect(() => {
-    if (!selectedRecipeId && recipeOptions[0]?.value) {
-      setSelectedRecipeId(recipeOptions[0].value);
+    if (!selectedSandboxTemplateId && sandboxTemplateOptions[0]?.value) {
+      setSelectedSandboxTemplateId(sandboxTemplateOptions[0].value);
     }
-  }, [recipeOptions, selectedRecipeId]);
+  }, [sandboxTemplateOptions, selectedSandboxTemplateId]);
 
   useEffect(() => {
     if (!selectedExistingSandboxId && leaseOptions[0]?.lease_id) {
@@ -357,23 +357,23 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decodedAgentId]);
 
-  const selectedRecipe = useMemo(
-    () => recipeOptions.find((item) => item.value === selectedRecipeId)?.recipe ?? recipeOptions[0]?.recipe ?? null,
-    [recipeOptions, selectedRecipeId],
+  const selectedSandboxTemplate = useMemo(
+    () => sandboxTemplateOptions.find((item) => item.value === selectedSandboxTemplateId)?.sandboxTemplate ?? sandboxTemplateOptions[0]?.sandboxTemplate ?? null,
+    [sandboxTemplateOptions, selectedSandboxTemplateId],
   );
   useEffect(() => {
-    if (!selectedRecipe) return;
-    setSelectedRecipeFeatures(selectedRecipe.features ?? {});
-  }, [selectedRecipeId, selectedRecipe]);
+    if (!selectedSandboxTemplate) return;
+    setSelectedSandboxTemplateFeatures(selectedSandboxTemplate.features ?? {});
+  }, [selectedSandboxTemplateId, selectedSandboxTemplate]);
 
-  const selectedRecipeSnapshot = selectedRecipe
+  const selectedSandboxTemplateSnapshot = selectedSandboxTemplate
     ? {
-      ...selectedRecipe,
-      features: { ...(selectedRecipe.features ?? {}), ...selectedRecipeFeatures },
+      ...selectedSandboxTemplate,
+      features: { ...(selectedSandboxTemplate.features ?? {}), ...selectedSandboxTemplateFeatures },
     }
     : null;
   const activeWorkspace = selectedWorkspace || settings?.default_workspace || "";
-  const localRecipeSelected = createMode === "new" && selectedRecipe?.provider_type === "local";
+  const localSandboxTemplateSelected = createMode === "new" && selectedSandboxTemplate?.provider_type === "local";
 
   async function handleSend(message: string, model: string) {
     const workspace = selectedWorkspace || settings?.default_workspace || undefined;
@@ -394,7 +394,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         selectedLease.lease_id,
       );
     } else {
-      if (!selectedRecipeSnapshot) {
+      if (!selectedSandboxTemplateSnapshot) {
         throw new Error("沙盒模板不存在");
       }
       const cwd = workspace || settings?.default_workspace || undefined;
@@ -404,7 +404,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         decodedAgentId,
         model,
         undefined,
-        selectedRecipeSnapshot.id,
+        selectedSandboxTemplateSnapshot.id,
       );
     }
     postRun(threadId, message, undefined, model ? { model } : undefined).catch(err => {
@@ -419,8 +419,8 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     setCreateMode(config.create_mode);
     setSelectedProviderConfig(config.provider_config || "");
     setSelectedExistingSandboxId(config.existing_sandbox_id || "");
-    setSelectedRecipeId(config.recipe_id || config.recipe?.id || "");
-    setSelectedRecipeFeatures(config.recipe?.features ?? {});
+    setSelectedSandboxTemplateId(config.sandbox_template_id || config.sandbox_template?.id || "");
+    setSelectedSandboxTemplateFeatures(config.sandbox_template?.features ?? {});
     setSelectedWorkspace(config.workspace || "");
     setSelectedModel(config.model || settings?.default_model || "leon:large");
   }
@@ -430,21 +430,21 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
       if (!selectedLease) return "复用旧沙盒";
       return `${selectedLease.provider_name} · ${selectedLease.recipe_name}`;
     }
-    const recipe = selectedRecipeSnapshot;
-    if (!recipe) return "选择沙盒模板";
-    const featureSuffix = enabledFeatureLabels(recipe).join(" · ");
-    if (recipe.provider_type !== "local") return [recipe.name, featureSuffix].filter(Boolean).join(" · ");
-    if (!activeWorkspace) return [recipe.name, featureSuffix, "选择工作区"].filter(Boolean).join(" · ");
+    const sandboxTemplate = selectedSandboxTemplateSnapshot;
+    if (!sandboxTemplate) return "选择沙盒模板";
+    const featureSuffix = enabledFeatureLabels(sandboxTemplate).join(" · ");
+    if (sandboxTemplate.provider_type !== "local") return [sandboxTemplate.name, featureSuffix].filter(Boolean).join(" · ");
+    if (!activeWorkspace) return [sandboxTemplate.name, featureSuffix, "选择工作区"].filter(Boolean).join(" · ");
     const parts = activeWorkspace.split("/").filter(Boolean);
-    return [recipe.name, featureSuffix, parts.at(-1) ?? activeWorkspace].filter(Boolean).join(" · ");
+    return [sandboxTemplate.name, featureSuffix, parts.at(-1) ?? activeWorkspace].filter(Boolean).join(" · ");
   }
 
   function buildConfigSnapshot(): ConfigSnapshot {
     return {
       createMode,
       selectedExistingSandboxId: selectedExistingSandboxId || leaseOptions[0]?.lease_id || "",
-      selectedRecipeId,
-      selectedRecipeFeatures: { ...selectedRecipeFeatures },
+      selectedSandboxTemplateId,
+      selectedSandboxTemplateFeatures: { ...selectedSandboxTemplateFeatures },
       selectedWorkspace: activeWorkspace,
       selectedProviderConfig: selectedProviderConfig || selectedSandbox || "local",
     };
@@ -464,8 +464,8 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     if (!configSnapshot) return resetConfigPanel();
     setCreateMode(configSnapshot.createMode);
     setSelectedExistingSandboxId(configSnapshot.selectedExistingSandboxId);
-    setSelectedRecipeId(configSnapshot.selectedRecipeId);
-    setSelectedRecipeFeatures(configSnapshot.selectedRecipeFeatures);
+    setSelectedSandboxTemplateId(configSnapshot.selectedSandboxTemplateId);
+    setSelectedSandboxTemplateFeatures(configSnapshot.selectedSandboxTemplateFeatures);
     setSelectedWorkspace(configSnapshot.selectedWorkspace);
     setSelectedProviderConfig(configSnapshot.selectedProviderConfig);
     resetConfigPanel();
@@ -476,7 +476,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     await saveDefaultThreadConfig(decodedAgentId, {
       create_mode: createMode,
       provider_config: selectedProviderConfig,
-      recipe_id: selectedRecipeSnapshot?.id || null,
+      sandbox_template_id: selectedSandboxTemplateSnapshot?.id || null,
       existing_sandbox_id: createMode === "existing" ? selectedExistingSandboxId || null : null,
       model: draftModel,
       workspace,
@@ -489,7 +489,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
       return false;
     }
     if (configStep === 2) {
-      if (localRecipeSelected) {
+      if (localSandboxTemplateSelected) {
         setConfigStep(3);
         return false;
       }
@@ -500,7 +500,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
       return true;
     }
     const nextWorkspace = activeWorkspace;
-    if (createMode === "new" && selectedRecipeSnapshot?.provider_type === "local" && nextWorkspace) {
+    if (createMode === "new" && selectedSandboxTemplateSnapshot?.provider_type === "local" && nextWorkspace) {
       await setDefaultWorkspace(nextWorkspace);
     }
     await persistDefaultConfig(draftModel, nextWorkspace || null);
@@ -523,16 +523,16 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     || providerTypeFromName(selectedProviderConfig || "local");
   useEffect(() => {
     if (createMode !== "new") return;
-    const firstMatchingRecipe = recipeOptions.find((item) => item.recipe.provider_type === selectedProviderType);
-    if (!firstMatchingRecipe) return;
-    if (selectedRecipe?.provider_type === selectedProviderType) return;
-    setSelectedRecipeId(firstMatchingRecipe.value);
-  }, [createMode, recipeOptions, selectedProviderType, selectedRecipe?.provider_type]);
+    const firstMatchingSandboxTemplate = sandboxTemplateOptions.find((item) => item.sandboxTemplate.provider_type === selectedProviderType);
+    if (!firstMatchingSandboxTemplate) return;
+    if (selectedSandboxTemplate?.provider_type === selectedProviderType) return;
+    setSelectedSandboxTemplateId(firstMatchingSandboxTemplate.value);
+  }, [createMode, sandboxTemplateOptions, selectedProviderType, selectedSandboxTemplate?.provider_type]);
 
   const providerSummaryLabel = selectedProviderConfig
     ? providerConfigLabel(selectedProviderConfig)
     : "未选择 provider";
-  const recipeSummaryLabel = selectedRecipe?.name ?? "未选择沙盒模板";
+  const sandboxTemplateSummaryLabel = selectedSandboxTemplate?.name ?? "未选择沙盒模板";
   const selectedProviderResource = selectedProviderConfig
     ? sandboxResourceByProvider.get(selectedProviderConfig)
     : undefined;
@@ -543,7 +543,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   const newSandboxProviderUnavailable = createMode === "new" && selectedProviderOption?.available === false;
   const stepSummary = createMode === "existing"
     ? `复用 ${providerSummaryLabel} 的现有沙盒`
-    : `新建 ${providerSummaryLabel} 沙盒 · ${recipeSummaryLabel}`;
+    : `新建 ${providerSummaryLabel} 沙盒 · ${sandboxTemplateSummaryLabel}`;
 
   // @@@defer-default-config - default config should refine the create form, not block
   // entry into the no-main-thread UI. If the config fetch stalls, users still need the
@@ -594,7 +594,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
           defaultModel={selectedModel || settings?.default_model || "leon:large"}
           environmentControl={{
             panelClassName: "max-h-[calc(100vh-4rem)]",
-            applyLabel: configStep === 3 ? "确认" : (configStep === 1 ? "下一步" : (localRecipeSelected ? "下一步" : "确认")),
+            applyLabel: configStep === 3 ? "确认" : (configStep === 1 ? "下一步" : (localSandboxTemplateSelected ? "下一步" : "确认")),
             applyDisabled: (configStep === 1 && (newSandboxQuotaBlocked || newSandboxProviderUnavailable))
               || (configStep === 2 && createMode === "existing" && !selectedExistingSandboxId),
             showBack: configStep > 1,
@@ -605,17 +605,17 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
             onCancel: cancelConfigChanges,
             onApply: applyConfigChanges,
             renderPanel: ({ draftModel, setDraftModel }) => {
-              const activeRecipe = selectedRecipe;
-              const filteredRecipeOptions = selectedProviderType
-                ? recipeOptions.filter((item) => item.recipe.provider_type === selectedProviderType)
-                : recipeOptions;
+              const activeSandboxTemplate = selectedSandboxTemplate;
+              const filteredSandboxTemplateOptions = selectedProviderType
+                ? sandboxTemplateOptions.filter((item) => item.sandboxTemplate.provider_type === selectedProviderType)
+                : sandboxTemplateOptions;
               const filteredLeaseOptions = selectedProviderConfig
                 ? leaseOptions.filter((lease) => lease.provider_name === selectedProviderConfig)
                 : leaseOptions;
-              const configurableFeatureOptions = (activeRecipe?.feature_options ?? [])
-                .filter((item) => activeRecipe?.configurable_features?.[item.key]);
+              const configurableFeatureOptions = (activeSandboxTemplate?.feature_options ?? [])
+                .filter((item) => activeSandboxTemplate?.configurable_features?.[item.key]);
               const existingCount = filteredLeaseOptions.length;
-              const totalSteps = localRecipeSelected ? 3 : 2;
+              const totalSteps = localSandboxTemplateSelected ? 3 : 2;
               const renderModelChoices = (compact = false) => (
                 <div className={cn("flex flex-wrap items-center", compact ? "gap-1.5" : "gap-2")}>
                   {MODEL_OPTIONS.map((entry) => (
@@ -703,10 +703,10 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                             const nextProviderType = providerConfigOptions.find((item) => item.value === nextProviderConfig)?.providerType
                               || providerTypeFromName(nextProviderConfig);
                             setSelectedProviderConfig(nextProviderConfig);
-                            const nextRecipes = recipeOptions.filter((item) => item.recipe.provider_type === nextProviderType);
-                            if (nextRecipes.length > 0 && !nextRecipes.some((item) => item.value === selectedRecipeId)) {
-                              setSelectedRecipeId(nextRecipes[0].value);
-                            }
+                          const nextSandboxTemplates = sandboxTemplateOptions.filter((item) => item.sandboxTemplate.provider_type === nextProviderType);
+                          if (nextSandboxTemplates.length > 0 && !nextSandboxTemplates.some((item) => item.value === selectedSandboxTemplateId)) {
+                            setSelectedSandboxTemplateId(nextSandboxTemplates[0].value);
+                          }
                             const nextLease = leaseOptions.find((lease) => lease.provider_name === nextProviderConfig);
                             if (createMode === "existing") {
                               setSelectedExistingSandboxId(nextLease?.lease_id || "");
@@ -768,12 +768,12 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                         <>
                           <div>
                             <div className="mb-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">沙盒模板</div>
-                            <Select value={selectedRecipeId} onValueChange={setSelectedRecipeId}>
+                            <Select value={selectedSandboxTemplateId} onValueChange={setSelectedSandboxTemplateId}>
                               <SelectTrigger className="h-10 text-sm">
                                 <SelectValue placeholder="选择沙盒模板" />
                               </SelectTrigger>
                               <SelectContent>
-                                {filteredRecipeOptions.map((item) => (
+                                {filteredSandboxTemplateOptions.map((item) => (
                                   <SelectItem key={item.value} value={item.value}>
                                     {item.label}
                                   </SelectItem>
@@ -787,23 +787,23 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                               <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">临时修改</div>
                               <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
                                 {configurableFeatureOptions.map((option) => {
-                                  const checked = Boolean(selectedRecipeFeatures[option.key]);
+                                          const checked = Boolean(selectedSandboxTemplateFeatures[option.key]);
                                   return (
                                     <div
                                       key={option.key}
                                       onClick={() => {
-                                        setSelectedRecipeFeatures((current) => ({
-                                          ...current,
-                                          [option.key]: !checked,
-                                        }));
+                                            setSelectedSandboxTemplateFeatures((current) => ({
+                                              ...current,
+                                              [option.key]: !checked,
+                                            }));
                                       }}
                                       onKeyDown={(event) => {
                                         if (event.key === "Enter" || event.key === " ") {
                                           event.preventDefault();
-                                          setSelectedRecipeFeatures((current) => ({
-                                            ...current,
-                                            [option.key]: !checked,
-                                          }));
+                                              setSelectedSandboxTemplateFeatures((current) => ({
+                                                ...current,
+                                                [option.key]: !checked,
+                                              }));
                                         }
                                       }}
                                       role="button"
@@ -898,11 +898,11 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                     </div>
                   )}
 
-                  {configStep === 3 && localRecipeSelected && (
+                  {configStep === 3 && localSandboxTemplateSelected && (
                     <div className="space-y-3">
                       <div className="flex items-center justify-between gap-3">
                         <div className="truncate text-xs text-muted-foreground">
-                          {[recipeSummaryLabel, ...enabledFeatureLabels(selectedRecipeSnapshot)].join(" · ")}
+                          {[sandboxTemplateSummaryLabel, ...enabledFeatureLabels(selectedSandboxTemplateSnapshot)].join(" · ")}
                         </div>
                       </div>
 

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -651,6 +651,8 @@ async def test_get_default_thread_config_runs_sync_repo_work_off_event_loop(monk
             "create_mode": "existing",
             "provider_config": "local",
             "existing_sandbox_id": "lease-1",
+            "sandbox_template_id": None,
+            "sandbox_template": None,
         },
     }
     assert to_thread_calls == [("_resolve_default_config_for_owned_agent", (app, "owner-1", "agent-user-1"))]
@@ -762,6 +764,8 @@ def test_get_default_thread_config_route_uses_owner_and_agent_user_contract(monk
         "config": {
             "create_mode": "existing",
             "provider_config": "local",
+            "sandbox_template_id": None,
+            "sandbox_template": None,
         },
     }
     assert calls == [(app, "owner-1", "agent-user-1")]
@@ -783,7 +787,7 @@ def test_save_default_thread_config_route_persists_confirmed_agent_user_payload(
                 "agent_user_id": "agent-user-1",
                 "create_mode": "new",
                 "provider_config": "local",
-                "recipe_id": "local:default",
+                "sandbox_template_id": "local:default",
                 "existing_sandbox_id": None,
                 "model": "gpt-5.4-mini",
                 "workspace": "/tmp/demo",
@@ -874,7 +878,7 @@ async def test_create_thread_carries_recipe_snapshot_into_resources_and_successf
             "agent_user_id": "agent-user-1",
             "model": "gpt-5.4-mini",
             "sandbox": "local",
-            "recipe_id": "local:custom:lark",
+            "sandbox_template_id": "local:custom:lark",
         }
     )
     normalized_recipe = normalize_recipe_snapshot("local", repo_recipe)
@@ -918,7 +922,7 @@ async def test_create_thread_rejects_unowned_recipe_snapshot() -> None:
             "agent_user_id": "agent-user-1",
             "model": "gpt-5.4-mini",
             "sandbox": "local",
-            "recipe_id": "local:custom:foreign",
+            "sandbox_template_id": "local:custom:foreign",
         }
     )
 


### PR DESCRIPTION
## Summary
- add replay-25 and replay-26 preflight docs for the recipe -> sandbox template lane
- rename the outward thread-create / default-config contract from `recipe` to `sandbox_template`
- update backend route translation, frontend API/types, and NewChatPage wiring without changing library taxonomy or runtime/resource truths

## Test Plan
- [x] `uv run pytest tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q`
- [x] `cd frontend/app && pnpm vitest run src/api/client.test.ts src/pages/NewChatPage.test.tsx`
- [x] `uv run ruff check backend/web/models/requests.py backend/web/routers/threads.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py`
- [x] `uv run ruff format --check backend/web/models/requests.py backend/web/routers/threads.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py`
- [x] `cd frontend/app && pnpm exec tsc --noEmit`
- [x] `cd frontend/app && pnpm exec eslint src/api/client.ts src/api/types.ts src/api/client.test.ts src/hooks/use-thread-manager.ts src/pages/NewChatPage.tsx src/pages/NewChatPage.test.tsx`
- [x] `git diff --check`
