### PR TITLE
chore: cut over lease cleanup backend wrapper

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -12,6 +12,7 @@ from backend.web.services.resource_cache import (
     get_resource_overview_snapshot,
     refresh_resource_overview_sync,
 )
+from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 router = APIRouter(prefix="/api/monitor")
 
@@ -56,6 +57,20 @@ async def _resource_io(fn, *args):
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
+def _resolve_sandbox_id_for_lease(lease_id: str) -> str:
+    repo = make_sandbox_monitor_repo()
+    try:
+        for row in repo.query_sandboxes():
+            if str(row.get("lease_id") or "").strip() == str(lease_id or "").strip():
+                sandbox_id = str(row.get("sandbox_id") or "").strip()
+                if sandbox_id:
+                    return sandbox_id
+                break
+    finally:
+        repo.close()
+    raise KeyError(f"Lease not found: {lease_id}")
+
+
 @router.get("/leases")
 def leases_snapshot():
     return monitor_service.list_leases()
@@ -96,7 +111,7 @@ def sandbox_detail_snapshot(sandbox_id: str):
 
 @router.post("/leases/{lease_id}/cleanup")
 def lease_cleanup_action(lease_id: str):
-    return _or_404(monitor_service.request_monitor_lease_cleanup, lease_id)
+    return _or_404(monitor_service.request_monitor_sandbox_cleanup, _resolve_sandbox_id_for_lease(lease_id))
 
 
 @router.post("/sandboxes/{sandbox_id}/cleanup")

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -144,7 +144,6 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
         ("get", "/api/monitor/providers/daytona", "get_monitor_provider_detail", {"provider": {"id": "daytona"}}),
         ("get", "/api/monitor/leases/lease-1", "get_monitor_lease_detail", {"lease": {"lease_id": "lease-1"}}),
         ("get", "/api/monitor/sandboxes/sandbox-1", "get_monitor_sandbox_detail", {"sandbox": {"sandbox_id": "sandbox-1"}}),
-        ("post", "/api/monitor/leases/lease-1/cleanup", "request_monitor_lease_cleanup", {"accepted": True}),
         ("post", "/api/monitor/sandboxes/sandbox-1/cleanup", "request_monitor_sandbox_cleanup", {"accepted": True}),
         (
             "post",
@@ -176,6 +175,35 @@ def test_monitor_routes_delegate_to_service(monkeypatch, method, path, service_n
     assert response.status_code == 200
     assert response.json() == payload
     assert calls
+
+
+def test_monitor_lease_cleanup_route_bridges_to_canonical_sandbox_cleanup(monkeypatch):
+    class _Repo:
+        def query_sandboxes(self):
+            return [{"sandbox_id": "sandbox-1", "lease_id": "lease-1"}]
+
+        def close(self):
+            return None
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(monitor, "make_sandbox_monitor_repo", lambda: _Repo())
+    monkeypatch.setattr(
+        monitor_service,
+        "request_monitor_sandbox_cleanup",
+        lambda sandbox_id: calls.append(sandbox_id) or {"accepted": True},
+    )
+    monkeypatch.setattr(
+        monitor_service,
+        "request_monitor_lease_cleanup",
+        lambda _lease_id: (_ for _ in ()).throw(AssertionError("lease cleanup route should bridge to canonical sandbox cleanup")),
+    )
+
+    response = _request("post", "/api/monitor/leases/lease-1/cleanup")
+
+    assert response.status_code == 200
+    assert response.json() == {"accepted": True}
+    assert calls == ["sandbox-1"]
 
 
 def test_monitor_threads_routes_use_authenticated_owner(monkeypatch):


### PR DESCRIPTION
## Summary
- bridge the lease cleanup route directly to canonical sandbox cleanup
- keep the lease-shaped cleanup path as the outward compatibility shell
- avoid mixing lease detail read into this slice

## Verification
- uv run python -m pytest -q tests/Integration/test_monitor_resources_route.py -k "monitor_routes_delegate_to_service or monitor_lease_cleanup_route_bridges_to_canonical_sandbox_cleanup"
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py -k "request_monitor_lease_cleanup or request_monitor_sandbox_cleanup or get_monitor_lease_detail"
- uv run python -m pytest -q tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py
- uv run ruff check backend/web/routers/monitor.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check