### PR TITLE
resource snapshot sandbox wrapper

### DIFF
--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -13,8 +13,25 @@ from backend.web.services.resource_common import resolve_provider_name
 from backend.web.services.resource_common import resolve_provider_type as _resolve_provider_type
 from backend.web.services.resource_common import to_resource_status as _to_resource_status
 from backend.web.services.sandbox_service import build_provider_from_config_name
-from sandbox.resource_snapshot import probe_and_upsert_for_instance, upsert_lease_resource_snapshot
+from sandbox.resource_snapshot import probe_and_upsert_for_instance
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
+from storage.runtime import upsert_resource_snapshot_for_sandbox
+
+
+class _SandboxSnapshotRepoAdapter:
+    def __init__(self, *, sandbox_id: str) -> None:
+        self._sandbox_id = sandbox_id
+
+    # @@@snapshot-write-bridge - resource probe callers are sandbox-shaped now,
+    # but the storage contract is still lease-keyed. Keep the bridge inside the
+    # adapter so service callers stop leaking lease as the outward write subject.
+    def upsert_lease_resource_snapshot(self, **kwargs) -> None:
+        lease_id = kwargs.pop("lease_id", None)
+        upsert_resource_snapshot_for_sandbox(
+            sandbox_id=self._sandbox_id,
+            legacy_lease_id=lease_id,
+            **kwargs,
+        )
 
 
 def get_provider_display_contract(config_name: str) -> dict[str, Any]:
@@ -181,8 +198,9 @@ def refresh_resource_snapshots() -> dict[str, Any]:
             provider = build_provider_from_config_name(provider_key)
             provider_cache[provider_key] = provider
         if provider is None:
-            upsert_lease_resource_snapshot(
-                lease_id=lease_id,
+            upsert_resource_snapshot_for_sandbox(
+                sandbox_id=sandbox_id,
+                legacy_lease_id=lease_id,
                 provider_name=provider_key,
                 observed_state=status,
                 probe_mode=probe_mode,
@@ -198,6 +216,7 @@ def refresh_resource_snapshots() -> dict[str, Any]:
             probe_mode=probe_mode,
             provider=provider,
             instance_id=instance_id,
+            repo=_SandboxSnapshotRepoAdapter(sandbox_id=sandbox_id),
         )
         probed += 1
         if not result["ok"]:

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -170,6 +170,54 @@ def list_resource_snapshots(
         repo.close()
 
 
+def upsert_resource_snapshot_for_sandbox(
+    *,
+    sandbox_id: str,
+    legacy_lease_id: str,
+    provider_name: str,
+    observed_state: str,
+    probe_mode: str,
+    cpu_used: float | None = None,
+    cpu_limit: float | None = None,
+    memory_used_mb: float | None = None,
+    memory_total_mb: float | None = None,
+    disk_used_gb: float | None = None,
+    disk_total_gb: float | None = None,
+    network_rx_kbps: float | None = None,
+    network_tx_kbps: float | None = None,
+    probe_error: str | None = None,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+) -> None:
+    if not sandbox_id:
+        raise RuntimeError("Resource snapshot write requires sandbox_id.")
+    if not legacy_lease_id:
+        raise RuntimeError("Resource snapshot write requires legacy_lease_id bridge.")
+
+    repo = build_resource_snapshot_repo(
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+    )
+    try:
+        repo.upsert_lease_resource_snapshot(
+            lease_id=legacy_lease_id,
+            provider_name=provider_name,
+            observed_state=observed_state,
+            probe_mode=probe_mode,
+            cpu_used=cpu_used,
+            cpu_limit=cpu_limit,
+            memory_used_mb=memory_used_mb,
+            memory_total_mb=memory_total_mb,
+            disk_used_gb=disk_used_gb,
+            disk_total_gb=disk_total_gb,
+            network_rx_kbps=network_rx_kbps,
+            network_tx_kbps=network_tx_kbps,
+            probe_error=probe_error,
+        )
+    finally:
+        repo.close()
+
+
 def _resolve_supabase_client(
     client: Any | None = None,
     factory_ref: str | None = None,

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -26,6 +26,55 @@ class _FakeSnapshotRepo:
         self.upserts.append(kwargs)
 
 
+def test_refresh_resource_snapshots_routes_successful_probe_through_sandbox_wrapper(monkeypatch):
+    monkeypatch.setattr(
+        resource_service,
+        "make_sandbox_monitor_repo",
+        lambda: _make_probe_repo(
+            [
+                {
+                    "provider_name": "p1",
+                    "instance_id": "s-1",
+                    "sandbox_id": "sandbox-1",
+                    "legacy_lease_id": "l-1",
+                    "observed_state": "detached",
+                },
+            ]
+        ),
+    )
+    monkeypatch.setattr(resource_service, "build_provider_from_config_name", lambda _: _FakeProvider())
+
+    captured: list[dict] = []
+
+    def _fake_upsert_resource_snapshot_for_sandbox(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(resource_service, "upsert_resource_snapshot_for_sandbox", _fake_upsert_resource_snapshot_for_sandbox)
+
+    result = resource_service.refresh_resource_snapshots()
+
+    assert result["probed"] == 1
+    assert result["errors"] == 1
+    assert captured == [
+        {
+            "sandbox_id": "sandbox-1",
+            "legacy_lease_id": "l-1",
+            "provider_name": "p1",
+            "observed_state": "detached",
+            "probe_mode": "running_runtime",
+            "cpu_used": None,
+            "cpu_limit": None,
+            "memory_used_mb": None,
+            "memory_total_mb": None,
+            "disk_used_gb": None,
+            "disk_total_gb": None,
+            "network_rx_kbps": None,
+            "network_tx_kbps": None,
+            "probe_error": "metrics unavailable",
+        }
+    ]
+
+
 def test_refresh_resource_snapshots_skips_paused_leases(monkeypatch):
     monkeypatch.setattr(
         resource_service,
@@ -85,18 +134,28 @@ def test_refresh_resource_snapshots_counts_provider_build_error(monkeypatch):
         ),
     )
     monkeypatch.setattr(resource_service, "build_provider_from_config_name", lambda _: None)
-    snapshot_repo = _FakeSnapshotRepo()
-    monkeypatch.setattr(resource_service, "upsert_lease_resource_snapshot", snapshot_repo.upsert_lease_resource_snapshot)
+    captured: list[dict] = []
+
+    def _fake_upsert_resource_snapshot_for_sandbox(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(resource_service, "upsert_resource_snapshot_for_sandbox", _fake_upsert_resource_snapshot_for_sandbox)
 
     result = resource_service.refresh_resource_snapshots()
     assert result["probed"] == 0
     assert result["errors"] == 1
     assert result["running_targets"] == 1
     assert result["non_running_targets"] == 0
-    assert len(snapshot_repo.upserts) == 1
-    assert snapshot_repo.upserts[0]["lease_id"] == "l-1"
-    assert snapshot_repo.upserts[0]["probe_mode"] == "running_runtime"
-    assert snapshot_repo.upserts[0]["probe_error"] == "provider init failed: p-missing"
+    assert captured == [
+        {
+            "sandbox_id": "sandbox-1",
+            "legacy_lease_id": "l-1",
+            "provider_name": "p-missing",
+            "observed_state": "detached",
+            "probe_mode": "running_runtime",
+            "probe_error": "provider init failed: p-missing",
+        }
+    ]
 
 
 def test_refresh_resource_snapshots_skips_paused_provider_build_error(monkeypatch):
@@ -117,8 +176,12 @@ def test_refresh_resource_snapshots_skips_paused_provider_build_error(monkeypatc
     )
     monkeypatch.setattr(resource_service, "build_provider_from_config_name", lambda _: None)
 
-    repo = _FakeSnapshotRepo()
-    monkeypatch.setattr(resource_service, "upsert_lease_resource_snapshot", repo.upsert_lease_resource_snapshot)
+    captured: list[dict] = []
+
+    def _fake_upsert_resource_snapshot_for_sandbox(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(resource_service, "upsert_resource_snapshot_for_sandbox", _fake_upsert_resource_snapshot_for_sandbox)
 
     result = resource_service.refresh_resource_snapshots()
 
@@ -126,4 +189,4 @@ def test_refresh_resource_snapshots_skips_paused_provider_build_error(monkeypatc
     assert result["errors"] == 0
     assert result["running_targets"] == 0
     assert result["non_running_targets"] == 0
-    assert repo.upserts == []
+    assert captured == []


### PR DESCRIPTION
## Summary
- add a sandbox-shaped snapshot write wrapper in `storage/runtime.py`
- route `refresh_resource_snapshots()` through the wrapper for provider-init failures and successful probes
- keep the deeper snapshot repo/table contract lease-keyed

## Verification
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_probe.py -q`
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_resource_probe.py -q`
- `uv run ruff check backend/web/services/resource_service.py storage/runtime.py tests/Unit/monitor/test_monitor_resource_probe.py`
- `git diff --check`
