### PR TITLE
refactor: remove workspace launch-config lease bridge residue

### DIFF
--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -220,7 +220,6 @@ def _derive_default_config(
             app=app,
             current_workspace_id=thread["current_workspace_id"],
             owner_user_id=owner_user_id,
-            leases_by_id=leases_by_id,
         )
         if config is not None:
             return config
@@ -275,7 +274,6 @@ def _resolve_workspace_backed_existing_config(
     app: Any,
     current_workspace_id: str,
     owner_user_id: str,
-    leases_by_id: dict[str, dict[str, Any]],
 ) -> dict[str, Any] | None:
     workspace_repo = getattr(app.state, "workspace_repo", None)
     get_by_id = getattr(workspace_repo, "get_by_id", None)
@@ -296,10 +294,6 @@ def _resolve_workspace_backed_existing_config(
             sandbox_owner_user_id = _required_bridge_text(sandbox, "owner_user_id", "sandbox")
             if sandbox_owner_user_id != owner_user_id:
                 raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
-            legacy_lease_id = _required_bridge_config_text(sandbox, "legacy_lease_id", "sandbox")
-            lease = leases_by_id.get(legacy_lease_id)
-            if lease is None:
-                return None
             sandbox_template = _resolve_workspace_backed_sandbox_template(
                 app=app,
                 owner_user_id=owner_user_id,

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -449,7 +449,7 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
         status="ready",
         observed_at=2.0,
         last_error=None,
-        config={"legacy_lease_id": "lease-2"},
+        config={},
         created_at=2.0,
         updated_at=2.0,
     )
@@ -474,13 +474,6 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
                     "provider_name": "local",
                     "recipe": default_recipe_snapshot("local"),
                     "cwd": "/workspace/wrong",
-                    "thread_ids": [],
-                },
-                {
-                    "lease_id": "lease-2",
-                    "provider_name": "daytona_selfhost",
-                    "recipe": default_recipe_snapshot("daytona"),
-                    "cwd": "/workspace/from-lease",
                     "thread_ids": [],
                 },
             ],
@@ -546,7 +539,7 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
         status="ready",
         observed_at=3.0,
         last_error=None,
-        config={"legacy_lease_id": "lease-3"},
+        config={},
         created_at=3.0,
         updated_at=3.0,
     )
@@ -583,15 +576,7 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
         patch.object(
             thread_launch_config_service.sandbox_service,
             "list_user_leases",
-            return_value=[
-                {
-                    "lease_id": "lease-3",
-                    "provider_name": "daytona_selfhost",
-                    "recipe": default_recipe_snapshot("daytona"),
-                    "cwd": "/workspace/from-lease",
-                    "thread_ids": [],
-                }
-            ],
+            return_value=[],
         ),
         patch.object(
             thread_launch_config_service.sandbox_service,


### PR DESCRIPTION
## Summary
- remove workspace-backed launch-config existing-mode dependence on `sandbox.config.legacy_lease_id`
- keep legacy pure lease-backed fallback for old `current_workspace_id` values
- tighten integration proof so workspace-backed existing-mode succeeds without a bridge lease

## Test Plan
- [x] `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py -k 'workspace_backed_current_workspace_id or sandbox_template_id_over_lease_recipe or legacy_lease_backed_current_workspace_id' -q`
- [x] `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py -q`
- [x] `uv run ruff check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py`
- [x] `git diff --check`
