### PR TITLE
refactor: cut resource live stats helper to sandbox

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -386,7 +386,8 @@ def visible_resource_session_stats() -> dict[str, dict[str, int]]:
             provider_stats["sessions"] += 1
 
         lease_id = str(session.get("lease_id") or "")
-        runtime_session_id = runtime_session_ids.get(lease_id)
+        sandbox_id = str(session.get("sandbox_id") or "").strip()
+        runtime_session_id = runtime_session_ids.get(sandbox_id)
         normalized = _resource_display_status(
             observed_state=session.get("observed_state"),
             desired_state=session.get("desired_state"),

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -442,3 +442,32 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_leases(mon
 
     assert [session["runtimeSessionId"] for session in sessions] == ["runtime-a", "runtime-b"]
     assert repo.batch_calls == [["sandbox-a", "sandbox-b"]]
+
+
+def test_visible_resource_session_stats_uses_sandbox_keyed_runtime_lookup(monkeypatch):
+    rows = [
+        {
+            "provider": "daytona_selfhost",
+            "session_id": None,
+            "thread_id": "thread-a",
+            "sandbox_id": "sandbox-a",
+            "lease_id": "lease-a",
+            "observed_state": "detached",
+            "desired_state": "running",
+            "created_at": "2026-04-08T00:00:00",
+        },
+    ]
+
+    class _BatchOnlyRepo(_FakeRepo):
+        def __init__(self):
+            super().__init__(rows, instance_ids={"sandbox-a": "runtime-a"})
+
+        def query_lease_instance_ids(self, lease_ids: list[str]):
+            raise AssertionError(f"unexpected lease batch lookup: {lease_ids}")
+
+    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _BatchOnlyRepo())
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+
+    stats = resource_projection_service.visible_resource_session_stats()
+
+    assert stats == {"daytona_selfhost": {"sessions": 1, "running": 1}}


### PR DESCRIPTION
## Summary
- switch resource live-stats helper runtime lookup to sandbox-shaped caller contract
- keep snapshot metrics lease-keyed for now
- add focused regression proof for visible_resource_session_stats

## Test Plan
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k visible_resource_session_stats_uses_sandbox_keyed_runtime_lookup -q
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q
- uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py
- git diff --check