### PR TITLE
feat: proxy marketplace read paths through backend

### DIFF
--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -31,6 +31,39 @@ async def _verify_user_ownership(agent_user_id: str, user_id: str, user_repo: An
     await asyncio.to_thread(_check)
 
 
+@router.get("/items")
+async def list_marketplace_items(
+    type: str | None = None,
+    q: str | None = None,
+    sort: str = "downloads",
+    page: int = 1,
+    page_size: int = 20,
+) -> dict[str, Any]:
+    return await asyncio.to_thread(
+        marketplace_client.list_items,
+        type=type,
+        q=q,
+        sort=sort,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/items/{item_id}")
+async def get_marketplace_item_detail(item_id: str) -> dict[str, Any]:
+    return await asyncio.to_thread(marketplace_client.get_item_detail, item_id)
+
+
+@router.get("/items/{item_id}/lineage")
+async def get_marketplace_item_lineage(item_id: str) -> dict[str, Any]:
+    return await asyncio.to_thread(marketplace_client.get_item_lineage, item_id)
+
+
+@router.get("/items/{item_id}/versions/{version}")
+async def get_marketplace_item_version_snapshot(item_id: str, version: str) -> dict[str, Any]:
+    return await asyncio.to_thread(marketplace_client.get_item_version_snapshot, item_id, version)
+
+
 @router.post("/publish-agent-user")
 async def publish_agent_user_to_marketplace(
     req: PublishAgentUserToMarketplaceRequest,

--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -44,6 +44,38 @@ def _hub_api(method: str, path: str, **kwargs: Any) -> dict:
         raise HTTPException(status_code=503, detail="Marketplace Hub unavailable")
 
 
+def list_items(
+    *,
+    type: str | None = None,
+    q: str | None = None,
+    sort: str = "downloads",
+    page: int = 1,
+    page_size: int = 20,
+) -> dict:
+    params: dict[str, Any] = {
+        "sort": sort,
+        "page": page,
+        "page_size": page_size,
+    }
+    if type:
+        params["type"] = type
+    if q:
+        params["q"] = q
+    return _hub_api("GET", "/items", params=params)
+
+
+def get_item_detail(item_id: str) -> dict:
+    return _hub_api("GET", f"/items/{item_id}")
+
+
+def get_item_lineage(item_id: str) -> dict:
+    return _hub_api("GET", f"/items/{item_id}/lineage")
+
+
+def get_item_version_snapshot(item_id: str, version: str) -> dict:
+    return _hub_api("GET", f"/items/{item_id}/versions/{version}")
+
+
 def _read_json(path: Path) -> dict:
     if not path.exists():
         return {}

--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -37,6 +37,8 @@ describe("useMarketplaceStore", () => {
     await useMarketplaceStore.getState().fetchItems();
 
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/marketplace/items?");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("localhost:8090");
     expect(consoleError).not.toHaveBeenCalled();
   });
 
@@ -53,6 +55,8 @@ describe("useMarketplaceStore", () => {
     await useMarketplaceStore.getState().fetchDetail("item-1");
 
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/marketplace/items/item-1");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("localhost:8090");
     expect(consoleError).not.toHaveBeenCalled();
   });
 
@@ -69,6 +73,8 @@ describe("useMarketplaceStore", () => {
     await useMarketplaceStore.getState().fetchLineage("item-1");
 
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/marketplace/items/item-1/lineage");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("localhost:8090");
     expect(consoleError).not.toHaveBeenCalled();
   });
 
@@ -85,6 +91,8 @@ describe("useMarketplaceStore", () => {
     await useMarketplaceStore.getState().fetchVersionSnapshot("item-1", "1.0.0");
 
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/marketplace/items/item-1/versions/1.0.0");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("localhost:8090");
     expect(consoleError).not.toHaveBeenCalled();
   });
 

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { useAuthStore } from "./auth-store";
 
-const HUB_URL = import.meta.env.VITE_MYCEL_HUB_URL || "http://localhost:8090";
 const API = "/api/marketplace";
 
 export interface MarketplaceItemSummary {
@@ -107,24 +106,6 @@ function isActiveMarketplaceDetailRoute(itemId: string): boolean {
   return path === `/marketplace/${encodeURIComponent(itemId)}`;
 }
 
-async function hubApi<T = unknown>(path: string): Promise<T> {
-  try {
-    const res = await fetch(`${HUB_URL}/api/v1${path}`);
-    if (!res.ok) {
-      if (res.status >= 502) {
-        throw new Error("Marketplace Hub unavailable");
-      }
-      throw new Error(`Hub API error: ${res.status}`);
-    }
-    return res.json();
-  } catch (e) {
-    if (e instanceof TypeError) {
-      throw new Error("Marketplace Hub unavailable");
-    }
-    throw e;
-  }
-}
-
 async function backendApi<T = unknown>(path: string, opts?: RequestInit): Promise<T> {
   const token = useAuthStore.getState().token;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -155,7 +136,7 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       params.set("sort", sort);
       params.set("page", String(page));
       params.set("page_size", "20");
-      const data = await hubApi<{ items: MarketplaceItemSummary[]; total: number }>(`/items?${params}`);
+      const data = await backendApi<{ items: MarketplaceItemSummary[]; total: number }>(`/items?${params}`);
       set({ items: data.items, total: data.total });
     } catch (e) {
       // @@@marketplace-route-teardown - explore fetches can resolve after the
@@ -175,7 +156,7 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
   fetchDetail: async (id) => {
     set({ error: null, detailLoading: true, detail: null });
     try {
-      const data = await hubApi<MarketplaceItemDetail>(`/items/${id}`);
+      const data = await backendApi<MarketplaceItemDetail>(`/items/${id}`);
       set({ detail: data });
     } catch (e) {
       // @@@marketplace-detail-route-teardown - detail fetches can resolve after
@@ -197,7 +178,7 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
   fetchVersionSnapshot: async (itemId, version) => {
     set({ snapshotLoading: true, versionSnapshot: null });
     try {
-      const data = await hubApi<{ snapshot: MarketplaceVersionSnapshot | null }>(`/items/${itemId}/versions/${version}`);
+      const data = await backendApi<{ snapshot: MarketplaceVersionSnapshot | null }>(`/items/${itemId}/versions/${version}`);
       set({ versionSnapshot: data.snapshot ?? null });
     } catch (e) {
       // @@@marketplace-snapshot-route-teardown - snapshot fetches can resolve
@@ -217,7 +198,7 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
   fetchLineage: async (id) => {
     set({ error: null });
     try {
-      const data = await hubApi<{ ancestors: LineageNode[]; children: LineageNode[] }>(`/items/${id}/lineage`);
+      const data = await backendApi<{ ancestors: LineageNode[]; children: LineageNode[] }>(`/items/${id}/lineage`);
       set({ lineage: data });
     } catch (e) {
       // @@@marketplace-lineage-route-teardown - lineage fetches can resolve

--- a/tests/Integration/test_marketplace_router_user_shell.py
+++ b/tests/Integration/test_marketplace_router_user_shell.py
@@ -13,6 +13,10 @@ def test_marketplace_router_exposes_agent_user_publish_not_generic_publish() -> 
     paths = {route.path for route in marketplace_router.router.routes}
     assert "/api/marketplace/publish-agent-user" in paths
     assert "/api/marketplace/publish" not in paths
+    assert "/api/marketplace/items" in paths
+    assert "/api/marketplace/items/{item_id}" in paths
+    assert "/api/marketplace/items/{item_id}/lineage" in paths
+    assert "/api/marketplace/items/{item_id}/versions/{version}" in paths
 
 
 @pytest.mark.asyncio
@@ -109,6 +113,65 @@ async def test_download_from_marketplace_uses_user_and_agent_config_repos(monkey
     assert seen["owner_user_id"] == "owner-1"
     assert seen["user_repo"] is request.app.state.user_repo
     assert seen["agent_config_repo"] is request.app.state.agent_config_repo
+
+
+@pytest.mark.asyncio
+async def test_list_marketplace_items_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        marketplace_router.marketplace_client,
+        "list_items",
+        lambda **kwargs: seen.update(kwargs) or {"items": [{"id": "item-1"}], "total": 1},
+        raising=False,
+    )
+
+    result = await marketplace_router.list_marketplace_items(type="skill", q="search", sort="newest", page=2, page_size=10)
+
+    assert result == {"items": [{"id": "item-1"}], "total": 1}
+    assert seen == {"type": "skill", "q": "search", "sort": "newest", "page": 2, "page_size": 10}
+
+
+@pytest.mark.asyncio
+async def test_get_marketplace_item_detail_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        marketplace_router.marketplace_client,
+        "get_item_detail",
+        lambda item_id: {"id": item_id, "name": "Repo Item"},
+        raising=False,
+    )
+
+    result = await marketplace_router.get_marketplace_item_detail("item-1")
+
+    assert result == {"id": "item-1", "name": "Repo Item"}
+
+
+@pytest.mark.asyncio
+async def test_get_marketplace_item_lineage_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        marketplace_router.marketplace_client,
+        "get_item_lineage",
+        lambda item_id: {"ancestors": [], "children": [{"id": item_id}]},
+        raising=False,
+    )
+
+    result = await marketplace_router.get_marketplace_item_lineage("item-1")
+
+    assert result == {"ancestors": [], "children": [{"id": "item-1"}]}
+
+
+@pytest.mark.asyncio
+async def test_get_marketplace_item_version_snapshot_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        marketplace_router.marketplace_client,
+        "get_item_version_snapshot",
+        lambda item_id, version: {"snapshot": {"meta": {"id": item_id, "version": version}}},
+        raising=False,
+    )
+
+    result = await marketplace_router.get_marketplace_item_version_snapshot("item-1", "1.2.3")
+
+    assert result == {"snapshot": {"meta": {"id": "item-1", "version": "1.2.3"}}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add backend read-side marketplace proxy endpoints for items/detail/lineage/version snapshot
- switch frontend marketplace read store calls from direct Hub fetches to /api/marketplace/... 
- add focused backend/frontend proof for request target and router forwarding

## Verification
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_marketplace_router_user_shell.py -q
- env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Integration/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_client.py -q
- cd frontend/app && npm test -- src/store/marketplace-store.test.ts
- cd frontend/app && npm run build
- uv run ruff check backend/web/routers/marketplace.py backend/web/services/marketplace_client.py tests/Integration/test_marketplace_router_user_shell.py
- cd frontend/app && npx eslint src/store/marketplace-store.ts src/store/marketplace-store.test.ts
- git diff --check