### PR TITLE
refactor: contract monitor service lease wrappers

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -638,13 +638,24 @@ def get_monitor_sandbox_detail(sandbox_id: str) -> dict[str, Any]:
         repo.close()
 
 
+def _sandbox_id_for_lease(repo: Any, lease_id: str, *, operation: str) -> str:
+    lease_key = str(lease_id or "").strip()
+    if not lease_key:
+        raise KeyError(f"Lease not found: {lease_id}")
+    for sandbox in repo.query_sandboxes():
+        if str(sandbox.get("lease_id") or "").strip() != lease_key:
+            continue
+        sandbox_id = str(sandbox.get("sandbox_id") or "").strip()
+        if not sandbox_id:
+            raise RuntimeError(f"{operation} lease target missing sandbox bridge")
+        return sandbox_id
+    raise KeyError(f"Lease not found: {lease_id}")
+
+
 def get_monitor_lease_detail(lease_id: str) -> dict[str, Any]:
     repo = make_sandbox_monitor_repo()
     try:
-        lease = repo.query_lease(lease_id)
-        if lease is None:
-            raise KeyError(f"Lease not found: {lease_id}")
-        payload = _build_monitor_sandbox_detail(repo, str(lease.get("sandbox_id") or ""))
+        payload = _build_monitor_sandbox_detail(repo, _sandbox_id_for_lease(repo, lease_id, operation="get_monitor_lease_detail"))
     finally:
         repo.close()
 
@@ -751,15 +762,9 @@ async def get_monitor_thread_detail(app: Any, thread_id: str) -> dict[str, Any]:
 def request_monitor_lease_cleanup(lease_id: str) -> dict[str, Any]:
     repo = make_sandbox_monitor_repo()
     try:
-        lease = repo.query_lease(lease_id)
+        sandbox_id = _sandbox_id_for_lease(repo, lease_id, operation="request_monitor_lease_cleanup")
     finally:
         repo.close()
-    if lease is None:
-        raise KeyError(f"Lease not found: {lease_id}")
-
-    sandbox_id = str(lease.get("sandbox_id") or "").strip()
-    if not sandbox_id:
-        raise RuntimeError("monitor lease cleanup target missing sandbox bridge")
     return request_monitor_sandbox_cleanup(sandbox_id)
 
 
@@ -821,15 +826,9 @@ def get_monitor_operation_detail(operation_id: str) -> dict[str, Any]:
 
     repo = make_sandbox_monitor_repo()
     try:
-        lease = repo.query_lease(lease_id)
+        sandbox_id = _sandbox_id_for_lease(repo, lease_id, operation="get_monitor_operation_detail")
     finally:
         repo.close()
-    if lease is None:
-        raise RuntimeError("monitor operation lease target missing sandbox bridge")
-
-    sandbox_id = str(lease.get("sandbox_id") or "").strip()
-    if not sandbox_id:
-        raise RuntimeError("monitor operation lease target missing sandbox bridge")
     return {**payload, "sandbox_id": sandbox_id}
 
 

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -82,7 +82,13 @@ class FakeLeaseRepo:
         return {**lease, "sandbox_id": lease.get("sandbox_id") or sandbox_id}
 
     def query_sandboxes(self):
-        return self.leases
+        if self.leases:
+            return self.leases
+        if self.lease is _MISSING:
+            return []
+        if self.lease is not None:
+            return [self.lease]
+        return [_lease_row()]
 
     def query_sandbox_threads(self, _sandbox_id):
         return self.threads
@@ -480,6 +486,9 @@ def test_list_monitor_sandboxes_is_canonical_single_emit(monkeypatch):
 
 def test_get_monitor_lease_detail_uses_canonical_sandbox_source(monkeypatch):
     class CanonicalOnlyRepo(FakeLeaseRepo):
+        def query_lease(self, _lease_id):
+            raise AssertionError("legacy lease wrapper should not keep query_lease as single source")
+
         def query_lease_threads(self, _lease_id):
             raise AssertionError("legacy lease detail queries should not remain single source")
 
@@ -672,7 +681,11 @@ def test_request_monitor_sandbox_cleanup_uses_canonical_sandbox_target(monkeypat
 
 
 def test_request_monitor_lease_cleanup_wraps_canonical_sandbox_cleanup(monkeypatch):
-    _use_monitor_repo(monkeypatch, FakeLeaseRepo(lease=_detached_lease()))
+    class CanonicalOnlyRepo(FakeLeaseRepo):
+        def query_lease(self, _lease_id):
+            raise AssertionError("legacy lease cleanup wrapper should not keep query_lease as single source")
+
+    _use_monitor_repo(monkeypatch, CanonicalOnlyRepo(lease=_detached_lease()))
     calls: list[str] = []
     monkeypatch.setattr(
         monitor_service,
@@ -684,6 +697,26 @@ def test_request_monitor_lease_cleanup_wraps_canonical_sandbox_cleanup(monkeypat
 
     assert payload == {"accepted": True, "operation": {"target_type": "sandbox"}}
     assert calls == ["sandbox-1"]
+
+
+def test_get_monitor_operation_detail_uses_canonical_sandbox_source(monkeypatch):
+    class CanonicalOnlyRepo(FakeLeaseRepo):
+        def query_lease(self, _lease_id):
+            raise AssertionError("legacy lease operation wrapper should not keep query_lease as single source")
+
+    _use_monitor_repo(monkeypatch, CanonicalOnlyRepo(lease=_lease_row()))
+    monkeypatch.setattr(
+        monitor_service.monitor_operation_service,
+        "get_operation_detail",
+        lambda operation_id: {
+            "operation": {"operation_id": operation_id},
+            "target": {"target_type": "lease", "target_id": "lease-1"},
+        },
+    )
+
+    payload = monitor_service.get_monitor_operation_detail("op-1")
+
+    assert payload["sandbox_id"] == "sandbox-1"
 
 
 def test_request_monitor_provider_session_cleanup_uses_sandbox_manager(monkeypatch):


### PR DESCRIPTION
## Summary
- stop the monitor-service lease wrappers from treating `query_lease()` as the single bridge source
- resolve lease -> sandbox through canonical sandbox summary truth instead
- keep sandbox_service/resource clusters untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py -k "canonical_sandbox_source or wraps_canonical_sandbox_cleanup or operation_detail_uses_canonical_sandbox_source"
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py -k "get_monitor_lease_detail or request_monitor_lease_cleanup or get_monitor_operation_detail or query_lease"
- uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format --check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check
