### PR TITLE
refactor: contract monitor probe target bridge

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -323,12 +323,15 @@ class SupabaseSandboxMonitorRepo:
             if lease.get("observed_state") in {"running", "detached", "paused"}
         ]
 
-        instance_map = self.query_lease_instance_ids([lease["lease_id"] for lease in leases])
+        instance_map = self.query_sandbox_instance_ids(
+            [sandbox_id for sandbox_id in (lease.get("sandbox_id") for lease in leases) if sandbox_id]
+        )
 
         targets = []
         for lease in leases:
             lid = lease["lease_id"]
-            instance_id = instance_map.get(lid) or lease.get("current_instance_id") or ""
+            sandbox_id = str(lease.get("sandbox_id") or "").strip()
+            instance_id = instance_map.get(sandbox_id) or lease.get("current_instance_id") or ""
             if lid and lease.get("provider_name") and instance_id:
                 targets.append(
                     {

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -620,6 +620,59 @@ def test_list_probe_targets_prefers_provider_session_id() -> None:
     ]
 
 
+def test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-running",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-lease",
+                    observed_state="detached",
+                    updated_at="2026-04-05T10:10:00",
+                    legacy_lease_id="lease-running",
+                ),
+                _sandbox(
+                    "sandbox-paused",
+                    provider_env_id="instance-local",
+                    desired_state="paused",
+                    observed_state="paused",
+                    updated_at="2026-04-05T10:11:00",
+                    legacy_lease_id="lease-paused",
+                ),
+            ],
+            "sandbox_instances": [
+                {"lease_id": "lease-running", "provider_session_id": "provider-session-1"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "query_lease_instance_ids",
+        lambda lease_ids: (_ for _ in ()).throw(
+            AssertionError("probe-target assembly should not roundtrip through query_lease_instance_ids")
+        ),
+    )
+
+    assert repo.list_probe_targets() == [
+        {
+            "sandbox_id": "sandbox-paused",
+            "legacy_lease_id": "lease-paused",
+            "provider_name": "local",
+            "instance_id": "instance-local",
+            "observed_state": "paused",
+        },
+        {
+            "sandbox_id": "sandbox-running",
+            "legacy_lease_id": "lease-running",
+            "provider_name": "daytona_selfhost",
+            "instance_id": "provider-session-1",
+            "observed_state": "detached",
+        },
+    ]
+
+
 @pytest.mark.parametrize(
     ("include_updated_at", "caller"),
     [


### PR DESCRIPTION
## Summary
- route probe target assembly through the sandbox-shaped instance lookup
- add focused proof that list_probe_targets no longer roundtrips through query_lease_instance_ids
- keep broader lease/thread/event monitor surfaces untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k no_longer_roundtrips_through_lease_instance_bridge
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'no_longer_roundtrips_through_lease_instance_bridge or list_probe_targets_prefers_provider_session_id or query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge or query_lease_instance_ids_chunks_large_lookup'
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check