### PR TITLE
refactor: cut monitor probe target contract to sandboxes

### DIFF
--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -159,7 +159,12 @@ def refresh_resource_snapshots() -> dict[str, Any]:
     non_running_targets = 0
 
     for item in probe_targets:
-        lease_id = item["lease_id"]
+        sandbox_id = item["sandbox_id"]
+        # @@@probe-target-bridge - probe targets are now sandbox-shaped outward,
+        # but snapshot persistence still joins on the legacy lease bridge.
+        lease_id = item["legacy_lease_id"]
+        if not sandbox_id:
+            raise RuntimeError("Probe target missing sandbox_id")
         provider_key = item["provider_name"]
         instance_id = item["instance_id"]
         status = item["observed_state"]

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -279,7 +279,8 @@ class SupabaseSandboxMonitorRepo:
             if lid and lease.get("provider_name") and instance_id:
                 targets.append(
                     {
-                        "lease_id": lid,
+                        "sandbox_id": lease["sandbox_id"],
+                        "legacy_lease_id": lid,
                         "provider_name": lease["provider_name"],
                         "instance_id": instance_id,
                         "observed_state": lease.get("observed_state", "unknown"),

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -32,8 +32,20 @@ def test_refresh_resource_snapshots_skips_paused_leases(monkeypatch):
         "make_sandbox_monitor_repo",
         lambda: _make_probe_repo(
             [
-                {"provider_name": "p1", "instance_id": "s-1", "lease_id": "l-1", "observed_state": "detached"},
-                {"provider_name": "p1", "instance_id": "s-2", "lease_id": "l-2", "observed_state": "paused"},
+                {
+                    "provider_name": "p1",
+                    "instance_id": "s-1",
+                    "sandbox_id": "sandbox-1",
+                    "legacy_lease_id": "l-1",
+                    "observed_state": "detached",
+                },
+                {
+                    "provider_name": "p1",
+                    "instance_id": "s-2",
+                    "sandbox_id": "sandbox-2",
+                    "legacy_lease_id": "l-2",
+                    "observed_state": "paused",
+                },
             ]
         ),
     )
@@ -53,8 +65,7 @@ def test_refresh_resource_snapshots_skips_paused_leases(monkeypatch):
     assert result["running_targets"] == 1
     assert result["non_running_targets"] == 0
     assert {call["lease_id"] for call in calls} == {"l-1"}
-    modes = {call["lease_id"]: call["probe_mode"] for call in calls}
-    assert modes["l-1"] == "running_runtime"
+    assert {call["probe_mode"] for call in calls} == {"running_runtime"}
 
 
 def test_refresh_resource_snapshots_counts_provider_build_error(monkeypatch):
@@ -63,7 +74,13 @@ def test_refresh_resource_snapshots_counts_provider_build_error(monkeypatch):
         "make_sandbox_monitor_repo",
         lambda: _make_probe_repo(
             [
-                {"provider_name": "p-missing", "instance_id": "s-1", "lease_id": "l-1", "observed_state": "detached"},
+                {
+                    "provider_name": "p-missing",
+                    "instance_id": "s-1",
+                    "sandbox_id": "sandbox-1",
+                    "legacy_lease_id": "l-1",
+                    "observed_state": "detached",
+                },
             ]
         ),
     )
@@ -88,7 +105,13 @@ def test_refresh_resource_snapshots_skips_paused_provider_build_error(monkeypatc
         "make_sandbox_monitor_repo",
         lambda: _make_probe_repo(
             [
-                {"provider_name": "p-missing", "instance_id": "s-1", "lease_id": "l-1", "observed_state": "paused"},
+                {
+                    "provider_name": "p-missing",
+                    "instance_id": "s-1",
+                    "sandbox_id": "sandbox-1",
+                    "legacy_lease_id": "l-1",
+                    "observed_state": "paused",
+                },
             ]
         ),
     )

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -558,13 +558,15 @@ def test_list_probe_targets_prefers_provider_session_id() -> None:
 
     assert repo.list_probe_targets() == [
         {
-            "lease_id": "lease-paused",
+            "sandbox_id": "sandbox-paused",
+            "legacy_lease_id": "lease-paused",
             "provider_name": "local",
             "instance_id": "instance-local",
             "observed_state": "paused",
         },
         {
-            "lease_id": "lease-running",
+            "sandbox_id": "sandbox-running",
+            "legacy_lease_id": "lease-running",
             "provider_name": "daytona_selfhost",
             "instance_id": "provider-session-1",
             "observed_state": "detached",


### PR DESCRIPTION
## Summary
- make monitor probe targets outward sandbox-shaped with `sandbox_id + legacy_lease_id`
- update `refresh_resource_snapshots()` to consume sandbox-shaped targets while keeping deeper snapshot persistence lease-keyed
- tighten focused probe tests around the new contract

## Verification
- `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_resource_probe.py -q`
- `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'list_probe_targets_prefers_provider_session_id or instance_lookup_failures_are_loud' -q`
- `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_sandbox_repo.py -q`
- `uv run ruff check backend/web/services/resource_service.py storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_sandbox_repo.py`
- `git diff --check`
