### PR TITLE
feat: add sandbox-shaped resource snapshot table wrapper

### DIFF
--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -638,6 +638,24 @@ class SyncFileRepo(Protocol):
 
 class ResourceSnapshotRepo(Protocol):
     def close(self) -> None: ...
+    def upsert_resource_snapshot_for_sandbox(
+        self,
+        *,
+        sandbox_id: str,
+        legacy_lease_id: str,
+        provider_name: str,
+        observed_state: str,
+        probe_mode: str,
+        cpu_used: float | None = None,
+        cpu_limit: float | None = None,
+        memory_used_mb: float | None = None,
+        memory_total_mb: float | None = None,
+        disk_used_gb: float | None = None,
+        disk_total_gb: float | None = None,
+        network_rx_kbps: float | None = None,
+        network_tx_kbps: float | None = None,
+        probe_error: str | None = None,
+    ) -> None: ...
     def upsert_lease_resource_snapshot(
         self,
         *,
@@ -655,6 +673,7 @@ class ResourceSnapshotRepo(Protocol):
         network_tx_kbps: float | None = None,
         probe_error: str | None = None,
     ) -> None: ...
+    def list_snapshots_by_sandbox_ids(self, sessions: list[dict[str, str]]) -> dict[str, dict[str, Any]]: ...
     def list_snapshots_by_lease_ids(self, lease_ids: list[str]) -> dict[str, dict[str, Any]]: ...
 
 

--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -81,6 +81,43 @@ class SupabaseResourceSnapshotRepo:
     def close(self) -> None:
         return None
 
+    def upsert_resource_snapshot_for_sandbox(
+        self,
+        *,
+        sandbox_id: str,
+        legacy_lease_id: str,
+        provider_name: str,
+        observed_state: str,
+        probe_mode: str,
+        cpu_used: float | None = None,
+        cpu_limit: float | None = None,
+        memory_used_mb: float | None = None,
+        memory_total_mb: float | None = None,
+        disk_used_gb: float | None = None,
+        disk_total_gb: float | None = None,
+        network_rx_kbps: float | None = None,
+        network_tx_kbps: float | None = None,
+        probe_error: str | None = None,
+    ) -> None:
+        if not sandbox_id:
+            raise RuntimeError("sandbox-shaped snapshot repo write requires sandbox_id")
+        upsert_lease_resource_snapshot(
+            lease_id=legacy_lease_id,
+            provider_name=provider_name,
+            observed_state=observed_state,
+            probe_mode=probe_mode,
+            cpu_used=cpu_used,
+            cpu_limit=cpu_limit,
+            memory_used_mb=memory_used_mb,
+            memory_total_mb=memory_total_mb,
+            disk_used_gb=disk_used_gb,
+            disk_total_gb=disk_total_gb,
+            network_rx_kbps=network_rx_kbps,
+            network_tx_kbps=network_tx_kbps,
+            probe_error=probe_error,
+            client=self._client,
+        )
+
     def upsert_lease_resource_snapshot(
         self,
         *,
@@ -114,6 +151,25 @@ class SupabaseResourceSnapshotRepo:
             probe_error=probe_error,
             client=self._client,
         )
+
+    def list_snapshots_by_sandbox_ids(self, sessions: list[dict[str, str]]) -> dict[str, dict[str, Any]]:
+        lease_ids: list[str] = []
+        sandbox_by_lease: dict[str, str] = {}
+        for session in sessions:
+            sandbox_id = str(session.get("sandbox_id") or "").strip()
+            lease_id = str(session.get("lease_id") or "").strip()
+            if not sandbox_id or not lease_id or lease_id in sandbox_by_lease:
+                continue
+            sandbox_by_lease[lease_id] = sandbox_id
+            lease_ids.append(lease_id)
+
+        snapshot_by_lease = list_snapshots_by_lease_ids(lease_ids, client=self._client)
+        snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
+        for lease_id, snapshot in snapshot_by_lease.items():
+            sandbox_id = sandbox_by_lease.get(lease_id)
+            if sandbox_id:
+                snapshot_by_sandbox[sandbox_id] = snapshot
+        return snapshot_by_sandbox
 
     def list_snapshots_by_lease_ids(self, lease_ids: list[str]) -> dict[str, dict[str, Any]]:
         return list_snapshots_by_lease_ids(lease_ids, client=self._client)

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -49,6 +49,23 @@ def test_supabase_resource_snapshot_repo_upserts_with_client() -> None:
     assert client.table_obj.upsert_payload["provider_name"] == "daytona"
 
 
+def test_supabase_resource_snapshot_repo_upserts_for_sandbox_with_legacy_bridge() -> None:
+    client = _FakeClient()
+    repo = SupabaseResourceSnapshotRepo(client)
+
+    repo.upsert_resource_snapshot_for_sandbox(
+        sandbox_id="sandbox-1",
+        legacy_lease_id="lease-1",
+        provider_name="daytona",
+        observed_state="running",
+        probe_mode="runtime",
+    )
+
+    assert client.table_obj.upsert_payload is not None
+    assert client.table_obj.upsert_payload["lease_id"] == "lease-1"
+    assert client.table_obj.upsert_payload["provider_name"] == "daytona"
+
+
 def test_supabase_resource_snapshot_repo_lists_snapshots_by_lease_ids() -> None:
     client = _FakeClient()
     repo = SupabaseResourceSnapshotRepo(client)
@@ -56,6 +73,21 @@ def test_supabase_resource_snapshot_repo_lists_snapshots_by_lease_ids() -> None:
     rows = repo.list_snapshots_by_lease_ids(["lease-1", "lease-2"])
 
     assert rows == {"lease-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
+    assert ("lease_id", ["lease-1", "lease-2"]) in client.table_obj.in_calls
+
+
+def test_supabase_resource_snapshot_repo_lists_snapshots_by_sandbox_ids() -> None:
+    client = _FakeClient()
+    repo = SupabaseResourceSnapshotRepo(client)
+
+    rows = repo.list_snapshots_by_sandbox_ids(
+        [
+            {"sandbox_id": "sandbox-1", "lease_id": "lease-1"},
+            {"sandbox_id": "sandbox-2", "lease_id": "lease-2"},
+        ]
+    )
+
+    assert rows == {"sandbox-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
     assert ("lease_id", ["lease-1", "lease-2"]) in client.table_obj.in_calls
 
 


### PR DESCRIPTION
## Summary
- add sandbox-shaped read/write wrapper methods to the resource snapshot repo protocol
- implement sandbox-shaped wrapper methods in the Supabase snapshot repo while keeping lease-keyed table truth underneath
- prove the new repo impl wrapper with focused storage tests and wider resource monitor tests

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_resource_snapshot_repo.py -q
- uv run python -m pytest tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py -q
- uv run ruff check storage/contracts.py storage/providers/supabase/resource_snapshot_repo.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py
- git diff --check