### PR TITLE
refactor: establish canonical monitor sandbox reads

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -486,7 +486,7 @@ def get_monitor_evaluation_batch_detail(batch_id: str) -> dict[str, Any]:
     return make_eval_batch_service().get_batch_detail(batch_id)
 
 
-def _map_leases(rows: list[dict[str, Any]]) -> dict[str, Any]:
+def _map_monitor_sandboxes(rows: list[dict[str, Any]], *, title: str) -> dict[str, Any]:
     live_threads = _live_thread_ids([str(row.get("thread_id") or "").strip() for row in rows])
     items = []
     for row in rows:
@@ -531,7 +531,7 @@ def _map_leases(rows: list[dict[str, Any]]) -> dict[str, Any]:
     )
 
     return {
-        "title": "All Leases",
+        "title": title,
         "count": len(items),
         "summary": summary,
         "groups": groups,
@@ -543,12 +543,17 @@ def _map_leases(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def list_leases() -> dict[str, Any]:
+def list_monitor_sandboxes() -> dict[str, Any]:
     repo = make_sandbox_monitor_repo()
     try:
-        return _map_leases(repo.query_leases())
+        return _map_monitor_sandboxes(repo.query_sandboxes(), title="All Sandboxes")
     finally:
         repo.close()
+
+
+def list_leases() -> dict[str, Any]:
+    payload = list_monitor_sandboxes()
+    return {**payload, "title": "All Leases"}
 
 
 def list_monitor_provider_sessions() -> dict[str, Any]:
@@ -566,42 +571,39 @@ def list_monitor_provider_sessions() -> dict[str, Any]:
     return {"count": len(sessions), "sessions": sessions}
 
 
-def get_monitor_lease_detail(lease_id: str) -> dict[str, Any]:
-    repo = make_sandbox_monitor_repo()
-    try:
-        lease = repo.query_lease(lease_id)
-        if lease is None:
-            raise KeyError(f"Lease not found: {lease_id}")
+def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
+    sandbox = repo.query_sandbox(sandbox_id)
+    if sandbox is None:
+        raise KeyError(f"Sandbox not found: {sandbox_id}")
 
-        threads = repo.query_lease_threads(lease_id)
-        sessions = repo.query_lease_sessions(lease_id)
-        runtime_session_id = repo.query_lease_instance_id(lease_id)
-    finally:
-        repo.close()
+    threads = repo.query_sandbox_threads(sandbox_id)
+    sessions = repo.query_sandbox_sessions(sandbox_id)
+    runtime_session_id = repo.query_sandbox_instance_id(sandbox_id)
 
     raw_thread_ids = [str(item.get("thread_id") or "").strip() for item in threads if str(item.get("thread_id") or "").strip()]
     live_threads = _live_thread_ids(raw_thread_ids)
     live_thread_refs = [{"thread_id": thread_id} for thread_id in raw_thread_ids if thread_id in live_threads]
-    badge = _make_badge(lease.get("desired_state"), lease.get("observed_state"))
+    badge = _make_badge(sandbox.get("desired_state"), sandbox.get("observed_state"))
     triage = _classify_lease_triage(
         thread_id=live_thread_refs[0]["thread_id"] if live_thread_refs else None,
         badge=badge,
-        observed_state=lease.get("observed_state"),
-        desired_state=lease.get("desired_state"),
-        updated_at=lease.get("updated_at"),
+        observed_state=sandbox.get("observed_state"),
+        desired_state=sandbox.get("desired_state"),
+        updated_at=sandbox.get("updated_at"),
     )
-    provider_name = str(lease.get("provider_name") or "").strip()
+    provider_name = str(sandbox.get("provider_name") or "").strip()
+    lease_id = str(sandbox.get("lease_id") or "").strip()
 
     return {
-        "lease": {
-            "sandbox_id": lease.get("sandbox_id"),
-            "lease_id": str(lease.get("lease_id") or lease_id),
+        "sandbox": {
+            "sandbox_id": sandbox.get("sandbox_id"),
+            "lease_id": lease_id,
             "provider_name": provider_name,
-            "desired_state": lease.get("desired_state"),
-            "observed_state": lease.get("observed_state"),
-            "current_instance_id": lease.get("current_instance_id"),
-            "updated_at": lease.get("updated_at"),
-            "last_error": lease.get("last_error"),
+            "desired_state": sandbox.get("desired_state"),
+            "observed_state": sandbox.get("observed_state"),
+            "current_instance_id": sandbox.get("current_instance_id"),
+            "updated_at": sandbox.get("updated_at"),
+            "last_error": sandbox.get("last_error"),
             "badge": badge,
         },
         "triage": triage,
@@ -625,13 +627,42 @@ def get_monitor_lease_detail(lease_id: str) -> dict[str, Any]:
             for item in sessions
         ],
         "cleanup": monitor_operation_service.build_lease_cleanup_truth(
-            lease_id=str(lease.get("lease_id") or lease_id),
+            lease_id=lease_id,
             triage=triage,
             provider_name=provider_name,
             runtime_session_id=runtime_session_id,
             sessions=sessions,
             threads=live_thread_refs,
         ),
+    }
+
+
+def get_monitor_sandbox_detail(sandbox_id: str) -> dict[str, Any]:
+    repo = make_sandbox_monitor_repo()
+    try:
+        return _build_monitor_sandbox_detail(repo, sandbox_id)
+    finally:
+        repo.close()
+
+
+def get_monitor_lease_detail(lease_id: str) -> dict[str, Any]:
+    repo = make_sandbox_monitor_repo()
+    try:
+        lease = repo.query_lease(lease_id)
+        if lease is None:
+            raise KeyError(f"Lease not found: {lease_id}")
+        payload = _build_monitor_sandbox_detail(repo, str(lease.get("sandbox_id") or ""))
+    finally:
+        repo.close()
+
+    return {
+        "lease": payload["sandbox"],
+        "triage": payload["triage"],
+        "provider": payload["provider"],
+        "runtime": payload["runtime"],
+        "threads": payload["threads"],
+        "sessions": payload["sessions"],
+        "cleanup": payload["cleanup"],
     }
 
 

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -84,37 +84,54 @@ class SupabaseSandboxMonitorRepo:
         lease_map = self._sandboxes_by_legacy_lease_id("query_thread_sessions")
         return [self._session_with_lease(s, lease_map.get(s.get("lease_id") or "")) for s in sessions]
 
-    def query_leases(self) -> list[dict]:
-        sandboxes = self._ordered_sandboxes("query_leases")
-        leases = [self._lease_row_from_sandbox(sandbox) for sandbox in sandboxes]
-        if not leases:
+    def query_sandboxes(self) -> list[dict]:
+        sandboxes = self._ordered_sandboxes("query_sandboxes")
+        rows = [self._lease_row_from_sandbox(sandbox) for sandbox in sandboxes]
+        if not rows:
             return []
 
-        lease_ids = [le["lease_id"] for le in leases]
+        lease_ids = [row["lease_id"] for row in rows]
         terminals = q.rows_in_chunks(
             lambda: self._client.table("abstract_terminals").select("lease_id,thread_id,created_at"),
             "lease_id",
             lease_ids,
             _REPO,
-            "query_leases terminals",
+            "query_sandboxes terminals",
         )
-        # Pick most recent terminal per lease
-        term_map: dict[str, str] = {}
-        for t in sorted(terminals, key=lambda x: x.get("created_at") or ""):
-            term_map[t["lease_id"]] = t["thread_id"]
+        thread_by_lease: dict[str, str] = {}
+        for row in sorted(terminals, key=lambda x: x.get("created_at") or ""):
+            thread_by_lease[str(row.get("lease_id") or "")] = row["thread_id"]
 
         result = []
-        for lease in leases:
-            row = dict(lease)
-            row["thread_id"] = term_map.get(lease["lease_id"])
-            result.append(row)
+        for row in rows:
+            item = dict(row)
+            item["thread_id"] = thread_by_lease.get(row["lease_id"])
+            result.append(item)
         return result
+
+    def query_leases(self) -> list[dict]:
+        return self.query_sandboxes()
 
     def list_leases_with_threads(self) -> list[dict]:
         return self.query_leases()
 
+    def query_sandbox(self, sandbox_id: str) -> dict | None:
+        sandbox_key = str(sandbox_id or "").strip()
+        if not sandbox_key:
+            return None
+        for sandbox in self._ordered_sandboxes("query_sandbox"):
+            if str(sandbox.get("id") or "").strip() == sandbox_key:
+                return self._lease_row_from_sandbox(sandbox)
+        return None
+
     def query_lease(self, lease_id: str) -> dict | None:
         return self._sandboxes_by_legacy_lease_id("query_lease").get(lease_id)
+
+    def query_sandbox_sessions(self, sandbox_id: str) -> list[dict]:
+        sandbox = self.query_sandbox(sandbox_id)
+        if sandbox is None:
+            return []
+        return self.query_lease_sessions(str(sandbox.get("lease_id") or ""))
 
     def query_lease_sessions(self, lease_id: str) -> list[dict]:
         sessions = q.rows(
@@ -132,6 +149,12 @@ class SupabaseSandboxMonitorRepo:
         )
         lease = self.query_lease(lease_id)
         return [self._session_with_lease(session, lease, include_thread=True) for session in sessions]
+
+    def query_sandbox_threads(self, sandbox_id: str) -> list[dict]:
+        sandbox = self.query_sandbox(sandbox_id)
+        if sandbox is None:
+            return []
+        return self.query_lease_threads(str(sandbox.get("lease_id") or ""))
 
     def query_lease_threads(self, lease_id: str) -> list[dict]:
         self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_threads")
@@ -153,6 +176,12 @@ class SupabaseSandboxMonitorRepo:
                 seen.add(r["thread_id"])
                 result.append({"thread_id": r["thread_id"]})
         return result
+
+    def query_sandbox_instance_id(self, sandbox_id: str) -> str | None:
+        sandbox = self.query_sandbox(sandbox_id)
+        if sandbox is None:
+            return None
+        return self.query_lease_instance_id(str(sandbox.get("lease_id") or ""))
 
     def query_lease_events(self, lease_id: str) -> list[dict]:
         self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_events")

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -69,6 +69,24 @@ class FakeLeaseRepo:
     def query_leases(self):
         return self.leases
 
+    def query_sandbox(self, sandbox_id):
+        lease = self.lease if self.lease is not None else _lease_row(sandbox_id=sandbox_id)
+        if lease is _MISSING:
+            return None
+        return {**lease, "sandbox_id": lease.get("sandbox_id") or sandbox_id}
+
+    def query_sandboxes(self):
+        return self.leases
+
+    def query_sandbox_threads(self, _sandbox_id):
+        return self.threads
+
+    def query_sandbox_sessions(self, _sandbox_id):
+        return self.sessions
+
+    def query_sandbox_instance_id(self, _sandbox_id):
+        return self.runtime_session_id
+
     def close(self):
         return None
 
@@ -351,6 +369,76 @@ def test_get_monitor_lease_detail_merges_monitor_repo_state(monkeypatch):
     ]
 
 
+def test_get_monitor_sandbox_detail_merges_monitor_repo_state(monkeypatch):
+    _use_monitor_repo(
+        monkeypatch,
+        FakeLeaseRepo(
+            threads=[{"thread_id": "thread-1"}],
+            sessions=[{"chat_session_id": "session-1", "thread_id": "thread-1", "status": "active"}],
+        ),
+    )
+
+    payload = monitor_service.get_monitor_sandbox_detail("sandbox-1")
+
+    assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
+    assert payload["sandbox"]["lease_id"] == "lease-1"
+    assert payload["provider"] == {"id": "daytona", "name": "daytona"}
+    assert payload["runtime"] == {"runtime_session_id": "runtime-1"}
+    assert payload["threads"] == [{"thread_id": "thread-1"}]
+    assert "lease" not in payload
+
+
+def test_list_leases_uses_canonical_sandbox_source(monkeypatch):
+    class CanonicalOnlyRepo(FakeLeaseRepo):
+        def query_leases(self):
+            raise AssertionError("legacy lease source should not be the single source anymore")
+
+        def query_sandboxes(self):
+            return [
+                _lease_row(
+                    sandbox_id="sandbox-1",
+                    lease_id="lease-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    thread_id="thread-gone",
+                )
+            ]
+
+    _use_monitor_repo(monkeypatch, CanonicalOnlyRepo())
+    monkeypatch.setattr(monitor_service, "_live_thread_ids", lambda thread_ids: set())
+
+    payload = monitor_service.list_leases()
+
+    assert payload["items"][0]["sandbox_id"] == "sandbox-1"
+    assert payload["items"][0]["lease_id"] == "lease-1"
+
+
+def test_get_monitor_lease_detail_uses_canonical_sandbox_source(monkeypatch):
+    class CanonicalOnlyRepo(FakeLeaseRepo):
+        def query_lease_threads(self, _lease_id):
+            raise AssertionError("legacy lease detail queries should not remain single source")
+
+        def query_lease_sessions(self, _lease_id):
+            raise AssertionError("legacy lease detail queries should not remain single source")
+
+        def query_lease_instance_id(self, _lease_id):
+            raise AssertionError("legacy lease detail queries should not remain single source")
+
+    _use_monitor_repo(
+        monkeypatch,
+        CanonicalOnlyRepo(
+            threads=[{"thread_id": "thread-1"}],
+            sessions=[{"chat_session_id": "session-1", "thread_id": "thread-1", "status": "active"}],
+        ),
+    )
+
+    payload = monitor_service.get_monitor_lease_detail("lease-1")
+
+    assert payload["lease"]["sandbox_id"] == "sandbox-1"
+    assert payload["lease"]["lease_id"] == "lease-1"
+    assert "sandbox" not in payload
+
+
 def test_get_monitor_lease_detail_exposes_cleanup_state(monkeypatch):
     _use_monitor_repo(monkeypatch, FakeLeaseRepo(lease=_detached_lease()))
 
@@ -592,6 +680,23 @@ def test_list_leases_ignores_stale_thread_refs_when_classifying_triage(monkeypat
     assert payload["items"][0]["lease_id"] == "lease-1"
     assert payload["items"][0]["thread"] == {"thread_id": None, "is_orphan": True}
     assert payload["items"][0]["triage"]["category"] == "orphan_cleanup"
+
+
+def test_list_monitor_sandboxes_ignores_stale_thread_refs_when_classifying_triage(monkeypatch):
+    _use_monitor_repo(
+        monkeypatch,
+        FakeLeaseRepo(
+            leases=[_lease_row(sandbox_id="sandbox-1", desired_state="paused", observed_state="paused", thread_id="thread-gone")]
+        ),
+    )
+    monkeypatch.setattr(monitor_service, "_live_thread_ids", lambda thread_ids: set())
+
+    payload = monitor_service.list_monitor_sandboxes()
+
+    assert payload["title"] == "All Sandboxes"
+    assert payload["triage"]["summary"]["orphan_cleanup"] == 1
+    assert payload["items"][0]["sandbox_id"] == "sandbox-1"
+    assert payload["items"][0]["lease_id"] == "lease-1"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -209,6 +209,38 @@ def test_query_lease_reads_container_sandbox_row() -> None:
     }
 
 
+def test_query_sandbox_reads_container_sandbox_row_by_id() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="provider-env-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-1",
+                    sandbox_template_id="template-1",
+                )
+            ]
+        }
+    )
+
+    assert repo.query_sandbox("sandbox-1") == {
+        "sandbox_id": "sandbox-1",
+        "lease_id": "lease-1",
+        "provider_name": "daytona_selfhost",
+        "recipe_id": "template-1",
+        "recipe_json": None,
+        "desired_state": "paused",
+        "observed_state": "paused",
+        "current_instance_id": "provider-env-1",
+        "last_error": None,
+        "updated_at": "2026-04-05T10:10:00",
+    }
+
+
 def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
     repo = _repo(
         {
@@ -283,6 +315,44 @@ def test_query_leases_uses_latest_terminal_binding() -> None:
             "recipe_id": None,
             "recipe_json": None,
             "last_error": None,
+            "thread_id": "thread-new",
+        }
+    ]
+
+
+def test_query_sandboxes_uses_latest_terminal_binding() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-1",
+                )
+            ],
+            "abstract_terminals": [
+                _terminal("term-old", "lease-1", "thread-old", "2026-04-05T10:01:00"),
+                _terminal("term-new", "lease-1", "thread-new", "2026-04-05T10:02:00"),
+            ],
+        }
+    )
+
+    assert repo.query_sandboxes() == [
+        {
+            "sandbox_id": "sandbox-1",
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "recipe_id": None,
+            "recipe_json": None,
+            "desired_state": "paused",
+            "observed_state": "paused",
+            "current_instance_id": "instance-1",
+            "last_error": None,
+            "updated_at": "2026-04-05T10:10:00",
             "thread_id": "thread-new",
         }
     ]


### PR DESCRIPTION
## Summary
- establish canonical sandbox-shaped monitor read sources in repo and service layers
- keep `/api/monitor/leases*` on compatibility wrappers instead of single-source lease queries
- add focused monitor tests proving canonical source plus compatibility shell behavior

## Test plan
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py -q
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Integration/test_monitor_resources_route.py tests/Integration/test_schema_redesign_baseline_contract.py -q
- uv run ruff check backend/web/services/monitor_service.py storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Integration/test_monitor_resources_route.py tests/Integration/test_schema_redesign_baseline_contract.py
- git diff --check