### PR TITLE
refactor: contract resource snapshot lease compatibility shell

### DIFF
--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -29,14 +29,6 @@ class _SandboxSnapshotRepoAdapter:
         kwargs.pop("sandbox_id", None)
         upsert_resource_snapshot_for_sandbox(sandbox_id=self._sandbox_id, **kwargs)
 
-    def upsert_lease_resource_snapshot(self, **kwargs) -> None:
-        lease_id = kwargs.pop("lease_id", None)
-        upsert_resource_snapshot_for_sandbox(
-            sandbox_id=self._sandbox_id,
-            legacy_lease_id=lease_id,
-            **kwargs,
-        )
-
 
 def get_provider_display_contract(config_name: str) -> dict[str, Any]:
     provider_name = resolve_provider_name(config_name, sandboxes_dir=SANDBOXES_DIR)

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -154,22 +154,6 @@ def build_summary_repo(*, supabase_client: Any | None = None, supabase_client_fa
     return _build_storage_repo("summary_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
-def list_resource_snapshots(
-    lease_ids: list[str],
-    *,
-    supabase_client: Any | None = None,
-    supabase_client_factory: str | None = None,
-) -> dict[str, Any]:
-    repo = build_resource_snapshot_repo(
-        supabase_client=supabase_client,
-        supabase_client_factory=supabase_client_factory,
-    )
-    try:
-        return repo.list_snapshots_by_lease_ids(lease_ids)
-    finally:
-        repo.close()
-
-
 def list_resource_snapshots_by_sandbox(
     sessions: list[dict[str, Any]],
     *,

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -77,6 +77,10 @@ def _patch_daytona_projection(monkeypatch, repo, owners, *, console_url=None):
     monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
 
+def test_storage_runtime_no_longer_exposes_lease_shaped_snapshot_read_shell() -> None:
+    assert not hasattr(storage_runtime, "list_resource_snapshots")
+
+
 def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch):
     rows = [
         {

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -35,6 +35,12 @@ class _FakeSandboxSnapshotRepo:
         self.upserts.append(kwargs)
 
 
+def test_resource_snapshot_adapter_no_longer_exposes_lease_shaped_write_shell() -> None:
+    adapter = resource_service._SandboxSnapshotRepoAdapter(sandbox_id="sandbox-1")
+
+    assert not hasattr(adapter, "upsert_lease_resource_snapshot")
+
+
 def test_probe_and_upsert_for_instance_accepts_sandbox_shaped_repo() -> None:
     repo = _FakeSandboxSnapshotRepo()
 


### PR DESCRIPTION
## Summary
- contract resource snapshot lease compatibility shell by removing unused lease-shaped read/write outward surfaces
- keep active sandbox-shaped snapshot read/write paths and lease-shaped fallback compatibility where still required
- avoid any repo/table/column remap

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k 'resource_snapshot_adapter_no_longer_exposes_lease_shaped_write_shell'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k 'storage_runtime_no_longer_exposes_lease_shaped_snapshot_read_shell'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
- uv run ruff check backend/web/services/resource_service.py storage/runtime.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
- git diff --check
