### PR TITLE
feat: land thin container sandboxes

### DIFF
--- a/backend/web/services/thread_runtime_binding_service.py
+++ b/backend/web/services/thread_runtime_binding_service.py
@@ -70,7 +70,7 @@ def resolve_thread_runtime_binding(
         sandbox_status=_optional_text(sandbox, "status"),
         sandbox_desired_state=_optional_text(sandbox, "desired_state"),
         sandbox_observed_state=_optional_text(sandbox, "observed_state"),
-        sandbox_template_id=_optional_text(sandbox, "template_id"),
+        sandbox_template_id=_optional_text(sandbox, "sandbox_template_id"),
         sandbox_config=_config_dict(sandbox),
         model=_optional_text(thread, "model"),
         legacy_cwd=_optional_text(thread, "cwd"),

--- a/storage/container.py
+++ b/storage/container.py
@@ -22,6 +22,7 @@ from .contracts import (
     RecipeRepo,
     ResourceSnapshotRepo,
     RunEventRepo,
+    SandboxRepo,
     SandboxVolumeRepo,
     SummaryRepo,
     SyncFileRepo,
@@ -56,6 +57,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "thread_repo": ("storage.providers.supabase.thread_repo", "SupabaseThreadRepo"),
     "thread_launch_pref_repo": ("storage.providers.supabase.thread_launch_pref_repo", "SupabaseThreadLaunchPrefRepo"),
     "workspace_repo": ("storage.providers.supabase.workspace_repo", "SupabaseWorkspaceRepo"),
+    "sandbox_repo": ("storage.providers.supabase.sandbox_repo", "SupabaseSandboxRepo"),
     "recipe_repo": ("storage.providers.supabase.recipe_repo", "SupabaseRecipeRepo"),
     "chat_repo": ("storage.providers.supabase.chat_repo", "SupabaseChatRepo"),
     "invite_code_repo": ("storage.providers.supabase.invite_code_repo", "SupabaseInviteCodeRepo"),
@@ -141,6 +143,9 @@ class StorageContainer:
 
     def workspace_repo(self) -> WorkspaceRepo:
         return self._build("workspace_repo")
+
+    def sandbox_repo(self) -> SandboxRepo:
+        return self._build("sandbox_repo")
 
     def recipe_repo(self) -> RecipeRepo:
         return self._build("recipe_repo")

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -313,6 +313,36 @@ class WorkspaceRow(BaseModel):
         return value
 
 
+class SandboxRow(BaseModel):
+    id: str
+    owner_user_id: str
+    provider_name: str
+    provider_env_id: str | None = None
+    sandbox_template_id: str | None = None
+    desired_state: str
+    observed_state: str
+    status: str
+    observed_at: float | str
+    last_error: str | None = None
+    config: Any = Field(default_factory=dict)
+    created_at: float | str
+    updated_at: float | str | None = None
+
+    @field_validator("id", "owner_user_id", "provider_name", "desired_state", "observed_state", "status")
+    @classmethod
+    def _validate_identity_fields(cls, value: str, info: Any) -> str:
+        if not value.strip():
+            raise ValueError(f"sandbox row requires {info.field_name}")
+        return value
+
+    @field_validator("config")
+    @classmethod
+    def _validate_config_object(cls, value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError("sandbox row config must be an object")
+        return dict(value)
+
+
 class ChatRow(BaseModel):
     id: str
     type: str
@@ -793,6 +823,12 @@ class WorkspaceRepo(Protocol):
     def create(self, row: WorkspaceRow) -> None: ...
     def get_by_id(self, workspace_id: str) -> WorkspaceRow | None: ...
     def list_by_sandbox_id(self, sandbox_id: str) -> list[WorkspaceRow]: ...
+
+
+class SandboxRepo(Protocol):
+    def close(self) -> None: ...
+    def create(self, row: SandboxRow) -> None: ...
+    def get_by_id(self, sandbox_id: str) -> SandboxRow | None: ...
 
 
 class ThreadRepo(Protocol):

--- a/storage/providers/supabase/sandbox_repo.py
+++ b/storage/providers/supabase/sandbox_repo.py
@@ -1,0 +1,90 @@
+"""Supabase repository for container sandboxes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from storage.contracts import SandboxRow
+from storage.providers.supabase import _query as q
+
+_REPO = "sandbox repo"
+_SCHEMA = "container"
+_TABLE = "sandboxes"
+_COLS = (
+    "id",
+    "owner_user_id",
+    "provider_name",
+    "provider_env_id",
+    "sandbox_template_id",
+    "desired_state",
+    "observed_state",
+    "status",
+    "observed_at",
+    "last_error",
+    "config",
+    "created_at",
+    "updated_at",
+)
+
+
+def _to_timestamptz(value: float | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return datetime.fromtimestamp(value, UTC).isoformat()
+
+
+def _to_row(row: dict[str, Any]) -> SandboxRow:
+    return SandboxRow(
+        id=str(row["id"]),
+        owner_user_id=str(row["owner_user_id"]),
+        provider_name=str(row["provider_name"]),
+        provider_env_id=row.get("provider_env_id"),
+        sandbox_template_id=row.get("sandbox_template_id"),
+        desired_state=str(row["desired_state"]),
+        observed_state=str(row["observed_state"]),
+        status=str(row["status"]),
+        observed_at=row["observed_at"],
+        last_error=row.get("last_error"),
+        config=row.get("config") or {},
+        created_at=row["created_at"],
+        updated_at=row.get("updated_at"),
+    )
+
+
+class SupabaseSandboxRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
+
+    def create(self, row: SandboxRow) -> None:
+        created_at = _to_timestamptz(row.created_at)
+        self._t().insert(
+            {
+                "id": row.id,
+                "owner_user_id": row.owner_user_id,
+                "provider_name": row.provider_name,
+                "provider_env_id": row.provider_env_id,
+                "sandbox_template_id": row.sandbox_template_id,
+                "desired_state": row.desired_state,
+                "observed_state": row.observed_state,
+                "status": row.status,
+                "observed_at": _to_timestamptz(row.observed_at),
+                "last_error": row.last_error,
+                "config": row.config,
+                "created_at": created_at,
+                "updated_at": _to_timestamptz(row.updated_at) or created_at,
+            }
+        ).execute()
+
+    def get_by_id(self, sandbox_id: str) -> SandboxRow | None:
+        response = self._t().select(", ".join(_COLS)).eq("id", sandbox_id).execute()
+        rows = q.rows(response, _REPO, "get_by_id")
+        return _to_row(rows[0]) if rows else None

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -65,6 +65,10 @@ def build_workspace_repo(*, supabase_client: Any | None = None, supabase_client_
     return _build_storage_repo("workspace_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
+def build_sandbox_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo("sandbox_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
+
+
 def build_user_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
     return _build_storage_repo("user_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -10,6 +10,7 @@ from backend.web.services.thread_runtime_binding_service import (
     ThreadRuntimeBindingError,
     resolve_thread_runtime_binding,
 )
+from storage.contracts import SandboxRow
 
 
 class _Repo:
@@ -59,19 +60,22 @@ def _workspace(**overrides):
 
 
 def _sandbox(**overrides):
-    return {
-        "id": "sandbox-1",
-        "owner_user_id": "owner-1",
-        "device_id": "device-1",
-        "provider_name": "daytona",
-        "provider_env_id": "provider-env-1",
-        "status": "ready",
-        "desired_state": "running",
-        "observed_state": "running",
-        "template_id": "template-1",
-        "config": {"sdk": "preinstalled"},
-        **overrides,
-    }
+    sandbox = SandboxRow(
+        id="sandbox-1",
+        owner_user_id="owner-1",
+        provider_name="daytona",
+        provider_env_id="provider-env-1",
+        sandbox_template_id="template-1",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=123.0,
+        last_error=None,
+        config={"sdk": "preinstalled"},
+        created_at=100.0,
+        updated_at=123.0,
+    )
+    return sandbox.model_copy(update=overrides)
 
 
 def test_resolves_thread_workspace_sandbox_binding_without_legacy_runtime_ids() -> None:
@@ -90,7 +94,6 @@ def test_resolves_thread_workspace_sandbox_binding_without_legacy_runtime_ids() 
     assert binding.workspace_desired_state == "running"
     assert binding.workspace_observed_state == "running"
     assert binding.sandbox_id == "sandbox-1"
-    assert binding.device_id == "device-1"
     assert binding.provider_name == "daytona"
     assert binding.provider_env_id == "provider-env-1"
     assert binding.sandbox_status == "ready"
@@ -190,6 +193,20 @@ def test_resolves_binding_with_thin_workspace_shape() -> None:
     assert binding.workspace_observed_state is None
 
 
+def test_resolve_thread_runtime_binding_reads_sandbox_fields_from_workspace_chain() -> None:
+    binding = resolve_thread_runtime_binding(
+        **_repos(thread=_thread(), workspace=_workspace(sandbox_id="sandbox-1"), sandbox=_sandbox()),
+        thread_id="thread-1",
+        owner_user_id="owner-1",
+    )
+
+    assert binding.sandbox_id == "sandbox-1"
+    assert binding.provider_name == "daytona"
+    assert binding.provider_env_id == "provider-env-1"
+    assert binding.sandbox_template_id == "template-1"
+    assert binding.sandbox_config == {"sdk": "preinstalled"}
+
+
 def test_workspace_without_workspace_path_fails_loudly() -> None:
     with pytest.raises(ThreadRuntimeBindingError) as excinfo:
         resolve_thread_runtime_binding(
@@ -199,3 +216,12 @@ def test_workspace_without_workspace_path_fails_loudly() -> None:
         )
 
     assert "workspace_path" in str(excinfo.value)
+
+
+def test_resolve_thread_runtime_binding_rejects_non_object_sandbox_config() -> None:
+    with pytest.raises(ThreadRuntimeBindingError, match="sandbox.config must be an object"):
+        resolve_thread_runtime_binding(
+            **_repos(thread=_thread(), workspace=_workspace(sandbox_id="sandbox-1"), sandbox=_sandbox(config="bad")),
+            thread_id="thread-1",
+            owner_user_id="owner-1",
+        )

--- a/tests/Unit/storage/test_sandbox_identity_contract.py
+++ b/tests/Unit/storage/test_sandbox_identity_contract.py
@@ -1,0 +1,62 @@
+import pytest
+
+from storage.contracts import SandboxRow
+
+
+def test_sandbox_row_accepts_thin_container_shape() -> None:
+    row = SandboxRow(
+        id="sandbox-1",
+        owner_user_id="owner-1",
+        provider_name="daytona_selfhost",
+        provider_env_id="env-1",
+        sandbox_template_id="tpl-1",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=123.0,
+        last_error=None,
+        config={"region": "cn"},
+        created_at=100.0,
+        updated_at=123.0,
+    )
+
+    assert row.id == "sandbox-1"
+    assert row.config == {"region": "cn"}
+
+
+def test_sandbox_row_rejects_blank_required_identity() -> None:
+    with pytest.raises(ValueError, match="sandbox row requires id"):
+        SandboxRow(
+            id=" ",
+            owner_user_id="owner-1",
+            provider_name="local",
+            provider_env_id=None,
+            sandbox_template_id=None,
+            desired_state="running",
+            observed_state="running",
+            status="ready",
+            observed_at=1.0,
+            last_error=None,
+            config={},
+            created_at=1.0,
+            updated_at=1.0,
+        )
+
+
+def test_sandbox_row_requires_object_config() -> None:
+    with pytest.raises(ValueError, match="sandbox row config must be an object"):
+        SandboxRow(
+            id="sandbox-1",
+            owner_user_id="owner-1",
+            provider_name="local",
+            provider_env_id=None,
+            sandbox_template_id=None,
+            desired_state="running",
+            observed_state="running",
+            status="ready",
+            observed_at=1.0,
+            last_error=None,
+            config="bad",
+            created_at=1.0,
+            updated_at=1.0,
+        )

--- a/tests/Unit/storage/test_sandbox_runtime_wiring.py
+++ b/tests/Unit/storage/test_sandbox_runtime_wiring.py
@@ -1,0 +1,28 @@
+from storage.container import StorageContainer
+from storage.runtime import build_sandbox_repo, build_storage_container
+
+
+class _FakeClient:
+    def table(self, _name):
+        raise AssertionError("table() should not be touched during wiring-only tests")
+
+    def schema(self, _name):
+        return self
+
+
+def test_storage_container_exposes_sandbox_repo() -> None:
+    container = StorageContainer(supabase_client=_FakeClient())
+
+    assert container.sandbox_repo().__class__.__name__ == "SupabaseSandboxRepo"
+
+
+def test_runtime_builder_exposes_sandbox_repo() -> None:
+    repo = build_sandbox_repo(supabase_client=_FakeClient())
+
+    assert repo.__class__.__name__ == "SupabaseSandboxRepo"
+
+
+def test_build_storage_container_exposes_sandbox_repo() -> None:
+    container = build_storage_container(supabase_client=_FakeClient())
+
+    assert container.sandbox_repo().__class__.__name__ == "SupabaseSandboxRepo"

--- a/tests/Unit/storage/test_supabase_sandbox_repo.py
+++ b/tests/Unit/storage/test_supabase_sandbox_repo.py
@@ -39,6 +39,10 @@ class _FakeClient:
         self.schema_name = None
         self.table_name = None
 
+    def table(self, name):
+        self.table_name = name
+        return self.table_obj
+
     def schema(self, name):
         self.schema_name = name
         return _FakeSchema(self.table_obj)

--- a/tests/Unit/storage/test_supabase_sandbox_repo.py
+++ b/tests/Unit/storage/test_supabase_sandbox_repo.py
@@ -1,0 +1,113 @@
+from storage.contracts import SandboxRow
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.insert_payload = None
+        self.rows: list[dict] = []
+        self.eq_calls: list[tuple[str, object]] = []
+
+    def insert(self, payload):
+        self.insert_payload = payload
+        return self
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, key, value):
+        self.eq_calls.append((key, value))
+        return self
+
+    def execute(self):
+        rows = self.rows
+        for key, value in self.eq_calls:
+            rows = [row for row in rows if row.get(key) == value]
+        return type("Resp", (), {"data": rows})()
+
+
+class _FakeSchema:
+    def __init__(self, table_obj: _FakeTable) -> None:
+        self.table_obj = table_obj
+
+    def table(self, _name):
+        return self.table_obj
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.table_obj = _FakeTable()
+        self.schema_name = None
+        self.table_name = None
+
+    def schema(self, name):
+        self.schema_name = name
+        return _FakeSchema(self.table_obj)
+
+
+def test_supabase_sandbox_repo_create_writes_container_shape() -> None:
+    from storage.providers.supabase.sandbox_repo import SupabaseSandboxRepo
+
+    client = _FakeClient()
+    repo = SupabaseSandboxRepo(client)
+    row = SandboxRow(
+        id="sandbox-1",
+        owner_user_id="owner-1",
+        provider_name="local",
+        provider_env_id="env-1",
+        sandbox_template_id="tpl-1",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=123.0,
+        last_error=None,
+        config={"cwd": "/workspace"},
+        created_at=100.0,
+        updated_at=123.0,
+    )
+
+    repo.create(row)
+
+    assert client.schema_name == "container"
+    assert client.table_obj.insert_payload["id"] == "sandbox-1"
+    assert client.table_obj.insert_payload["provider_name"] == "local"
+    assert client.table_obj.insert_payload["config"] == {"cwd": "/workspace"}
+
+
+def test_supabase_sandbox_repo_get_by_id_returns_row() -> None:
+    from storage.providers.supabase.sandbox_repo import SupabaseSandboxRepo
+
+    client = _FakeClient()
+    client.table_obj.rows = [
+        {
+            "id": "sandbox-1",
+            "owner_user_id": "owner-1",
+            "provider_name": "local",
+            "provider_env_id": "env-1",
+            "sandbox_template_id": "tpl-1",
+            "desired_state": "running",
+            "observed_state": "running",
+            "status": "ready",
+            "observed_at": "2026-04-15T00:00:00+00:00",
+            "last_error": None,
+            "config": {"cwd": "/workspace"},
+            "created_at": "2026-04-15T00:00:00+00:00",
+            "updated_at": "2026-04-15T00:01:00+00:00",
+        }
+    ]
+    repo = SupabaseSandboxRepo(client)
+
+    row = repo.get_by_id("sandbox-1")
+
+    assert row is not None
+    assert row.id == "sandbox-1"
+    assert row.provider_name == "local"
+    assert row.config == {"cwd": "/workspace"}
+
+
+def test_supabase_sandbox_repo_get_by_id_returns_none_when_missing() -> None:
+    from storage.providers.supabase.sandbox_repo import SupabaseSandboxRepo
+
+    client = _FakeClient()
+    repo = SupabaseSandboxRepo(client)
+
+    assert repo.get_by_id("missing") is None


### PR DESCRIPTION
## Summary
- add thin `container.sandboxes` storage contract and Supabase repo
- wire sandbox repo into storage container/runtime helpers
- align runtime binding proof to read real sandbox rows through `thread -> workspace -> sandbox`

## Test Plan
- uv run python -m pytest tests/Unit/storage/test_sandbox_identity_contract.py tests/Unit/storage/test_supabase_sandbox_repo.py tests/Unit/storage/test_sandbox_runtime_wiring.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py -q
- uv run ruff check storage/contracts.py storage/providers/supabase/sandbox_repo.py storage/container.py storage/runtime.py tests/Unit/storage/test_sandbox_identity_contract.py tests/Unit/storage/test_supabase_sandbox_repo.py tests/Unit/storage/test_sandbox_runtime_wiring.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py backend/web/services/thread_runtime_binding_service.py
- git diff --check origin/dev...HEAD
