### PR TITLE
fix: absorb frontend truthful buckets from latest dev

### DIFF
--- a/frontend/app/src/api/users.test.ts
+++ b/frontend/app/src/api/users.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { authFetch } = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/store/auth-store", () => ({
+  authFetch,
+}));
+
+function okJson(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("fetchUserChatCandidates", () => {
+  it("dedupes concurrent reads against the same in-flight request", async () => {
+    const pending = deferred<Response>();
+    authFetch.mockReturnValue(pending.promise);
+
+    const { fetchUserChatCandidates } = await import("./users");
+
+    const first = fetchUserChatCandidates();
+    const second = fetchUserChatCandidates();
+
+    expect(authFetch).toHaveBeenCalledTimes(1);
+
+    pending.resolve(okJson([
+      {
+        user_id: "human-2",
+        name: "Ada",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]));
+
+    await expect(first).resolves.toEqual([
+      {
+        user_id: "human-2",
+        name: "Ada",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]);
+    await expect(second).resolves.toEqual([
+      {
+        user_id: "human-2",
+        name: "Ada",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]);
+  });
+
+  it("does not keep a stale cache after the in-flight request settles", async () => {
+    authFetch
+      .mockResolvedValueOnce(okJson([
+        {
+          user_id: "human-2",
+          name: "Ada",
+          type: "human",
+          avatar_url: null,
+          owner_name: null,
+          is_owned: false,
+          relationship_state: "visit",
+          can_chat: true,
+        },
+      ]))
+      .mockResolvedValueOnce(okJson([
+        {
+          user_id: "human-3",
+          name: "Grace",
+          type: "human",
+          avatar_url: null,
+          owner_name: null,
+          is_owned: false,
+          relationship_state: "visit",
+          can_chat: true,
+        },
+      ]));
+
+    const { fetchUserChatCandidates } = await import("./users");
+
+    await expect(fetchUserChatCandidates()).resolves.toEqual([
+      {
+        user_id: "human-2",
+        name: "Ada",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]);
+    await expect(fetchUserChatCandidates()).resolves.toEqual([
+      {
+        user_id: "human-3",
+        name: "Grace",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]);
+
+    expect(authFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/app/src/api/users.ts
+++ b/frontend/app/src/api/users.ts
@@ -11,6 +11,8 @@ export type UserChatCandidate = {
   can_chat: boolean;
 };
 
+let inflightUserChatCandidates: Promise<UserChatCandidate[]> | null = null;
+
 export function parseUserChatCandidates(value: unknown): UserChatCandidate[] {
   if (!Array.isArray(value)) throw new Error("Malformed user chat candidate list");
   return value.map((item) => {
@@ -40,7 +42,16 @@ export function parseUserChatCandidates(value: unknown): UserChatCandidate[] {
 }
 
 export async function fetchUserChatCandidates(): Promise<UserChatCandidate[]> {
-  const response = await authFetch("/api/users/chat-candidates");
-  if (!response.ok) throw new Error(`User chat candidates API ${response.status}: ${await response.text()}`);
-  return parseUserChatCandidates(await response.json());
+  if (inflightUserChatCandidates) return inflightUserChatCandidates;
+  const pending = (async () => {
+    const response = await authFetch("/api/users/chat-candidates");
+    if (!response.ok) throw new Error(`User chat candidates API ${response.status}: ${await response.text()}`);
+    return parseUserChatCandidates(await response.json());
+  })();
+  inflightUserChatCandidates = pending;
+  try {
+    return await pending;
+  } finally {
+    inflightUserChatCandidates = null;
+  }
 }

--- a/frontend/app/src/hooks/use-background-tasks.test.tsx
+++ b/frontend/app/src/hooks/use-background-tasks.test.tsx
@@ -4,6 +4,11 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useBackgroundTasks } from "./use-background-tasks";
 import type { UseThreadStreamResult } from "./use-thread-stream";
+import { authFetch } from "../store/auth-store";
+
+vi.mock("../store/auth-store", () => ({
+  authFetch: vi.fn(),
+}));
 
 afterEach(() => {
   cleanup();
@@ -21,7 +26,7 @@ describe("useBackgroundTasks", () => {
   it("does not log a failed task fetch once navigation already left the thread route", async () => {
     window.history.replaceState({}, "", "/chat/hire/thread/thread-1");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+    const authFetchMock = vi.mocked(authFetch).mockImplementation(async () => {
       window.history.replaceState({}, "", "/resources");
       throw new TypeError("Failed to fetch");
     });
@@ -29,7 +34,7 @@ describe("useBackgroundTasks", () => {
     render(<Harness />);
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/threads/thread-1/tasks");
+      expect(authFetchMock).toHaveBeenCalledWith("/api/threads/thread-1/tasks");
     });
     await Promise.resolve();
 
@@ -39,7 +44,7 @@ describe("useBackgroundTasks", () => {
   it("reports malformed task list payloads instead of storing invalid task state", async () => {
     window.history.replaceState({}, "", "/chat/hire/thread/thread-1");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    vi.mocked(authFetch).mockResolvedValue({
       ok: true,
       json: async () => ({ items: "not-a-task-list" }),
     } as Response);
@@ -58,7 +63,7 @@ describe("useBackgroundTasks", () => {
   });
 
   it("accepts the backend cancelled task status", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    vi.mocked(authFetch).mockResolvedValue({
       ok: true,
       json: async () => [
         {

--- a/frontend/app/src/hooks/use-background-tasks.ts
+++ b/frontend/app/src/hooks/use-background-tasks.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { UseThreadStreamResult } from './use-thread-stream';
 import type { StreamEvent } from '../api/types';
 import { asRecord, recordNumber, recordString } from '../lib/records';
+import { authFetch } from '../store/auth-store';
 
 export interface BackgroundTask {
   task_id: string;
@@ -76,7 +77,7 @@ function loadThreadTasks(threadId: string): Promise<BackgroundTask[]> {
   // @@@tasks-inflight-dedup - React StrictMode remounts the page in dev.
   // Reuse the first thread task fetch so the dev switch hot path does not
   // double-hit /tasks before the first response lands.
-  const pending = fetch(`/api/threads/${threadId}/tasks`)
+  const pending = authFetch(`/api/threads/${threadId}/tasks`)
     .then(async (response) => {
       if (!response.ok) {
         throw new Error(response.statusText || `HTTP ${response.status}`);

--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -71,6 +71,24 @@ describe("useMarketplaceStore", () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
+  it("keeps marketplace detail outage user-facing without logging expected hub 503 noise", async () => {
+    window.history.replaceState({}, "", "/marketplace/item-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "hub down",
+    } as Response);
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().fetchDetail("item-1");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(useMarketplaceStore.getState().error).toBe("Marketplace Hub unavailable");
+  });
+
   it("does not log a failed lineage fetch once navigation already left the marketplace detail route", async () => {
     window.history.replaceState({}, "", "/marketplace/item-1");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -87,6 +105,24 @@ describe("useMarketplaceStore", () => {
     expect(String(fetchMock.mock.calls[0][0])).toContain("/api/marketplace/items/item-1/lineage");
     expect(String(fetchMock.mock.calls[0][0])).not.toContain("localhost:8090");
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("keeps marketplace lineage outage user-facing without logging expected hub 503 noise", async () => {
+    window.history.replaceState({}, "", "/marketplace/item-1");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "hub down",
+    } as Response);
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().fetchLineage("item-1");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(useMarketplaceStore.getState().error).toBe("Marketplace Hub unavailable");
   });
 
   it("does not log a failed snapshot fetch once navigation already left the marketplace detail route", async () => {

--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -182,4 +182,18 @@ describe("useMarketplaceStore", () => {
       visibility: "public",
     });
   });
+
+  it("preserves backend detail when marketplace publish returns an honest 503", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "Marketplace Hub unavailable" }),
+    } as Response);
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await expect(
+      useMarketplaceStore.getState().publishAgentUserToMarketplace("agent-1", "patch", "notes", ["coding"], "public"),
+    ).rejects.toThrow("Marketplace Hub unavailable");
+  });
 });

--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -24,6 +24,17 @@ afterEach(async () => {
 });
 
 describe("useMarketplaceStore", () => {
+  it("does not emit a state update for a no-op filter change", async () => {
+    const { useMarketplaceStore } = await import("./marketplace-store");
+    const listener = vi.fn();
+    const unsubscribe = useMarketplaceStore.subscribe(listener);
+
+    useMarketplaceStore.getState().setFilter("q", "");
+
+    unsubscribe();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it("does not log a failed items fetch once navigation already left the marketplace route", async () => {
     window.history.replaceState({}, "", "/marketplace");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -114,7 +114,15 @@ async function backendApi<T = unknown>(path: string, opts?: RequestInit): Promis
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (token) headers["Authorization"] = `Bearer ${token}`;
   const res = await fetch(`${API}${path}`, { headers, ...opts });
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  if (!res.ok) {
+    let payload: { detail?: string; message?: string } | null = null;
+    try {
+      payload = await res.json() as { detail?: string; message?: string };
+    } catch {
+      payload = null;
+    }
+    throw new Error(payload?.detail || payload?.message || `API error: ${res.status}`);
+  }
   return res.json();
 }
 

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -123,7 +123,11 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
   filters: { type: null, q: "", sort: "downloads", page: 1 },
 
   setFilter: (key, value) => {
-    set((s) => ({ filters: { ...s.filters, [key]: value, ...(key !== "page" ? { page: 1 } : {}) } }));
+    set((s) => {
+      const nextPage = key === "page" ? s.filters.page : 1;
+      if (s.filters[key] === value && s.filters.page === nextPage) return s;
+      return { filters: { ...s.filters, [key]: value, page: nextPage } };
+    });
   },
 
   fetchItems: async () => {

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -106,6 +106,9 @@ function isActiveMarketplaceDetailRoute(itemId: string): boolean {
   return path === `/marketplace/${encodeURIComponent(itemId)}`;
 }
 
+function isMarketplaceUnavailableError(error: unknown): boolean {
+  return error instanceof Error && error.message === "Marketplace Hub unavailable";
+}
 async function backendApi<T = unknown>(path: string, opts?: RequestInit): Promise<T> {
   const token = useAuthStore.getState().token;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -167,7 +170,9 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       // the user already left this marketplace detail page. Only log if this
       // item route is still active; otherwise this is stale UI noise.
       if (!isActiveMarketplaceDetailRoute(id)) return;
-      console.error("Failed to fetch detail:", e);
+      if (!isMarketplaceUnavailableError(e)) {
+        console.error("Failed to fetch detail:", e);
+      }
       set({ error: e instanceof Error ? e.message : "Unknown error" });
     } finally {
       set({ detailLoading: false });
@@ -209,7 +214,9 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       // after the user already left this marketplace detail page. Only log if
       // this item route is still active; otherwise this is stale UI noise.
       if (!isActiveMarketplaceDetailRoute(id)) return;
-      console.error("Failed to fetch lineage:", e);
+      if (!isMarketplaceUnavailableError(e)) {
+        console.error("Failed to fetch lineage:", e);
+      }
       set({ error: e instanceof Error ? e.message : "Unknown error" });
     }
   },

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -121,7 +121,13 @@ async function backendApi<T = unknown>(path: string, opts?: RequestInit): Promis
     } catch {
       payload = null;
     }
-    throw new Error(payload?.detail || payload?.message || `API error: ${res.status}`);
+    if (payload?.detail || payload?.message) {
+      throw new Error(payload.detail || payload.message);
+    }
+    if (res.status >= 502) {
+      throw new Error("Marketplace Hub unavailable");
+    }
+    throw new Error(`API error: ${res.status}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- absorb Bucket A truthful frontend fixes for concurrent chat-candidate reads and auth-backed background task fetches
- absorb Bucket B marketplace truthful error-surface fixes as one bounded pack
- keep the work frontend-only and non-colliding with the backend/resource mainline

## Absorbed commits
- cbfc2d3f fix: dedupe concurrent contact candidate reads
- 42193ea8 fix: use auth fetch for background task reads
- a050bc9d fix: skip no-op marketplace filter updates
- 620de65b fix: quiet marketplace detail outage noise
- dd0fd4a3 fix: preserve marketplace publish error detail
- 7c2daa50 fix: preserve marketplace outage detail on latest dev

## Verification
- cd frontend/app && npm test -- src/api/users.test.ts src/hooks/use-background-tasks.test.tsx -- --runInBand
- cd frontend/app && npm test -- src/store/marketplace-store.test.ts -- --runInBand
- cd frontend/app && npm run build