### PR TITLE
fix: preserve repo sub-agent tools json

### DIFF
--- a/config/loader.py
+++ b/config/loader.py
@@ -429,10 +429,11 @@ def load_bundle_from_repo(agent_config_repo: Any, agent_config_id: str) -> Agent
     agents_by_name = {agent.name: agent for agent in loader._discover_agents(loader._system_defaults_dir)}
     sub_agent_rows = agent_config_repo.list_sub_agents(agent_config_id)
     for sa in sub_agent_rows:
+        tools = sa.get("tools_json") if "tools_json" in sa and sa.get("tools_json") is not None else sa.get("tools", ["*"])
         sub_agent = AgentConfig(
             name=sa.get("name", ""),
             description=sa.get("description", ""),
-            tools=sa.get("tools", ["*"]),
+            tools=tools,
             system_prompt=sa.get("system_prompt", ""),
             model=sa.get("model"),
             source_dir=None,

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -269,3 +269,85 @@ def test_load_bundle_from_repo_uses_agent_config_id_root_key() -> None:
         ("sub_agents", "cfg-1"),
         ("skills", "cfg-1"),
     ]
+
+
+def test_load_bundle_from_repo_reads_sub_agent_tools_json() -> None:
+    class _Repo:
+        def get_config(self, _agent_config_id: str):
+            return {
+                "id": "cfg-1",
+                "name": "Toad",
+                "description": "test config",
+                "tools": ["search"],
+                "system_prompt": "be helpful",
+                "status": "active",
+                "version": "1.0.0",
+                "created_at": 1,
+                "updated_at": 2,
+                "meta": {},
+                "runtime": {},
+                "mcp": {},
+            }
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return [
+                {
+                    "name": "Scout",
+                    "description": "helper",
+                    "tools_json": ["search"],
+                    "system_prompt": "look around",
+                }
+            ]
+
+        def list_skills(self, _agent_config_id: str):
+            return []
+
+    bundle = load_bundle_from_repo(_Repo(), "cfg-1")
+
+    assert bundle is not None
+    scout = next(agent for agent in bundle.agents if agent.name == "Scout")
+    assert scout.tools == ["search"]
+
+
+def test_load_bundle_from_repo_preserves_empty_sub_agent_tools_json() -> None:
+    class _Repo:
+        def get_config(self, _agent_config_id: str):
+            return {
+                "id": "cfg-1",
+                "name": "Toad",
+                "description": "test config",
+                "tools": ["search"],
+                "system_prompt": "be helpful",
+                "status": "active",
+                "version": "1.0.0",
+                "created_at": 1,
+                "updated_at": 2,
+                "meta": {},
+                "runtime": {},
+                "mcp": {},
+            }
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return [
+                {
+                    "name": "Scout",
+                    "description": "helper",
+                    "tools_json": [],
+                    "system_prompt": "look around",
+                }
+            ]
+
+        def list_skills(self, _agent_config_id: str):
+            return []
+
+    bundle = load_bundle_from_repo(_Repo(), "cfg-1")
+
+    assert bundle is not None
+    scout = next(agent for agent in bundle.agents if agent.name == "Scout")
+    assert scout.tools == []


### PR DESCRIPTION
## Summary
- make repo-backed sub-agent reload prefer persisted `tools_json`
- preserve explicit empty `tools_json=[]` instead of falling back to `["*"]`
- add focused loader regressions for both non-empty and empty persisted tool lists

## Verification
-   env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Config/test_loader.py -q
-   uv run ruff check config/loader.py tests/Config/test_loader.py
-   git diff --check

## Scope
- narrow lane-02 integrity slice only
- no clone-contract proof
- no panel/marketplace route changes