### PR TITLE
refactor: contract monitor lease events shell

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -278,7 +278,8 @@ class SupabaseSandboxMonitorRepo:
         return result
 
     def query_lease_events(self, lease_id: str) -> list[dict]:
-        self._require_sandbox_rows_by_legacy_lease_ids([lease_id], "query_lease_events")
+        if lease_id not in self._sandbox_rows_by_legacy_lease_id("query_lease_events"):
+            raise RuntimeError("sandbox legacy bridge is required")
         # provider_events is the Supabase equivalent
         rows = q.rows(
             q.order(

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -337,6 +337,36 @@ def test_query_lease_threads_no_longer_roundtrips_through_legacy_bridge_requirem
     ]
 
 
+def test_query_lease_events_no_longer_roundtrips_through_legacy_bridge_requirement(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    legacy_lease_id="lease-1",
+                )
+            ],
+            "provider_events": [
+                {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:02:00", "event": "newer"},
+                {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:01:00", "event": "older"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "_require_sandbox_rows_by_legacy_lease_ids",
+        lambda lease_ids, operation: (_ for _ in ()).throw(
+            AssertionError("query_lease_events should not roundtrip through _require_sandbox_rows_by_legacy_lease_ids")
+        ),
+    )
+
+    assert repo.query_lease_events("lease-1") == [
+        {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:02:00", "event": "newer"},
+        {"matched_lease_id": "lease-1", "created_at": "2026-04-05T10:01:00", "event": "older"},
+    ]
+
+
 def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
     repo = _repo(
         {


### PR DESCRIPTION
## Summary
- route query_lease_events through the narrower lease events detail path
- add focused proof that it no longer roundtrips through the legacy bridge requirement helper
- keep broader session aggregation surfaces untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_lease_events_no_longer_roundtrips_through_legacy_bridge_requirement'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_lease_events_no_longer_roundtrips_through_legacy_bridge_requirement or query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell or query_lease_threads_no_longer_roundtrips_through_legacy_bridge_requirement or query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell or query_lease_sessions_no_longer_roundtrips_through_query_lease or query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell or query_threads_no_longer_roundtrips_through_lease_summary_shell'
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check