### PR TITLE
refactor: dual accept existing sandbox request identity

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -113,9 +113,20 @@ def _save_default_config_for_owned_agent(
     payload: SaveThreadLaunchConfigRequest,
 ) -> dict[str, bool]:
     _require_owned_agent(app, payload.agent_user_id, owner_user_id)
+    normalized_payload = payload
+    if payload.create_mode == "existing" and payload.existing_sandbox_id:
+        normalized_payload = payload.model_copy(
+            update={
+                "existing_sandbox_id": _normalize_existing_sandbox_request_lease_id(
+                    app,
+                    owner_user_id,
+                    payload.existing_sandbox_id,
+                )
+            }
+        )
     if payload.create_mode == "new":
         _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.sandbox_template_id)
-    save_last_confirmed_config(app, owner_user_id, payload.agent_user_id, payload.model_dump())
+    save_last_confirmed_config(app, owner_user_id, normalized_payload.agent_user_id, normalized_payload.model_dump())
     return {"ok": True}
 
 
@@ -299,12 +310,7 @@ def _serialize_permission_answers(payload: Any) -> list[dict[str, Any]] | None:
 def _validate_sandbox_provider_gate(app: Any, owner_user_id: str, payload: CreateThreadRequest) -> JSONResponse | None:
     sandbox_type = payload.sandbox or "local"
     if payload.existing_sandbox_id:
-        owned_lease = sandbox_service.resolve_owned_lease(
-            owner_user_id,
-            payload.existing_sandbox_id,
-            thread_repo=app.state.thread_repo,
-            user_repo=app.state.user_repo,
-        )
+        owned_lease = _resolve_owned_existing_sandbox_request_lease(app, owner_user_id, payload.existing_sandbox_id)
         if owned_lease is not None:
             sandbox_type = str(owned_lease["provider_name"] or sandbox_type)
     if sandbox_type == "local":
@@ -331,6 +337,79 @@ def _validate_sandbox_quota_gate(app: Any, owner_user_id: str, payload: CreateTh
             },
         )
     return None
+
+
+def _request_bridge_text(row: Any, key: str, *, label: str) -> str:
+    value = row.get(key) if isinstance(row, dict) else getattr(row, key, None)
+    if isinstance(value, str):
+        value = value.strip()
+    if value is None or value == "":
+        raise RuntimeError(f"{label}.{key} is required")
+    return str(value)
+
+
+def _request_bridge_config_text(row: Any, key: str, *, label: str) -> str:
+    config = row.get("config") if isinstance(row, dict) else getattr(row, "config", None)
+    if not isinstance(config, dict):
+        raise RuntimeError(f"{label}.config must be an object")
+    value = config.get(key)
+    if isinstance(value, str):
+        value = value.strip()
+    if value is None or value == "":
+        raise RuntimeError(f"{label}.config.{key} is required")
+    return str(value)
+
+
+def _resolve_owned_existing_sandbox_request_lease(
+    app: Any,
+    owner_user_id: str,
+    existing_sandbox_id: str,
+) -> dict[str, Any] | None:
+    normalized_id = str(existing_sandbox_id or "").strip()
+    if not normalized_id:
+        return None
+
+    owned_lease = sandbox_service.resolve_owned_lease(
+        owner_user_id,
+        normalized_id,
+        thread_repo=app.state.thread_repo,
+        user_repo=app.state.user_repo,
+    )
+    if owned_lease is not None:
+        return owned_lease
+
+    sandbox_repo = getattr(app.state, "sandbox_repo", None)
+    sandbox_get_by_id = getattr(sandbox_repo, "get_by_id", None)
+    if not callable(sandbox_get_by_id):
+        return None
+    sandbox = sandbox_get_by_id(normalized_id)
+    if sandbox is None:
+        return None
+
+    # @@@existing-sandbox-request-bridge - Phase A only widens request parsing.
+    # Incoming sandbox ids are normalized back to the canonical lease-shaped shell
+    # so existing create/save surfaces keep their outward contract unchanged.
+    sandbox_owner_user_id = _request_bridge_text(sandbox, "owner_user_id", label="sandbox")
+    if sandbox_owner_user_id != owner_user_id:
+        raise HTTPException(403, "Not authorized")
+    legacy_lease_id = _request_bridge_config_text(sandbox, "legacy_lease_id", label="sandbox")
+    return sandbox_service.resolve_owned_lease(
+        owner_user_id,
+        legacy_lease_id,
+        thread_repo=app.state.thread_repo,
+        user_repo=app.state.user_repo,
+    )
+
+
+def _normalize_existing_sandbox_request_lease_id(
+    app: Any,
+    owner_user_id: str,
+    existing_sandbox_id: str,
+) -> str:
+    owned_lease = _resolve_owned_existing_sandbox_request_lease(app, owner_user_id, existing_sandbox_id)
+    if owned_lease is None:
+        raise HTTPException(403, "Lease not authorized")
+    return _request_bridge_text(owned_lease, "lease_id", label="lease")
 
 
 def _get_agent_for_thread(app: Any, thread_id: str) -> Any | None:
@@ -730,9 +809,14 @@ def _create_owned_thread(
     if not agent_user or agent_user.owner_user_id != owner_user_id:
         raise HTTPException(403, "Not authorized")
 
-    selected_lease_id = payload.existing_sandbox_id
+    selected_lease_id = None
     owned_lease: dict[str, Any] | None = None
-    if selected_lease_id:
+    if payload.existing_sandbox_id:
+        selected_lease_id = _normalize_existing_sandbox_request_lease_id(
+            app,
+            owner_user_id,
+            payload.existing_sandbox_id,
+        )
         owned_lease = sandbox_service.resolve_owned_lease(
             owner_user_id,
             selected_lease_id,

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -1070,6 +1070,83 @@ async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(mon
         "save_last_confirmed_config",
         lambda app_obj, owner_user_id, agent_user_id, config: saved.append((app_obj, owner_user_id, agent_user_id, config)),
     )
+    monkeypatch.setattr(
+        threads_router.sandbox_service,
+        "resolve_owned_lease",
+        lambda owner_user_id, lease_id, **_: (
+            {
+                "lease_id": "lease-1",
+                "provider_name": "daytona_selfhost",
+            }
+            if owner_user_id == "owner-1" and lease_id == "lease-1"
+            else None
+        ),
+    )
+
+    result = await threads_router.save_default_thread_config(payload, "owner-1", app)
+
+    assert result == {"ok": True}
+    assert to_thread_calls == [("_save_default_config_for_owned_agent", (app, "owner-1", payload))]
+    assert saved == [
+        (
+            app,
+            "owner-1",
+            "agent-user-1",
+            {
+                "agent_user_id": "agent-user-1",
+                "create_mode": "existing",
+                "provider_config": "daytona_selfhost",
+                "sandbox_template_id": None,
+                "existing_sandbox_id": "lease-1",
+                "model": "gpt-5.4-mini",
+                "workspace": "/workspace/reused",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_save_default_thread_config_accepts_sandbox_shaped_existing_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_threads_app()
+    app.state.sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
+    payload = threads_router.SaveThreadLaunchConfigRequest(
+        agent_user_id="agent-user-1",
+        create_mode="existing",
+        provider_config="daytona_selfhost",
+        existing_sandbox_id="sandbox-1",
+        model="gpt-5.4-mini",
+        workspace="/workspace/reused",
+    )
+    saved: list[tuple[object, str, str, dict[str, object]]] = []
+    to_thread_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_to_thread(fn, *args):
+        to_thread_calls.append((fn.__name__, args))
+        return fn(*args)
+
+    monkeypatch.setattr(threads_router.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(threads_router, "_require_owned_agent", lambda app_obj, agent_user_id, owner_user_id: object())
+    monkeypatch.setattr(
+        threads_router,
+        "save_last_confirmed_config",
+        lambda app_obj, owner_user_id, agent_user_id, config: saved.append((app_obj, owner_user_id, agent_user_id, config)),
+    )
+    monkeypatch.setattr(
+        threads_router.sandbox_service,
+        "resolve_owned_lease",
+        lambda owner_user_id, lease_id, **_: (
+            {
+                "lease_id": "lease-1",
+                "provider_name": "daytona_selfhost",
+            }
+            if owner_user_id == "owner-1" and lease_id == "lease-1"
+            else None
+        ),
+    )
 
     result = await threads_router.save_default_thread_config(payload, "owner-1", app)
 

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -619,6 +619,49 @@ async def test_create_thread_route_existing_sandbox_still_saves_existing_launch_
 
 
 @pytest.mark.asyncio
+async def test_create_thread_route_accepts_sandbox_shaped_existing_identity() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
+    payload = CreateThreadRequest.model_validate(
+        {
+            "agent_user_id": "agent-user-1",
+            "existing_sandbox_id": "sandbox-1",
+            "cwd": "/workspace/reused",
+        }
+    )
+    save_config = MagicMock()
+
+    def _resolve_owned_lease(owner_user_id: str, lease_id: str, **_: Any) -> dict[str, Any] | None:
+        if owner_user_id == "owner-1" and lease_id == "lease-1":
+            return {
+                "lease_id": "lease-1",
+                "sandbox_id": "sandbox-1",
+                "provider_name": "local",
+                "cwd": "/workspace/reused",
+                "recipe": {"id": "local:default"},
+            }
+        return None
+
+    with (
+        patch.object(threads_router.sandbox_service, "resolve_owned_lease", side_effect=_resolve_owned_lease),
+        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
+        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused") as bind_helper,
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", save_config),
+    ):
+        result = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    bind_helper.assert_called_once_with(result["thread_id"], "lease-1", cwd="/workspace/reused")
+    assert save_config.call_args.args[3]["existing_sandbox_id"] == "lease-1"
+
+
+@pytest.mark.asyncio
 async def test_create_thread_route_new_sandbox_still_saves_new_launch_config() -> None:
     workspace_repo = _FakeWorkspaceRepo()
     app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)


### PR DESCRIPTION
## Summary
- dual-accept lease-shaped and sandbox-shaped incoming `existing_sandbox_id` on request surfaces
- normalize sandbox-shaped request identities back to the canonical lease-shaped shell for create/save paths
- keep response and persisted emit shapes unchanged in Phase A

## Verification
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -q
- uv run ruff check backend/web/routers/threads.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py
- git diff --check