### PR TITLE
refactor: cut monitor cleanup shell to sandbox

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -99,6 +99,11 @@ def lease_cleanup_action(lease_id: str):
     return _or_404(monitor_service.request_monitor_lease_cleanup, lease_id)
 
 
+@router.post("/sandboxes/{sandbox_id}/cleanup")
+def sandbox_cleanup_action(sandbox_id: str):
+    return _or_404(monitor_service.request_monitor_sandbox_cleanup, sandbox_id)
+
+
 @router.post("/provider-sessions/{provider_id}/{session_id}/cleanup")
 def provider_session_cleanup_action(provider_id: str, session_id: str):
     return monitor_service.request_monitor_provider_session_cleanup(provider_id, session_id)

--- a/backend/web/services/monitor_operation_service.py
+++ b/backend/web/services/monitor_operation_service.py
@@ -28,6 +28,7 @@ def _operation_view(operation: dict[str, Any]) -> dict[str, Any]:
         "updated_at": operation["updated_at"],
         "summary": operation["summary"],
         "reason": operation["reason"],
+        "result_truth": dict(operation.get("result_truth") or {}),
     }
 
 
@@ -194,8 +195,8 @@ def request_lease_cleanup(lease_detail: dict[str, Any]) -> dict[str, Any]:
         )
     except Exception as exc:
         operation["result_truth"] = {
-            "lease_state_before": lease.get("observed_state"),
-            "lease_state_after": lease.get("observed_state"),
+            "sandbox_state_before": lease.get("observed_state"),
+            "sandbox_state_after": lease.get("observed_state"),
             "runtime_state_after": str(runtime.get("runtime_session_id") or "").strip() or None,
             "thread_state_after": thread_ids or None,
         }
@@ -211,8 +212,8 @@ def request_lease_cleanup(lease_detail: dict[str, Any]) -> dict[str, Any]:
         }
 
     operation["result_truth"] = {
-        "lease_state_before": lease.get("observed_state"),
-        "lease_state_after": None,
+        "sandbox_state_before": lease.get("observed_state"),
+        "sandbox_state_after": None,
         "runtime_state_after": None,
         "thread_state_after": thread_ids or None,
         "destroy_result": result,

--- a/frontend/monitor/src/pages/LeaseDetailPage.test.ts
+++ b/frontend/monitor/src/pages/LeaseDetailPage.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLeaseDetailShell } from "./LeaseDetailPage";
+
+describe("lease detail page shell", () => {
+  it("keeps cleanup as compatibility shell after sandbox cleanup rollout", () => {
+    const shell = buildLeaseDetailShell({
+      lease: { lease_id: "lease-1" },
+      triage: { description: "Lease state and cleanup readiness." },
+      cleanup: { allowed: true },
+    });
+
+    expect(shell.title).toBe("Lease lease-1");
+    expect(shell.cleanupTitle).toBe("Compatibility Cleanup");
+    expect(shell.cleanupHint).toBe("Legacy lease-shaped cleanup entry kept during sandbox cleanup rollout.");
+    expect(shell.cleanupButtonLabel).toBe("Start compatibility cleanup");
+    expect(shell.compatibilityOnly).toBe(true);
+  });
+});

--- a/frontend/monitor/src/pages/LeaseDetailPage.tsx
+++ b/frontend/monitor/src/pages/LeaseDetailPage.tsx
@@ -77,6 +77,17 @@ const CLEANUP_STATUS_CLASS_BY_STATUS: Record<string, string> = {
   rejected: "cleanup-status cleanup-status--danger",
 };
 
+export function buildLeaseDetailShell(data: Pick<LeaseDetailPayload, "lease" | "triage" | "cleanup">) {
+  return {
+    title: `Lease ${data.lease.lease_id}`,
+    description: data.triage?.description ?? "Lease state and cleanup readiness.",
+    cleanupTitle: "Compatibility Cleanup",
+    cleanupHint: "Legacy lease-shaped cleanup entry kept during sandbox cleanup rollout.",
+    cleanupButtonLabel: "Start compatibility cleanup",
+    compatibilityOnly: true,
+  };
+}
+
 export default function LeaseDetailPage() {
   const params = useParams<{ leaseId: string }>();
   const leaseId = params.leaseId ?? "";
@@ -104,6 +115,7 @@ export default function LeaseDetailPage() {
     (operation) => operation.operation_id !== cleanup.operation?.operation_id,
   );
   const latestSession = sessions[0] ?? null;
+  const shell = buildLeaseDetailShell(leaseData);
   const cleanupDecision = cleanup.allowed ? "Managed cleanup ready" : "Cleanup blocked";
   const cleanupActionSummary = cleanup.recommended_action ?? "No managed action";
   const cleanupActionHint = cleanup.allowed
@@ -142,8 +154,8 @@ export default function LeaseDetailPage() {
 
   return (
     <div className="page">
-      <h1>{`Lease ${leaseData.lease.lease_id}`}</h1>
-      <p className="description">{leaseData.triage?.description ?? "Lease state and cleanup readiness."}</p>
+      <h1>{shell.title}</h1>
+      <p className="description">{shell.description}</p>
       <section className="surface-section">
         <h2>State</h2>
         <div className="surface-grid">
@@ -158,8 +170,8 @@ export default function LeaseDetailPage() {
         </div>
       </section>
       <section className="surface-section">
-        <h2>Cleanup</h2>
-        <p className="description">{cleanup.reason ?? "Managed cleanup readiness for this lease."}</p>
+        <h2>{shell.cleanupTitle}</h2>
+        <p className="description">{cleanup.reason ?? shell.cleanupHint}</p>
         <div className="surface-grid cleanup-grid">
           <article className="surface-card">
             <p className="surface-card__eyebrow">Decision</p>
@@ -186,7 +198,7 @@ export default function LeaseDetailPage() {
               disabled={!cleanup.allowed || cleanupPending}
               onClick={() => void startCleanup()}
             >
-              Start lease cleanup
+              {shell.cleanupButtonLabel}
             </button>
             <p className="surface-card__body">{cleanupActionHint}</p>
           </article>

--- a/frontend/monitor/src/pages/MonitorRelationShell.test.ts
+++ b/frontend/monitor/src/pages/MonitorRelationShell.test.ts
@@ -50,7 +50,7 @@ describe("monitor relation shell", () => {
       operation: { operation_id: "op-1", status: "succeeded" },
       target: { target_type: "lease", target_id: "lease-1" },
       sandbox_id: "sandbox-1",
-      result_truth: { lease_state_before: "running", lease_state_after: "destroyed" },
+      result_truth: { sandbox_state_before: "running", sandbox_state_after: "destroyed" },
       events: [],
     });
 
@@ -59,6 +59,8 @@ describe("monitor relation shell", () => {
     expect(shell.targetLabel).toBe("Sandbox");
     expect(shell.beforeLabel).toBe("Sandbox Before");
     expect(shell.afterLabel).toBe("Sandbox After");
+    expect(shell.runtimeBody).toBe("Runtime session linked to the target sandbox.");
+    expect(shell.providerBody).toBe("Provider surface responsible for the target sandbox runtime.");
   });
 
   it("uses sandbox detail link for resource group relation shell", () => {

--- a/frontend/monitor/src/pages/OperationDetailPage.tsx
+++ b/frontend/monitor/src/pages/OperationDetailPage.tsx
@@ -20,8 +20,8 @@ type OperationDetailPayload = {
   } | null;
   sandbox_id?: string | null;
   result_truth?: {
-    lease_state_before?: string | null;
-    lease_state_after?: string | null;
+    sandbox_state_before?: string | null;
+    sandbox_state_after?: string | null;
     runtime_state_after?: string | null;
     thread_state_after?: string[] | string | null;
   } | null;
@@ -48,6 +48,8 @@ export function buildOperationDetailShell(data: OperationDetailPayload) {
     targetHref: sandboxId ? `/sandboxes/${sandboxId}` : null,
     beforeLabel: "Sandbox Before",
     afterLabel: "Sandbox After",
+    runtimeBody: "Runtime session linked to the target sandbox.",
+    providerBody: "Provider surface responsible for the target sandbox runtime.",
   };
 }
 
@@ -122,14 +124,14 @@ export default function OperationDetailPage() {
                 "-"
               )}
             </p>
-            <p className="surface-card__body">Runtime session linked to the target lease.</p>
+            <p className="surface-card__body">{shell.runtimeBody}</p>
           </article>
           <article className="surface-card">
             <p className="surface-card__eyebrow">Provider</p>
             <p className="surface-card__value surface-card__value--compact">
               {target.provider_id ? <Link to={`/providers/${target.provider_id}`}>{target.provider_id}</Link> : "-"}
             </p>
-            <p className="surface-card__body">Provider surface responsible for the target runtime.</p>
+            <p className="surface-card__body">{shell.providerBody}</p>
           </article>
         </div>
       </section>
@@ -138,12 +140,12 @@ export default function OperationDetailPage() {
         <div className="surface-grid">
           <article className="surface-card">
             <p className="surface-card__eyebrow">{shell.beforeLabel}</p>
-            <p className="surface-card__value surface-card__value--compact">{result.lease_state_before ?? "-"}</p>
+            <p className="surface-card__value surface-card__value--compact">{result.sandbox_state_before ?? "-"}</p>
             <p className="surface-card__body">Observed sandbox state when the operation started.</p>
           </article>
           <article className="surface-card">
             <p className="surface-card__eyebrow">{shell.afterLabel}</p>
-            <p className="surface-card__value surface-card__value--compact">{result.lease_state_after ?? "-"}</p>
+            <p className="surface-card__value surface-card__value--compact">{result.sandbox_state_after ?? "-"}</p>
             <p className="surface-card__body">Most recent post-operation sandbox state.</p>
           </article>
           <article className="surface-card">

--- a/frontend/monitor/src/pages/SandboxDetailPage.test.ts
+++ b/frontend/monitor/src/pages/SandboxDetailPage.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildSandboxDetailShell } from "./SandboxDetailPage";
 
 describe("sandbox detail page shell", () => {
-  it("uses sandbox-shaped read-only shell without cleanup lane", () => {
+  it("uses sandbox-shaped shell with cleanup lane", () => {
     const shell = buildSandboxDetailShell({
       sandbox: {
         sandbox_id: "sandbox-1",
@@ -33,6 +33,6 @@ describe("sandbox detail page shell", () => {
 
     expect(shell.title).toBe("Sandbox sandbox-1");
     expect(shell.surfaceHref).toBe("/sandboxes");
-    expect(shell.cleanupIncluded).toBe(false);
+    expect(shell.cleanupIncluded).toBe(true);
   });
 });

--- a/frontend/monitor/src/pages/SandboxDetailPage.tsx
+++ b/frontend/monitor/src/pages/SandboxDetailPage.tsx
@@ -1,6 +1,7 @@
-import { Link, useParams } from "react-router-dom";
+import React from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { useMonitorData } from "../app/fetch";
+import { postMonitorData, useMonitorData } from "../app/fetch";
 import ErrorState from "../components/ErrorState";
 import StateBadge from "../components/StateBadge";
 
@@ -43,14 +44,17 @@ export function buildSandboxDetailShell(data: SandboxDetailPayload) {
     title: `Sandbox ${data.sandbox.sandbox_id}`,
     description: data.triage?.description ?? "Sandbox state and current read-only relations.",
     surfaceHref: "/sandboxes",
-    cleanupIncluded: false,
+    cleanupIncluded: true,
   };
 }
 
 export default function SandboxDetailPage() {
   const params = useParams<{ sandboxId: string }>();
+  const navigate = useNavigate();
   const sandboxId = params.sandboxId ?? "";
   const { data, error } = useMonitorData<SandboxDetailPayload>(`/sandboxes/${sandboxId}`);
+  const [cleanupPending, setCleanupPending] = React.useState(false);
+  const [cleanupMessage, setCleanupMessage] = React.useState<string | null>(null);
 
   if (error) return <ErrorState title={`Sandbox ${sandboxId}`} error={error} />;
   if (!data) return <div>Loading...</div>;
@@ -59,6 +63,22 @@ export default function SandboxDetailPage() {
   const threads = data.threads ?? [];
   const sessions = data.sessions ?? [];
   const latestSession = sessions[0] ?? null;
+  const cleanupAllowed = Boolean(data.triage?.category && data.triage.category !== "healthy_capacity");
+
+  async function startCleanup() {
+    setCleanupPending(true);
+    try {
+      const result = await postMonitorData<{ accepted?: boolean; message?: string | null; operation?: { operation_id?: string | null } | null }>(
+        `/sandboxes/${sandboxId}/cleanup`,
+      );
+      setCleanupMessage(result.message ?? null);
+      if (result.operation?.operation_id) {
+        navigate(`/operations/${result.operation.operation_id}`);
+      }
+    } finally {
+      setCleanupPending(false);
+    }
+  }
 
   return (
     <div className="page">
@@ -76,6 +96,26 @@ export default function SandboxDetailPage() {
             <p className="surface-card__value">{data.triage?.title ?? "-"}</p>
           </article>
         </div>
+      </section>
+      <section className="surface-section">
+        <h2>Cleanup</h2>
+        <div className="surface-grid cleanup-grid">
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Action Lane</p>
+            <button
+              type="button"
+              className="monitor-action-button"
+              disabled={!cleanupAllowed || cleanupPending}
+              onClick={() => void startCleanup()}
+            >
+              Start sandbox cleanup
+            </button>
+            <p className="surface-card__body">
+              {cleanupAllowed ? "This sandbox can enter the managed cleanup flow." : "This sandbox is not ready for managed cleanup."}
+            </p>
+          </article>
+        </div>
+        {cleanupMessage ? <p className="description">{cleanupMessage}</p> : null}
       </section>
       <section className="surface-section">
         <h2>Relations</h2>

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -145,6 +145,7 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
         ("get", "/api/monitor/leases/lease-1", "get_monitor_lease_detail", {"lease": {"lease_id": "lease-1"}}),
         ("get", "/api/monitor/sandboxes/sandbox-1", "get_monitor_sandbox_detail", {"sandbox": {"sandbox_id": "sandbox-1"}}),
         ("post", "/api/monitor/leases/lease-1/cleanup", "request_monitor_lease_cleanup", {"accepted": True}),
+        ("post", "/api/monitor/sandboxes/sandbox-1/cleanup", "request_monitor_sandbox_cleanup", {"accepted": True}),
         (
             "post",
             "/api/monitor/provider-sessions/daytona_selfhost/session-1/cleanup",

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -664,6 +664,10 @@ def test_request_monitor_sandbox_cleanup_uses_canonical_sandbox_target(monkeypat
     assert payload["message"] == "Lease cleanup completed."
     assert payload["operation"]["target_type"] == "sandbox"
     assert payload["operation"]["target_id"] == "sandbox-1"
+    assert payload["operation"]["result_truth"]["sandbox_state_before"] == "detached"
+    assert payload["operation"]["result_truth"]["sandbox_state_after"] is None
+    assert "lease_state_before" not in payload["operation"]["result_truth"]
+    assert "lease_state_after" not in payload["operation"]["result_truth"]
     assert calls == [("lease-1", "daytona", True)]
 
 


### PR DESCRIPTION
## Summary
- add canonical sandbox cleanup route for monitor
- move cleanup result truth and operation wording toward sandbox-shaped caller-visible shell
- demote LeaseDetailPage cleanup to an explicit compatibility shell during rollout

## Verification
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py -q
- cd frontend/monitor && npm test -- --run src/pages/LeaseDetailPage.test.ts src/pages/SandboxDetailPage.test.ts src/pages/MonitorRelationShell.test.ts
- cd frontend/monitor && npm run build
- uv run ruff check backend/web/routers/monitor.py backend/web/services/monitor_operation_service.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check