### PR TITLE
refactor: contract monitor thread session shell

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -35,7 +35,8 @@ class SupabaseSandboxMonitorRepo:
         if not sessions:
             return []
 
-        lease_map = self._sandboxes_by_legacy_lease_id("query_threads")
+        sandbox_rows = self._sandbox_rows_by_legacy_lease_id("query_threads")
+        lease_map = {lease_id: self._lease_row_from_sandbox(sandbox) for lease_id, sandbox in sandbox_rows.items()}
 
         # Aggregate per thread_id
         by_thread: dict[str, dict] = {}
@@ -82,7 +83,8 @@ class SupabaseSandboxMonitorRepo:
         if not sessions:
             return []
 
-        lease_map = self._sandboxes_by_legacy_lease_id("query_thread_sessions")
+        sandbox_rows = self._sandbox_rows_by_legacy_lease_id("query_thread_sessions")
+        lease_map = {lease_id: self._lease_row_from_sandbox(sandbox) for lease_id, sandbox in sandbox_rows.items()}
         return [self._session_with_lease(s, lease_map.get(s.get("lease_id") or "")) for s in sessions]
 
     def query_sandboxes(self) -> list[dict]:

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -155,6 +155,45 @@ def test_query_threads_accepts_optional_thread_filter() -> None:
     ]
 
 
+def test_query_threads_no_longer_roundtrips_through_lease_summary_shell(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_env_id="instance-1",
+                    legacy_lease_id="lease-1",
+                )
+            ],
+            "chat_sessions": [
+                _session("sess-1", "thread-1", "lease-1", last_active_at="2026-04-05T10:01:00"),
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "_sandboxes_by_legacy_lease_id",
+        lambda operation: (_ for _ in ()).throw(
+            AssertionError("query_threads should not roundtrip through _sandboxes_by_legacy_lease_id")
+        ),
+    )
+
+    assert repo.query_threads() == [
+        {
+            "thread_id": "thread-1",
+            "session_count": 1,
+            "sandbox_id": "sandbox-1",
+            "last_active": "2026-04-05T10:01:00",
+            "lease_id": "lease-1",
+            "provider_name": "local",
+            "desired_state": "running",
+            "observed_state": "running",
+            "current_instance_id": "instance-1",
+        }
+    ]
+
+
 def test_query_threads_chunks_lease_lookup() -> None:
     sessions = [
         _session(f"sess-{index}", f"thread-{index}", f"lease-{index}", last_active_at=f"2026-04-05T10:{index % 60:02d}:00")
@@ -264,6 +303,56 @@ def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
                 }
             ],
         }
+    )
+
+    assert repo.query_thread_sessions("thread-1") == [
+        {
+            "chat_session_id": "sess-1",
+            "status": "active",
+            "started_at": "2026-04-05T10:01:00",
+            "ended_at": None,
+            "close_reason": None,
+            "sandbox_id": "sandbox-1",
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "desired_state": "paused",
+            "observed_state": "paused",
+            "current_instance_id": "instance-1",
+            "last_error": "last boom",
+        }
+    ]
+
+
+def test_query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    legacy_lease_id="lease-1",
+                    last_error="last boom",
+                )
+            ],
+            "chat_sessions": [
+                {
+                    **_session("sess-1", "thread-1", "lease-1", started_at="2026-04-05T10:01:00"),
+                    "ended_at": None,
+                    "close_reason": None,
+                }
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "_sandboxes_by_legacy_lease_id",
+        lambda operation: (_ for _ in ()).throw(
+            AssertionError("query_thread_sessions should not roundtrip through _sandboxes_by_legacy_lease_id")
+        ),
     )
 
     assert repo.query_thread_sessions("thread-1") == [

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -174,9 +174,7 @@ def test_query_threads_no_longer_roundtrips_through_lease_summary_shell(monkeypa
     monkeypatch.setattr(
         repo,
         "_sandboxes_by_legacy_lease_id",
-        lambda operation: (_ for _ in ()).throw(
-            AssertionError("query_threads should not roundtrip through _sandboxes_by_legacy_lease_id")
-        ),
+        lambda operation: (_ for _ in ()).throw(AssertionError("query_threads should not roundtrip through _sandboxes_by_legacy_lease_id")),
     )
 
     assert repo.query_threads() == [


### PR DESCRIPTION
## Summary
- route query_threads and query_thread_sessions through sandbox rows instead of the lease summary shell
- add focused proof that both paths no longer roundtrip through _sandboxes_by_legacy_lease_id
- keep broader lease event/thread/session aggregation surfaces untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_threads_no_longer_roundtrips_through_lease_summary_shell or query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_threads_no_longer_roundtrips_through_lease_summary_shell or query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell or query_threads_accepts_optional_thread_filter or query_thread_sessions_reads_container_sandbox_rows or query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge or list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge'
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check