### PR TITLE
fix: preserve repo-backed skill desc projection

### DIFF
--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -61,8 +61,16 @@ def _skills_from_repo(agent_config_id: str, config: dict[str, Any], agent_config
     for row in agent_config_repo.list_skills(agent_config_id):
         runtime_key = f"skills:{row['name']}"
         override = runtime.get(runtime_key, {}) if isinstance(runtime.get(runtime_key), dict) else {}
-        desc = override.get("desc")
-        if not desc:
+        desc = None
+        if "desc" in override and override.get("desc") is not None:
+            desc = str(override.get("desc") or "")
+        else:
+            # @@@skill-desc-precedence - repo skill meta is the stable slow-variable truth.
+            # Library desc is only a last fallback when neither runtime override nor repo meta carries one.
+            meta = row.get("meta_json") if isinstance(row.get("meta_json"), dict) else {}
+            if "desc" in meta and meta.get("desc") is not None:
+                desc = str(meta.get("desc") or "")
+        if desc is None:
             from backend.web.services.library_service import get_library_skill_desc
 
             desc = get_library_skill_desc(str(row["name"]))
@@ -735,7 +743,9 @@ def install_from_snapshot(
         if not isinstance(skill, dict):
             continue
         skill_name = _sanitize_name(str(skill.get("name") or "default"))
-        skill_meta = skill.get("meta") if isinstance(skill.get("meta"), dict) else None
+        skill_meta = dict(skill.get("meta")) if isinstance(skill.get("meta"), dict) else {}
+        if skill.get("desc") is not None:
+            skill_meta["desc"] = str(skill.get("desc") or "")
         agent_config_repo.save_skill(agent_config_id, skill_name, str(skill.get("content") or ""), meta=skill_meta)
 
     for row in agent_config_repo.list_sub_agents(agent_config_id):

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -553,6 +553,222 @@ def test_agent_config_exposes_and_persists_compaction_trigger_tokens():
     assert configs["cfg-1"]["runtime"] == {"tools:Bash": {"enabled": True, "desc": "shell"}}
 
 
+def test_get_agent_user_prefers_repo_skill_desc_over_library_fallback(monkeypatch: pytest.MonkeyPatch):
+    agent = UserRow(
+        id="agent-1",
+        type=UserType.AGENT,
+        display_name="Toad",
+        owner_user_id="user-1",
+        agent_config_id="cfg-1",
+        created_at=1.0,
+    )
+    monkeypatch.setattr(library_service, "get_library_skill_desc", lambda _name: "library desc")
+
+    class _AgentConfigRepo:
+        def get_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return {
+                "agent_user_id": "agent-1",
+                "name": "Toad",
+                "description": "probe",
+                "model": "leon:large",
+                "tools": ["*"],
+                "system_prompt": "",
+                "status": "draft",
+                "version": "0.1.0",
+                "created_at": 1,
+                "updated_at": 1,
+                "runtime": {},
+                "mcp": {},
+            }
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def list_skills(self, _agent_config_id: str):
+            return [{"name": "Search", "content": "skill body", "meta_json": {"desc": "repo desc"}}]
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return []
+
+    result = agent_user_service.get_agent_user(
+        "agent-1",
+        user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
+        agent_config_repo=_AgentConfigRepo(),
+    )
+
+    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "repo desc"}]
+
+
+def test_get_agent_user_keeps_runtime_skill_desc_override_ahead_of_repo_meta(monkeypatch: pytest.MonkeyPatch):
+    agent = UserRow(
+        id="agent-1",
+        type=UserType.AGENT,
+        display_name="Toad",
+        owner_user_id="user-1",
+        agent_config_id="cfg-1",
+        created_at=1.0,
+    )
+    monkeypatch.setattr(library_service, "get_library_skill_desc", lambda _name: "library desc")
+
+    class _AgentConfigRepo:
+        def get_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return {
+                "agent_user_id": "agent-1",
+                "name": "Toad",
+                "description": "probe",
+                "model": "leon:large",
+                "tools": ["*"],
+                "system_prompt": "",
+                "status": "draft",
+                "version": "0.1.0",
+                "created_at": 1,
+                "updated_at": 1,
+                "runtime": {"skills:Search": {"desc": "runtime desc"}},
+                "mcp": {},
+            }
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def list_skills(self, _agent_config_id: str):
+            return [{"name": "Search", "content": "skill body", "meta_json": {"desc": "repo desc"}}]
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return []
+
+    result = agent_user_service.get_agent_user(
+        "agent-1",
+        user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
+        agent_config_repo=_AgentConfigRepo(),
+    )
+
+    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "runtime desc"}]
+
+
+def test_get_agent_user_preserves_explicit_empty_repo_skill_desc(monkeypatch: pytest.MonkeyPatch):
+    agent = UserRow(
+        id="agent-1",
+        type=UserType.AGENT,
+        display_name="Toad",
+        owner_user_id="user-1",
+        agent_config_id="cfg-1",
+        created_at=1.0,
+    )
+    monkeypatch.setattr(library_service, "get_library_skill_desc", lambda _name: "library desc")
+
+    class _AgentConfigRepo:
+        def get_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return {
+                "agent_user_id": "agent-1",
+                "name": "Toad",
+                "description": "probe",
+                "model": "leon:large",
+                "tools": ["*"],
+                "system_prompt": "",
+                "status": "draft",
+                "version": "0.1.0",
+                "created_at": 1,
+                "updated_at": 1,
+                "runtime": {},
+                "mcp": {},
+            }
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def list_skills(self, _agent_config_id: str):
+            return [{"name": "Search", "content": "skill body", "meta_json": {"desc": ""}}]
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return []
+
+    result = agent_user_service.get_agent_user(
+        "agent-1",
+        user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
+        agent_config_repo=_AgentConfigRepo(),
+    )
+
+    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": ""}]
+
+
+def test_install_from_snapshot_persists_skill_desc_from_snapshot_meta_into_repo_meta():
+    saved_skill_rows: list[dict[str, object]] = []
+
+    class _UserRepo:
+        def create(self, _row: UserRow) -> None:
+            return None
+
+    class _AgentConfigRepo:
+        def save_config(self, _agent_config_id: str, _data: dict[str, object]) -> None:
+            return None
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def delete_rule(self, _row_id: str) -> None:
+            return None
+
+        def save_rule(self, _agent_config_id: str, _filename: str, _content: str) -> None:
+            return None
+
+        def list_skills(self, _agent_config_id: str):
+            return []
+
+        def delete_skill(self, _row_id: str) -> None:
+            return None
+
+        def save_skill(self, agent_config_id: str, name: str, content: str, meta: dict[str, object] | None = None) -> None:
+            saved_skill_rows.append(
+                {
+                    "agent_config_id": agent_config_id,
+                    "name": name,
+                    "content": content,
+                    "meta": meta,
+                }
+            )
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return []
+
+        def delete_sub_agent(self, _row_id: str) -> None:
+            return None
+
+        def save_sub_agent(self, *_args, **_kwargs) -> None:
+            return None
+
+    agent_user_service.install_from_snapshot(
+        snapshot={
+            "agent_md": "---\nname: Repo Agent\n---\nhello\n",
+            "skills": [
+                {
+                    "name": "Search",
+                    "content": "skill body",
+                    "meta": {"name": "Search", "desc": "repo desc"},
+                }
+            ],
+        },
+        name="Repo Agent",
+        description="probe",
+        marketplace_item_id="item-1",
+        installed_version="1.0.0",
+        owner_user_id="user-1",
+        user_repo=_UserRepo(),
+        agent_config_repo=_AgentConfigRepo(),
+    )
+
+    assert saved_skill_rows == [
+        {
+            "agent_config_id": saved_skill_rows[0]["agent_config_id"],
+            "name": "Search",
+            "content": "skill body",
+            "meta": {"name": "Search", "desc": "repo desc"},
+        }
+    ]
+
+
 def _agent_delete_runner(*, pref_error: str | None = None, contact_error: str | None = None):
     agent = UserRow(
         id="agent-1",


### PR DESCRIPTION
## Summary
- preserve repo-backed skill desc via runtime override -> repo meta_json.desc -> library fallback precedence
- keep explicit empty repo desc instead of reviving library fallback
- persist skill desc from snapshot meta into repo skill meta during install_from_snapshot

## Verification
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Integration/test_panel_auth_shell_coherence.py -k 'repo_skill_desc or runtime_skill_desc_override or explicit_empty_repo_skill_desc or persists_skill_desc_from_snapshot_meta' -q
- env -u ALL_PROXY -u all_proxy uv run python -m pytest tests/Integration/test_panel_auth_shell_coherence.py tests/Unit/platform/test_marketplace_client.py -q
- uv run ruff check backend/web/services/agent_user_service.py tests/Integration/test_panel_auth_shell_coherence.py
- git diff --check