### PR TITLE
fix: preserve supabase schema-scoped postgrest clients

### DIFF
--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -17,12 +17,46 @@ def validate_client(client: Any, repo: str) -> Any:
     return client
 
 
+def _preserve_postgrest_session(client: Any, schema: str) -> Any | None:
+    postgrest = getattr(client, "postgrest", None)
+    if postgrest is None:
+        return None
+    session = getattr(postgrest, "session", None)
+    client_class = getattr(postgrest, "__class__", None)
+    base_url = getattr(postgrest, "base_url", None)
+    headers = getattr(postgrest, "headers", None)
+    if session is None or client_class is None or base_url is None or headers is None:
+        return None
+
+    # @@@preserve-schema-session - postgrest-py schema() reconstructs a fresh httpx client
+    # and drops any injected trust_env=False session; keep the original transport when scoping.
+    try:
+        scoped = client_class(
+            base_url=str(base_url),
+            schema=schema,
+            headers=dict(headers),
+            http_client=session,
+        )
+        if hasattr(postgrest, "timeout"):
+            scoped.timeout = postgrest.timeout
+        if hasattr(postgrest, "verify"):
+            scoped.verify = postgrest.verify
+        if hasattr(postgrest, "proxy"):
+            scoped.proxy = postgrest.proxy
+        return scoped
+    except TypeError:
+        return None
+
+
 def schema_table(client: Any, schema: str, table: str, repo: str) -> Any:
     """Return a schema-qualified table query root, failing loudly if unsupported."""
+    scoped = _preserve_postgrest_session(client, schema)
     schema_method = getattr(client, "schema", None)
-    if not callable(schema_method):
+    if scoped is None and not callable(schema_method):
         raise RuntimeError(f"Supabase {repo} requires client.schema({schema!r}) support for {schema}.{table}.")
-    scoped = schema_method(schema)
+    if scoped is None:
+        assert callable(schema_method)
+        scoped = schema_method(schema)
     table_method = getattr(scoped, "table", None)
     if not callable(table_method):
         raise RuntimeError(f"Supabase {repo} schema({schema!r}) result must expose table(name).")

--- a/tests/Unit/storage/test_supabase_query_helpers.py
+++ b/tests/Unit/storage/test_supabase_query_helpers.py
@@ -1,4 +1,6 @@
+import httpx
 import pytest
+from postgrest import SyncPostgrestClient
 
 from storage.providers.supabase import _query as q
 
@@ -22,6 +24,17 @@ class _Query:
     def execute(self):
         column, values = self.in_calls[-1]
         return _Response([row for row in self._rows if row.get(column) in values])
+
+
+class _SupabaseStyleClient:
+    def __init__(self, postgrest_client: SyncPostgrestClient):
+        self.postgrest = postgrest_client
+
+    def schema(self, schema: str):
+        return self.postgrest.schema(schema)
+
+    def table(self, table: str):
+        return self.postgrest.table(table)
 
 
 def test_rows_in_chunks_splits_large_in_filters() -> None:
@@ -62,3 +75,22 @@ def test_execute_in_chunks_splits_large_in_filters() -> None:
     q.execute_in_chunks(make_query, "id", [f"item-{index}" for index in range(175)], "test repo", "delete")
 
     assert [len(query.in_calls[0][1]) for query in queries] == [80, 80, 15]
+
+
+def test_schema_table_preserves_injected_postgrest_http_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALL_PROXY", "socks5://127.0.0.1:1")
+
+    session = httpx.Client(trust_env=False)
+    client = _SupabaseStyleClient(
+        SyncPostgrestClient(
+            "http://example.test",
+            schema="public",
+            http_client=session,
+        )
+    )
+
+    query = q.schema_table(client, "agent", "threads", "test repo")
+
+    assert query.session is session
+    assert str(query.path) == "http://example.test/threads"
+    assert query.headers["accept-profile"] == "agent"


### PR DESCRIPTION
## Summary
- preserve the injected PostgREST `http_client`/session when schema-scoping Supabase repos instead of calling the library path that reconstructs a fresh transport
- add a regression test that reproduces the schema-hop failure under proxy-influenced env and proves the original session survives
- keep the fix constrained to `storage/providers/supabase/_query.py` so thread/tool-task/schedule repos inherit it without widening product behavior

## Test Plan
- `uv run python -m pytest tests/Unit/storage/test_supabase_query_helpers.py -q`
- `uv run python -m pytest tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/storage/test_supabase_tool_task_repo.py tests/Unit/core/test_supabase_factory.py -q`
- frontend YATU on isolated brother stack `8017/5189` with latest `origin/dev` base + this commit:
  - `/chat -> 新建对话 -> Agent1775591401`
  - created new thread `m_dKjuBBLbR1bw-212`
  - sent `Reply exactly SCHEMA_FIX_OK_1776176508778`
  - final UI rendered exact assistant token `SCHEMA_FIX_OK_1776176508778`
  - evidence: `schema-fix-final.yaml`
