### PR TITLE
test: align remaining lease protocol fake shells

### DIFF
--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -58,17 +58,6 @@ class FakeLeaseRepo:
         self.runtime_session_id = runtime_session_id
         self.leases = leases or []
 
-    def query_lease(self, lease_id):
-        if self.lease is _MISSING:
-            return None
-        return self.lease if self.lease is not None else _lease_row(lease_id=lease_id)
-
-    def query_lease_threads(self, _lease_id):
-        return self.threads
-
-    def query_lease_sessions(self, _lease_id):
-        return self.sessions
-
     def query_leases(self):
         return self.leases
 
@@ -104,6 +93,14 @@ def test_fake_lease_repo_no_longer_exposes_lease_instance_shell() -> None:
     repo = FakeLeaseRepo()
 
     assert not hasattr(repo, "query_lease_instance_id")
+
+
+def test_fake_lease_repo_no_longer_exposes_broader_lease_protocol_shell() -> None:
+    repo = FakeLeaseRepo()
+
+    assert not hasattr(repo, "query_lease")
+    assert not hasattr(repo, "query_lease_threads")
+    assert not hasattr(repo, "query_lease_sessions")
 
 
 def _use_monitor_repo(monkeypatch, repo):

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -14,9 +14,6 @@ class _FakeRepo:
     def query_resource_sessions(self):
         return list(self._rows)
 
-    def query_lease_threads(self, lease_id: str):
-        return [{"thread_id": tid} for tid in self._lease_threads.get(lease_id, [])]
-
     def query_sandbox_threads(self, sandbox_id: str):
         return [{"thread_id": tid} for tid in self._sandbox_threads.get(sandbox_id, [])]
 
@@ -32,6 +29,12 @@ def test_fake_resource_repo_no_longer_exposes_lease_instance_shell() -> None:
 
     assert not hasattr(repo, "query_lease_instance_id")
     assert not hasattr(repo, "query_lease_instance_ids")
+
+
+def test_fake_resource_repo_no_longer_exposes_lease_thread_shell() -> None:
+    repo = _FakeRepo([])
+
+    assert not hasattr(repo, "query_lease_threads")
 
 
 class _FakeThreadRepo:

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -66,15 +66,6 @@ class _FakeMonitorRepo:
     def query_sandboxes(self):
         return list(self._rows)
 
-    def query_lease(self, lease_id: str):
-        for row in self._rows:
-            if row.get("lease_id") == lease_id:
-                return dict(row)
-        return None
-
-    def query_lease_threads(self, lease_id: str):
-        return [{"thread_id": row.get("thread_id")} for row in self._rows if row.get("lease_id") == lease_id]
-
     def query_sandbox_threads(self, sandbox_id: str):
         return [{"thread_id": row.get("thread_id")} for row in self._rows if row.get("sandbox_id") == sandbox_id]
 
@@ -93,6 +84,13 @@ def test_fake_monitor_repo_no_longer_exposes_lease_instance_shell() -> None:
     repo = _FakeMonitorRepo([])
 
     assert not hasattr(repo, "query_lease_instance_id")
+
+
+def test_fake_monitor_repo_no_longer_exposes_broader_lease_protocol_shell() -> None:
+    repo = _FakeMonitorRepo([])
+
+    assert not hasattr(repo, "query_lease")
+    assert not hasattr(repo, "query_lease_threads")
 
 
 class _FakeThreadRepo:


### PR DESCRIPTION
## Summary\n- remove broader query_lease* compatibility shell from remaining base test fakes\n- keep deliberate fail-loud guard overrides intact\n- keep the lane tests-only with no production contract changes\n\n## Verification\n- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py -k 'fake_lease_repo_no_longer_exposes_broader_lease_protocol_shell'\n- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -k 'fake_resource_repo_no_longer_exposes_lease_thread_shell'\n- uv run python -m pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py -k 'fake_monitor_repo_no_longer_exposes_broader_lease_protocol_shell'\n- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py\n- uv run ruff check tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py\n- uv run ruff format --check tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/sandbox/test_sandbox_user_leases.py\n- git diff --check