### PR TITLE
refactor: contract sandbox single instance bridge

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -217,10 +217,10 @@ class SupabaseSandboxMonitorRepo:
         return result
 
     def query_sandbox_instance_id(self, sandbox_id: str) -> str | None:
-        sandbox = self.query_sandbox(sandbox_id)
-        if sandbox is None:
+        sandbox_key = str(sandbox_id or "").strip()
+        if not sandbox_key:
             return None
-        return self.query_lease_instance_id(str(sandbox.get("lease_id") or ""))
+        return self.query_sandbox_instance_ids([sandbox_key]).get(sandbox_key)
 
     def query_sandbox_instance_ids(self, sandbox_ids: list[str]) -> dict[str, str | None]:
         ordered_ids = [str(sandbox_id or "").strip() for sandbox_id in sandbox_ids if str(sandbox_id or "").strip()]

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -806,6 +806,29 @@ def test_query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge(mo
     }
 
 
+def test_query_sandbox_instance_id_no_longer_roundtrips_through_lease_bridge(monkeypatch) -> None:
+    repo = _repo(
+        {
+            "container.sandboxes": [
+                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", legacy_lease_id="lease-1"),
+            ],
+            "sandbox_instances": [
+                {"lease_id": "lease-1", "provider_session_id": "provider-session-1"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        repo,
+        "query_lease_instance_id",
+        lambda _lease_id: (_ for _ in ()).throw(
+            AssertionError("single sandbox instance lookup should not roundtrip through query_lease_instance_id")
+        ),
+    )
+
+    assert repo.query_sandbox_instance_id("sandbox-1") == "provider-session-1"
+
+
 def test_query_lease_events_requires_sandbox_bridge() -> None:
     repo = _repo(
         {


### PR DESCRIPTION
## Summary
- route single sandbox instance lookup through the canonical sandbox batch path
- remove the single-id roundtrip through query_lease_instance_id
- keep service-layer callers and outward contracts unchanged

## Testing
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py -k 'query_sandbox_instance_id_no_longer_roundtrips_through_lease_bridge or query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge or instance_lookup_failures_are_loud'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py -k 'sandbox_instance_id or runtime_session_id_contract or resolve_owned_lease or instance_lookup_failures_are_loud'
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py
- git diff --check