### PR TITLE
refactor: emit sandbox ids in monitor lease payloads

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -503,6 +503,7 @@ def _map_leases(rows: list[dict[str, Any]]) -> dict[str, Any]:
         )
         items.append(
             {
+                "sandbox_id": row.get("sandbox_id"),
                 "lease_id": row["lease_id"],
                 "provider": row["provider_name"],
                 "instance_id": row["current_instance_id"],
@@ -593,6 +594,7 @@ def get_monitor_lease_detail(lease_id: str) -> dict[str, Any]:
 
     return {
         "lease": {
+            "sandbox_id": lease.get("sandbox_id"),
             "lease_id": str(lease.get("lease_id") or lease_id),
             "provider_name": provider_name,
             "desired_state": lease.get("desired_state"),

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -353,6 +353,7 @@ class SupabaseSandboxMonitorRepo:
         if not legacy_lease_id:
             raise RuntimeError("sandbox.config.legacy_lease_id is required")
         return {
+            "sandbox_id": str(sandbox.get("id") or "").strip() or None,
             "lease_id": legacy_lease_id,
             "provider_name": sandbox.get("provider_name"),
             "recipe_id": sandbox.get("sandbox_template_id"),

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -28,6 +28,7 @@ def _default_eval_batch_service(monkeypatch):
 
 def _lease_row(**overrides):
     row = {
+        "sandbox_id": "sandbox-1",
         "lease_id": "lease-1",
         "provider_name": "daytona",
         "desired_state": "running",
@@ -333,6 +334,7 @@ def test_get_monitor_lease_detail_merges_monitor_repo_state(monkeypatch):
 
     payload = monitor_service.get_monitor_lease_detail("lease-1")
 
+    assert payload["lease"]["sandbox_id"] == "sandbox-1"
     assert payload["lease"]["lease_id"] == "lease-1"
     assert payload["provider"] == {"id": "daytona", "name": "daytona"}
     assert payload["runtime"] == {"runtime_session_id": "runtime-1"}
@@ -586,6 +588,8 @@ def test_list_leases_ignores_stale_thread_refs_when_classifying_triage(monkeypat
 
     assert payload["triage"]["summary"]["orphan_cleanup"] == 1
     assert payload["triage"]["summary"]["healthy_capacity"] == 0
+    assert payload["items"][0]["sandbox_id"] == "sandbox-1"
+    assert payload["items"][0]["lease_id"] == "lease-1"
     assert payload["items"][0]["thread"] == {"thread_id": None, "is_orphan": True}
     assert payload["items"][0]["triage"]["category"] == "orphan_cleanup"
 

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -196,6 +196,7 @@ def test_query_lease_reads_container_sandbox_row() -> None:
     )
 
     assert repo.query_lease("lease-1") == {
+        "sandbox_id": "sandbox-1",
         "lease_id": "lease-1",
         "provider_name": "daytona_selfhost",
         "recipe_id": "template-1",
@@ -272,6 +273,7 @@ def test_query_leases_uses_latest_terminal_binding() -> None:
 
     assert repo.query_leases() == [
         {
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "provider_name": "daytona_selfhost",
             "desired_state": "paused",
@@ -309,6 +311,7 @@ def test_query_leases_reads_container_sandboxes_with_terminal_binding() -> None:
 
     assert repo.query_leases() == [
         {
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "provider_name": "daytona_selfhost",
             "desired_state": "paused",


### PR DESCRIPTION
## Summary
- add canonical `sandbox_id` to monitor lease list/detail payloads
- preserve legacy `lease_id` as the compatibility read shell
- keep route paths and cleanup/browse/read surfaces unchanged

## Test Plan
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py -q
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Integration/test_schema_redesign_baseline_contract.py -q
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py
