### PR TITLE
chore: add dev validity smoke gate

### DIFF
--- a/scripts/check-dev-validity.sh
+++ b/scripts/check-dev-validity.sh
@@ -78,6 +78,35 @@ def request_json(path: str, *, method: str, payload: dict[str, object] | None = 
     return parsed
 
 
+def _is_string_or_nullish(value: object) -> bool:
+    return value is None or isinstance(value, str)
+
+
+def has_frontend_valid_launch_config(payload: dict[str, object]) -> bool:
+    # @@@default-config-shape - keep smoke acceptance aligned with the frontend parser
+    # so this gate cannot pass a payload that `getDefaultThreadConfig()` would reject.
+    source = payload.get("source")
+    if source not in {"last_successful", "last_confirmed", "derived"}:
+        return False
+    config = payload.get("config")
+    if not isinstance(config, dict):
+        return False
+    create_mode = config.get("create_mode")
+    provider_config = config.get("provider_config")
+    sandbox_template = config.get("sandbox_template")
+    if create_mode not in {"new", "existing"}:
+        return False
+    if not isinstance(provider_config, str) or not provider_config:
+        return False
+    if sandbox_template is not None and not isinstance(sandbox_template, dict):
+        return False
+    return (
+        _is_string_or_nullish(config.get("existing_sandbox_id"))
+        and _is_string_or_nullish(config.get("model"))
+        and _is_string_or_nullish(config.get("workspace"))
+    )
+
+
 login = request_json(
     "/api/auth/login",
     method="POST",
@@ -107,9 +136,8 @@ default_config = request_json(
     method="GET",
     token=token,
 )
-config = default_config.get("config")
-if not isinstance(config, dict):
-    fail("/api/threads/default-config returned no config object")
+if not has_frontend_valid_launch_config(default_config):
+    fail("/api/threads/default-config returned malformed launch config")
 print("default-config ok")
 print("dev validity smoke passed")
 PY

--- a/scripts/check-dev-validity.sh
+++ b/scripts/check-dev-validity.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_env=(
+  LEON_STORAGE_STRATEGY
+  LEON_SUPABASE_CLIENT_FACTORY
+  LEON_DB_SCHEMA
+  SUPABASE_PUBLIC_URL
+  SUPABASE_INTERNAL_URL
+  SUPABASE_AUTH_URL
+  SUPABASE_ANON_KEY
+  LEON_SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_JWT_SECRET
+  LEON_POSTGRES_URL
+  MYCEL_BACKEND_BASE_URL
+  MYCEL_SMOKE_IDENTIFIER
+  MYCEL_SMOKE_PASSWORD
+)
+
+missing=()
+for key in "${required_env[@]}"; do
+  if [[ -z "${!key:-}" ]]; then
+    missing+=("$key")
+  fi
+done
+
+if [[ -z "${OPENAI_API_KEY:-}" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  missing+=("OPENAI_API_KEY|ANTHROPIC_API_KEY")
+fi
+
+if (( ${#missing[@]} > 0 )); then
+  printf 'Missing required environment variables:\n' >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+from urllib import error, parse, request
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+base_url = os.environ["MYCEL_BACKEND_BASE_URL"].rstrip("/")
+identifier = os.environ["MYCEL_SMOKE_IDENTIFIER"]
+password = os.environ["MYCEL_SMOKE_PASSWORD"]
+
+
+def request_json(path: str, *, method: str, payload: dict[str, object] | None = None, token: str | None = None) -> dict[str, object]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = request.Request(f"{base_url}{path}", data=body, method=method)
+    if payload is not None:
+        req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with request.urlopen(req, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").strip()
+        fail(f"{path} returned {exc.code}: {detail or '<empty body>'}")
+    except Exception as exc:  # noqa: BLE001
+        fail(f"{path} request failed: {exc}")
+
+    try:
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        fail(f"{path} returned non-JSON body: {exc}")
+    if not isinstance(parsed, dict):
+        fail(f"{path} returned non-object JSON")
+    return parsed
+
+
+login = request_json(
+    "/api/auth/login",
+    method="POST",
+    payload={"identifier": identifier, "password": password},
+)
+token = str(login.get("token") or "").strip()
+if not token:
+    fail("/api/auth/login returned no token")
+print("login ok")
+
+agents = request_json("/api/panel/agents", method="GET", token=token)
+items = agents.get("items")
+if not isinstance(items, list):
+    fail("/api/panel/agents returned no items list")
+if not items:
+    fail("/api/panel/agents returned no owned agents")
+first_agent = items[0]
+if not isinstance(first_agent, dict):
+    fail("/api/panel/agents first item is not an object")
+agent_user_id = str(first_agent.get("id") or "").strip()
+if not agent_user_id:
+    fail("/api/panel/agents first item has no id")
+print(f"panel agents ok: {agent_user_id}")
+
+default_config = request_json(
+    f"/api/threads/default-config?agent_user_id={parse.quote(agent_user_id, safe='')}",
+    method="GET",
+    token=token,
+)
+config = default_config.get("config")
+if not isinstance(config, dict):
+    fail("/api/threads/default-config returned no config object")
+print("default-config ok")
+print("dev validity smoke passed")
+PY

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -8,7 +8,6 @@ import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "scripts" / "check-dev-validity.sh"
 

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -121,6 +121,31 @@ class CheckDevValidityScriptTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("/api/panel/agents returned no owned agents", result.stderr)
 
+    def test_fails_when_default_config_payload_is_frontend_malformed(self) -> None:
+        class MalformedDefaultConfigHandler(_SmokeHandler):
+            default_config_payload = {
+                "config": {
+                    "provider_config": "local",
+                },
+            }
+
+        with ThreadingHTTPServer(("127.0.0.1", 0), MalformedDefaultConfigHandler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                result = self._run_script(
+                    {
+                        **REQUIRED_ENV,
+                        "MYCEL_BACKEND_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    }
+                )
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("/api/threads/default-config returned malformed launch config", result.stderr)
+
     def test_passes_when_real_smoke_sequence_succeeds(self) -> None:
         with ThreadingHTTPServer(("127.0.0.1", 0), _SmokeHandler) as server:
             thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "check-dev-validity.sh"
+
+
+REQUIRED_ENV = {
+    "LEON_STORAGE_STRATEGY": "supabase",
+    "LEON_SUPABASE_CLIENT_FACTORY": "backend.web.core.supabase_factory:create_supabase_client",
+    "LEON_DB_SCHEMA": "staging",
+    "SUPABASE_PUBLIC_URL": "https://supabase.mycel.nextmind.space",
+    "SUPABASE_INTERNAL_URL": "https://supabase.mycel.nextmind.space",
+    "SUPABASE_AUTH_URL": "https://supabase.mycel.nextmind.space/auth/v1",
+    "SUPABASE_ANON_KEY": "anon",
+    "LEON_SUPABASE_SERVICE_ROLE_KEY": "service-role",
+    "SUPABASE_JWT_SECRET": "jwt-secret",
+    "LEON_POSTGRES_URL": "postgresql://postgres:pw@127.0.0.1:5432/postgres",
+    "OPENAI_API_KEY": "sk-test",
+    "MYCEL_BACKEND_BASE_URL": "http://127.0.0.1:1",
+    "MYCEL_SMOKE_IDENTIFIER": "coder@example.com",
+    "MYCEL_SMOKE_PASSWORD": "pw-123456",
+}
+
+
+class _SmokeHandler(BaseHTTPRequestHandler):
+    agents_payload = {"items": [{"id": "agent-1", "name": "Toad"}]}
+    default_config_payload = {
+        "source": "derived",
+        "config": {
+            "create_mode": "new",
+            "provider_config": "local",
+            "sandbox_template_id": None,
+            "sandbox_template": None,
+        },
+    }
+
+    def _write_json(self, status: int, payload: dict[str, object]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/api/auth/login":
+            self._write_json(404, {"detail": "not found"})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        if payload != {"identifier": "coder@example.com", "password": "pw-123456"}:
+            self._write_json(401, {"detail": "bad credentials"})
+            return
+        self._write_json(200, {"token": "tok-1"})
+
+    def do_GET(self) -> None:  # noqa: N802
+        auth_header = self.headers.get("Authorization")
+        if auth_header != "Bearer tok-1":
+            self._write_json(401, {"detail": "missing bearer"})
+            return
+        if self.path == "/api/panel/agents":
+            self._write_json(200, type(self).agents_payload)
+            return
+        if self.path == "/api/threads/default-config?agent_user_id=agent-1":
+            self._write_json(200, type(self).default_config_payload)
+            return
+        self._write_json(404, {"detail": "not found"})
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+
+class CheckDevValidityScriptTests(unittest.TestCase):
+    def _run_script(self, extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        env = {"PATH": os.environ["PATH"], "HOME": os.environ.get("HOME", "")}
+        env.update(extra_env)
+        return subprocess.run(
+            [str(SCRIPT)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_fails_loudly_when_required_env_is_missing(self) -> None:
+        result = self._run_script({})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required environment variables", result.stderr)
+        self.assertIn("LEON_STORAGE_STRATEGY", result.stderr)
+        self.assertIn("MYCEL_BACKEND_BASE_URL", result.stderr)
+
+    def test_fails_when_owner_has_no_agents_for_default_config_probe(self) -> None:
+        class EmptyAgentHandler(_SmokeHandler):
+            agents_payload = {"items": []}
+
+        with ThreadingHTTPServer(("127.0.0.1", 0), EmptyAgentHandler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                result = self._run_script(
+                    {
+                        **REQUIRED_ENV,
+                        "MYCEL_BACKEND_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    }
+                )
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("/api/panel/agents returned no owned agents", result.stderr)
+
+    def test_passes_when_real_smoke_sequence_succeeds(self) -> None:
+        with ThreadingHTTPServer(("127.0.0.1", 0), _SmokeHandler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                result = self._run_script(
+                    {
+                        **REQUIRED_ENV,
+                        "MYCEL_BACKEND_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    }
+                )
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("dev validity smoke passed", result.stdout)
+        self.assertIn("login ok", result.stdout)
+        self.assertIn("default-config ok", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import threading
 import unittest
@@ -82,8 +83,11 @@ class CheckDevValidityScriptTests(unittest.TestCase):
     def _run_script(self, extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         env = {"PATH": os.environ["PATH"], "HOME": os.environ.get("HOME", "")}
         env.update(extra_env)
+        command = [str(SCRIPT)]
+        if os.name == "nt":
+            command = [shutil.which("bash") or "bash", str(SCRIPT)]
         return subprocess.run(
-            [str(SCRIPT)],
+            command,
             cwd=ROOT,
             env=env,
             text=True,


### PR DESCRIPTION
## Summary
- add a fail-loud `scripts/check-dev-validity.sh` smoke gate for shared `dev`
- add narrow unit coverage for missing env, empty agents, malformed `default-config`, and happy-path smoke flow
- align the smoke gate's `default-config` validation with the frontend launch-config parser

## Verification
- `uv run ruff check tests/Unit/scripts/test_check_dev_validity.py`
- `uv run ruff format --check tests/Unit/scripts/test_check_dev_validity.py`
- `uv run python -m pytest tests/Unit/scripts/test_check_dev_validity.py -q`
