### PR TITLE
refactor: contract snapshot helper fallback

### DIFF
--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -47,43 +47,6 @@ def upsert_resource_snapshot_for_sandbox(
         repo.close()
 
 
-def _upsert_lease_resource_snapshot(
-    *,
-    lease_id: str,
-    provider_name: str,
-    observed_state: str,
-    probe_mode: str,
-    cpu_used: float | None = None,
-    cpu_limit: float | None = None,
-    memory_used_mb: float | None = None,
-    memory_total_mb: float | None = None,
-    disk_used_gb: float | None = None,
-    disk_total_gb: float | None = None,
-    network_rx_kbps: float | None = None,
-    network_tx_kbps: float | None = None,
-    probe_error: str | None = None,
-) -> None:
-    repo = build_resource_snapshot_repo()
-    try:
-        repo.upsert_lease_resource_snapshot(
-            lease_id=lease_id,
-            provider_name=provider_name,
-            observed_state=observed_state,
-            probe_mode=probe_mode,
-            cpu_used=cpu_used,
-            cpu_limit=cpu_limit,
-            memory_used_mb=memory_used_mb,
-            memory_total_mb=memory_total_mb,
-            disk_used_gb=disk_used_gb,
-            disk_total_gb=disk_total_gb,
-            network_rx_kbps=network_rx_kbps,
-            network_tx_kbps=network_tx_kbps,
-            probe_error=probe_error,
-        )
-    finally:
-        repo.close()
-
-
 __all__ = [
     "upsert_resource_snapshot_for_sandbox",
     "probe_and_upsert_for_instance",
@@ -117,6 +80,9 @@ def probe_and_upsert_for_instance(
     repo: Any | None = None,
 ) -> dict[str, Any]:
     """Probe provider metrics and persist to storage."""
+    if not sandbox_id:
+        return {"ok": False, "error": "sandbox-shaped snapshot helper requires sandbox_id"}
+
     metrics = None
     cpu_used = None
     cpu_limit = None
@@ -178,43 +144,22 @@ def probe_and_upsert_for_instance(
                 probe_error=probe_error,
             )
         else:
-            # @@@snapshot-runtime-active-path - mainline runtime/helper flow should prefer
-            # sandbox-shaped write entry when sandbox_id is already present; the lease-shaped
-            # helper remains only as compatibility residue for callers that still lack sandbox truth.
-            if sandbox_id:
-                upsert_resource_snapshot_for_sandbox(
-                    sandbox_id=sandbox_id,
-                    legacy_lease_id=lease_id,
-                    provider_name=provider_name,
-                    observed_state=observed_state,
-                    probe_mode=probe_mode,
-                    cpu_used=cpu_used,
-                    cpu_limit=cpu_limit,
-                    memory_used_mb=memory_used_mb,
-                    memory_total_mb=memory_total_mb,
-                    disk_used_gb=disk_used_gb,
-                    disk_total_gb=disk_total_gb,
-                    network_rx_kbps=network_rx_kbps,
-                    network_tx_kbps=network_tx_kbps,
-                    probe_error=probe_error,
-                )
-            else:
-                upsert = repo.upsert_lease_resource_snapshot if repo is not None else _upsert_lease_resource_snapshot
-                upsert(
-                    lease_id=lease_id,
-                    provider_name=provider_name,
-                    observed_state=observed_state,
-                    probe_mode=probe_mode,
-                    cpu_used=cpu_used,
-                    cpu_limit=cpu_limit,
-                    memory_used_mb=memory_used_mb,
-                    memory_total_mb=memory_total_mb,
-                    disk_used_gb=disk_used_gb,
-                    disk_total_gb=disk_total_gb,
-                    network_rx_kbps=network_rx_kbps,
-                    network_tx_kbps=network_tx_kbps,
-                    probe_error=probe_error,
-                )
+            upsert_resource_snapshot_for_sandbox(
+                sandbox_id=sandbox_id,
+                legacy_lease_id=lease_id,
+                provider_name=provider_name,
+                observed_state=observed_state,
+                probe_mode=probe_mode,
+                cpu_used=cpu_used,
+                cpu_limit=cpu_limit,
+                memory_used_mb=memory_used_mb,
+                memory_total_mb=memory_total_mb,
+                disk_used_gb=disk_used_gb,
+                disk_total_gb=disk_total_gb,
+                network_rx_kbps=network_rx_kbps,
+                network_tx_kbps=network_tx_kbps,
+                probe_error=probe_error,
+            )
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
     return {"ok": probe_error is None, "error": probe_error}

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1059,7 +1059,6 @@ async def test_run_agent_reuses_parent_lease_for_child_thread_terminal(monkeypat
         db_path=temp_db,
     )
     monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(temp_db))
-    monkeypatch.setattr("sandbox.resource_snapshot._upsert_lease_resource_snapshot", lambda **_kwargs: None)
     monkeypatch.setattr(manager, "_setup_mounts", lambda thread_id: {"source": object(), "remote_path": str(tmp_path)})
     monkeypatch.setattr(manager, "_sync_to_sandbox", lambda *args, **kwargs: None)
 

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -60,6 +60,7 @@ def test_resource_snapshot_adapter_no_longer_exposes_lease_shaped_write_shell() 
 
 def test_resource_snapshot_module_no_longer_exposes_lease_shaped_write_helper() -> None:
     assert not hasattr(resource_snapshot, "upsert_lease_resource_snapshot")
+    assert not hasattr(resource_snapshot, "_upsert_lease_resource_snapshot")
 
 
 def test_probe_and_upsert_for_instance_accepts_sandbox_shaped_repo() -> None:
@@ -104,11 +105,6 @@ def test_probe_and_upsert_for_instance_without_repo_prefers_sandbox_shaped_helpe
         captured.append(kwargs)
 
     monkeypatch.setattr(resource_snapshot, "upsert_resource_snapshot_for_sandbox", _fake_upsert_resource_snapshot_for_sandbox)
-    monkeypatch.setattr(
-        resource_snapshot,
-        "_upsert_lease_resource_snapshot",
-        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("lease-shaped helper should not be the active path")),
-    )
 
     result = resource_snapshot.probe_and_upsert_for_instance(
         sandbox_id="sandbox-1",
@@ -140,6 +136,20 @@ def test_probe_and_upsert_for_instance_without_repo_prefers_sandbox_shaped_helpe
             "probe_error": "metrics unavailable",
         }
     ]
+
+
+def test_probe_and_upsert_for_instance_requires_sandbox_id() -> None:
+    result = resource_snapshot.probe_and_upsert_for_instance(
+        lease_id="lease-1",
+        provider_name="p1",
+        observed_state="detached",
+        probe_mode="running_runtime",
+        provider=_FakeProvider(),
+        instance_id="instance-1",
+        repo=None,
+    )
+
+    assert result == {"ok": False, "error": "sandbox-shaped snapshot helper requires sandbox_id"}
 
 
 def test_refresh_resource_snapshots_routes_successful_probe_through_sandbox_wrapper(monkeypatch):

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -501,7 +501,6 @@ def test_sync_uploads_skips_local_volume_sync_when_lease_has_no_volume_id():
 
 
 def test_get_sandbox_local_provider_does_not_require_volume_bootstrap(tmp_path, monkeypatch):
-    monkeypatch.setattr("sandbox.resource_snapshot._upsert_lease_resource_snapshot", lambda **_kwargs: None)
     manager = SandboxManager(
         provider=LocalSessionProvider(default_cwd=str(tmp_path)),
         db_path=tmp_path / "sandbox.db",


### PR DESCRIPTION
## Summary
- contract `sandbox.resource_snapshot` to require `sandbox_id` on the active helper path
- remove the helper-level lease-shaped fallback write shell
- clean up adjacent tests that were only monkeypatching the removed private fallback

## Verification
- `uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k "requires_sandbox_id or refresh_resource_snapshots or probe_and_upsert_for_instance or no_longer_exposes_lease_shaped_write_helper"`
- `uv run python -m pytest -q tests/Unit/core/test_agent_service.py -k reuses_parent_lease_for_child_thread_terminal`
- `uv run python -m pytest -q tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -k local_provider_does_not_require_volume_bootstrap`
- `uv run ruff check sandbox/resource_snapshot.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/core/test_agent_service.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
- `git diff --check`
