### PR TITLE
feat: contract resource snapshot runtime bridge

### DIFF
--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -8,6 +8,45 @@ from sandbox.provider import SandboxProvider
 from storage.runtime import build_resource_snapshot_repo
 
 
+def upsert_resource_snapshot_for_sandbox(
+    *,
+    sandbox_id: str,
+    legacy_lease_id: str,
+    provider_name: str,
+    observed_state: str,
+    probe_mode: str,
+    cpu_used: float | None = None,
+    cpu_limit: float | None = None,
+    memory_used_mb: float | None = None,
+    memory_total_mb: float | None = None,
+    disk_used_gb: float | None = None,
+    disk_total_gb: float | None = None,
+    network_rx_kbps: float | None = None,
+    network_tx_kbps: float | None = None,
+    probe_error: str | None = None,
+) -> None:
+    repo = build_resource_snapshot_repo()
+    try:
+        repo.upsert_resource_snapshot_for_sandbox(
+            sandbox_id=sandbox_id,
+            legacy_lease_id=legacy_lease_id,
+            provider_name=provider_name,
+            observed_state=observed_state,
+            probe_mode=probe_mode,
+            cpu_used=cpu_used,
+            cpu_limit=cpu_limit,
+            memory_used_mb=memory_used_mb,
+            memory_total_mb=memory_total_mb,
+            disk_used_gb=disk_used_gb,
+            disk_total_gb=disk_total_gb,
+            network_rx_kbps=network_rx_kbps,
+            network_tx_kbps=network_tx_kbps,
+            probe_error=probe_error,
+        )
+    finally:
+        repo.close()
+
+
 def upsert_lease_resource_snapshot(
     *,
     lease_id: str,
@@ -46,6 +85,7 @@ def upsert_lease_resource_snapshot(
 
 
 __all__ = [
+    "upsert_resource_snapshot_for_sandbox",
     "upsert_lease_resource_snapshot",
     "probe_and_upsert_for_instance",
 ]
@@ -139,22 +179,43 @@ def probe_and_upsert_for_instance(
                 probe_error=probe_error,
             )
         else:
-            upsert = repo.upsert_lease_resource_snapshot if repo is not None else upsert_lease_resource_snapshot
-            upsert(
-                lease_id=lease_id,
-                provider_name=provider_name,
-                observed_state=observed_state,
-                probe_mode=probe_mode,
-                cpu_used=cpu_used,
-                cpu_limit=cpu_limit,
-                memory_used_mb=memory_used_mb,
-                memory_total_mb=memory_total_mb,
-                disk_used_gb=disk_used_gb,
-                disk_total_gb=disk_total_gb,
-                network_rx_kbps=network_rx_kbps,
-                network_tx_kbps=network_tx_kbps,
-                probe_error=probe_error,
-            )
+            # @@@snapshot-runtime-active-path - mainline runtime/helper flow should prefer
+            # sandbox-shaped write entry when sandbox_id is already present; the lease-shaped
+            # helper remains only as compatibility residue for callers that still lack sandbox truth.
+            if sandbox_id:
+                upsert_resource_snapshot_for_sandbox(
+                    sandbox_id=sandbox_id,
+                    legacy_lease_id=lease_id,
+                    provider_name=provider_name,
+                    observed_state=observed_state,
+                    probe_mode=probe_mode,
+                    cpu_used=cpu_used,
+                    cpu_limit=cpu_limit,
+                    memory_used_mb=memory_used_mb,
+                    memory_total_mb=memory_total_mb,
+                    disk_used_gb=disk_used_gb,
+                    disk_total_gb=disk_total_gb,
+                    network_rx_kbps=network_rx_kbps,
+                    network_tx_kbps=network_tx_kbps,
+                    probe_error=probe_error,
+                )
+            else:
+                upsert = repo.upsert_lease_resource_snapshot if repo is not None else upsert_lease_resource_snapshot
+                upsert(
+                    lease_id=lease_id,
+                    provider_name=provider_name,
+                    observed_state=observed_state,
+                    probe_mode=probe_mode,
+                    cpu_used=cpu_used,
+                    cpu_limit=cpu_limit,
+                    memory_used_mb=memory_used_mb,
+                    memory_total_mb=memory_total_mb,
+                    disk_used_gb=disk_used_gb,
+                    disk_total_gb=disk_total_gb,
+                    network_rx_kbps=network_rx_kbps,
+                    network_tx_kbps=network_tx_kbps,
+                    probe_error=probe_error,
+                )
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
     return {"ok": probe_error is None, "error": probe_error}

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -176,27 +176,33 @@ def list_resource_snapshots_by_sandbox(
     supabase_client: Any | None = None,
     supabase_client_factory: str | None = None,
 ) -> dict[str, dict[str, Any]]:
-    lease_ids: list[str] = []
-    sandbox_by_lease: dict[str, str] = {}
-    for session in sessions:
-        sandbox_id = str(session.get("sandbox_id") or "").strip()
-        lease_id = str(session.get("lease_id") or "").strip()
-        if not sandbox_id or not lease_id or lease_id in sandbox_by_lease:
-            continue
-        sandbox_by_lease[lease_id] = sandbox_id
-        lease_ids.append(lease_id)
-
-    snapshot_by_lease = list_resource_snapshots(
-        lease_ids,
+    repo = build_resource_snapshot_repo(
         supabase_client=supabase_client,
         supabase_client_factory=supabase_client_factory,
     )
-    snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
-    for lease_id, snapshot in snapshot_by_lease.items():
-        sandbox_id = sandbox_by_lease.get(lease_id)
-        if sandbox_id:
-            snapshot_by_sandbox[sandbox_id] = snapshot
-    return snapshot_by_sandbox
+    try:
+        if hasattr(repo, "list_snapshots_by_sandbox_ids"):
+            return repo.list_snapshots_by_sandbox_ids(sessions)
+
+        lease_ids: list[str] = []
+        sandbox_by_lease: dict[str, str] = {}
+        for session in sessions:
+            sandbox_id = str(session.get("sandbox_id") or "").strip()
+            lease_id = str(session.get("lease_id") or "").strip()
+            if not sandbox_id or not lease_id or lease_id in sandbox_by_lease:
+                continue
+            sandbox_by_lease[lease_id] = sandbox_id
+            lease_ids.append(lease_id)
+
+        snapshot_by_lease = repo.list_snapshots_by_lease_ids(lease_ids)
+        snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
+        for lease_id, snapshot in snapshot_by_lease.items():
+            sandbox_id = sandbox_by_lease.get(lease_id)
+            if sandbox_id:
+                snapshot_by_sandbox[sandbox_id] = snapshot
+        return snapshot_by_sandbox
+    finally:
+        repo.close()
 
 
 def upsert_resource_snapshot_for_sandbox(
@@ -228,21 +234,39 @@ def upsert_resource_snapshot_for_sandbox(
         supabase_client_factory=supabase_client_factory,
     )
     try:
-        repo.upsert_lease_resource_snapshot(
-            lease_id=legacy_lease_id,
-            provider_name=provider_name,
-            observed_state=observed_state,
-            probe_mode=probe_mode,
-            cpu_used=cpu_used,
-            cpu_limit=cpu_limit,
-            memory_used_mb=memory_used_mb,
-            memory_total_mb=memory_total_mb,
-            disk_used_gb=disk_used_gb,
-            disk_total_gb=disk_total_gb,
-            network_rx_kbps=network_rx_kbps,
-            network_tx_kbps=network_tx_kbps,
-            probe_error=probe_error,
-        )
+        if hasattr(repo, "upsert_resource_snapshot_for_sandbox"):
+            repo.upsert_resource_snapshot_for_sandbox(
+                sandbox_id=sandbox_id,
+                legacy_lease_id=legacy_lease_id,
+                provider_name=provider_name,
+                observed_state=observed_state,
+                probe_mode=probe_mode,
+                cpu_used=cpu_used,
+                cpu_limit=cpu_limit,
+                memory_used_mb=memory_used_mb,
+                memory_total_mb=memory_total_mb,
+                disk_used_gb=disk_used_gb,
+                disk_total_gb=disk_total_gb,
+                network_rx_kbps=network_rx_kbps,
+                network_tx_kbps=network_tx_kbps,
+                probe_error=probe_error,
+            )
+        else:
+            repo.upsert_lease_resource_snapshot(
+                lease_id=legacy_lease_id,
+                provider_name=provider_name,
+                observed_state=observed_state,
+                probe_mode=probe_mode,
+                cpu_used=cpu_used,
+                cpu_limit=cpu_limit,
+                memory_used_mb=memory_used_mb,
+                memory_total_mb=memory_total_mb,
+                disk_used_gb=disk_used_gb,
+                disk_total_gb=disk_total_gb,
+                network_rx_kbps=network_rx_kbps,
+                network_tx_kbps=network_tx_kbps,
+                probe_error=probe_error,
+            )
     finally:
         repo.close()
 

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -490,7 +490,15 @@ def test_list_resource_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_e
         "lease-b": {"lease_id": "lease-b", "cpu_used": 22},
     }
 
-    monkeypatch.setattr(storage_runtime, "list_resource_snapshots", lambda _lease_ids, **_kwargs: snapshot_by_lease)
+    class _LeaseOnlyRepo:
+        def close(self):
+            return None
+
+        def list_snapshots_by_lease_ids(self, lease_ids):
+            assert lease_ids == ["lease-a", "lease-b"]
+            return snapshot_by_lease
+
+    monkeypatch.setattr(storage_runtime, "build_resource_snapshot_repo", lambda **_kwargs: _LeaseOnlyRepo())
 
     snapshot_by_sandbox = storage_runtime.list_resource_snapshots_by_sandbox(sessions)
 
@@ -498,6 +506,32 @@ def test_list_resource_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_e
         "sandbox-a": {"lease_id": "lease-a", "cpu_used": 11},
         "sandbox-b": {"lease_id": "lease-b", "cpu_used": 22},
     }
+
+
+def test_list_resource_snapshots_by_sandbox_prefers_repo_sandbox_wrapper(monkeypatch):
+    sessions = [
+        {
+            "sandbox_id": "sandbox-a",
+            "lease_id": "lease-a",
+        },
+    ]
+
+    class _SandboxWrappedRepo:
+        def close(self):
+            return None
+
+        def list_snapshots_by_sandbox_ids(self, items):
+            assert items == sessions
+            return {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}}
+
+        def list_snapshots_by_lease_ids(self, _lease_ids):
+            raise AssertionError("lease-keyed snapshot read should not be the active path")
+
+    monkeypatch.setattr(storage_runtime, "build_resource_snapshot_repo", lambda **_kwargs: _SandboxWrappedRepo())
+
+    snapshot_by_sandbox = storage_runtime.list_resource_snapshots_by_sandbox(sessions)
+
+    assert snapshot_by_sandbox == {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}}
 
 
 def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_telemetry(monkeypatch):

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -70,6 +70,51 @@ def test_probe_and_upsert_for_instance_accepts_sandbox_shaped_repo() -> None:
     ]
 
 
+def test_probe_and_upsert_for_instance_without_repo_prefers_sandbox_shaped_helper(monkeypatch) -> None:
+    captured: list[dict] = []
+
+    def _fake_upsert_resource_snapshot_for_sandbox(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(resource_snapshot, "upsert_resource_snapshot_for_sandbox", _fake_upsert_resource_snapshot_for_sandbox)
+    monkeypatch.setattr(
+        resource_snapshot,
+        "upsert_lease_resource_snapshot",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("lease-shaped helper should not be the active path")),
+    )
+
+    result = resource_snapshot.probe_and_upsert_for_instance(
+        sandbox_id="sandbox-1",
+        lease_id="lease-1",
+        provider_name="p1",
+        observed_state="detached",
+        probe_mode="running_runtime",
+        provider=_FakeProvider(),
+        instance_id="instance-1",
+        repo=None,
+    )
+
+    assert result == {"ok": False, "error": "metrics unavailable"}
+    assert captured == [
+        {
+            "sandbox_id": "sandbox-1",
+            "legacy_lease_id": "lease-1",
+            "provider_name": "p1",
+            "observed_state": "detached",
+            "probe_mode": "running_runtime",
+            "cpu_used": None,
+            "cpu_limit": None,
+            "memory_used_mb": None,
+            "memory_total_mb": None,
+            "disk_used_gb": None,
+            "disk_total_gb": None,
+            "network_rx_kbps": None,
+            "network_tx_kbps": None,
+            "probe_error": "metrics unavailable",
+        }
+    ]
+
+
 def test_refresh_resource_snapshots_routes_successful_probe_through_sandbox_wrapper(monkeypatch):
     monkeypatch.setattr(
         resource_service,


### PR DESCRIPTION
## Summary
- make storage/runtime prefer sandbox-shaped snapshot repo methods for active read and write paths
- add a sandbox-shaped module helper in sandbox/resource_snapshot and make the active helper path prefer it when sandbox_id is present
- keep lease-shaped paths as compatibility residue without touching deeper table or column contracts

## Verification
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py -k 'prefers_repo_sandbox_wrapper or prefers_sandbox_shaped_helper' -q
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py -q
- uv run ruff check storage/runtime.py sandbox/resource_snapshot.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py
- git diff --check