### PR TITLE
refactor: cut sandbox monitor session surfaces to sandbox rows

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -23,7 +23,7 @@ class SupabaseSandboxMonitorRepo:
         return None
 
     def query_threads(self, *, thread_id: str | None = None) -> list[dict]:
-        # Fetch active chat_sessions joined with sandbox_leases via lease_id
+        # Fetch active chat_sessions joined with sandbox summaries via legacy lease bridge.
         q_sessions = self._client.table("chat_sessions").select("thread_id,chat_session_id,last_active_at,lease_id").neq("status", "closed")
         if thread_id is not None:
             q_sessions = q_sessions.eq("thread_id", thread_id)
@@ -35,11 +35,7 @@ class SupabaseSandboxMonitorRepo:
         if not sessions:
             return []
 
-        lease_map = self._leases_by_id(
-            [s["lease_id"] for s in sessions if s.get("lease_id")],
-            "lease_id,provider_name,desired_state,observed_state,current_instance_id",
-            "query_threads leases",
-        )
+        lease_map = self._sandboxes_by_legacy_lease_id("query_threads")
 
         # Aggregate per thread_id
         by_thread: dict[str, dict] = {}
@@ -85,11 +81,7 @@ class SupabaseSandboxMonitorRepo:
         if not sessions:
             return []
 
-        lease_map = self._leases_by_id(
-            [s["lease_id"] for s in sessions if s.get("lease_id")],
-            "lease_id,provider_name,desired_state,observed_state,current_instance_id,last_error",
-            "query_thread_sessions leases",
-        )
+        lease_map = self._sandboxes_by_legacy_lease_id("query_thread_sessions")
         return [self._session_with_lease(s, lease_map.get(s.get("lease_id") or "")) for s in sessions]
 
     def query_leases(self) -> list[dict]:
@@ -183,12 +175,14 @@ class SupabaseSandboxMonitorRepo:
             "list_sessions_with_leases active",
         )
 
-        # All leases for terminal-derived resource rows.
-        leases = q.rows(
-            self._client.table("sandbox_leases").select("lease_id,provider_name,observed_state,desired_state,created_at").execute(),
-            _REPO,
-            "list_sessions_with_leases leases",
-        )
+        # @@@sandbox-monitor-session-base - session aggregation surfaces now use
+        # container.sandboxes as the object base and only keep lease ids as the
+        # residue join key for chat_sessions / terminals / instances.
+        leases = []
+        for sandbox in self._ordered_sandboxes("list_sessions_with_leases"):
+            lease = self._lease_row_from_sandbox(sandbox)
+            lease["created_at"] = sandbox.get("created_at")
+            leases.append(lease)
         lease_map = {le["lease_id"]: le for le in leases}
 
         all_terminals = q.rows(
@@ -240,10 +234,7 @@ class SupabaseSandboxMonitorRepo:
     def list_probe_targets(self) -> list[dict]:
         leases = [
             lease
-            for lease in (
-                self._lease_row_from_sandbox(sandbox)
-                for sandbox in self._ordered_sandboxes("list_probe_targets")
-            )
+            for lease in (self._lease_row_from_sandbox(sandbox) for sandbox in self._ordered_sandboxes("list_probe_targets"))
             if lease.get("observed_state") in {"running", "detached", "paused"}
         ]
 

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -7,6 +7,10 @@ from typing import Any
 from storage.providers.supabase import _query as q
 
 _REPO = "sandbox_monitor repo"
+_SANDBOX_SELECT = (
+    "id,owner_user_id,provider_name,provider_env_id,sandbox_template_id,"
+    "desired_state,observed_state,status,observed_at,last_error,config,created_at,updated_at"
+)
 
 
 class SupabaseSandboxMonitorRepo:
@@ -89,19 +93,8 @@ class SupabaseSandboxMonitorRepo:
         return [self._session_with_lease(s, lease_map.get(s.get("lease_id") or "")) for s in sessions]
 
     def query_leases(self) -> list[dict]:
-        leases = q.rows(
-            q.order(
-                self._client.table("sandbox_leases").select(
-                    "lease_id,provider_name,recipe_id,recipe_json,desired_state,observed_state,current_instance_id,last_error,updated_at"
-                ),
-                "updated_at",
-                desc=True,
-                repo=_REPO,
-                operation="query_leases",
-            ).execute(),
-            _REPO,
-            "query_leases",
-        )
+        sandboxes = self._ordered_sandboxes("query_leases")
+        leases = [self._lease_row_from_sandbox(sandbox) for sandbox in sandboxes]
         if not leases:
             return []
 
@@ -129,12 +122,7 @@ class SupabaseSandboxMonitorRepo:
         return self.query_leases()
 
     def query_lease(self, lease_id: str) -> dict | None:
-        rows = q.rows(
-            self._client.table("sandbox_leases").select("*").eq("lease_id", lease_id).execute(),
-            _REPO,
-            "query_lease",
-        )
-        return dict(rows[0]) if rows else None
+        return self._sandboxes_by_legacy_lease_id("query_lease").get(lease_id)
 
     def query_lease_sessions(self, lease_id: str) -> list[dict]:
         sessions = q.rows(
@@ -250,19 +238,14 @@ class SupabaseSandboxMonitorRepo:
         return result
 
     def list_probe_targets(self) -> list[dict]:
-        leases = q.rows(
-            q.order(
-                self._client.table("sandbox_leases")
-                .select("lease_id,provider_name,current_instance_id,observed_state,updated_at")
-                .in_("observed_state", ["running", "detached", "paused"]),
-                "updated_at",
-                desc=True,
-                repo=_REPO,
-                operation="list_probe_targets",
-            ).execute(),
-            _REPO,
-            "list_probe_targets",
-        )
+        leases = [
+            lease
+            for lease in (
+                self._lease_row_from_sandbox(sandbox)
+                for sandbox in self._ordered_sandboxes("list_probe_targets")
+            )
+            if lease.get("observed_state") in {"running", "detached", "paused"}
+        ]
 
         instance_map = self.query_lease_instance_ids([lease["lease_id"] for lease in leases])
 
@@ -333,6 +316,45 @@ class SupabaseSandboxMonitorRepo:
             operation,
         )
         return {row["lease_id"]: row for row in rows}
+
+    def _ordered_sandboxes(self, operation: str) -> list[dict[str, Any]]:
+        query = q.order(
+            q.schema_table(self._client, "container", "sandboxes", _REPO).select(_SANDBOX_SELECT),
+            "updated_at",
+            desc=True,
+            repo=_REPO,
+            operation=operation,
+        )
+        return q.rows(query.execute(), _REPO, operation)
+
+    def _sandboxes_by_legacy_lease_id(self, operation: str) -> dict[str, dict[str, Any]]:
+        result: dict[str, dict[str, Any]] = {}
+        for sandbox in self._ordered_sandboxes(operation):
+            lease = self._lease_row_from_sandbox(sandbox)
+            result[lease["lease_id"]] = lease
+        return result
+
+    def _lease_row_from_sandbox(self, sandbox: dict[str, Any]) -> dict[str, Any]:
+        # @@@sandbox-monitor-bridge - summary surfaces now use container.sandboxes as the
+        # object truth, but still expose legacy lease_id while monitor/runtime residue
+        # remains lease-keyed.
+        config = sandbox.get("config")
+        if not isinstance(config, dict):
+            raise RuntimeError("sandbox.config must be an object")
+        legacy_lease_id = str(config.get("legacy_lease_id") or "").strip()
+        if not legacy_lease_id:
+            raise RuntimeError("sandbox.config.legacy_lease_id is required")
+        return {
+            "lease_id": legacy_lease_id,
+            "provider_name": sandbox.get("provider_name"),
+            "recipe_id": sandbox.get("sandbox_template_id"),
+            "recipe_json": None,
+            "desired_state": sandbox.get("desired_state"),
+            "observed_state": sandbox.get("observed_state"),
+            "current_instance_id": sandbox.get("provider_env_id"),
+            "last_error": sandbox.get("last_error"),
+            "updated_at": sandbox.get("updated_at"),
+        }
 
     def _session_with_lease(self, session: dict, lease: dict | None, *, include_thread: bool = False) -> dict:
         row = {

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -126,7 +126,13 @@ def _sandbox(
 def test_query_threads_accepts_optional_thread_filter() -> None:
     repo = _repo(
         {
-            "sandbox_leases": [_lease("lease-1", current_instance_id="instance-1")],
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_env_id="instance-1",
+                    legacy_lease_id="lease-1",
+                )
+            ],
             "chat_sessions": [
                 _session("sess-1", "thread-1", "lease-1", last_active_at="2026-04-05T10:01:00"),
                 _session("sess-2", "thread-2", "lease-1", last_active_at="2026-04-05T10:06:00"),
@@ -153,12 +159,14 @@ def test_query_threads_chunks_lease_lookup() -> None:
         _session(f"sess-{index}", f"thread-{index}", f"lease-{index}", last_active_at=f"2026-04-05T10:{index % 60:02d}:00")
         for index in range(175)
     ]
-    leases = [_lease(f"lease-{index}", current_instance_id=f"instance-{index}") for index in range(175)]
+    sandboxes = [
+        _sandbox(f"sandbox-{index}", provider_env_id=f"instance-{index}", legacy_lease_id=f"lease-{index}") for index in range(175)
+    ]
     repo = SupabaseSandboxMonitorRepo(
         _MaxInFilterClient(
             {
                 "chat_sessions": sessions,
-                "sandbox_leases": leases,
+                "container.sandboxes": sandboxes,
             }
         )
     )
@@ -198,6 +206,47 @@ def test_query_lease_reads_container_sandbox_row() -> None:
         "last_error": None,
         "updated_at": "2026-04-05T10:10:00",
     }
+
+
+def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    legacy_lease_id="lease-1",
+                    last_error="last boom",
+                )
+            ],
+            "chat_sessions": [
+                {
+                    **_session("sess-1", "thread-1", "lease-1", started_at="2026-04-05T10:01:00"),
+                    "ended_at": None,
+                    "close_reason": None,
+                }
+            ],
+        }
+    )
+
+    assert repo.query_thread_sessions("thread-1") == [
+        {
+            "chat_session_id": "sess-1",
+            "status": "active",
+            "started_at": "2026-04-05T10:01:00",
+            "ended_at": None,
+            "close_reason": None,
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "desired_state": "paused",
+            "observed_state": "paused",
+            "current_instance_id": "instance-1",
+            "last_error": "last boom",
+        }
+    ]
 
 
 def test_query_leases_uses_latest_terminal_binding() -> None:
@@ -263,14 +312,14 @@ def test_query_leases_reads_container_sandboxes_with_terminal_binding() -> None:
             "lease_id": "lease-1",
             "provider_name": "daytona_selfhost",
             "desired_state": "paused",
-                "observed_state": "paused",
-                "current_instance_id": "provider-env-1",
-                "updated_at": "2026-04-05T10:10:00",
-                "recipe_id": None,
-                "recipe_json": None,
-                "last_error": None,
-                "thread_id": "thread-new",
-            }
+            "observed_state": "paused",
+            "current_instance_id": "provider-env-1",
+            "updated_at": "2026-04-05T10:10:00",
+            "recipe_id": None,
+            "recipe_json": None,
+            "last_error": None,
+            "thread_id": "thread-new",
+        }
     ]
 
 
@@ -433,21 +482,23 @@ def test_instance_lookup_failures_are_loud(include_updated_at, caller) -> None:
 def test_list_sessions_with_leases_keeps_active_terminal_and_latest_closed_session_rows() -> None:
     repo = _repo(
         {
-            "sandbox_leases": [
-                _lease("lease-active", created_at="2026-04-05T10:00:00"),
-                _lease(
-                    "lease-terminal",
+            "container.sandboxes": [
+                _sandbox("sandbox-active", created_at="2026-04-05T10:00:00", legacy_lease_id="lease-active"),
+                _sandbox(
+                    "sandbox-terminal",
                     provider_name="daytona_selfhost",
                     desired_state="paused",
                     observed_state="paused",
                     created_at="2026-04-05T11:00:00",
+                    legacy_lease_id="lease-terminal",
                 ),
-                _lease(
-                    "lease-recent",
+                _sandbox(
+                    "sandbox-recent",
                     provider_name="docker",
                     desired_state="paused",
                     observed_state="paused",
                     created_at="2026-04-05T12:00:00",
+                    legacy_lease_id="lease-recent",
                 ),
             ],
             "abstract_terminals": [

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -86,6 +86,43 @@ def _terminal(terminal_id: str, lease_id: str, thread_id: str, created_at: str) 
     }
 
 
+def _sandbox(
+    sandbox_id: str,
+    *,
+    owner_user_id: str = "owner-1",
+    provider_name: str = "local",
+    provider_env_id: str | None = None,
+    sandbox_template_id: str | None = None,
+    desired_state: str = "running",
+    observed_state: str = "running",
+    status: str = "ready",
+    observed_at: str = "2026-04-05T10:00:00",
+    updated_at: str = "2026-04-05T10:00:00",
+    created_at: str = "2026-04-05T09:00:00",
+    last_error: str | None = None,
+    legacy_lease_id: str | None = None,
+    **config_extra,
+) -> dict:
+    config = dict(config_extra)
+    if legacy_lease_id is not None:
+        config["legacy_lease_id"] = legacy_lease_id
+    return {
+        "id": sandbox_id,
+        "owner_user_id": owner_user_id,
+        "provider_name": provider_name,
+        "provider_env_id": provider_env_id,
+        "sandbox_template_id": sandbox_template_id,
+        "desired_state": desired_state,
+        "observed_state": observed_state,
+        "status": status,
+        "observed_at": observed_at,
+        "updated_at": updated_at,
+        "created_at": created_at,
+        "last_error": last_error,
+        "config": config,
+    }
+
+
 def test_query_threads_accepts_optional_thread_filter() -> None:
     repo = _repo(
         {
@@ -132,20 +169,49 @@ def test_query_threads_chunks_lease_lookup() -> None:
     assert next(row for row in rows if row["thread_id"] == "thread-174")["current_instance_id"] == "instance-174"
 
 
+def test_query_lease_reads_container_sandbox_row() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="provider-env-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-1",
+                    sandbox_template_id="template-1",
+                )
+            ]
+        }
+    )
+
+    assert repo.query_lease("lease-1") == {
+        "lease_id": "lease-1",
+        "provider_name": "daytona_selfhost",
+        "recipe_id": "template-1",
+        "recipe_json": None,
+        "desired_state": "paused",
+        "observed_state": "paused",
+        "current_instance_id": "provider-env-1",
+        "last_error": None,
+        "updated_at": "2026-04-05T10:10:00",
+    }
+
+
 def test_query_leases_uses_latest_terminal_binding() -> None:
     repo = _repo(
         {
-            "sandbox_leases": [
-                _lease(
-                    "lease-1",
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
                     provider_name="daytona_selfhost",
+                    provider_env_id="instance-1",
                     desired_state="paused",
                     observed_state="paused",
-                    current_instance_id="instance-1",
                     updated_at="2026-04-05T10:10:00",
-                    recipe_id=None,
-                    recipe_json=None,
-                    last_error=None,
+                    legacy_lease_id="lease-1",
                 )
             ],
             "abstract_terminals": [
@@ -171,21 +237,57 @@ def test_query_leases_uses_latest_terminal_binding() -> None:
     ]
 
 
+def test_query_leases_reads_container_sandboxes_with_terminal_binding() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="provider-env-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-1",
+                )
+            ],
+            "abstract_terminals": [
+                _terminal("term-old", "lease-1", "thread-old", "2026-04-05T10:01:00"),
+                _terminal("term-new", "lease-1", "thread-new", "2026-04-05T10:02:00"),
+            ],
+        }
+    )
+
+    assert repo.query_leases() == [
+        {
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "desired_state": "paused",
+                "observed_state": "paused",
+                "current_instance_id": "provider-env-1",
+                "updated_at": "2026-04-05T10:10:00",
+                "recipe_id": None,
+                "recipe_json": None,
+                "last_error": None,
+                "thread_id": "thread-new",
+            }
+    ]
+
+
 def test_query_leases_chunks_terminal_binding_lookup() -> None:
-    leases = [
-        _lease(
-            f"lease-{index}",
+    sandboxes = [
+        _sandbox(
+            f"sandbox-{index}",
+            provider_env_id=f"instance-{index}",
             updated_at=f"2026-04-05T10:{index % 60:02d}:00",
-            recipe_id=None,
-            recipe_json=None,
-            last_error=None,
+            legacy_lease_id=f"lease-{index}",
         )
         for index in range(175)
     ]
     repo = SupabaseSandboxMonitorRepo(
         _MaxInFilterClient(
             {
-                "sandbox_leases": leases,
+                "container.sandboxes": sandboxes,
                 "abstract_terminals": [_terminal("term-174", "lease-174", "thread-174", "2026-04-05T10:02:00")],
             }
         )
@@ -246,28 +348,31 @@ def test_query_lease_instance_ids_chunks_large_lookup() -> None:
 def test_list_probe_targets_prefers_provider_session_id() -> None:
     repo = _repo(
         {
-            "sandbox_leases": [
-                _lease(
-                    "lease-running",
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-running",
                     provider_name="daytona_selfhost",
+                    provider_env_id="instance-lease",
                     observed_state="detached",
-                    current_instance_id="instance-lease",
                     updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-running",
                 ),
-                _lease(
-                    "lease-paused",
+                _sandbox(
+                    "sandbox-paused",
+                    provider_env_id="instance-local",
                     desired_state="paused",
                     observed_state="paused",
-                    current_instance_id="instance-local",
                     updated_at="2026-04-05T10:11:00",
+                    legacy_lease_id="lease-paused",
                 ),
-                _lease(
-                    "lease-stopped",
+                _sandbox(
+                    "sandbox-stopped",
                     provider_name="docker",
+                    provider_env_id="instance-stopped",
                     desired_state="stopped",
                     observed_state="stopped",
-                    current_instance_id="instance-stopped",
                     updated_at="2026-04-05T10:12:00",
+                    legacy_lease_id="lease-stopped",
                 ),
             ],
             "sandbox_instances": [
@@ -301,10 +406,25 @@ def test_list_probe_targets_prefers_provider_session_id() -> None:
     ids=["query-lease-instance-id", "list-probe-targets"],
 )
 def test_instance_lookup_failures_are_loud(include_updated_at, caller) -> None:
-    lease = _lease("lease-1", provider_name="daytona_selfhost", observed_state="detached", current_instance_id="instance-lease")
+    tables = {
+        "sandbox_leases": [
+            _lease("lease-1", provider_name="daytona_selfhost", observed_state="detached", current_instance_id="instance-lease")
+        ]
+    }
     if include_updated_at:
-        lease["updated_at"] = "2026-04-05T10:10:00"
-    repo = SupabaseSandboxMonitorRepo(_BrokenSandboxInstancesClient({"sandbox_leases": [lease]}))
+        tables = {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-lease",
+                    observed_state="detached",
+                    updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-1",
+                )
+            ]
+        }
+    repo = SupabaseSandboxMonitorRepo(_BrokenSandboxInstancesClient(tables))
 
     with pytest.raises(RuntimeError, match="sandbox_instances exploded"):
         caller(repo)


### PR DESCRIPTION
## Summary
- cut sandbox monitor session aggregation surfaces to use `container.sandboxes` as the base object truth
- keep `chat_sessions`, `abstract_terminals`, and legacy lease ids only as residue join keys
- preserve the already-cut summary surfaces as separate work in #538

## Test Plan
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py -q
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py -q
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check
