### PR TITLE
refactor: cut monitor cleanup source to sandbox

### DIFF
--- a/backend/web/services/monitor_operation_service.py
+++ b/backend/web/services/monitor_operation_service.py
@@ -146,6 +146,7 @@ def request_lease_cleanup(lease_detail: dict[str, Any]) -> dict[str, Any]:
     )
 
     lease_id = str(lease.get("lease_id") or "")
+    sandbox_id = str(lease.get("sandbox_id") or "")
     if not cleanup["allowed"]:
         return {
             "accepted": False,
@@ -163,12 +164,12 @@ def request_lease_cleanup(lease_detail: dict[str, Any]) -> dict[str, Any]:
 
     operation = _new_operation(
         kind="lease_cleanup",
-        target_type="lease",
-        target_id=lease_id,
+        target_type="sandbox",
+        target_id=sandbox_id,
         reason=cleanup["reason"],
         target={
-            "target_type": "lease",
-            "target_id": lease_id,
+            "target_type": "sandbox",
+            "target_id": sandbox_id,
             "provider_id": provider_name,
             "runtime_session_id": runtime_session_id or None,
             "thread_ids": thread_ids,

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -749,7 +749,48 @@ async def get_monitor_thread_detail(app: Any, thread_id: str) -> dict[str, Any]:
 
 
 def request_monitor_lease_cleanup(lease_id: str) -> dict[str, Any]:
-    return monitor_operation_service.request_lease_cleanup(get_monitor_lease_detail(lease_id))
+    repo = make_sandbox_monitor_repo()
+    try:
+        lease = repo.query_lease(lease_id)
+    finally:
+        repo.close()
+    if lease is None:
+        raise KeyError(f"Lease not found: {lease_id}")
+
+    sandbox_id = str(lease.get("sandbox_id") or "").strip()
+    if not sandbox_id:
+        raise RuntimeError("monitor lease cleanup target missing sandbox bridge")
+    return request_monitor_sandbox_cleanup(sandbox_id)
+
+
+def request_monitor_sandbox_cleanup(sandbox_id: str) -> dict[str, Any]:
+    payload = get_monitor_sandbox_detail(sandbox_id)
+    sandbox = payload["sandbox"]
+    provider = payload.get("provider") or {}
+    runtime = payload.get("runtime") or {}
+    threads = payload.get("threads") or []
+
+    lease_id = _sandbox_cleanup_lease_id(sandbox_id)
+    lease_detail = {
+        "lease": {
+            **sandbox,
+            "lease_id": lease_id,
+        },
+        "triage": payload.get("triage"),
+        "provider": provider,
+        "runtime": runtime,
+        "threads": threads,
+        "sessions": payload.get("sessions") or [],
+        "cleanup": monitor_operation_service.build_lease_cleanup_truth(
+            lease_id=lease_id,
+            triage=payload.get("triage"),
+            provider_name=str(provider.get("id") or sandbox.get("provider_name") or ""),
+            runtime_session_id=str(runtime.get("runtime_session_id") or ""),
+            sessions=payload.get("sessions") or [],
+            threads=threads,
+        ),
+    }
+    return monitor_operation_service.request_lease_cleanup(lease_detail)
 
 
 def request_monitor_provider_session_cleanup(provider_name: str, session_id: str) -> dict[str, Any]:
@@ -764,7 +805,14 @@ def request_monitor_provider_session_cleanup(provider_name: str, session_id: str
 def get_monitor_operation_detail(operation_id: str) -> dict[str, Any]:
     payload = monitor_operation_service.get_operation_detail(operation_id)
     target = payload.get("target") or {}
-    if str(target.get("target_type") or "").strip() != "lease":
+    target_type = str(target.get("target_type") or "").strip()
+    if target_type == "sandbox":
+        sandbox_id = str(target.get("target_id") or "").strip()
+        if not sandbox_id:
+            raise RuntimeError("monitor operation sandbox target is missing")
+        return {**payload, "sandbox_id": sandbox_id}
+
+    if target_type != "lease":
         return payload
 
     lease_id = str(target.get("target_id") or "").strip()
@@ -783,6 +831,21 @@ def get_monitor_operation_detail(operation_id: str) -> dict[str, Any]:
     if not sandbox_id:
         raise RuntimeError("monitor operation lease target missing sandbox bridge")
     return {**payload, "sandbox_id": sandbox_id}
+
+
+def _sandbox_cleanup_lease_id(sandbox_id: str) -> str:
+    repo = make_sandbox_monitor_repo()
+    try:
+        sandbox = repo.query_sandbox(sandbox_id)
+    finally:
+        repo.close()
+    if sandbox is None:
+        raise KeyError(f"Sandbox not found: {sandbox_id}")
+
+    lease_id = str(sandbox.get("lease_id") or "").strip()
+    if not lease_id:
+        raise RuntimeError("monitor sandbox cleanup target missing lease bridge")
+    return lease_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -26,6 +26,12 @@ def _default_eval_batch_service(monkeypatch):
     monkeypatch.setattr(monitor_service, "make_eval_batch_service", lambda: FakeBatchService())
 
 
+@pytest.fixture(autouse=True)
+def _clear_monitor_cleanup_operations():
+    monitor_service.monitor_operation_service._OPERATIONS.clear()
+    monitor_service.monitor_operation_service._TARGET_INDEX.clear()
+
+
 def _lease_row(**overrides):
     row = {
         "sandbox_id": "sandbox-1",
@@ -636,6 +642,46 @@ def test_request_monitor_lease_cleanup_closes_stale_active_sessions(monkeypatch)
     assert calls == [("lease-1", "daytona", True)]
 
 
+def test_request_monitor_sandbox_cleanup_uses_canonical_sandbox_target(monkeypatch):
+    calls: list[tuple[str, str, bool]] = []
+    _use_monitor_repo(
+        monkeypatch,
+        FakeLeaseRepo(
+            lease=_detached_lease(),
+            threads=[{"thread_id": "thread-historical"}],
+            runtime_session_id="runtime-1",
+        ),
+    )
+    monkeypatch.setattr(
+        "backend.web.services.sandbox_service.destroy_sandbox_lease",
+        _record_destroy(calls),
+        raising=False,
+    )
+
+    payload = monitor_service.request_monitor_sandbox_cleanup("sandbox-1")
+
+    assert payload["accepted"] is True
+    assert payload["message"] == "Lease cleanup completed."
+    assert payload["operation"]["target_type"] == "sandbox"
+    assert payload["operation"]["target_id"] == "sandbox-1"
+    assert calls == [("lease-1", "daytona", True)]
+
+
+def test_request_monitor_lease_cleanup_wraps_canonical_sandbox_cleanup(monkeypatch):
+    _use_monitor_repo(monkeypatch, FakeLeaseRepo(lease=_detached_lease()))
+    calls: list[str] = []
+    monkeypatch.setattr(
+        monitor_service,
+        "request_monitor_sandbox_cleanup",
+        lambda sandbox_id: calls.append(sandbox_id) or {"accepted": True, "operation": {"target_type": "sandbox"}},
+    )
+
+    payload = monitor_service.request_monitor_lease_cleanup("lease-1")
+
+    assert payload == {"accepted": True, "operation": {"target_type": "sandbox"}}
+    assert calls == ["sandbox-1"]
+
+
 def test_request_monitor_provider_session_cleanup_uses_sandbox_manager(monkeypatch):
     calls: list[tuple[str, str, str, str | None]] = []
     monkeypatch.setattr(
@@ -911,6 +957,33 @@ def test_get_monitor_operation_detail_exposes_sandbox_relation_shell(monkeypatch
     assert payload["sandbox_id"] == "sandbox-1"
     assert payload["target"]["target_type"] == "lease"
     assert payload["target"]["target_id"] == "lease-1"
+
+
+def test_get_monitor_operation_detail_preserves_canonical_sandbox_target(monkeypatch):
+    monkeypatch.setattr(
+        monitor_service.monitor_operation_service,
+        "get_operation_detail",
+        lambda _operation_id: {
+            "operation": {"operation_id": "op-1", "kind": "lease_cleanup", "status": "succeeded"},
+            "target": {
+                "target_type": "sandbox",
+                "target_id": "sandbox-1",
+                "provider_id": "daytona",
+                "runtime_session_id": "runtime-1",
+            },
+            "result_truth": {
+                "lease_state_before": "running",
+                "lease_state_after": "destroyed",
+            },
+            "events": [],
+        },
+    )
+
+    payload = monitor_service.get_monitor_operation_detail("op-1")
+
+    assert payload["sandbox_id"] == "sandbox-1"
+    assert payload["target"]["target_type"] == "sandbox"
+    assert payload["target"]["target_id"] == "sandbox-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add canonical `request_monitor_sandbox_cleanup(sandbox_id)` in monitor service
- downgrade legacy lease cleanup request path to a sandbox-resolving wrapper
- switch cleanup operation target truth to sandbox-shaped while leaving browse/read untouched

## Test Plan
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py -k 'request_monitor_sandbox_cleanup or request_monitor_lease_cleanup_wraps_canonical_sandbox_cleanup or preserves_canonical_sandbox_target' -q
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py -k 'cleanup or operation_detail' -q
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py -q
- uv run ruff check backend/web/services/monitor_service.py backend/web/services/monitor_operation_service.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check
