### PR TITLE
refactor: cut resource session shell to sandboxes

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -53,10 +53,12 @@ def _build_provider_card(config_name: str, leases: list[dict[str, Any]]) -> dict
         status = map_lease_to_session_status(lease.get("observed_state"), lease.get("desired_state"))
         if status == "running":
             running_count += 1
+        sandbox_id = str(lease.get("sandbox_id") or "").strip() or None
+        session_identity = f"{sandbox_id}:{thread_id}" if sandbox_id and thread_id else f"{lease['lease_id']}:{thread_id}"
         sessions.append(
             resource_service.build_resource_session_payload(
-                session_identity=f"{lease['lease_id']}:{thread_id}",
-                sandbox_id=str(lease.get("sandbox_id") or "").strip() or None,
+                session_identity=session_identity,
+                sandbox_id=sandbox_id,
                 lease_id=str(lease["lease_id"]),
                 thread_id=thread_id,
                 runtime_session_id=lease.get("runtime_session_id"),
@@ -188,8 +190,14 @@ def _is_resource_visible_thread(thread_id: str | None) -> bool:
 
 
 def _resource_session_identity(session: dict[str, Any]) -> str:
+    sandbox_id = str(session.get("sandbox_id") or "")
     lease_id = str(session.get("lease_id") or "")
     thread_id = str(session.get("thread_id") or "")
+    # @@@resource-session-shell - resource session shell is now sandbox-first.
+    # lease ids remain compatibility residue for enrichment joins, not the
+    # primary user-visible session identity.
+    if sandbox_id and thread_id:
+        return f"{sandbox_id}:{thread_id}"
     if lease_id and thread_id:
         # @@@resource-session-contract - resource cards are lease/thread scoped, not chat-session scoped.
         # Terminal-derived rows can carry distinct session ids for the same visible lease+thread binding.

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -61,6 +61,7 @@ def _patch_provider_contracts(monkeypatch, *, description: str, vendor: str, typ
 def _lease(
     lease_id: str,
     *,
+    sandbox_id: str | None = None,
     provider_name: str = "daytona_selfhost",
     thread_id: str,
     agent_user_id: str,
@@ -75,6 +76,7 @@ def _lease(
 ) -> dict:
     payload = {
         "lease_id": lease_id,
+        "sandbox_id": sandbox_id,
         "provider_name": provider_name,
         "thread_ids": [thread_id],
         "agents": [{"agent_user_id": agent_user_id, "agent_name": agent_name, "avatar_url": avatar_url}],
@@ -139,6 +141,7 @@ def test_user_resource_projection_groups_visible_leases_into_provider_cards(monk
         lambda owner_user_id, **_kwargs: [
             _lease(
                 "lease-1",
+                sandbox_id="sandbox-1",
                 thread_id="thread-1",
                 agent_user_id="agent-1",
                 agent_name="Morel",
@@ -167,6 +170,8 @@ def test_user_resource_projection_groups_visible_leases_into_provider_cards(monk
     assert payload["providers"][0]["type"] == "cloud"
     assert payload["providers"][0]["consoleUrl"] == "https://example.com/daytona"
     assert payload["providers"][0]["sessions"][0]["leaseId"] == "lease-1"
+    assert payload["providers"][0]["sessions"][0]["sandboxId"] == "sandbox-1"
+    assert payload["providers"][0]["sessions"][0]["id"] == "sandbox-1:thread-1"
     assert payload["providers"][0]["sessions"][0]["threadId"] == "thread-1"
     assert payload["providers"][0]["sessions"][0]["agentUserId"] == "agent-1"
     assert payload["providers"][0]["sessions"][0]["agentName"] == "Morel"

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -79,6 +79,7 @@ def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch)
             "provider": "local",
             "session_id": None,
             "thread_id": "thread-1",
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "observed_state": "running",
             "desired_state": "running",
@@ -88,6 +89,7 @@ def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch)
             "provider": "local",
             "session_id": None,
             "thread_id": "thread-1",
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "observed_state": "running",
             "desired_state": "running",
@@ -119,7 +121,8 @@ def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch)
     assert local["telemetry"]["running"]["used"] == 1
     assert local["sessions"] == [
         {
-            "id": "lease-1:thread-1",
+            "id": "sandbox-1:thread-1",
+            "sandboxId": "sandbox-1",
             "leaseId": "lease-1",
             "threadId": "thread-1",
             "agentUserId": "agent-1",
@@ -138,6 +141,7 @@ def test_list_resource_providers_resolves_owner_metadata_from_runtime_storage(mo
             "provider": "daytona",
             "session_id": "sess-1",
             "thread_id": "thread-supabase",
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "observed_state": "running",
             "desired_state": "running",
@@ -174,7 +178,8 @@ def test_list_resource_providers_resolves_owner_metadata_from_runtime_storage(mo
 
     assert payload["providers"][0]["sessions"] == [
         {
-            "id": "lease-1:thread-supabase",
+            "id": "sandbox-1:thread-supabase",
+            "sandboxId": "sandbox-1",
             "leaseId": "lease-1",
             "threadId": "thread-supabase",
             "agentUserId": "agent-1",
@@ -242,6 +247,7 @@ def test_list_resource_providers_projects_visible_parent_when_raw_monitor_row_is
             "provider": "daytona_selfhost",
             "session_id": None,
             "thread_id": "subagent-deadbeef",
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "observed_state": "paused",
             "desired_state": "paused",
@@ -278,7 +284,8 @@ def test_list_resource_providers_projects_visible_parent_when_raw_monitor_row_is
 
     assert sessions == [
         {
-            "id": "lease-1:thread-parent",
+            "id": "sandbox-1:thread-parent",
+            "sandboxId": "sandbox-1",
             "leaseId": "lease-1",
             "threadId": "thread-parent",
             "agentUserId": "agent-1",
@@ -297,6 +304,7 @@ def test_list_resource_providers_deduplicates_same_lease_thread_even_with_distin
             "provider": "daytona_selfhost",
             "session_id": "sess-a",
             "thread_id": "thread-parent",
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "observed_state": "running",
             "desired_state": "running",
@@ -306,6 +314,7 @@ def test_list_resource_providers_deduplicates_same_lease_thread_even_with_distin
             "provider": "daytona_selfhost",
             "session_id": "sess-b",
             "thread_id": "thread-parent",
+            "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
             "observed_state": "running",
             "desired_state": "running",
@@ -324,7 +333,8 @@ def test_list_resource_providers_deduplicates_same_lease_thread_even_with_distin
 
     assert sessions == [
         {
-            "id": "lease-1:thread-parent",
+            "id": "sandbox-1:thread-parent",
+            "sandboxId": "sandbox-1",
             "leaseId": "lease-1",
             "threadId": "thread-parent",
             "agentUserId": "agent-1",


### PR DESCRIPTION
## Summary
- make resource overview user-visible session identity sandbox-first
- keep `leaseId` as compatibility residue while leaving runtime-session and snapshot joins untouched
- tighten focused resource overview tests around sandbox-shaped session shell

## Verification
- `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py -q`
- `uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py`
- `git diff --check`
