### PR TITLE
fix: reuse openai runtime clients across configurable model calls

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -25,6 +25,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import SystemMessage
 
@@ -269,6 +270,8 @@ class LeonAgent:
             self.workspace_root.mkdir(parents=True, exist_ok=True)
 
         # Initialize model
+        self._model_http_client: httpx.Client | None = None
+        self._model_http_async_client: httpx.AsyncClient | None = None
         self.model = self._create_model()
 
         # Store current model config for per-request override via configurable_fields
@@ -366,6 +369,7 @@ class LeonAgent:
 
         # Wire CleanupRegistry for priority-ordered resource teardown
         self._cleanup_registry = CleanupRegistry()
+        self._cleanup_registry.register(self._cleanup_model_clients, priority=1)
         self._cleanup_registry.register(self._cleanup_sandbox, priority=2)
         self._cleanup_registry.register(self._mark_terminated, priority=3)
         self._cleanup_registry.register(self._cleanup_mcp_client, priority=4)
@@ -727,13 +731,32 @@ class LeonAgent:
         Uses configurable_fields so model/provider/api_key/base_url can be
         overridden per-request via LangGraph config without rebuilding the graph.
         """
-        kwargs = normalize_model_kwargs(self.model_name, self._build_model_kwargs())
+        kwargs = self._build_model_kwargs()
+        kwargs.update(self._build_openai_http_clients(kwargs.get("model_provider")))
+        kwargs = normalize_model_kwargs(self.model_name, kwargs)
         return init_chat_model(
             self.model_name,
             api_key=self.api_key,
             configurable_fields=("model", "model_provider", "api_key", "base_url"),
             **kwargs,
         )
+
+    def _build_openai_http_clients(self, provider: str | None) -> dict[str, Any]:
+        if provider != "openai":
+            return {}
+
+        # @@@configurable-openai-client-reuse - LangChain's configurable model
+        # rebuilds the concrete ChatOpenAI on each invoke. Reuse explicit httpx
+        # clients so provider traffic does not inherit process proxies and does
+        # not churn a fresh transport pool per call.
+        if self._model_http_client is None:
+            self._model_http_client = httpx.Client(trust_env=False)
+        if self._model_http_async_client is None:
+            self._model_http_async_client = httpx.AsyncClient(trust_env=False)
+        return {
+            "http_client": self._model_http_client,
+            "http_async_client": self._model_http_async_client,
+        }
 
     def _create_extraction_model(self):
         """Create a small model for WebFetch AI extraction (leon:mini)."""
@@ -911,6 +934,17 @@ class LeonAgent:
         finally:
             self._closed = True
             self._closing = False
+
+    async def _cleanup_model_clients(self) -> None:
+        async_client = getattr(self, "_model_http_async_client", None)
+        sync_client = getattr(self, "_model_http_client", None)
+        self._model_http_async_client = None
+        self._model_http_client = None
+
+        if async_client is not None:
+            await async_client.aclose()
+        if sync_client is not None:
+            await asyncio.to_thread(sync_client.close)
 
     def _build_session_hook_payload(self, event: str) -> dict[str, Any]:
         return {

--- a/tests/Unit/core/test_agent_model_clients.py
+++ b/tests/Unit/core/test_agent_model_clients.py
@@ -1,0 +1,70 @@
+from typing import Any, cast
+
+import pytest
+
+from core.runtime.agent import LeonAgent
+
+
+class _RuntimeModelProbe:
+    def __init__(self) -> None:
+        self.model_name = "gpt-5.4"
+        self.api_key = "sk-test"
+        self._model_http_client = None
+        self._model_http_async_client = None
+
+    def _build_model_kwargs(self) -> dict[str, Any]:
+        return {
+            "model_provider": "openai",
+            "base_url": "http://provider.test/v1",
+            "stream_usage": True,
+        }
+
+    def _build_openai_http_clients(self, provider: str | None) -> dict[str, Any]:
+        return LeonAgent._build_openai_http_clients(cast(Any, self), provider)
+
+
+def test_runtime_model_uses_persistent_openai_http_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_init_chat_model(model_name: str, **kwargs: Any) -> object:
+        calls.append((model_name, kwargs))
+        return object()
+
+    monkeypatch.setattr("core.runtime.agent.init_chat_model", fake_init_chat_model)
+
+    agent = _RuntimeModelProbe()
+
+    LeonAgent._create_model(cast(Any, agent))
+
+    assert len(calls) == 1
+    model_name, kwargs = calls[0]
+    assert model_name == "gpt-5.4"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["configurable_fields"] == ("model", "model_provider", "api_key", "base_url")
+    assert kwargs["http_client"]._trust_env is False
+    assert kwargs["http_async_client"]._trust_env is False
+    assert agent._model_http_client is kwargs["http_client"]
+    assert agent._model_http_async_client is kwargs["http_async_client"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_model_client_cleanup_closes_both_clients() -> None:
+    events: list[str] = []
+
+    class _SyncClient:
+        def close(self) -> None:
+            events.append("sync")
+
+    class _AsyncClient:
+        async def aclose(self) -> None:
+            events.append("async")
+
+    agent = cast(Any, object.__new__(LeonAgent))
+    agent._model_http_client = _SyncClient()
+    agent._model_http_async_client = _AsyncClient()
+
+    await LeonAgent._cleanup_model_clients(agent)
+
+    assert events == ["async", "sync"]
+    assert agent._model_http_client is None
+    assert agent._model_http_async_client is None


### PR DESCRIPTION
## Summary
- reuse openai runtime clients across configurable model calls to avoid rebuilding per-call clients on the live runnable path
- add focused runtime client coverage in `tests/Unit/core/test_agent_model_clients.py`
- record that current `dev` runnable closure is proven separately through real API and Playwright YATU evidence

## Test Plan
- [x] `uv run python -m pytest tests/Unit/core/test_agent_model_clients.py -q`
- [x] real API proof: login -> panel agents -> default-config -> fresh thread create -> message send -> final assistant reply `RC-OK-2`
- [x] Playwright CLI proof: login -> open thread -> browser send -> final assistant reply `BROWSER-OK-1`
- [x] `git diff --check origin/dev...HEAD`
