### PR TITLE
refactor: contract monitor lease outward shell

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -128,7 +128,11 @@ class SupabaseSandboxMonitorRepo:
         return None
 
     def query_lease(self, lease_id: str) -> dict | None:
-        return self._sandboxes_by_legacy_lease_id("query_lease").get(lease_id)
+        sandbox_rows = self._sandbox_rows_by_legacy_lease_id("query_lease")
+        sandbox = sandbox_rows.get(str(lease_id or "").strip())
+        if sandbox is None:
+            return None
+        return self._lease_row_from_sandbox(sandbox)
 
     def query_sandbox_sessions(self, sandbox_id: str) -> list[dict]:
         sandbox = self.query_sandbox(sandbox_id)

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -247,6 +247,39 @@ def test_query_lease_reads_container_sandbox_row() -> None:
     }
 
 
+def test_query_lease_no_longer_roundtrips_through_legacy_lease_shell(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox(
+                    "sandbox-1",
+                    legacy_lease_id="lease-1",
+                    provider_env_id="provider-env-1",
+                )
+            ]
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "_sandboxes_by_legacy_lease_id",
+        lambda operation: (_ for _ in ()).throw(AssertionError("query_lease should not roundtrip through _sandboxes_by_legacy_lease_id")),
+    )
+
+    assert repo.query_lease("lease-1") == {
+        "sandbox_id": "sandbox-1",
+        "lease_id": "lease-1",
+        "provider_name": "local",
+        "recipe_id": None,
+        "recipe_json": None,
+        "desired_state": "running",
+        "observed_state": "running",
+        "current_instance_id": "provider-env-1",
+        "last_error": None,
+        "updated_at": "2026-04-05T10:00:00",
+    }
+
+
 def test_query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell(monkeypatch) -> None:
     repo = _repo(
         {


### PR DESCRIPTION
## Summary
- stop `query_lease()` from roundtripping through `_sandboxes_by_legacy_lease_id(...)`
- keep `query_leases()` and `list_leases_with_threads()` as thin aliases with unchanged outward behavior
- add focused proof that single lease lookup now reads directly from sandbox rows

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k "query_lease_no_longer_roundtrips_through_legacy_lease_shell or query_lease_reads_container_sandbox_row"
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k "query_leases or list_sessions_with_leases or query_sandbox_threads or query_lease_sessions or query_lease_events"
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format --check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check
