### PR TITLE
chore: cut over browse/read route naming

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -12,7 +12,6 @@ from backend.web.services.resource_cache import (
     get_resource_overview_snapshot,
     refresh_resource_overview_sync,
 )
-from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 router = APIRouter(prefix="/api/monitor")
 
@@ -55,30 +54,6 @@ async def _resource_io(fn, *args):
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
-
-
-async def _lease_resource_io(fn, lease_id: str, *args):
-    try:
-        sandbox_id = _resolve_sandbox_id_for_lease(lease_id)
-        return await asyncio.to_thread(fn, sandbox_id, *args)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-
-
-def _resolve_sandbox_id_for_lease(lease_id: str) -> str:
-    repo = make_sandbox_monitor_repo()
-    try:
-        for row in repo.query_sandboxes():
-            if str(row.get("lease_id") or "").strip() == str(lease_id or "").strip():
-                sandbox_id = str(row.get("sandbox_id") or "").strip()
-                if sandbox_id:
-                    return sandbox_id
-                break
-    finally:
-        repo.close()
-    raise KeyError(f"Lease not found: {lease_id}")
 
 
 @router.get("/leases")
@@ -259,11 +234,11 @@ async def resources_refresh():
     return await asyncio.to_thread(_refresh_monitor_resources_sync)
 
 
-@router.get("/sandbox/{lease_id}/browse")
-async def sandbox_browse(lease_id: str, path: str = Query(default="/")):
-    return await _lease_resource_io(resource_service.browse_sandbox, lease_id, path)
+@router.get("/sandboxes/{sandbox_id}/browse")
+async def sandbox_browse(sandbox_id: str, path: str = Query(default="/")):
+    return await _resource_io(resource_service.browse_sandbox, sandbox_id, path)
 
 
-@router.get("/sandbox/{lease_id}/read")
-async def sandbox_read_file(lease_id: str, path: str = Query(...)):
-    return await _lease_resource_io(resource_service.read_sandbox, lease_id, path)
+@router.get("/sandboxes/{sandbox_id}/read")
+async def sandbox_read_file(sandbox_id: str, path: str = Query(...)):
+    return await _resource_io(resource_service.read_sandbox, sandbox_id, path)

--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -1119,7 +1119,7 @@ function SandboxInspector({
             ) : null}
           </div>
           <MonitorFileBrowser
-            leaseId={group.leaseId}
+            sandboxId={group.sandboxId}
             providerType={providerType}
             disabled={group.status === "stopped" || group.status === "destroying"}
             unavailableReason={browserUnavailableReason}
@@ -1154,17 +1154,17 @@ function MetricBlock({
 }
 
 function MonitorFileBrowser({
-  leaseId,
+  sandboxId,
   providerType,
   disabled,
   unavailableReason,
 }: {
-  leaseId: string;
+  sandboxId: string;
   providerType: ProviderInfo["type"];
   disabled: boolean;
   unavailableReason?: string | null;
 }) {
-  const isLocal = providerType === "local" || !leaseId;
+  const isLocal = providerType === "local" || !sandboxId;
   const defaultPath = isLocal ? "~" : "/";
   const [currentPath, setCurrentPath] = React.useState(defaultPath);
   const [parentPath, setParentPath] = React.useState<string | null>(null);
@@ -1189,7 +1189,7 @@ function MonitorFileBrowser({
                 parent_path?: string | null;
                 items?: BrowseItem[];
               }>(`/api/settings/browse?path=${encodeURIComponent(path)}&include_files=true`)
-          : await browseMonitorSandbox(leaseId, path);
+          : await browseMonitorSandbox(sandboxId, path);
         setCurrentPath(data.current_path ?? path);
         setParentPath(data.parent_path ?? null);
         setItems(data.items ?? []);
@@ -1199,7 +1199,7 @@ function MonitorFileBrowser({
         setLoading(false);
       }
     },
-    [isLocal, leaseId],
+    [isLocal, sandboxId],
   );
 
   React.useEffect(() => {
@@ -1220,7 +1220,7 @@ function MonitorFileBrowser({
           ? await fetchJsonOrThrow<{ content: string; truncated: boolean }>(
               `/api/settings/read?path=${encodeURIComponent(path)}`,
             )
-          : await readMonitorSandboxFile(leaseId, path);
+          : await readMonitorSandboxFile(sandboxId, path);
         setFileContent(data.content);
         if (data.truncated) {
           setFileError("内容已截断至 100 KB");
@@ -1231,7 +1231,7 @@ function MonitorFileBrowser({
         setFileLoading(false);
       }
     },
-    [isLocal, leaseId],
+    [isLocal, sandboxId],
   );
 
   const openFile = React.useCallback(

--- a/frontend/monitor/src/resources/api.test.ts
+++ b/frontend/monitor/src/resources/api.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { cleanupMonitorProviderSession, fetchMonitorProviderSessions } from "./api";
+import {
+  browseMonitorSandbox,
+  cleanupMonitorProviderSession,
+  fetchMonitorProviderSessions,
+  readMonitorSandboxFile,
+} from "./api";
 
 describe("monitor resource API", () => {
   afterEach(() => {
@@ -57,5 +62,31 @@ describe("monitor resource API", () => {
       headers: { "Content-Type": "application/json" },
     });
     expect(payload.operation?.status).toBe("succeeded");
+  });
+
+  it("browses monitor sandbox files through sandbox-shaped route naming", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ current_path: "/workspace", parent_path: "/", items: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const payload = await browseMonitorSandbox("sandbox-1", "/workspace");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/monitor/sandboxes/sandbox-1/browse?path=%2Fworkspace", undefined);
+    expect(payload.current_path).toBe("/workspace");
+  });
+
+  it("reads monitor sandbox files through sandbox-shaped route naming", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ path: "/README.md", content: "hello", truncated: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const payload = await readMonitorSandboxFile("sandbox-1", "/README.md");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/monitor/sandboxes/sandbox-1/read?path=%2FREADME.md", undefined);
+    expect(payload.content).toBe("hello");
   });
 });

--- a/frontend/monitor/src/resources/api.ts
+++ b/frontend/monitor/src/resources/api.ts
@@ -66,17 +66,17 @@ export async function cleanupMonitorProviderSession(
   });
 }
 
-export async function browseMonitorSandbox(leaseId: string, path: string): Promise<{
+export async function browseMonitorSandbox(sandboxId: string, path: string): Promise<{
   current_path: string;
   parent_path: string | null;
   items: BrowseItem[];
 }> {
-  return fetchJsonOrThrow(`/api/monitor/sandbox/${leaseId}/browse?path=${encodeURIComponent(path)}`);
+  return fetchJsonOrThrow(`/api/monitor/sandboxes/${sandboxId}/browse?path=${encodeURIComponent(path)}`);
 }
 
 export async function readMonitorSandboxFile(
-  leaseId: string,
+  sandboxId: string,
   path: string,
 ): Promise<{ path: string; content: string; truncated: boolean }> {
-  return fetchJsonOrThrow(`/api/monitor/sandbox/${leaseId}/read?path=${encodeURIComponent(path)}`);
+  return fetchJsonOrThrow(`/api/monitor/sandboxes/${sandboxId}/read?path=${encodeURIComponent(path)}`);
 }

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -275,15 +275,14 @@ def test_monitor_evaluation_batch_create_and_start_pass_request_context(monkeypa
 @pytest.mark.parametrize(
     ("verb", "path", "service_name"),
     [
-        ("get", "/api/monitor/sandbox/lease-1/browse", "browse_sandbox"),
-        ("get", "/api/monitor/sandbox/lease-1/read?path=/README.md", "read_sandbox"),
+        ("get", "/api/monitor/sandboxes/sandbox-1/browse", "browse_sandbox"),
+        ("get", "/api/monitor/sandboxes/sandbox-1/read?path=/README.md", "read_sandbox"),
     ],
 )
 def test_monitor_sandbox_routes_map_runtime_failures_to_503(monkeypatch, verb, path, service_name):
     def _raise(*_args, **_kwargs):
         raise RuntimeError("provider unavailable")
 
-    monkeypatch.setattr(monitor, "_resolve_sandbox_id_for_lease", lambda _lease_id: "sandbox-1")
     monkeypatch.setattr(resource_service, service_name, _raise)
 
     response = _request(verb, path, raise_server_exceptions=False)
@@ -295,21 +294,13 @@ def test_monitor_sandbox_routes_map_runtime_failures_to_503(monkeypatch, verb, p
 @pytest.mark.parametrize(
     ("path", "service_name", "expected_args"),
     [
-        ("/api/monitor/sandbox/lease-1/browse?path=/workspace", "browse_sandbox", ("sandbox-1", "/workspace")),
-        ("/api/monitor/sandbox/lease-1/read?path=/README.md", "read_sandbox", ("sandbox-1", "/README.md")),
+        ("/api/monitor/sandboxes/sandbox-1/browse?path=/workspace", "browse_sandbox", ("sandbox-1", "/workspace")),
+        ("/api/monitor/sandboxes/sandbox-1/read?path=/README.md", "read_sandbox", ("sandbox-1", "/README.md")),
     ],
 )
-def test_monitor_sandbox_routes_bridge_lease_wrapper_to_sandbox_shaped_service(monkeypatch, path, service_name, expected_args):
-    class _Repo:
-        def query_sandboxes(self):
-            return [{"sandbox_id": "sandbox-1", "lease_id": "lease-1"}]
-
-        def close(self):
-            return None
-
+def test_monitor_sandbox_routes_use_sandbox_shaped_path_subject(monkeypatch, path, service_name, expected_args):
     calls: list[tuple[str, str]] = []
 
-    monkeypatch.setattr(monitor, "make_sandbox_monitor_repo", lambda: _Repo())
     monkeypatch.setattr(
         resource_service,
         service_name,


### PR DESCRIPTION
## Summary
- switch monitor browse/read routes to sandbox-shaped path subjects
- move monitor frontend browse/read callers to sandboxId
- remove the old lease-shaped browse/read route naming

## Verification
- uv run python -m pytest -q tests/Integration/test_monitor_resources_route.py -k "monitor_sandbox_routes_map_runtime_failures_to_503 or monitor_sandbox_routes_use_sandbox_shaped_path_subject"
- cd frontend/monitor && npm test -- src/resources/api.test.ts -- --runInBand
- uv run python -m pytest -q tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_resource_probe.py
- cd frontend/monitor && npm run build
- git diff --check