### PR TITLE
refactor: contract monitor lease session shell

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -134,7 +134,23 @@ class SupabaseSandboxMonitorRepo:
         sandbox = self.query_sandbox(sandbox_id)
         if sandbox is None:
             return []
-        return self.query_lease_sessions(str(sandbox.get("lease_id") or ""))
+        lease_id = str(sandbox.get("lease_id") or "").strip()
+        if not lease_id:
+            return []
+        sessions = q.rows(
+            q.order(
+                self._client.table("chat_sessions")
+                .select("chat_session_id,thread_id,status,started_at,ended_at,close_reason,lease_id")
+                .eq("lease_id", lease_id),
+                "started_at",
+                desc=True,
+                repo=_REPO,
+                operation="query_sandbox_sessions",
+            ).execute(),
+            _REPO,
+            "query_sandbox_sessions",
+        )
+        return [self._session_with_lease(session, sandbox, include_thread=True) for session in sessions]
 
     def query_lease_sessions(self, lease_id: str) -> list[dict]:
         sessions = q.rows(
@@ -150,7 +166,8 @@ class SupabaseSandboxMonitorRepo:
             _REPO,
             "query_lease_sessions",
         )
-        lease = self.query_lease(lease_id)
+        sandbox_rows = self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_sessions")
+        lease = self._lease_row_from_sandbox(sandbox_rows[lease_id])
         return [self._session_with_lease(session, lease, include_thread=True) for session in sessions]
 
     def query_sandbox_threads(self, sandbox_id: str) -> list[dict]:

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -321,6 +321,108 @@ def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
     ]
 
 
+def test_query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    legacy_lease_id="lease-1",
+                    last_error="last boom",
+                )
+            ],
+            "chat_sessions": [
+                {
+                    **_session("sess-1", "thread-1", "lease-1", started_at="2026-04-05T10:01:00"),
+                    "ended_at": None,
+                    "close_reason": None,
+                }
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "query_lease_sessions",
+        lambda lease_id: (_ for _ in ()).throw(
+            AssertionError("query_sandbox_sessions should not roundtrip through query_lease_sessions")
+        ),
+    )
+
+    assert repo.query_sandbox_sessions("sandbox-1") == [
+        {
+            "chat_session_id": "sess-1",
+            "status": "active",
+            "started_at": "2026-04-05T10:01:00",
+            "ended_at": None,
+            "close_reason": None,
+            "sandbox_id": "sandbox-1",
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "desired_state": "paused",
+            "observed_state": "paused",
+            "current_instance_id": "instance-1",
+            "last_error": "last boom",
+            "thread_id": "thread-1",
+        }
+    ]
+
+
+def test_query_lease_sessions_no_longer_roundtrips_through_query_lease(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    provider_name="daytona_selfhost",
+                    provider_env_id="instance-1",
+                    desired_state="paused",
+                    observed_state="paused",
+                    legacy_lease_id="lease-1",
+                    last_error="last boom",
+                )
+            ],
+            "chat_sessions": [
+                {
+                    **_session("sess-1", "thread-1", "lease-1", started_at="2026-04-05T10:01:00"),
+                    "ended_at": None,
+                    "close_reason": None,
+                }
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "query_lease",
+        lambda lease_id: (_ for _ in ()).throw(
+            AssertionError("query_lease_sessions should not roundtrip through query_lease")
+        ),
+    )
+
+    assert repo.query_lease_sessions("lease-1") == [
+        {
+            "chat_session_id": "sess-1",
+            "status": "active",
+            "started_at": "2026-04-05T10:01:00",
+            "ended_at": None,
+            "close_reason": None,
+            "sandbox_id": "sandbox-1",
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "desired_state": "paused",
+            "observed_state": "paused",
+            "current_instance_id": "instance-1",
+            "last_error": "last boom",
+            "thread_id": "thread-1",
+        }
+    ]
+
+
 def test_query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell(monkeypatch) -> None:
     repo = _repo(
         {

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -348,9 +348,7 @@ def test_query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell
     monkeypatch.setattr(
         repo,
         "query_lease_sessions",
-        lambda lease_id: (_ for _ in ()).throw(
-            AssertionError("query_sandbox_sessions should not roundtrip through query_lease_sessions")
-        ),
+        lambda lease_id: (_ for _ in ()).throw(AssertionError("query_sandbox_sessions should not roundtrip through query_lease_sessions")),
     )
 
     assert repo.query_sandbox_sessions("sandbox-1") == [
@@ -399,9 +397,7 @@ def test_query_lease_sessions_no_longer_roundtrips_through_query_lease(monkeypat
     monkeypatch.setattr(
         repo,
         "query_lease",
-        lambda lease_id: (_ for _ in ()).throw(
-            AssertionError("query_lease_sessions should not roundtrip through query_lease")
-        ),
+        lambda lease_id: (_ for _ in ()).throw(AssertionError("query_lease_sessions should not roundtrip through query_lease")),
     )
 
     assert repo.query_lease_sessions("lease-1") == [


### PR DESCRIPTION
## Summary
- route query_sandbox_sessions and query_lease_sessions through sandbox-shaped detail decoration
- add focused proof that neither path roundtrips through the old lease session shell
- keep broader lease thread/event/session aggregation surfaces untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell or query_lease_sessions_no_longer_roundtrips_through_query_lease'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell or query_lease_sessions_no_longer_roundtrips_through_query_lease or query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell or query_threads_no_longer_roundtrips_through_lease_summary_shell or test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge or test_query_thread_sessions_reads_container_sandbox_rows'
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check