### PR TITLE
resource snapshot repo wrapper

### DIFF
--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -25,6 +25,10 @@ class _SandboxSnapshotRepoAdapter:
     # @@@snapshot-write-bridge - resource probe callers are sandbox-shaped now,
     # but the storage contract is still lease-keyed. Keep the bridge inside the
     # adapter so service callers stop leaking lease as the outward write subject.
+    def upsert_resource_snapshot_for_sandbox(self, **kwargs) -> None:
+        kwargs.pop("sandbox_id", None)
+        upsert_resource_snapshot_for_sandbox(sandbox_id=self._sandbox_id, **kwargs)
+
     def upsert_lease_resource_snapshot(self, **kwargs) -> None:
         lease_id = kwargs.pop("lease_id", None)
         upsert_resource_snapshot_for_sandbox(
@@ -210,6 +214,7 @@ def refresh_resource_snapshots() -> dict[str, Any]:
             continue
 
         result = probe_and_upsert_for_instance(
+            sandbox_id=sandbox_id,
             lease_id=lease_id,
             provider_name=provider_key,
             observed_state=status,

--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -68,6 +68,7 @@ def _metric_float(metrics: Any, field: str) -> float | None:
 
 def probe_and_upsert_for_instance(
     *,
+    sandbox_id: str | None = None,
     lease_id: str,
     provider_name: str,
     observed_state: str,
@@ -114,26 +115,46 @@ def probe_and_upsert_for_instance(
     ) and probe_error is None:
         probe_error = "metrics unavailable"
 
-    upsert = repo.upsert_lease_resource_snapshot if repo is not None else upsert_lease_resource_snapshot
     try:
         # @@@snapshot-write-nonblocking - runtime startup truth belongs to lease/session creation;
         # snapshot persistence is auxiliary monitor data and must report write failure
         # without turning local sandbox bringup into a Supabase-config contract.
-        upsert(
-            lease_id=lease_id,
-            provider_name=provider_name,
-            observed_state=observed_state,
-            probe_mode=probe_mode,
-            cpu_used=cpu_used,
-            cpu_limit=cpu_limit,
-            memory_used_mb=memory_used_mb,
-            memory_total_mb=memory_total_mb,
-            disk_used_gb=disk_used_gb,
-            disk_total_gb=disk_total_gb,
-            network_rx_kbps=network_rx_kbps,
-            network_tx_kbps=network_tx_kbps,
-            probe_error=probe_error,
-        )
+        if repo is not None and hasattr(repo, "upsert_resource_snapshot_for_sandbox"):
+            if not sandbox_id:
+                raise RuntimeError("sandbox-shaped snapshot repo requires sandbox_id")
+            repo.upsert_resource_snapshot_for_sandbox(
+                sandbox_id=sandbox_id,
+                legacy_lease_id=lease_id,
+                provider_name=provider_name,
+                observed_state=observed_state,
+                probe_mode=probe_mode,
+                cpu_used=cpu_used,
+                cpu_limit=cpu_limit,
+                memory_used_mb=memory_used_mb,
+                memory_total_mb=memory_total_mb,
+                disk_used_gb=disk_used_gb,
+                disk_total_gb=disk_total_gb,
+                network_rx_kbps=network_rx_kbps,
+                network_tx_kbps=network_tx_kbps,
+                probe_error=probe_error,
+            )
+        else:
+            upsert = repo.upsert_lease_resource_snapshot if repo is not None else upsert_lease_resource_snapshot
+            upsert(
+                lease_id=lease_id,
+                provider_name=provider_name,
+                observed_state=observed_state,
+                probe_mode=probe_mode,
+                cpu_used=cpu_used,
+                cpu_limit=cpu_limit,
+                memory_used_mb=memory_used_mb,
+                memory_total_mb=memory_total_mb,
+                disk_used_gb=disk_used_gb,
+                disk_total_gb=disk_total_gb,
+                network_rx_kbps=network_rx_kbps,
+                network_tx_kbps=network_tx_kbps,
+                probe_error=probe_error,
+            )
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
     return {"ok": probe_error is None, "error": probe_error}

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from backend.web.services import resource_service
+from sandbox import resource_snapshot
 
 
 class _FakeProvider:
@@ -24,6 +25,49 @@ class _FakeSnapshotRepo:
 
     def upsert_lease_resource_snapshot(self, **kwargs):
         self.upserts.append(kwargs)
+
+
+class _FakeSandboxSnapshotRepo:
+    def __init__(self) -> None:
+        self.upserts: list[dict] = []
+
+    def upsert_resource_snapshot_for_sandbox(self, **kwargs):
+        self.upserts.append(kwargs)
+
+
+def test_probe_and_upsert_for_instance_accepts_sandbox_shaped_repo() -> None:
+    repo = _FakeSandboxSnapshotRepo()
+
+    result = resource_snapshot.probe_and_upsert_for_instance(
+        sandbox_id="sandbox-1",
+        lease_id="lease-1",
+        provider_name="p1",
+        observed_state="detached",
+        probe_mode="running_runtime",
+        provider=_FakeProvider(),
+        instance_id="instance-1",
+        repo=repo,
+    )
+
+    assert result == {"ok": False, "error": "metrics unavailable"}
+    assert repo.upserts == [
+        {
+            "sandbox_id": "sandbox-1",
+            "legacy_lease_id": "lease-1",
+            "provider_name": "p1",
+            "observed_state": "detached",
+            "probe_mode": "running_runtime",
+            "cpu_used": None,
+            "cpu_limit": None,
+            "memory_used_mb": None,
+            "memory_total_mb": None,
+            "disk_used_gb": None,
+            "disk_total_gb": None,
+            "network_rx_kbps": None,
+            "network_tx_kbps": None,
+            "probe_error": "metrics unavailable",
+        }
+    ]
 
 
 def test_refresh_resource_snapshots_routes_successful_probe_through_sandbox_wrapper(monkeypatch):
@@ -114,6 +158,7 @@ def test_refresh_resource_snapshots_skips_paused_leases(monkeypatch):
     assert result["running_targets"] == 1
     assert result["non_running_targets"] == 0
     assert {call["lease_id"] for call in calls} == {"l-1"}
+    assert {call["sandbox_id"] for call in calls} == {"sandbox-1"}
     assert {call["probe_mode"] for call in calls} == {"running_runtime"}
 
 


### PR DESCRIPTION
## Summary
- let snapshot probe helper prefer a sandbox-shaped repo/protocol wrapper
- pass `sandbox_id` through the successful probe path
- keep the deeper snapshot repo/table contract lease-keyed

## Verification
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_probe.py -k 'accepts_sandbox_shaped_repo or skips_paused_leases' -q`
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q`
- `uv run ruff check backend/web/services/resource_service.py sandbox/resource_snapshot.py tests/Unit/monitor/test_monitor_resource_probe.py`
- `git diff --check`
