### PR TITLE
refactor: contract snapshot write bridge

### DIFF
--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -196,7 +196,6 @@ def refresh_resource_snapshots() -> dict[str, Any]:
         if provider is None:
             upsert_resource_snapshot_for_sandbox(
                 sandbox_id=sandbox_id,
-                legacy_lease_id=lease_id,
                 provider_name=provider_key,
                 observed_state=status,
                 probe_mode=probe_mode,

--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -11,7 +11,6 @@ from storage.runtime import build_resource_snapshot_repo
 def upsert_resource_snapshot_for_sandbox(
     *,
     sandbox_id: str,
-    legacy_lease_id: str,
     provider_name: str,
     observed_state: str,
     probe_mode: str,
@@ -29,7 +28,6 @@ def upsert_resource_snapshot_for_sandbox(
     try:
         repo.upsert_resource_snapshot_for_sandbox(
             sandbox_id=sandbox_id,
-            legacy_lease_id=legacy_lease_id,
             provider_name=provider_name,
             observed_state=observed_state,
             probe_mode=probe_mode,
@@ -129,7 +127,6 @@ def probe_and_upsert_for_instance(
                 raise RuntimeError("sandbox-shaped snapshot repo requires sandbox_id")
             repo.upsert_resource_snapshot_for_sandbox(
                 sandbox_id=sandbox_id,
-                legacy_lease_id=lease_id,
                 provider_name=provider_name,
                 observed_state=observed_state,
                 probe_mode=probe_mode,
@@ -146,7 +143,6 @@ def probe_and_upsert_for_instance(
         else:
             upsert_resource_snapshot_for_sandbox(
                 sandbox_id=sandbox_id,
-                legacy_lease_id=lease_id,
                 provider_name=provider_name,
                 observed_state=observed_state,
                 probe_mode=probe_mode,

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -642,7 +642,6 @@ class ResourceSnapshotRepo(Protocol):
         self,
         *,
         sandbox_id: str,
-        legacy_lease_id: str,
         provider_name: str,
         observed_state: str,
         probe_mode: str,

--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -112,7 +112,6 @@ class SupabaseResourceSnapshotRepo:
         self,
         *,
         sandbox_id: str,
-        legacy_lease_id: str,
         provider_name: str,
         observed_state: str,
         probe_mode: str,

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -175,7 +175,6 @@ def list_resource_snapshots_by_sandbox(
 def upsert_resource_snapshot_for_sandbox(
     *,
     sandbox_id: str,
-    legacy_lease_id: str,
     provider_name: str,
     observed_state: str,
     probe_mode: str,
@@ -193,8 +192,6 @@ def upsert_resource_snapshot_for_sandbox(
 ) -> None:
     if not sandbox_id:
         raise RuntimeError("Resource snapshot write requires sandbox_id.")
-    if not legacy_lease_id:
-        raise RuntimeError("Resource snapshot write requires legacy_lease_id bridge.")
 
     repo = build_resource_snapshot_repo(
         supabase_client=supabase_client,
@@ -205,7 +202,6 @@ def upsert_resource_snapshot_for_sandbox(
             raise RuntimeError("sandbox-shaped snapshot repo write requires upsert_resource_snapshot_for_sandbox")
         repo.upsert_resource_snapshot_for_sandbox(
             sandbox_id=sandbox_id,
-            legacy_lease_id=legacy_lease_id,
             provider_name=provider_name,
             observed_state=observed_state,
             probe_mode=probe_mode,

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -34,6 +34,9 @@ class _FakeSandboxSnapshotRepo:
     def __init__(self) -> None:
         self.upserts: list[dict] = []
 
+    def close(self) -> None:
+        return None
+
     def upsert_resource_snapshot_for_sandbox(self, **kwargs):
         self.upserts.append(kwargs)
 
@@ -45,11 +48,40 @@ def test_upsert_resource_snapshot_for_sandbox_requires_repo_sandbox_wrapper(monk
     with pytest.raises(RuntimeError, match="sandbox-shaped snapshot repo write requires upsert_resource_snapshot_for_sandbox"):
         storage_runtime.upsert_resource_snapshot_for_sandbox(
             sandbox_id="sandbox-1",
-            legacy_lease_id="lease-1",
             provider_name="p1",
             observed_state="detached",
             probe_mode="running_runtime",
         )
+
+
+def test_upsert_resource_snapshot_for_sandbox_no_longer_requires_legacy_lease_bridge(monkeypatch) -> None:
+    repo = _FakeSandboxSnapshotRepo()
+    monkeypatch.setattr(storage_runtime, "build_resource_snapshot_repo", lambda **_kwargs: repo)
+
+    storage_runtime.upsert_resource_snapshot_for_sandbox(
+        sandbox_id="sandbox-1",
+        provider_name="p1",
+        observed_state="detached",
+        probe_mode="running_runtime",
+    )
+
+    assert repo.upserts == [
+        {
+            "sandbox_id": "sandbox-1",
+            "provider_name": "p1",
+            "observed_state": "detached",
+            "probe_mode": "running_runtime",
+            "cpu_used": None,
+            "cpu_limit": None,
+            "memory_used_mb": None,
+            "memory_total_mb": None,
+            "disk_used_gb": None,
+            "disk_total_gb": None,
+            "network_rx_kbps": None,
+            "network_tx_kbps": None,
+            "probe_error": None,
+        }
+    ]
 
 
 def test_resource_snapshot_adapter_no_longer_exposes_lease_shaped_write_shell() -> None:
@@ -81,7 +113,6 @@ def test_probe_and_upsert_for_instance_accepts_sandbox_shaped_repo() -> None:
     assert repo.upserts == [
         {
             "sandbox_id": "sandbox-1",
-            "legacy_lease_id": "lease-1",
             "provider_name": "p1",
             "observed_state": "detached",
             "probe_mode": "running_runtime",
@@ -121,7 +152,6 @@ def test_probe_and_upsert_for_instance_without_repo_prefers_sandbox_shaped_helpe
     assert captured == [
         {
             "sandbox_id": "sandbox-1",
-            "legacy_lease_id": "lease-1",
             "provider_name": "p1",
             "observed_state": "detached",
             "probe_mode": "running_runtime",
@@ -184,7 +214,6 @@ def test_refresh_resource_snapshots_routes_successful_probe_through_sandbox_wrap
     assert captured == [
         {
             "sandbox_id": "sandbox-1",
-            "legacy_lease_id": "l-1",
             "provider_name": "p1",
             "observed_state": "detached",
             "probe_mode": "running_runtime",
@@ -276,7 +305,6 @@ def test_refresh_resource_snapshots_counts_provider_build_error(monkeypatch):
     assert captured == [
         {
             "sandbox_id": "sandbox-1",
-            "legacy_lease_id": "l-1",
             "provider_name": "p-missing",
             "observed_state": "detached",
             "probe_mode": "running_runtime",

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -43,7 +43,6 @@ def test_supabase_resource_snapshot_repo_upserts_for_sandbox_without_lease_shape
 
     repo.upsert_resource_snapshot_for_sandbox(
         sandbox_id="sandbox-1",
-        legacy_lease_id="lease-1",
         provider_name="daytona",
         observed_state="running",
         probe_mode="runtime",


### PR DESCRIPTION
## Summary
- remove the remaining `legacy_lease_id` bridge parameter from the active sandbox-shaped snapshot write path
- align runtime/helper/repo write contracts with current `sandbox_resource_snapshots` persistence truth
- keep read path and monitor lanes untouched

## Verification
- `uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k "no_longer_requires_legacy_lease_bridge or refresh_resource_snapshots or probe_and_upsert_for_instance" tests/Unit/storage/test_supabase_resource_snapshot_repo.py -q`
- `uv run ruff check storage/contracts.py storage/runtime.py storage/providers/supabase/resource_snapshot_repo.py sandbox/resource_snapshot.py backend/web/services/resource_service.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py`
- `git diff --check`
