### PR TITLE
chore: add dev validity smoke gate

### DIFF
--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -320,8 +320,8 @@ async def get_resource_content(
 
 @router.put("/library/{resource_type}/{resource_id}/content")
 async def update_resource_content(resource_type: str, resource_id: str, req: UpdateResourceContentRequest) -> dict[str, Any]:
-    if resource_type == "recipe":
-        raise HTTPException(400, "Recipes are read-only")
+    if resource_type == "sandbox-template":
+        raise HTTPException(400, "Sandbox templates are read-only")
     ok = await asyncio.to_thread(library_service.update_resource_content, resource_type, resource_id, req.content)
     if not ok:
         raise HTTPException(404, "Resource not found or invalid content")

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -104,31 +104,15 @@ def _resolve_default_config_for_owned_agent(app: Any, owner_user_id: str, agent_
     _require_owned_agent(app, agent_user_id, owner_user_id)
     return resolve_default_config(app, owner_user_id, agent_user_id)
 
-
-def _translate_internal_launch_config_to_outward(config: dict[str, Any]) -> dict[str, Any]:
-    translated = dict(config)
-    translated["sandbox_template_id"] = translated.pop("recipe_id", None)
-    translated["sandbox_template"] = translated.pop("recipe", None)
-    return translated
-
-
-def _translate_outward_launch_config_to_internal(config: dict[str, Any]) -> dict[str, Any]:
-    translated = dict(config)
-    translated["recipe_id"] = translated.pop("sandbox_template_id", None)
-    translated.pop("sandbox_template", None)
-    return translated
-
-
 def _save_default_config_for_owned_agent(
     app: Any,
     owner_user_id: str,
     payload: SaveThreadLaunchConfigRequest,
 ) -> dict[str, bool]:
     _require_owned_agent(app, payload.agent_user_id, owner_user_id)
-    config = _translate_outward_launch_config_to_internal(payload.model_dump())
     if payload.create_mode == "new":
         _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.sandbox_template_id)
-    save_last_confirmed_config(app, owner_user_id, payload.agent_user_id, config)
+    save_last_confirmed_config(app, owner_user_id, payload.agent_user_id, payload.model_dump())
     return {"ok": True}
 
 
@@ -711,7 +695,7 @@ def _create_owned_thread(
     else:
         successful_config = build_new_launch_config(
             provider_config=sandbox_type,
-            recipe_id=selected_recipe["id"] if selected_recipe else None,
+            sandbox_template_id=selected_recipe["id"] if selected_recipe else None,
             model=payload.model,
             workspace=app.state.thread_cwd.get(new_thread_id) or payload.cwd,
         )
@@ -810,10 +794,7 @@ async def get_default_thread_config(
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any]:
     config = await asyncio.to_thread(_resolve_default_config_for_owned_agent, app, user_id, agent_user_id)
-    return {
-        **config,
-        "config": _translate_internal_launch_config_to_outward(dict(config.get("config") or {})),
-    }
+    return config
 
 
 @router.post("/default-config")

--- a/backend/web/services/library_service.py
+++ b/backend/web/services/library_service.py
@@ -1,4 +1,4 @@
-"""Library CRUD for file-backed assets and DB-backed recipes."""
+"""Library CRUD for file-backed assets and DB-backed sandbox templates."""
 
 import json
 import shutil
@@ -30,8 +30,8 @@ def _write_json(path: Path, data: Any) -> None:
 
 
 def _require_recipe_owner(owner_user_id: str | None) -> str:
-    # @@@recipe-user-scope - custom recipes and builtin overrides are account-scoped resources.
-    # Callers must pass owner_user_id for recipe operations so one user's edits never leak into another's library.
+    # @@@sandbox-template-user-scope - custom sandbox templates and builtin overrides are account-scoped resources.
+    # Callers must pass owner_user_id so one user's template edits never leak into another user's library.
     if not owner_user_id:
         raise ValueError("owner_user_id is required for recipe operations")
     return str(owner_user_id or "")
@@ -45,7 +45,7 @@ def _normalize_recipe_item(data: dict[str, Any], *, builtin: bool) -> dict[str, 
     snapshot = normalize_recipe_snapshot(provider_type, {**data, "provider_name": provider_name})
     return {
         **snapshot,
-        "type": "recipe",
+        "type": "sandbox-template",
         "provider_name": provider_name,
         "provider_type": provider_type,
         "created_at": int(data.get("created_at") or 0),
@@ -101,7 +101,7 @@ def list_library(
     recipe_repo: RecipeRepo | None = None,
 ) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
-    if resource_type == "recipe":
+    if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         recipe_repo = _require_recipe_repo(recipe_repo)
         return [
@@ -146,7 +146,7 @@ def seed_default_recipes(
         provider_type = str(sandbox.get("provider") or provider_type_from_name(provider_name)).strip()
         recipe = {
             **default_recipe_snapshot(provider_type, provider_name=provider_name),
-            "type": "recipe",
+            "type": "sandbox-template",
             "provider_name": provider_name,
             "provider_type": provider_type,
             "available": bool(sandbox.get("available", True)),
@@ -208,7 +208,7 @@ def create_resource(
 ) -> dict[str, Any]:
     now = int(time.time() * 1000)
     cat = category or "未分类"
-    if resource_type == "recipe":
+    if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         recipe_repo = _require_recipe_repo(recipe_repo)
         provider_name, provider_type = _resolve_recipe_provider(provider_name)
@@ -276,7 +276,7 @@ def update_resource(
 ) -> dict[str, Any] | None:
     updates = {key: value for key, value in {"name": name, "desc": desc, "features": features}.items() if value is not None}
     now = int(time.time() * 1000)
-    if resource_type == "recipe":
+    if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         recipe_repo = _require_recipe_repo(recipe_repo)
         row = recipe_repo.get(owner_user_id, resource_id)
@@ -322,7 +322,7 @@ def delete_resource(
     owner_user_id: str | None = None,
     recipe_repo: RecipeRepo | None = None,
 ) -> bool:
-    if resource_type == "recipe":
+    if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         recipe_repo = _require_recipe_repo(recipe_repo)
         row = recipe_repo.get(owner_user_id, resource_id)
@@ -335,7 +335,7 @@ def delete_resource(
             now = int(time.time() * 1000)
             reset = {
                 **default_recipe_snapshot(provider_type, provider_name=provider_name),
-                "type": "recipe",
+                "type": "sandbox-template",
                 "provider_name": provider_name,
                 "provider_type": provider_type,
                 "available": bool(data.get("available", True)),
@@ -427,9 +427,9 @@ def get_resource_content(
     recipe_repo: RecipeRepo | None = None,
 ) -> str | None:
     """Read the .md content file for a skill or agent resource."""
-    if resource_type == "recipe":
+    if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
-        for item in list_library("recipe", owner_user_id=owner_user_id, recipe_repo=recipe_repo):
+        for item in list_library("sandbox-template", owner_user_id=owner_user_id, recipe_repo=recipe_repo):
             if item["id"] == resource_id:
                 return json.dumps(item, ensure_ascii=False, indent=2)
         return None
@@ -456,7 +456,7 @@ def get_resource_content(
 def update_resource_content(resource_type: str, resource_id: str, content: str) -> bool:
     """Write the .md content file for a skill or agent resource."""
     now = int(time.time() * 1000)
-    if resource_type == "recipe":
+    if resource_type == "sandbox-template":
         return False
     content_path = _file_resource_content_path(resource_type, resource_id)
     meta_path = _file_resource_meta_path(resource_type, resource_id)

--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -17,7 +17,7 @@ def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return {
         "create_mode": create_mode,
         "provider_config": str(payload.get("provider_config") or "").strip(),
-        "recipe_id": str(payload.get("recipe_id") or "").strip() or None,
+        "sandbox_template_id": str(payload.get("sandbox_template_id") or "").strip() or None,
         "existing_sandbox_id": existing_sandbox_id,
         "model": str(payload.get("model") or "").strip() or None,
         "workspace": str(payload.get("workspace") or "").strip() or None,
@@ -44,7 +44,7 @@ def build_existing_launch_config(
 def build_new_launch_config(
     *,
     provider_config: str,
-    recipe_id: str | None,
+    sandbox_template_id: str | None,
     model: str | None,
     workspace: str | None,
 ) -> dict[str, Any]:
@@ -52,7 +52,7 @@ def build_new_launch_config(
         {
             "create_mode": "new",
             "provider_config": provider_config,
-            "recipe_id": recipe_id,
+            "sandbox_template_id": sandbox_template_id,
             "existing_sandbox_id": None,
             "model": model,
             "workspace": workspace,
@@ -76,16 +76,26 @@ def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> 
         user_repo=app.state.user_repo,
     )
     providers = [item for item in sandbox_service.available_sandbox_types() if item.get("available")]
-    recipes = list_library("recipe", owner_user_id=owner_user_id, recipe_repo=app.state.recipe_repo)
+    sandbox_templates = list_library("sandbox-template", owner_user_id=owner_user_id, recipe_repo=app.state.recipe_repo)
     agent_threads = app.state.thread_repo.list_by_agent_user(agent_user_id)
 
     # @@@thread-launch-default-precedence - prefer the last successful thread config, then the last confirmed draft,
     # and only then derive from current leases/providers. This keeps defaults tied to actual agent usage first.
-    successful = _validate_saved_config(prefs.get("last_successful"), leases=leases, providers=providers, recipes=recipes)
+    successful = _validate_saved_config(
+        prefs.get("last_successful"),
+        leases=leases,
+        providers=providers,
+        sandbox_templates=sandbox_templates,
+    )
     if successful is not None:
         return {"source": "last_successful", "config": successful}
 
-    confirmed = _validate_saved_config(prefs.get("last_confirmed"), leases=leases, providers=providers, recipes=recipes)
+    confirmed = _validate_saved_config(
+        prefs.get("last_confirmed"),
+        leases=leases,
+        providers=providers,
+        sandbox_templates=sandbox_templates,
+    )
     if confirmed is not None:
         return {"source": "last_confirmed", "config": confirmed}
 
@@ -95,7 +105,7 @@ def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> 
             agent_threads=agent_threads,
             leases=leases,
             providers=providers,
-            recipes=recipes,
+            sandbox_templates=sandbox_templates,
         ),
     }
 
@@ -105,14 +115,18 @@ def _validate_saved_config(
     *,
     leases: list[dict[str, Any]],
     providers: list[dict[str, Any]],
-    recipes: list[dict[str, Any]],
+    sandbox_templates: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
     if not isinstance(payload, dict):
         return None
 
     config = normalize_launch_config_payload(payload)
     provider_names = {str(item["name"]) for item in providers}
-    recipes_by_id = {str(item["id"]): item for item in recipes if item.get("available", True) and item.get("provider_type")}
+    sandbox_templates_by_id = {
+        str(item["id"]): item
+        for item in sandbox_templates
+        if item.get("available", True) and item.get("provider_type")
+    }
 
     if config["create_mode"] == "existing":
         existing_sandbox_id = config.get("existing_sandbox_id")
@@ -124,21 +138,25 @@ def _validate_saved_config(
         return _existing_config_from_lease(lease, model=config.get("model"), workspace=lease.get("cwd"))
 
     provider_config = config.get("provider_config")
-    recipe_id = str(config.get("recipe_id") or "").strip()
-    if not provider_config or provider_config not in provider_names or not recipe_id:
+    sandbox_template_id = str(config.get("sandbox_template_id") or "").strip()
+    if not provider_config or provider_config not in provider_names or not sandbox_template_id:
         return None
-    if not recipe_id or recipe_id not in recipes_by_id:
+    if sandbox_template_id not in sandbox_templates_by_id:
         return None
-    recipe = recipes_by_id[recipe_id]
-    if not _recipe_matches_provider(recipe, provider_config):
+    sandbox_template = sandbox_templates_by_id[sandbox_template_id]
+    if not _sandbox_template_matches_provider(sandbox_template, provider_config):
         return None
-    recipe_snapshot = normalize_recipe_snapshot(provider_type_from_name(provider_config), recipe, provider_name=provider_config)
+    sandbox_template_snapshot = normalize_recipe_snapshot(
+        provider_type_from_name(provider_config),
+        sandbox_template,
+        provider_name=provider_config,
+    )
 
     return {
         "create_mode": "new",
         "provider_config": provider_config,
-        "recipe_id": recipe_id,
-        "recipe": recipe_snapshot,
+        "sandbox_template_id": sandbox_template_id,
+        "sandbox_template": sandbox_template_snapshot,
         "existing_sandbox_id": None,
         "model": config.get("model"),
         "workspace": config.get("workspace"),
@@ -157,7 +175,7 @@ def _existing_config_from_lease(lease: dict[str, Any], *, model: str | None, wor
     return {
         "create_mode": "existing",
         "provider_config": lease.get("provider_name"),
-        "recipe": lease.get("recipe"),
+        "sandbox_template": lease.get("recipe"),
         "existing_sandbox_id": lease.get("lease_id"),
         "model": model,
         "workspace": workspace,
@@ -169,7 +187,7 @@ def _derive_default_config(
     agent_threads: list[dict[str, Any]],
     leases: list[dict[str, Any]],
     providers: list[dict[str, Any]],
-    recipes: list[dict[str, Any]],
+    sandbox_templates: list[dict[str, Any]],
 ) -> dict[str, Any]:
     leases_by_id = {str(lease.get("lease_id") or "").strip(): lease for lease in leases if str(lease.get("lease_id") or "").strip()}
     for thread in _iter_default_bridge_threads(agent_threads):
@@ -179,20 +197,28 @@ def _derive_default_config(
 
     provider_names = [str(item["name"]) for item in providers]
     provider_config = "local" if "local" in provider_names else (provider_names[0] if provider_names else "local")
-    recipe = next(
-        (item for item in recipes if item.get("available", True) and _recipe_matches_provider(item, provider_config)),
+    sandbox_template = next(
+        (
+            item
+            for item in sandbox_templates
+            if item.get("available", True) and _sandbox_template_matches_provider(item, provider_config)
+        ),
         None,
     )
-    recipe_snapshot = (
-        normalize_recipe_snapshot(provider_type_from_name(provider_config), recipe, provider_name=provider_config)
-        if recipe is not None
+    sandbox_template_snapshot = (
+        normalize_recipe_snapshot(
+            provider_type_from_name(provider_config),
+            sandbox_template,
+            provider_name=provider_config,
+        )
+        if sandbox_template is not None
         else None
     )
     return {
         "create_mode": "new",
         "provider_config": provider_config,
-        "recipe_id": str(recipe["id"]) if recipe is not None else None,
-        "recipe": recipe_snapshot,
+        "sandbox_template_id": str(sandbox_template["id"]) if sandbox_template is not None else None,
+        "sandbox_template": sandbox_template_snapshot,
         "existing_sandbox_id": None,
         "model": None,
         "workspace": None,
@@ -214,9 +240,9 @@ def _iter_default_bridge_threads(agent_threads: list[dict[str, Any]]) -> list[di
     return threads_with_bridge
 
 
-def _recipe_matches_provider(recipe: dict[str, Any], provider_config: str) -> bool:
-    provider_name = str(recipe.get("provider_name") or "").strip()
+def _sandbox_template_matches_provider(sandbox_template: dict[str, Any], provider_config: str) -> bool:
+    provider_name = str(sandbox_template.get("provider_name") or "").strip()
     if provider_name:
         return provider_name == provider_config
     provider_type = provider_type_from_name(provider_config)
-    return str(recipe.get("provider_type") or "") == provider_type
+    return str(sandbox_template.get("provider_type") or "") == provider_type

--- a/frontend/app/src/components/SandboxTemplateEditor.tsx
+++ b/frontend/app/src/components/SandboxTemplateEditor.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { useAppStore } from "@/store/app-store";
 import type { ResourceItem } from "@/store/types";
 
-interface RecipeEditorProps {
+interface SandboxTemplateEditorProps {
   item: ResourceItem | null;
   providerOptions?: ResourceItem[];
   onCreated?: (item: ResourceItem) => void;
@@ -26,7 +26,12 @@ function featureStateFor(options: RecipeFeatureOption[], item: ResourceItem | nu
   return Object.fromEntries(options.map((option) => [option.key, Boolean(item?.features?.[option.key])]));
 }
 
-export default function RecipeEditor({ item, providerOptions = EMPTY_PROVIDER_OPTIONS, onCreated, onDeleted }: RecipeEditorProps) {
+export default function SandboxTemplateEditor({
+  item,
+  providerOptions = EMPTY_PROVIDER_OPTIONS,
+  onCreated,
+  onDeleted,
+}: SandboxTemplateEditorProps) {
   const addResource = useAppStore((s) => s.addResource);
   const updateResource = useAppStore((s) => s.updateResource);
   const deleteResource = useAppStore((s) => s.deleteResource);
@@ -69,12 +74,12 @@ export default function RecipeEditor({ item, providerOptions = EMPTY_PROVIDER_OP
     try {
       if (isCreate) {
         if (!providerName) throw new Error("请选择 Sandbox provider");
-        const created = await addResource("recipe", name.trim(), desc.trim(), { provider_name: providerName, features });
-        toast.success("Sandbox recipe 已创建");
+        const created = await addResource("sandbox-template", name.trim(), desc.trim(), { provider_name: providerName, features });
+        toast.success("Sandbox template 已创建");
         onCreated?.(created);
       } else if (item) {
-        await updateResource("recipe", item.id, { name, desc, features });
-        toast.success("Sandbox recipe 已保存");
+        await updateResource("sandbox-template", item.id, { name, desc, features });
+        toast.success("Sandbox template 已保存");
       }
     } catch (error) {
       toast.error(`${isCreate ? "创建" : "保存"}失败: ${error instanceof Error ? error.message : String(error)}`);
@@ -85,12 +90,12 @@ export default function RecipeEditor({ item, providerOptions = EMPTY_PROVIDER_OP
 
   async function handleDeleteOrReset() {
     if (!item) return;
-    const action = item.builtin ? "重置" : "删除";
+      const action = item.builtin ? "重置" : "删除";
     if (!window.confirm(`${action} ${item.name}?`)) return;
     setSaving(true);
     try {
-      await deleteResource("recipe", item.id);
-      toast.success(item.builtin ? "Sandbox recipe 已重置" : "Sandbox recipe 已删除");
+      await deleteResource("sandbox-template", item.id);
+      toast.success(item.builtin ? "Sandbox template 已重置" : "Sandbox template 已删除");
       if (!item.builtin) onDeleted?.();
     } catch (error) {
       toast.error(`${action}失败: ${error instanceof Error ? error.message : String(error)}`);
@@ -117,19 +122,19 @@ export default function RecipeEditor({ item, providerOptions = EMPTY_PROVIDER_OP
 
       <div className="space-y-5 px-5 py-5">
         <div className="space-y-2">
-          <label htmlFor="recipe-name" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          <label htmlFor="sandbox-template-name" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
             Name
           </label>
-          <Input id="recipe-name" value={name} onChange={(event) => setName(event.target.value)} />
+          <Input id="sandbox-template-name" value={name} onChange={(event) => setName(event.target.value)} />
         </div>
 
         {isCreate && (
           <div className="space-y-2">
-            <label htmlFor="recipe-provider" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            <label htmlFor="sandbox-template-provider" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
               Provider
             </label>
             <select
-              id="recipe-provider"
+              id="sandbox-template-provider"
               value={providerName}
               onChange={(event) => setProviderName(event.target.value)}
               className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
@@ -144,10 +149,10 @@ export default function RecipeEditor({ item, providerOptions = EMPTY_PROVIDER_OP
         )}
 
         <div className="space-y-2">
-          <label htmlFor="recipe-desc" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          <label htmlFor="sandbox-template-desc" className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
             Description
           </label>
-          <Input id="recipe-desc" value={desc} onChange={(event) => setDesc(event.target.value)} />
+          <Input id="sandbox-template-desc" value={desc} onChange={(event) => setDesc(event.target.value)} />
         </div>
 
         <div className="space-y-2">

--- a/frontend/app/src/components/agent-shell-contract.test.tsx
+++ b/frontend/app/src/components/agent-shell-contract.test.tsx
@@ -64,7 +64,7 @@ describe("frontend agent wording contract", () => {
       librarySkills: [],
       libraryMcps: [],
       libraryAgents: [],
-      libraryRecipes: [],
+      librarySandboxTemplates: [],
       userProfile: { name: "User", initials: "U", email: "" },
       loaded: true,
       error: null,

--- a/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
@@ -39,11 +39,11 @@ describe("LibraryItemDetailPage", () => {
         updated_at: 1,
       }],
       librarySkills: [],
-      libraryRecipes: [{
+      librarySandboxTemplates: [{
         id: "daytona:default",
         name: "Daytona Default",
         desc: "Default recipe for daytona",
-        type: "recipe",
+        type: "sandbox-template",
         provider_name: "daytona_selfhost",
         provider_type: "daytona",
         features: { lark_cli: false },
@@ -81,7 +81,7 @@ describe("LibraryItemDetailPage", () => {
 
   it("renders sandbox recipe details as an editor instead of a blank raw-content page", async () => {
     render(
-      <MemoryRouter initialEntries={["/library/recipe/daytona:default"]}>
+      <MemoryRouter initialEntries={["/library/sandbox-template/daytona:default"]}>
         <Routes>
           <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
         </Routes>
@@ -98,7 +98,7 @@ describe("LibraryItemDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "保存" }));
 
     await waitFor(() => {
-      expect(updateResource).toHaveBeenCalledWith("recipe", "daytona:default", {
+      expect(updateResource).toHaveBeenCalledWith("sandbox-template", "daytona:default", {
         name: "Daytona Default",
         desc: "Updated sandbox template",
         features: { lark_cli: false },

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { ArrowLeft, Zap, Users, RefreshCw } from "lucide-react";
-import RecipeEditor from "@/components/RecipeEditor";
+import SandboxTemplateEditor from "@/components/SandboxTemplateEditor";
 import { useAppStore } from "@/store/app-store";
 import type { ResourceItem } from "@/store/types";
 
-type DetailLibraryType = "skill" | "agent" | "recipe";
+type DetailLibraryType = "skill" | "agent" | "sandbox-template";
 
 function detailLibraryType(value: string | undefined): DetailLibraryType | null {
-  return value === "skill" || value === "agent" || value === "recipe" ? value : null;
+  return value === "skill" || value === "agent" || value === "sandbox-template" ? value : null;
 }
 
 export default function LibraryItemDetailPage() {
@@ -16,7 +16,7 @@ export default function LibraryItemDetailPage() {
   const navigate = useNavigate();
   const librarySkills = useAppStore((s) => s.librarySkills);
   const libraryAgents = useAppStore((s) => s.libraryAgents);
-  const libraryRecipes = useAppStore((s) => s.libraryRecipes);
+  const librarySandboxTemplates = useAppStore((s) => s.librarySandboxTemplates);
   const librariesLoaded = useAppStore((s) => s.librariesLoaded);
   const ensureLibrary = useAppStore((s) => s.ensureLibrary);
   const fetchResourceContent = useAppStore((s) => s.fetchResourceContent);
@@ -32,9 +32,9 @@ export default function LibraryItemDetailPage() {
 
   const item = useMemo<ResourceItem | null>(() => {
     if (!type || !id) return null;
-    const list = type === "skill" ? librarySkills : type === "agent" ? libraryAgents : type === "recipe" ? libraryRecipes : [];
+    const list = type === "skill" ? librarySkills : type === "agent" ? libraryAgents : type === "sandbox-template" ? librarySandboxTemplates : [];
     return list.find((i) => i.id === id) ?? null;
-  }, [librarySkills, libraryAgents, libraryRecipes, type, id]);
+  }, [librarySkills, libraryAgents, librarySandboxTemplates, type, id]);
 
   useEffect(() => {
     if (!libraryType || librariesLoaded[libraryType]) return;
@@ -50,7 +50,7 @@ export default function LibraryItemDetailPage() {
   }, [ensureLibrary, librariesLoaded, libraryType]);
 
   useEffect(() => {
-    if (!type || !id || type === "recipe") return;
+    if (!type || !id || type === "sandbox-template") return;
     const key = `${type}:${id}`;
     let cancelled = false;
     fetchResourceContent(type, id)
@@ -74,10 +74,10 @@ export default function LibraryItemDetailPage() {
   }, [type, id, fetchResourceContent]);
 
   const isSkill = type === "skill";
-  const isRecipe = type === "recipe";
+  const isSandboxTemplate = type === "sandbox-template";
   const filename = isSkill ? "SKILL.md" : "agent.md";
   const loadingLibrary = !!libraryType && !librariesLoaded[libraryType] && !libraryError;
-  const loading = loadingLibrary || (!isRecipe && !!contentKey && contentState.key !== contentKey);
+  const loading = loadingLibrary || (!isSandboxTemplate && !!contentKey && contentState.key !== contentKey);
   const content = contentState.key === contentKey ? contentState.content : "";
   const error = libraryError ?? (contentState.key === contentKey ? contentState.error : null);
 
@@ -101,7 +101,7 @@ export default function LibraryItemDetailPage() {
           返回
         </button>
 
-        {!isRecipe && (
+        {!isSandboxTemplate && (
           <div className="flex items-start gap-4 mb-6">
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-1">
@@ -122,8 +122,8 @@ export default function LibraryItemDetailPage() {
           </div>
         )}
 
-        {isRecipe && item ? (
-          <RecipeEditor item={item} onDeleted={() => navigate("/marketplace?tab=installed&sub=recipe")} />
+        {isSandboxTemplate && item ? (
+          <SandboxTemplateEditor item={item} onDeleted={() => navigate("/marketplace?tab=installed&sub=sandbox-template")} />
         ) : (
           <div className="surface-card p-4">
           <div className="flex items-center gap-2 mb-3">

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -6,13 +6,13 @@ import { useAppStore } from "@/store/app-store";
 import { useIsMobile } from "@/hooks/use-mobile";
 import MarketplaceCard from "@/components/marketplace/MarketplaceCard";
 import UpdateDialog from "@/components/marketplace/UpdateDialog";
-import RecipeEditor from "@/components/RecipeEditor";
+import SandboxTemplateEditor from "@/components/SandboxTemplateEditor";
 import type { Agent, ResourceItem } from "@/store/types";
 import type { UpdateAvailable } from "@/store/marketplace-store";
 import { HUB_AGENT_USER_ITEM_TYPE } from "@/lib/marketplace-types";
 
 type Tab = "explore" | "installed";
-type InstalledSubTab = "agent-user" | "skill" | "agent" | "recipe";
+type InstalledSubTab = "agent-user" | "skill" | "agent" | "sandbox-template";
 type TypeFilter = "all" | typeof HUB_AGENT_USER_ITEM_TYPE | "agent" | "skill" | "env";
 type InstalledAgentUser = Agent & {
   source?: {
@@ -26,7 +26,7 @@ function isTab(value: string | null): value is Tab {
 }
 
 function isInstalledSubTab(value: string | null): value is InstalledSubTab {
-  return value === "agent-user" || value === "skill" || value === "agent" || value === "recipe";
+  return value === "agent-user" || value === "skill" || value === "agent" || value === "sandbox-template";
 }
 
 const typeFilters: { id: TypeFilter; label: string }[] = [
@@ -69,7 +69,7 @@ export default function MarketplacePage() {
   const agentList = useAppStore((s) => s.agentList);
   const librarySkills = useAppStore((s) => s.librarySkills);
   const libraryAgents = useAppStore((s) => s.libraryAgents);
-  const libraryRecipes = useAppStore((s) => s.libraryRecipes);
+  const librarySandboxTemplates = useAppStore((s) => s.librarySandboxTemplates);
   const agentsLoaded = useAppStore((s) => s.agentsLoaded);
   const librariesLoaded = useAppStore((s) => s.librariesLoaded);
   const deleteResource = useAppStore((s) => s.deleteResource);
@@ -114,24 +114,24 @@ export default function MarketplacePage() {
   const filteredAgents = libraryAgents.filter((a) =>
     !installedSearch || a.name.toLowerCase().includes(installedSearch.toLowerCase())
   );
-  const filteredRecipes = libraryRecipes.filter((recipe) =>
-    !installedSearch || recipe.name.toLowerCase().includes(installedSearch.toLowerCase())
+  const filteredSandboxTemplates = librarySandboxTemplates.filter((sandboxTemplate) =>
+    !installedSearch || sandboxTemplate.name.toLowerCase().includes(installedSearch.toLowerCase())
   );
   const recipeProviderOptions = useMemo<ResourceItem[]>(() => {
     const seen = new Set<string>();
-    return libraryRecipes.filter((recipe) => {
-      const providerName = recipe.provider_name;
+    return librarySandboxTemplates.filter((sandboxTemplate) => {
+      const providerName = sandboxTemplate.provider_name;
       if (!providerName || seen.has(providerName)) return false;
       seen.add(providerName);
       return true;
     });
-  }, [libraryRecipes]);
+  }, [librarySandboxTemplates]);
 
   const installedSubTabs: { id: InstalledSubTab; label: string; icon: React.ElementType; count: number }[] = [
     { id: "agent-user", label: "Agent", icon: Package, count: installedAgentUsers.length },
     { id: "skill", label: "Skill", icon: Zap, count: librarySkills.length },
     { id: "agent", label: "Subagent", icon: Users, count: libraryAgents.length },
-    { id: "recipe", label: "Sandbox", icon: Box, count: libraryRecipes.length },
+    { id: "sandbox-template", label: "Sandbox", icon: Box, count: librarySandboxTemplates.length },
   ];
   const installedSubTabLoaded = installedSubTab === "agent-user" ? agentsLoaded : librariesLoaded[installedSubTab];
 
@@ -372,11 +372,11 @@ export default function MarketplacePage() {
                   ))}
                 </div>
 
-                {installedSubTabLoaded && installedSubTab === "recipe" && (
+                {installedSubTabLoaded && installedSubTab === "sandbox-template" && (
                   <div className="mb-4 flex items-center justify-between rounded-xl border border-border bg-card px-3 py-2">
                     <div>
                       <p className="text-sm font-medium text-foreground">Sandbox 模板</p>
-                      <p className="text-xs text-muted-foreground">为当前账号创建可复用的 sandbox recipe。</p>
+                      <p className="text-xs text-muted-foreground">为当前账号创建可复用的 sandbox template。</p>
                     </div>
                     <button
                       type="button"
@@ -504,14 +504,14 @@ export default function MarketplacePage() {
                   </>
                 )}
 
-                {/* Sandbox recipe list */}
-                {installedSubTabLoaded && installedSubTab === "recipe" && (
+                {/* Sandbox template list */}
+                {installedSubTabLoaded && installedSubTab === "sandbox-template" && (
                   <>
                     <div className={`grid ${isMobile ? "grid-cols-1" : "grid-cols-2"} gap-3`}>
-                      {filteredRecipes.map((recipe) => (
+                      {filteredSandboxTemplates.map((sandboxTemplate) => (
                         <div
-                          key={recipe.id}
-                          onClick={() => navigate(`/library/recipe/${recipe.id}`)}
+                          key={sandboxTemplate.id}
+                          onClick={() => navigate(`/library/sandbox-template/${sandboxTemplate.id}`)}
                           className="surface-interactive p-4 cursor-pointer group relative"
                         >
                           <div className="flex items-start gap-3">
@@ -519,16 +519,16 @@ export default function MarketplacePage() {
                               <Box className="w-4 h-4 text-primary" />
                             </div>
                             <div className="min-w-0 flex-1 pr-8">
-                              <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{recipe.name}</h4>
-                              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{recipe.desc || "暂无描述"}</p>
+                              <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{sandboxTemplate.name}</h4>
+                              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{sandboxTemplate.desc || "暂无描述"}</p>
                               <p className="text-2xs text-muted-foreground mt-2 font-mono truncate">
-                                Sandbox · {recipe.provider_name || recipe.provider_type || "unknown"}
+                                Sandbox · {sandboxTemplate.provider_name || sandboxTemplate.provider_type || "unknown"}
                               </p>
                             </div>
                           </div>
-                          {!recipe.builtin && (
+                          {!sandboxTemplate.builtin && (
                             <button
-                              onClick={(e) => { e.stopPropagation(); deleteResource("recipe", recipe.id); }}
+                              onClick={(e) => { e.stopPropagation(); deleteResource("sandbox-template", sandboxTemplate.id); }}
                               className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
                               title="删除"
                             >
@@ -538,7 +538,7 @@ export default function MarketplacePage() {
                         </div>
                       ))}
                     </div>
-                    {filteredRecipes.length === 0 && (
+                    {filteredSandboxTemplates.length === 0 && (
                       <div className="text-center py-12 text-sm text-muted-foreground">暂无已安装的 Sandbox</div>
                     )}
                   </>
@@ -573,7 +573,7 @@ export default function MarketplacePage() {
                 <X className="h-4 w-4" />
               </button>
             </div>
-            <RecipeEditor
+            <SandboxTemplateEditor
               item={null}
               providerOptions={recipeProviderOptions}
               onCreated={() => setRecipeCreateOpen(false)}

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -62,7 +62,7 @@ describe("MarketplacePage wording contract", () => {
       id: "daytona_selfhost:custom:probe",
       name: "Selfhost Custom",
       desc: "custom self-host sandbox",
-      type: "recipe",
+      type: "sandbox-template",
       provider_name: "daytona_selfhost",
       provider_type: "daytona",
       features: { lark_cli: false },
@@ -74,12 +74,12 @@ describe("MarketplacePage wording contract", () => {
       agentsLoaded: true,
       librarySkills: [],
       libraryAgents: [],
-      libraryRecipes: [
+      librarySandboxTemplates: [
         {
           id: "daytona:selfhost:default",
           name: "Self-host Daytona",
           desc: "Use the self-host Daytona provider",
-          type: "recipe",
+          type: "sandbox-template",
           provider_type: "daytona",
           provider_name: "daytona_selfhost",
           features: { lark_cli: false },
@@ -90,7 +90,7 @@ describe("MarketplacePage wording contract", () => {
           }],
         },
       ],
-      librariesLoaded: { skill: true, mcp: true, agent: true, recipe: true },
+      librariesLoaded: { skill: true, mcp: true, agent: true, "sandbox-template": true },
       fetchLibrary: appStoreFetchLibrary,
       deleteResource: appStoreDeleteResource,
       addResource: appStoreAddResource,
@@ -153,7 +153,7 @@ describe("MarketplacePage wording contract", () => {
 
   it("shows installed sandbox recipes as the sandbox library tab", () => {
     render(
-      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=recipe"]}>
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=sandbox-template"]}>
         <Routes>
           <Route path="/marketplace" element={<MarketplacePage />} />
         </Routes>
@@ -169,12 +169,12 @@ describe("MarketplacePage wording contract", () => {
   it("does not show installed sandbox empty state before recipe library is loaded", () => {
     appStoreState = {
       ...appStoreState,
-      libraryRecipes: [],
-      librariesLoaded: { skill: true, mcp: true, agent: true, recipe: false },
+      librarySandboxTemplates: [],
+      librariesLoaded: { skill: true, mcp: true, agent: true, "sandbox-template": false },
     };
 
     render(
-      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=recipe"]}>
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=sandbox-template"]}>
         <Routes>
           <Route path="/marketplace" element={<MarketplacePage />} />
         </Routes>
@@ -187,7 +187,7 @@ describe("MarketplacePage wording contract", () => {
 
   it("creates sandbox recipes with concrete provider_name from backend-loaded recipes", async () => {
     render(
-      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=recipe"]}>
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=sandbox-template"]}>
         <Routes>
           <Route path="/marketplace" element={<MarketplacePage />} />
         </Routes>
@@ -200,7 +200,7 @@ describe("MarketplacePage wording contract", () => {
     fireEvent.click(screen.getByRole("button", { name: "创建" }));
 
     await waitFor(() => {
-      expect(appStoreAddResource).toHaveBeenCalledWith("recipe", "Selfhost Custom", "custom self-host sandbox", {
+      expect(appStoreAddResource).toHaveBeenCalledWith("sandbox-template", "Selfhost Custom", "custom self-host sandbox", {
         provider_name: "daytona_selfhost",
         features: { lark_cli: false },
       });

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -175,7 +175,7 @@ describe("NewChatPage", () => {
       librarySkills: [],
       libraryMcps: [],
       libraryAgents: [],
-      libraryRecipes: [],
+      librarySandboxTemplates: [],
       userProfile: { name: "User", initials: "U", email: "" },
       loaded: true,
       error: null,
@@ -332,9 +332,9 @@ describe("NewChatPage", () => {
       },
     });
     useAppStore.setState({
-      libraryRecipes: [{
+      librarySandboxTemplates: [{
         id: "local-recipe",
-        type: "recipe",
+        type: "sandbox-template",
         name: "Local",
         desc: "",
         provider_type: "local",
@@ -387,9 +387,9 @@ describe("NewChatPage", () => {
       },
     });
     useAppStore.setState({
-      libraryRecipes: [{
+      librarySandboxTemplates: [{
         id: "local-recipe",
-        type: "recipe",
+        type: "sandbox-template",
         name: "Local",
         desc: "",
         provider_type: "local",
@@ -439,9 +439,9 @@ describe("NewChatPage", () => {
       },
     });
     useAppStore.setState({
-      libraryRecipes: [{
+      librarySandboxTemplates: [{
         id: "other-recipe",
-        type: "recipe",
+        type: "sandbox-template",
         name: "Other Local",
         desc: "",
         provider_type: "local",
@@ -453,7 +453,7 @@ describe("NewChatPage", () => {
         updated_at: 0,
       }, {
         id: "local-recipe",
-        type: "recipe",
+        type: "sandbox-template",
         name: "Local",
         desc: "",
         provider_type: "local",
@@ -585,9 +585,9 @@ describe("NewChatPage", () => {
       },
     });
     useAppStore.setState({
-      libraryRecipes: [{
+      librarySandboxTemplates: [{
         id: "daytona-recipe",
-        type: "recipe",
+        type: "sandbox-template",
         name: "Self-host Daytona",
         desc: "",
         provider_type: "daytona",
@@ -648,9 +648,9 @@ describe("NewChatPage", () => {
       },
     });
     useAppStore.setState({
-      libraryRecipes: [{
+      librarySandboxTemplates: [{
         id: "daytona-recipe",
-        type: "recipe",
+        type: "sandbox-template",
         name: "Self-host Daytona",
         desc: "",
         provider_type: "daytona",

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -146,7 +146,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
 
   const authAgent = useAuthStore(s => s.agent);
   const agentList = useAppStore(s => s.agentList);
-  const libraryRecipes = useAppStore(s => s.libraryRecipes);
+  const librarySandboxTemplates = useAppStore(s => s.librarySandboxTemplates);
   const decodedAgentId = agentId ? decodeURIComponent(agentId) : null;
   const resolvedAgent = decodedAgentId ? agentList.find(agent => agent.id === decodedAgentId) : undefined;
   const isOwnedAgent = decodedAgentId === authAgent?.id;
@@ -251,7 +251,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   }, []);
 
   const sandboxTemplateOptions = useMemo(() => (
-    libraryRecipes
+    librarySandboxTemplates
       .filter((item) => item.available !== false && item.provider_type)
       .map((item) => ({
         value: item.id,
@@ -267,7 +267,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
           feature_options: (item as { feature_options?: RecipeFeatureOption[] }).feature_options ?? [],
         } satisfies SandboxTemplateSnapshot,
       }))
-  ), [libraryRecipes]);
+  ), [librarySandboxTemplates]);
   const selectedLease = leaseOptions.find((lease) => lease.lease_id === selectedExistingSandboxId) ?? null;
   const sandboxResourceByProvider = useMemo(() => {
     const map = new Map<string, AccountResourceLimit>();

--- a/frontend/app/src/store/app-store.ts
+++ b/frontend/app/src/store/app-store.ts
@@ -13,7 +13,7 @@ interface AppState {
   librarySkills: ResourceItem[];
   libraryMcps: ResourceItem[];
   libraryAgents: ResourceItem[];
-  libraryRecipes: ResourceItem[];
+  librarySandboxTemplates: ResourceItem[];
   userProfile: UserProfile;
   loaded: boolean;
   agentsLoaded: boolean;
@@ -60,21 +60,21 @@ interface AppState {
   getResourceUsedBy: (type: string, name: string) => string[];
 }
 
-type LibraryType = "skill" | "mcp" | "agent" | "recipe";
-type LibraryStateKey = "librarySkills" | "libraryMcps" | "libraryAgents" | "libraryRecipes";
+type LibraryType = "skill" | "mcp" | "agent" | "sandbox-template";
+type LibraryStateKey = "librarySkills" | "libraryMcps" | "libraryAgents" | "librarySandboxTemplates";
 
 const DEFAULT_PROFILE: UserProfile = { name: "User", initials: "U", email: "" };
 const LIBRARY_STATE_KEYS: Record<LibraryType, LibraryStateKey> = {
   skill: "librarySkills",
   mcp: "libraryMcps",
   agent: "libraryAgents",
-  recipe: "libraryRecipes",
+  "sandbox-template": "librarySandboxTemplates",
 };
 const EMPTY_LIBRARY_LOADED: Record<LibraryType, boolean> = {
   skill: false,
   mcp: false,
   agent: false,
-  recipe: false,
+  "sandbox-template": false,
 };
 const EMPTY_AGENT_CONFIG: Agent["config"] = {
   prompt: "",
@@ -100,7 +100,7 @@ function emptySessionState() {
     librarySkills: [],
     libraryMcps: [],
     libraryAgents: [],
-    libraryRecipes: [],
+    librarySandboxTemplates: [],
     userProfile: DEFAULT_PROFILE,
     loaded: false,
     agentsLoaded: false,
@@ -162,7 +162,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
           get().ensureLibrary("skill"),
           get().ensureLibrary("mcp"),
           get().ensureLibrary("agent"),
-          get().ensureLibrary("recipe"),
+          get().ensureLibrary("sandbox-template"),
           get().fetchProfile(),
         ]);
         set({ loaded: true });
@@ -332,9 +332,9 @@ export const useAppStore = create<AppState>()((set, get) => ({
 
   deleteResource: async (type, id) => {
     await api(`/library/${type}/${id}`, { method: "DELETE" });
-    if (type === "recipe") {
+    if (type === "sandbox-template") {
       const data = await api<{ items: ResourceItem[] }>(`/library/${type}`);
-      set({ libraryRecipes: data.items });
+      set({ librarySandboxTemplates: data.items });
       return;
     }
     const key = getLibraryStateKey(type);
@@ -373,7 +373,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
   getAgentNames: () => get().agentList.map((s) => ({ id: s.id, name: s.name })),
 
   getResourceUsedBy: (type, name) => {
-    if (type === "recipe") return [];
+    if (type === "sandbox-template") return [];
     const key = type === "skill" ? "skills" : type === "mcp" ? "mcps" : "subAgents";
     return get().agentList.filter((s) =>
       (s.config?.[key as keyof typeof s.config] as { name: string }[] | undefined)?.some((i) => i.name === name)

--- a/scripts/check-dev-validity.sh
+++ b/scripts/check-dev-validity.sh
@@ -78,6 +78,35 @@ def request_json(path: str, *, method: str, payload: dict[str, object] | None = 
     return parsed
 
 
+def _is_string_or_nullish(value: object) -> bool:
+    return value is None or isinstance(value, str)
+
+
+def has_frontend_valid_launch_config(payload: dict[str, object]) -> bool:
+    # @@@default-config-shape - keep smoke acceptance aligned with the frontend parser
+    # so this gate cannot pass a payload that `getDefaultThreadConfig()` would reject.
+    source = payload.get("source")
+    if source not in {"last_successful", "last_confirmed", "derived"}:
+        return False
+    config = payload.get("config")
+    if not isinstance(config, dict):
+        return False
+    create_mode = config.get("create_mode")
+    provider_config = config.get("provider_config")
+    sandbox_template = config.get("sandbox_template")
+    if create_mode not in {"new", "existing"}:
+        return False
+    if not isinstance(provider_config, str) or not provider_config:
+        return False
+    if sandbox_template is not None and not isinstance(sandbox_template, dict):
+        return False
+    return (
+        _is_string_or_nullish(config.get("existing_sandbox_id"))
+        and _is_string_or_nullish(config.get("model"))
+        and _is_string_or_nullish(config.get("workspace"))
+    )
+
+
 login = request_json(
     "/api/auth/login",
     method="POST",
@@ -107,9 +136,8 @@ default_config = request_json(
     method="GET",
     token=token,
 )
-config = default_config.get("config")
-if not isinstance(config, dict):
-    fail("/api/threads/default-config returned no config object")
+if not has_frontend_valid_launch_config(default_config):
+    fail("/api/threads/default-config returned malformed launch config")
 print("default-config ok")
 print("dev validity smoke passed")
 PY

--- a/scripts/check-dev-validity.sh
+++ b/scripts/check-dev-validity.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_env=(
+  LEON_STORAGE_STRATEGY
+  LEON_SUPABASE_CLIENT_FACTORY
+  LEON_DB_SCHEMA
+  SUPABASE_PUBLIC_URL
+  SUPABASE_INTERNAL_URL
+  SUPABASE_AUTH_URL
+  SUPABASE_ANON_KEY
+  LEON_SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_JWT_SECRET
+  LEON_POSTGRES_URL
+  MYCEL_BACKEND_BASE_URL
+  MYCEL_SMOKE_IDENTIFIER
+  MYCEL_SMOKE_PASSWORD
+)
+
+missing=()
+for key in "${required_env[@]}"; do
+  if [[ -z "${!key:-}" ]]; then
+    missing+=("$key")
+  fi
+done
+
+if [[ -z "${OPENAI_API_KEY:-}" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  missing+=("OPENAI_API_KEY|ANTHROPIC_API_KEY")
+fi
+
+if (( ${#missing[@]} > 0 )); then
+  printf 'Missing required environment variables:\n' >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+from urllib import error, parse, request
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+base_url = os.environ["MYCEL_BACKEND_BASE_URL"].rstrip("/")
+identifier = os.environ["MYCEL_SMOKE_IDENTIFIER"]
+password = os.environ["MYCEL_SMOKE_PASSWORD"]
+
+
+def request_json(path: str, *, method: str, payload: dict[str, object] | None = None, token: str | None = None) -> dict[str, object]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = request.Request(f"{base_url}{path}", data=body, method=method)
+    if payload is not None:
+        req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with request.urlopen(req, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").strip()
+        fail(f"{path} returned {exc.code}: {detail or '<empty body>'}")
+    except Exception as exc:  # noqa: BLE001
+        fail(f"{path} request failed: {exc}")
+
+    try:
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        fail(f"{path} returned non-JSON body: {exc}")
+    if not isinstance(parsed, dict):
+        fail(f"{path} returned non-object JSON")
+    return parsed
+
+
+login = request_json(
+    "/api/auth/login",
+    method="POST",
+    payload={"identifier": identifier, "password": password},
+)
+token = str(login.get("token") or "").strip()
+if not token:
+    fail("/api/auth/login returned no token")
+print("login ok")
+
+agents = request_json("/api/panel/agents", method="GET", token=token)
+items = agents.get("items")
+if not isinstance(items, list):
+    fail("/api/panel/agents returned no items list")
+if not items:
+    fail("/api/panel/agents returned no owned agents")
+first_agent = items[0]
+if not isinstance(first_agent, dict):
+    fail("/api/panel/agents first item is not an object")
+agent_user_id = str(first_agent.get("id") or "").strip()
+if not agent_user_id:
+    fail("/api/panel/agents first item has no id")
+print(f"panel agents ok: {agent_user_id}")
+
+default_config = request_json(
+    f"/api/threads/default-config?agent_user_id={parse.quote(agent_user_id, safe='')}",
+    method="GET",
+    token=token,
+)
+config = default_config.get("config")
+if not isinstance(config, dict):
+    fail("/api/threads/default-config returned no config object")
+print("default-config ok")
+print("dev validity smoke passed")
+PY

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -133,7 +133,7 @@ def _recipe_library_entry(provider_type: str) -> dict[str, object]:
     recipe = default_recipe_snapshot(provider_type)
     return {
         **recipe,
-        "type": "recipe",
+        "type": "sandbox-template",
         "available": True,
         "created_at": 0,
         "updated_at": 0,
@@ -150,7 +150,7 @@ def test_save_last_confirmed_config_normalizes_payload() -> None:
         payload={
             "create_mode": "wat",
             "provider_config": "  local  ",
-            "recipe_id": "  local:default  ",
+            "sandbox_template_id": "  local:default  ",
             "existing_sandbox_id": "  ",
             "model": "  gpt-5.4-mini  ",
             "workspace": "  /tmp/demo  ",
@@ -164,7 +164,7 @@ def test_save_last_confirmed_config_normalizes_payload() -> None:
             {
                 "create_mode": "new",
                 "provider_config": "local",
-                "recipe_id": "local:default",
+                "sandbox_template_id": "local:default",
                 "existing_sandbox_id": None,
                 "model": "gpt-5.4-mini",
                 "workspace": "/tmp/demo",
@@ -183,7 +183,7 @@ def test_save_last_confirmed_config_drops_stray_lease_id_for_new_mode() -> None:
         payload={
             "create_mode": "new",
             "provider_config": "local",
-            "recipe_id": "local:default",
+            "sandbox_template_id": "local:default",
             "existing_sandbox_id": "lease-stray",
             "model": "gpt-5.4-mini",
             "workspace": "/tmp/demo",
@@ -197,7 +197,7 @@ def test_save_last_confirmed_config_drops_stray_lease_id_for_new_mode() -> None:
             {
                 "create_mode": "new",
                 "provider_config": "local",
-                "recipe_id": "local:default",
+                "sandbox_template_id": "local:default",
                 "existing_sandbox_id": None,
                 "model": "gpt-5.4-mini",
                 "workspace": "/tmp/demo",
@@ -219,17 +219,17 @@ def test_build_existing_launch_config_uses_canonical_shape() -> None:
     assert config == {
         "create_mode": "existing",
         "provider_config": "daytona_selfhost",
-        "recipe_id": None,
+        "sandbox_template_id": None,
         "existing_sandbox_id": "lease-1",
         "model": "gpt-5.4",
         "workspace": "/workspace/reused",
     }
 
 
-def test_build_new_launch_config_uses_recipe_id() -> None:
+def test_build_new_launch_config_uses_sandbox_template_id() -> None:
     config = thread_launch_config_service.build_new_launch_config(
         provider_config="local",
-        recipe_id="local:custom",
+        sandbox_template_id="local:custom",
         model="gpt-5.4-mini",
         workspace="/tmp/custom",
     )
@@ -237,7 +237,7 @@ def test_build_new_launch_config_uses_recipe_id() -> None:
     assert config == {
         "create_mode": "new",
         "provider_config": "local",
-        "recipe_id": "local:custom",
+        "sandbox_template_id": "local:custom",
         "existing_sandbox_id": None,
         "model": "gpt-5.4-mini",
         "workspace": "/tmp/custom",
@@ -252,7 +252,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
                     "last_successful": {
                         "create_mode": "existing",
                         "provider_config": "local",
-                        "recipe": {"id": "stale"},
+                        "sandbox_template": {"id": "stale"},
                         "existing_sandbox_id": "lease-1",
                         "model": "gpt-5.4",
                         "workspace": "/workspace/stale",
@@ -260,7 +260,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
                     "last_confirmed": {
                         "create_mode": "new",
                         "provider_config": "local",
-                        "recipe_id": "local:default",
+                        "sandbox_template_id": "local:default",
                         "existing_sandbox_id": None,
                         "model": "gpt-4.1",
                         "workspace": "/tmp/draft",
@@ -309,7 +309,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
         "config": {
             "create_mode": "existing",
             "provider_config": "local",
-            "recipe": default_recipe_snapshot("local"),
+            "sandbox_template": default_recipe_snapshot("local"),
             "existing_sandbox_id": "lease-1",
             "model": "gpt-5.4",
             "workspace": "/workspace/reused",
@@ -325,7 +325,7 @@ def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() ->
                     "last_successful": {
                         "create_mode": "existing",
                         "provider_config": "local",
-                        "recipe": None,
+                        "sandbox_template": None,
                         "existing_sandbox_id": "missing-lease",
                         "model": "gpt-5.4",
                         "workspace": "/workspace/missing",
@@ -333,7 +333,7 @@ def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() ->
                     "last_confirmed": {
                         "create_mode": "new",
                         "provider_config": "local",
-                        "recipe_id": "local:default",
+                        "sandbox_template_id": "local:default",
                         "existing_sandbox_id": None,
                         "model": "gpt-4.1",
                         "workspace": "/tmp/draft",
@@ -374,8 +374,8 @@ def test_resolve_default_config_skips_invalid_successful_and_uses_confirmed() ->
         "config": {
             "create_mode": "new",
             "provider_config": "local",
-            "recipe_id": "local:default",
-            "recipe": default_recipe_snapshot("local"),
+            "sandbox_template_id": "local:default",
+            "sandbox_template": default_recipe_snapshot("local"),
             "existing_sandbox_id": None,
             "model": "gpt-4.1",
             "workspace": "/tmp/draft",
@@ -443,7 +443,7 @@ def test_resolve_default_config_derives_existing_from_thread_current_workspace_i
         "config": {
             "create_mode": "existing",
             "provider_config": "daytona_selfhost",
-            "recipe": default_recipe_snapshot("daytona"),
+            "sandbox_template": default_recipe_snapshot("daytona"),
             "existing_sandbox_id": "lease-2",
             "model": None,
             "workspace": "/workspace/right",
@@ -505,8 +505,8 @@ def test_resolve_default_config_falls_back_to_new_default_when_thread_workspace_
         "config": {
             "create_mode": "new",
             "provider_config": "local",
-            "recipe_id": "local:default",
-            "recipe": default_recipe_snapshot("local"),
+            "sandbox_template_id": "local:default",
+            "sandbox_template": default_recipe_snapshot("local"),
             "existing_sandbox_id": None,
             "model": None,
             "workspace": None,
@@ -570,7 +570,7 @@ async def test_create_thread_persists_existing_lease_successful_config() -> None
         {
             "create_mode": "existing",
             "provider_config": "daytona_selfhost",
-            "recipe_id": None,
+            "sandbox_template_id": None,
             "existing_sandbox_id": "lease-1",
             "model": "gpt-5.4",
             "workspace": "/workspace/reused",
@@ -651,8 +651,6 @@ async def test_get_default_thread_config_runs_sync_repo_work_off_event_loop(monk
             "create_mode": "existing",
             "provider_config": "local",
             "existing_sandbox_id": "lease-1",
-            "sandbox_template_id": None,
-            "sandbox_template": None,
         },
     }
     assert to_thread_calls == [("_resolve_default_config_for_owned_agent", (app, "owner-1", "agent-user-1"))]
@@ -724,7 +722,7 @@ async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(mon
                 "agent_user_id": "agent-user-1",
                 "create_mode": "existing",
                 "provider_config": "daytona_selfhost",
-                "recipe_id": None,
+                "sandbox_template_id": None,
                 "existing_sandbox_id": "lease-1",
                 "model": "gpt-5.4-mini",
                 "workspace": "/workspace/reused",
@@ -764,8 +762,6 @@ def test_get_default_thread_config_route_uses_owner_and_agent_user_contract(monk
         "config": {
             "create_mode": "existing",
             "provider_config": "local",
-            "sandbox_template_id": None,
-            "sandbox_template": None,
         },
     }
     assert calls == [(app, "owner-1", "agent-user-1")]
@@ -805,7 +801,7 @@ def test_save_default_thread_config_route_persists_confirmed_agent_user_payload(
                 "agent_user_id": "agent-user-1",
                 "create_mode": "new",
                 "provider_config": "local",
-                "recipe_id": "local:default",
+                "sandbox_template_id": "local:default",
                 "existing_sandbox_id": None,
                 "model": "gpt-5.4-mini",
                 "workspace": "/tmp/demo",
@@ -842,7 +838,7 @@ async def test_create_thread_persists_new_launch_successful_config() -> None:
         {
             "create_mode": "new",
             "provider_config": "local",
-            "recipe_id": "local:default",
+            "sandbox_template_id": "local:default",
             "existing_sandbox_id": None,
             "model": "gpt-5.4-mini",
             "workspace": "/tmp/fresh-local-thread",
@@ -906,7 +902,7 @@ async def test_create_thread_carries_recipe_snapshot_into_resources_and_successf
         {
             "create_mode": "new",
             "provider_config": "local",
-            "recipe_id": "local:custom:lark",
+            "sandbox_template_id": "local:custom:lark",
             "existing_sandbox_id": None,
             "model": "gpt-5.4-mini",
             "workspace": None,

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -8,7 +8,6 @@ import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "scripts" / "check-dev-validity.sh"
 

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -121,6 +121,31 @@ class CheckDevValidityScriptTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("/api/panel/agents returned no owned agents", result.stderr)
 
+    def test_fails_when_default_config_payload_is_frontend_malformed(self) -> None:
+        class MalformedDefaultConfigHandler(_SmokeHandler):
+            default_config_payload = {
+                "config": {
+                    "provider_config": "local",
+                },
+            }
+
+        with ThreadingHTTPServer(("127.0.0.1", 0), MalformedDefaultConfigHandler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                result = self._run_script(
+                    {
+                        **REQUIRED_ENV,
+                        "MYCEL_BACKEND_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    }
+                )
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("/api/threads/default-config returned malformed launch config", result.stderr)
+
     def test_passes_when_real_smoke_sequence_succeeds(self) -> None:
         with ThreadingHTTPServer(("127.0.0.1", 0), _SmokeHandler) as server:
             thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "check-dev-validity.sh"
+
+
+REQUIRED_ENV = {
+    "LEON_STORAGE_STRATEGY": "supabase",
+    "LEON_SUPABASE_CLIENT_FACTORY": "backend.web.core.supabase_factory:create_supabase_client",
+    "LEON_DB_SCHEMA": "staging",
+    "SUPABASE_PUBLIC_URL": "https://supabase.mycel.nextmind.space",
+    "SUPABASE_INTERNAL_URL": "https://supabase.mycel.nextmind.space",
+    "SUPABASE_AUTH_URL": "https://supabase.mycel.nextmind.space/auth/v1",
+    "SUPABASE_ANON_KEY": "anon",
+    "LEON_SUPABASE_SERVICE_ROLE_KEY": "service-role",
+    "SUPABASE_JWT_SECRET": "jwt-secret",
+    "LEON_POSTGRES_URL": "postgresql://postgres:pw@127.0.0.1:5432/postgres",
+    "OPENAI_API_KEY": "sk-test",
+    "MYCEL_BACKEND_BASE_URL": "http://127.0.0.1:1",
+    "MYCEL_SMOKE_IDENTIFIER": "coder@example.com",
+    "MYCEL_SMOKE_PASSWORD": "pw-123456",
+}
+
+
+class _SmokeHandler(BaseHTTPRequestHandler):
+    agents_payload = {"items": [{"id": "agent-1", "name": "Toad"}]}
+    default_config_payload = {
+        "source": "derived",
+        "config": {
+            "create_mode": "new",
+            "provider_config": "local",
+            "sandbox_template_id": None,
+            "sandbox_template": None,
+        },
+    }
+
+    def _write_json(self, status: int, payload: dict[str, object]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/api/auth/login":
+            self._write_json(404, {"detail": "not found"})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        if payload != {"identifier": "coder@example.com", "password": "pw-123456"}:
+            self._write_json(401, {"detail": "bad credentials"})
+            return
+        self._write_json(200, {"token": "tok-1"})
+
+    def do_GET(self) -> None:  # noqa: N802
+        auth_header = self.headers.get("Authorization")
+        if auth_header != "Bearer tok-1":
+            self._write_json(401, {"detail": "missing bearer"})
+            return
+        if self.path == "/api/panel/agents":
+            self._write_json(200, type(self).agents_payload)
+            return
+        if self.path == "/api/threads/default-config?agent_user_id=agent-1":
+            self._write_json(200, type(self).default_config_payload)
+            return
+        self._write_json(404, {"detail": "not found"})
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+
+class CheckDevValidityScriptTests(unittest.TestCase):
+    def _run_script(self, extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        env = {"PATH": os.environ["PATH"], "HOME": os.environ.get("HOME", "")}
+        env.update(extra_env)
+        return subprocess.run(
+            [str(SCRIPT)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_fails_loudly_when_required_env_is_missing(self) -> None:
+        result = self._run_script({})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required environment variables", result.stderr)
+        self.assertIn("LEON_STORAGE_STRATEGY", result.stderr)
+        self.assertIn("MYCEL_BACKEND_BASE_URL", result.stderr)
+
+    def test_fails_when_owner_has_no_agents_for_default_config_probe(self) -> None:
+        class EmptyAgentHandler(_SmokeHandler):
+            agents_payload = {"items": []}
+
+        with ThreadingHTTPServer(("127.0.0.1", 0), EmptyAgentHandler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                result = self._run_script(
+                    {
+                        **REQUIRED_ENV,
+                        "MYCEL_BACKEND_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    }
+                )
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("/api/panel/agents returned no owned agents", result.stderr)
+
+    def test_passes_when_real_smoke_sequence_succeeds(self) -> None:
+        with ThreadingHTTPServer(("127.0.0.1", 0), _SmokeHandler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                result = self._run_script(
+                    {
+                        **REQUIRED_ENV,
+                        "MYCEL_BACKEND_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    }
+                )
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("dev validity smoke passed", result.stdout)
+        self.assertIn("login ok", result.stdout)
+        self.assertIn("default-config ok", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a fail-loud `scripts/check-dev-validity.sh` smoke gate for shared `dev`
- add narrow unit coverage for missing env, empty agents, malformed `default-config`, and happy-path smoke flow
- align the smoke gate's `default-config` validation with the frontend launch-config parser
- keep lane narrative out of repo `docs/`; shared task artifact / Ledger internal notes carry the checkpoint story
- restack this lane cleanly onto `dev` so the PR tree only carries the mechanism slice

## Verification
- `bash -n scripts/check-dev-validity.sh`
- `uv run python -m unittest tests.Unit.scripts.test_check_dev_validity`
- live smoke on local backend `127.0.0.1:8017`:
  - `login ok`
  - `panel agents ok: m_dKjuBBLbR1bw`
  - `default-config ok`
  - `dev validity smoke passed`
- same live smoke also passes on a helper-started backend after fixing the private ops launcher path

## Notes
- smoke credential drift was repaired in private ops memory by rotating the documented full OTP account password and revalidating direct public GoTrue password grant
- the private ops backend helper now uses `uv run python -m uvicorn ...` because copied worktree console-script shebangs are not trustworthy
- shared task artifact has been updated with the blocker history, placement ruling, clean-stack correction, and the stricter frontend-aligned validation
- this PR is the `dev-validity-contract` mechanism slice, not runnable-closure proof by itself
