### PR TITLE
refactor: wrap resource runtime session lookup by sandbox

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -102,11 +102,11 @@ def _build_provider_card(config_name: str, leases: list[dict[str, Any]]) -> dict
     }
 
 
-def _query_runtime_session_ids(repo: Any, lease_ids: list[str]) -> dict[str, str | None]:
+def _query_runtime_session_ids(repo: Any, sandbox_ids: list[str]) -> dict[str, str | None]:
     ordered_ids = []
     seen: set[str] = set()
-    for lease_id in lease_ids:
-        normalized = str(lease_id or "").strip()
+    for sandbox_id in sandbox_ids:
+        normalized = str(sandbox_id or "").strip()
         if not normalized or normalized in seen:
             continue
         seen.add(normalized)
@@ -114,13 +114,13 @@ def _query_runtime_session_ids(repo: Any, lease_ids: list[str]) -> dict[str, str
     if not ordered_ids:
         return {}
 
-    return repo.query_lease_instance_ids(ordered_ids)
+    return repo.query_sandbox_instance_ids(ordered_ids)
 
 
-def _load_runtime_session_ids(lease_ids: list[str]) -> dict[str, str | None]:
+def _load_runtime_session_ids(sandbox_ids: list[str]) -> dict[str, str | None]:
     repo = make_sandbox_monitor_repo()
     try:
-        return _query_runtime_session_ids(repo, lease_ids)
+        return _query_runtime_session_ids(repo, sandbox_ids)
     finally:
         repo.close()
 
@@ -129,7 +129,7 @@ def _load_visible_resource_runtime() -> tuple[list[dict[str, Any]], dict[str, st
     repo = make_sandbox_monitor_repo()
     try:
         sessions = _project_user_visible_resource_sessions(repo, repo.list_sessions_with_leases())
-        runtime_session_ids = _query_runtime_session_ids(repo, [str(session.get("lease_id") or "") for session in sessions])
+        runtime_session_ids = _query_runtime_session_ids(repo, [str(session.get("sandbox_id") or "") for session in sessions])
     finally:
         repo.close()
 
@@ -142,10 +142,10 @@ def _backfill_runtime_session_ids(leases: list[dict[str, Any]]) -> None:
     if not pending_leases:
         return
 
-    runtime_session_ids = _load_runtime_session_ids([str(lease.get("lease_id") or "") for lease in pending_leases])
+    runtime_session_ids = _load_runtime_session_ids([str(lease.get("sandbox_id") or "") for lease in pending_leases])
     for lease in pending_leases:
-        lease_id = str(lease.get("lease_id") or "").strip()
-        runtime_session_id = runtime_session_ids.get(lease_id)
+        sandbox_id = str(lease.get("sandbox_id") or "").strip()
+        runtime_session_id = runtime_session_ids.get(sandbox_id)
         if runtime_session_id:
             lease["runtime_session_id"] = runtime_session_id
 
@@ -293,7 +293,7 @@ def list_resource_providers() -> dict[str, Any]:
             desired_state = session.get("desired_state")
             thread_id = str(session.get("thread_id") or "")
             lease_id = str(session.get("lease_id") or "")
-            runtime_session_id = runtime_session_ids.get(lease_id)
+            runtime_session_id = runtime_session_ids.get(str(session.get("sandbox_id") or "").strip())
             session_metrics = _to_session_metrics(snapshot_by_lease.get(lease_id))
             normalized = _resource_display_status(
                 observed_state=observed_state,

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -184,6 +184,24 @@ class SupabaseSandboxMonitorRepo:
             return None
         return self.query_lease_instance_id(str(sandbox.get("lease_id") or ""))
 
+    def query_sandbox_instance_ids(self, sandbox_ids: list[str]) -> dict[str, str | None]:
+        ordered_ids = [str(sandbox_id or "").strip() for sandbox_id in sandbox_ids if str(sandbox_id or "").strip()]
+        if not ordered_ids:
+            return {}
+
+        sandbox_rows = {sandbox_id: self.query_sandbox(sandbox_id) for sandbox_id in ordered_ids}
+        lease_ids = [str(row.get("lease_id") or "").strip() for row in sandbox_rows.values() if row is not None]
+        lease_instance_ids = self.query_lease_instance_ids(lease_ids)
+
+        result: dict[str, str | None] = {}
+        for sandbox_id in ordered_ids:
+            sandbox = sandbox_rows.get(sandbox_id)
+            if sandbox is None:
+                result[sandbox_id] = None
+                continue
+            result[sandbox_id] = lease_instance_ids.get(str(sandbox.get("lease_id") or "").strip())
+        return result
+
     def query_lease_events(self, lease_id: str) -> list[dict]:
         self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_events")
         # provider_events is the Supabase equivalent

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -30,8 +30,11 @@ class _FakeMonitorRepo:
         raise AssertionError(f"unexpected per-lease runtime-session probe: {lease_id}")
 
     def query_lease_instance_ids(self, lease_ids: list[str]) -> dict[str, str | None]:
-        self.batch_calls.append(list(lease_ids))
-        return {lease_id: self._runtime_session_ids.get(lease_id) for lease_id in lease_ids}
+        raise AssertionError(f"unexpected lease batch runtime-session probe: {lease_ids}")
+
+    def query_sandbox_instance_ids(self, sandbox_ids: list[str]) -> dict[str, str | None]:
+        self.batch_calls.append(list(sandbox_ids))
+        return {sandbox_id: self._runtime_session_ids.get(sandbox_id) for sandbox_id in sandbox_ids}
 
     def close(self) -> None:
         return None
@@ -236,6 +239,7 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
             [
                 _lease(
                     "lease-local",
+                    sandbox_id="sandbox-local",
                     provider_name="local",
                     thread_id="thread-local",
                     agent_user_id="agent-local",
@@ -246,6 +250,7 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
                 ),
                 _lease(
                     "lease-remote",
+                    sandbox_id="sandbox-remote",
                     thread_id="thread-remote",
                     agent_user_id="agent-remote",
                     agent_name="Remote",
@@ -255,7 +260,7 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
                     created_at="2026-04-07T10:00:01Z",
                 ),
             ],
-            {"lease-local": None, "lease-remote": "provider-session-remote"},
+            {"sandbox-local": None, "sandbox-remote": "provider-session-remote"},
             lambda payload: (
                 "runtimeSessionId" not in {item["id"]: item for item in payload["providers"]}["local"]["sessions"][0],
                 {item["id"]: item for item in payload["providers"]}["daytona_selfhost"]["sessions"][0]["runtimeSessionId"]
@@ -266,6 +271,7 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
             [
                 _lease(
                     "lease-remote-a",
+                    sandbox_id="sandbox-a",
                     thread_id="thread-a",
                     agent_user_id="agent-a",
                     agent_name="A",
@@ -275,6 +281,7 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
                 ),
                 _lease(
                     "lease-remote-b",
+                    sandbox_id="sandbox-b",
                     thread_id="thread-b",
                     agent_user_id="agent-b",
                     agent_name="B",
@@ -284,7 +291,7 @@ def test_user_resource_projection_marks_provider_unavailable_when_capability_pro
                     created_at="2026-04-07T10:00:01Z",
                 ),
             ],
-            {"lease-remote-a": "provider-session-a", "lease-remote-b": "provider-session-b"},
+            {"sandbox-a": "provider-session-a", "sandbox-b": "provider-session-b"},
             lambda payload: (
                 [session["runtimeSessionId"] for session in payload["providers"][0]["sessions"]]
                 == ["provider-session-a", "provider-session-b"],
@@ -313,7 +320,7 @@ def test_user_resource_projection_runtime_backfill_contract(monkeypatch, leases,
     payload = resource_projection_service.list_user_resource_providers(_App(), "owner-1")
 
     assert all(assertions(payload))
-    assert monitor_repo.batch_calls == [[lease["lease_id"] for lease in leases]]
+    assert monitor_repo.batch_calls == [[lease["sandbox_id"] for lease in leases]]
 
 
 def test_resources_overview_route_surfaces_actor_first_user_payload(monkeypatch) -> None:

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -19,6 +19,9 @@ class _FakeRepo:
     def query_lease_instance_ids(self, lease_ids: list[str]):
         return {lease_id: self._instance_ids.get(lease_id) for lease_id in lease_ids}
 
+    def query_sandbox_instance_ids(self, sandbox_ids: list[str]):
+        return {sandbox_id: self._instance_ids.get(sandbox_id) for sandbox_id in sandbox_ids}
+
     def close(self):
         pass
 
@@ -353,6 +356,7 @@ def test_list_resource_providers_keeps_remote_runtime_session_id_actor_first(mon
             "provider": "daytona_selfhost",
             "session_id": "provider-session-1",
             "thread_id": "thread-remote",
+            "sandbox_id": "sandbox-remote",
             "lease_id": "lease-remote",
             "observed_state": "running",
             "desired_state": "running",
@@ -362,7 +366,7 @@ def test_list_resource_providers_keeps_remote_runtime_session_id_actor_first(mon
 
     _patch_daytona_projection(
         monkeypatch,
-        _FakeRepo(rows, instance_ids={"lease-remote": "provider-session-1"}),
+        _FakeRepo(rows, instance_ids={"sandbox-remote": "provider-session-1"}),
         lambda thread_ids: {
             tid: {
                 "agent_user_id": "agent-remote",
@@ -393,6 +397,7 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_leases(mon
             "provider": "daytona_selfhost",
             "session_id": None,
             "thread_id": "thread-a",
+            "sandbox_id": "sandbox-a",
             "lease_id": "lease-a",
             "observed_state": "detached",
             "desired_state": "running",
@@ -402,6 +407,7 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_leases(mon
             "provider": "daytona_selfhost",
             "session_id": None,
             "thread_id": "thread-b",
+            "sandbox_id": "sandbox-b",
             "lease_id": "lease-b",
             "observed_state": "detached",
             "desired_state": "running",
@@ -411,15 +417,18 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_leases(mon
 
     class _BatchOnlyRepo(_FakeRepo):
         def __init__(self):
-            super().__init__(rows, instance_ids={"lease-a": "runtime-a", "lease-b": "runtime-b"})
+            super().__init__(rows, instance_ids={"sandbox-a": "runtime-a", "sandbox-b": "runtime-b"})
             self.batch_calls: list[list[str]] = []
 
         def query_lease_instance_id(self, lease_id: str):
             raise AssertionError(f"unexpected per-lease lookup: {lease_id}")
 
         def query_lease_instance_ids(self, lease_ids: list[str]):
-            self.batch_calls.append(list(lease_ids))
-            return super().query_lease_instance_ids(lease_ids)
+            raise AssertionError(f"unexpected lease batch lookup: {lease_ids}")
+
+        def query_sandbox_instance_ids(self, sandbox_ids: list[str]):
+            self.batch_calls.append(list(sandbox_ids))
+            return super().query_sandbox_instance_ids(sandbox_ids)
 
     repo = _BatchOnlyRepo()
     _patch_daytona_projection(
@@ -432,4 +441,4 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_leases(mon
     sessions = payload["providers"][0]["sessions"]
 
     assert [session["runtimeSessionId"] for session in sessions] == ["runtime-a", "runtime-b"]
-    assert repo.batch_calls == [["lease-a", "lease-b"]]
+    assert repo.batch_calls == [["sandbox-a", "sandbox-b"]]

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -485,6 +485,25 @@ def test_query_lease_instance_ids_chunks_large_lookup() -> None:
     assert result["lease-174"] == "provider-session-174"
 
 
+def test_query_sandbox_instance_ids_uses_legacy_bridge() -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", legacy_lease_id="lease-1"),
+                _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", legacy_lease_id="lease-2"),
+            ],
+            "sandbox_instances": [
+                {"lease_id": "lease-2", "provider_session_id": "provider-session-2"},
+            ],
+        }
+    )
+
+    assert repo.query_sandbox_instance_ids(["sandbox-1", "sandbox-2"]) == {
+        "sandbox-1": "sandbox-instance-1",
+        "sandbox-2": "provider-session-2",
+    }
+
+
 def test_query_lease_events_requires_sandbox_bridge() -> None:
     repo = _repo(
         {


### PR DESCRIPTION
## Summary
- move resource runtime-session enrichment caller contract to sandbox-shaped lookup
- add repo wrapper that bridges sandbox ids back to legacy lease-keyed runtime-session lookup
- keep snapshot enrichment and deeper storage contracts untouched

## Verification
- `env -u ALL_PROXY -u all_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_sandbox_repo.py -q`
- `uv run ruff check backend/web/services/resource_projection_service.py storage/providers/supabase/sandbox_monitor_repo.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_sandbox_repo.py`
- `git diff --check`
