### PR TITLE
feat: land thin workspace repo contract

### DIFF
--- a/storage/container.py
+++ b/storage/container.py
@@ -31,6 +31,7 @@ from .contracts import (
     ToolTaskRepo,
     UserRepo,
     UserSettingsRepo,
+    WorkspaceRepo,
 )
 
 _REPO_REGISTRY: dict[str, tuple[str, str]] = {
@@ -54,6 +55,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "user_repo": ("storage.providers.supabase.user_repo", "SupabaseUserRepo"),
     "thread_repo": ("storage.providers.supabase.thread_repo", "SupabaseThreadRepo"),
     "thread_launch_pref_repo": ("storage.providers.supabase.thread_launch_pref_repo", "SupabaseThreadLaunchPrefRepo"),
+    "workspace_repo": ("storage.providers.supabase.workspace_repo", "SupabaseWorkspaceRepo"),
     "recipe_repo": ("storage.providers.supabase.recipe_repo", "SupabaseRecipeRepo"),
     "chat_repo": ("storage.providers.supabase.chat_repo", "SupabaseChatRepo"),
     "invite_code_repo": ("storage.providers.supabase.invite_code_repo", "SupabaseInviteCodeRepo"),
@@ -136,6 +138,9 @@ class StorageContainer:
 
     def thread_launch_pref_repo(self) -> ThreadLaunchPrefRepo:
         return self._build("thread_launch_pref_repo")
+
+    def workspace_repo(self) -> WorkspaceRepo:
+        return self._build("workspace_repo")
 
     def recipe_repo(self) -> RecipeRepo:
         return self._build("recipe_repo")

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -296,6 +296,23 @@ class ThreadRow(BaseModel):
         return value
 
 
+class WorkspaceRow(BaseModel):
+    id: str
+    sandbox_id: str
+    owner_user_id: str
+    workspace_path: str
+    name: str | None = None
+    created_at: float | str
+    updated_at: float | str | None = None
+
+    @field_validator("id", "sandbox_id", "owner_user_id", "workspace_path")
+    @classmethod
+    def _validate_non_blank(cls, value: str, info: Any) -> str:
+        if not value.strip():
+            raise ValueError(f"workspace.{info.field_name} must not be blank")
+        return value
+
+
 class ChatRow(BaseModel):
     id: str
     type: str
@@ -769,6 +786,13 @@ class ChatRepo(Protocol):
     def get_by_id(self, chat_id: str) -> ChatRow | None: ...
     def list_by_ids(self, chat_ids: list[str]) -> list[ChatRow]: ...
     def delete(self, chat_id: str) -> None: ...
+
+
+class WorkspaceRepo(Protocol):
+    def close(self) -> None: ...
+    def create(self, row: WorkspaceRow) -> None: ...
+    def get_by_id(self, workspace_id: str) -> WorkspaceRow | None: ...
+    def list_by_sandbox_id(self, sandbox_id: str) -> list[WorkspaceRow]: ...
 
 
 class ThreadRepo(Protocol):

--- a/storage/providers/supabase/workspace_repo.py
+++ b/storage/providers/supabase/workspace_repo.py
@@ -1,0 +1,76 @@
+"""Supabase repository for container workspaces."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from storage.contracts import WorkspaceRow
+from storage.providers.supabase import _query as q
+
+_REPO = "workspace repo"
+_SCHEMA = "container"
+_TABLE = "workspaces"
+_COLS = (
+    "id",
+    "sandbox_id",
+    "owner_user_id",
+    "workspace_path",
+    "name",
+    "created_at",
+    "updated_at",
+)
+
+
+def _to_timestamptz(value: float | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return datetime.fromtimestamp(value, UTC).isoformat()
+
+
+def _to_row(row: dict[str, Any]) -> WorkspaceRow:
+    return WorkspaceRow(
+        id=str(row["id"]),
+        sandbox_id=str(row["sandbox_id"]),
+        owner_user_id=str(row["owner_user_id"]),
+        workspace_path=str(row["workspace_path"]),
+        name=row.get("name"),
+        created_at=row["created_at"],
+        updated_at=row.get("updated_at"),
+    )
+
+
+class SupabaseWorkspaceRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
+
+    def create(self, row: WorkspaceRow) -> None:
+        created_at = _to_timestamptz(row.created_at)
+        self._t().insert(
+            {
+                "id": row.id,
+                "sandbox_id": row.sandbox_id,
+                "owner_user_id": row.owner_user_id,
+                "workspace_path": row.workspace_path,
+                "name": row.name,
+                "created_at": created_at,
+                "updated_at": _to_timestamptz(row.updated_at) or created_at,
+            }
+        ).execute()
+
+    def get_by_id(self, workspace_id: str) -> WorkspaceRow | None:
+        response = self._t().select(", ".join(_COLS)).eq("id", workspace_id).execute()
+        rows = q.rows(response, _REPO, "get_by_id")
+        return _to_row(rows[0]) if rows else None
+
+    def list_by_sandbox_id(self, sandbox_id: str) -> list[WorkspaceRow]:
+        response = self._t().select(", ".join(_COLS)).eq("sandbox_id", sandbox_id).execute()
+        return [_to_row(row) for row in q.rows(response, _REPO, "list_by_sandbox_id")]

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -61,6 +61,10 @@ def build_thread_repo(*, supabase_client: Any | None = None, supabase_client_fac
     return _build_storage_repo("thread_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
+def build_workspace_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo("workspace_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
+
+
 def build_user_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
     return _build_storage_repo("user_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -165,3 +165,37 @@ def test_service_does_not_import_legacy_runtime_glue() -> None:
     assert "chat_session" not in source
     assert "sandbox_volume" not in source
     assert "sync_file" not in source
+
+
+def test_resolves_binding_with_thin_workspace_shape() -> None:
+    binding = resolve_thread_runtime_binding(
+        **_repos(
+            thread=_thread(),
+            workspace={
+                "id": "workspace-1",
+                "owner_user_id": "owner-1",
+                "sandbox_id": "sandbox-1",
+                "workspace_path": "/workspace",
+            },
+            sandbox=_sandbox(),
+        ),
+        thread_id="thread-1",
+        owner_user_id="owner-1",
+    )
+
+    assert binding.workspace_id == "workspace-1"
+    assert binding.workspace_path == "/workspace"
+    assert binding.workspace_status is None
+    assert binding.workspace_desired_state is None
+    assert binding.workspace_observed_state is None
+
+
+def test_workspace_without_workspace_path_fails_loudly() -> None:
+    with pytest.raises(ThreadRuntimeBindingError) as excinfo:
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(), workspace=_workspace(workspace_path=None), sandbox=_sandbox()),
+            thread_id="thread-1",
+            owner_user_id="owner-1",
+        )
+
+    assert "workspace_path" in str(excinfo.value)

--- a/tests/Unit/storage/test_supabase_workspace_repo.py
+++ b/tests/Unit/storage/test_supabase_workspace_repo.py
@@ -1,0 +1,67 @@
+from storage.contracts import WorkspaceRow
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.insert_payload = None
+        self.rows: list[dict] = []
+        self.eq_calls: list[tuple[str, object]] = []
+
+    def insert(self, payload):
+        self.insert_payload = payload
+        return self
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, key, value):
+        self.eq_calls.append((key, value))
+        return self
+
+    def execute(self):
+        rows = self.rows
+        for key, value in self.eq_calls:
+            rows = [row for row in rows if row.get(key) == value]
+        return type("Resp", (), {"data": rows})()
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.table_obj = _FakeTable()
+
+    def schema(self, _name):
+        return self
+
+    def table(self, _name):
+        return self.table_obj
+
+
+def test_supabase_workspace_repo_create_writes_container_shape() -> None:
+    from storage.providers.supabase.workspace_repo import SupabaseWorkspaceRepo
+
+    client = _FakeClient()
+    repo = SupabaseWorkspaceRepo(client)
+
+    repo.create(
+        WorkspaceRow(
+            id="workspace-1",
+            sandbox_id="sandbox-1",
+            owner_user_id="owner-1",
+            workspace_path="/workspace/demo",
+            name="demo",
+            created_at=1.0,
+            updated_at=2.0,
+        )
+    )
+
+    assert client.table_obj.insert_payload["id"] == "workspace-1"
+    assert client.table_obj.insert_payload["workspace_path"] == "/workspace/demo"
+
+
+def test_supabase_workspace_repo_get_by_id_returns_none_when_missing() -> None:
+    from storage.providers.supabase.workspace_repo import SupabaseWorkspaceRepo
+
+    client = _FakeClient()
+    repo = SupabaseWorkspaceRepo(client)
+
+    assert repo.get_by_id("missing") is None

--- a/tests/Unit/storage/test_workspace_identity_contract.py
+++ b/tests/Unit/storage/test_workspace_identity_contract.py
@@ -1,0 +1,39 @@
+import pytest
+
+from storage.contracts import WorkspaceRow
+
+
+def test_workspace_row_accepts_thin_directory_shape() -> None:
+    row = WorkspaceRow(
+        id="workspace-1",
+        sandbox_id="sandbox-1",
+        owner_user_id="owner-1",
+        workspace_path="/workspace/demo",
+        name="demo",
+        created_at=1.0,
+        updated_at=2.0,
+    )
+
+    assert row.workspace_path == "/workspace/demo"
+
+
+def test_workspace_row_requires_non_blank_identity_fields() -> None:
+    with pytest.raises(ValueError, match="workspace.id must not be blank"):
+        WorkspaceRow(
+            id="   ",
+            sandbox_id="sandbox-1",
+            owner_user_id="owner-1",
+            workspace_path="/workspace/demo",
+            created_at=1.0,
+        )
+
+
+def test_workspace_row_requires_non_blank_workspace_path() -> None:
+    with pytest.raises(ValueError, match="workspace.workspace_path must not be blank"):
+        WorkspaceRow(
+            id="workspace-1",
+            sandbox_id="sandbox-1",
+            owner_user_id="owner-1",
+            workspace_path="  ",
+            created_at=1.0,
+        )

--- a/tests/Unit/storage/test_workspace_runtime_wiring.py
+++ b/tests/Unit/storage/test_workspace_runtime_wiring.py
@@ -1,0 +1,25 @@
+from storage.container import StorageContainer
+from storage.runtime import build_storage_container, build_workspace_repo
+
+
+class _FakeClient:
+    def table(self, _name):
+        raise AssertionError("table() should not be touched during wiring-only tests")
+
+
+def test_storage_container_exposes_workspace_repo() -> None:
+    container = StorageContainer(supabase_client=_FakeClient())
+
+    assert container.workspace_repo().__class__.__name__ == "SupabaseWorkspaceRepo"
+
+
+def test_runtime_builder_exposes_workspace_repo() -> None:
+    repo = build_workspace_repo(supabase_client=_FakeClient())
+
+    assert repo.__class__.__name__ == "SupabaseWorkspaceRepo"
+
+
+def test_build_storage_container_exposes_workspace_repo() -> None:
+    container = build_storage_container(supabase_client=_FakeClient())
+
+    assert container.workspace_repo().__class__.__name__ == "SupabaseWorkspaceRepo"


### PR DESCRIPTION
## Summary
- add a thin `WorkspaceRow` / `WorkspaceRepo` contract and Supabase implementation for `container.workspaces`
- wire `workspace_repo` through storage container/runtime composition without widening create/default-config cutover scope
- add focused contract tests for workspace identity, repo wiring, and runtime binding against the thin workspace shape

## Test Plan
- uv run python -m pytest tests/Unit/storage/test_workspace_identity_contract.py tests/Unit/storage/test_supabase_workspace_repo.py tests/Unit/storage/test_workspace_runtime_wiring.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py -q
- git diff --check origin/dev...HEAD