### PR TITLE
refactor: wrap resource provider telemetry by sandbox

### DIFF
--- a/backend/web/services/resource_common.py
+++ b/backend/web/services/resource_common.py
@@ -257,10 +257,10 @@ def aggregate_provider_telemetry(
     *,
     provider_sessions: list[dict[str, Any]],
     running_count: int,
-    snapshot_by_lease: dict[str, dict[str, Any]],
+    snapshot_by_sandbox: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    lease_ids = sorted({str(session.get("lease_id") or "") for session in provider_sessions if session.get("lease_id")})
-    snapshots = [snapshot_by_lease[lease_id] for lease_id in lease_ids if lease_id in snapshot_by_lease]
+    sandbox_ids = sorted({str(session.get("sandbox_id") or "").strip() for session in provider_sessions if session.get("sandbox_id")})
+    snapshots = [snapshot_by_sandbox[sandbox_id] for sandbox_id in sandbox_ids if sandbox_id in snapshot_by_sandbox]
 
     freshness = "stale"
     if snapshots:

--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -141,6 +141,22 @@ def _index_session_snapshots_by_sandbox(
     return snapshot_by_sandbox
 
 
+def _index_provider_snapshots_by_sandbox(
+    provider_sessions: list[dict[str, Any]],
+    snapshot_by_lease: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
+    for session in provider_sessions:
+        sandbox_id = str(session.get("sandbox_id") or "").strip()
+        lease_id = str(session.get("lease_id") or "").strip()
+        if not sandbox_id or not lease_id or sandbox_id in snapshot_by_sandbox:
+            continue
+        snapshot = snapshot_by_lease.get(lease_id)
+        if snapshot is not None:
+            snapshot_by_sandbox[sandbox_id] = snapshot
+    return snapshot_by_sandbox
+
+
 def _load_visible_resource_runtime() -> tuple[
     list[dict[str, Any]],
     dict[str, str | None],
@@ -350,7 +366,7 @@ def list_resource_providers() -> dict[str, Any]:
         telemetry = _aggregate_provider_telemetry(
             provider_sessions=provider_sessions,
             running_count=running_count,
-            snapshot_by_lease=snapshot_by_lease,
+            snapshot_by_sandbox=_index_provider_snapshots_by_sandbox(provider_sessions, snapshot_by_lease),
         )
         if config_name == "local" and effective_available and capabilities.get("metrics"):
             host_metrics = LocalSessionProvider().get_metrics("host")

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -498,3 +498,49 @@ def test_index_session_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_e
         "sandbox-a": {"lease_id": "lease-a", "cpu_used": 11},
         "sandbox-b": {"lease_id": "lease-b", "cpu_used": 22},
     }
+
+
+def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_telemetry(monkeypatch):
+    rows = [
+        {
+            "provider": "daytona_selfhost",
+            "session_id": None,
+            "thread_id": "thread-a",
+            "sandbox_id": "sandbox-a",
+            "lease_id": "lease-a",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-08T00:00:00",
+        },
+    ]
+
+    _patch_daytona_projection(
+        monkeypatch,
+        _FakeRepo(rows),
+        lambda thread_ids: {tid: {"agent_user_id": f"agent-{tid}", "agent_name": tid, "avatar_url": None} for tid in thread_ids},
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "list_resource_snapshots",
+        lambda _lease_ids: {"lease-a": {"lease_id": "lease-a", "cpu_used": 11}},
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_aggregate_provider_telemetry(*, provider_sessions, running_count, snapshot_by_sandbox):
+        captured["provider_sessions"] = provider_sessions
+        captured["running_count"] = running_count
+        captured["snapshot_keys"] = sorted(snapshot_by_sandbox.keys())
+        return {
+            "running": {"used": running_count},
+            "cpu": {"used": 11},
+            "memory": {"used": None},
+            "disk": {"used": None},
+        }
+
+    monkeypatch.setattr(resource_projection_service, "_aggregate_provider_telemetry", _fake_aggregate_provider_telemetry)
+
+    payload = resource_projection_service.list_resource_providers()
+
+    assert captured["snapshot_keys"] == ["sandbox-a"]
+    assert payload["providers"][0]["telemetry"]["cpu"]["used"] == 11


### PR DESCRIPTION
## Summary
- add a sandbox-shaped provider telemetry wrapper inside resource projection
- switch provider card telemetry to use sandbox-keyed snapshot input
- keep deeper snapshot storage contracts lease-keyed

## Verification
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k passes_sandbox_keyed_snapshots_to_provider_telemetry -q
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q
- uv run ruff check backend/web/services/resource_projection_service.py backend/web/services/resource_common.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py
- git diff --check