### PR TITLE
refactor: contract snapshot runtime repo bridge

### DIFF
--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -165,26 +165,9 @@ def list_resource_snapshots_by_sandbox(
         supabase_client_factory=supabase_client_factory,
     )
     try:
-        if hasattr(repo, "list_snapshots_by_sandbox_ids"):
-            return repo.list_snapshots_by_sandbox_ids(sessions)
-
-        lease_ids: list[str] = []
-        sandbox_by_lease: dict[str, str] = {}
-        for session in sessions:
-            sandbox_id = str(session.get("sandbox_id") or "").strip()
-            lease_id = str(session.get("lease_id") or "").strip()
-            if not sandbox_id or not lease_id or lease_id in sandbox_by_lease:
-                continue
-            sandbox_by_lease[lease_id] = sandbox_id
-            lease_ids.append(lease_id)
-
-        snapshot_by_lease = repo.list_snapshots_by_lease_ids(lease_ids)
-        snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
-        for lease_id, snapshot in snapshot_by_lease.items():
-            sandbox_id = sandbox_by_lease.get(lease_id)
-            if sandbox_id:
-                snapshot_by_sandbox[sandbox_id] = snapshot
-        return snapshot_by_sandbox
+        if not hasattr(repo, "list_snapshots_by_sandbox_ids"):
+            raise RuntimeError("sandbox-shaped snapshot repo read requires list_snapshots_by_sandbox_ids")
+        return repo.list_snapshots_by_sandbox_ids(sessions)
     finally:
         repo.close()
 
@@ -218,39 +201,24 @@ def upsert_resource_snapshot_for_sandbox(
         supabase_client_factory=supabase_client_factory,
     )
     try:
-        if hasattr(repo, "upsert_resource_snapshot_for_sandbox"):
-            repo.upsert_resource_snapshot_for_sandbox(
-                sandbox_id=sandbox_id,
-                legacy_lease_id=legacy_lease_id,
-                provider_name=provider_name,
-                observed_state=observed_state,
-                probe_mode=probe_mode,
-                cpu_used=cpu_used,
-                cpu_limit=cpu_limit,
-                memory_used_mb=memory_used_mb,
-                memory_total_mb=memory_total_mb,
-                disk_used_gb=disk_used_gb,
-                disk_total_gb=disk_total_gb,
-                network_rx_kbps=network_rx_kbps,
-                network_tx_kbps=network_tx_kbps,
-                probe_error=probe_error,
-            )
-        else:
-            repo.upsert_lease_resource_snapshot(
-                lease_id=legacy_lease_id,
-                provider_name=provider_name,
-                observed_state=observed_state,
-                probe_mode=probe_mode,
-                cpu_used=cpu_used,
-                cpu_limit=cpu_limit,
-                memory_used_mb=memory_used_mb,
-                memory_total_mb=memory_total_mb,
-                disk_used_gb=disk_used_gb,
-                disk_total_gb=disk_total_gb,
-                network_rx_kbps=network_rx_kbps,
-                network_tx_kbps=network_tx_kbps,
-                probe_error=probe_error,
-            )
+        if not hasattr(repo, "upsert_resource_snapshot_for_sandbox"):
+            raise RuntimeError("sandbox-shaped snapshot repo write requires upsert_resource_snapshot_for_sandbox")
+        repo.upsert_resource_snapshot_for_sandbox(
+            sandbox_id=sandbox_id,
+            legacy_lease_id=legacy_lease_id,
+            provider_name=provider_name,
+            observed_state=observed_state,
+            probe_mode=probe_mode,
+            cpu_used=cpu_used,
+            cpu_limit=cpu_limit,
+            memory_used_mb=memory_used_mb,
+            memory_total_mb=memory_total_mb,
+            disk_used_gb=disk_used_gb,
+            disk_total_gb=disk_total_gb,
+            network_rx_kbps=network_rx_kbps,
+            network_tx_kbps=network_tx_kbps,
+            probe_error=probe_error,
+        )
     finally:
         repo.close()
 

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -491,6 +491,7 @@ def test_list_resource_snapshots_by_sandbox_requires_repo_sandbox_wrapper(monkey
             "lease_id": "lease-b",
         },
     ]
+
     class _LeaseOnlyRepo:
         def close(self):
             return None

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -1,3 +1,5 @@
+import pytest
+
 from backend.web.services import resource_common, resource_projection_service
 from storage import runtime as storage_runtime
 
@@ -478,7 +480,7 @@ def test_visible_resource_session_stats_uses_sandbox_keyed_runtime_lookup(monkey
     assert stats == {"daytona_selfhost": {"sessions": 1, "running": 1}}
 
 
-def test_list_resource_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_enrichment(monkeypatch):
+def test_list_resource_snapshots_by_sandbox_requires_repo_sandbox_wrapper(monkeypatch):
     sessions = [
         {
             "sandbox_id": "sandbox-a",
@@ -489,27 +491,17 @@ def test_list_resource_snapshots_by_sandbox_rekeys_lease_snapshots_for_session_e
             "lease_id": "lease-b",
         },
     ]
-    snapshot_by_lease = {
-        "lease-a": {"lease_id": "lease-a", "cpu_used": 11},
-        "lease-b": {"lease_id": "lease-b", "cpu_used": 22},
-    }
-
     class _LeaseOnlyRepo:
         def close(self):
             return None
 
         def list_snapshots_by_lease_ids(self, lease_ids):
-            assert lease_ids == ["lease-a", "lease-b"]
-            return snapshot_by_lease
+            raise AssertionError("lease-shaped snapshot read shell should not remain an active runtime bridge")
 
     monkeypatch.setattr(storage_runtime, "build_resource_snapshot_repo", lambda **_kwargs: _LeaseOnlyRepo())
 
-    snapshot_by_sandbox = storage_runtime.list_resource_snapshots_by_sandbox(sessions)
-
-    assert snapshot_by_sandbox == {
-        "sandbox-a": {"lease_id": "lease-a", "cpu_used": 11},
-        "sandbox-b": {"lease_id": "lease-b", "cpu_used": 22},
-    }
+    with pytest.raises(RuntimeError, match="sandbox-shaped snapshot repo read requires list_snapshots_by_sandbox_ids"):
+        storage_runtime.list_resource_snapshots_by_sandbox(sessions)
 
 
 def test_list_resource_snapshots_by_sandbox_prefers_repo_sandbox_wrapper(monkeypatch):

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -1,7 +1,10 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from backend.web.services import resource_service
 from sandbox import resource_snapshot
+from storage import runtime as storage_runtime
 
 
 class _FakeProvider:
@@ -33,6 +36,20 @@ class _FakeSandboxSnapshotRepo:
 
     def upsert_resource_snapshot_for_sandbox(self, **kwargs):
         self.upserts.append(kwargs)
+
+
+def test_upsert_resource_snapshot_for_sandbox_requires_repo_sandbox_wrapper(monkeypatch) -> None:
+    repo = _FakeSnapshotRepo()
+    monkeypatch.setattr(storage_runtime, "build_resource_snapshot_repo", lambda **_kwargs: repo)
+
+    with pytest.raises(RuntimeError, match="sandbox-shaped snapshot repo write requires upsert_resource_snapshot_for_sandbox"):
+        storage_runtime.upsert_resource_snapshot_for_sandbox(
+            sandbox_id="sandbox-1",
+            legacy_lease_id="lease-1",
+            provider_name="p1",
+            observed_state="detached",
+            probe_mode="running_runtime",
+        )
 
 
 def test_resource_snapshot_adapter_no_longer_exposes_lease_shaped_write_shell() -> None:


### PR DESCRIPTION
## Summary
- contract snapshot runtime repo bridge so runtime read/write wrappers require sandbox-shaped repo methods
- remove lease-only repo fallback from the active runtime snapshot path
- keep deeper repo/table truth unchanged

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k 'requires_repo_sandbox_wrapper or prefers_repo_sandbox_wrapper'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k 'requires_repo_sandbox_wrapper or accepts_sandbox_shaped_repo or without_repo_prefers_sandbox_shaped_helper'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py
- uv run ruff check storage/runtime.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py
- git diff --check
