### PR TITLE
feat: add canonical monitor sandbox read endpoints

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -61,6 +61,11 @@ def leases_snapshot():
     return monitor_service.list_leases()
 
 
+@router.get("/sandboxes")
+def sandboxes_snapshot():
+    return monitor_service.list_monitor_sandboxes()
+
+
 @router.get("/provider-sessions")
 def provider_sessions_snapshot():
     return monitor_service.list_monitor_provider_sessions()
@@ -82,6 +87,11 @@ def provider_detail_snapshot(provider_id: str):
 @router.get("/leases/{lease_id}")
 def lease_detail_snapshot(lease_id: str):
     return _or_404(monitor_service.get_monitor_lease_detail, lease_id)
+
+
+@router.get("/sandboxes/{sandbox_id}")
+def sandbox_detail_snapshot(sandbox_id: str):
+    return _or_404(monitor_service.get_monitor_sandbox_detail, sandbox_id)
 
 
 @router.post("/leases/{lease_id}/cleanup")

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -134,9 +134,11 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
     ("method", "path", "service_name", "payload"),
     [
         ("get", "/api/monitor/leases", "list_leases", {"summary": {}, "groups": []}),
+        ("get", "/api/monitor/sandboxes", "list_monitor_sandboxes", {"summary": {}, "groups": [], "items": []}),
         ("get", "/api/monitor/provider-sessions", "list_monitor_provider_sessions", {"sessions": [], "count": 0}),
         ("get", "/api/monitor/providers/daytona", "get_monitor_provider_detail", {"provider": {"id": "daytona"}}),
         ("get", "/api/monitor/leases/lease-1", "get_monitor_lease_detail", {"lease": {"lease_id": "lease-1"}}),
+        ("get", "/api/monitor/sandboxes/sandbox-1", "get_monitor_sandbox_detail", {"sandbox": {"sandbox_id": "sandbox-1"}}),
         ("post", "/api/monitor/leases/lease-1/cleanup", "request_monitor_lease_cleanup", {"accepted": True}),
         (
             "post",
@@ -206,6 +208,7 @@ def test_monitor_thread_detail_route_awaits_service(monkeypatch):
     [
         ("/api/monitor/providers/missing", "get_monitor_provider_detail", "Provider not found: missing"),
         ("/api/monitor/leases/missing", "get_monitor_lease_detail", "Lease not found: missing"),
+        ("/api/monitor/sandboxes/missing", "get_monitor_sandbox_detail", "Sandbox not found: missing"),
         ("/api/monitor/operations/missing", "get_monitor_operation_detail", "Operation not found: missing"),
         ("/api/monitor/runtimes/missing", "get_monitor_runtime_detail", "Runtime not found: missing"),
         ("/api/monitor/evaluation/batches/missing", "get_monitor_evaluation_batch_detail", "Evaluation batch not found: missing"),


### PR DESCRIPTION
## Summary
- add canonical /api/monitor/sandboxes and /api/monitor/sandboxes/{sandbox_id} read-only routes
- wire the new routes to list_monitor_sandboxes and get_monitor_sandbox_detail
- keep existing /api/monitor/leases* routes untouched as compatibility shell

## Test Plan
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py -q
- uv run ruff check backend/web/routers/monitor.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format --check backend/web/routers/monitor.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check