### PR TITLE
feat: share cold-read interruption repair helper

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -46,6 +46,7 @@ from backend.web.services.thread_launch_config_service import (
     save_last_confirmed_config,
     save_last_successful_config,
 )
+from backend.web.services.thread_message_interruption_service import repair_interrupted_tool_call_messages
 from backend.web.services.thread_runtime_convergence import converge_owner_thread_runtime, summarize_owner_thread_runtime
 from backend.web.services.thread_state_service import (
     get_lease_status,
@@ -460,6 +461,7 @@ async def _get_thread_display_entries(app: Any, thread_id: str) -> list[dict[str
     state = await agent.agent.aget_state(config)
     values = getattr(state, "values", {}) if state else {}
     messages = values.get("messages", []) if isinstance(values, dict) else []
+    messages = repair_interrupted_tool_call_messages(list(messages))
     serialized = [serialize_message(msg) for msg in messages]
 
     from core.runtime.visibility import annotate_owner_visibility

--- a/backend/web/services/thread_history_service.py
+++ b/backend/web/services/thread_history_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.web.services.thread_message_interruption_service import repair_interrupted_tool_call_messages
 from backend.web.utils.serializers import extract_text_content
 
 
@@ -75,6 +76,7 @@ async def get_thread_history_payload(
         checkpoint_state = await checkpoint_store.load(thread_id)
         values = {"messages": list(checkpoint_state.messages) if checkpoint_state is not None else []}
     all_messages = values.get("messages", []) if isinstance(values, dict) else []
+    all_messages = repair_interrupted_tool_call_messages(list(all_messages))
     total = len(all_messages)
     messages = all_messages[-limit:] if limit > 0 else all_messages
 

--- a/backend/web/services/thread_message_interruption_service.py
+++ b/backend/web/services/thread_message_interruption_service.py
@@ -1,0 +1,41 @@
+"""Shared message-level interruption repair for cold thread reads."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import ToolMessage
+
+_INTERRUPTED_RESULT = "Error: task was interrupted (server restart or timeout). Results unavailable."
+
+
+def repair_interrupted_tool_call_messages(messages: list[Any]) -> list[Any]:
+    matched_tool_call_ids = {
+        str(getattr(msg, "tool_call_id"))
+        for msg in messages
+        if getattr(msg, "__class__", None).__name__ == "ToolMessage" and getattr(msg, "tool_call_id", None)
+    }
+    repaired: list[Any] = []
+
+    for msg in messages:
+        repaired.append(msg)
+        if getattr(msg, "__class__", None).__name__ != "AIMessage":
+            continue
+        tool_calls = getattr(msg, "tool_calls", []) or []
+        # @@@interrupted-tool-repair-order - insert synthetic interrupted ToolMessages
+        # immediately after the owning AIMessage so cold detail/history rebuilds see
+        # the same caller-visible sequence as live repair.
+        for tc in tool_calls:
+            tc_id = str(tc.get("id") or "").strip()
+            if not tc_id or tc_id in matched_tool_call_ids:
+                continue
+            repaired.append(
+                ToolMessage(
+                    content=_INTERRUPTED_RESULT,
+                    name=str(tc.get("name") or "tool"),
+                    tool_call_id=tc_id,
+                )
+            )
+            matched_tool_call_ids.add(tc_id)
+
+    return repaired

--- a/tests/Integration/test_query_loop_backend_bridge.py
+++ b/tests/Integration/test_query_loop_backend_bridge.py
@@ -740,6 +740,62 @@ async def test_get_thread_history_skips_empty_ai_messages_after_notifications():
 
 
 @pytest.mark.asyncio
+async def test_cold_detail_and_history_share_interrupted_tool_call_repair():
+    checkpointer = _MemoryCheckpointer()
+    loop = _make_loop(checkpointer=checkpointer)
+    broken_ai = AIMessage(
+        content="",
+        tool_calls=[{"name": "Read", "args": {"file_path": "/tmp/a.txt"}, "id": "tc-1"}],
+    )
+    checkpointer.store["cold-repair-thread"] = {
+        "channel_values": {
+            "messages": [
+                HumanMessage(content="hello"),
+                broken_ai,
+            ]
+        }
+    }
+
+    fake_agent = SimpleNamespace(
+        agent=loop,
+        runtime=SimpleNamespace(current_state=AgentState.IDLE),
+    )
+    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    _put_local_agent_in_pool(fake_app, "cold-repair-thread", fake_agent)
+
+    with (
+        patch("backend.web.routers.threads.get_or_create_agent", return_value=fake_agent),
+        patch("backend.web.routers.threads.resolve_thread_sandbox", return_value="local"),
+        patch("backend.web.routers.threads.get_sandbox_info", return_value={"type": "local"}),
+    ):
+        detail = await get_thread_messages(
+            "cold-repair-thread",
+            user_id="u",
+            app=fake_app,
+        )
+        history = await get_thread_history(
+            "cold-repair-thread",
+            limit=20,
+            truncate=400,
+            user_id="u",
+            app=fake_app,
+        )
+
+    assert any(
+        entry.get("role") == "assistant"
+        and any(
+            seg.get("type") == "tool"
+            and seg.get("step", {}).get("name") == "Read"
+            and seg.get("step", {}).get("result") == "Error: task was interrupted (server restart or timeout). Results unavailable."
+            for seg in entry.get("segments", [])
+        )
+        for entry in detail["entries"]
+    )
+    assert [item["role"] for item in history["messages"]] == ["human", "tool_call", "tool_result"]
+    assert history["messages"][-1]["text"] == "Error: task was interrupted (server restart or timeout). Results unavailable."
+
+
+@pytest.mark.asyncio
 async def test_get_thread_history_retains_tool_search_inline_select_error():
     checkpointer = _MemoryCheckpointer()
     registry = ToolRegistry()


### PR DESCRIPTION
## Summary
- add a shared message-level interruption repair helper for cold thread reads
- use the helper from thread detail rebuild and thread history payload reads
- add integration proof that detail/history share interrupted truth for broken tool-call checkpoints

## Verification
- uv run python -m pytest -q tests/Integration/test_query_loop_backend_bridge.py
- uv run ruff check backend/web/services/thread_message_interruption_service.py backend/web/services/thread_history_service.py backend/web/routers/threads.py tests/Integration/test_query_loop_backend_bridge.py
- git diff --check