### PR TITLE
refactor: drop create-time snapshot probe callsite

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -943,18 +943,6 @@ class SQLiteLease(SandboxLease):
                     source="run.create",
                     payload={"created": True, "instance_id": session_info.session_id},
                 )
-            from sandbox.resource_snapshot import probe_and_upsert_for_instance
-
-            probe_result = probe_and_upsert_for_instance(
-                lease_id=self.lease_id,
-                provider_name=self.provider_name,
-                observed_state=self.observed_state,
-                probe_mode="create_running",
-                provider=provider,
-                instance_id=session_info.session_id,
-            )
-            if not probe_result["ok"]:
-                print(f"[lease:{self.lease_id}] create probe error: {probe_result['error']}")
             if not self._current_instance:
                 raise RuntimeError(f"Lease {self.lease_id}: failed to bind created instance")
             return self._current_instance

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -13,7 +13,7 @@ import pytest
 
 from sandbox.chat_session import ChatSessionManager
 from sandbox.interfaces.executor import ExecuteResult
-from sandbox.lease import SandboxInstance, lease_from_row
+from sandbox.lease import SandboxInstance, SQLiteLease, lease_from_row
 from sandbox.provider import ProviderExecResult
 from sandbox.providers.local import LocalPersistentShellRuntime
 from sandbox.runtime import (
@@ -126,6 +126,13 @@ def test_sqlite_lease_repo_delete_no_longer_carries_legacy_snapshot_cleanup_shel
     source = inspect.getsource(SQLiteLeaseRepo.delete)
 
     assert "lease_resource_snapshots" not in source
+
+
+def test_sqlite_lease_ensure_active_instance_no_longer_carries_create_snapshot_probe():
+    source = inspect.getsource(SQLiteLease.ensure_active_instance)
+
+    assert "probe_and_upsert_for_instance" not in source
+    assert "create_running" not in source
 
 
 def test_remote_runtime_treats_daytona_pty_1011_as_infra_error():


### PR DESCRIPTION
## Summary
- remove the create-time snapshot probe callsite from `SQLiteLease.ensure_active_instance`
- keep the later sandbox-shaped refresh/probe path intact
- add focused proof that the create-time lease path no longer carries the snapshot probe shell

## Verification
- `uv run python -m pytest -q tests/Unit/core/test_runtime.py -k create_snapshot_probe`
- `uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k "refresh_resource_snapshots or probe_and_upsert_for_instance"`
- `uv run ruff check sandbox/lease.py tests/Unit/core/test_runtime.py tests/Unit/monitor/test_monitor_resource_probe.py`
- `git diff --check`
