### PR TITLE
feat: cut thread create path to workspace ids

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import time
 import uuid
 from datetime import UTC
 from typing import Annotated, Any
@@ -60,6 +61,7 @@ from sandbox.config import MountSpec
 from sandbox.manager import bind_thread_to_existing_lease
 from sandbox.recipes import default_recipe_id, normalize_recipe_snapshot, provider_type_from_name
 from sandbox.thread_context import set_current_thread_id
+from storage.contracts import WorkspaceRow
 
 logger = logging.getLogger(__name__)
 
@@ -518,6 +520,9 @@ def _create_thread_sandbox_resources(
     sandbox_type: str,
     recipe: dict[str, Any] | None,
     cwd: str | None = None,
+    *,
+    workspace_repo: Any,
+    owner_user_id: str,
 ) -> str:
     """Create volume, lease, and terminal eagerly so volume exists before file uploads."""
     from datetime import datetime
@@ -575,7 +580,42 @@ def _create_thread_sandbox_resources(
         )
     finally:
         terminal_repo.close()
-    return lease_id
+    return _materialize_workspace_for_sandbox(
+        workspace_repo,
+        sandbox_id=lease_id,
+        owner_user_id=owner_user_id,
+        workspace_path=initial_cwd,
+    )
+
+
+def _materialize_workspace_for_sandbox(
+    workspace_repo: Any,
+    *,
+    sandbox_id: str,
+    owner_user_id: str,
+    workspace_path: str | None,
+) -> str:
+    normalized_path = str(workspace_path or "").strip() or "/workspace"
+    for row in workspace_repo.list_by_sandbox_id(sandbox_id):
+        if row.owner_user_id == owner_user_id and row.workspace_path == normalized_path:
+            return row.id
+
+    workspace_id = f"workspace-{uuid.uuid4().hex}"
+    now = time.time()
+    # @@@workspace-bridge-write - Phase 2 only cuts thread create writes to a real
+    # workspace row; sandbox identity can stay lease-backed until container.sandboxes lands.
+    workspace_repo.create(
+        WorkspaceRow(
+            id=workspace_id,
+            sandbox_id=sandbox_id,
+            owner_user_id=owner_user_id,
+            workspace_path=normalized_path,
+            name=None,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    return workspace_id
 
 
 def _resolve_owned_recipe_snapshot(
@@ -648,11 +688,16 @@ def _create_owned_thread(
     branch_index = 0 if resolved_is_main else app.state.thread_repo.get_next_branch_index(agent_user_id)
 
     if selected_lease_id:
-        current_workspace_id = selected_lease_id
         bound_cwd = bind_thread_to_existing_lease(
             new_thread_id,
             selected_lease_id,
             cwd=payload.cwd,
+        )
+        current_workspace_id = _materialize_workspace_for_sandbox(
+            app.state.workspace_repo,
+            sandbox_id=str(owned_lease.get("sandbox_id") or owned_lease["lease_id"]),
+            owner_user_id=owner_user_id,
+            workspace_path=bound_cwd,
         )
     else:
         # @@@create-write-bridge-first - replay-13 requires supported create paths
@@ -663,6 +708,8 @@ def _create_owned_thread(
             sandbox_type,
             selected_recipe,
             payload.cwd,
+            workspace_repo=app.state.workspace_repo,
+            owner_user_id=owner_user_id,
         )
         bound_cwd = None
 

--- a/storage/container.py
+++ b/storage/container.py
@@ -31,6 +31,7 @@ from .contracts import (
     ToolTaskRepo,
     UserRepo,
     UserSettingsRepo,
+    WorkspaceRepo,
 )
 
 _REPO_REGISTRY: dict[str, tuple[str, str]] = {
@@ -54,6 +55,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "user_repo": ("storage.providers.supabase.user_repo", "SupabaseUserRepo"),
     "thread_repo": ("storage.providers.supabase.thread_repo", "SupabaseThreadRepo"),
     "thread_launch_pref_repo": ("storage.providers.supabase.thread_launch_pref_repo", "SupabaseThreadLaunchPrefRepo"),
+    "workspace_repo": ("storage.providers.supabase.workspace_repo", "SupabaseWorkspaceRepo"),
     "recipe_repo": ("storage.providers.supabase.recipe_repo", "SupabaseRecipeRepo"),
     "chat_repo": ("storage.providers.supabase.chat_repo", "SupabaseChatRepo"),
     "invite_code_repo": ("storage.providers.supabase.invite_code_repo", "SupabaseInviteCodeRepo"),
@@ -136,6 +138,9 @@ class StorageContainer:
 
     def thread_launch_pref_repo(self) -> ThreadLaunchPrefRepo:
         return self._build("thread_launch_pref_repo")
+
+    def workspace_repo(self) -> WorkspaceRepo:
+        return self._build("workspace_repo")
 
     def recipe_repo(self) -> RecipeRepo:
         return self._build("recipe_repo")

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -296,6 +296,23 @@ class ThreadRow(BaseModel):
         return value
 
 
+class WorkspaceRow(BaseModel):
+    id: str
+    sandbox_id: str
+    owner_user_id: str
+    workspace_path: str
+    name: str | None = None
+    created_at: float | str
+    updated_at: float | str | None = None
+
+    @field_validator("id", "sandbox_id", "owner_user_id", "workspace_path")
+    @classmethod
+    def _validate_non_blank(cls, value: str, info: Any) -> str:
+        if not value.strip():
+            raise ValueError(f"workspace.{info.field_name} must not be blank")
+        return value
+
+
 class ChatRow(BaseModel):
     id: str
     type: str
@@ -769,6 +786,13 @@ class ChatRepo(Protocol):
     def get_by_id(self, chat_id: str) -> ChatRow | None: ...
     def list_by_ids(self, chat_ids: list[str]) -> list[ChatRow]: ...
     def delete(self, chat_id: str) -> None: ...
+
+
+class WorkspaceRepo(Protocol):
+    def close(self) -> None: ...
+    def create(self, row: WorkspaceRow) -> None: ...
+    def get_by_id(self, workspace_id: str) -> WorkspaceRow | None: ...
+    def list_by_sandbox_id(self, sandbox_id: str) -> list[WorkspaceRow]: ...
 
 
 class ThreadRepo(Protocol):

--- a/storage/providers/supabase/workspace_repo.py
+++ b/storage/providers/supabase/workspace_repo.py
@@ -1,0 +1,76 @@
+"""Supabase repository for container workspaces."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from storage.contracts import WorkspaceRow
+from storage.providers.supabase import _query as q
+
+_REPO = "workspace repo"
+_SCHEMA = "container"
+_TABLE = "workspaces"
+_COLS = (
+    "id",
+    "sandbox_id",
+    "owner_user_id",
+    "workspace_path",
+    "name",
+    "created_at",
+    "updated_at",
+)
+
+
+def _to_timestamptz(value: float | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return datetime.fromtimestamp(value, UTC).isoformat()
+
+
+def _to_row(row: dict[str, Any]) -> WorkspaceRow:
+    return WorkspaceRow(
+        id=str(row["id"]),
+        sandbox_id=str(row["sandbox_id"]),
+        owner_user_id=str(row["owner_user_id"]),
+        workspace_path=str(row["workspace_path"]),
+        name=row.get("name"),
+        created_at=row["created_at"],
+        updated_at=row.get("updated_at"),
+    )
+
+
+class SupabaseWorkspaceRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
+
+    def create(self, row: WorkspaceRow) -> None:
+        created_at = _to_timestamptz(row.created_at)
+        self._t().insert(
+            {
+                "id": row.id,
+                "sandbox_id": row.sandbox_id,
+                "owner_user_id": row.owner_user_id,
+                "workspace_path": row.workspace_path,
+                "name": row.name,
+                "created_at": created_at,
+                "updated_at": _to_timestamptz(row.updated_at) or created_at,
+            }
+        ).execute()
+
+    def get_by_id(self, workspace_id: str) -> WorkspaceRow | None:
+        response = self._t().select(", ".join(_COLS)).eq("id", workspace_id).execute()
+        rows = q.rows(response, _REPO, "get_by_id")
+        return _to_row(rows[0]) if rows else None
+
+    def list_by_sandbox_id(self, sandbox_id: str) -> list[WorkspaceRow]:
+        response = self._t().select(", ".join(_COLS)).eq("sandbox_id", sandbox_id).execute()
+        return [_to_row(row) for row in q.rows(response, _REPO, "list_by_sandbox_id")]

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -61,6 +61,10 @@ def build_thread_repo(*, supabase_client: Any | None = None, supabase_client_fac
     return _build_storage_repo("thread_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
+def build_workspace_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo("workspace_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
+
+
 def build_user_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
     return _build_storage_repo("user_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -103,6 +103,19 @@ class _FakeRecipeRepo:
         return [row for (owner, _recipe_id), row in self.rows.items() if owner == owner_user_id]
 
 
+class _FakeWorkspaceRepo:
+    def __init__(self) -> None:
+        self.created: list[object] = []
+        self.by_sandbox_id: dict[str, list[object]] = {}
+
+    def list_by_sandbox_id(self, sandbox_id: str):
+        return list(self.by_sandbox_id.get(sandbox_id, []))
+
+    def create(self, row) -> None:
+        self.created.append(row)
+        self.by_sandbox_id.setdefault(row.sandbox_id, []).append(row)
+
+
 def _make_threads_app():
     return SimpleNamespace(
         state=SimpleNamespace(
@@ -110,6 +123,7 @@ def _make_threads_app():
             thread_repo=_FakeThreadRepo(),
             thread_launch_pref_repo=_FakeThreadLaunchPrefRepo(),
             recipe_repo=_FakeRecipeRepo(),
+            workspace_repo=_FakeWorkspaceRepo(),
             thread_sandbox={},
             thread_cwd={},
         )
@@ -894,6 +908,8 @@ async def test_create_thread_carries_recipe_snapshot_into_resources_and_successf
         "local",
         normalized_recipe,
         None,
+        workspace_repo=app.state.workspace_repo,
+        owner_user_id="owner-1",
     )
     save_successful.assert_called_once_with(
         app,

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -69,6 +69,19 @@ class _FakeThreadRepo:
         self.rows[kwargs["thread_id"]] = dict(kwargs)
 
 
+class _FakeWorkspaceRepo:
+    def __init__(self) -> None:
+        self.created: list[Any] = []
+        self.by_sandbox_id: dict[str, list[Any]] = {}
+
+    def list_by_sandbox_id(self, sandbox_id: str) -> list[Any]:
+        return list(self.by_sandbox_id.get(sandbox_id, []))
+
+    def create(self, row: Any) -> None:
+        self.created.append(row)
+        self.by_sandbox_id.setdefault(row.sandbox_id, []).append(row)
+
+
 class _FakeAuthService:
     def __init__(self) -> None:
         self.tokens: list[str] = []
@@ -338,6 +351,7 @@ def _make_threads_app(
             user_repo=state_overrides.pop("user_repo", _FakeUserRepo()),
             thread_repo=thread_repo or _FakeThreadRepo(),
             recipe_repo=state_overrides.pop("recipe_repo", _FakeRecipeRepo()),
+            workspace_repo=state_overrides.pop("workspace_repo", _FakeWorkspaceRepo()),
             **state_overrides,
         )
     )
@@ -458,8 +472,9 @@ async def test_create_thread_route_uses_canonical_existing_lease_binding_helper(
 
 
 @pytest.mark.asyncio
-async def test_create_thread_route_persists_current_workspace_id_for_existing_lease() -> None:
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={})
+async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -472,7 +487,13 @@ async def test_create_thread_route_persists_current_workspace_id_for_existing_le
         patch.object(
             threads_router.sandbox_service,
             "resolve_owned_lease",
-            return_value={"lease_id": "lease-1", "provider_name": "local", "recipe": None},
+            return_value={
+                "lease_id": "lease-1",
+                "sandbox_id": "sandbox-1",
+                "provider_name": "local",
+                "cwd": "/workspace/reused",
+                "recipe": None,
+            },
         ),
         patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
         patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
@@ -482,12 +503,14 @@ async def test_create_thread_route_persists_current_workspace_id_for_existing_le
         created = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
 
     row = app.state.thread_repo.rows[created["thread_id"]]
-    assert row["current_workspace_id"] == "lease-1"
+    assert len(workspace_repo.created) == 1
+    assert row["current_workspace_id"] == workspace_repo.created[0].id
 
 
 @pytest.mark.asyncio
 async def test_create_thread_route_passes_local_cwd_into_sandbox_bootstrap():
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={})
+    workspace_repo = _FakeWorkspaceRepo()
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -503,12 +526,15 @@ async def test_create_thread_route_passes_local_cwd_into_sandbox_bootstrap():
         "local",
         default_recipe_snapshot("local"),
         "/tmp/fresh-local-thread",
+        workspace_repo=workspace_repo,
+        owner_user_id="owner-1",
     )
 
 
 @pytest.mark.asyncio
-async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox_bridge() -> None:
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={})
+async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -520,7 +546,7 @@ async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox
         patch.object(threads_router, "_validate_sandbox_provider_gate", return_value=None),
         patch.object(threads_router, "_validate_sandbox_quota_gate", return_value=None),
         patch.object(threads_router, "_validate_mount_capability_gate", return_value=None),
-        patch.object(threads_router, "_create_thread_sandbox_resources", return_value="lease-new") as create_resources,
+        patch.object(threads_router, "_create_thread_sandbox_resources", return_value="workspace-new") as create_resources,
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", return_value=None),
     ):
@@ -531,9 +557,71 @@ async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox
         "local",
         default_recipe_snapshot("local"),
         "/tmp/fresh-local-thread",
+        workspace_repo=workspace_repo,
+        owner_user_id="owner-1",
     )
     row = app.state.thread_repo.rows[created["thread_id"]]
-    assert row["current_workspace_id"] == "lease-new"
+    assert row["current_workspace_id"] == "workspace-new"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_route_existing_sandbox_still_saves_existing_launch_config() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
+    payload = CreateThreadRequest.model_validate(
+        {
+            "agent_user_id": "agent-user-1",
+            "existing_sandbox_id": "lease-1",
+            "cwd": "/workspace/reused",
+        }
+    )
+    save_config = MagicMock()
+
+    with (
+        patch.object(
+            threads_router.sandbox_service,
+            "resolve_owned_lease",
+            return_value={
+                "lease_id": "lease-1",
+                "sandbox_id": "sandbox-1",
+                "provider_name": "local",
+                "cwd": "/workspace/reused",
+                "recipe": {"id": "local:default"},
+            },
+        ),
+        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
+        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", save_config),
+    ):
+        await threads_router.create_thread(payload, "owner-1", app)
+
+    assert save_config.call_args.args[3]["create_mode"] == "existing"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_route_new_sandbox_still_saves_new_launch_config() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
+    payload = CreateThreadRequest.model_validate(
+        {
+            "agent_user_id": "agent-user-1",
+            "cwd": "/tmp/fresh-local-thread",
+        }
+    )
+    save_config = MagicMock()
+
+    with (
+        patch.object(threads_router, "_validate_sandbox_provider_gate", return_value=None),
+        patch.object(threads_router, "_validate_sandbox_quota_gate", return_value=None),
+        patch.object(threads_router, "_validate_mount_capability_gate", return_value=None),
+        patch.object(threads_router, "_create_thread_sandbox_resources", return_value="workspace-new"),
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", save_config),
+    ):
+        await threads_router.create_thread(payload, "owner-1", app)
+
+    assert save_config.call_args.args[3]["create_mode"] == "new"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/backend/web/routers/test_thread_resource_creation.py
+++ b/tests/Unit/backend/web/routers/test_thread_resource_creation.py
@@ -50,19 +50,24 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
     volume_repo = _VolumeRepo()
     lease_repo = _LeaseRepo()
     terminal_repo = _TerminalRepo()
+    workspace_repo = object()
 
     monkeypatch.setattr(helpers, "_get_container", lambda: _Container(volume_repo))
     monkeypatch.setattr("backend.web.core.config.SANDBOX_VOLUME_ROOT", tmp_path / "volumes")
     monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
     monkeypatch.setattr("storage.runtime.build_terminal_repo", lambda: terminal_repo)
+    monkeypatch.setattr(threads_router, "_materialize_workspace_for_sandbox", lambda *args, **kwargs: "workspace-1")
 
-    threads_router._create_thread_sandbox_resources(
+    workspace_id = threads_router._create_thread_sandbox_resources(
         "thread-1",
         "local",
         {"id": "local:default", "provider_name": "local", "provider_type": "local"},
         cwd="/tmp/workspace",
+        workspace_repo=workspace_repo,
+        owner_user_id="owner-1",
     )
 
+    assert workspace_id == "workspace-1"
     assert len(volume_repo.created) == 1
     assert len(lease_repo.created) == 1
     assert lease_repo.created[0]["provider_name"] == "local"
@@ -73,3 +78,27 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
     assert volume_repo.closed
     assert lease_repo.closed
     assert terminal_repo.closed
+
+
+def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_path):
+    volume_repo = _VolumeRepo()
+    lease_repo = _LeaseRepo()
+    terminal_repo = _TerminalRepo()
+    workspace_repo = object()
+
+    monkeypatch.setattr(helpers, "_get_container", lambda: _Container(volume_repo))
+    monkeypatch.setattr("backend.web.core.config.SANDBOX_VOLUME_ROOT", tmp_path / "volumes")
+    monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
+    monkeypatch.setattr("storage.runtime.build_terminal_repo", lambda: terminal_repo)
+    monkeypatch.setattr(threads_router, "_materialize_workspace_for_sandbox", lambda *args, **kwargs: "workspace-new")
+
+    workspace_id = threads_router._create_thread_sandbox_resources(
+        "thread-1",
+        "local",
+        {"id": "local:default", "provider_name": "local", "provider_type": "local"},
+        cwd="/tmp/workspace",
+        workspace_repo=workspace_repo,
+        owner_user_id="owner-1",
+    )
+
+    assert workspace_id == "workspace-new"

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -165,3 +165,37 @@ def test_service_does_not_import_legacy_runtime_glue() -> None:
     assert "chat_session" not in source
     assert "sandbox_volume" not in source
     assert "sync_file" not in source
+
+
+def test_resolves_binding_with_thin_workspace_shape() -> None:
+    binding = resolve_thread_runtime_binding(
+        **_repos(
+            thread=_thread(),
+            workspace={
+                "id": "workspace-1",
+                "owner_user_id": "owner-1",
+                "sandbox_id": "sandbox-1",
+                "workspace_path": "/workspace",
+            },
+            sandbox=_sandbox(),
+        ),
+        thread_id="thread-1",
+        owner_user_id="owner-1",
+    )
+
+    assert binding.workspace_id == "workspace-1"
+    assert binding.workspace_path == "/workspace"
+    assert binding.workspace_status is None
+    assert binding.workspace_desired_state is None
+    assert binding.workspace_observed_state is None
+
+
+def test_workspace_without_workspace_path_fails_loudly() -> None:
+    with pytest.raises(ThreadRuntimeBindingError) as excinfo:
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(), workspace=_workspace(workspace_path=None), sandbox=_sandbox()),
+            thread_id="thread-1",
+            owner_user_id="owner-1",
+        )
+
+    assert "workspace_path" in str(excinfo.value)

--- a/tests/Unit/storage/test_supabase_workspace_repo.py
+++ b/tests/Unit/storage/test_supabase_workspace_repo.py
@@ -1,0 +1,67 @@
+from storage.contracts import WorkspaceRow
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.insert_payload = None
+        self.rows: list[dict] = []
+        self.eq_calls: list[tuple[str, object]] = []
+
+    def insert(self, payload):
+        self.insert_payload = payload
+        return self
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, key, value):
+        self.eq_calls.append((key, value))
+        return self
+
+    def execute(self):
+        rows = self.rows
+        for key, value in self.eq_calls:
+            rows = [row for row in rows if row.get(key) == value]
+        return type("Resp", (), {"data": rows})()
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.table_obj = _FakeTable()
+
+    def schema(self, _name):
+        return self
+
+    def table(self, _name):
+        return self.table_obj
+
+
+def test_supabase_workspace_repo_create_writes_container_shape() -> None:
+    from storage.providers.supabase.workspace_repo import SupabaseWorkspaceRepo
+
+    client = _FakeClient()
+    repo = SupabaseWorkspaceRepo(client)
+
+    repo.create(
+        WorkspaceRow(
+            id="workspace-1",
+            sandbox_id="sandbox-1",
+            owner_user_id="owner-1",
+            workspace_path="/workspace/demo",
+            name="demo",
+            created_at=1.0,
+            updated_at=2.0,
+        )
+    )
+
+    assert client.table_obj.insert_payload["id"] == "workspace-1"
+    assert client.table_obj.insert_payload["workspace_path"] == "/workspace/demo"
+
+
+def test_supabase_workspace_repo_get_by_id_returns_none_when_missing() -> None:
+    from storage.providers.supabase.workspace_repo import SupabaseWorkspaceRepo
+
+    client = _FakeClient()
+    repo = SupabaseWorkspaceRepo(client)
+
+    assert repo.get_by_id("missing") is None

--- a/tests/Unit/storage/test_workspace_identity_contract.py
+++ b/tests/Unit/storage/test_workspace_identity_contract.py
@@ -1,0 +1,39 @@
+import pytest
+
+from storage.contracts import WorkspaceRow
+
+
+def test_workspace_row_accepts_thin_directory_shape() -> None:
+    row = WorkspaceRow(
+        id="workspace-1",
+        sandbox_id="sandbox-1",
+        owner_user_id="owner-1",
+        workspace_path="/workspace/demo",
+        name="demo",
+        created_at=1.0,
+        updated_at=2.0,
+    )
+
+    assert row.workspace_path == "/workspace/demo"
+
+
+def test_workspace_row_requires_non_blank_identity_fields() -> None:
+    with pytest.raises(ValueError, match="workspace.id must not be blank"):
+        WorkspaceRow(
+            id="   ",
+            sandbox_id="sandbox-1",
+            owner_user_id="owner-1",
+            workspace_path="/workspace/demo",
+            created_at=1.0,
+        )
+
+
+def test_workspace_row_requires_non_blank_workspace_path() -> None:
+    with pytest.raises(ValueError, match="workspace.workspace_path must not be blank"):
+        WorkspaceRow(
+            id="workspace-1",
+            sandbox_id="sandbox-1",
+            owner_user_id="owner-1",
+            workspace_path="  ",
+            created_at=1.0,
+        )

--- a/tests/Unit/storage/test_workspace_runtime_wiring.py
+++ b/tests/Unit/storage/test_workspace_runtime_wiring.py
@@ -1,0 +1,25 @@
+from storage.container import StorageContainer
+from storage.runtime import build_storage_container, build_workspace_repo
+
+
+class _FakeClient:
+    def table(self, _name):
+        raise AssertionError("table() should not be touched during wiring-only tests")
+
+
+def test_storage_container_exposes_workspace_repo() -> None:
+    container = StorageContainer(supabase_client=_FakeClient())
+
+    assert container.workspace_repo().__class__.__name__ == "SupabaseWorkspaceRepo"
+
+
+def test_runtime_builder_exposes_workspace_repo() -> None:
+    repo = build_workspace_repo(supabase_client=_FakeClient())
+
+    assert repo.__class__.__name__ == "SupabaseWorkspaceRepo"
+
+
+def test_build_storage_container_exposes_workspace_repo() -> None:
+    container = build_storage_container(supabase_client=_FakeClient())
+
+    assert container.workspace_repo().__class__.__name__ == "SupabaseWorkspaceRepo"


### PR DESCRIPTION
## Summary
- cut thread create-path writes so `current_workspace_id` stores a real workspace id for both existing and new sandbox create paths
- materialize thin workspace rows during create without widening into read/default-config cutover
- update router and resource-creation tests to prove workspace-id writes and preserve launch-config side effects

## Test Plan
- uv run python -m pytest tests/Integration/test_threads_router.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/storage/test_workspace_identity_contract.py tests/Unit/storage/test_supabase_workspace_repo.py tests/Unit/storage/test_workspace_runtime_wiring.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py -q
- uv run ruff check backend/web/routers/threads.py tests/Integration/test_threads_router.py tests/Unit/backend/web/routers/test_thread_resource_creation.py
- git diff --check origin/dev...HEAD