### PR TITLE
refactor: contract snapshot helper protocol shell

### DIFF
--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -47,7 +47,7 @@ def upsert_resource_snapshot_for_sandbox(
         repo.close()
 
 
-def upsert_lease_resource_snapshot(
+def _upsert_lease_resource_snapshot(
     *,
     lease_id: str,
     provider_name: str,
@@ -86,7 +86,6 @@ def upsert_lease_resource_snapshot(
 
 __all__ = [
     "upsert_resource_snapshot_for_sandbox",
-    "upsert_lease_resource_snapshot",
     "probe_and_upsert_for_instance",
 ]
 
@@ -200,7 +199,7 @@ def probe_and_upsert_for_instance(
                     probe_error=probe_error,
                 )
             else:
-                upsert = repo.upsert_lease_resource_snapshot if repo is not None else upsert_lease_resource_snapshot
+                upsert = repo.upsert_lease_resource_snapshot if repo is not None else _upsert_lease_resource_snapshot
                 upsert(
                     lease_id=lease_id,
                     provider_name=provider_name,

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -656,25 +656,7 @@ class ResourceSnapshotRepo(Protocol):
         network_tx_kbps: float | None = None,
         probe_error: str | None = None,
     ) -> None: ...
-    def upsert_lease_resource_snapshot(
-        self,
-        *,
-        lease_id: str,
-        provider_name: str,
-        observed_state: str,
-        probe_mode: str,
-        cpu_used: float | None = None,
-        cpu_limit: float | None = None,
-        memory_used_mb: float | None = None,
-        memory_total_mb: float | None = None,
-        disk_used_gb: float | None = None,
-        disk_total_gb: float | None = None,
-        network_rx_kbps: float | None = None,
-        network_tx_kbps: float | None = None,
-        probe_error: str | None = None,
-    ) -> None: ...
     def list_snapshots_by_sandbox_ids(self, sessions: list[dict[str, str]]) -> dict[str, dict[str, Any]]: ...
-    def list_snapshots_by_lease_ids(self, lease_ids: list[str]) -> dict[str, dict[str, Any]]: ...
 
 
 class FileOperationRepo(Protocol):

--- a/storage/providers/supabase/__init__.py
+++ b/storage/providers/supabase/__init__.py
@@ -13,7 +13,7 @@ from .lease_repo import SupabaseLeaseRepo
 from .provider_event_repo import SupabaseProviderEventRepo
 from .queue_repo import SupabaseQueueRepo
 from .recipe_repo import SupabaseRecipeRepo
-from .resource_snapshot_repo import SupabaseResourceSnapshotRepo, list_snapshots_by_lease_ids, upsert_lease_resource_snapshot
+from .resource_snapshot_repo import SupabaseResourceSnapshotRepo
 from .run_event_repo import SupabaseRunEventRepo
 from .sandbox_monitor_repo import SupabaseSandboxMonitorRepo
 from .sandbox_volume_repo import SupabaseSandboxVolumeRepo
@@ -54,6 +54,4 @@ __all__ = [
     "SupabaseToolTaskRepo",
     "SupabaseUserSettingsRepo",
     "SupabaseUserRepo",
-    "list_snapshots_by_lease_ids",
-    "upsert_lease_resource_snapshot",
 ]

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1059,7 +1059,7 @@ async def test_run_agent_reuses_parent_lease_for_child_thread_terminal(monkeypat
         db_path=temp_db,
     )
     monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(temp_db))
-    monkeypatch.setattr("sandbox.resource_snapshot.upsert_lease_resource_snapshot", lambda **_kwargs: None)
+    monkeypatch.setattr("sandbox.resource_snapshot._upsert_lease_resource_snapshot", lambda **_kwargs: None)
     monkeypatch.setattr(manager, "_setup_mounts", lambda thread_id: {"source": object(), "remote_path": str(tmp_path)})
     monkeypatch.setattr(manager, "_sync_to_sandbox", lambda *args, **kwargs: None)
 

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -58,6 +58,10 @@ def test_resource_snapshot_adapter_no_longer_exposes_lease_shaped_write_shell() 
     assert not hasattr(adapter, "upsert_lease_resource_snapshot")
 
 
+def test_resource_snapshot_module_no_longer_exposes_lease_shaped_write_helper() -> None:
+    assert not hasattr(resource_snapshot, "upsert_lease_resource_snapshot")
+
+
 def test_probe_and_upsert_for_instance_accepts_sandbox_shaped_repo() -> None:
     repo = _FakeSandboxSnapshotRepo()
 
@@ -102,7 +106,7 @@ def test_probe_and_upsert_for_instance_without_repo_prefers_sandbox_shaped_helpe
     monkeypatch.setattr(resource_snapshot, "upsert_resource_snapshot_for_sandbox", _fake_upsert_resource_snapshot_for_sandbox)
     monkeypatch.setattr(
         resource_snapshot,
-        "upsert_lease_resource_snapshot",
+        "_upsert_lease_resource_snapshot",
         lambda **_kwargs: (_ for _ in ()).throw(AssertionError("lease-shaped helper should not be the active path")),
     )
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -501,7 +501,7 @@ def test_sync_uploads_skips_local_volume_sync_when_lease_has_no_volume_id():
 
 
 def test_get_sandbox_local_provider_does_not_require_volume_bootstrap(tmp_path, monkeypatch):
-    monkeypatch.setattr("sandbox.resource_snapshot.upsert_lease_resource_snapshot", lambda **_kwargs: None)
+    monkeypatch.setattr("sandbox.resource_snapshot._upsert_lease_resource_snapshot", lambda **_kwargs: None)
     manager = SandboxManager(
         provider=LocalSessionProvider(default_cwd=str(tmp_path)),
         db_path=tmp_path / "sandbox.db",

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -1,3 +1,5 @@
+import storage.providers.supabase as supabase_provider
+from storage.contracts import ResourceSnapshotRepo
 from storage.providers.supabase.resource_snapshot_repo import SupabaseResourceSnapshotRepo
 
 
@@ -100,3 +102,13 @@ def test_supabase_resource_snapshot_repo_chunks_large_snapshot_lookup() -> None:
 
     assert rows == {"lease-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
     assert [len(values) for _, values in client.table_obj.in_calls] == [80, 80, 15]
+
+
+def test_resource_snapshot_repo_protocol_no_longer_declares_lease_shaped_methods() -> None:
+    assert "upsert_lease_resource_snapshot" not in ResourceSnapshotRepo.__dict__
+    assert "list_snapshots_by_lease_ids" not in ResourceSnapshotRepo.__dict__
+
+
+def test_supabase_provider_package_no_longer_exports_lease_shaped_snapshot_helpers() -> None:
+    assert not hasattr(supabase_provider, "upsert_lease_resource_snapshot")
+    assert not hasattr(supabase_provider, "list_snapshots_by_lease_ids")


### PR DESCRIPTION
## Summary
- contract the outward lease-shaped snapshot helper/protocol surface
- keep repo implementation bridge targets intact for sandbox-shaped snapshot methods
- update focused snapshot helper and repo tests to lock the new outward boundary

## Verification
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k 'resource_snapshot_module_no_longer_exposes_lease_shaped_write_helper or probe_and_upsert_for_instance_without_repo_prefers_sandbox_shaped_helper or probe_and_upsert_for_instance_accepts_sandbox_shaped_repo'
- uv run python -m pytest -q tests/Unit/storage/test_supabase_resource_snapshot_repo.py -k 'resource_snapshot_repo_protocol_no_longer_declares_lease_shaped_methods or supabase_provider_package_no_longer_exports_lease_shaped_snapshot_helpers or supabase_resource_snapshot_repo_upserts_for_sandbox_with_legacy_bridge or supabase_resource_snapshot_repo_lists_snapshots_by_sandbox_ids'
- uv run python -m pytest -q tests/Unit/core/test_agent_service.py -k 'test_run_agent_reuses_parent_lease_for_child_thread_terminal'
- uv run python -m pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -k 'test_get_sandbox_local_provider_does_not_require_volume_bootstrap'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/core/test_agent_service.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- uv run ruff check storage/contracts.py storage/providers/supabase/__init__.py sandbox/resource_snapshot.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/core/test_agent_service.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
- git diff --check