### PR TITLE
refactor: cut sandbox monitor residue keyed surfaces

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -134,6 +134,7 @@ class SupabaseSandboxMonitorRepo:
         return [self._session_with_lease(session, lease, include_thread=True) for session in sessions]
 
     def query_lease_threads(self, lease_id: str) -> list[dict]:
+        self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_threads")
         rows = q.rows(
             q.order(
                 self._client.table("abstract_terminals").select("thread_id").eq("lease_id", lease_id),
@@ -154,6 +155,7 @@ class SupabaseSandboxMonitorRepo:
         return result
 
     def query_lease_events(self, lease_id: str) -> list[dict]:
+        self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_events")
         # provider_events is the Supabase equivalent
         rows = q.rows(
             q.order(
@@ -263,6 +265,7 @@ class SupabaseSandboxMonitorRepo:
         if not ordered_ids:
             return {}
 
+        sandbox_rows = self._require_sandbox_rows_by_legacy_lease_ids(ordered_ids, "query_lease_instance_ids")
         instance_map: dict[str, str | None] = {lease_id: None for lease_id in ordered_ids}
         instances = q.rows_in_chunks(
             lambda: self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
@@ -281,18 +284,10 @@ class SupabaseSandboxMonitorRepo:
         if not missing_ids:
             return instance_map
 
-        leases = q.rows_in_chunks(
-            lambda: self._client.table("sandbox_leases").select("lease_id,current_instance_id"),
-            "lease_id",
-            missing_ids,
-            _REPO,
-            "query_lease_instance_ids leases",
-        )
-        for row in leases:
-            lease_id = str(row.get("lease_id") or "").strip()
-            current_instance_id = str(row.get("current_instance_id") or "").strip()
-            if lease_id and current_instance_id:
-                instance_map[lease_id] = current_instance_id
+        for lease_id in missing_ids:
+            provider_env_id = str(sandbox_rows[lease_id].get("provider_env_id") or "").strip()
+            if provider_env_id:
+                instance_map[lease_id] = provider_env_id
         return instance_map
 
     def _leases_by_id(self, lease_ids: list[str], select: str, operation: str) -> dict[str, dict]:
@@ -320,10 +315,32 @@ class SupabaseSandboxMonitorRepo:
 
     def _sandboxes_by_legacy_lease_id(self, operation: str) -> dict[str, dict[str, Any]]:
         result: dict[str, dict[str, Any]] = {}
-        for sandbox in self._ordered_sandboxes(operation):
+        for lease_id, sandbox in self._sandbox_rows_by_legacy_lease_id(operation).items():
             lease = self._lease_row_from_sandbox(sandbox)
-            result[lease["lease_id"]] = lease
+            result[lease_id] = lease
         return result
+
+    def _sandbox_rows_by_legacy_lease_id(self, operation: str) -> dict[str, dict[str, Any]]:
+        result: dict[str, dict[str, Any]] = {}
+        for sandbox in self._ordered_sandboxes(operation):
+            config = sandbox.get("config")
+            if not isinstance(config, dict):
+                raise RuntimeError("sandbox.config must be an object")
+            legacy_lease_id = str(config.get("legacy_lease_id") or "").strip()
+            if not legacy_lease_id:
+                raise RuntimeError("sandbox legacy bridge is required")
+            result[legacy_lease_id] = sandbox
+        return result
+
+    def _require_sandbox_rows_by_legacy_lease_ids(self, lease_ids: list[str], operation: str) -> dict[str, dict[str, Any]]:
+        # @@@sandbox-monitor-residue-bridge - residue-keyed monitor surfaces still
+        # accept legacy lease ids, but they must resolve through container.sandboxes
+        # first; missing bridge state is data corruption, not a soft miss.
+        sandbox_rows = self._sandbox_rows_by_legacy_lease_id(operation)
+        missing = [lease_id for lease_id in lease_ids if lease_id not in sandbox_rows]
+        if missing:
+            raise RuntimeError("sandbox legacy bridge is required")
+        return {lease_id: sandbox_rows[lease_id] for lease_id in lease_ids}
 
     def _lease_row_from_sandbox(self, sandbox: dict[str, Any]) -> dict[str, Any]:
         # @@@sandbox-monitor-bridge - summary surfaces now use container.sandboxes as the

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -351,11 +351,14 @@ def test_query_leases_chunks_terminal_binding_lookup() -> None:
 def test_query_lease_threads_returns_latest_unique_threads_first() -> None:
     repo = _repo(
         {
+            "container.sandboxes": [
+                _sandbox("sandbox-1", legacy_lease_id="lease-1"),
+            ],
             "abstract_terminals": [
                 _terminal("term-old", "lease-1", "thread-old", "2026-04-05T10:01:00"),
                 _terminal("term-new", "lease-1", "thread-new", "2026-04-05T10:02:00"),
                 _terminal("term-dupe", "lease-1", "thread-new", "2026-04-05T10:03:00"),
-            ]
+            ],
         }
     )
 
@@ -365,8 +368,14 @@ def test_query_lease_threads_returns_latest_unique_threads_first() -> None:
 def test_query_lease_instance_id_prefers_provider_session_id() -> None:
     repo = _repo(
         {
-            "sandbox_leases": [
-                _lease("lease-1", provider_name="daytona_selfhost", observed_state="detached", current_instance_id="instance-lease")
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    observed_state="detached",
+                    provider_env_id="instance-sandbox",
+                    legacy_lease_id="lease-1",
+                )
             ],
             "sandbox_instances": [
                 {"lease_id": "lease-1", "provider_session_id": "provider-session-1"},
@@ -382,7 +391,14 @@ def test_query_lease_instance_ids_chunks_large_lookup() -> None:
     repo = SupabaseSandboxMonitorRepo(
         _MaxInFilterClient(
             {
-                "sandbox_leases": [{"lease_id": lease_id, "current_instance_id": f"lease-instance-{lease_id}"} for lease_id in lease_ids],
+                "container.sandboxes": [
+                    _sandbox(
+                        f"sandbox-{index}",
+                        provider_env_id=f"sandbox-instance-{lease_ids[index]}",
+                        legacy_lease_id=lease_ids[index],
+                    )
+                    for index in range(175)
+                ],
                 "sandbox_instances": [{"lease_id": "lease-174", "provider_session_id": "provider-session-174"}],
             }
         )
@@ -390,8 +406,43 @@ def test_query_lease_instance_ids_chunks_large_lookup() -> None:
 
     result = repo.query_lease_instance_ids(lease_ids)
 
-    assert result["lease-0"] == "lease-instance-lease-0"
+    assert result["lease-0"] == "sandbox-instance-lease-0"
     assert result["lease-174"] == "provider-session-174"
+
+
+def test_query_lease_events_requires_sandbox_bridge() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox("sandbox-1", legacy_lease_id="lease-1"),
+            ],
+            "provider_events": [
+                {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:02:00", "event": "newer"},
+                {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:01:00", "event": "older"},
+            ],
+        }
+    )
+
+    assert repo.query_lease_events("lease-1") == [
+        {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:02:00", "event": "newer"},
+        {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:01:00", "event": "older"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("caller", "expected"),
+    [
+        (lambda repo: repo.query_lease_threads("lease-missing"), "sandbox legacy bridge is required"),
+        (lambda repo: repo.query_lease_events("lease-missing"), "sandbox legacy bridge is required"),
+        (lambda repo: repo.query_lease_instance_id("lease-missing"), "sandbox legacy bridge is required"),
+    ],
+    ids=["lease-threads", "lease-events", "lease-instance-id"],
+)
+def test_residue_keyed_surfaces_fail_loud_without_sandbox_bridge(caller, expected) -> None:
+    repo = _repo({"container.sandboxes": []})
+
+    with pytest.raises(RuntimeError, match=expected):
+        caller(repo)
 
 
 def test_list_probe_targets_prefers_provider_session_id() -> None:
@@ -456,23 +507,17 @@ def test_list_probe_targets_prefers_provider_session_id() -> None:
 )
 def test_instance_lookup_failures_are_loud(include_updated_at, caller) -> None:
     tables = {
-        "sandbox_leases": [
-            _lease("lease-1", provider_name="daytona_selfhost", observed_state="detached", current_instance_id="instance-lease")
+        "container.sandboxes": [
+            _sandbox(
+                "sandbox-1",
+                provider_name="daytona_selfhost",
+                provider_env_id="instance-lease",
+                observed_state="detached",
+                updated_at="2026-04-05T10:10:00" if include_updated_at else "2026-04-05T10:00:00",
+                legacy_lease_id="lease-1",
+            )
         ]
     }
-    if include_updated_at:
-        tables = {
-            "container.sandboxes": [
-                _sandbox(
-                    "sandbox-1",
-                    provider_name="daytona_selfhost",
-                    provider_env_id="instance-lease",
-                    observed_state="detached",
-                    updated_at="2026-04-05T10:10:00",
-                    legacy_lease_id="lease-1",
-                )
-            ]
-        }
     repo = SupabaseSandboxMonitorRepo(_BrokenSandboxInstancesClient(tables))
 
     with pytest.raises(RuntimeError, match="sandbox_instances exploded"):


### PR DESCRIPTION
## Summary
- cut the remaining residue-keyed sandbox monitor surfaces away from `sandbox_leases` as a base table
- require an explicit sandbox legacy bridge before serving lease-keyed events, threads, or instance ids
- use `container.sandboxes` as the fallback source for instance ids when `sandbox_instances` has no provider session id

## Test Plan
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/sandbox/test_sandbox_user_leases.py -q
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format --check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check
