### PR TITLE
refactor: remove legacy sqlite snapshot cleanup shell

### DIFF
--- a/storage/providers/sqlite/lease_repo.py
+++ b/storage/providers/sqlite/lease_repo.py
@@ -396,11 +396,6 @@ class SQLiteLeaseRepo:
         with self._lock:
             self._conn.execute("DELETE FROM sandbox_instances WHERE lease_id = ?", (lease_id,))
             self._conn.execute("DELETE FROM lease_events WHERE lease_id = ?", (lease_id,))
-            # lease_resource_snapshots may not exist yet — guard with try
-            try:
-                self._conn.execute("DELETE FROM lease_resource_snapshots WHERE lease_id = ?", (lease_id,))
-            except sqlite3.OperationalError:
-                pass
             self._conn.execute("DELETE FROM sandbox_leases WHERE lease_id = ?", (lease_id,))
             self._conn.commit()
 

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -1,6 +1,7 @@
 """Unit tests for PhysicalTerminalRuntime."""
 
 import asyncio
+import inspect
 import re
 import sqlite3
 import sys
@@ -119,6 +120,12 @@ def test_sqlite_terminal_repo_create_repairs_stale_active_pointer(temp_db):
         assert active["terminal_id"] == "term-new"
     finally:
         repo.close()
+
+
+def test_sqlite_lease_repo_delete_no_longer_carries_legacy_snapshot_cleanup_shell():
+    source = inspect.getsource(SQLiteLeaseRepo.delete)
+
+    assert "lease_resource_snapshots" not in source
 
 
 def test_remote_runtime_treats_daytona_pty_1011_as_infra_error():


### PR DESCRIPTION
## Summary
- remove the stale sqlite lease cleanup SQL that still referenced `lease_resource_snapshots`
- keep sqlite/local cleanup behavior intact for active callers while dropping the obsolete snapshot cleanup shell
- add a focused runtime test to pin that the legacy cleanup shell is gone

## Verification
- uv run python -m pytest -q tests/Unit/core/test_runtime.py -k legacy_snapshot_cleanup_shell
- uv run python -m pytest -q tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_service_session_mutation.py tests/Unit/sandbox/test_sandbox_service_cleanup.py
- uv run ruff check storage/providers/sqlite/lease_repo.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_service_session_mutation.py tests/Unit/sandbox/test_sandbox_service_cleanup.py