### PR TITLE
feat: cut workspace sandbox bridge to sandbox ids

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -68,6 +68,8 @@ async def lifespan(app: FastAPI):
     app.state.sandbox_volume_repo = storage_container.sandbox_volume_repo()
     app.state.thread_launch_pref_repo = storage_container.thread_launch_pref_repo()
     app.state.recipe_repo = storage_container.recipe_repo()
+    app.state.workspace_repo = storage_container.workspace_repo()
+    app.state.sandbox_repo = storage_container.sandbox_repo()
     app.state.chat_repo = storage_container.chat_repo()
     app.state.invite_code_repo = storage_container.invite_code_repo()
     app.state.user_settings_repo = storage_container.user_settings_repo()

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -61,7 +61,7 @@ from sandbox.config import MountSpec
 from sandbox.manager import bind_thread_to_existing_lease
 from sandbox.recipes import default_recipe_id, normalize_recipe_snapshot, provider_type_from_name
 from sandbox.thread_context import set_current_thread_id
-from storage.contracts import WorkspaceRow
+from storage.contracts import SandboxRow, WorkspaceRow
 
 logger = logging.getLogger(__name__)
 
@@ -522,6 +522,7 @@ def _create_thread_sandbox_resources(
     cwd: str | None = None,
     *,
     workspace_repo: Any,
+    sandbox_repo: Any,
     owner_user_id: str,
 ) -> str:
     """Create volume, lease, and terminal eagerly so volume exists before file uploads."""
@@ -558,6 +559,21 @@ def _create_thread_sandbox_resources(
     finally:
         lease_repo.close()
 
+    sandbox_id = _materialize_sandbox_for_lease(
+        sandbox_repo,
+        lease={
+            "lease_id": lease_id,
+            "provider_name": sandbox_type,
+            "provider_env_id": None,
+            "recipe": normalized_recipe,
+            "desired_state": "running",
+            "observed_state": "running",
+            "status": "ready",
+            "last_error": None,
+        },
+        owner_user_id=owner_user_id,
+    )
+
     terminal_repo = make_terminal_repo()
     try:
         terminal_id = f"term-{uuid.uuid4().hex[:12]}"
@@ -582,10 +598,63 @@ def _create_thread_sandbox_resources(
         terminal_repo.close()
     return _materialize_workspace_for_sandbox(
         workspace_repo,
-        sandbox_id=lease_id,
+        sandbox_id=sandbox_id,
         owner_user_id=owner_user_id,
         workspace_path=initial_cwd,
     )
+
+
+def _materialize_sandbox_for_lease(
+    sandbox_repo: Any,
+    *,
+    lease: dict[str, Any],
+    owner_user_id: str,
+) -> str:
+    lease_id = str(lease.get("lease_id") or "").strip()
+    if not lease_id:
+        raise RuntimeError("lease.lease_id is required")
+    provider_name = str(lease.get("provider_name") or "").strip()
+    if not provider_name:
+        raise RuntimeError("lease.provider_name is required")
+
+    sandbox_id = f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, f'mycel-lease-bridge:{lease_id}').hex}"
+    get_by_id = getattr(sandbox_repo, "get_by_id", None)
+    if callable(get_by_id):
+        existing = get_by_id(sandbox_id)
+        if existing is not None:
+            if str(getattr(existing, "owner_user_id", "")).strip() != owner_user_id:
+                raise RuntimeError(f"sandbox owner mismatch for lease bridge {lease_id}")
+            return sandbox_id
+
+    recipe = lease.get("recipe")
+    sandbox_template_id = None
+    if isinstance(recipe, dict):
+        sandbox_template_id = str(recipe.get("id") or "").strip() or None
+    if sandbox_template_id is None:
+        sandbox_template_id = str(lease.get("recipe_id") or "").strip() or None
+
+    now = time.time()
+    # @@@sandbox-bridge-write - Phase 5 lands real sandbox rows but keeps the
+    # legacy lease pointer explicit in sandbox.config so read-side cutover can
+    # be truthful without guessing which live lease backs the sandbox row.
+    sandbox_repo.create(
+        SandboxRow(
+            id=sandbox_id,
+            owner_user_id=owner_user_id,
+            provider_name=provider_name,
+            provider_env_id=str(lease.get("provider_env_id") or lease.get("current_instance_id") or "").strip() or None,
+            sandbox_template_id=sandbox_template_id,
+            desired_state=str(lease.get("desired_state") or lease.get("status") or "running"),
+            observed_state=str(lease.get("observed_state") or lease.get("status") or "unknown"),
+            status=str(lease.get("status") or "unknown"),
+            observed_at=now,
+            last_error=str(lease.get("last_error") or "").strip() or None,
+            config={"legacy_lease_id": lease_id},
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    return sandbox_id
 
 
 def _materialize_workspace_for_sandbox(
@@ -693,9 +762,14 @@ def _create_owned_thread(
             selected_lease_id,
             cwd=payload.cwd,
         )
+        sandbox_id = _materialize_sandbox_for_lease(
+            app.state.sandbox_repo,
+            lease=owned_lease,
+            owner_user_id=owner_user_id,
+        )
         current_workspace_id = _materialize_workspace_for_sandbox(
             app.state.workspace_repo,
-            sandbox_id=str(owned_lease.get("sandbox_id") or owned_lease["lease_id"]),
+            sandbox_id=sandbox_id,
             owner_user_id=owner_user_id,
             workspace_path=bound_cwd,
         )
@@ -709,6 +783,7 @@ def _create_owned_thread(
             selected_recipe,
             payload.cwd,
             workspace_repo=app.state.workspace_repo,
+            sandbox_repo=app.state.sandbox_repo,
             owner_user_id=owner_user_id,
         )
         bound_cwd = None

--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -261,7 +261,18 @@ def _resolve_bridge_lease(
             workspace_owner_user_id = _required_bridge_text(workspace, "owner_user_id", "workspace")
             if workspace_owner_user_id != owner_user_id:
                 raise PermissionError(f"workspace owner mismatch: expected {owner_user_id}, got {workspace_owner_user_id}")
-            return leases_by_id.get(sandbox_id)
+            sandbox_repo = getattr(app.state, "sandbox_repo", None)
+            sandbox_get_by_id = getattr(sandbox_repo, "get_by_id", None)
+            if not callable(sandbox_get_by_id):
+                raise RuntimeError("sandbox_repo must support get_by_id")
+            sandbox = sandbox_get_by_id(sandbox_id)
+            if sandbox is None:
+                raise RuntimeError(f"sandbox not found: {sandbox_id}")
+            sandbox_owner_user_id = _required_bridge_text(sandbox, "owner_user_id", "sandbox")
+            if sandbox_owner_user_id != owner_user_id:
+                raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
+            legacy_lease_id = _required_bridge_config_text(sandbox, "legacy_lease_id", "sandbox")
+            return leases_by_id.get(legacy_lease_id)
     return leases_by_id.get(current_workspace_id)
 
 
@@ -271,6 +282,18 @@ def _required_bridge_text(row: Any, key: str, label: str) -> str:
         value = value.strip()
     if value is None or value == "":
         raise RuntimeError(f"{label}.{key} is required")
+    return str(value)
+
+
+def _required_bridge_config_text(row: Any, key: str, label: str) -> str:
+    config = row.get("config") if isinstance(row, dict) else getattr(row, "config", None)
+    if not isinstance(config, dict):
+        raise RuntimeError(f"{label}.config must be an object")
+    value = config.get(key)
+    if isinstance(value, str):
+        value = value.strip()
+    if value is None or value == "":
+        raise RuntimeError(f"{label}.config.{key} is required")
     return str(value)
 
 

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -121,6 +121,19 @@ class _FakeWorkspaceRepo:
         self.by_sandbox_id.setdefault(row.sandbox_id, []).append(row)
 
 
+class _FakeSandboxRepo:
+    def __init__(self) -> None:
+        self.created: list[object] = []
+        self.by_id: dict[str, object] = {}
+
+    def get_by_id(self, sandbox_id: str):
+        return self.by_id.get(sandbox_id)
+
+    def create(self, row) -> None:
+        self.created.append(row)
+        self.by_id[row.id] = row
+
+
 def _make_threads_app():
     return SimpleNamespace(
         state=SimpleNamespace(
@@ -129,6 +142,7 @@ def _make_threads_app():
             thread_launch_pref_repo=_FakeThreadLaunchPrefRepo(),
             recipe_repo=_FakeRecipeRepo(),
             workspace_repo=_FakeWorkspaceRepo(),
+            sandbox_repo=_FakeSandboxRepo(),
             thread_sandbox={},
             thread_cwd={},
         )
@@ -415,10 +429,26 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
     workspace_repo = _FakeWorkspaceRepo()
     workspace_repo.by_id["ws-2"] = SimpleNamespace(
         id="ws-2",
-        sandbox_id="lease-2",
+        sandbox_id="sandbox-2",
         owner_user_id="owner-1",
         workspace_path="/workspace/right",
         name=None,
+        created_at=2.0,
+        updated_at=2.0,
+    )
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-2"] = SimpleNamespace(
+        id="sandbox-2",
+        owner_user_id="owner-1",
+        provider_name="daytona_selfhost",
+        provider_env_id="provider-env-2",
+        sandbox_template_id="daytona:default",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=2.0,
+        last_error=None,
+        config={"legacy_lease_id": "lease-2"},
         created_at=2.0,
         updated_at=2.0,
     )
@@ -429,6 +459,7 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
             user_repo=SimpleNamespace(),
             recipe_repo=object(),
             workspace_repo=workspace_repo,
+            sandbox_repo=sandbox_repo,
         )
     )
 
@@ -499,6 +530,7 @@ def test_resolve_default_config_derives_existing_from_legacy_lease_backed_curren
             user_repo=SimpleNamespace(),
             recipe_repo=object(),
             workspace_repo=_FakeWorkspaceRepo(),
+            sandbox_repo=_FakeSandboxRepo(),
         )
     )
 
@@ -1040,6 +1072,7 @@ async def test_create_thread_carries_recipe_snapshot_into_resources_and_successf
         normalized_recipe,
         None,
         workspace_repo=app.state.workspace_repo,
+        sandbox_repo=app.state.sandbox_repo,
         owner_user_id="owner-1",
     )
     save_successful.assert_called_once_with(

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -82,6 +82,19 @@ class _FakeWorkspaceRepo:
         self.by_sandbox_id.setdefault(row.sandbox_id, []).append(row)
 
 
+class _FakeSandboxRepo:
+    def __init__(self) -> None:
+        self.created: list[Any] = []
+        self.by_id: dict[str, Any] = {}
+
+    def get_by_id(self, sandbox_id: str):
+        return self.by_id.get(sandbox_id)
+
+    def create(self, row: Any) -> None:
+        self.created.append(row)
+        self.by_id[row.id] = row
+
+
 class _FakeAuthService:
     def __init__(self) -> None:
         self.tokens: list[str] = []
@@ -352,6 +365,7 @@ def _make_threads_app(
             thread_repo=thread_repo or _FakeThreadRepo(),
             recipe_repo=state_overrides.pop("recipe_repo", _FakeRecipeRepo()),
             workspace_repo=state_overrides.pop("workspace_repo", _FakeWorkspaceRepo()),
+            sandbox_repo=state_overrides.pop("sandbox_repo", _FakeSandboxRepo()),
             **state_overrides,
         )
     )
@@ -474,7 +488,8 @@ async def test_create_thread_route_uses_canonical_existing_lease_binding_helper(
 @pytest.mark.asyncio
 async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() -> None:
     workspace_repo = _FakeWorkspaceRepo()
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
+    sandbox_repo = _FakeSandboxRepo()
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -503,8 +518,10 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
         created = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
 
     row = app.state.thread_repo.rows[created["thread_id"]]
+    assert len(sandbox_repo.created) == 1
     assert len(workspace_repo.created) == 1
     assert row["current_workspace_id"] == workspace_repo.created[0].id
+    assert workspace_repo.created[0].sandbox_id == sandbox_repo.created[0].id
 
 
 @pytest.mark.asyncio
@@ -527,6 +544,7 @@ async def test_create_thread_route_passes_local_cwd_into_sandbox_bootstrap():
         default_recipe_snapshot("local"),
         "/tmp/fresh-local-thread",
         workspace_repo=workspace_repo,
+        sandbox_repo=app.state.sandbox_repo,
         owner_user_id="owner-1",
     )
 
@@ -558,6 +576,7 @@ async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox
         default_recipe_snapshot("local"),
         "/tmp/fresh-local-thread",
         workspace_repo=workspace_repo,
+        sandbox_repo=app.state.sandbox_repo,
         owner_user_id="owner-1",
     )
     row = app.state.thread_repo.rows[created["thread_id"]]

--- a/tests/Unit/backend/web/routers/test_thread_resource_creation.py
+++ b/tests/Unit/backend/web/routers/test_thread_resource_creation.py
@@ -46,17 +46,31 @@ class _TerminalRepo:
         self.closed = True
 
 
+class _SandboxRepo:
+    def __init__(self) -> None:
+        self.created: list[object] = []
+
+    def create(self, row) -> None:
+        self.created.append(row)
+
+
 def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(monkeypatch, tmp_path):
     volume_repo = _VolumeRepo()
     lease_repo = _LeaseRepo()
     terminal_repo = _TerminalRepo()
+    sandbox_repo = _SandboxRepo()
     workspace_repo = object()
+    materialize_calls: list[dict[str, object]] = []
 
     monkeypatch.setattr(helpers, "_get_container", lambda: _Container(volume_repo))
     monkeypatch.setattr("backend.web.core.config.SANDBOX_VOLUME_ROOT", tmp_path / "volumes")
     monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
     monkeypatch.setattr("storage.runtime.build_terminal_repo", lambda: terminal_repo)
-    monkeypatch.setattr(threads_router, "_materialize_workspace_for_sandbox", lambda *args, **kwargs: "workspace-1")
+    monkeypatch.setattr(
+        threads_router,
+        "_materialize_workspace_for_sandbox",
+        lambda _workspace_repo, **kwargs: materialize_calls.append(dict(kwargs)) or "workspace-1",
+    )
 
     workspace_id = threads_router._create_thread_sandbox_resources(
         "thread-1",
@@ -64,17 +78,21 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
         {"id": "local:default", "provider_name": "local", "provider_type": "local"},
         cwd="/tmp/workspace",
         workspace_repo=workspace_repo,
+        sandbox_repo=sandbox_repo,
         owner_user_id="owner-1",
     )
 
     assert workspace_id == "workspace-1"
     assert len(volume_repo.created) == 1
     assert len(lease_repo.created) == 1
+    assert len(sandbox_repo.created) == 1
     assert lease_repo.created[0]["provider_name"] == "local"
     assert len(terminal_repo.created) == 1
     assert terminal_repo.created[0]["thread_id"] == "thread-1"
     assert terminal_repo.created[0]["lease_id"] == lease_repo.created[0]["lease_id"]
     assert terminal_repo.created[0]["initial_cwd"] == "/tmp/workspace"
+    assert sandbox_repo.created[0].config["legacy_lease_id"] == lease_repo.created[0]["lease_id"]
+    assert materialize_calls[0]["sandbox_id"] == sandbox_repo.created[0].id
     assert volume_repo.closed
     assert lease_repo.closed
     assert terminal_repo.closed
@@ -84,6 +102,7 @@ def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_p
     volume_repo = _VolumeRepo()
     lease_repo = _LeaseRepo()
     terminal_repo = _TerminalRepo()
+    sandbox_repo = _SandboxRepo()
     workspace_repo = object()
 
     monkeypatch.setattr(helpers, "_get_container", lambda: _Container(volume_repo))
@@ -98,6 +117,7 @@ def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_p
         {"id": "local:default", "provider_name": "local", "provider_type": "local"},
         cwd="/tmp/workspace",
         workspace_repo=workspace_repo,
+        sandbox_repo=sandbox_repo,
         owner_user_id="owner-1",
     )
 


### PR DESCRIPTION
## Summary
- write real sandbox ids into new workspace rows for both existing and new sandbox create paths
- resolve workspace-backed launch config through sandbox rows using an explicit legacy lease bridge
- wire workspace_repo and sandbox_repo into web lifespan so the live app can exercise the new bridge

## Verification
- uv run python -m pytest tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py tests/Unit/storage/test_sandbox_identity_contract.py tests/Unit/storage/test_supabase_sandbox_repo.py tests/Unit/storage/test_workspace_identity_contract.py tests/Unit/storage/test_supabase_workspace_repo.py tests/Unit/storage/test_workspace_runtime_wiring.py tests/Unit/storage/test_sandbox_runtime_wiring.py -q
- uv run ruff check backend/web/core/lifespan.py backend/web/routers/threads.py backend/web/services/thread_launch_config_service.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py tests/Unit/backend/web/routers/test_thread_resource_creation.py
- git diff --check origin/dev...HEAD