### PR TITLE
feat: add sandbox detail cleanup parity

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -579,6 +579,9 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
     sandbox = repo.query_sandbox(sandbox_id)
     if sandbox is None:
         raise KeyError(f"Sandbox not found: {sandbox_id}")
+    lease_id = str(sandbox.get("lease_id") or "").strip()
+    if not lease_id:
+        raise RuntimeError("monitor sandbox detail target missing lease bridge")
 
     threads = repo.query_sandbox_threads(sandbox_id)
     sessions = repo.query_sandbox_sessions(sandbox_id)
@@ -627,6 +630,24 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
             }
             for item in sessions
         ],
+        "cleanup": monitor_operation_service.build_lease_cleanup_truth(
+            lease_id=lease_id,
+            triage=triage,
+            provider_name=provider_name,
+            runtime_session_id=runtime_session_id,
+            sessions=[
+                {
+                    "chat_session_id": item.get("chat_session_id"),
+                    "thread_id": item.get("thread_id"),
+                    "status": item.get("status"),
+                    "started_at": item.get("started_at"),
+                    "ended_at": item.get("ended_at"),
+                    "close_reason": item.get("close_reason"),
+                }
+                for item in sessions
+            ],
+            threads=live_thread_refs,
+        ),
     }
 
 

--- a/frontend/monitor/src/pages/SandboxDetailPage.test.ts
+++ b/frontend/monitor/src/pages/SandboxDetailPage.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildSandboxDetailShell } from "./SandboxDetailPage";
 
 describe("sandbox detail page shell", () => {
-  it("uses sandbox-shaped shell with cleanup lane", () => {
+  it("uses sandbox-shaped shell with cleanup parity lane", () => {
     const shell = buildSandboxDetailShell({
       sandbox: {
         sandbox_id: "sandbox-1",
@@ -29,10 +29,26 @@ describe("sandbox detail page shell", () => {
       },
       threads: [{ thread_id: "thread-1" }],
       sessions: [{ chat_session_id: "chat-1", thread_id: "thread-1", status: "active" }],
+      cleanup: {
+        allowed: true,
+        recommended_action: "lease_cleanup",
+        reason: "Lease is orphan cleanup residue and can enter managed cleanup.",
+        operation: {
+          operation_id: "op-1",
+          kind: "lease_cleanup",
+          status: "succeeded",
+          summary: "Lease cleanup completed.",
+        },
+        recent_operations: [],
+      },
     });
 
     expect(shell.title).toBe("Sandbox sandbox-1");
     expect(shell.surfaceHref).toBe("/sandboxes");
     expect(shell.cleanupIncluded).toBe(true);
+    expect(shell.cleanupTitle).toBe("Cleanup");
+    expect(shell.cleanupHint).toBe("Canonical sandbox cleanup lane for current operation and recent cleanup history.");
+    expect(shell.cleanupButtonLabel).toBe("Start sandbox cleanup");
+    expect(shell.cleanupLedgerTitle).toBe("Recent Operations");
   });
 });

--- a/frontend/monitor/src/pages/SandboxDetailPage.tsx
+++ b/frontend/monitor/src/pages/SandboxDetailPage.tsx
@@ -36,7 +36,35 @@ export type SandboxDetailPayload = {
     chat_session_id?: string | null;
     thread_id?: string | null;
     status?: string | null;
+    started_at?: string | null;
+    ended_at?: string | null;
+    close_reason?: string | null;
   }> | null;
+  cleanup?: {
+    allowed?: boolean;
+    recommended_action?: string | null;
+    reason?: string | null;
+    operation?: {
+      operation_id?: string | null;
+      kind?: string | null;
+      status?: string | null;
+      summary?: string | null;
+    } | null;
+    recent_operations?: Array<{
+      operation_id?: string | null;
+      kind?: string | null;
+      status?: string | null;
+      summary?: string | null;
+    }> | null;
+  } | null;
+};
+
+const CLEANUP_STATUS_CLASS_BY_STATUS: Record<string, string> = {
+  pending: "cleanup-status cleanup-status--warning",
+  running: "cleanup-status cleanup-status--warning",
+  succeeded: "cleanup-status cleanup-status--ok",
+  failed: "cleanup-status cleanup-status--danger",
+  rejected: "cleanup-status cleanup-status--danger",
 };
 
 export function buildSandboxDetailShell(data: SandboxDetailPayload) {
@@ -45,6 +73,10 @@ export function buildSandboxDetailShell(data: SandboxDetailPayload) {
     description: data.triage?.description ?? "Sandbox state and current read-only relations.",
     surfaceHref: "/sandboxes",
     cleanupIncluded: true,
+    cleanupTitle: "Cleanup",
+    cleanupHint: "Canonical sandbox cleanup lane for current operation and recent cleanup history.",
+    cleanupButtonLabel: "Start sandbox cleanup",
+    cleanupLedgerTitle: "Recent Operations",
   };
 }
 
@@ -63,7 +95,19 @@ export default function SandboxDetailPage() {
   const threads = data.threads ?? [];
   const sessions = data.sessions ?? [];
   const latestSession = sessions[0] ?? null;
-  const cleanupAllowed = Boolean(data.triage?.category && data.triage.category !== "healthy_capacity");
+  const cleanup = data.cleanup ?? {};
+  const cleanupAllowed = Boolean(cleanup.allowed);
+  const recentOperations = (cleanup.recent_operations ?? []).filter(
+    (operation) => operation.operation_id !== cleanup.operation?.operation_id,
+  );
+  const cleanupDecision = cleanup.allowed ? "Managed cleanup ready" : "Cleanup blocked";
+  const cleanupActionSummary = cleanup.recommended_action ?? "No managed action";
+  const cleanupActionHint = cleanup.allowed
+    ? "This sandbox can enter the managed cleanup flow."
+    : "This sandbox is not ready for managed cleanup.";
+  const cleanupOperationStatus = cleanup.operation?.status ?? "idle";
+  const cleanupOperationSummary = cleanup.operation?.summary ?? "No active cleanup operation.";
+  const cleanupOperationClass = CLEANUP_STATUS_CLASS_BY_STATUS[cleanupOperationStatus] ?? "cleanup-status cleanup-status--muted";
 
   async function startCleanup() {
     setCleanupPending(true);
@@ -98,8 +142,26 @@ export default function SandboxDetailPage() {
         </div>
       </section>
       <section className="surface-section">
-        <h2>Cleanup</h2>
+        <h2>{shell.cleanupTitle}</h2>
+        <p className="description">{cleanup.reason ?? shell.cleanupHint}</p>
         <div className="surface-grid cleanup-grid">
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Decision</p>
+            <p className="surface-card__value surface-card__value--compact">{cleanupDecision}</p>
+            <p className="surface-card__body">{cleanupActionSummary}</p>
+          </article>
+          <article className="surface-card">
+            <p className="surface-card__eyebrow">Current Operation</p>
+            <div className="cleanup-current-op">
+              <span className={cleanupOperationClass}>{cleanupOperationStatus}</span>
+              {cleanup.operation?.operation_id ? (
+                <Link to={`/operations/${cleanup.operation.operation_id}`} className="cleanup-operation-link">
+                  {cleanup.operation.operation_id}
+                </Link>
+              ) : null}
+            </div>
+            <p className="surface-card__body">{cleanupOperationSummary}</p>
+          </article>
           <article className="surface-card">
             <p className="surface-card__eyebrow">Action Lane</p>
             <button
@@ -108,14 +170,41 @@ export default function SandboxDetailPage() {
               disabled={!cleanupAllowed || cleanupPending}
               onClick={() => void startCleanup()}
             >
-              Start sandbox cleanup
+              {shell.cleanupButtonLabel}
             </button>
-            <p className="surface-card__body">
-              {cleanupAllowed ? "This sandbox can enter the managed cleanup flow." : "This sandbox is not ready for managed cleanup."}
-            </p>
+            <p className="surface-card__body">{cleanupActionHint}</p>
           </article>
         </div>
         {cleanupMessage ? <p className="description">{cleanupMessage}</p> : null}
+        <div className="cleanup-ledger">
+          <h3>{shell.cleanupLedgerTitle}</h3>
+          {recentOperations.length > 0 ? (
+            <div className="cleanup-ledger__list">
+              {recentOperations.map((operation) => {
+                const operationStatus = operation.status ?? "unknown";
+                const operationClass =
+                  CLEANUP_STATUS_CLASS_BY_STATUS[operationStatus] ?? "cleanup-status cleanup-status--muted";
+                return (
+                  <article className="cleanup-ledger__item" key={operation.operation_id ?? "missing-operation"}>
+                    <div className="cleanup-ledger__header">
+                      <span className={operationClass}>{operationStatus}</span>
+                      {operation.operation_id ? (
+                        <Link to={`/operations/${operation.operation_id}`} className="cleanup-operation-link mono">
+                          {operation.operation_id}
+                        </Link>
+                      ) : (
+                        <span className="mono">-</span>
+                      )}
+                    </div>
+                    <p className="cleanup-ledger__summary">{operation.summary ?? "-"}</p>
+                  </article>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="cleanup-ledger__empty">No recorded cleanup operations.</p>
+          )}
+        </div>
       </section>
       <section className="surface-section">
         <h2>Relations</h2>

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -432,7 +432,7 @@ def test_get_monitor_sandbox_detail_merges_monitor_repo_state(monkeypatch):
     assert payload["provider"] == {"id": "daytona", "name": "daytona"}
     assert payload["runtime"] == {"runtime_session_id": "runtime-1"}
     assert payload["threads"] == [{"thread_id": "thread-1"}]
-    assert "cleanup" not in payload
+    assert payload["cleanup"]["allowed"] is False
     assert "lease" not in payload
 
 
@@ -537,7 +537,17 @@ def test_get_monitor_sandbox_detail_is_canonical_single_emit(monkeypatch):
 
     assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
     assert "lease_id" not in payload["sandbox"]
-    assert "cleanup" not in payload
+    assert payload["cleanup"]["allowed"] is False
+    assert payload["cleanup"]["recommended_action"] is None
+
+
+def test_get_monitor_sandbox_detail_exposes_cleanup_state(monkeypatch):
+    _use_monitor_repo(monkeypatch, FakeLeaseRepo(lease=_detached_lease()))
+
+    payload = monitor_service.get_monitor_sandbox_detail("sandbox-1")
+
+    assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
+    assert payload["cleanup"] == _cleanup_state("Lease is orphan cleanup residue and can enter managed cleanup.")
 
 
 def test_get_monitor_lease_detail_exposes_cleanup_state(monkeypatch):


### PR DESCRIPTION
## Summary
- add cleanup truth to canonical sandbox detail payload
- extend SandboxDetailPage to show cleanup operation and recent operation ledger
- keep lease detail route/page unchanged in this slice

## Verification
- uv run python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py
- cd frontend/monitor && npm test -- src/pages/SandboxDetailPage.test.ts src/pages/LeaseDetailPage.test.ts
- cd frontend/monitor && npm run build
- uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check