### PR TITLE
feat: remap resource snapshots to sandbox naming

### DIFF
--- a/docs/en/sandbox.mdx
+++ b/docs/en/sandbox.mdx
@@ -198,4 +198,4 @@ Sessions are tracked in SQLite (`~/.leon/sandbox.db`):
 | `sandbox_leases` | Lease lifecycle — provider, desired/observed state |
 | `sandbox_instances` | Provider-side session IDs |
 | `abstract_terminals` | Virtual terminals bound to Thread + lease |
-| `lease_resource_snapshots` | CPU, memory, disk metrics |
+| `sandbox_resource_snapshots` | CPU, memory, disk metrics |

--- a/docs/zh/sandbox.mdx
+++ b/docs/zh/sandbox.mdx
@@ -200,4 +200,4 @@ Agent
 | `sandbox_leases` | 租约生命周期 — 提供商、期望状态/实际状态 |
 | `sandbox_instances` | 提供商侧的会话 ID |
 | `abstract_terminals` | 绑定到 Thread + 租约的虚拟终端 |
-| `lease_resource_snapshots` | CPU、内存、磁盘指标 |
+| `sandbox_resource_snapshots` | CPU、内存、磁盘指标 |

--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -10,9 +10,9 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-def upsert_lease_resource_snapshot(
+def upsert_sandbox_resource_snapshot(
     *,
-    lease_id: str,
+    sandbox_id: str,
     provider_name: str,
     observed_state: str,
     probe_mode: str,
@@ -28,11 +28,11 @@ def upsert_lease_resource_snapshot(
     client: Any = None,
 ) -> None:
     if client is None:
-        raise RuntimeError("upsert_lease_resource_snapshot requires a client")
+        raise RuntimeError("upsert_sandbox_resource_snapshot requires a client")
     now = _now_iso()
-    client.table("lease_resource_snapshots").upsert(
+    client.table("sandbox_resource_snapshots").upsert(
         {
-            "lease_id": lease_id,
+            "sandbox_id": sandbox_id,
             "provider_name": provider_name,
             "observed_state": observed_state,
             "probe_mode": probe_mode,
@@ -51,27 +51,54 @@ def upsert_lease_resource_snapshot(
     ).execute()
 
 
-def list_snapshots_by_lease_ids(
-    lease_ids: list[str],
+def list_snapshots_by_sandbox_ids(
+    sandbox_ids: list[str],
     client: Any = None,
 ) -> dict[str, dict[str, Any]]:
     if client is None:
-        raise RuntimeError("list_snapshots_by_lease_ids requires a client")
-    if not lease_ids:
+        raise RuntimeError("list_snapshots_by_sandbox_ids requires a client")
+    if not sandbox_ids:
         return {}
-    unique_ids = sorted({lid for lid in lease_ids if lid})
+    unique_ids = sorted({sid for sid in sandbox_ids if sid})
     if not unique_ids:
         return {}
     from storage.providers.supabase import _query as q
 
     rows = q.rows_in_chunks(
-        lambda: client.table("lease_resource_snapshots").select("*"),
-        "lease_id",
+        lambda: client.table("sandbox_resource_snapshots").select("*"),
+        "sandbox_id",
         unique_ids,
         "resource_snapshot",
         "list_by_ids",
     )
-    return {str(r["lease_id"]): dict(r) for r in rows}
+    return {str(r["sandbox_id"]): dict(r) for r in rows}
+
+
+def upsert_lease_resource_snapshot(
+    *,
+    lease_id: str,
+    provider_name: str,
+    observed_state: str,
+    probe_mode: str,
+    cpu_used: float | None = None,
+    cpu_limit: float | None = None,
+    memory_used_mb: float | None = None,
+    memory_total_mb: float | None = None,
+    disk_used_gb: float | None = None,
+    disk_total_gb: float | None = None,
+    network_rx_kbps: float | None = None,
+    network_tx_kbps: float | None = None,
+    probe_error: str | None = None,
+    client: Any = None,
+) -> None:
+    raise RuntimeError("lease-shaped snapshot repo write is no longer supported")
+
+
+def list_snapshots_by_lease_ids(
+    lease_ids: list[str],
+    client: Any = None,
+) -> dict[str, dict[str, Any]]:
+    raise RuntimeError("lease-shaped snapshot repo read is no longer supported")
 
 
 class SupabaseResourceSnapshotRepo:
@@ -101,8 +128,8 @@ class SupabaseResourceSnapshotRepo:
     ) -> None:
         if not sandbox_id:
             raise RuntimeError("sandbox-shaped snapshot repo write requires sandbox_id")
-        upsert_lease_resource_snapshot(
-            lease_id=legacy_lease_id,
+        upsert_sandbox_resource_snapshot(
+            sandbox_id=sandbox_id,
             provider_name=provider_name,
             observed_state=observed_state,
             probe_mode=probe_mode,
@@ -153,23 +180,14 @@ class SupabaseResourceSnapshotRepo:
         )
 
     def list_snapshots_by_sandbox_ids(self, sessions: list[dict[str, str]]) -> dict[str, dict[str, Any]]:
-        lease_ids: list[str] = []
-        sandbox_by_lease: dict[str, str] = {}
+        sandbox_ids: list[str] = []
         for session in sessions:
             sandbox_id = str(session.get("sandbox_id") or "").strip()
-            lease_id = str(session.get("lease_id") or "").strip()
-            if not sandbox_id or not lease_id or lease_id in sandbox_by_lease:
+            if not sandbox_id or sandbox_id in sandbox_ids:
                 continue
-            sandbox_by_lease[lease_id] = sandbox_id
-            lease_ids.append(lease_id)
+            sandbox_ids.append(sandbox_id)
 
-        snapshot_by_lease = list_snapshots_by_lease_ids(lease_ids, client=self._client)
-        snapshot_by_sandbox: dict[str, dict[str, Any]] = {}
-        for lease_id, snapshot in snapshot_by_lease.items():
-            sandbox_id = sandbox_by_lease.get(lease_id)
-            if sandbox_id:
-                snapshot_by_sandbox[sandbox_id] = snapshot
-        return snapshot_by_sandbox
+        return list_snapshots_by_sandbox_ids(sandbox_ids, client=self._client)
 
     def list_snapshots_by_lease_ids(self, lease_ids: list[str]) -> dict[str, dict[str, Any]]:
         return list_snapshots_by_lease_ids(lease_ids, client=self._client)

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -553,7 +553,7 @@ def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_tele
     monkeypatch.setattr(
         resource_projection_service,
         "list_resource_snapshots_by_sandbox",
-        lambda _sessions: {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}},
+        lambda _sessions: {"sandbox-a": {"sandbox_id": "sandbox-a", "cpu_used": 11}},
     )
 
     captured: dict[str, object] = {}
@@ -595,7 +595,7 @@ def test_load_visible_resource_runtime_uses_sandbox_snapshot_wrapper(monkeypatch
     monkeypatch.setattr(
         resource_projection_service,
         "list_resource_snapshots_by_sandbox",
-        lambda sessions: {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}},
+        lambda sessions: {"sandbox-a": {"sandbox_id": "sandbox-a", "cpu_used": 11}},
     )
 
     sessions, runtime_session_ids, snapshot_by_lease, snapshot_by_sandbox = resource_projection_service._load_visible_resource_runtime()
@@ -603,4 +603,4 @@ def test_load_visible_resource_runtime_uses_sandbox_snapshot_wrapper(monkeypatch
     assert [session["sandbox_id"] for session in sessions] == ["sandbox-a"]
     assert runtime_session_ids == {"sandbox-a": None}
     assert snapshot_by_lease == {}
-    assert snapshot_by_sandbox == {"sandbox-a": {"lease_id": "lease-a", "cpu_used": 11}}
+    assert snapshot_by_sandbox == {"sandbox-a": {"sandbox_id": "sandbox-a", "cpu_used": 11}}

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -77,9 +77,7 @@ def test_supabase_resource_snapshot_repo_chunks_large_snapshot_lookup() -> None:
     client.table_obj.max_in_values = 80
     repo = SupabaseResourceSnapshotRepo(client)
 
-    rows = repo.list_snapshots_by_sandbox_ids(
-        [{"sandbox_id": f"sandbox-{index}", "lease_id": f"lease-{index}"} for index in range(175)]
-    )
+    rows = repo.list_snapshots_by_sandbox_ids([{"sandbox_id": f"sandbox-{index}", "lease_id": f"lease-{index}"} for index in range(175)])
 
     assert rows == {"sandbox-1": {"sandbox_id": "sandbox-1", "cpu_used": 1.0}}
     assert [len(values) for _, values in client.table_obj.in_calls] == [80, 80, 15]

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -8,7 +8,7 @@ class _FakeTable:
         self.upsert_payload = None
         self.in_calls: list[tuple[str, list[str]]] = []
         self.max_in_values: int | None = None
-        self.rows = [{"lease_id": "lease-1", "cpu_used": 1.0}]
+        self.rows = [{"sandbox_id": "sandbox-1", "cpu_used": 1.0}]
 
     def upsert(self, payload):
         self.upsert_payload = payload
@@ -30,28 +30,14 @@ class _FakeTable:
 class _FakeClient:
     def __init__(self) -> None:
         self.table_obj = _FakeTable()
+        self.last_table_name: str | None = None
 
-    def table(self, _name):
+    def table(self, name):
+        self.last_table_name = name
         return self.table_obj
 
 
-def test_supabase_resource_snapshot_repo_upserts_with_client() -> None:
-    client = _FakeClient()
-    repo = SupabaseResourceSnapshotRepo(client)
-
-    repo.upsert_lease_resource_snapshot(
-        lease_id="lease-1",
-        provider_name="daytona",
-        observed_state="running",
-        probe_mode="runtime",
-    )
-
-    assert client.table_obj.upsert_payload is not None
-    assert client.table_obj.upsert_payload["lease_id"] == "lease-1"
-    assert client.table_obj.upsert_payload["provider_name"] == "daytona"
-
-
-def test_supabase_resource_snapshot_repo_upserts_for_sandbox_with_legacy_bridge() -> None:
+def test_supabase_resource_snapshot_repo_upserts_for_sandbox_without_lease_shaped_row_key() -> None:
     client = _FakeClient()
     repo = SupabaseResourceSnapshotRepo(client)
 
@@ -64,18 +50,10 @@ def test_supabase_resource_snapshot_repo_upserts_for_sandbox_with_legacy_bridge(
     )
 
     assert client.table_obj.upsert_payload is not None
-    assert client.table_obj.upsert_payload["lease_id"] == "lease-1"
+    assert client.last_table_name == "sandbox_resource_snapshots"
+    assert client.table_obj.upsert_payload["sandbox_id"] == "sandbox-1"
+    assert "lease_id" not in client.table_obj.upsert_payload
     assert client.table_obj.upsert_payload["provider_name"] == "daytona"
-
-
-def test_supabase_resource_snapshot_repo_lists_snapshots_by_lease_ids() -> None:
-    client = _FakeClient()
-    repo = SupabaseResourceSnapshotRepo(client)
-
-    rows = repo.list_snapshots_by_lease_ids(["lease-1", "lease-2"])
-
-    assert rows == {"lease-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
-    assert ("lease_id", ["lease-1", "lease-2"]) in client.table_obj.in_calls
 
 
 def test_supabase_resource_snapshot_repo_lists_snapshots_by_sandbox_ids() -> None:
@@ -89,8 +67,9 @@ def test_supabase_resource_snapshot_repo_lists_snapshots_by_sandbox_ids() -> Non
         ]
     )
 
-    assert rows == {"sandbox-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
-    assert ("lease_id", ["lease-1", "lease-2"]) in client.table_obj.in_calls
+    assert rows == {"sandbox-1": {"sandbox_id": "sandbox-1", "cpu_used": 1.0}}
+    assert client.last_table_name == "sandbox_resource_snapshots"
+    assert ("sandbox_id", ["sandbox-1", "sandbox-2"]) in client.table_obj.in_calls
 
 
 def test_supabase_resource_snapshot_repo_chunks_large_snapshot_lookup() -> None:
@@ -98,9 +77,11 @@ def test_supabase_resource_snapshot_repo_chunks_large_snapshot_lookup() -> None:
     client.table_obj.max_in_values = 80
     repo = SupabaseResourceSnapshotRepo(client)
 
-    rows = repo.list_snapshots_by_lease_ids([f"lease-{index}" for index in range(175)])
+    rows = repo.list_snapshots_by_sandbox_ids(
+        [{"sandbox_id": f"sandbox-{index}", "lease_id": f"lease-{index}"} for index in range(175)]
+    )
 
-    assert rows == {"lease-1": {"lease_id": "lease-1", "cpu_used": 1.0}}
+    assert rows == {"sandbox-1": {"sandbox_id": "sandbox-1", "cpu_used": 1.0}}
     assert [len(values) for _, values in client.table_obj.in_calls] == [80, 80, 15]
 
 


### PR DESCRIPTION
## Summary
- remap supabase resource snapshot repo reads and writes to sandbox-shaped table/key naming
- update focused monitor/storage tests and sandbox docs to consume sandbox-shaped snapshot rows
- keep the lease-shaped compatibility residue out of active snapshot read/write paths

## Verification
- uv run python -m pytest -q tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
- uv run ruff check storage/providers/supabase/resource_snapshot_repo.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
- git diff --check