### PR TITLE
chore: cut over browse/read backend wrapper

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -12,6 +12,7 @@ from backend.web.services.resource_cache import (
     get_resource_overview_snapshot,
     refresh_resource_overview_sync,
 )
+from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 router = APIRouter(prefix="/api/monitor")
 
@@ -54,6 +55,30 @@ async def _resource_io(fn, *args):
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+async def _lease_resource_io(fn, lease_id: str, *args):
+    try:
+        sandbox_id = _resolve_sandbox_id_for_lease(lease_id)
+        return await asyncio.to_thread(fn, sandbox_id, *args)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def _resolve_sandbox_id_for_lease(lease_id: str) -> str:
+    repo = make_sandbox_monitor_repo()
+    try:
+        for row in repo.query_sandboxes():
+            if str(row.get("lease_id") or "").strip() == str(lease_id or "").strip():
+                sandbox_id = str(row.get("sandbox_id") or "").strip()
+                if sandbox_id:
+                    return sandbox_id
+                break
+    finally:
+        repo.close()
+    raise KeyError(f"Lease not found: {lease_id}")
 
 
 @router.get("/leases")
@@ -236,9 +261,9 @@ async def resources_refresh():
 
 @router.get("/sandbox/{lease_id}/browse")
 async def sandbox_browse(lease_id: str, path: str = Query(default="/")):
-    return await _resource_io(resource_service.sandbox_browse, lease_id, path)
+    return await _lease_resource_io(resource_service.browse_sandbox, lease_id, path)
 
 
 @router.get("/sandbox/{lease_id}/read")
 async def sandbox_read_file(lease_id: str, path: str = Query(...)):
-    return await _resource_io(resource_service.sandbox_read, lease_id, path)
+    return await _lease_resource_io(resource_service.read_sandbox, lease_id, path)

--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -84,35 +84,26 @@ def build_resource_session_payload(
     return payload
 
 
-def _query_sandbox_summary_for_lease(repo: Any, lease_id: str) -> dict[str, Any] | None:
-    lease_key = str(lease_id or "").strip()
-    if not lease_key:
-        return None
-    # @@@runtime-target-bridge-source - browse/read routes are still lease-shaped
-    # outward, but canonical runtime target truth now comes from sandbox summary.
-    for row in repo.query_sandboxes():
-        if str(row.get("lease_id") or "").strip() == lease_key:
-            return dict(row)
-    return None
+def _resolve_sandbox_provider(sandbox_id: str) -> tuple[Any, str]:
+    sandbox_key = str(sandbox_id or "").strip()
+    if not sandbox_key:
+        raise KeyError("Sandbox not found: ")
 
-
-def _resolve_sandbox_provider(lease_id: str) -> tuple[Any, str]:
     repo = make_sandbox_monitor_repo()
     try:
-        sandbox = _query_sandbox_summary_for_lease(repo, lease_id)
-        sandbox_id = str((sandbox or {}).get("sandbox_id") or "").strip()
-        instance_id = repo.query_sandbox_instance_id(sandbox_id) if sandbox_id else None
+        instance_id = repo.query_sandbox_instance_id(sandbox_key)
+        provider_name = ""
+        for row in repo.query_sandboxes():
+            if str(row.get("sandbox_id") or "").strip() == sandbox_key:
+                provider_name = str(row.get("provider_name") or "").strip()
+                break
     finally:
         repo.close()
 
-    if not sandbox:
-        raise KeyError(f"Lease not found: {lease_id}")
-
-    provider_name = str(sandbox.get("provider_name") or "").strip()
     if not provider_name:
-        raise RuntimeError("Lease has no provider")
+        raise KeyError(f"Sandbox not found: {sandbox_key}")
     if not instance_id:
-        raise RuntimeError("No active instance for this lease — sandbox may be destroyed or paused")
+        raise RuntimeError("No active instance for this sandbox — sandbox may be destroyed or paused")
 
     provider = build_provider_from_config_name(provider_name)
     if provider is None:
@@ -120,11 +111,11 @@ def _resolve_sandbox_provider(lease_id: str) -> tuple[Any, str]:
     return provider, instance_id
 
 
-def sandbox_browse(lease_id: str, path: str) -> dict[str, Any]:
-    """Browse the filesystem of a sandbox lease via its provider."""
+def browse_sandbox(sandbox_id: str, path: str) -> dict[str, Any]:
+    """Browse the filesystem of a sandbox via its provider."""
     from pathlib import PurePosixPath
 
-    provider, instance_id = _resolve_sandbox_provider(lease_id)
+    provider, instance_id = _resolve_sandbox_provider(sandbox_id)
 
     try:
         entries = provider.list_dir(instance_id, path)
@@ -153,9 +144,9 @@ def sandbox_browse(lease_id: str, path: str) -> dict[str, Any]:
 _READ_MAX_BYTES = 100 * 1024
 
 
-def sandbox_read(lease_id: str, path: str) -> dict[str, Any]:
-    """Read a file from a sandbox lease via its provider."""
-    provider, instance_id = _resolve_sandbox_provider(lease_id)
+def read_sandbox(sandbox_id: str, path: str) -> dict[str, Any]:
+    """Read a file from a sandbox via its provider."""
+    provider, instance_id = _resolve_sandbox_provider(sandbox_id)
 
     try:
         content = provider.read_file(instance_id, path)

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -275,17 +275,49 @@ def test_monitor_evaluation_batch_create_and_start_pass_request_context(monkeypa
 @pytest.mark.parametrize(
     ("verb", "path", "service_name"),
     [
-        ("get", "/api/monitor/sandbox/lease-1/browse", "sandbox_browse"),
-        ("get", "/api/monitor/sandbox/lease-1/read?path=/README.md", "sandbox_read"),
+        ("get", "/api/monitor/sandbox/lease-1/browse", "browse_sandbox"),
+        ("get", "/api/monitor/sandbox/lease-1/read?path=/README.md", "read_sandbox"),
     ],
 )
 def test_monitor_sandbox_routes_map_runtime_failures_to_503(monkeypatch, verb, path, service_name):
     def _raise(*_args, **_kwargs):
         raise RuntimeError("provider unavailable")
 
+    monkeypatch.setattr(monitor, "_resolve_sandbox_id_for_lease", lambda _lease_id: "sandbox-1")
     monkeypatch.setattr(resource_service, service_name, _raise)
 
     response = _request(verb, path, raise_server_exceptions=False)
 
     assert response.status_code == 503
     assert "provider unavailable" in response.text
+
+
+@pytest.mark.parametrize(
+    ("path", "service_name", "expected_args"),
+    [
+        ("/api/monitor/sandbox/lease-1/browse?path=/workspace", "browse_sandbox", ("sandbox-1", "/workspace")),
+        ("/api/monitor/sandbox/lease-1/read?path=/README.md", "read_sandbox", ("sandbox-1", "/README.md")),
+    ],
+)
+def test_monitor_sandbox_routes_bridge_lease_wrapper_to_sandbox_shaped_service(monkeypatch, path, service_name, expected_args):
+    class _Repo:
+        def query_sandboxes(self):
+            return [{"sandbox_id": "sandbox-1", "lease_id": "lease-1"}]
+
+        def close(self):
+            return None
+
+    calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(monitor, "make_sandbox_monitor_repo", lambda: _Repo())
+    monkeypatch.setattr(
+        resource_service,
+        service_name,
+        lambda sandbox_id, value: calls.append((sandbox_id, value)) or {"ok": True},
+    )
+
+    response = _request("get", path)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert calls == [expected_args]

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -376,7 +376,7 @@ def test_refresh_resource_snapshots_skips_paused_provider_build_error(monkeypatc
     assert captured == []
 
 
-def test_sandbox_browse_uses_canonical_sandbox_bridge_source(monkeypatch) -> None:
+def test_browse_sandbox_uses_canonical_sandbox_instance_lookup(monkeypatch) -> None:
     monkeypatch.setattr(
         resource_service,
         "make_sandbox_monitor_repo",
@@ -393,13 +393,13 @@ def test_sandbox_browse_uses_canonical_sandbox_bridge_source(monkeypatch) -> Non
     )
     monkeypatch.setattr(resource_service, "build_provider_from_config_name", lambda _name: _ReadableProvider())
 
-    payload = resource_service.sandbox_browse("lease-1", "/workspace")
+    payload = resource_service.browse_sandbox("sandbox-1", "/workspace")
 
     assert payload["current_path"] == "/workspace"
     assert payload["items"] == [{"name": "README.md", "path": "/workspace/README.md", "is_dir": False}]
 
 
-def test_sandbox_read_uses_canonical_sandbox_instance_lookup(monkeypatch) -> None:
+def test_read_sandbox_uses_canonical_sandbox_instance_lookup(monkeypatch) -> None:
     monkeypatch.setattr(
         resource_service,
         "make_sandbox_monitor_repo",
@@ -416,6 +416,11 @@ def test_sandbox_read_uses_canonical_sandbox_instance_lookup(monkeypatch) -> Non
     )
     monkeypatch.setattr(resource_service, "build_provider_from_config_name", lambda _name: _ReadableProvider())
 
-    payload = resource_service.sandbox_read("lease-1", "/README.md")
+    payload = resource_service.read_sandbox("sandbox-1", "/README.md")
 
     assert payload == {"path": "/README.md", "content": "instance-1:/README.md", "truncated": False}
+
+
+def test_resource_service_no_longer_exposes_lease_shaped_browse_read_shell() -> None:
+    assert not hasattr(resource_service, "sandbox_browse")
+    assert not hasattr(resource_service, "sandbox_read")


### PR DESCRIPTION
## Summary
- make resource browse/read service APIs sandbox-shaped
- keep lease-shaped browse/read compatibility shell in monitor router
- align focused backend route/service tests to the new seam

## Verification
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py -k "browse_sandbox_uses_canonical_sandbox_instance_lookup or read_sandbox_uses_canonical_sandbox_instance_lookup or resource_service_no_longer_exposes_lease_shaped_browse_read_shell"
- uv run python -m pytest -q tests/Integration/test_monitor_resources_route.py -k "monitor_sandbox_routes_map_runtime_failures_to_503 or monitor_sandbox_routes_bridge_lease_wrapper_to_sandbox_shaped_service"
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_resource_probe.py tests/Integration/test_monitor_resources_route.py
- uv run ruff check backend/web/routers/monitor.py backend/web/services/resource_service.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Integration/test_monitor_resources_route.py
- uv run ruff format --check backend/web/routers/monitor.py backend/web/services/resource_service.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Integration/test_monitor_resources_route.py
- git diff --check