### PR TITLE
refactor: contract sandbox owned lease shell

### DIFF
--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -182,6 +182,16 @@ def count_user_visible_leases_by_provider(
         monitor_repo.close()
 
 
+def _query_sandbox_summary_for_lease(monitor_repo: Any, lease_id: str) -> dict[str, Any] | None:
+    lease_key = str(lease_id or "").strip()
+    if not lease_key:
+        return None
+    for row in monitor_repo.query_sandboxes():
+        if str(row.get("lease_id") or "").strip() == lease_key:
+            return dict(row)
+    return None
+
+
 def resolve_owned_lease(
     user_id: str,
     lease_id: str,
@@ -193,15 +203,18 @@ def resolve_owned_lease(
     if thread_repo is None or user_repo is None:
         raise RuntimeError("thread_repo and user_repo are required for resolve_owned_lease")
     try:
-        lease = monitor_repo.query_lease(lease_id)
+        lease = _query_sandbox_summary_for_lease(monitor_repo, lease_id)
         if lease is None:
             return None
         if not _is_user_visible_lease_state(lease):
             return None
+        sandbox_id = str(lease.get("sandbox_id") or "").strip()
+        if not sandbox_id:
+            raise RuntimeError("sandbox_id is required for resolve_owned_lease")
 
         thread_ids: list[str] = []
         agents: list[dict[str, Any]] = []
-        for row in monitor_repo.query_lease_threads(lease_id):
+        for row in monitor_repo.query_sandbox_threads(sandbox_id):
             thread_id = str(row.get("thread_id") or "").strip()
             if not _is_user_visible_lease_thread(thread_id) or thread_id in thread_ids:
                 continue
@@ -227,7 +240,7 @@ def resolve_owned_lease(
         result["thread_ids"] = thread_ids
         result["agents"] = agents
         _apply_lease_recipe(result, provider_name, lease.get("recipe_json"))
-        runtime_session_id = monitor_repo.query_lease_instance_id(lease_id)
+        runtime_session_id = monitor_repo.query_sandbox_instance_id(sandbox_id)
         if runtime_session_id:
             result["runtime_session_id"] = runtime_session_id
         return result

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -79,6 +79,15 @@ class _FakeMonitorRepo:
     def query_lease_threads(self, lease_id: str):
         return [{"thread_id": row.get("thread_id")} for row in self._rows if row.get("lease_id") == lease_id]
 
+    def query_sandbox_threads(self, sandbox_id: str):
+        return [{"thread_id": row.get("thread_id")} for row in self._rows if row.get("sandbox_id") == sandbox_id]
+
+    def query_sandbox_instance_id(self, sandbox_id: str):
+        for row in self._rows:
+            if row.get("sandbox_id") == sandbox_id:
+                return self._instance_ids.get(str(row.get("lease_id") or ""))
+        return None
+
     def close(self):
         pass
 
@@ -402,8 +411,14 @@ def test_list_user_leases_runtime_session_id_contract(
 
 def test_resolve_owned_lease_filters_to_single_authorized_lease(monkeypatch):
     rows = [
-        _lease_row("lease-1", "thread-parent", provider_name="daytona_selfhost", cwd="/home/daytona/files/app"),
-        _lease_row("lease-2", "thread-other", created_at="2026-04-07T10:01:00Z", cwd="/tmp/other"),
+        _lease_row(
+            "lease-1",
+            "thread-parent",
+            provider_name="daytona_selfhost",
+            cwd="/home/daytona/files/app",
+            sandbox_id="sandbox-1",
+        ),
+        _lease_row("lease-2", "thread-other", created_at="2026-04-07T10:01:00Z", cwd="/tmp/other", sandbox_id="sandbox-2"),
     ]
     thread_repo = _FakeThreadRepo(
         {
@@ -448,6 +463,53 @@ def test_resolve_owned_lease_filters_to_single_authorized_lease(monkeypatch):
             "avatar_url": "/api/users/agent-1/avatar",
         }
     ]
+    _assert_daytona_recipe(lease, runtime_session_id="provider-session-1")
+
+
+def test_resolve_owned_lease_uses_canonical_sandbox_source(monkeypatch):
+    rows = [
+        _lease_row("lease-1", "thread-parent", provider_name="daytona_selfhost", cwd="/home/daytona/files/app", sandbox_id="sandbox-1"),
+    ]
+    thread_repo = _FakeThreadRepo(
+        {
+            "thread-parent": {"agent_user_id": "agent-1"},
+        }
+    )
+    user_repo = _FakeUserRepo(
+        {
+            "agent-1": _agent_user("agent-1", "Morel", avatar="x", owner_user_id="owner-1"),
+        }
+    )
+
+    class _SandboxOnlyMonitorRepo:
+        def query_sandboxes(self):
+            return list(rows)
+
+        def query_sandbox_threads(self, sandbox_id: str):
+            assert sandbox_id == "sandbox-1"
+            return [{"thread_id": "thread-parent"}]
+
+        def query_sandbox_instance_id(self, sandbox_id: str):
+            assert sandbox_id == "sandbox-1"
+            return "provider-session-1"
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(sandbox_service, "make_sandbox_monitor_repo", lambda: _SandboxOnlyMonitorRepo())
+
+    lease = sandbox_service.resolve_owned_lease(
+        "owner-1",
+        "lease-1",
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+    )
+
+    assert lease is not None
+    assert lease["lease_id"] == "lease-1"
+    assert lease["provider_name"] == "daytona_selfhost"
+    assert lease["thread_id"] == "thread-parent"
+    assert lease["thread_ids"] == ["thread-parent"]
     _assert_daytona_recipe(lease, runtime_session_id="provider-session-1")
 
 


### PR DESCRIPTION
## Summary
- cut `resolve_owned_lease(...)` over to canonical sandbox-shaped monitor queries
- stop using lease-shaped `query_lease` / `query_lease_threads` / `query_lease_instance_id` as the active owned-lease bridge
- add focused proof that owned-lease resolution still works with sandbox-only monitor surfaces

## Verification
- `uv run python -m pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py`
- `uv run python -m pytest -q tests/Integration/test_threads_router.py -k existing_sandbox`
- `uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py`
- `git diff --check`