### PR TITLE
refactor: cut monitor summary shell to sandboxes

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -130,11 +130,11 @@ async def thread_detail_snapshot(request: Request, thread_id: str):
 @router.get("/dashboard")
 def dashboard_snapshot():
     resources = get_resource_overview_snapshot()
-    leases = monitor_service.list_leases()
+    sandboxes = monitor_service.list_monitor_sandboxes()
     evaluation = monitor_service.get_monitor_evaluation_workbench()
 
     resource_summary = resources.get("summary") or {}
-    lease_summary = leases.get("summary") or {}
+    sandbox_summary = sandboxes.get("summary") or {}
     evaluation_overview = evaluation.get("overview") or {}
     latest_evaluation = evaluation.get("selected_run") or {}
 
@@ -143,9 +143,9 @@ def dashboard_snapshot():
         "infra": {
             "providers_active": int(resource_summary.get("active_providers") or 0),
             "providers_unavailable": int(resource_summary.get("unavailable_providers") or 0),
-            "leases_total": int(lease_summary.get("total") or leases.get("count") or 0),
-            "leases_diverged": int(lease_summary.get("diverged") or 0) + int(lease_summary.get("orphan_diverged") or 0),
-            "leases_orphan": int(lease_summary.get("orphan") or 0) + int(lease_summary.get("orphan_diverged") or 0),
+            "sandboxes_total": int(sandbox_summary.get("total") or sandboxes.get("count") or 0),
+            "sandboxes_diverged": int(sandbox_summary.get("diverged") or 0) + int(sandbox_summary.get("orphan_diverged") or 0),
+            "sandboxes_orphan": int(sandbox_summary.get("orphan") or 0) + int(sandbox_summary.get("orphan_diverged") or 0),
         },
         "workload": {
             "running_sessions": int(resource_summary.get("running_sessions") or 0),

--- a/backend/web/services/resource_cache.py
+++ b/backend/web/services/resource_cache.py
@@ -39,8 +39,8 @@ def _read_refresh_interval_sec() -> float:
 
 
 def _attach_monitor_triage(payload: dict[str, Any]) -> dict[str, Any]:
-    lease_payload = monitor_service.list_leases()
-    triage = lease_payload.get("triage") or {"summary": {}, "groups": []}
+    sandbox_payload = monitor_service.list_monitor_sandboxes()
+    triage = sandbox_payload.get("triage") or {"summary": {}, "groups": []}
     payload["triage"] = triage
     return payload
 

--- a/frontend/monitor/src/app/monitor-nav.test.ts
+++ b/frontend/monitor/src/app/monitor-nav.test.ts
@@ -7,4 +7,10 @@ describe("monitor navigation", () => {
     expect(monitorNav.some((item) => item.to === "/sandbox-configs" && item.label === "Sandbox Configs")).toBe(true);
     expect(resolveMonitorNav("/sandbox-configs").to).toBe("/sandbox-configs");
   });
+
+  it("treats sandboxes as the canonical runtime shell", () => {
+    expect(monitorNav.some((item) => item.to === "/sandboxes" && item.label === "Sandboxes")).toBe(true);
+    expect(resolveMonitorNav("/sandboxes").to).toBe("/sandboxes");
+    expect(resolveMonitorNav("/leases").to).toBe("/sandboxes");
+  });
 });

--- a/frontend/monitor/src/app/monitor-nav.ts
+++ b/frontend/monitor/src/app/monitor-nav.ts
@@ -8,7 +8,7 @@ export type MonitorNavItem = {
 export const monitorNav: readonly MonitorNavItem[] = [
   { to: "/dashboard", label: "Dashboard", eyebrow: "Overview" },
   { to: "/resources", label: "Resources", eyebrow: "Runtime", matchPrefixes: ["/resources", "/providers", "/runtimes"] },
-  { to: "/leases", label: "Leases", eyebrow: "Runtime", matchPrefixes: ["/leases", "/operations"] },
+  { to: "/sandboxes", label: "Sandboxes", eyebrow: "Runtime", matchPrefixes: ["/sandboxes", "/leases", "/operations"] },
   { to: "/sandbox-configs", label: "Sandbox Configs", eyebrow: "Config" },
   { to: "/threads", label: "Threads", eyebrow: "Workbench", matchPrefixes: ["/threads"] },
   { to: "/evaluation", label: "Evaluation", eyebrow: "Operators", matchPrefixes: ["/evaluation"] },

--- a/frontend/monitor/src/app/routes.tsx
+++ b/frontend/monitor/src/app/routes.tsx
@@ -24,6 +24,8 @@ export function MonitorRoutes() {
         <Route path="/resources" element={<ResourcesPage />} />
         <Route path="/sandbox-configs" element={<SandboxConfigsPage />} />
         <Route path="/providers/:providerId" element={<ProviderDetailPage />} />
+        <Route path="/sandboxes" element={<LeasesPage />} />
+        <Route path="/sandboxes/:leaseId" element={<LeaseDetailPage />} />
         <Route path="/leases" element={<LeasesPage />} />
         <Route path="/leases/:leaseId" element={<LeaseDetailPage />} />
         <Route path="/operations/:operationId" element={<OperationDetailPage />} />

--- a/frontend/monitor/src/pages/DashboardPage.test.ts
+++ b/frontend/monitor/src/pages/DashboardPage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDashboardAttentionLinks, buildDashboardSurfaces, type DashboardPayload } from "./DashboardPage";
+
+const payload: DashboardPayload = {
+  snapshot_at: "2026-04-15T00:00:00Z",
+  infra: {
+    providers_active: 2,
+    providers_unavailable: 1,
+    sandboxes_total: 3,
+    sandboxes_diverged: 1,
+    sandboxes_orphan: 0,
+  },
+  workload: {
+    running_sessions: 4,
+    evaluations_running: 1,
+  },
+  latest_evaluation: {
+    headline: "Most recent evaluation batch is still running.",
+  },
+};
+
+describe("dashboard summary shell", () => {
+  it("uses sandbox-shaped labels and canonical sandbox links", () => {
+    expect(buildDashboardSurfaces(payload)).toContainEqual({
+      label: "Tracked Sandboxes",
+      value: 3,
+      to: "/sandboxes",
+    });
+    expect(buildDashboardAttentionLinks(payload)).toContainEqual({
+      label: "Sandbox Drift",
+      body: "1 diverged sandboxes, 0 orphan sandboxes.",
+      to: "/sandboxes",
+    });
+  });
+});

--- a/frontend/monitor/src/pages/DashboardPage.tsx
+++ b/frontend/monitor/src/pages/DashboardPage.tsx
@@ -3,14 +3,14 @@ import { Link } from "react-router-dom";
 import ErrorState from "../components/ErrorState";
 import { useMonitorData } from "../app/fetch";
 
-type DashboardPayload = {
+export type DashboardPayload = {
   snapshot_at: string;
   infra: {
     providers_active: number;
     providers_unavailable: number;
-    leases_total: number;
-    leases_diverged: number;
-    leases_orphan: number;
+    sandboxes_total: number;
+    sandboxes_diverged: number;
+    sandboxes_orphan: number;
   };
   workload: {
     running_sessions: number;
@@ -21,28 +21,25 @@ type DashboardPayload = {
   };
 };
 
-export default function DashboardPage() {
-  const { data, error } = useMonitorData<DashboardPayload>("/dashboard");
-
-  if (error) return <ErrorState title="Dashboard" error={error} />;
-  if (!data) return <div>Loading...</div>;
-
-  const surfaces = [
+export function buildDashboardSurfaces(data: DashboardPayload) {
+  return [
     { label: "Running Sessions", value: data.workload.running_sessions, to: "/resources" },
     { label: "Evaluations Running", value: data.workload.evaluations_running, to: "/evaluation" },
-    { label: "Tracked Leases", value: data.infra.leases_total, to: "/leases" },
+    { label: "Tracked Sandboxes", value: data.infra.sandboxes_total, to: "/sandboxes" },
   ];
+}
 
-  const attentionLinks = [
+export function buildDashboardAttentionLinks(data: DashboardPayload) {
+  return [
     {
       label: "Provider Coverage",
       body: `${data.infra.providers_active} active providers, ${data.infra.providers_unavailable} unavailable.`,
       to: "/resources",
     },
     {
-      label: "Lease Drift",
-      body: `${data.infra.leases_diverged} diverged leases, ${data.infra.leases_orphan} orphan leases.`,
-      to: "/leases",
+      label: "Sandbox Drift",
+      body: `${data.infra.sandboxes_diverged} diverged sandboxes, ${data.infra.sandboxes_orphan} orphan sandboxes.`,
+      to: "/sandboxes",
     },
     {
       label: "Latest Evaluation",
@@ -50,6 +47,16 @@ export default function DashboardPage() {
       to: "/evaluation",
     },
   ];
+}
+
+export default function DashboardPage() {
+  const { data, error } = useMonitorData<DashboardPayload>("/dashboard");
+
+  if (error) return <ErrorState title="Dashboard" error={error} />;
+  if (!data) return <div>Loading...</div>;
+
+  const surfaces = buildDashboardSurfaces(data);
+  const attentionLinks = buildDashboardAttentionLinks(data);
 
   return (
     <div className="page">

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -49,7 +49,7 @@ def _stub_dashboard_dependencies(monkeypatch):
     monkeypatch.setattr(monitor, "get_resource_overview_snapshot", _resource_snapshot)
     monkeypatch.setattr(
         monitor.monitor_service,
-        "list_leases",
+        "list_monitor_sandboxes",
         lambda: {
             "summary": {"total": 2, "diverged": 1, "orphan": 0, "orphan_diverged": 0},
             "groups": [],
@@ -108,6 +108,11 @@ def test_monitor_and_product_resource_routes_coexist(monkeypatch):
 
 def test_monitor_dashboard_uses_service_summaries(monkeypatch):
     _stub_dashboard_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        monitor.monitor_service,
+        "list_leases",
+        lambda: (_ for _ in ()).throw(AssertionError("dashboard should not use legacy lease shell")),
+    )
 
     response = _request("get", "/api/monitor/dashboard")
 
@@ -117,9 +122,9 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
         "infra": {
             "providers_active": 1,
             "providers_unavailable": 0,
-            "leases_total": 2,
-            "leases_diverged": 1,
-            "leases_orphan": 0,
+            "sandboxes_total": 2,
+            "sandboxes_diverged": 1,
+            "sandboxes_orphan": 0,
         },
         "workload": {"running_sessions": 1, "evaluations_running": 1},
         "latest_evaluation": {

--- a/tests/Unit/monitor/test_monitor_resource_overview_cache.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_cache.py
@@ -42,7 +42,7 @@ def test_resource_overview_cache_refresh_adds_metadata(monkeypatch):
     monkeypatch.setattr(
         cache,
         "monitor_service",
-        type("_MonitorService", (), {"list_leases": staticmethod(lambda: _triage_payload("detached_residue"))}),
+        type("_MonitorService", (), {"list_monitor_sandboxes": staticmethod(lambda: _triage_payload("detached_residue"))}),
         raising=False,
     )
 
@@ -81,7 +81,7 @@ def test_resource_overview_cache_refresh_fails_loudly_on_refresh_error(monkeypat
     monkeypatch.setattr(
         cache,
         "monitor_service",
-        type("_MonitorService", (), {"list_leases": staticmethod(lambda: _triage_payload("orphan_cleanup"))}),
+        type("_MonitorService", (), {"list_monitor_sandboxes": staticmethod(lambda: _triage_payload("orphan_cleanup"))}),
         raising=False,
     )
     cache.refresh_resource_overview_sync()
@@ -157,7 +157,7 @@ def test_resource_overview_cache_refreshes_when_live_session_counts_drift(monkey
     monkeypatch.setattr(
         cache,
         "monitor_service",
-        type("_MonitorService", (), {"list_leases": staticmethod(lambda: _triage_payload("healthy_capacity"))}),
+        type("_MonitorService", (), {"list_monitor_sandboxes": staticmethod(lambda: _triage_payload("healthy_capacity"))}),
         raising=False,
     )
 


### PR DESCRIPTION
## Summary
- rename monitor dashboard summary payload from lease-shaped fields to sandbox-shaped fields
- switch resource overview triage attachment to canonical sandbox monitor source
- cut frontend dashboard/nav shell to sandbox wording and canonical /sandboxes links

## Verification
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py -q
- cd frontend/monitor && npm test -- --run src/app/monitor-nav.test.ts src/pages/DashboardPage.test.ts
- cd frontend/monitor && npm run build
- uv run ruff check backend/web/routers/monitor.py backend/web/services/resource_cache.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_resource_overview_cache.py
- git diff --check