### PR TITLE
refactor: contract snapshot repo impl shell

### DIFF
--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -74,33 +74,6 @@ def list_snapshots_by_sandbox_ids(
     return {str(r["sandbox_id"]): dict(r) for r in rows}
 
 
-def upsert_lease_resource_snapshot(
-    *,
-    lease_id: str,
-    provider_name: str,
-    observed_state: str,
-    probe_mode: str,
-    cpu_used: float | None = None,
-    cpu_limit: float | None = None,
-    memory_used_mb: float | None = None,
-    memory_total_mb: float | None = None,
-    disk_used_gb: float | None = None,
-    disk_total_gb: float | None = None,
-    network_rx_kbps: float | None = None,
-    network_tx_kbps: float | None = None,
-    probe_error: str | None = None,
-    client: Any = None,
-) -> None:
-    raise RuntimeError("lease-shaped snapshot repo write is no longer supported")
-
-
-def list_snapshots_by_lease_ids(
-    lease_ids: list[str],
-    client: Any = None,
-) -> dict[str, dict[str, Any]]:
-    raise RuntimeError("lease-shaped snapshot repo read is no longer supported")
-
-
 class SupabaseResourceSnapshotRepo:
     def __init__(self, client: Any) -> None:
         self._client = client
@@ -144,40 +117,6 @@ class SupabaseResourceSnapshotRepo:
             client=self._client,
         )
 
-    def upsert_lease_resource_snapshot(
-        self,
-        *,
-        lease_id: str,
-        provider_name: str,
-        observed_state: str,
-        probe_mode: str,
-        cpu_used: float | None = None,
-        cpu_limit: float | None = None,
-        memory_used_mb: float | None = None,
-        memory_total_mb: float | None = None,
-        disk_used_gb: float | None = None,
-        disk_total_gb: float | None = None,
-        network_rx_kbps: float | None = None,
-        network_tx_kbps: float | None = None,
-        probe_error: str | None = None,
-    ) -> None:
-        upsert_lease_resource_snapshot(
-            lease_id=lease_id,
-            provider_name=provider_name,
-            observed_state=observed_state,
-            probe_mode=probe_mode,
-            cpu_used=cpu_used,
-            cpu_limit=cpu_limit,
-            memory_used_mb=memory_used_mb,
-            memory_total_mb=memory_total_mb,
-            disk_used_gb=disk_used_gb,
-            disk_total_gb=disk_total_gb,
-            network_rx_kbps=network_rx_kbps,
-            network_tx_kbps=network_tx_kbps,
-            probe_error=probe_error,
-            client=self._client,
-        )
-
     def list_snapshots_by_sandbox_ids(self, sessions: list[dict[str, str]]) -> dict[str, dict[str, Any]]:
         sandbox_ids: list[str] = []
         for session in sessions:
@@ -187,6 +126,3 @@ class SupabaseResourceSnapshotRepo:
             sandbox_ids.append(sandbox_id)
 
         return list_snapshots_by_sandbox_ids(sandbox_ids, client=self._client)
-
-    def list_snapshots_by_lease_ids(self, lease_ids: list[str]) -> dict[str, dict[str, Any]]:
-        return list_snapshots_by_lease_ids(lease_ids, client=self._client)

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -90,3 +90,10 @@ def test_resource_snapshot_repo_protocol_no_longer_declares_lease_shaped_methods
 def test_supabase_provider_package_no_longer_exports_lease_shaped_snapshot_helpers() -> None:
     assert not hasattr(supabase_provider, "upsert_lease_resource_snapshot")
     assert not hasattr(supabase_provider, "list_snapshots_by_lease_ids")
+
+
+def test_supabase_resource_snapshot_repo_instance_no_longer_exposes_lease_shaped_methods() -> None:
+    repo = SupabaseResourceSnapshotRepo(_FakeClient())
+
+    assert not hasattr(repo, "upsert_lease_resource_snapshot")
+    assert not hasattr(repo, "list_snapshots_by_lease_ids")


### PR DESCRIPTION
## Summary
- remove dead lease-shaped helpers from `storage.providers.supabase.resource_snapshot_repo`
- remove matching dead shell methods from `SupabaseResourceSnapshotRepo`
- keep sandbox-shaped snapshot read/write surface unchanged

## Verification
- `uv run python -m pytest -q tests/Unit/storage/test_supabase_resource_snapshot_repo.py`
- `uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k "list_resource_snapshots_by_sandbox_requires_repo_sandbox_wrapper or list_resource_snapshots_by_sandbox_prefers_repo_sandbox_wrapper"`
- `uv run ruff check storage/providers/supabase/resource_snapshot_repo.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py`
- `git diff --check`
