### PR TITLE
refactor: cut launch config template source

### DIFF
--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from backend.web.services import sandbox_service
 from backend.web.services.library_service import list_library
-from sandbox.recipes import normalize_recipe_snapshot, provider_type_from_name
+from sandbox.recipes import default_recipe_id, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 
 
 def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -280,15 +280,53 @@ def _resolve_workspace_backed_existing_config(
             lease = leases_by_id.get(legacy_lease_id)
             if lease is None:
                 return None
+            sandbox_template = _resolve_workspace_backed_sandbox_template(
+                app=app,
+                owner_user_id=owner_user_id,
+                sandbox=sandbox,
+            )
             return {
                 "create_mode": "existing",
                 "provider_config": _required_bridge_text(sandbox, "provider_name", "sandbox"),
-                "sandbox_template": lease.get("recipe"),
+                "sandbox_template": sandbox_template,
                 "existing_sandbox_id": lease.get("lease_id"),
                 "model": None,
                 "workspace": _required_bridge_text(workspace, "workspace_path", "workspace"),
             }
     return None
+
+
+def _resolve_workspace_backed_sandbox_template(
+    *,
+    app: Any,
+    owner_user_id: str,
+    sandbox: Any,
+) -> dict[str, Any]:
+    sandbox_template_id = _required_bridge_text(sandbox, "sandbox_template_id", "sandbox")
+    template_provider_name = str(sandbox_template_id.split(":", 1)[0]).strip()
+    if not template_provider_name:
+        raise RuntimeError("sandbox.sandbox_template_id must include provider name")
+
+    if sandbox_template_id == default_recipe_id(template_provider_name):
+        return default_recipe_snapshot(
+            provider_type_from_name(template_provider_name),
+            provider_name=template_provider_name,
+        )
+
+    recipe_repo = getattr(app.state, "recipe_repo", None)
+    get = getattr(recipe_repo, "get", None)
+    if not callable(get):
+        raise RuntimeError("recipe_repo must support get")
+    row = get(owner_user_id, sandbox_template_id)
+    if row is None:
+        raise RuntimeError(f"sandbox template not found: {sandbox_template_id}")
+    data = row.get("data") if isinstance(row, dict) else getattr(row, "data", None)
+    if not isinstance(data, dict):
+        raise RuntimeError("sandbox template row data must be an object")
+    provider_type = str(data.get("provider_type") or provider_type_from_name(template_provider_name)).strip()
+    if not provider_type:
+        raise RuntimeError("sandbox template provider_type is required")
+    return normalize_recipe_snapshot(provider_type, data)
 
 
 def _required_bridge_text(row: Any, key: str, label: str) -> str:

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -513,6 +513,191 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
     }
 
 
+def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_workspace_backed_existing_mode() -> None:
+    thread_repo = _FakeThreadRepo()
+    thread_repo.rows["agent-user-1-1"] = {
+        "thread_id": "agent-user-1-1",
+        "agent_user_id": "agent-user-1",
+        "current_workspace_id": "ws-3",
+        "is_main": True,
+        "branch_index": 0,
+        "created_at": 3.0,
+    }
+    workspace_repo = _FakeWorkspaceRepo()
+    workspace_repo.by_id["ws-3"] = SimpleNamespace(
+        id="ws-3",
+        sandbox_id="sandbox-3",
+        owner_user_id="owner-1",
+        workspace_path="/workspace/template-from-sandbox",
+        name=None,
+        created_at=3.0,
+        updated_at=3.0,
+    )
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-3"] = SimpleNamespace(
+        id="sandbox-3",
+        owner_user_id="owner-1",
+        provider_name="daytona_selfhost",
+        provider_env_id="provider-env-3",
+        sandbox_template_id="daytona:custom:lark",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=3.0,
+        last_error=None,
+        config={"legacy_lease_id": "lease-3"},
+        created_at=3.0,
+        updated_at=3.0,
+    )
+    recipe_repo = _FakeRecipeRepo()
+    recipe_repo.rows[("owner-1", "daytona:custom:lark")] = {
+        "owner_user_id": "owner-1",
+        "recipe_id": "daytona:custom:lark",
+        "kind": "custom",
+        "provider_type": "daytona",
+        "data": {
+            "id": "daytona:custom:lark",
+            "name": "Daytona Custom Lark",
+            "desc": "custom",
+            "provider_name": "daytona_selfhost",
+            "provider_type": "daytona",
+            "features": {"lark_cli": True},
+            "builtin": False,
+        },
+        "created_at": 0,
+        "updated_at": 0,
+    }
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_launch_pref_repo=SimpleNamespace(get=lambda _owner_user_id, _agent_user_id: {}),
+            thread_repo=thread_repo,
+            user_repo=SimpleNamespace(),
+            recipe_repo=recipe_repo,
+            workspace_repo=workspace_repo,
+            sandbox_repo=sandbox_repo,
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "list_user_leases",
+            return_value=[
+                {
+                    "lease_id": "lease-3",
+                    "provider_name": "daytona_selfhost",
+                    "recipe": default_recipe_snapshot("daytona"),
+                    "cwd": "/workspace/from-lease",
+                    "thread_ids": [],
+                }
+            ],
+        ),
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "available_sandbox_types",
+            return_value=[{"name": "daytona_selfhost", "available": True}],
+        ),
+        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+    ):
+        result = thread_launch_config_service.resolve_default_config(
+            app=app,
+            owner_user_id="owner-1",
+            agent_user_id="agent-user-1",
+        )
+
+    assert result == {
+        "source": "derived",
+        "config": {
+            "create_mode": "existing",
+            "provider_config": "daytona_selfhost",
+            "sandbox_template": normalize_recipe_snapshot(
+                "daytona",
+                recipe_repo.rows[("owner-1", "daytona:custom:lark")]["data"],
+                provider_name="daytona_selfhost",
+            ),
+            "existing_sandbox_id": "lease-3",
+            "model": None,
+            "workspace": "/workspace/template-from-sandbox",
+        },
+    }
+
+
+def test_resolve_default_config_fails_loudly_when_workspace_backed_template_source_is_missing() -> None:
+    thread_repo = _FakeThreadRepo()
+    thread_repo.rows["agent-user-1-1"] = {
+        "thread_id": "agent-user-1-1",
+        "agent_user_id": "agent-user-1",
+        "current_workspace_id": "ws-missing-template",
+        "is_main": True,
+        "branch_index": 0,
+        "created_at": 4.0,
+    }
+    workspace_repo = _FakeWorkspaceRepo()
+    workspace_repo.by_id["ws-missing-template"] = SimpleNamespace(
+        id="ws-missing-template",
+        sandbox_id="sandbox-missing-template",
+        owner_user_id="owner-1",
+        workspace_path="/workspace/missing-template",
+        name=None,
+        created_at=4.0,
+        updated_at=4.0,
+    )
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-missing-template"] = SimpleNamespace(
+        id="sandbox-missing-template",
+        owner_user_id="owner-1",
+        provider_name="daytona_selfhost",
+        provider_env_id="provider-env-4",
+        sandbox_template_id="daytona:custom:missing",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=4.0,
+        last_error=None,
+        config={"legacy_lease_id": "lease-4"},
+        created_at=4.0,
+        updated_at=4.0,
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_launch_pref_repo=SimpleNamespace(get=lambda _owner_user_id, _agent_user_id: {}),
+            thread_repo=thread_repo,
+            user_repo=SimpleNamespace(),
+            recipe_repo=_FakeRecipeRepo(),
+            workspace_repo=workspace_repo,
+            sandbox_repo=sandbox_repo,
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "list_user_leases",
+            return_value=[
+                {
+                    "lease_id": "lease-4",
+                    "provider_name": "daytona_selfhost",
+                    "recipe": default_recipe_snapshot("daytona"),
+                    "cwd": "/workspace/from-lease",
+                    "thread_ids": [],
+                }
+            ],
+        ),
+        patch.object(
+            thread_launch_config_service.sandbox_service,
+            "available_sandbox_types",
+            return_value=[{"name": "daytona_selfhost", "available": True}],
+        ),
+        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+        pytest.raises(RuntimeError, match="sandbox template not found: daytona:custom:missing"),
+    ):
+        thread_launch_config_service.resolve_default_config(
+            app=app,
+            owner_user_id="owner-1",
+            agent_user_id="agent-user-1",
+        )
+
+
 def test_resolve_default_config_derives_existing_from_legacy_lease_backed_current_workspace_id() -> None:
     thread_repo = _FakeThreadRepo()
     thread_repo.rows["agent-user-1-1"] = {


### PR DESCRIPTION
## Summary
- source workspace-backed existing-mode sandbox_template from sandbox template ids
- keep existing_sandbox_id on the legacy lease-shaped shell
- fail loudly when the workspace-backed template source is missing

## Verification
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py -q
- uv run ruff check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py
- git diff --check
