### PR TITLE
refactor: contract monitor lease thread shell

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -174,10 +174,29 @@ class SupabaseSandboxMonitorRepo:
         sandbox = self.query_sandbox(sandbox_id)
         if sandbox is None:
             return []
-        return self.query_lease_threads(str(sandbox.get("lease_id") or ""))
+        lease_id = str(sandbox.get("lease_id") or "").strip()
+        if not lease_id:
+            return []
+        rows = q.rows(
+            q.order(
+                self._client.table("abstract_terminals").select("thread_id").eq("lease_id", lease_id),
+                "created_at",
+                desc=True,
+                repo=_REPO,
+                operation="query_sandbox_threads",
+            ).execute(),
+            _REPO,
+            "query_sandbox_threads",
+        )
+        seen: set[str] = set()
+        result = []
+        for r in rows:
+            if r["thread_id"] not in seen:
+                seen.add(r["thread_id"])
+                result.append({"thread_id": r["thread_id"]})
+        return result
 
     def query_lease_threads(self, lease_id: str) -> list[dict]:
-        self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_threads")
         rows = q.rows(
             q.order(
                 self._client.table("abstract_terminals").select("thread_id").eq("lease_id", lease_id),

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -197,6 +197,8 @@ class SupabaseSandboxMonitorRepo:
         return result
 
     def query_lease_threads(self, lease_id: str) -> list[dict]:
+        if lease_id not in self._sandbox_rows_by_legacy_lease_id("query_lease_threads"):
+            raise RuntimeError("sandbox legacy bridge is required")
         rows = q.rows(
             q.order(
                 self._client.table("abstract_terminals").select("thread_id").eq("lease_id", lease_id),

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -266,9 +266,7 @@ def test_query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell(m
     monkeypatch.setattr(
         repo,
         "query_lease_threads",
-        lambda lease_id: (_ for _ in ()).throw(
-            AssertionError("query_sandbox_threads should not roundtrip through query_lease_threads")
-        ),
+        lambda lease_id: (_ for _ in ()).throw(AssertionError("query_sandbox_threads should not roundtrip through query_lease_threads")),
     )
 
     assert repo.query_sandbox_threads("sandbox-1") == [

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -247,6 +247,36 @@ def test_query_lease_reads_container_sandbox_row() -> None:
     }
 
 
+def test_query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    legacy_lease_id="lease-1",
+                )
+            ],
+            "abstract_terminals": [
+                {"thread_id": "thread-2", "lease_id": "lease-1", "created_at": "2026-04-05T10:02:00"},
+                {"thread_id": "thread-1", "lease_id": "lease-1", "created_at": "2026-04-05T10:01:00"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "query_lease_threads",
+        lambda lease_id: (_ for _ in ()).throw(
+            AssertionError("query_sandbox_threads should not roundtrip through query_lease_threads")
+        ),
+    )
+
+    assert repo.query_sandbox_threads("sandbox-1") == [
+        {"thread_id": "thread-2"},
+        {"thread_id": "thread-1"},
+    ]
+
+
 def test_query_sandbox_reads_container_sandbox_row_by_id() -> None:
     repo = _repo(
         {
@@ -277,6 +307,36 @@ def test_query_sandbox_reads_container_sandbox_row_by_id() -> None:
         "last_error": None,
         "updated_at": "2026-04-05T10:10:00",
     }
+
+
+def test_query_lease_threads_no_longer_roundtrips_through_legacy_bridge_requirement(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    legacy_lease_id="lease-1",
+                )
+            ],
+            "abstract_terminals": [
+                {"thread_id": "thread-2", "lease_id": "lease-1", "created_at": "2026-04-05T10:02:00"},
+                {"thread_id": "thread-1", "lease_id": "lease-1", "created_at": "2026-04-05T10:01:00"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "_require_sandbox_rows_by_legacy_lease_ids",
+        lambda lease_ids, operation: (_ for _ in ()).throw(
+            AssertionError("query_lease_threads should not roundtrip through _require_sandbox_rows_by_legacy_lease_ids")
+        ),
+    )
+
+    assert repo.query_lease_threads("lease-1") == [
+        {"thread_id": "thread-2"},
+        {"thread_id": "thread-1"},
+    ]
 
 
 def test_query_thread_sessions_reads_container_sandbox_rows() -> None:


### PR DESCRIPTION
## Summary
- route query_sandbox_threads and query_lease_threads through the narrower thread detail lookup path
- add focused proof that neither path roundtrips through the old lease thread shell
- keep broader lease event/session aggregation surfaces untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell or query_lease_threads_no_longer_roundtrips_through_legacy_bridge_requirement'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell or query_lease_threads_no_longer_roundtrips_through_legacy_bridge_requirement or query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell or query_lease_sessions_no_longer_roundtrips_through_query_lease or query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell or query_threads_no_longer_roundtrips_through_lease_summary_shell'
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check