### PR TITLE
feat: add canonical monitor sandbox detail shell

### DIFF
--- a/frontend/monitor/src/app/routes.tsx
+++ b/frontend/monitor/src/app/routes.tsx
@@ -10,7 +10,9 @@ import LeasesPage from "../pages/LeasesPage";
 import OperationDetailPage from "../pages/OperationDetailPage";
 import ProviderDetailPage from "../pages/ProviderDetailPage";
 import RuntimeDetailPage from "../pages/RuntimeDetailPage";
+import SandboxDetailPage from "../pages/SandboxDetailPage";
 import SandboxConfigsPage from "../pages/SandboxConfigsPage";
+import SandboxesPage from "../pages/SandboxesPage";
 import ThreadDetailPage from "../pages/ThreadDetailPage";
 import ThreadsPage from "../pages/ThreadsPage";
 import { MonitorShell } from "./MonitorShell";
@@ -24,8 +26,8 @@ export function MonitorRoutes() {
         <Route path="/resources" element={<ResourcesPage />} />
         <Route path="/sandbox-configs" element={<SandboxConfigsPage />} />
         <Route path="/providers/:providerId" element={<ProviderDetailPage />} />
-        <Route path="/sandboxes" element={<LeasesPage />} />
-        <Route path="/sandboxes/:leaseId" element={<LeaseDetailPage />} />
+        <Route path="/sandboxes" element={<SandboxesPage />} />
+        <Route path="/sandboxes/:sandboxId" element={<SandboxDetailPage />} />
         <Route path="/leases" element={<LeasesPage />} />
         <Route path="/leases/:leaseId" element={<LeaseDetailPage />} />
         <Route path="/operations/:operationId" element={<OperationDetailPage />} />

--- a/frontend/monitor/src/pages/SandboxDetailPage.test.ts
+++ b/frontend/monitor/src/pages/SandboxDetailPage.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSandboxDetailShell } from "./SandboxDetailPage";
+
+describe("sandbox detail page shell", () => {
+  it("uses sandbox-shaped read-only shell without cleanup lane", () => {
+    const shell = buildSandboxDetailShell({
+      sandbox: {
+        sandbox_id: "sandbox-1",
+        provider_name: "docker",
+        desired_state: "running",
+        observed_state: "running",
+        current_instance_id: "runtime-1",
+        updated_at: "2026-04-15T00:00:00Z",
+        last_error: null,
+        badge: { text: "running" },
+      },
+      triage: {
+        category: "healthy_capacity",
+        title: "Healthy Capacity",
+        description: "Sandbox is converged and attached.",
+      },
+      provider: {
+        id: "docker",
+        name: "docker",
+      },
+      runtime: {
+        runtime_session_id: "runtime-1",
+      },
+      threads: [{ thread_id: "thread-1" }],
+      sessions: [{ chat_session_id: "chat-1", thread_id: "thread-1", status: "active" }],
+    });
+
+    expect(shell.title).toBe("Sandbox sandbox-1");
+    expect(shell.surfaceHref).toBe("/sandboxes");
+    expect(shell.cleanupIncluded).toBe(false);
+  });
+});

--- a/frontend/monitor/src/pages/SandboxDetailPage.tsx
+++ b/frontend/monitor/src/pages/SandboxDetailPage.tsx
@@ -1,0 +1,143 @@
+import { Link, useParams } from "react-router-dom";
+
+import { useMonitorData } from "../app/fetch";
+import ErrorState from "../components/ErrorState";
+import StateBadge from "../components/StateBadge";
+
+export type SandboxDetailPayload = {
+  sandbox: {
+    sandbox_id: string;
+    provider_name?: string | null;
+    desired_state?: string | null;
+    observed_state?: string | null;
+    updated_at?: string | null;
+    last_error?: string | null;
+    current_instance_id?: string | null;
+    badge?: Record<string, unknown>;
+  };
+  triage?: {
+    category?: string | null;
+    title?: string | null;
+    description?: string | null;
+    tone?: string | null;
+  } | null;
+  provider?: {
+    id?: string | null;
+    name?: string | null;
+  } | null;
+  runtime?: {
+    runtime_session_id?: string | null;
+  } | null;
+  threads?: Array<{
+    thread_id?: string | null;
+  }> | null;
+  sessions?: Array<{
+    chat_session_id?: string | null;
+    thread_id?: string | null;
+    status?: string | null;
+  }> | null;
+};
+
+export function buildSandboxDetailShell(data: SandboxDetailPayload) {
+  return {
+    title: `Sandbox ${data.sandbox.sandbox_id}`,
+    description: data.triage?.description ?? "Sandbox state and current read-only relations.",
+    surfaceHref: "/sandboxes",
+    cleanupIncluded: false,
+  };
+}
+
+export default function SandboxDetailPage() {
+  const params = useParams<{ sandboxId: string }>();
+  const sandboxId = params.sandboxId ?? "";
+  const { data, error } = useMonitorData<SandboxDetailPayload>(`/sandboxes/${sandboxId}`);
+
+  if (error) return <ErrorState title={`Sandbox ${sandboxId}`} error={error} />;
+  if (!data) return <div>Loading...</div>;
+
+  const shell = buildSandboxDetailShell(data);
+  const threads = data.threads ?? [];
+  const sessions = data.sessions ?? [];
+  const latestSession = sessions[0] ?? null;
+
+  return (
+    <div className="page">
+      <h1>{shell.title}</h1>
+      <p className="description">{shell.description}</p>
+      <section className="surface-section">
+        <h2>State</h2>
+        <div className="surface-grid">
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">State</p>
+            <StateBadge badge={data.sandbox.badge ?? { text: data.sandbox.observed_state ?? "-" }} />
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Triage</p>
+            <p className="surface-card__value">{data.triage?.title ?? "-"}</p>
+          </article>
+        </div>
+      </section>
+      <section className="surface-section">
+        <h2>Relations</h2>
+        <h3>Object Links</h3>
+        <div className="surface-grid">
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Provider</p>
+            <p className="surface-card__value surface-card__value--compact">
+              {data.provider?.id ? (
+                <Link to={`/providers/${data.provider.id}`}>{data.provider.name ?? data.provider.id}</Link>
+              ) : (
+                data.provider?.name ?? data.sandbox.provider_name ?? "-"
+              )}
+            </p>
+            <p className="surface-card__body">Provider surface and capacity state.</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Runtime</p>
+            <p className="surface-card__value surface-card__value--compact">
+              {data.runtime?.runtime_session_id ? (
+                <Link to={`/runtimes/${data.runtime.runtime_session_id}`}>{data.runtime.runtime_session_id}</Link>
+              ) : (
+                "-"
+              )}
+            </p>
+            <p className="surface-card__body">Live runtime session linked to this sandbox.</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Thread</p>
+            <p className="surface-card__value surface-card__value--compact">
+              {threads[0]?.thread_id ? <Link to={`/threads/${threads[0].thread_id}`}>{threads[0].thread_id}</Link> : "No related thread"}
+            </p>
+            <p className="surface-card__body">Primary thread currently linked to this sandbox.</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Session</p>
+            <p className="surface-card__value surface-card__value--compact">{latestSession?.chat_session_id ?? "No recorded session"}</p>
+            <p className="surface-card__body">Most recent chat session observed for this sandbox.</p>
+          </article>
+        </div>
+        <h3>Context</h3>
+        <div className="info-grid">
+          <div>
+            <strong>Updated</strong>
+            <span>{data.sandbox.updated_at ?? "-"}</span>
+          </div>
+          <div>
+            <strong>Surface</strong>
+            <span>
+              <Link to={shell.surfaceHref}>Sandboxes</Link>
+            </span>
+          </div>
+          <div>
+            <strong>Last error</strong>
+            <span>{data.sandbox.last_error ?? "-"}</span>
+          </div>
+          <div>
+            <strong>Session status</strong>
+            <span>{latestSession?.status ?? "-"}</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/monitor/src/pages/SandboxesPage.test.ts
+++ b/frontend/monitor/src/pages/SandboxesPage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSandboxWorkbenchShell } from "./SandboxesPage";
+
+describe("sandboxes page shell", () => {
+  it("uses sandbox-shaped headings and canonical sandbox links", () => {
+    const shell = buildSandboxWorkbenchShell({
+      title: "All Sandboxes",
+      count: 2,
+      triage: {
+        summary: {
+          active_drift: 1,
+          detached_residue: 0,
+          orphan_cleanup: 0,
+          healthy_capacity: 1,
+        },
+      },
+      items: [
+        {
+          sandbox_id: "sandbox-1",
+          provider: "docker",
+          instance_id: "runtime-1",
+          triage: { category: "active_drift", title: "Active Drift" },
+          thread: { thread_id: "thread-1" },
+          state_badge: { text: "running" },
+          updated_ago: "1m ago",
+          error: null,
+        },
+      ],
+    });
+
+    expect(shell.triageTitle).toBe("Sandbox Triage");
+    expect(shell.workbenchTitle).toBe("Sandbox Workbench");
+    expect(shell.rows[0].href).toBe("/sandboxes/sandbox-1");
+  });
+});

--- a/frontend/monitor/src/pages/SandboxesPage.tsx
+++ b/frontend/monitor/src/pages/SandboxesPage.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import ErrorState from "../components/ErrorState";
+import StateBadge from "../components/StateBadge";
+import { useMonitorData } from "../app/fetch";
+
+export type SandboxesPayload = {
+  title: string;
+  count: number;
+  triage?: {
+    summary?: {
+      active_drift?: number;
+      detached_residue?: number;
+      orphan_cleanup?: number;
+      healthy_capacity?: number;
+      total?: number;
+    };
+  };
+  items: Array<{
+    sandbox_id: string;
+    provider: string;
+    instance_id?: string | null;
+    triage?: {
+      category?: string | null;
+      title?: string | null;
+    };
+    thread: {
+      thread_id?: string | null;
+    };
+    state_badge: Record<string, unknown>;
+    updated_ago?: string | null;
+    error?: string | null;
+  }>;
+};
+
+type TriageFilter = "all" | "active_drift" | "detached_residue" | "orphan_cleanup" | "healthy_capacity";
+
+export function buildSandboxWorkbenchShell(data: SandboxesPayload) {
+  const triage = data.triage?.summary ?? {};
+  const triageCards = [
+    { key: "active_drift" as const, label: "Active Drift", value: triage.active_drift ?? 0 },
+    { key: "detached_residue" as const, label: "Detached Residue", value: triage.detached_residue ?? 0 },
+    { key: "orphan_cleanup" as const, label: "Orphan Cleanup", value: triage.orphan_cleanup ?? 0 },
+    { key: "healthy_capacity" as const, label: "Healthy Capacity", value: triage.healthy_capacity ?? 0 },
+  ] satisfies Array<{ key: TriageFilter; label: string; value: number }>;
+
+  return {
+    triageTitle: "Sandbox Triage",
+    workbenchTitle: "Sandbox Workbench",
+    triageCards,
+    rows: data.items.map((item) => ({
+      ...item,
+      href: `/sandboxes/${item.sandbox_id}`,
+    })),
+  };
+}
+
+export default function SandboxesPage() {
+  const { data, error } = useMonitorData<SandboxesPayload>("/sandboxes");
+  const [selectedFilter, setSelectedFilter] = React.useState<TriageFilter>("all");
+
+  if (error) return <ErrorState title="Sandboxes" error={error} />;
+  if (!data) return <div>Loading...</div>;
+
+  const shell = buildSandboxWorkbenchShell(data);
+  const visibleRows =
+    selectedFilter === "all"
+      ? shell.rows
+      : shell.rows.filter((item) => (item.triage?.category ?? "") === selectedFilter);
+  const activeCard = shell.triageCards.find((card) => card.key === selectedFilter);
+
+  return (
+    <div className="page">
+      <h1>{data.title}</h1>
+      <p className="count">Total: {data.count}</p>
+      <section className="surface-section">
+        <h2>{shell.triageTitle}</h2>
+        <div className="surface-grid">
+          <button
+            type="button"
+            className={`surface-card lease-triage-card ${selectedFilter === "all" ? "lease-triage-card--active" : ""}`}
+            onClick={() => setSelectedFilter("all")}
+          >
+            <p className="surface-card__eyebrow">All Triage</p>
+            <p className="surface-card__value">{data.count}</p>
+          </button>
+          {shell.triageCards.map((card) => (
+            <button
+              type="button"
+              className={`surface-card lease-triage-card ${selectedFilter === card.key ? "lease-triage-card--active" : ""}`}
+              key={card.label}
+              onClick={() => setSelectedFilter(card.key)}
+            >
+              <p className="surface-card__eyebrow">{card.label}</p>
+              <p className="surface-card__value">{card.value}</p>
+            </button>
+          ))}
+        </div>
+      </section>
+      <div className="leases-workbench-header">
+        <div>
+          <h2>{shell.workbenchTitle}</h2>
+          <p className="description">
+            {activeCard ? `Showing ${activeCard.label}` : "Showing All Triage"}
+          </p>
+        </div>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Sandbox ID</th>
+            <th>Topology</th>
+            <th>Triage</th>
+            <th>State</th>
+            <th>Updated</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((item) => (
+            <tr key={item.sandbox_id}>
+              <td className="mono">
+                <Link to={item.href}>{item.sandbox_id}</Link>
+              </td>
+              <td>
+                <div className="lease-topology">
+                  <div className="lease-topology__row">
+                    <span className="lease-topology__label">provider</span>
+                    {item.provider ? <Link to={`/providers/${item.provider}`}>{item.provider}</Link> : <span>-</span>}
+                  </div>
+                  <div className="lease-topology__row">
+                    <span className="lease-topology__label">runtime</span>
+                    {item.instance_id ? (
+                      <Link className="mono" to={`/runtimes/${item.instance_id}`}>
+                        {item.instance_id.slice(0, 12)}
+                      </Link>
+                    ) : (
+                      <span>-</span>
+                    )}
+                  </div>
+                  <div className="lease-topology__row">
+                    <span className="lease-topology__label">thread</span>
+                    {item.thread.thread_id ? (
+                      <Link className="mono" to={`/threads/${item.thread.thread_id}`}>
+                        {item.thread.thread_id.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      <span className="orphan">orphan</span>
+                    )}
+                  </div>
+                </div>
+              </td>
+              <td>
+                <span className="lease-triage-chip">{item.triage?.title ?? "-"}</span>
+              </td>
+              <td>
+                <StateBadge badge={item.state_badge} />
+              </td>
+              <td>{item.updated_ago}</td>
+              <td className="error">{item.error || "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add canonical sandbox-shaped monitor read-only workbench pages
- route /api/monitor frontend /sandboxes* to the canonical sandbox detail shell
- keep legacy /leases* pages unchanged as compatibility shell while cleanup stays separate

## Verification
- cd frontend/monitor && npm test -- --run src/pages/SandboxesPage.test.ts src/pages/SandboxDetailPage.test.ts src/app/monitor-nav.test.ts src/pages/DashboardPage.test.ts
- cd frontend/monitor && npm run build
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py -q
- git diff --check