### PR TITLE
refactor: contract monitor instance bridge

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -189,9 +189,38 @@ class SupabaseSandboxMonitorRepo:
         if not ordered_ids:
             return {}
 
-        sandbox_rows = {sandbox_id: self.query_sandbox(sandbox_id) for sandbox_id in ordered_ids}
-        lease_ids = [str(row.get("lease_id") or "").strip() for row in sandbox_rows.values() if row is not None]
-        lease_instance_ids = self.query_lease_instance_ids(lease_ids)
+        sandbox_rows = {
+            str(sandbox.get("id") or "").strip(): sandbox
+            for sandbox in self._ordered_sandboxes("query_sandbox_instance_ids")
+            if str(sandbox.get("id") or "").strip() in ordered_ids
+        }
+
+        instance_by_lease: dict[str, str | None] = {}
+        lease_ids = []
+        for sandbox_id in ordered_ids:
+            sandbox = sandbox_rows.get(sandbox_id)
+            if sandbox is None:
+                continue
+            lease = self._lease_row_from_sandbox(sandbox)
+            lease_id = str(lease.get("lease_id") or "").strip()
+            if not lease_id:
+                continue
+            lease_ids.append(lease_id)
+            instance_by_lease[lease_id] = None
+
+        if lease_ids:
+            instances = q.rows_in_chunks(
+                lambda: self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
+                "lease_id",
+                lease_ids,
+                _REPO,
+                "query_sandbox_instance_ids instances",
+            )
+            for row in instances:
+                lease_id = str(row.get("lease_id") or "").strip()
+                provider_session_id = str(row.get("provider_session_id") or "").strip()
+                if lease_id and provider_session_id:
+                    instance_by_lease[lease_id] = provider_session_id
 
         result: dict[str, str | None] = {}
         for sandbox_id in ordered_ids:
@@ -199,7 +228,13 @@ class SupabaseSandboxMonitorRepo:
             if sandbox is None:
                 result[sandbox_id] = None
                 continue
-            result[sandbox_id] = lease_instance_ids.get(str(sandbox.get("lease_id") or "").strip())
+            lease = self._lease_row_from_sandbox(sandbox)
+            lease_id = str(lease.get("lease_id") or "").strip()
+            result[sandbox_id] = instance_by_lease.get(lease_id)
+            if result[sandbox_id]:
+                continue
+            provider_env_id = str(sandbox.get("provider_env_id") or "").strip()
+            result[sandbox_id] = provider_env_id or None
         return result
 
     def query_lease_events(self, lease_id: str) -> list[dict]:

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -520,7 +520,9 @@ def test_query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge(mo
     monkeypatch.setattr(
         repo,
         "query_lease_instance_ids",
-        lambda _lease_ids: (_ for _ in ()).throw(AssertionError("sandbox-shaped instance lookup should not roundtrip through query_lease_instance_ids")),
+        lambda _lease_ids: (_ for _ in ()).throw(
+            AssertionError("sandbox-shaped instance lookup should not roundtrip through query_lease_instance_ids")
+        ),
     )
 
     assert repo.query_sandbox_instance_ids(["sandbox-1", "sandbox-2"]) == {

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -504,6 +504,31 @@ def test_query_sandbox_instance_ids_uses_legacy_bridge() -> None:
     }
 
 
+def test_query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", legacy_lease_id="lease-1"),
+                _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", legacy_lease_id="lease-2"),
+            ],
+            "sandbox_instances": [
+                {"lease_id": "lease-2", "provider_session_id": "provider-session-2"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "query_lease_instance_ids",
+        lambda _lease_ids: (_ for _ in ()).throw(AssertionError("sandbox-shaped instance lookup should not roundtrip through query_lease_instance_ids")),
+    )
+
+    assert repo.query_sandbox_instance_ids(["sandbox-1", "sandbox-2"]) == {
+        "sandbox-1": "sandbox-instance-1",
+        "sandbox-2": "provider-session-2",
+    }
+
+
 def test_query_lease_events_requires_sandbox_bridge() -> None:
     repo = _repo(
         {


### PR DESCRIPTION
## Summary
- stop `query_sandbox_instance_ids()` from roundtripping through the lease-first instance bridge
- resolve sandbox-shaped instance lookup directly inside `SupabaseSandboxMonitorRepo`
- keep broader lease/thread/event monitor surfaces untouched

## Verification
- `uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k "no_longer_roundtrips_through_lease_bridge or query_sandbox_instance_ids_uses_legacy_bridge or query_lease_instance_ids_chunks_large_lookup"`
- `uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py`
- `git diff --check`
