### PR TITLE
refactor: single emit existing sandbox identity

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -39,6 +39,7 @@ from backend.web.services.streaming_service import (
     observe_thread_events,
 )
 from backend.web.services.thread_launch_config_service import (
+    _existing_sandbox_shell_id,
     build_existing_launch_config,
     build_new_launch_config,
     resolve_default_config,
@@ -115,15 +116,12 @@ def _save_default_config_for_owned_agent(
     _require_owned_agent(app, payload.agent_user_id, owner_user_id)
     normalized_payload = payload
     if payload.create_mode == "existing" and payload.existing_sandbox_id:
-        normalized_payload = payload.model_copy(
-            update={
-                "existing_sandbox_id": _normalize_existing_sandbox_request_lease_id(
-                    app,
-                    owner_user_id,
-                    payload.existing_sandbox_id,
-                )
-            }
+        normalized_existing_lease_id = _normalize_existing_sandbox_request_lease_id(
+            app,
+            owner_user_id,
+            payload.existing_sandbox_id,
         )
+        normalized_payload = payload.model_copy(update={"existing_sandbox_id": _existing_sandbox_shell_id(normalized_existing_lease_id)})
     if payload.create_mode == "new":
         _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.sandbox_template_id)
     save_last_confirmed_config(app, owner_user_id, normalized_payload.agent_user_id, normalized_payload.model_dump())
@@ -898,6 +896,7 @@ def _create_owned_thread(
             lease=owned_lease,
             model=payload.model,
             workspace=app.state.thread_cwd.get(new_thread_id),
+            existing_sandbox_id=sandbox_id,
         )
     else:
         successful_config = build_new_launch_config(

--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from backend.web.services import sandbox_service
@@ -24,17 +25,28 @@ def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _existing_sandbox_shell_id(lease_id: str) -> str:
+    normalized_lease_id = str(lease_id or "").strip()
+    if not normalized_lease_id:
+        raise RuntimeError("lease.lease_id is required")
+    # @@@existing-sandbox-shell-id - Phase B only cuts outward emit identity.
+    # Keep the bridge deterministic so old lease-backed reads can emit the same
+    # sandbox-shaped shell as workspace-backed paths without inventing aliases.
+    return f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, f'mycel-lease-bridge:{normalized_lease_id}').hex}"
+
+
 def build_existing_launch_config(
     *,
     lease: dict[str, Any],
     model: str | None,
     workspace: str | None,
+    existing_sandbox_id: str | None = None,
 ) -> dict[str, Any]:
     return normalize_launch_config_payload(
         {
             "create_mode": "existing",
             "provider_config": lease.get("provider_name"),
-            "existing_sandbox_id": lease.get("lease_id"),
+            "existing_sandbox_id": existing_sandbox_id or _existing_sandbox_shell_id(str(lease.get("lease_id") or "")),
             "model": model,
             "workspace": workspace,
         }
@@ -132,7 +144,15 @@ def _validate_saved_config(
         existing_sandbox_id = config.get("existing_sandbox_id")
         if not existing_sandbox_id:
             return None
-        lease = next((item for item in leases if item["lease_id"] == existing_sandbox_id), None)
+        lease = next(
+            (
+                item
+                for item in leases
+                if item["lease_id"] == existing_sandbox_id
+                or _existing_sandbox_shell_id(str(item.get("lease_id") or "")) == existing_sandbox_id
+            ),
+            None,
+        )
         if lease is None:
             return None
         return _existing_config_from_lease(lease, model=config.get("model"), workspace=lease.get("cwd"))
@@ -176,7 +196,7 @@ def _existing_config_from_lease(lease: dict[str, Any], *, model: str | None, wor
         "create_mode": "existing",
         "provider_config": lease.get("provider_name"),
         "sandbox_template": lease.get("recipe"),
-        "existing_sandbox_id": lease.get("lease_id"),
+        "existing_sandbox_id": _existing_sandbox_shell_id(str(lease.get("lease_id") or "")),
         "model": model,
         "workspace": workspace,
     }
@@ -289,7 +309,7 @@ def _resolve_workspace_backed_existing_config(
                 "create_mode": "existing",
                 "provider_config": _required_bridge_text(sandbox, "provider_name", "sandbox"),
                 "sandbox_template": sandbox_template,
-                "existing_sandbox_id": lease.get("lease_id"),
+                "existing_sandbox_id": _required_bridge_text(sandbox, "id", "sandbox"),
                 "model": None,
                 "workspace": _required_bridge_text(workspace, "workspace_path", "workspace"),
             }

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -253,7 +254,7 @@ def test_build_existing_launch_config_uses_canonical_shape() -> None:
         "create_mode": "existing",
         "provider_config": "daytona_selfhost",
         "sandbox_template_id": None,
-        "existing_sandbox_id": "lease-1",
+        "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
         "model": "gpt-5.4",
         "workspace": "/workspace/reused",
     }
@@ -343,7 +344,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
             "create_mode": "existing",
             "provider_config": "local",
             "sandbox_template": default_recipe_snapshot("local"),
-            "existing_sandbox_id": "lease-1",
+            "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
             "model": "gpt-5.4",
             "workspace": "/workspace/reused",
         },
@@ -506,7 +507,7 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
             "create_mode": "existing",
             "provider_config": "agent_bay",
             "sandbox_template": default_recipe_snapshot("daytona"),
-            "existing_sandbox_id": "lease-2",
+            "existing_sandbox_id": "sandbox-2",
             "model": None,
             "workspace": "/workspace/right",
         },
@@ -615,7 +616,7 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
                 recipe_repo.rows[("owner-1", "daytona:custom:lark")]["data"],
                 provider_name="daytona_selfhost",
             ),
-            "existing_sandbox_id": "lease-3",
+            "existing_sandbox_id": "sandbox-3",
             "model": None,
             "workspace": "/workspace/template-from-sandbox",
         },
@@ -762,7 +763,7 @@ def test_resolve_default_config_derives_existing_from_legacy_lease_backed_curren
             "create_mode": "existing",
             "provider_config": "daytona_selfhost",
             "sandbox_template": default_recipe_snapshot("daytona"),
-            "existing_sandbox_id": "lease-2",
+            "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-2').hex}",
             "model": None,
             "workspace": "/workspace/right",
         },
@@ -933,7 +934,7 @@ async def test_create_thread_persists_existing_lease_successful_config() -> None
             "create_mode": "existing",
             "provider_config": "daytona_selfhost",
             "sandbox_template_id": None,
-            "existing_sandbox_id": "lease-1",
+            "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
             "model": "gpt-5.4",
             "workspace": "/workspace/reused",
         },
@@ -1097,7 +1098,7 @@ async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(mon
                 "create_mode": "existing",
                 "provider_config": "daytona_selfhost",
                 "sandbox_template_id": None,
-                "existing_sandbox_id": "lease-1",
+                "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
                 "model": "gpt-5.4-mini",
                 "workspace": "/workspace/reused",
             },
@@ -1162,7 +1163,7 @@ async def test_save_default_thread_config_accepts_sandbox_shaped_existing_identi
                 "create_mode": "existing",
                 "provider_config": "daytona_selfhost",
                 "sandbox_template_id": None,
-                "existing_sandbox_id": "lease-1",
+                "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
                 "model": "gpt-5.4-mini",
                 "workspace": "/workspace/reused",
             },

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import threading
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -658,7 +659,10 @@ async def test_create_thread_route_accepts_sandbox_shaped_existing_identity() ->
         result = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
 
     bind_helper.assert_called_once_with(result["thread_id"], "lease-1", cwd="/workspace/reused")
-    assert save_config.call_args.args[3]["existing_sandbox_id"] == "lease-1"
+    assert (
+        save_config.call_args.args[3]["existing_sandbox_id"]
+        == f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- switch existing-mode response/save surfaces to sandbox-shaped `existing_sandbox_id`
- keep request-side dual-accept for lease-shaped and sandbox-shaped incoming identity
- preserve internal lease bridge while removing it from outward emit surfaces

## Verification
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q
- uv run ruff check backend/web/services/thread_launch_config_service.py backend/web/routers/threads.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py
- git diff --check