### PR TITLE
resource snapshot read wrapper

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -23,7 +23,7 @@ from backend.web.services.sandbox_service import available_sandbox_types
 from sandbox.providers.local import LocalSessionProvider
 from storage.models import map_lease_to_session_status
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
-from storage.runtime import list_resource_snapshots
+from storage.runtime import list_resource_snapshots_by_sandbox
 
 
 def _now_iso() -> str:
@@ -125,38 +125,6 @@ def _load_runtime_session_ids(sandbox_ids: list[str]) -> dict[str, str | None]:
         repo.close()
 
 
-def _index_session_snapshots_by_sandbox(
-    sessions: list[dict[str, Any]],
-    snapshot_by_lease: dict[str, dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
-    for session in sessions:
-        sandbox_id = str(session.get("sandbox_id") or "").strip()
-        lease_id = str(session.get("lease_id") or "").strip()
-        if not sandbox_id or not lease_id or sandbox_id in snapshot_by_sandbox:
-            continue
-        snapshot = snapshot_by_lease.get(lease_id)
-        if snapshot is not None:
-            snapshot_by_sandbox[sandbox_id] = snapshot
-    return snapshot_by_sandbox
-
-
-def _index_provider_snapshots_by_sandbox(
-    provider_sessions: list[dict[str, Any]],
-    snapshot_by_lease: dict[str, dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
-    for session in provider_sessions:
-        sandbox_id = str(session.get("sandbox_id") or "").strip()
-        lease_id = str(session.get("lease_id") or "").strip()
-        if not sandbox_id or not lease_id or sandbox_id in snapshot_by_sandbox:
-            continue
-        snapshot = snapshot_by_lease.get(lease_id)
-        if snapshot is not None:
-            snapshot_by_sandbox[sandbox_id] = snapshot
-    return snapshot_by_sandbox
-
-
 def _load_visible_resource_runtime() -> tuple[
     list[dict[str, Any]],
     dict[str, str | None],
@@ -170,8 +138,8 @@ def _load_visible_resource_runtime() -> tuple[
     finally:
         repo.close()
 
-    snapshot_by_lease = list_resource_snapshots([str(session.get("lease_id") or "") for session in sessions])
-    snapshot_by_sandbox = _index_session_snapshots_by_sandbox(sessions, snapshot_by_lease)
+    snapshot_by_sandbox = list_resource_snapshots_by_sandbox(sessions)
+    snapshot_by_lease: dict[str, dict[str, Any]] = {}
     return sessions, runtime_session_ids, snapshot_by_lease, snapshot_by_sandbox
 
 
@@ -366,7 +334,11 @@ def list_resource_providers() -> dict[str, Any]:
         telemetry = _aggregate_provider_telemetry(
             provider_sessions=provider_sessions,
             running_count=running_count,
-            snapshot_by_sandbox=_index_provider_snapshots_by_sandbox(provider_sessions, snapshot_by_lease),
+            snapshot_by_sandbox={
+                str(session.get("sandbox_id") or "").strip(): snapshot_by_sandbox[str(session.get("sandbox_id") or "").strip()]
+                for session in provider_sessions
+                if str(session.get("sandbox_id") or "").strip() in snapshot_by_sandbox
+            },
         )
         if config_name == "local" and effective_available and capabilities.get("metrics"):
             host_metrics = LocalSessionProvider().get_metrics("host")

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -170,6 +170,35 @@ def list_resource_snapshots(
         repo.close()
 
 
+def list_resource_snapshots_by_sandbox(
+    sessions: list[dict[str, Any]],
+    *,
+    supabase_client: Any | None = None,
+    supabase_client_factory: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    lease_ids: list[str] = []
+    sandbox_by_lease: dict[str, str] = {}
+    for session in sessions:
+        sandbox_id = str(session.get("sandbox_id") or "").strip()
+        lease_id = str(session.get("lease_id") or "").strip()
+        if not sandbox_id or not lease_id or lease_id in sandbox_by_lease:
+            continue
+        sandbox_by_lease[lease_id] = sandbox_id
+        lease_ids.append(lease_id)
+
+    snapshot_by_lease = list_resource_snapshots(
+        lease_ids,
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+    )
+    snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
+    for lease_id, snapshot in snapshot_by_lease.items():
+        sandbox_id = sandbox_by_lease.get(lease_id)
+        if sandbox_id:
+            snapshot_by_sandbox[sandbox_id] = snapshot
+    return snapshot_by_sandbox
+
+
 def upsert_resource_snapshot_for_sandbox(
     *,
     sandbox_id: str,

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -1,4 +1,5 @@
 from backend.web.services import resource_common, resource_projection_service
+from storage import runtime as storage_runtime
 
 
 class _FakeRepo:
@@ -73,7 +74,7 @@ def _patch_daytona_projection(monkeypatch, repo, owners, *, console_url=None):
         lambda _config_name: (resource_common.empty_capabilities(), None),
     )
     monkeypatch.setattr(resource_projection_service, "_thread_owners", owners)
-    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
 
 def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch):
@@ -116,7 +117,7 @@ def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch)
         "_thread_owners",
         lambda thread_ids: {tid: {"agent_user_id": "agent-1", "agent_name": "Toad", "avatar_url": None} for tid in thread_ids},
     )
-    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     payload = resource_projection_service.list_resource_providers()
     local = payload["providers"][0]
@@ -175,7 +176,7 @@ def test_list_resource_providers_resolves_owner_metadata_from_runtime_storage(mo
         "build_user_repo",
         lambda **_kwargs: _FakeUserRepo([_FakeUser("agent-1", "Toad")]),
     )
-    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     payload = resource_projection_service.list_resource_providers()
 
@@ -235,7 +236,7 @@ def test_list_resource_providers_hides_subagent_threads(monkeypatch):
         "_thread_owners",
         lambda thread_ids: {tid: {"agent_user_id": tid, "agent_name": tid, "avatar_url": None} for tid in thread_ids},
     )
-    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     payload = resource_projection_service.list_resource_providers()
     sessions = payload["providers"][0]["sessions"]
@@ -280,7 +281,7 @@ def test_list_resource_providers_projects_visible_parent_when_raw_monitor_row_is
         "_thread_owners",
         lambda thread_ids: {tid: {"agent_user_id": "agent-1", "agent_name": "Morel", "avatar_url": None} for tid in thread_ids},
     )
-    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     payload = resource_projection_service.list_resource_providers()
     sessions = payload["providers"][0]["sessions"]
@@ -466,14 +467,14 @@ def test_visible_resource_session_stats_uses_sandbox_keyed_runtime_lookup(monkey
             raise AssertionError(f"unexpected lease batch lookup: {lease_ids}")
 
     monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _BatchOnlyRepo())
-    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots", lambda _lease_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     stats = resource_projection_service.visible_resource_session_stats()
 
     assert stats == {"daytona_selfhost": {"sessions": 1, "running": 1}}
 
 
-def test_index_session_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_enrichment():
+def test_list_resource_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_enrichment(monkeypatch):
     sessions = [
         {
             "sandbox_id": "sandbox-a",
@@ -489,10 +490,9 @@ def test_index_session_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_e
         "lease-b": {"lease_id": "lease-b", "cpu_used": 22},
     }
 
-    snapshot_by_sandbox = resource_projection_service._index_session_snapshots_by_sandbox(  # type: ignore[attr-defined]
-        sessions,
-        snapshot_by_lease,
-    )
+    monkeypatch.setattr(storage_runtime, "list_resource_snapshots", lambda _lease_ids, **_kwargs: snapshot_by_lease)
+
+    snapshot_by_sandbox = storage_runtime.list_resource_snapshots_by_sandbox(sessions)
 
     assert snapshot_by_sandbox == {
         "sandbox-a": {"lease_id": "lease-a", "cpu_used": 11},
@@ -521,8 +521,8 @@ def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_tele
     )
     monkeypatch.setattr(
         resource_projection_service,
-        "list_resource_snapshots",
-        lambda _lease_ids: {"lease-a": {"lease_id": "lease-a", "cpu_used": 11}},
+        "list_resource_snapshots_by_sandbox",
+        lambda _sessions: {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}},
     )
 
     captured: dict[str, object] = {}
@@ -544,3 +544,32 @@ def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_tele
 
     assert captured["snapshot_keys"] == ["sandbox-a"]
     assert payload["providers"][0]["telemetry"]["cpu"]["used"] == 11
+
+
+def test_load_visible_resource_runtime_uses_sandbox_snapshot_wrapper(monkeypatch):
+    rows = [
+        {
+            "provider": "daytona_selfhost",
+            "session_id": None,
+            "thread_id": "thread-a",
+            "sandbox_id": "sandbox-a",
+            "lease_id": "lease-a",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-08T00:00:00",
+        },
+    ]
+
+    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _FakeRepo(rows))
+    monkeypatch.setattr(
+        resource_projection_service,
+        "list_resource_snapshots_by_sandbox",
+        lambda sessions: {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}},
+    )
+
+    sessions, runtime_session_ids, snapshot_by_lease, snapshot_by_sandbox = resource_projection_service._load_visible_resource_runtime()
+
+    assert [session["sandbox_id"] for session in sessions] == ["sandbox-a"]
+    assert runtime_session_ids == {"sandbox-a": None}
+    assert snapshot_by_lease == {}
+    assert snapshot_by_sandbox == {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}}


### PR DESCRIPTION
## Summary
- add a sandbox-shaped snapshot read wrapper in `storage/runtime.py`
- route `resource_projection_service` through the wrapper for visible runtime/session enrichment
- keep the deeper snapshot repo/table contract lease-keyed

## Verification
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k 'list_resource_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_enrichment or load_visible_resource_runtime_uses_sandbox_snapshot_wrapper or passes_sandbox_keyed_snapshots_to_provider_telemetry' -q`
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q`
- `uv run ruff check backend/web/services/resource_projection_service.py storage/runtime.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py`
- `git diff --check`
