### PR TITLE
chore: contract resource visible thread fallback

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -254,12 +254,11 @@ def _project_user_visible_resource_sessions(repo: Any, rows: list[dict[str, Any]
         sandbox_id = str(group[0].get("sandbox_id") or "").strip()
         # @@@resource-visible-thread-fallback - visible resource cards are now
         # sandbox-first. If the raw monitor row lands on a hidden/subagent
-        # thread, prefer the canonical sandbox thread bridge and only fall back
-        # to legacy lease thread lookup when sandbox truth is absent.
-        if sandbox_id:
-            thread_rows = repo.query_sandbox_threads(sandbox_id)
-        else:
-            thread_rows = repo.query_lease_threads(lease_id)
+        # thread without sandbox truth, this row is no longer eligible for
+        # visible-parent projection on the user-facing resource surface.
+        if not sandbox_id:
+            continue
+        thread_rows = repo.query_sandbox_threads(sandbox_id)
         preferred_thread_id = next(
             (str(item.get("thread_id") or "").strip() for item in thread_rows if _is_resource_visible_thread(item.get("thread_id"))),
             "",

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -373,6 +373,50 @@ def test_list_resource_providers_uses_canonical_sandbox_thread_fallback(monkeypa
     ]
 
 
+def test_list_resource_providers_no_longer_uses_lease_shaped_visible_thread_fallback_without_sandbox_id(monkeypatch):
+    rows = [
+        {
+            "provider": "daytona_selfhost",
+            "session_id": None,
+            "thread_id": "subagent-deadbeef",
+            "sandbox_id": None,
+            "lease_id": "lease-1",
+            "observed_state": "paused",
+            "desired_state": "paused",
+            "created_at": "2026-04-04T00:00:00",
+        },
+    ]
+
+    class _NoLeaseFallbackRepo(_FakeRepo):
+        def query_lease_threads(self, lease_id: str):
+            raise AssertionError(f"lease-shaped visible-thread fallback should be gone: {lease_id}")
+
+    monkeypatch.setattr(
+        resource_projection_service,
+        "make_sandbox_monitor_repo",
+        lambda: _NoLeaseFallbackRepo(rows),
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "available_sandbox_types",
+        lambda: [{"name": "daytona_selfhost", "available": True}],
+    )
+    monkeypatch.setattr(resource_projection_service, "resolve_provider_name", lambda *_args, **_kwargs: "daytona")
+    monkeypatch.setattr(resource_projection_service, "_resolve_console_url", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_resolve_instance_capabilities",
+        lambda _config_name: (resource_common.empty_capabilities(), None),
+    )
+    monkeypatch.setattr(resource_projection_service, "_thread_owners", lambda _thread_ids: {})
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
+
+    payload = resource_projection_service.list_resource_providers()
+
+    assert payload["providers"][0]["sessions"] == []
+    assert payload["summary"]["running_sessions"] == 0
+
+
 def test_list_resource_providers_deduplicates_same_lease_thread_even_with_distinct_session_ids(monkeypatch):
     rows = [
         {


### PR DESCRIPTION
## Summary
- remove the lease-shaped visible-thread fallback from resource session projection
- require sandbox-first thread lookup for visible-parent projection
- keep browse/read outward contract untouched

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py
- uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py
- uv run ruff format --check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py
- git diff --check