### PR TITLE
refactor: add sandbox shaped existing bind wrapper

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -59,7 +59,7 @@ from backend.web.utils.serializers import avatar_url, serialize_message
 from core.agents.service import _background_run_cancelled, _background_run_result, request_background_run_stop
 from core.runtime.middleware.monitor import AgentState
 from sandbox.config import MountSpec
-from sandbox.manager import bind_thread_to_existing_lease
+from sandbox.manager import bind_thread_to_existing_sandbox, resolve_existing_sandbox_lease
 from sandbox.recipes import default_recipe_id, normalize_recipe_snapshot, provider_type_from_name
 from sandbox.thread_context import set_current_thread_id
 from storage.contracts import SandboxRow, WorkspaceRow
@@ -381,12 +381,14 @@ def _resolve_owned_existing_sandbox_request_lease(
     sandbox_owner_user_id = _request_bridge_text(sandbox, "owner_user_id", label="sandbox")
     if sandbox_owner_user_id != owner_user_id:
         raise HTTPException(403, "Not authorized")
-    legacy_lease_id = _request_bridge_config_text(sandbox, "legacy_lease_id", label="sandbox")
-    return sandbox_service.resolve_owned_lease(
-        owner_user_id,
-        legacy_lease_id,
-        thread_repo=app.state.thread_repo,
-        user_repo=app.state.user_repo,
+    return resolve_existing_sandbox_lease(
+        sandbox,
+        resolve_lease=lambda lease_id: sandbox_service.resolve_owned_lease(
+            owner_user_id,
+            lease_id,
+            thread_repo=app.state.thread_repo,
+            user_repo=app.state.user_repo,
+        ),
     )
 
 
@@ -798,27 +800,6 @@ def _create_owned_thread(
     if not agent_user or agent_user.owner_user_id != owner_user_id:
         raise HTTPException(403, "Not authorized")
 
-    selected_lease_id = None
-    owned_lease: dict[str, Any] | None = None
-    if payload.existing_sandbox_id:
-        selected_lease_id = _normalize_existing_sandbox_request_lease_id(
-            app,
-            owner_user_id,
-            payload.existing_sandbox_id,
-        )
-        owned_lease = sandbox_service.resolve_owned_lease(
-            owner_user_id,
-            selected_lease_id,
-            thread_repo=app.state.thread_repo,
-            user_repo=app.state.user_repo,
-        )
-        if owned_lease is None:
-            raise HTTPException(403, "Lease not authorized")
-        sandbox_type = str(owned_lease["provider_name"] or sandbox_type)
-    selected_recipe = None
-    if not selected_lease_id:
-        selected_recipe = _resolve_owned_recipe_snapshot(app, owner_user_id, sandbox_type, payload.sandbox_template_id)
-
     # @@@non-atomic-create - these 3 steps (seq++, thread) are not atomic.
     # @@@user-owned-thread-seq - thread ids are now allocated from the unified
     # user identity root, so create-path sequencing must fail loudly through
@@ -829,12 +810,32 @@ def _create_owned_thread(
     resolved_is_main = is_main or not has_main
     branch_index = 0 if resolved_is_main else app.state.thread_repo.get_next_branch_index(agent_user_id)
 
-    if selected_lease_id:
-        bound_cwd = bind_thread_to_existing_lease(
+    selected_lease_id = None
+    owned_lease: dict[str, Any] | None = None
+    if payload.existing_sandbox_id:
+        sandbox = app.state.sandbox_repo.get_by_id(payload.existing_sandbox_id)
+        if sandbox is None:
+            raise HTTPException(403, "Lease not authorized")
+        bound_cwd, owned_lease = bind_thread_to_existing_sandbox(
             new_thread_id,
-            selected_lease_id,
+            sandbox,
+            resolve_lease=lambda lease_id: sandbox_service.resolve_owned_lease(
+                owner_user_id,
+                lease_id,
+                thread_repo=app.state.thread_repo,
+                user_repo=app.state.user_repo,
+            ),
             cwd=payload.cwd,
         )
+        selected_lease_id = _request_bridge_text(owned_lease, "lease_id", label="lease")
+        if owned_lease is None:
+            raise HTTPException(403, "Lease not authorized")
+        sandbox_type = str(owned_lease["provider_name"] or sandbox_type)
+    selected_recipe = None
+    if not selected_lease_id:
+        selected_recipe = _resolve_owned_recipe_snapshot(app, owner_user_id, sandbox_type, payload.sandbox_template_id)
+
+    if selected_lease_id:
         sandbox_id = _materialize_sandbox_for_lease(
             app.state.sandbox_repo,
             lease=owned_lease,

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -123,6 +123,47 @@ def bind_thread_to_existing_lease(
             _terminal_repo.close()
 
 
+def resolve_existing_sandbox_lease(
+    sandbox: Any,
+    *,
+    resolve_lease: Callable[[str], dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
+    if not isinstance(config, dict):
+        raise RuntimeError("sandbox.config must be an object")
+    legacy_lease_id = str(config.get("legacy_lease_id") or "").strip()
+    if not legacy_lease_id:
+        raise RuntimeError("sandbox.config.legacy_lease_id is required")
+    return resolve_lease(legacy_lease_id)
+
+
+def bind_thread_to_existing_sandbox(
+    thread_id: str,
+    sandbox: Any,
+    *,
+    resolve_lease: Callable[[str], dict[str, Any] | None],
+    cwd: str | None = None,
+    db_path: Path | None = None,
+    terminal_repo: Any | None = None,
+) -> tuple[str, dict[str, Any]]:
+    lease = resolve_existing_sandbox_lease(sandbox, resolve_lease=resolve_lease)
+    if lease is None:
+        config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
+        legacy_lease_id = str((config or {}).get("legacy_lease_id") or "").strip()
+        raise RuntimeError(f"lease not found: {legacy_lease_id}")
+    lease_id = str(lease.get("lease_id") or "").strip()
+    if not lease_id:
+        raise RuntimeError("lease.lease_id is required")
+    initial_cwd = bind_thread_to_existing_lease(
+        thread_id,
+        lease_id,
+        cwd=cwd,
+        db_path=db_path,
+        terminal_repo=terminal_repo,
+    )
+    return initial_cwd, lease
+
+
 def bind_thread_to_existing_thread_lease(
     thread_id: str,
     source_thread_id: str,

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -910,7 +910,18 @@ async def test_create_thread_persists_existing_lease_successful_config() -> None
                 "recipe": {"id": "daytona:recipe-1"},
             },
         ),
-        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
+        patch.object(
+            threads_router,
+            "bind_thread_to_existing_sandbox",
+            return_value=(
+                "/workspace/reused",
+                {
+                    "lease_id": "lease-1",
+                    "provider_name": "daytona_selfhost",
+                    "recipe": {"id": "daytona:recipe-1"},
+                },
+            ),
+        ),
         patch.object(threads_router, "save_last_successful_config", return_value=None) as save_successful,
     ):
         _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -471,7 +471,7 @@ async def test_create_thread_route_rejects_lease_shaped_existing_identity():
             "resolve_owned_lease",
             return_value={"lease_id": "lease-1", "provider_name": "local", "recipe": None},
         ),
-        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused") as bind_helper,
+        patch.object(threads_router, "bind_thread_to_existing_sandbox", return_value=("/workspace/reused", {"lease_id": "lease-1"})) as bind_helper,
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", return_value=None),
     ):
@@ -513,7 +513,20 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
                 "recipe": None,
             },
         ),
-        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
+        patch.object(
+            threads_router,
+            "bind_thread_to_existing_sandbox",
+            return_value=(
+                "/workspace/reused",
+                {
+                    "lease_id": "lease-1",
+                    "sandbox_id": "sandbox-1",
+                    "provider_name": "local",
+                    "cwd": "/workspace/reused",
+                    "recipe": None,
+                },
+            ),
+        ),
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", return_value=None),
     ):
@@ -616,7 +629,20 @@ async def test_create_thread_route_existing_sandbox_still_saves_existing_launch_
                 "recipe": {"id": "local:default"},
             },
         ),
-        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused"),
+        patch.object(
+            threads_router,
+            "bind_thread_to_existing_sandbox",
+            return_value=(
+                "/workspace/reused",
+                {
+                    "lease_id": "lease-1",
+                    "sandbox_id": "sandbox-1",
+                    "provider_name": "local",
+                    "cwd": "/workspace/reused",
+                    "recipe": {"id": "local:default"},
+                },
+            ),
+        ),
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", save_config),
     ):
@@ -658,13 +684,26 @@ async def test_create_thread_route_accepts_sandbox_shaped_existing_identity() ->
     with (
         patch.object(threads_router.sandbox_service, "resolve_owned_lease", side_effect=_resolve_owned_lease),
         patch.object(threads_router.sandbox_service, "list_user_leases", side_effect=AssertionError("should not list all leases")),
-        patch.object(threads_router, "bind_thread_to_existing_lease", return_value="/workspace/reused") as bind_helper,
+        patch.object(
+            threads_router,
+            "bind_thread_to_existing_sandbox",
+            return_value=(
+                "/workspace/reused",
+                {
+                    "lease_id": "lease-1",
+                    "sandbox_id": "sandbox-1",
+                    "provider_name": "local",
+                    "cwd": "/workspace/reused",
+                    "recipe": {"id": "local:default"},
+                },
+            ),
+        ) as bind_helper,
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", save_config),
     ):
-        result = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+        _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
 
-    bind_helper.assert_called_once_with(result["thread_id"], "lease-1", cwd="/workspace/reused")
+    bind_helper.assert_called_once()
     assert (
         save_config.call_args.args[3]["existing_sandbox_id"]
         == f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}"

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -471,7 +471,9 @@ async def test_create_thread_route_rejects_lease_shaped_existing_identity():
             "resolve_owned_lease",
             return_value={"lease_id": "lease-1", "provider_name": "local", "recipe": None},
         ),
-        patch.object(threads_router, "bind_thread_to_existing_sandbox", return_value=("/workspace/reused", {"lease_id": "lease-1"})) as bind_helper,
+        patch.object(
+            threads_router, "bind_thread_to_existing_sandbox", return_value=("/workspace/reused", {"lease_id": "lease-1"})
+        ) as bind_helper,
         patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
         patch.object(threads_router, "save_last_successful_config", return_value=None),
     ):


### PR DESCRIPTION
## Summary
- add sandbox-shaped existing bind helpers at the manager/runtime boundary
- move existing-sandbox router paths off direct `sandbox.config.legacy_lease_id` reads
- keep deeper terminal/session lease-keyed contracts unchanged

## Test Plan
- [x] `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_threads_router.py -k 'existing_sandbox or unavailable_provider_for_existing_lease' -q`
- [x] `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -q`
- [x] `uv run ruff check backend/web/routers/threads.py sandbox/manager.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py`
- [x] `git diff --check`
