### PR TITLE
feat: cut over frontend lease detail shell

### DIFF
--- a/frontend/monitor/src/pages/LeaseDetailPage.test.ts
+++ b/frontend/monitor/src/pages/LeaseDetailPage.test.ts
@@ -3,17 +3,16 @@ import { describe, expect, it } from "vitest";
 import { buildLeaseDetailShell } from "./LeaseDetailPage";
 
 describe("lease detail page shell", () => {
-  it("keeps cleanup as compatibility shell after sandbox cleanup rollout", () => {
+  it("becomes a compatibility redirect shell after sandbox detail parity lands", () => {
     const shell = buildLeaseDetailShell({
-      lease: { lease_id: "lease-1" },
+      lease: { lease_id: "lease-1", sandbox_id: "sandbox-1" },
       triage: { description: "Lease state and cleanup readiness." },
-      cleanup: { allowed: true },
+      cleanup: { reason: "Canonical sandbox detail is ready." },
     });
 
-    expect(shell.title).toBe("Lease lease-1");
-    expect(shell.cleanupTitle).toBe("Compatibility Cleanup");
-    expect(shell.cleanupHint).toBe("Legacy lease-shaped cleanup entry kept during sandbox cleanup rollout.");
-    expect(shell.cleanupButtonLabel).toBe("Start compatibility cleanup");
+    expect(shell.title).toBe("Lease compatibility redirect");
+    expect(shell.description).toBe("Legacy lease-shaped detail route now redirects to canonical sandbox detail.");
+    expect(shell.canonicalHref).toBe("/sandboxes/sandbox-1");
     expect(shell.compatibilityOnly).toBe(true);
   });
 });

--- a/frontend/monitor/src/pages/LeaseDetailPage.tsx
+++ b/frontend/monitor/src/pages/LeaseDetailPage.tsx
@@ -1,89 +1,33 @@
 import React from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { fetchAPI, postMonitorData, type MonitorFetchError, useMonitorData } from "../app/fetch";
+import { useMonitorData } from "../app/fetch";
 import ErrorState from "../components/ErrorState";
-import StateBadge from "../components/StateBadge";
 
 type LeaseDetailPayload = {
   lease: {
     lease_id: string;
+    sandbox_id?: string | null;
     provider_name?: string | null;
     desired_state?: string | null;
     observed_state?: string | null;
     updated_at?: string | null;
-    updated_ago?: string | null;
-    last_error?: string | null;
-    badge?: Record<string, unknown>;
   };
   triage?: {
-    category?: string | null;
-    title?: string | null;
     description?: string | null;
-    tone?: string | null;
   } | null;
-  provider?: {
-    id?: string | null;
-    name?: string | null;
-  } | null;
-  runtime?: {
-    runtime_session_id?: string | null;
-  } | null;
-  threads?: Array<{
-    thread_id?: string | null;
-  }> | null;
-  sessions?: Array<{
-    chat_session_id?: string | null;
-    thread_id?: string | null;
-    status?: string | null;
-  }> | null;
   cleanup?: {
-    allowed?: boolean;
-    recommended_action?: string | null;
     reason?: string | null;
-    operation?: {
-      operation_id?: string | null;
-      kind?: string | null;
-      status?: string | null;
-      summary?: string | null;
-    } | null;
-    recent_operations?: Array<{
-      operation_id?: string | null;
-      kind?: string | null;
-      status?: string | null;
-      summary?: string | null;
-    }> | null;
   } | null;
-};
-
-type LeaseCleanupActionPayload = {
-  accepted: boolean;
-  message?: string | null;
-  operation?: {
-    operation_id?: string | null;
-    kind?: string | null;
-    target_type?: string | null;
-    target_id?: string | null;
-    status?: string | null;
-    summary?: string | null;
-  } | null;
-};
-
-const CLEANUP_STATUS_CLASS_BY_STATUS: Record<string, string> = {
-  pending: "cleanup-status cleanup-status--warning",
-  running: "cleanup-status cleanup-status--warning",
-  succeeded: "cleanup-status cleanup-status--ok",
-  failed: "cleanup-status cleanup-status--danger",
-  rejected: "cleanup-status cleanup-status--danger",
 };
 
 export function buildLeaseDetailShell(data: Pick<LeaseDetailPayload, "lease" | "triage" | "cleanup">) {
+  const sandboxId = String(data.lease.sandbox_id ?? "").trim();
   return {
-    title: `Lease ${data.lease.lease_id}`,
-    description: data.triage?.description ?? "Lease state and cleanup readiness.",
-    cleanupTitle: "Compatibility Cleanup",
-    cleanupHint: "Legacy lease-shaped cleanup entry kept during sandbox cleanup rollout.",
-    cleanupButtonLabel: "Start compatibility cleanup",
+    title: "Lease compatibility redirect",
+    description: "Legacy lease-shaped detail route now redirects to canonical sandbox detail.",
+    reason: data.cleanup?.reason ?? data.triage?.description ?? "Canonical sandbox detail is now the source of truth.",
+    canonicalHref: sandboxId ? `/sandboxes/${sandboxId}` : null,
     compatibilityOnly: true,
   };
 }
@@ -93,206 +37,38 @@ export default function LeaseDetailPage() {
   const leaseId = params.leaseId ?? "";
   const navigate = useNavigate();
   const { data, error } = useMonitorData<LeaseDetailPayload>(`/leases/${leaseId}`);
-  const [leaseData, setLeaseData] = React.useState<LeaseDetailPayload | null>(null);
-  const [cleanupMessage, setCleanupMessage] = React.useState<string | null>(null);
-  const [cleanupPending, setCleanupPending] = React.useState(false);
-
-  React.useEffect(() => {
-    if (data) {
-      setLeaseData(data);
-      setCleanupMessage(null);
-      setCleanupPending(false);
-    }
-  }, [data]);
 
   if (error) return <ErrorState title={`Lease ${leaseId}`} error={error} />;
-  if (!leaseData) return <div>Loading...</div>;
+  if (!data) return <div>Loading...</div>;
 
-  const threads = leaseData.threads ?? [];
-  const sessions = leaseData.sessions ?? [];
-  const cleanup = leaseData.cleanup ?? {};
-  const recentOperations = (cleanup.recent_operations ?? []).filter(
-    (operation) => operation.operation_id !== cleanup.operation?.operation_id,
-  );
-  const latestSession = sessions[0] ?? null;
-  const shell = buildLeaseDetailShell(leaseData);
-  const cleanupDecision = cleanup.allowed ? "Managed cleanup ready" : "Cleanup blocked";
-  const cleanupActionSummary = cleanup.recommended_action ?? "No managed action";
-  const cleanupActionHint = cleanup.allowed
-    ? "This lease can enter the managed destroy flow."
-    : "This lease cannot enter the managed flow until its state changes.";
-  const cleanupOperationStatus = cleanup.operation?.status ?? "idle";
-  const cleanupOperationSummary = cleanup.operation?.summary ?? "No active cleanup operation.";
-  const cleanupOperationClass = CLEANUP_STATUS_CLASS_BY_STATUS[cleanupOperationStatus] ?? "cleanup-status cleanup-status--muted";
-  const cleanupFeedbackMessage =
-    cleanupMessage && cleanupMessage !== cleanupOperationSummary ? cleanupMessage : null;
+  const shell = buildLeaseDetailShell(data);
 
-  async function startCleanup() {
-    setCleanupPending(true);
-    try {
-      const result = await postMonitorData<LeaseCleanupActionPayload>(`/leases/${leaseId}/cleanup`);
-      setCleanupMessage(result.message ?? null);
-      if (result.accepted && result.operation?.status === "succeeded" && result.operation.operation_id) {
-        navigate(`/operations/${result.operation.operation_id}`);
-        return;
-      }
-      try {
-        const refreshed = await fetchAPI<LeaseDetailPayload>(`/leases/${leaseId}`);
-        setLeaseData(refreshed);
-      } catch (err: unknown) {
-        const fetchError = err as MonitorFetchError;
-        if (fetchError?.status === 404 && result.operation?.operation_id) {
-          navigate(`/operations/${result.operation.operation_id}`);
-          return;
-        }
-        throw err;
-      }
-    } finally {
-      setCleanupPending(false);
+  React.useEffect(() => {
+    if (shell.canonicalHref) {
+      navigate(shell.canonicalHref, { replace: true });
     }
-  }
+  }, [navigate, shell.canonicalHref]);
 
   return (
     <div className="page">
       <h1>{shell.title}</h1>
       <p className="description">{shell.description}</p>
       <section className="surface-section">
-        <h2>State</h2>
+        <h2>Compatibility Route</h2>
+        <p className="description">{shell.reason}</p>
         <div className="surface-grid">
           <article className="surface-card">
-            <p className="surface-card__eyebrow">State</p>
-            <StateBadge badge={leaseData.lease.badge ?? { text: leaseData.lease.observed_state ?? "-" }} />
+            <p className="surface-card__eyebrow">Legacy Lease Route</p>
+            <p className="surface-card__value surface-card__value--compact mono">{leaseId}</p>
+            <p className="surface-card__body">This detail surface is now compatibility-only.</p>
           </article>
           <article className="surface-card">
-            <p className="surface-card__eyebrow">Triage</p>
-            <p className="surface-card__value">{leaseData.triage?.title ?? "-"}</p>
-          </article>
-        </div>
-      </section>
-      <section className="surface-section">
-        <h2>{shell.cleanupTitle}</h2>
-        <p className="description">{cleanup.reason ?? shell.cleanupHint}</p>
-        <div className="surface-grid cleanup-grid">
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Decision</p>
-            <p className="surface-card__value surface-card__value--compact">{cleanupDecision}</p>
-            <p className="surface-card__body">{cleanupActionSummary}</p>
-          </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Current Operation</p>
-            <div className="cleanup-current-op">
-              <span className={cleanupOperationClass}>{cleanupOperationStatus}</span>
-              {cleanup.operation?.operation_id ? (
-                <Link to={`/operations/${cleanup.operation.operation_id}`} className="cleanup-operation-link">
-                  {cleanup.operation.operation_id}
-                </Link>
-              ) : null}
-            </div>
-            <p className="surface-card__body">{cleanupOperationSummary}</p>
-          </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Action Lane</p>
-            <button
-              type="button"
-              className="monitor-action-button"
-              disabled={!cleanup.allowed || cleanupPending}
-              onClick={() => void startCleanup()}
-            >
-              {shell.cleanupButtonLabel}
-            </button>
-            <p className="surface-card__body">{cleanupActionHint}</p>
-          </article>
-        </div>
-        {cleanupFeedbackMessage ? <p className="description">{cleanupFeedbackMessage}</p> : null}
-        <div className="cleanup-ledger">
-          <h3>Recent Operations</h3>
-          {recentOperations.length > 0 ? (
-            <div className="cleanup-ledger__list">
-              {recentOperations.map((operation) => {
-                const operationStatus = operation.status ?? "unknown";
-                const operationClass =
-                  CLEANUP_STATUS_CLASS_BY_STATUS[operationStatus] ?? "cleanup-status cleanup-status--muted";
-                return (
-                  <article className="cleanup-ledger__item" key={operation.operation_id ?? "missing-operation"}>
-                    <div className="cleanup-ledger__header">
-                      <span className={operationClass}>{operationStatus}</span>
-                      {operation.operation_id ? (
-                        <Link to={`/operations/${operation.operation_id}`} className="cleanup-operation-link mono">
-                          {operation.operation_id}
-                        </Link>
-                      ) : (
-                        <span className="mono">-</span>
-                      )}
-                    </div>
-                    <p className="cleanup-ledger__summary">{operation.summary ?? "-"}</p>
-                  </article>
-                );
-              })}
-            </div>
-          ) : (
-            <p className="cleanup-ledger__empty">No recorded cleanup operations.</p>
-          )}
-        </div>
-      </section>
-      <section className="surface-section">
-        <h2>Relations</h2>
-        <h3>Object Links</h3>
-        <div className="surface-grid">
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Provider</p>
+            <p className="surface-card__eyebrow">Canonical Sandbox Route</p>
             <p className="surface-card__value surface-card__value--compact">
-              {leaseData.provider?.id ? (
-                <Link to={`/providers/${leaseData.provider.id}`}>{leaseData.provider.name ?? leaseData.provider.id}</Link>
-              ) : (
-                leaseData.provider?.name ?? leaseData.lease.provider_name ?? "-"
-              )}
+              {shell.canonicalHref ? <Link to={shell.canonicalHref}>{shell.canonicalHref}</Link> : "-"}
             </p>
-            <p className="surface-card__body">Provider surface and capacity state.</p>
+            <p className="surface-card__body">Opening the sandbox detail surface instead.</p>
           </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Runtime</p>
-            <p className="surface-card__value surface-card__value--compact">
-              {leaseData.runtime?.runtime_session_id ? (
-                <Link to={`/runtimes/${leaseData.runtime.runtime_session_id}`}>{leaseData.runtime.runtime_session_id}</Link>
-              ) : (
-                "-"
-              )}
-            </p>
-            <p className="surface-card__body">Live sandbox/runtime session for this lease.</p>
-          </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Thread</p>
-            <p className="surface-card__value surface-card__value--compact">
-              {threads[0]?.thread_id ? <Link to={`/threads/${threads[0].thread_id}`}>{threads[0].thread_id}</Link> : "No related thread"}
-            </p>
-            <p className="surface-card__body">Primary thread currently linked to this lease.</p>
-          </article>
-          <article className="surface-card">
-            <p className="surface-card__eyebrow">Session</p>
-            <p className="surface-card__value surface-card__value--compact">{latestSession?.chat_session_id ?? "No recorded session"}</p>
-            <p className="surface-card__body">Most recent chat session observed for this lease.</p>
-          </article>
-        </div>
-        <h3>Context</h3>
-        <div className="info-grid">
-          <div>
-            <strong>Updated</strong>
-            <span>{leaseData.lease.updated_ago ?? leaseData.lease.updated_at ?? "-"}</span>
-          </div>
-          <div>
-            <strong>Surface</strong>
-            <span>
-              <Link to="/leases">Leases</Link>
-            </span>
-          </div>
-          <div>
-            <strong>Last error</strong>
-            <span>{leaseData.lease.last_error ?? "-"}</span>
-          </div>
-          <div>
-            <strong>Session status</strong>
-            <span>{latestSession?.status ?? "-"}</span>
-          </div>
         </div>
       </section>
     </div>

--- a/frontend/monitor/src/pages/LeasesPage.test.ts
+++ b/frontend/monitor/src/pages/LeasesPage.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLeaseWorkbenchShell } from "./LeasesPage";
+
+describe("leases page shell", () => {
+  it("uses lease rows as compatibility links into canonical sandbox detail", () => {
+    const shell = buildLeaseWorkbenchShell({
+      title: "All Leases",
+      count: 1,
+      triage: {
+        summary: {
+          active_drift: 0,
+          detached_residue: 0,
+          orphan_cleanup: 1,
+          healthy_capacity: 0,
+        },
+      },
+      items: [
+        {
+          sandbox_id: "sandbox-1",
+          lease_id: "lease-1",
+          provider: "docker",
+          instance_id: "runtime-1",
+          triage: { category: "orphan_cleanup", title: "Orphan Cleanup" },
+          thread: { thread_id: "thread-1" },
+          state_badge: { text: "paused" },
+          updated_ago: "1m ago",
+          error: null,
+        },
+      ],
+    });
+
+    expect(shell.triageTitle).toBe("Lease Triage");
+    expect(shell.workbenchTitle).toBe("Lease Workbench");
+    expect(shell.rows[0].href).toBe("/sandboxes/sandbox-1");
+    expect(shell.rows[0].compatibilityLeaseId).toBe("lease-1");
+  });
+});

--- a/frontend/monitor/src/pages/LeasesPage.tsx
+++ b/frontend/monitor/src/pages/LeasesPage.tsx
@@ -18,6 +18,7 @@ type LeasesPayload = {
     };
   };
   items: Array<{
+    sandbox_id: string;
     lease_id: string;
     provider: string;
     instance_id?: string | null;
@@ -36,13 +37,7 @@ type LeasesPayload = {
 
 type TriageFilter = "all" | "active_drift" | "detached_residue" | "orphan_cleanup" | "healthy_capacity";
 
-export default function LeasesPage() {
-  const { data, error } = useMonitorData<LeasesPayload>("/leases");
-  const [selectedFilter, setSelectedFilter] = React.useState<TriageFilter>("all");
-
-  if (error) return <ErrorState title="Leases" error={error} />;
-  if (!data) return <div>Loading...</div>;
-
+export function buildLeaseWorkbenchShell(data: LeasesPayload) {
   const triage = data.triage?.summary ?? {};
   const triageCards = [
     { key: "active_drift" as const, label: "Active Drift", value: triage.active_drift ?? 0 },
@@ -50,18 +45,39 @@ export default function LeasesPage() {
     { key: "orphan_cleanup" as const, label: "Orphan Cleanup", value: triage.orphan_cleanup ?? 0 },
     { key: "healthy_capacity" as const, label: "Healthy Capacity", value: triage.healthy_capacity ?? 0 },
   ] satisfies Array<{ key: TriageFilter; label: string; value: number }>;
+
+  return {
+    triageTitle: "Lease Triage",
+    workbenchTitle: "Lease Workbench",
+    triageCards,
+    rows: data.items.map((item) => ({
+      ...item,
+      href: `/sandboxes/${item.sandbox_id}`,
+      compatibilityLeaseId: item.lease_id,
+    })),
+  };
+}
+
+export default function LeasesPage() {
+  const { data, error } = useMonitorData<LeasesPayload>("/leases");
+  const [selectedFilter, setSelectedFilter] = React.useState<TriageFilter>("all");
+
+  if (error) return <ErrorState title="Leases" error={error} />;
+  if (!data) return <div>Loading...</div>;
+
+  const shell = buildLeaseWorkbenchShell(data);
   const visibleItems =
     selectedFilter === "all"
-      ? data.items
-      : data.items.filter((item) => (item.triage?.category ?? "") === selectedFilter);
-  const activeCard = triageCards.find((card) => card.key === selectedFilter);
+      ? shell.rows
+      : shell.rows.filter((item) => (item.triage?.category ?? "") === selectedFilter);
+  const activeCard = shell.triageCards.find((card) => card.key === selectedFilter);
 
   return (
     <div className="page">
       <h1>{data.title}</h1>
       <p className="count">Total: {data.count}</p>
       <section className="surface-section">
-        <h2>Lease Triage</h2>
+        <h2>{shell.triageTitle}</h2>
         <div className="surface-grid">
           <button
             type="button"
@@ -71,7 +87,7 @@ export default function LeasesPage() {
             <p className="surface-card__eyebrow">All Triage</p>
             <p className="surface-card__value">{data.count}</p>
           </button>
-          {triageCards.map((card) => (
+          {shell.triageCards.map((card) => (
             <button
               type="button"
               className={`surface-card lease-triage-card ${selectedFilter === card.key ? "lease-triage-card--active" : ""}`}
@@ -86,7 +102,7 @@ export default function LeasesPage() {
       </section>
       <div className="leases-workbench-header">
         <div>
-          <h2>Lease Workbench</h2>
+          <h2>{shell.workbenchTitle}</h2>
           <p className="description">
             {activeCard ? `Showing ${activeCard.label}` : "Showing All Triage"}
           </p>
@@ -107,7 +123,7 @@ export default function LeasesPage() {
           {visibleItems.map((item) => (
             <tr key={item.lease_id}>
               <td className="mono">
-                <Link to={`/leases/${item.lease_id}`}>{item.lease_id}</Link>
+                <Link to={item.href}>{item.lease_id}</Link>
               </td>
               <td>
                 <div className="lease-topology">


### PR DESCRIPTION
## Summary
- change lease workbench row links to canonical sandbox detail subjects
- turn LeaseDetailPage into a compatibility redirect shell
- keep backend lease detail route naming unchanged in this slice

## Verification
- cd frontend/monitor && npm test -- src/pages/LeaseDetailPage.test.ts src/pages/LeasesPage.test.ts src/pages/SandboxDetailPage.test.ts src/pages/SandboxesPage.test.ts
- cd frontend/monitor && npm run build
- git diff --check