### PR TITLE
test: align lease instance fake shells

### DIFF
--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -69,9 +69,6 @@ class FakeLeaseRepo:
     def query_lease_sessions(self, _lease_id):
         return self.sessions
 
-    def query_lease_instance_id(self, _lease_id):
-        return self.runtime_session_id
-
     def query_leases(self):
         return self.leases
 
@@ -101,6 +98,12 @@ class FakeLeaseRepo:
 
     def close(self):
         return None
+
+
+def test_fake_lease_repo_no_longer_exposes_lease_instance_shell() -> None:
+    repo = FakeLeaseRepo()
+
+    assert not hasattr(repo, "query_lease_instance_id")
 
 
 def _use_monitor_repo(monkeypatch, repo):

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -20,17 +20,18 @@ class _FakeRepo:
     def query_sandbox_threads(self, sandbox_id: str):
         return [{"thread_id": tid} for tid in self._sandbox_threads.get(sandbox_id, [])]
 
-    def query_lease_instance_id(self, lease_id: str):
-        return self._instance_ids.get(lease_id)
-
-    def query_lease_instance_ids(self, lease_ids: list[str]):
-        return {lease_id: self._instance_ids.get(lease_id) for lease_id in lease_ids}
-
     def query_sandbox_instance_ids(self, sandbox_ids: list[str]):
         return {sandbox_id: self._instance_ids.get(sandbox_id) for sandbox_id in sandbox_ids}
 
     def close(self):
         pass
+
+
+def test_fake_resource_repo_no_longer_exposes_lease_instance_shell() -> None:
+    repo = _FakeRepo([])
+
+    assert not hasattr(repo, "query_lease_instance_id")
+    assert not hasattr(repo, "query_lease_instance_ids")
 
 
 class _FakeThreadRepo:

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -61,15 +61,10 @@ class _FakeMonitorRepo:
     def __init__(self, rows, instance_ids=None):
         self._rows = rows
         self._instance_ids = instance_ids or {}
-        self.instance_id_calls: list[str] = []
         self.sandbox_instance_id_calls: list[str] = []
 
     def query_sandboxes(self):
         return list(self._rows)
-
-    def query_lease_instance_id(self, lease_id: str):
-        self.instance_id_calls.append(lease_id)
-        return self._instance_ids.get(lease_id)
 
     def query_lease(self, lease_id: str):
         for row in self._rows:
@@ -92,6 +87,12 @@ class _FakeMonitorRepo:
 
     def close(self):
         pass
+
+
+def test_fake_monitor_repo_no_longer_exposes_lease_instance_shell() -> None:
+    repo = _FakeMonitorRepo([])
+
+    assert not hasattr(repo, "query_lease_instance_id")
 
 
 class _FakeThreadRepo:
@@ -326,7 +327,6 @@ def test_count_user_visible_leases_by_provider_no_longer_roundtrips_through_leas
         "include_runtime_session_id",
         "instance_ids",
         "expected_runtime_session_id",
-        "expected_lease_calls",
         "expected_sandbox_calls",
     ),
     [
@@ -338,7 +338,6 @@ def test_count_user_visible_leases_by_provider_no_longer_roundtrips_through_leas
             True,
             {"lease-1": "provider-session-1", "sandbox-1": "provider-session-1"},
             "provider-session-1",
-            [],
             ["sandbox-1"],
         ),
         (
@@ -357,7 +356,6 @@ def test_count_user_visible_leases_by_provider_no_longer_roundtrips_through_leas
             {"lease-1": "provider-session-probed", "sandbox-1": "provider-session-probed"},
             "provider-session-inline",
             [],
-            [],
         ),
         (
             [
@@ -373,7 +371,6 @@ def test_count_user_visible_leases_by_provider_no_longer_roundtrips_through_leas
             True,
             {"lease-1": "provider-session-1", "sandbox-1": "provider-session-1"},
             "provider-session-1",
-            [],
             ["sandbox-1"],
         ),
         (
@@ -391,7 +388,6 @@ def test_count_user_visible_leases_by_provider_no_longer_roundtrips_through_leas
             {"lease-1": "provider-session-1", "sandbox-1": "provider-session-1"},
             None,
             [],
-            [],
         ),
     ],
     ids=["probe-once-per-sandbox", "prefer-inline-instance-id", "keep-runtime-session-id", "skip-probe-by-default"],
@@ -402,7 +398,6 @@ def test_list_user_leases_runtime_session_id_contract(
     include_runtime_session_id,
     instance_ids,
     expected_runtime_session_id,
-    expected_lease_calls,
     expected_sandbox_calls,
 ):
     monitor_repo = _FakeMonitorRepo(rows, instance_ids=instance_ids)
@@ -423,7 +418,6 @@ def test_list_user_leases_runtime_session_id_contract(
         assert "runtime_session_id" not in lease
     else:
         assert lease["runtime_session_id"] == expected_runtime_session_id
-    assert monitor_repo.instance_id_calls == expected_lease_calls
     assert monitor_repo.sandbox_instance_id_calls == expected_sandbox_calls
 
 


### PR DESCRIPTION
## Summary
- remove compatibility lease-instance methods from monitor and sandbox test fakes
- keep fail-loud guard overrides where the tests intentionally prove canonical sandbox-shaped lookup
- leave production contracts, repos, services, and outward surfaces untouched

## Verification
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/sandbox/test_sandbox_user_leases.py -k 'fake_lease_repo_no_longer_exposes_lease_instance_shell or fake_resource_repo_no_longer_exposes_lease_instance_shell or fake_monitor_repo_no_longer_exposes_lease_instance_shell or list_user_leases_runtime_session_id_contract'
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Integration/test_resource_overview_contract_split.py
- uv run ruff check tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Integration/test_resource_overview_contract_split.py
- uv run ruff format --check tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Integration/test_resource_overview_contract_split.py
- git diff --check