### PR TITLE
refactor: contract canonical monitor sandbox payload

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -486,7 +486,7 @@ def get_monitor_evaluation_batch_detail(batch_id: str) -> dict[str, Any]:
     return make_eval_batch_service().get_batch_detail(batch_id)
 
 
-def _map_monitor_sandboxes(rows: list[dict[str, Any]], *, title: str) -> dict[str, Any]:
+def _map_monitor_sandboxes(rows: list[dict[str, Any]], *, title: str, include_lease_id: bool) -> dict[str, Any]:
     live_threads = _live_thread_ids([str(row.get("thread_id") or "").strip() for row in rows])
     items = []
     for row in rows:
@@ -501,21 +501,21 @@ def _map_monitor_sandboxes(rows: list[dict[str, Any]], *, title: str) -> dict[st
             desired_state=row["desired_state"],
             updated_at=row["updated_at"],
         )
-        items.append(
-            {
-                "sandbox_id": row.get("sandbox_id"),
-                "lease_id": row["lease_id"],
-                "provider": row["provider_name"],
-                "instance_id": row["current_instance_id"],
-                "thread": _thread_ref(thread_id),
-                "state_badge": badge,
-                "semantics": _classify_lease_semantics(thread_id=thread_id, badge=badge),
-                "triage": triage,
-                "error": row["last_error"],
-                "updated_at": row["updated_at"],
-                "updated_ago": _format_time_ago(row["updated_at"]),
-            }
-        )
+        item = {
+            "sandbox_id": row.get("sandbox_id"),
+            "provider": row["provider_name"],
+            "instance_id": row["current_instance_id"],
+            "thread": _thread_ref(thread_id),
+            "state_badge": badge,
+            "semantics": _classify_lease_semantics(thread_id=thread_id, badge=badge),
+            "triage": triage,
+            "error": row["last_error"],
+            "updated_at": row["updated_at"],
+            "updated_ago": _format_time_ago(row["updated_at"]),
+        }
+        if include_lease_id:
+            item["lease_id"] = row["lease_id"]
+        items.append(item)
 
     summary, groups = _lease_groups(
         items=items,
@@ -546,14 +546,17 @@ def _map_monitor_sandboxes(rows: list[dict[str, Any]], *, title: str) -> dict[st
 def list_monitor_sandboxes() -> dict[str, Any]:
     repo = make_sandbox_monitor_repo()
     try:
-        return _map_monitor_sandboxes(repo.query_sandboxes(), title="All Sandboxes")
+        return _map_monitor_sandboxes(repo.query_sandboxes(), title="All Sandboxes", include_lease_id=False)
     finally:
         repo.close()
 
 
 def list_leases() -> dict[str, Any]:
-    payload = list_monitor_sandboxes()
-    return {**payload, "title": "All Leases"}
+    repo = make_sandbox_monitor_repo()
+    try:
+        return _map_monitor_sandboxes(repo.query_sandboxes(), title="All Leases", include_lease_id=True)
+    finally:
+        repo.close()
 
 
 def list_monitor_provider_sessions() -> dict[str, Any]:
@@ -592,12 +595,9 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
         updated_at=sandbox.get("updated_at"),
     )
     provider_name = str(sandbox.get("provider_name") or "").strip()
-    lease_id = str(sandbox.get("lease_id") or "").strip()
-
     return {
         "sandbox": {
             "sandbox_id": sandbox.get("sandbox_id"),
-            "lease_id": lease_id,
             "provider_name": provider_name,
             "desired_state": sandbox.get("desired_state"),
             "observed_state": sandbox.get("observed_state"),
@@ -626,14 +626,6 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
             }
             for item in sessions
         ],
-        "cleanup": monitor_operation_service.build_lease_cleanup_truth(
-            lease_id=lease_id,
-            triage=triage,
-            provider_name=provider_name,
-            runtime_session_id=runtime_session_id,
-            sessions=sessions,
-            threads=live_thread_refs,
-        ),
     }
 
 
@@ -655,14 +647,24 @@ def get_monitor_lease_detail(lease_id: str) -> dict[str, Any]:
     finally:
         repo.close()
 
+    sandbox_payload = payload["sandbox"]
+    lease_payload = {**sandbox_payload, "lease_id": lease_id}
+
     return {
-        "lease": payload["sandbox"],
+        "lease": lease_payload,
         "triage": payload["triage"],
         "provider": payload["provider"],
         "runtime": payload["runtime"],
         "threads": payload["threads"],
         "sessions": payload["sessions"],
-        "cleanup": payload["cleanup"],
+        "cleanup": monitor_operation_service.build_lease_cleanup_truth(
+            lease_id=lease_id,
+            triage=payload["triage"],
+            provider_name=str(sandbox_payload.get("provider_name") or ""),
+            runtime_session_id=payload["runtime"].get("runtime_session_id"),
+            sessions=payload["sessions"],
+            threads=payload["threads"],
+        ),
     }
 
 

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -381,10 +381,10 @@ def test_get_monitor_sandbox_detail_merges_monitor_repo_state(monkeypatch):
     payload = monitor_service.get_monitor_sandbox_detail("sandbox-1")
 
     assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
-    assert payload["sandbox"]["lease_id"] == "lease-1"
     assert payload["provider"] == {"id": "daytona", "name": "daytona"}
     assert payload["runtime"] == {"runtime_session_id": "runtime-1"}
     assert payload["threads"] == [{"thread_id": "thread-1"}]
+    assert "cleanup" not in payload
     assert "lease" not in payload
 
 
@@ -413,6 +413,29 @@ def test_list_leases_uses_canonical_sandbox_source(monkeypatch):
     assert payload["items"][0]["lease_id"] == "lease-1"
 
 
+def test_list_monitor_sandboxes_is_canonical_single_emit(monkeypatch):
+    _use_monitor_repo(
+        monkeypatch,
+        FakeLeaseRepo(
+            leases=[
+                _lease_row(
+                    sandbox_id="sandbox-1",
+                    lease_id="lease-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    thread_id="thread-gone",
+                )
+            ]
+        ),
+    )
+    monkeypatch.setattr(monitor_service, "_live_thread_ids", lambda thread_ids: set())
+
+    payload = monitor_service.list_monitor_sandboxes()
+
+    assert payload["items"][0]["sandbox_id"] == "sandbox-1"
+    assert "lease_id" not in payload["items"][0]
+
+
 def test_get_monitor_lease_detail_uses_canonical_sandbox_source(monkeypatch):
     class CanonicalOnlyRepo(FakeLeaseRepo):
         def query_lease_threads(self, _lease_id):
@@ -437,6 +460,33 @@ def test_get_monitor_lease_detail_uses_canonical_sandbox_source(monkeypatch):
     assert payload["lease"]["sandbox_id"] == "sandbox-1"
     assert payload["lease"]["lease_id"] == "lease-1"
     assert "sandbox" not in payload
+
+
+def test_get_monitor_lease_detail_rewraps_cleanup_and_lease_identity(monkeypatch):
+    _use_monitor_repo(monkeypatch, FakeLeaseRepo(lease=_detached_lease()))
+
+    payload = monitor_service.get_monitor_lease_detail("lease-1")
+
+    assert payload["lease"]["sandbox_id"] == "sandbox-1"
+    assert payload["lease"]["lease_id"] == "lease-1"
+    assert payload["cleanup"] == _cleanup_state("Lease is orphan cleanup residue and can enter managed cleanup.")
+
+
+def test_get_monitor_sandbox_detail_is_canonical_single_emit(monkeypatch):
+    _use_monitor_repo(
+        monkeypatch,
+        FakeLeaseRepo(
+            lease=_lease_row(),
+            threads=[{"thread_id": "thread-1"}],
+            sessions=[{"chat_session_id": "session-1", "thread_id": "thread-1", "status": "active"}],
+        ),
+    )
+
+    payload = monitor_service.get_monitor_sandbox_detail("sandbox-1")
+
+    assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
+    assert "lease_id" not in payload["sandbox"]
+    assert "cleanup" not in payload
 
 
 def test_get_monitor_lease_detail_exposes_cleanup_state(monkeypatch):
@@ -696,7 +746,7 @@ def test_list_monitor_sandboxes_ignores_stale_thread_refs_when_classifying_triag
     assert payload["title"] == "All Sandboxes"
     assert payload["triage"]["summary"]["orphan_cleanup"] == 1
     assert payload["items"][0]["sandbox_id"] == "sandbox-1"
-    assert payload["items"][0]["lease_id"] == "lease-1"
+    assert "lease_id" not in payload["items"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- contract canonical monitor sandbox list/detail payload so it no longer outward-emits lease-shaped fields
- keep list_leases and get_monitor_lease_detail as compatibility wrappers that reattach lease-shaped identity and cleanup truth
- update monitor detail tests to pin canonical single-emit behavior and compatibility wrapper behavior

## Test Plan
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Integration/test_monitor_resources_route.py -q
- uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Integration/test_monitor_resources_route.py
- uv run ruff format --check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Integration/test_monitor_resources_route.py
- git diff --check