### PR TITLE
refactor: remove lease-shaped existing sandbox requests

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -367,15 +367,6 @@ def _resolve_owned_existing_sandbox_request_lease(
     if not normalized_id:
         return None
 
-    owned_lease = sandbox_service.resolve_owned_lease(
-        owner_user_id,
-        normalized_id,
-        thread_repo=app.state.thread_repo,
-        user_repo=app.state.user_repo,
-    )
-    if owned_lease is not None:
-        return owned_lease
-
     sandbox_repo = getattr(app.state, "sandbox_repo", None)
     sandbox_get_by_id = getattr(sandbox_repo, "get_by_id", None)
     if not callable(sandbox_get_by_id):
@@ -384,9 +375,9 @@ def _resolve_owned_existing_sandbox_request_lease(
     if sandbox is None:
         return None
 
-    # @@@existing-sandbox-request-bridge - Phase A only widens request parsing.
-    # Incoming sandbox ids are normalized back to the canonical lease-shaped shell
-    # so existing create/save surfaces keep their outward contract unchanged.
+    # @@@existing-sandbox-request-cutover - Phase C removes lease-shaped request
+    # acceptance. Incoming existing_sandbox_id must already be sandbox-shaped;
+    # legacy lease identity remains an internal bridge only.
     sandbox_owner_user_id = _request_bridge_text(sandbox, "owner_user_id", label="sandbox")
     if sandbox_owner_user_id != owner_user_id:
         raise HTTPException(403, "Not authorized")

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -898,10 +898,15 @@ def test_require_owned_agent_raises_for_foreign_agent() -> None:
 @pytest.mark.asyncio
 async def test_create_thread_persists_existing_lease_successful_config() -> None:
     app = _make_threads_app()
+    app.state.sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "existing_sandbox_id": "lease-1",
+            "existing_sandbox_id": "sandbox-1",
             "model": "gpt-5.4",
             "cwd": "/workspace/requested",
         }
@@ -920,7 +925,6 @@ async def test_create_thread_persists_existing_lease_successful_config() -> None
                 "recipe": {"id": "daytona:recipe-1"},
             },
         ),
-        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
         patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
         patch.object(threads_router, "save_last_successful_config", return_value=None) as save_successful,
     ):
@@ -1049,66 +1053,6 @@ async def test_save_default_thread_config_uses_strict_agent_gate(monkeypatch: py
 @pytest.mark.asyncio
 async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     app = _make_threads_app()
-    payload = threads_router.SaveThreadLaunchConfigRequest(
-        agent_user_id="agent-user-1",
-        create_mode="existing",
-        provider_config="daytona_selfhost",
-        existing_sandbox_id="lease-1",
-        model="gpt-5.4-mini",
-        workspace="/workspace/reused",
-    )
-    saved: list[tuple[object, str, str, dict[str, object]]] = []
-    to_thread_calls: list[tuple[str, tuple[object, ...]]] = []
-
-    async def _fake_to_thread(fn, *args):
-        to_thread_calls.append((fn.__name__, args))
-        return fn(*args)
-
-    monkeypatch.setattr(threads_router.asyncio, "to_thread", _fake_to_thread)
-    monkeypatch.setattr(threads_router, "_require_owned_agent", lambda app_obj, agent_user_id, owner_user_id: object())
-    monkeypatch.setattr(
-        threads_router,
-        "save_last_confirmed_config",
-        lambda app_obj, owner_user_id, agent_user_id, config: saved.append((app_obj, owner_user_id, agent_user_id, config)),
-    )
-    monkeypatch.setattr(
-        threads_router.sandbox_service,
-        "resolve_owned_lease",
-        lambda owner_user_id, lease_id, **_: (
-            {
-                "lease_id": "lease-1",
-                "provider_name": "daytona_selfhost",
-            }
-            if owner_user_id == "owner-1" and lease_id == "lease-1"
-            else None
-        ),
-    )
-
-    result = await threads_router.save_default_thread_config(payload, "owner-1", app)
-
-    assert result == {"ok": True}
-    assert to_thread_calls == [("_save_default_config_for_owned_agent", (app, "owner-1", payload))]
-    assert saved == [
-        (
-            app,
-            "owner-1",
-            "agent-user-1",
-            {
-                "agent_user_id": "agent-user-1",
-                "create_mode": "existing",
-                "provider_config": "daytona_selfhost",
-                "sandbox_template_id": None,
-                "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
-                "model": "gpt-5.4-mini",
-                "workspace": "/workspace/reused",
-            },
-        )
-    ]
-
-
-@pytest.mark.asyncio
-async def test_save_default_thread_config_accepts_sandbox_shaped_existing_identity(monkeypatch: pytest.MonkeyPatch) -> None:
-    app = _make_threads_app()
     app.state.sandbox_repo.by_id["sandbox-1"] = {
         "id": "sandbox-1",
         "owner_user_id": "owner-1",
@@ -1169,6 +1113,46 @@ async def test_save_default_thread_config_accepts_sandbox_shaped_existing_identi
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_save_default_thread_config_accepts_sandbox_shaped_existing_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_threads_app()
+    payload = threads_router.SaveThreadLaunchConfigRequest(
+        agent_user_id="agent-user-1",
+        create_mode="existing",
+        provider_config="daytona_selfhost",
+        existing_sandbox_id="lease-1",
+        model="gpt-5.4-mini",
+        workspace="/workspace/reused",
+    )
+    to_thread_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_to_thread(fn, *args):
+        to_thread_calls.append((fn.__name__, args))
+        return fn(*args)
+
+    monkeypatch.setattr(threads_router.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(threads_router, "_require_owned_agent", lambda app_obj, agent_user_id, owner_user_id: object())
+    monkeypatch.setattr(
+        threads_router.sandbox_service,
+        "resolve_owned_lease",
+        lambda owner_user_id, lease_id, **_: (
+            {
+                "lease_id": "lease-1",
+                "provider_name": "daytona_selfhost",
+            }
+            if owner_user_id == "owner-1" and lease_id == "lease-1"
+            else None
+        ),
+    )
+
+    with pytest.raises(threads_router.HTTPException) as excinfo:
+        await threads_router.save_default_thread_config(payload, "owner-1", app)
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Lease not authorized"
+    assert to_thread_calls == [("_save_default_config_for_owned_agent", (app, "owner-1", payload))]
 
 
 def test_get_default_thread_config_route_rejects_unowned_agent() -> None:

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -455,7 +455,7 @@ async def test_create_thread_persists_agent_user_id():
 
 
 @pytest.mark.asyncio
-async def test_create_thread_route_uses_canonical_existing_lease_binding_helper():
+async def test_create_thread_route_rejects_lease_shaped_existing_identity():
     app = _make_threads_app(thread_sandbox={}, thread_cwd={})
     payload = CreateThreadRequest.model_validate(
         {
@@ -471,30 +471,32 @@ async def test_create_thread_route_uses_canonical_existing_lease_binding_helper(
             "resolve_owned_lease",
             return_value={"lease_id": "lease-1", "provider_name": "local", "recipe": None},
         ),
-        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
         patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused") as bind_helper,
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", return_value=None),
     ):
-        result = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+        with pytest.raises(threads_router.HTTPException) as excinfo:
+            await threads_router.create_thread(payload, "owner-1", app)
 
-    bind_helper.assert_called_once_with(
-        result["thread_id"],
-        "lease-1",
-        cwd="/workspace/reused",
-    )
-    assert app.state.thread_cwd[result["thread_id"]] == "/workspace/reused"
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Lease not authorized"
+    bind_helper.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() -> None:
     workspace_repo = _FakeWorkspaceRepo()
     sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
     app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "existing_sandbox_id": "lease-1",
+            "existing_sandbox_id": "sandbox-1",
             "cwd": "/workspace/reused",
         }
     )
@@ -511,7 +513,6 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
                 "recipe": None,
             },
         ),
-        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
         patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", return_value=None),
@@ -587,11 +588,17 @@ async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox
 @pytest.mark.asyncio
 async def test_create_thread_route_existing_sandbox_still_saves_existing_launch_config() -> None:
     workspace_repo = _FakeWorkspaceRepo()
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "existing_sandbox_id": "lease-1",
+            "existing_sandbox_id": "sandbox-1",
             "cwd": "/workspace/reused",
         }
     )
@@ -609,7 +616,6 @@ async def test_create_thread_route_existing_sandbox_still_saves_existing_launch_
                 "recipe": {"id": "local:default"},
             },
         ),
-        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
         patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", save_config),
@@ -941,10 +947,15 @@ async def test_create_thread_route_rejects_unavailable_provider():
 @pytest.mark.asyncio
 async def test_create_thread_route_rejects_unavailable_provider_for_existing_lease():
     app = _make_threads_app(thread_sandbox={}, thread_cwd={})
+    app.state.sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
-            "existing_sandbox_id": "lease-1",
+            "existing_sandbox_id": "sandbox-1",
         }
     )
 
@@ -954,7 +965,6 @@ async def test_create_thread_route_rejects_unavailable_provider_for_existing_lea
             "resolve_owned_lease",
             return_value={"lease_id": "lease-1", "provider_name": "daytona", "recipe": None},
         ),
-        patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
         patch.object(threads_router.sandbox_service, "build_provider_from_config_name", return_value=None),
     ):
         result = await threads_router.create_thread(payload, "owner-1", app)


### PR DESCRIPTION
## Summary
- remove lease-shaped request acceptance for existing sandbox create/save flows
- keep sandbox-shaped `existing_sandbox_id` as the only valid incoming request identity
- leave response emit and internal legacy bridges unchanged

## Test Plan
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -q
- uv run ruff check backend/web/routers/threads.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py
- backend API YATU: sandbox-shaped create/save -> 200, lease-shaped create/save -> 403
