### PR TITLE
refactor: cut sandbox volumes caller/runtime residue

### DIFF
--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -165,8 +165,14 @@ async def get_sandbox_files(
     thread_id: str,
 ) -> dict[str, Any]:
     """Get thread-scoped upload/download channel paths."""
-    source = await asyncio.to_thread(file_channel_service.get_file_channel_source, thread_id)
-    return {"thread_id": thread_id, "files_path": str(source.host_path)}
+    binding = await asyncio.to_thread(file_channel_service.get_file_channel_binding, thread_id)
+    files_path = str(binding.local_staging_root) if binding.local_staging_root is not None else binding.remote_files_dir
+    return {
+        "thread_id": thread_id,
+        "files_path": files_path,
+        "workspace_id": binding.workspace_id,
+        "workspace_path": binding.workspace_path,
+    }
 
 
 _MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -391,6 +391,7 @@ def _resolve_owned_existing_sandbox_request_lease(
         ),
     )
 
+
 def _get_agent_for_thread(app: Any, thread_id: str) -> Any | None:
     """Get agent instance for a thread from the agent pool."""
     pool = getattr(app.state, "agent_pool", None)

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -30,7 +30,7 @@ from backend.web.models.requests import (
 from backend.web.services import account_resource_service, sandbox_service
 from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
 from backend.web.services.event_buffer import ThreadEventBuffer
-from backend.web.services.file_channel_service import get_file_channel_source
+from backend.web.services.file_channel_service import get_file_channel_binding
 from backend.web.services.owner_thread_read_service import list_owner_thread_rows_for_auth_burst
 from backend.web.services.resource_cache import clear_resource_overview_cache
 from backend.web.services.sandbox_service import destroy_thread_resources_sync, init_providers_and_managers
@@ -155,8 +155,8 @@ async def _prepare_attachment_message(
     # For remote providers: container-side path
     if mgr and mgr.volume.capability.runtime_kind == "local":
         try:
-            source = get_file_channel_source(thread_id)
-            files_dir = str(source.host_path)
+            binding = get_file_channel_binding(thread_id)
+            files_dir = str(binding.local_staging_root) if binding.local_staging_root is not None else binding.workspace_path
         except ValueError:
             files_dir = "/workspace/files"
     else:

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -597,25 +597,9 @@ def _create_thread_sandbox_resources(
     sandbox_repo: Any,
     owner_user_id: str,
 ) -> str:
-    """Create volume, lease, and terminal eagerly so volume exists before file uploads."""
-    from datetime import datetime
-
-    from backend.web.core.config import SANDBOX_VOLUME_ROOT
-    from backend.web.utils.helpers import _get_container
-    from sandbox.volume_source import HostVolume
+    """Create lease and terminal resources without pre-provisioning volume metadata."""
     from storage.runtime import build_lease_repo as make_lease_repo
     from storage.runtime import build_terminal_repo as make_terminal_repo
-
-    now_str = datetime.now().isoformat()
-    volume_id = str(uuid.uuid4())
-    vol_path = SANDBOX_VOLUME_ROOT / volume_id
-    source = HostVolume(vol_path)
-
-    vol_repo = _get_container().sandbox_volume_repo()
-    try:
-        vol_repo.create(volume_id, json.dumps(source.serialize()), f"vol-{thread_id}", now_str)
-    finally:
-        vol_repo.close()
 
     lease_repo = make_lease_repo()
     try:
@@ -624,7 +608,6 @@ def _create_thread_sandbox_resources(
         lease_repo.create(
             lease_id,
             sandbox_type,
-            volume_id=volume_id,
             recipe_id=normalized_recipe["id"],
             recipe_json=json.dumps(normalized_recipe, ensure_ascii=False),
         )

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -729,6 +729,26 @@ def _materialize_workspace_for_sandbox(
     return workspace_id
 
 
+def _resolve_existing_sandbox_bind_cwd(
+    workspace_repo: Any,
+    *,
+    sandbox_id: str,
+    owner_user_id: str,
+    requested_cwd: str | None,
+) -> str | None:
+    normalized_requested = str(requested_cwd or "").strip()
+    if normalized_requested:
+        return normalized_requested
+
+    owned_rows = [row for row in workspace_repo.list_by_sandbox_id(sandbox_id) if row.owner_user_id == owner_user_id]
+    if len(owned_rows) != 1:
+        return None
+
+    # @@@existing-sandbox-workspace-cwd-candidate - only reuse workspace truth when
+    # caller side can point at one unambiguous owned workspace row for this sandbox.
+    return str(owned_rows[0].workspace_path or "").strip() or None
+
+
 def _resolve_owned_recipe_snapshot(
     app: Any,
     owner_user_id: str,
@@ -788,6 +808,24 @@ def _create_owned_thread(
         sandbox = app.state.sandbox_repo.get_by_id(payload.existing_sandbox_id)
         if sandbox is None:
             raise HTTPException(403, "Lease not authorized")
+        preview_lease = _resolve_owned_existing_sandbox_request_lease(
+            app,
+            owner_user_id,
+            payload.existing_sandbox_id,
+        )
+        if preview_lease is None:
+            raise HTTPException(403, "Lease not authorized")
+        sandbox_id = _materialize_sandbox_for_lease(
+            app.state.sandbox_repo,
+            lease=preview_lease,
+            owner_user_id=owner_user_id,
+        )
+        bind_cwd = _resolve_existing_sandbox_bind_cwd(
+            app.state.workspace_repo,
+            sandbox_id=sandbox_id,
+            owner_user_id=owner_user_id,
+            requested_cwd=payload.cwd,
+        )
         bound_cwd, owned_lease = bind_thread_to_existing_sandbox(
             new_thread_id,
             sandbox,
@@ -797,7 +835,7 @@ def _create_owned_thread(
                 thread_repo=app.state.thread_repo,
                 user_repo=app.state.user_repo,
             ),
-            cwd=payload.cwd,
+            cwd=bind_cwd,
         )
         selected_lease_id = _request_bridge_text(owned_lease, "lease_id", label="lease")
         if owned_lease is None:
@@ -808,16 +846,11 @@ def _create_owned_thread(
         selected_recipe = _resolve_owned_recipe_snapshot(app, owner_user_id, sandbox_type, payload.sandbox_template_id)
 
     if selected_lease_id:
-        sandbox_id = _materialize_sandbox_for_lease(
-            app.state.sandbox_repo,
-            lease=owned_lease,
-            owner_user_id=owner_user_id,
-        )
         current_workspace_id = _materialize_workspace_for_sandbox(
             app.state.workspace_repo,
             sandbox_id=sandbox_id,
             owner_user_id=owner_user_id,
-            workspace_path=bound_cwd,
+            workspace_path=bind_cwd or bound_cwd,
         )
     else:
         # @@@create-write-bridge-first - replay-13 requires supported create paths

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -39,7 +39,6 @@ from backend.web.services.streaming_service import (
     observe_thread_events,
 )
 from backend.web.services.thread_launch_config_service import (
-    _existing_sandbox_shell_id,
     build_existing_launch_config,
     build_new_launch_config,
     resolve_default_config,
@@ -115,17 +114,17 @@ def _save_default_config_for_owned_agent(
     payload: SaveThreadLaunchConfigRequest,
 ) -> dict[str, bool]:
     _require_owned_agent(app, payload.agent_user_id, owner_user_id)
-    normalized_payload = payload
     if payload.create_mode == "existing" and payload.existing_sandbox_id:
-        normalized_existing_lease_id = _normalize_existing_sandbox_request_lease_id(
+        owned_lease = _resolve_owned_existing_sandbox_request_lease(
             app,
             owner_user_id,
             payload.existing_sandbox_id,
         )
-        normalized_payload = payload.model_copy(update={"existing_sandbox_id": _existing_sandbox_shell_id(normalized_existing_lease_id)})
+        if owned_lease is None:
+            raise HTTPException(403, "Lease not authorized")
     if payload.create_mode == "new":
         _resolve_owned_recipe_snapshot(app, owner_user_id, payload.provider_config, payload.sandbox_template_id)
-    save_last_confirmed_config(app, owner_user_id, normalized_payload.agent_user_id, normalized_payload.model_dump())
+    save_last_confirmed_config(app, owner_user_id, payload.agent_user_id, payload.model_dump())
     return {"ok": True}
 
 
@@ -391,18 +390,6 @@ def _resolve_owned_existing_sandbox_request_lease(
             user_repo=app.state.user_repo,
         ),
     )
-
-
-def _normalize_existing_sandbox_request_lease_id(
-    app: Any,
-    owner_user_id: str,
-    existing_sandbox_id: str,
-) -> str:
-    owned_lease = _resolve_owned_existing_sandbox_request_lease(app, owner_user_id, existing_sandbox_id)
-    if owned_lease is None:
-        raise HTTPException(403, "Lease not authorized")
-    return _request_bridge_text(owned_lease, "lease_id", label="lease")
-
 
 def _get_agent_for_thread(app: Any, thread_id: str) -> Any | None:
     """Get agent instance for a thread from the agent pool."""

--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from backend.web.services.file_channel_service import get_file_channel_binding
 from core.identity.agent_registry import get_or_create_agent_id
 from core.runtime.agent import create_leon_agent
 from sandbox.manager import lookup_sandbox_for_thread
@@ -173,13 +174,13 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
                 "agent_config_repo": getattr(app_obj.state, "agent_config_repo", None),
             }
 
-        # @@@per-thread-file-access - ensure thread files are accessible from agent
-        from backend.web.services.file_channel_service import get_file_channel_source
-
         try:
-            source = get_file_channel_source(thread_id)
-            extra_allowed_paths: list[str] = [str(source.host_path)] if sandbox_type == "local" else []
-        except ValueError:
+            binding = get_file_channel_binding(thread_id)
+            if sandbox_type == "local" and binding.local_staging_root is not None:
+                extra_allowed_paths: list[str] = [str(binding.local_staging_root)]
+            else:
+                extra_allowed_paths = []
+        except Exception:
             extra_allowed_paths: list[str] = []
 
         # Merge user-configured allowed_paths from sandbox config

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -22,6 +22,7 @@ class FileChannelBinding:
     local_staging_root: Path | None
     remote_files_dir: str
 
+
 def get_file_channel_source(thread_id: str):
     """Get the local file-channel source for a thread."""
     from sandbox.volume_source import HostVolume

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -1,13 +1,7 @@
-"""File channel service — per-lease file storage for user↔agent file transfer.
-
-File channel is an application-layer concept. Under the hood it uses
-sandbox volumes (VolumeSource + SandboxVolume mount/sync engine).
-This service provides the app-layer API for file CRUD on a thread's channel.
-"""
+"""File channel service for workspace-owned user↔agent file transfer."""
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,7 +9,6 @@ from pathlib import Path
 from backend.web.utils.helpers import _get_container
 from config.user_paths import user_home_path
 from sandbox.clock import utc_now_iso
-from sandbox.control_plane_repos import make_lease_repo, make_terminal_repo
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
 
 logger = logging.getLogger(__name__)
@@ -29,51 +22,8 @@ class FileChannelBinding:
     local_staging_root: Path | None
     remote_files_dir: str
 
-
-def _resolve_volume_source(thread_id: str):
-    """Resolve VolumeSource for a thread via lease chain.
-
-    This is the application-layer entry point. Uses sandbox-layer stores
-    to walk: thread → terminal → lease → volume_id → sandbox_volumes.
-    """
-    from sandbox.volume_source import deserialize_volume_source
-
-    terminal_repo = make_terminal_repo()
-    try:
-        terminal_row = terminal_repo.get_active(thread_id)
-    finally:
-        terminal_repo.close()
-    if not terminal_row:
-        raise ValueError(f"No active terminal for thread {thread_id}")
-
-    lease_repo = make_lease_repo()
-    try:
-        lease_row = lease_repo.get(terminal_row["lease_id"])
-    finally:
-        lease_repo.close()
-    if not lease_row:
-        raise ValueError(f"Lease not found: {terminal_row['lease_id']}")
-    volume_id = lease_row.get("volume_id")
-    if not volume_id:
-        raise ValueError(f"Lease {terminal_row['lease_id']} has no volume_id")
-
-    repo = _get_container().sandbox_volume_repo()
-    try:
-        entry = repo.get(volume_id)
-    finally:
-        repo.close()
-
-    if not entry:
-        raise ValueError(f"Volume not found: {volume_id}")
-
-    return deserialize_volume_source(json.loads(entry["source"]))
-
-
 def get_file_channel_source(thread_id: str):
-    """Get VolumeSource for a thread's file channel.
-
-    Primary entry point for all app-layer code paths (upload, list, download, delete).
-    """
+    """Get the local file-channel source for a thread."""
     from sandbox.volume_source import HostVolume
 
     binding = get_file_channel_binding(thread_id)

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 
 from backend.web.utils.helpers import _get_container
 from sandbox.clock import utc_now_iso
@@ -16,6 +18,15 @@ from sandbox.control_plane_repos import make_lease_repo, make_terminal_repo
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FileChannelBinding:
+    thread_id: str
+    workspace_id: str
+    workspace_path: str
+    local_staging_root: Path | None
+    remote_files_dir: str
 
 
 def _resolve_volume_source(thread_id: str):
@@ -65,6 +76,48 @@ def get_file_channel_source(thread_id: str):
     return _resolve_volume_source(thread_id)
 
 
+def get_file_channel_binding(thread_id: str) -> FileChannelBinding:
+    """Resolve split file-channel truth for a thread.
+
+    Ownership/binding lives on the thread -> workspace edge.
+    Host staging remains whatever local file root the current runtime uses.
+    """
+    container = _get_container()
+    thread_repo = container.thread_repo()
+    try:
+        thread_row = thread_repo.get_by_id(thread_id)
+    finally:
+        _close_repo(thread_repo)
+    if thread_row is None:
+        raise ValueError(f"Thread not found: {thread_id}")
+
+    workspace_id = _required_text(thread_row, "current_workspace_id", "thread")
+
+    workspace_repo = container.workspace_repo()
+    try:
+        workspace_row = workspace_repo.get_by_id(workspace_id)
+    finally:
+        _close_repo(workspace_repo)
+    if workspace_row is None:
+        raise ValueError(f"Workspace not found: {workspace_id}")
+
+    local_staging_root: Path | None = None
+    try:
+        source = get_file_channel_source(thread_id)
+    except ValueError:
+        source = None
+    if source is not None:
+        local_staging_root = getattr(source, "host_path", None)
+
+    return FileChannelBinding(
+        thread_id=thread_id,
+        workspace_id=workspace_id,
+        workspace_path=_required_text(workspace_row, "workspace_path", "workspace"),
+        local_staging_root=local_staging_root,
+        remote_files_dir="/workspace/files",
+    )
+
+
 # ---------------------------------------------------------------------------
 # File CRUD — delegates to VolumeSource
 # ---------------------------------------------------------------------------
@@ -97,3 +150,24 @@ def resolve_channel_file(*, thread_id: str, relative_path: str):
 def delete_channel_file(*, thread_id: str, relative_path: str) -> None:
     """Delete file from the thread's file channel."""
     get_file_channel_source(thread_id).delete_file(relative_path)
+
+
+def _row_value(row, key: str):
+    if isinstance(row, dict):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _required_text(row, key: str, label: str) -> str:
+    value = _row_value(row, key)
+    if isinstance(value, str):
+        value = value.strip()
+    if value in (None, ""):
+        raise ValueError(f"{label}.{key} is required")
+    return str(value)
+
+
+def _close_repo(repo) -> None:
+    close = getattr(repo, "close", None)
+    if callable(close):
+        close()

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from backend.web.utils.helpers import _get_container
+from config.user_paths import user_home_path
 from sandbox.clock import utc_now_iso
 from sandbox.control_plane_repos import make_lease_repo, make_terminal_repo
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
@@ -73,7 +74,10 @@ def get_file_channel_source(thread_id: str):
 
     Primary entry point for all app-layer code paths (upload, list, download, delete).
     """
-    return _resolve_volume_source(thread_id)
+    from sandbox.volume_source import HostVolume
+
+    binding = get_file_channel_binding(thread_id)
+    return HostVolume(_required_path(binding.local_staging_root, "file_channel.local_staging_root"))
 
 
 def get_file_channel_binding(thread_id: str) -> FileChannelBinding:
@@ -101,19 +105,11 @@ def get_file_channel_binding(thread_id: str) -> FileChannelBinding:
     if workspace_row is None:
         raise ValueError(f"Workspace not found: {workspace_id}")
 
-    local_staging_root: Path | None = None
-    try:
-        source = get_file_channel_source(thread_id)
-    except ValueError:
-        source = None
-    if source is not None:
-        local_staging_root = getattr(source, "host_path", None)
-
     return FileChannelBinding(
         thread_id=thread_id,
         workspace_id=workspace_id,
         workspace_path=_required_text(workspace_row, "workspace_path", "workspace"),
-        local_staging_root=local_staging_root,
+        local_staging_root=_workspace_file_channel_root(workspace_id),
         remote_files_dir="/workspace/files",
     )
 
@@ -165,6 +161,16 @@ def _required_text(row, key: str, label: str) -> str:
     if value in (None, ""):
         raise ValueError(f"{label}.{key} is required")
     return str(value)
+
+
+def _required_path(value: Path | None, label: str) -> Path:
+    if value is None:
+        raise ValueError(f"{label} is required")
+    return value
+
+
+def _workspace_file_channel_root(workspace_id: str) -> Path:
+    return user_home_path("file_channels", workspace_id).expanduser().resolve()
 
 
 def _close_repo(repo) -> None:

--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -94,7 +94,9 @@ def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> 
     # @@@thread-launch-default-precedence - prefer the last successful thread config, then the last confirmed draft,
     # and only then derive from current leases/providers. This keeps defaults tied to actual agent usage first.
     successful = _validate_saved_config(
-        prefs.get("last_successful"),
+        app=app,
+        owner_user_id=owner_user_id,
+        payload=prefs.get("last_successful"),
         leases=leases,
         providers=providers,
         sandbox_templates=sandbox_templates,
@@ -103,7 +105,9 @@ def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> 
         return {"source": "last_successful", "config": successful}
 
     confirmed = _validate_saved_config(
-        prefs.get("last_confirmed"),
+        app=app,
+        owner_user_id=owner_user_id,
+        payload=prefs.get("last_confirmed"),
         leases=leases,
         providers=providers,
         sandbox_templates=sandbox_templates,
@@ -125,6 +129,8 @@ def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> 
 
 
 def _validate_saved_config(
+    app: Any,
+    owner_user_id: str,
     payload: dict[str, Any] | None,
     *,
     leases: list[dict[str, Any]],
@@ -144,18 +150,16 @@ def _validate_saved_config(
         existing_sandbox_id = config.get("existing_sandbox_id")
         if not existing_sandbox_id:
             return None
-        lease = next(
-            (
-                item
-                for item in leases
-                if item["lease_id"] == existing_sandbox_id
-                or _existing_sandbox_shell_id(str(item.get("lease_id") or "")) == existing_sandbox_id
-            ),
-            None,
+        workspace = _resolve_saved_existing_workspace(
+            app=app,
+            owner_user_id=owner_user_id,
+            existing_sandbox_id=existing_sandbox_id,
+            model=config.get("model"),
+            workspace_path=config.get("workspace"),
         )
-        if lease is None:
+        if workspace is None:
             return None
-        return _existing_config_from_lease(lease, model=config.get("model"), workspace=lease.get("cwd"))
+        return workspace
 
     provider_config = config.get("provider_config")
     sandbox_template_id = str(config.get("sandbox_template_id") or "").strip()
@@ -211,7 +215,6 @@ def _derive_default_config(
     providers: list[dict[str, Any]],
     sandbox_templates: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    leases_by_id = {str(lease.get("lease_id") or "").strip(): lease for lease in leases if str(lease.get("lease_id") or "").strip()}
     for thread in _iter_default_bridge_threads(agent_threads):
         # @@@workspace-bridge-read-precedence - launch-config now resolves workspace-backed existing-mode
         # defaults first, but only narrows field sources. `existing_sandbox_id` and `sandbox_template`
@@ -223,10 +226,6 @@ def _derive_default_config(
         )
         if config is not None:
             return config
-
-        lease = leases_by_id.get(thread["current_workspace_id"])
-        if lease is not None:
-            return _existing_config_from_lease(lease, model=None, workspace=lease.get("cwd"))
 
     provider_names = [str(item["name"]) for item in providers]
     provider_config = "local" if "local" in provider_names else (provider_names[0] if provider_names else "local")
@@ -350,6 +349,53 @@ def _required_bridge_text(row: Any, key: str, label: str) -> str:
     if value is None or value == "":
         raise RuntimeError(f"{label}.{key} is required")
     return str(value)
+
+
+def _resolve_saved_existing_workspace(
+    *,
+    app: Any,
+    owner_user_id: str,
+    existing_sandbox_id: str,
+    model: str | None,
+    workspace_path: str | None,
+) -> dict[str, Any] | None:
+    sandbox_repo = getattr(app.state, "sandbox_repo", None)
+    sandbox_get_by_id = getattr(sandbox_repo, "get_by_id", None)
+    if not callable(sandbox_get_by_id):
+        return None
+    sandbox = sandbox_get_by_id(existing_sandbox_id)
+    if sandbox is None:
+        return None
+    sandbox_owner_user_id = _required_bridge_text(sandbox, "owner_user_id", "sandbox")
+    if sandbox_owner_user_id != owner_user_id:
+        raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
+    workspace_repo = getattr(app.state, "workspace_repo", None)
+    list_by_sandbox_id = getattr(workspace_repo, "list_by_sandbox_id", None)
+    resolved_workspace_path = ""
+    if callable(list_by_sandbox_id):
+        for workspace in list_by_sandbox_id(_required_bridge_text(sandbox, "id", "sandbox")):
+            workspace_owner_user_id = _required_bridge_text(workspace, "owner_user_id", "workspace")
+            if workspace_owner_user_id != owner_user_id:
+                continue
+            resolved_workspace_path = _required_bridge_text(workspace, "workspace_path", "workspace")
+            break
+    if not resolved_workspace_path:
+        resolved_workspace_path = str(workspace_path or "").strip()
+    if not resolved_workspace_path:
+        return None
+    sandbox_template = _resolve_workspace_backed_sandbox_template(
+        app=app,
+        owner_user_id=owner_user_id,
+        sandbox=sandbox,
+    )
+    return {
+        "create_mode": "existing",
+        "provider_config": _required_bridge_text(sandbox, "provider_name", "sandbox"),
+        "sandbox_template": sandbox_template,
+        "existing_sandbox_id": _required_bridge_text(sandbox, "id", "sandbox"),
+        "model": model,
+        "workspace": resolved_workspace_path,
+    }
 
 
 def _required_bridge_config_text(row: Any, key: str, label: str) -> str:

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -594,6 +594,26 @@ class AgentService:
             current_workspace_id=current_workspace_id,
         )
 
+    def _resolve_parent_workspace_path(self, parent_thread_id: str | None) -> str | None:
+        if self._thread_repo is None or not parent_thread_id:
+            return None
+        parent_thread = self._thread_repo.get_by_id(parent_thread_id)
+        if parent_thread is None:
+            return None
+        current_workspace_id = str(parent_thread.get("current_workspace_id") or "").strip()
+        if not current_workspace_id:
+            return None
+        workspace_repo = getattr(getattr(self._web_app, "state", None), "workspace_repo", None)
+        if workspace_repo is None:
+            raise ValueError("parent workspace_repo is required")
+        workspace = workspace_repo.get_by_id(current_workspace_id)
+        if workspace is None:
+            raise ValueError(f"parent workspace {current_workspace_id} not found")
+        workspace_path = str(getattr(workspace, "workspace_path", "") or "").strip()
+        if not workspace_path:
+            raise ValueError(f"parent workspace {current_workspace_id} missing workspace_path")
+        return workspace_path
+
     async def _handle_agent(
         self,
         prompt: str,
@@ -866,7 +886,11 @@ class AgentService:
             if parent_thread_id and parent_thread_id != thread_id:
                 from sandbox.manager import bind_thread_to_existing_thread_lease
 
-                bind_thread_to_existing_thread_lease(thread_id, parent_thread_id)
+                bind_thread_to_existing_thread_lease(
+                    thread_id,
+                    parent_thread_id,
+                    cwd=self._resolve_parent_workspace_path(parent_thread_id),
+                )
 
             # Wire child agent events to the parent's EventBus subscription
             # so the parent SSE stream shows sub-agent activity.

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -886,10 +886,11 @@ class AgentService:
             if parent_thread_id and parent_thread_id != thread_id:
                 from sandbox.manager import bind_thread_to_existing_thread_lease
 
+                parent_workspace_cwd = self._resolve_parent_workspace_path(parent_thread_id) or str(child_workspace_root)
                 bind_thread_to_existing_thread_lease(
                     thread_id,
                     parent_thread_id,
-                    cwd=self._resolve_parent_workspace_path(parent_thread_id),
+                    cwd=parent_workspace_cwd,
                 )
 
             # Wire child agent events to the parent's EventBus subscription

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -531,9 +531,7 @@ class SandboxManager:
         if thread_row is None:
             raise ValueError(f"Thread not found: {thread_id}")
         workspace_id = (
-            thread_row.get("current_workspace_id")
-            if isinstance(thread_row, dict)
-            else getattr(thread_row, "current_workspace_id", None)
+            thread_row.get("current_workspace_id") if isinstance(thread_row, dict) else getattr(thread_row, "current_workspace_id", None)
         )
         if not workspace_id:
             raise ValueError("thread.current_workspace_id is required")

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -98,7 +98,7 @@ def resolve_existing_lease_cwd(
     provider = _build_provider_from_name(provider_name) if provider_name else None
     if provider is not None:
         return resolve_provider_cwd(provider)
-    return str(Path.home())
+    raise ValueError("provider default cwd is required")
 
 
 def bind_thread_to_existing_lease(

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -34,6 +34,12 @@ def resolve_provider_cwd(provider) -> str:
     return "/home/user"
 
 
+def _build_provider_from_name(name: str):
+    from backend.web.services.sandbox_service import build_provider_from_config_name
+
+    return build_provider_from_config_name(name)
+
+
 def lookup_sandbox_for_thread(
     thread_id: str,
     db_path: Path | None = None,
@@ -74,6 +80,7 @@ def resolve_existing_lease_cwd(
     db_path: Path | None = None,
     *,
     terminal_repo: Any | None = None,
+    lease_repo: Any | None = None,
 ) -> str:
     if requested_cwd:
         return requested_cwd
@@ -90,6 +97,19 @@ def resolve_existing_lease_cwd(
             _terminal_repo.close()
     if row and row.get("cwd"):
         return str(row["cwd"])
+    _lease_repo = lease_repo
+    own_lease_repo = _lease_repo is None
+    if _lease_repo is None:
+        _lease_repo = make_lease_repo(db_path=target_db)
+    try:
+        lease = _lease_repo.get(lease_id)
+    finally:
+        if own_lease_repo:
+            _lease_repo.close()
+    provider_name = str((lease or {}).get("provider_name") or "").strip()
+    provider = _build_provider_from_name(provider_name) if provider_name else None
+    if provider is not None:
+        return resolve_provider_cwd(provider)
     return str(Path.home())
 
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -411,12 +411,14 @@ class SandboxManager:
                 remote_path,
             )
 
+        source_path = source.host_path
+
         if isinstance(source, DaytonaVolume):
             self.volume.mount_managed_volume(thread_id, source.volume_name, remote_path)
         else:
             self.volume.mount(thread_id, source, remote_path)
 
-        return {"source": source, "remote_path": remote_path}
+        return {"source": source, "source_path": source_path, "remote_path": remote_path}
 
     def _upgrade_to_daytona_volume(self, thread_id: str, current_source, volume_id: str, remote_path: str):
         """First Daytona sandbox start: create managed volume, upgrade VolumeSource in DB."""
@@ -673,7 +675,7 @@ class SandboxManager:
 
         if instance and storage is not None:
             # @@@workspace-upload - sync files to sandbox after creation
-            self._sync_to_sandbox(thread_id, instance.instance_id, source=storage["source"])
+            self._sync_to_sandbox(thread_id, instance.instance_id, source=storage["source_path"])
             self._fire_session_ready(instance.instance_id, "create")
 
         return SandboxCapability(session, manager=self)

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -79,26 +79,12 @@ def resolve_existing_lease_cwd(
     requested_cwd: str | None = None,
     db_path: Path | None = None,
     *,
-    terminal_repo: Any | None = None,
     lease_repo: Any | None = None,
-    allow_latest_terminal_cwd: bool = True,
 ) -> str:
     if requested_cwd:
         return requested_cwd
 
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    if allow_latest_terminal_cwd:
-        _terminal_repo = terminal_repo
-        own_terminal_repo = _terminal_repo is None
-        if _terminal_repo is None:
-            _terminal_repo = make_terminal_repo(db_path=target_db)
-        try:
-            row = _terminal_repo.get_latest_by_lease(lease_id)
-        finally:
-            if own_terminal_repo:
-                _terminal_repo.close()
-        if row and row.get("cwd"):
-            return str(row["cwd"])
     _lease_repo = lease_repo
     own_lease_repo = _lease_repo is None
     if _lease_repo is None:
@@ -123,7 +109,6 @@ def bind_thread_to_existing_lease(
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
     lease_repo: Any | None = None,
-    allow_latest_terminal_cwd: bool = True,
 ) -> str:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
     _terminal_repo = terminal_repo
@@ -138,9 +123,7 @@ def bind_thread_to_existing_lease(
             lease_id,
             cwd,
             db_path=target_db,
-            terminal_repo=_terminal_repo,
             lease_repo=lease_repo,
-            allow_latest_terminal_cwd=allow_latest_terminal_cwd,
         )
         _terminal_repo.create(
             terminal_id=f"term-{uuid.uuid4().hex[:12]}",
@@ -223,7 +206,6 @@ def bind_thread_to_existing_sandbox(
         db_path=db_path,
         terminal_repo=terminal_repo,
         lease_repo=lease_repo,
-        allow_latest_terminal_cwd=False,
     )
     return initial_cwd, lease
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -238,6 +238,8 @@ def bind_thread_to_existing_thread_lease(
     lease_repo: Any | None = None,
 ) -> str | None:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    if not cwd:
+        raise ValueError("thread reuse cwd is required")
     _terminal_repo = terminal_repo
     own_terminal_repo = _terminal_repo is None
     if _terminal_repo is None:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -81,22 +81,24 @@ def resolve_existing_lease_cwd(
     *,
     terminal_repo: Any | None = None,
     lease_repo: Any | None = None,
+    allow_latest_terminal_cwd: bool = True,
 ) -> str:
     if requested_cwd:
         return requested_cwd
 
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    _terminal_repo = terminal_repo
-    own_terminal_repo = _terminal_repo is None
-    if _terminal_repo is None:
-        _terminal_repo = make_terminal_repo(db_path=target_db)
-    try:
-        row = _terminal_repo.get_latest_by_lease(lease_id)
-    finally:
-        if own_terminal_repo:
-            _terminal_repo.close()
-    if row and row.get("cwd"):
-        return str(row["cwd"])
+    if allow_latest_terminal_cwd:
+        _terminal_repo = terminal_repo
+        own_terminal_repo = _terminal_repo is None
+        if _terminal_repo is None:
+            _terminal_repo = make_terminal_repo(db_path=target_db)
+        try:
+            row = _terminal_repo.get_latest_by_lease(lease_id)
+        finally:
+            if own_terminal_repo:
+                _terminal_repo.close()
+        if row and row.get("cwd"):
+            return str(row["cwd"])
     _lease_repo = lease_repo
     own_lease_repo = _lease_repo is None
     if _lease_repo is None:
@@ -120,6 +122,8 @@ def bind_thread_to_existing_lease(
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
+    lease_repo: Any | None = None,
+    allow_latest_terminal_cwd: bool = True,
 ) -> str:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
     _terminal_repo = terminal_repo
@@ -130,7 +134,14 @@ def bind_thread_to_existing_lease(
         existing = _terminal_repo.get_active(thread_id)
         if existing is not None:
             return str(existing["cwd"])
-        initial_cwd = resolve_existing_lease_cwd(lease_id, cwd, db_path=target_db, terminal_repo=_terminal_repo)
+        initial_cwd = resolve_existing_lease_cwd(
+            lease_id,
+            cwd,
+            db_path=target_db,
+            terminal_repo=_terminal_repo,
+            lease_repo=lease_repo,
+            allow_latest_terminal_cwd=allow_latest_terminal_cwd,
+        )
         _terminal_repo.create(
             terminal_id=f"term-{uuid.uuid4().hex[:12]}",
             thread_id=thread_id,
@@ -190,8 +201,14 @@ def bind_thread_to_existing_sandbox(
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
+    lease_repo: Any | None = None,
 ) -> tuple[str, dict[str, Any]]:
-    lease = resolve_existing_sandbox_lease(sandbox, resolve_lease=resolve_lease, db_path=db_path)
+    lease = resolve_existing_sandbox_lease(
+        sandbox,
+        resolve_lease=resolve_lease,
+        db_path=db_path,
+        lease_repo=lease_repo,
+    )
     if lease is None:
         config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
         legacy_lease_id = str((config or {}).get("legacy_lease_id") or "").strip()
@@ -205,6 +222,8 @@ def bind_thread_to_existing_sandbox(
         cwd=cwd,
         db_path=db_path,
         terminal_repo=terminal_repo,
+        lease_repo=lease_repo,
+        allow_latest_terminal_cwd=False,
     )
     return initial_cwd, lease
 
@@ -216,6 +235,7 @@ def bind_thread_to_existing_thread_lease(
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
+    lease_repo: Any | None = None,
 ) -> str | None:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
     _terminal_repo = terminal_repo
@@ -238,6 +258,7 @@ def bind_thread_to_existing_thread_lease(
         cwd=cwd,
         db_path=target_db,
         terminal_repo=terminal_repo,
+        lease_repo=lease_repo,
     )
 
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -515,6 +515,28 @@ class SandboxManager:
         entry = self._resolve_volume_entry(thread_id, lease)
         return deserialize_volume_source(json.loads(entry["source"]))
 
+    def _resolve_sync_source_path(self, thread_id: str) -> Path:
+        # @@@sync-source-truth - sync no longer needs volume metadata truth; it only needs
+        # the workspace-owned local staging root that backs the current file channel.
+        container = build_storage_container()
+        thread_repo = container.thread_repo()
+        try:
+            thread_row = thread_repo.get_by_id(thread_id)
+        finally:
+            close = getattr(thread_repo, "close", None)
+            if callable(close):
+                close()
+        if thread_row is None:
+            raise ValueError(f"Thread not found: {thread_id}")
+        workspace_id = (
+            thread_row.get("current_workspace_id")
+            if isinstance(thread_row, dict)
+            else getattr(thread_row, "current_workspace_id", None)
+        )
+        if not workspace_id:
+            raise ValueError("thread.current_workspace_id is required")
+        return user_home_path("file_channels", str(workspace_id)).expanduser().resolve()
+
     def _skip_volume_sync_for_local_lease(self, lease) -> bool:
         # @@@local-no-volume-sync - local sessions may execute directly in host cwd with no sandbox volume row.
         # In that shape there is nothing to upload/download, so sync paths must no-op instead of inventing one.
@@ -525,7 +547,7 @@ class SandboxManager:
             lease = self._get_thread_lease(thread_id)
             if self._skip_volume_sync_for_local_lease(lease):
                 return
-            source = self.resolve_volume_source(thread_id)
+            source = self._resolve_sync_source_path(thread_id)
         self.volume.sync_upload(thread_id, instance_id, source, self.volume.resolve_mount_path(), files=files)
 
     def _sync_from_sandbox(self, thread_id: str, instance_id: str, source=None) -> None:
@@ -533,7 +555,7 @@ class SandboxManager:
             lease = self._get_thread_lease(thread_id)
             if self._skip_volume_sync_for_local_lease(lease):
                 return
-            source = self.resolve_volume_source(thread_id)
+            source = self._resolve_sync_source_path(thread_id)
         self.volume.sync_download(thread_id, instance_id, source, self.volume.resolve_mount_path())
 
     def sync_uploads(self, thread_id: str, files: list[str] | None = None) -> bool:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -127,7 +127,32 @@ def resolve_existing_sandbox_lease(
     sandbox: Any,
     *,
     resolve_lease: Callable[[str], dict[str, Any] | None],
+    db_path: Path | None = None,
+    lease_repo: Any | None = None,
 ) -> dict[str, Any] | None:
+    provider_name = str(
+        (sandbox.get("provider_name") if isinstance(sandbox, dict) else getattr(sandbox, "provider_name", None)) or ""
+    ).strip()
+    provider_env_id = str(
+        (sandbox.get("provider_env_id") if isinstance(sandbox, dict) else getattr(sandbox, "provider_env_id", None)) or ""
+    ).strip()
+    if provider_name and provider_env_id:
+        # @@@existing-sandbox-live-lease-first
+        # Existing-sandbox reuse should resolve the live lease from sandbox runtime identity first.
+        # legacy_lease_id stays only as the compatibility fallback when the live provider-env binding
+        # has not been materialized yet.
+        target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        _lease_repo = lease_repo
+        own_lease_repo = _lease_repo is None
+        if _lease_repo is None:
+            _lease_repo = make_lease_repo(db_path=target_db)
+        try:
+            lease = _lease_repo.find_by_instance(provider_name=provider_name, instance_id=provider_env_id)
+            if lease is not None:
+                return lease
+        finally:
+            if own_lease_repo:
+                _lease_repo.close()
     config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
     if not isinstance(config, dict):
         raise RuntimeError("sandbox.config must be an object")
@@ -146,7 +171,7 @@ def bind_thread_to_existing_sandbox(
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
 ) -> tuple[str, dict[str, Any]]:
-    lease = resolve_existing_sandbox_lease(sandbox, resolve_lease=resolve_lease)
+    lease = resolve_existing_sandbox_lease(sandbox, resolve_lease=resolve_lease, db_path=db_path)
     if lease is None:
         config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
         legacy_lease_id = str((config or {}).get("legacy_lease_id") or "").strip()

--- a/sandbox/volume.py
+++ b/sandbox/volume.py
@@ -11,6 +11,7 @@ This is sandbox infrastructure. It doesn't know what's being mounted
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from sandbox.volume_source import VolumeSource
 
@@ -53,19 +54,13 @@ class SandboxVolume:
         """Container-side path where volumes are mounted."""
         return getattr(self.provider, "WORKSPACE_ROOT", "/workspace") + "/files"
 
-    def sync_upload(self, thread_id: str, session_id: str, source: VolumeSource, remote_path: str, files: list[str] | None = None) -> None:
-        """Sync files from VolumeSource to sandbox."""
-        host = source.host_path
-        if not host:
-            return
-        self._sync.upload(host, remote_path, session_id, self.provider, files=files, state_key=thread_id)
+    def sync_upload(self, thread_id: str, session_id: str, source_path: Path, remote_path: str, files: list[str] | None = None) -> None:
+        """Sync files from local staging path to sandbox."""
+        self._sync.upload(source_path, remote_path, session_id, self.provider, files=files, state_key=thread_id)
 
-    def sync_download(self, thread_id: str, session_id: str, source: VolumeSource, remote_path: str) -> None:
-        """Sync files from sandbox back to VolumeSource."""
-        host = source.host_path
-        if not host:
-            return
-        self._sync.download(host, remote_path, session_id, self.provider, state_key=thread_id)
+    def sync_download(self, thread_id: str, session_id: str, source_path: Path, remote_path: str) -> None:
+        """Sync files from sandbox back to local staging path."""
+        self._sync.download(source_path, remote_path, session_id, self.provider, state_key=thread_id)
 
     def clear_sync_state(self, thread_id: str) -> None:
         """Remove all sync tracking state for a thread."""

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -17,7 +17,7 @@ def test_file_channel_service_no_longer_imports_storage_factory() -> None:
 
     assert "backend.web.core.storage_factory" not in file_channel_source
     assert "storage.runtime" in file_channel_source
-    assert "sandbox.control_plane_repos" in file_channel_source
+    assert "backend.web.utils.helpers" in file_channel_source
     assert "SQLiteTerminalRepo" not in file_channel_source
     assert "SQLiteLeaseRepo" not in file_channel_source
 

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -118,7 +118,7 @@ async def test_get_sandbox_files_exposes_workspace_binding_alongside_local_stagi
 
     assert result == {
         "thread_id": "thread-1",
-        "files_path": "/tmp/channel-root",
+        "files_path": str(Path("/tmp/channel-root")),
         "workspace_id": "workspace-1",
         "workspace_path": "/workspace/root",
     }

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -97,3 +98,27 @@ async def test_list_channel_files_returns_entries_payload(monkeypatch: pytest.Mo
     result = await thread_files_router.list_channel_files("thread-1")
 
     assert result == {"thread_id": "thread-1", "entries": [{"path": "notes.txt"}]}
+
+
+@pytest.mark.asyncio
+async def test_get_sandbox_files_exposes_workspace_binding_alongside_local_staging_root(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        thread_files_router.file_channel_service,
+        "get_file_channel_binding",
+        lambda thread_id: SimpleNamespace(
+            thread_id=thread_id,
+            workspace_id="workspace-1",
+            workspace_path="/workspace/root",
+            local_staging_root=Path("/tmp/channel-root"),
+        ),
+        raising=False,
+    )
+
+    result = await thread_files_router.get_sandbox_files("thread-1")
+
+    assert result == {
+        "thread_id": "thread-1",
+        "files_path": "/tmp/channel-root",
+        "workspace_id": "workspace-1",
+        "workspace_path": "/workspace/root",
+    }

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -279,6 +279,33 @@ def test_build_new_launch_config_uses_sandbox_template_id() -> None:
 
 
 def test_resolve_default_config_prefers_last_successful_over_last_confirmed() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    workspace_repo.by_id["ws-successful"] = SimpleNamespace(
+        id="ws-successful",
+        sandbox_id="sandbox-successful",
+        owner_user_id="owner-1",
+        workspace_path="/workspace/reused",
+        name=None,
+        created_at=1.0,
+        updated_at=1.0,
+    )
+    workspace_repo.by_sandbox_id["sandbox-successful"] = [workspace_repo.by_id["ws-successful"]]
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-successful"] = SimpleNamespace(
+        id="sandbox-successful",
+        owner_user_id="owner-1",
+        provider_name="local",
+        provider_env_id="provider-env-successful",
+        sandbox_template_id="local:default",
+        desired_state="running",
+        observed_state="running",
+        status="ready",
+        observed_at=1.0,
+        last_error=None,
+        config={},
+        created_at=1.0,
+        updated_at=1.0,
+    )
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_launch_pref_repo=SimpleNamespace(
@@ -287,7 +314,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
                         "create_mode": "existing",
                         "provider_config": "local",
                         "sandbox_template": {"id": "stale"},
-                        "existing_sandbox_id": "lease-1",
+                        "existing_sandbox_id": "sandbox-successful",
                         "model": "gpt-5.4",
                         "workspace": "/workspace/stale",
                     },
@@ -304,6 +331,8 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
             thread_repo=_FakeThreadRepo(),
             user_repo=SimpleNamespace(),
             recipe_repo=object(),
+            workspace_repo=workspace_repo,
+            sandbox_repo=sandbox_repo,
         )
     )
 
@@ -311,15 +340,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
         patch.object(
             thread_launch_config_service.sandbox_service,
             "list_user_leases",
-            return_value=[
-                {
-                    "lease_id": "lease-1",
-                    "provider_name": "local",
-                    "recipe": default_recipe_snapshot("local"),
-                    "cwd": "/workspace/reused",
-                    "thread_ids": [],
-                }
-            ],
+            return_value=[],
         ),
         patch.object(
             thread_launch_config_service.sandbox_service,
@@ -344,7 +365,7 @@ def test_resolve_default_config_prefers_last_successful_over_last_confirmed() ->
             "create_mode": "existing",
             "provider_config": "local",
             "sandbox_template": default_recipe_snapshot("local"),
-            "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
+            "existing_sandbox_id": "sandbox-successful",
             "model": "gpt-5.4",
             "workspace": "/workspace/reused",
         },
@@ -486,7 +507,11 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
                 {"name": "daytona_selfhost", "available": True},
             ],
         ),
-        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
     ):
         result = thread_launch_config_service.resolve_default_config(
             app=app,
@@ -583,7 +608,11 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
             "available_sandbox_types",
             return_value=[{"name": "daytona_selfhost", "available": True}],
         ),
-        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
     ):
         result = thread_launch_config_service.resolve_default_config(
             app=app,
@@ -674,7 +703,11 @@ def test_resolve_default_config_fails_loudly_when_workspace_backed_template_sour
             "available_sandbox_types",
             return_value=[{"name": "daytona_selfhost", "available": True}],
         ),
-        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
         pytest.raises(RuntimeError, match="sandbox template not found: daytona:custom:missing"),
     ):
         thread_launch_config_service.resolve_default_config(
@@ -734,7 +767,11 @@ def test_resolve_default_config_derives_existing_from_legacy_lease_backed_curren
                 {"name": "daytona_selfhost", "available": True},
             ],
         ),
-        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
     ):
         result = thread_launch_config_service.resolve_default_config(
             app=app,
@@ -745,12 +782,13 @@ def test_resolve_default_config_derives_existing_from_legacy_lease_backed_curren
     assert result == {
         "source": "derived",
         "config": {
-            "create_mode": "existing",
-            "provider_config": "daytona_selfhost",
-            "sandbox_template": default_recipe_snapshot("daytona"),
-            "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-2').hex}",
+            "create_mode": "new",
+            "provider_config": "local",
+            "sandbox_template_id": "local:default",
+            "sandbox_template": default_recipe_snapshot("local"),
+            "existing_sandbox_id": None,
             "model": None,
-            "workspace": "/workspace/right",
+            "workspace": None,
         },
     }
 
@@ -1103,7 +1141,7 @@ async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(mon
                 "create_mode": "existing",
                 "provider_config": "daytona_selfhost",
                 "sandbox_template_id": None,
-                "existing_sandbox_id": f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}",
+                "existing_sandbox_id": "sandbox-1",
                 "model": "gpt-5.4-mini",
                 "workspace": "/workspace/reused",
             },

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -542,6 +542,66 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
 
 
 @pytest.mark.asyncio
+async def test_create_thread_route_existing_sandbox_prefers_existing_workspace_path_for_bind_cwd() -> None:
+    workspace_repo = _FakeWorkspaceRepo()
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-1"] = {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "config": {"legacy_lease_id": "lease-1"},
+    }
+    bridge_sandbox_id = f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, 'mycel-lease-bridge:lease-1').hex}"
+    existing_workspace = SimpleNamespace(
+        id="workspace-existing",
+        sandbox_id=bridge_sandbox_id,
+        owner_user_id="owner-1",
+        workspace_path="/workspace/existing",
+    )
+    workspace_repo.by_sandbox_id[bridge_sandbox_id] = [existing_workspace]
+    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
+    payload = CreateThreadRequest.model_validate(
+        {
+            "agent_user_id": "agent-user-1",
+            "existing_sandbox_id": "sandbox-1",
+        }
+    )
+
+    with (
+        patch.object(
+            threads_router.sandbox_service,
+            "resolve_owned_lease",
+            return_value={
+                "lease_id": "lease-1",
+                "sandbox_id": "sandbox-1",
+                "provider_name": "local",
+                "recipe": None,
+            },
+        ),
+        patch.object(
+            threads_router,
+            "bind_thread_to_existing_sandbox",
+            return_value=(
+                "/workspace/existing",
+                {
+                    "lease_id": "lease-1",
+                    "sandbox_id": "sandbox-1",
+                    "provider_name": "local",
+                    "recipe": None,
+                },
+            ),
+        ) as bind_helper,
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+        patch.object(threads_router, "save_last_successful_config", return_value=None),
+    ):
+        created = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    row = app.state.thread_repo.rows[created["thread_id"]]
+    assert row["current_workspace_id"] == "workspace-existing"
+    assert workspace_repo.created == []
+    assert bind_helper.call_args.kwargs["cwd"] == "/workspace/existing"
+
+
+@pytest.mark.asyncio
 async def test_create_thread_route_passes_local_cwd_into_sandbox_bootstrap():
     workspace_repo = _FakeWorkspaceRepo()
     app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo)

--- a/tests/Unit/backend/web/routers/test_thread_resource_creation.py
+++ b/tests/Unit/backend/web/routers/test_thread_resource_creation.py
@@ -2,24 +2,8 @@ from backend.web.routers import threads as threads_router
 from backend.web.utils import helpers
 
 
-class _VolumeRepo:
-    def __init__(self) -> None:
-        self.created: list[tuple[str, str, str, str]] = []
-        self.closed = False
-
-    def create(self, volume_id: str, payload: str, name: str, created_at: str) -> None:
-        self.created.append((volume_id, payload, name, created_at))
-
-    def close(self) -> None:
-        self.closed = True
-
-
 class _Container:
-    def __init__(self, volume_repo: _VolumeRepo) -> None:
-        self._volume_repo = volume_repo
-
-    def sandbox_volume_repo(self) -> _VolumeRepo:
-        return self._volume_repo
+    pass
 
 
 class _LeaseRepo:
@@ -55,15 +39,13 @@ class _SandboxRepo:
 
 
 def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(monkeypatch, tmp_path):
-    volume_repo = _VolumeRepo()
     lease_repo = _LeaseRepo()
     terminal_repo = _TerminalRepo()
     sandbox_repo = _SandboxRepo()
     workspace_repo = object()
     materialize_calls: list[dict[str, object]] = []
 
-    monkeypatch.setattr(helpers, "_get_container", lambda: _Container(volume_repo))
-    monkeypatch.setattr("backend.web.core.config.SANDBOX_VOLUME_ROOT", tmp_path / "volumes")
+    monkeypatch.setattr(helpers, "_get_container", lambda: _Container())
     monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
     monkeypatch.setattr("storage.runtime.build_terminal_repo", lambda: terminal_repo)
     monkeypatch.setattr(
@@ -83,30 +65,27 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
     )
 
     assert workspace_id == "workspace-1"
-    assert len(volume_repo.created) == 1
     assert len(lease_repo.created) == 1
     assert len(sandbox_repo.created) == 1
     assert lease_repo.created[0]["provider_name"] == "local"
+    assert "volume_id" not in lease_repo.created[0]
     assert len(terminal_repo.created) == 1
     assert terminal_repo.created[0]["thread_id"] == "thread-1"
     assert terminal_repo.created[0]["lease_id"] == lease_repo.created[0]["lease_id"]
     assert terminal_repo.created[0]["initial_cwd"] == "/tmp/workspace"
     assert sandbox_repo.created[0].config["legacy_lease_id"] == lease_repo.created[0]["lease_id"]
     assert materialize_calls[0]["sandbox_id"] == sandbox_repo.created[0].id
-    assert volume_repo.closed
     assert lease_repo.closed
     assert terminal_repo.closed
 
 
 def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_path):
-    volume_repo = _VolumeRepo()
     lease_repo = _LeaseRepo()
     terminal_repo = _TerminalRepo()
     sandbox_repo = _SandboxRepo()
     workspace_repo = object()
 
-    monkeypatch.setattr(helpers, "_get_container", lambda: _Container(volume_repo))
-    monkeypatch.setattr("backend.web.core.config.SANDBOX_VOLUME_ROOT", tmp_path / "volumes")
+    monkeypatch.setattr(helpers, "_get_container", lambda: _Container())
     monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
     monkeypatch.setattr("storage.runtime.build_terminal_repo", lambda: terminal_repo)
     monkeypatch.setattr(threads_router, "_materialize_workspace_for_sandbox", lambda *args, **kwargs: "workspace-new")
@@ -122,3 +101,4 @@ def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_p
     )
 
     assert workspace_id == "workspace-new"
+    assert "volume_id" not in lease_repo.created[0]

--- a/tests/Unit/backend/web/routers/test_threads_attachment_paths.py
+++ b/tests/Unit/backend/web/routers/test_threads_attachment_paths.py
@@ -35,5 +35,5 @@ async def test_prepare_attachment_message_uses_binding_local_staging_root(monkey
         attachments=["notes.txt"],
     )
 
-    assert "/tmp/channel-root/" in message
+    assert f"{Path('/tmp/channel-root')}/" in message
     assert metadata == {"attachments": ["notes.txt"], "original_message": "hello"}

--- a/tests/Unit/backend/web/routers/test_threads_attachment_paths.py
+++ b/tests/Unit/backend/web/routers/test_threads_attachment_paths.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.web.routers import threads as threads_router
+
+
+@pytest.mark.asyncio
+async def test_prepare_attachment_message_uses_binding_local_staging_root(monkeypatch: pytest.MonkeyPatch):
+    fake_manager = SimpleNamespace(
+        volume=SimpleNamespace(capability=SimpleNamespace(runtime_kind="local")),
+        sync_uploads=lambda thread_id, attachments: True,
+    )
+
+    monkeypatch.setattr(threads_router, "init_providers_and_managers", lambda: ({}, {"local": fake_manager}))
+    monkeypatch.setattr(
+        threads_router,
+        "get_file_channel_binding",
+        lambda thread_id: SimpleNamespace(
+            local_staging_root=Path("/tmp/channel-root"),
+            workspace_id="workspace-1",
+            workspace_path="/workspace/root",
+            remote_files_dir="/workspace/files",
+        ),
+        raising=False,
+    )
+
+    message, metadata = await threads_router._prepare_attachment_message(
+        thread_id="thread-1",
+        sandbox_type="local",
+        message="hello",
+        attachments=["notes.txt"],
+    )
+
+    assert "/tmp/channel-root/" in message
+    assert metadata == {"attachments": ["notes.txt"], "original_message": "hello"}

--- a/tests/Unit/backend/web/services/test_file_channel_service.py
+++ b/tests/Unit/backend/web/services/test_file_channel_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from backend.web.services import file_channel_service
+
+
+class _ThreadRepo:
+    def get_by_id(self, thread_id: str):
+        assert thread_id == "thread-1"
+        return {"id": thread_id, "current_workspace_id": "workspace-1"}
+
+
+class _WorkspaceRepo:
+    def get_by_id(self, workspace_id: str):
+        assert workspace_id == "workspace-1"
+        return SimpleNamespace(id=workspace_id, workspace_path="/workspace/root")
+
+
+class _Container:
+    def thread_repo(self) -> _ThreadRepo:
+        return _ThreadRepo()
+
+    def workspace_repo(self) -> _WorkspaceRepo:
+        return _WorkspaceRepo()
+
+
+def test_get_file_channel_binding_splits_workspace_truth_from_local_staging_root(monkeypatch):
+    monkeypatch.setattr(file_channel_service, "_get_container", lambda: _Container())
+    monkeypatch.setattr(
+        file_channel_service,
+        "get_file_channel_source",
+        lambda thread_id: SimpleNamespace(host_path=Path("/tmp/channel-root")),
+    )
+
+    binding = file_channel_service.get_file_channel_binding("thread-1")
+
+    assert binding.thread_id == "thread-1"
+    assert binding.workspace_id == "workspace-1"
+    assert binding.workspace_path == "/workspace/root"
+    assert binding.local_staging_root == Path("/tmp/channel-root")

--- a/tests/Unit/backend/web/services/test_file_channel_service.py
+++ b/tests/Unit/backend/web/services/test_file_channel_service.py
@@ -26,17 +26,24 @@ class _Container:
         return _WorkspaceRepo()
 
 
-def test_get_file_channel_binding_splits_workspace_truth_from_local_staging_root(monkeypatch):
+def test_get_file_channel_binding_uses_workspace_owned_local_channel_root(monkeypatch):
     monkeypatch.setattr(file_channel_service, "_get_container", lambda: _Container())
-    monkeypatch.setattr(
-        file_channel_service,
-        "get_file_channel_source",
-        lambda thread_id: SimpleNamespace(host_path=Path("/tmp/channel-root")),
-    )
+    monkeypatch.setattr(file_channel_service, "user_home_path", lambda *parts: Path("/tmp/leon-home").joinpath(*parts))
+    expected_root = Path("/tmp/leon-home/file_channels/workspace-1").resolve()
 
     binding = file_channel_service.get_file_channel_binding("thread-1")
 
     assert binding.thread_id == "thread-1"
     assert binding.workspace_id == "workspace-1"
     assert binding.workspace_path == "/workspace/root"
-    assert binding.local_staging_root == Path("/tmp/channel-root")
+    assert binding.local_staging_root == expected_root
+
+
+def test_get_file_channel_source_uses_workspace_owned_local_channel_root(monkeypatch):
+    monkeypatch.setattr(file_channel_service, "_get_container", lambda: _Container())
+    monkeypatch.setattr(file_channel_service, "user_home_path", lambda *parts: Path("/tmp/leon-home").joinpath(*parts))
+    expected_root = Path("/tmp/leon-home/file_channels/workspace-1").resolve()
+
+    source = file_channel_service.get_file_channel_source("thread-1")
+
+    assert source.host_path == expected_root

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -291,6 +291,52 @@ async def test_get_or_create_agent_uses_thread_user_id_for_chat_identity(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_agent_uses_binding_local_staging_root_for_extra_allowed_paths(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+
+    def _fake_create_agent_sync(**kwargs) -> object:
+        captured["extra_allowed_paths"] = kwargs.get("extra_allowed_paths")
+        return SimpleNamespace()
+
+    class _ThreadRepo:
+        def get_by_id(self, thread_id: str):
+            return {
+                "id": thread_id,
+                "agent_user_id": "agent-user-binding",
+                "cwd": None,
+                "model": "leon:large",
+            }
+
+    class _UserRepo:
+        def get_by_id(self, user_id: str):
+            return SimpleNamespace(id=user_id, owner_user_id="owner-binding", agent_config_id="cfg-binding")
+
+    monkeypatch.setattr(agent_pool, "create_agent_sync", _fake_create_agent_sync)
+    monkeypatch.setattr(agent_pool, "get_or_create_agent_id", lambda **_: "agent-binding")
+    monkeypatch.setattr(
+        agent_pool,
+        "get_file_channel_binding",
+        lambda thread_id: SimpleNamespace(local_staging_root=Path("/tmp/channel-root")),
+        raising=False,
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_ThreadRepo(),
+            user_repo=_UserRepo(),
+            agent_config_repo=_EmptyAgentConfigRepo(),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-binding")
+
+    assert captured["extra_allowed_paths"] == ["/tmp/channel-root"]
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_requires_thread_agent_user_id_for_chat_identity(monkeypatch: pytest.MonkeyPatch):
     def _fake_create_agent_sync(**kwargs) -> object:
         return SimpleNamespace()

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -333,7 +333,7 @@ async def test_get_or_create_agent_uses_binding_local_staging_root_for_extra_all
 
     await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-binding")
 
-    assert captured["extra_allowed_paths"] == ["/tmp/channel-root"]
+    assert captured["extra_allowed_paths"] == [str(Path("/tmp/channel-root"))]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1260,6 +1260,46 @@ async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkey
 
 
 @pytest.mark.asyncio
+async def test_run_agent_falls_back_to_child_workspace_root_when_parent_workspace_truth_is_absent(monkeypatch, tmp_path):
+    _patch_create_leon_agent(monkeypatch)
+    monkeypatch.setattr(
+        "backend.web.services.streaming_service.run_child_thread_live",
+        AsyncMock(return_value="LIVE_CHILD_DONE"),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_bind(thread_id: str, parent_thread_id: str, *, cwd=None, **_kwargs):
+        captured["thread_id"] = thread_id
+        captured["parent_thread_id"] = parent_thread_id
+        captured["cwd"] = cwd
+        return cwd
+
+    monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_lease", fake_bind)
+
+    service = _make_service(tmp_path)
+
+    set_current_thread_id("parent-thread")
+    try:
+        result = await service._run_agent(
+            task_id="task-1",
+            agent_name="child",
+            thread_id="subagent-child",
+            prompt="hello",
+            subagent_type="explore",
+            max_turns=None,
+        )
+        assert result == "(Agent completed with no text output)"
+        assert captured == {
+            "thread_id": "subagent-child",
+            "parent_thread_id": "parent-thread",
+            "cwd": str(tmp_path),
+        }
+    finally:
+        set_current_thread_id("")
+
+
+@pytest.mark.asyncio
 async def test_run_agent_inherits_parent_sandbox_when_forking_child(monkeypatch, tmp_path):
     captured: dict[str, Any] = {}
     _patch_create_leon_agent(monkeypatch, captured=captured)

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -109,6 +109,16 @@ class _FakeUserRepo:
         return SimpleNamespace(id=user_id, display_name=name, avatar=None)
 
 
+class _FakeWorkspaceRepo:
+    def __init__(self, rows: dict[str, Any] | None = None):
+        self.rows = rows or {}
+        self.requested_ids: list[str] = []
+
+    def get_by_id(self, workspace_id: str):
+        self.requested_ids.append(workspace_id)
+        return self.rows.get(workspace_id)
+
+
 def test_fake_thread_repo_create_requires_current_workspace_id() -> None:
     repo = _FakeThreadRepo()
 
@@ -1098,6 +1108,122 @@ async def test_run_agent_reuses_parent_lease_for_child_thread_terminal(monkeypat
         assert observed["child_lease_id"] == parent_lease_id
     finally:
         manager.close()
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(monkeypatch, tmp_path):
+    _patch_create_leon_agent(monkeypatch)
+    monkeypatch.setattr(
+        "backend.web.services.streaming_service.run_child_thread_live",
+        AsyncMock(return_value="LIVE_CHILD_DONE"),
+    )
+
+    thread_repo = _FakeThreadRepo(
+        rows={
+            "parent-thread": {
+                "id": "parent-thread",
+                "agent_user_id": "agent-user-1",
+                "owner_user_id": "owner-1",
+                "current_workspace_id": "workspace-parent",
+                "sandbox_type": "daytona_selfhost",
+                "cwd": "/home/daytona",
+                "model": "gpt-parent",
+                "is_main": True,
+                "branch_index": 0,
+                "created_at": 1.0,
+            }
+        }
+    )
+    user_repo = _FakeUserRepo({"agent-user-1": "Toad"})
+    workspace_repo = _FakeWorkspaceRepo(
+        rows={
+            "workspace-parent": SimpleNamespace(
+                id="workspace-parent",
+                workspace_path="/workspace/parent",
+            )
+        }
+    )
+    web_app = SimpleNamespace(state=SimpleNamespace(workspace_repo=workspace_repo))
+    captured: dict[str, Any] = {}
+
+    def fake_bind(thread_id: str, parent_thread_id: str, *, cwd=None, **_kwargs):
+        captured["thread_id"] = thread_id
+        captured["parent_thread_id"] = parent_thread_id
+        captured["cwd"] = cwd
+        return "/workspace/parent"
+
+    monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_lease", fake_bind)
+
+    service = _make_service(
+        tmp_path,
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+        web_app=web_app,
+    )
+
+    set_current_thread_id("parent-thread")
+    try:
+        result = await service._run_agent(
+            task_id="task-1",
+            agent_name="child",
+            thread_id="subagent-child",
+            prompt="hello",
+            subagent_type="explore",
+            max_turns=None,
+        )
+        assert result == "LIVE_CHILD_DONE"
+        assert captured["parent_thread_id"] == "parent-thread"
+        assert captured["cwd"] == "/workspace/parent"
+        assert workspace_repo.requested_ids == ["workspace-parent"]
+    finally:
+        set_current_thread_id("")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkeypatch, tmp_path):
+    _patch_create_leon_agent(monkeypatch)
+    monkeypatch.setattr(
+        "backend.web.services.streaming_service.run_child_thread_live",
+        AsyncMock(return_value="LIVE_CHILD_DONE"),
+    )
+
+    thread_repo = _FakeThreadRepo(
+        rows={
+            "parent-thread": {
+                "id": "parent-thread",
+                "agent_user_id": "agent-user-1",
+                "owner_user_id": "owner-1",
+                "current_workspace_id": "workspace-parent",
+                "sandbox_type": "daytona_selfhost",
+                "cwd": "/home/daytona",
+                "model": "gpt-parent",
+                "is_main": True,
+                "branch_index": 0,
+                "created_at": 1.0,
+            }
+        }
+    )
+    user_repo = _FakeUserRepo({"agent-user-1": "Toad"})
+    service = _make_service(
+        tmp_path,
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+        web_app=SimpleNamespace(state=SimpleNamespace()),
+    )
+
+    set_current_thread_id("parent-thread")
+    try:
+        with pytest.raises(ValueError, match="parent workspace_repo is required"):
+            await service._run_agent(
+                task_id="task-1",
+                agent_name="child",
+                thread_id="subagent-child",
+                prompt="hello",
+                subagent_type="explore",
+                max_turns=None,
+            )
+    finally:
+        set_current_thread_id("")
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -121,9 +121,10 @@ class _FakeWorkspaceRepo:
 
 def test_fake_thread_repo_create_requires_current_workspace_id() -> None:
     repo = _FakeThreadRepo()
+    create = cast(Any, repo.create)
 
     with pytest.raises(TypeError):
-        repo.create(
+        create(
             thread_id="thread-1",
             agent_user_id="agent-user-1",
             sandbox_type="local",

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1088,9 +1088,42 @@ async def test_run_agent_reuses_parent_lease_for_child_thread_terminal(monkeypat
             return
 
     _patch_create_leon_agent(monkeypatch, child_cls=_LeaseCapturingChild, created=created)
+
+    async def _fake_run_child_thread_live(agent, thread_id, message, app, *, input_messages):
+        child_capability = manager.get_sandbox(thread_id)
+        observed["child_terminal_id"] = child_capability._session.terminal.terminal_id
+        observed["child_lease_id"] = child_capability._session.lease.lease_id
+        return "(Agent completed with no text output)"
+
+    monkeypatch.setattr(
+        "backend.web.services.streaming_service.run_child_thread_live",
+        _fake_run_child_thread_live,
+    )
     set_current_thread_id(parent_thread_id)
 
-    service = _make_service(tmp_path)
+    thread_repo = _FakeThreadRepo(
+        rows={
+            parent_thread_id: {
+                "id": parent_thread_id,
+                "agent_user_id": "agent-user-1",
+                "owner_user_id": "owner-user-1",
+                "current_workspace_id": "workspace-parent",
+            }
+        }
+    )
+    workspace_repo = _FakeWorkspaceRepo(
+        rows={
+            "workspace-parent": SimpleNamespace(
+                id="workspace-parent",
+                workspace_path=str(tmp_path / "parent-workspace"),
+            )
+        }
+    )
+    service = _make_service(
+        tmp_path,
+        thread_repo=thread_repo,
+        web_app=SimpleNamespace(state=SimpleNamespace(workspace_repo=workspace_repo)),
+    )
 
     try:
         result = await service._run_agent(

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -271,7 +271,7 @@ def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider
     assert terminal_repo.created[0]["initial_cwd"] == "/providers/local"
 
 
-def test_bind_thread_to_existing_thread_lease_keeps_latest_terminal_cwd_continuity(monkeypatch):
+def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monkeypatch):
     terminal_repo = _FakeBindTerminalRepo(
         latest_by_lease={"cwd": "/terminal/latest"},
         active_by_thread={"thread-parent": {"lease_id": "lease-1"}},
@@ -284,16 +284,18 @@ def test_bind_thread_to_existing_thread_lease_keeps_latest_terminal_cwd_continui
         lambda _name: (_ for _ in ()).throw(AssertionError("provider default should stay unused for continuity path")),
     )
 
-    initial_cwd = sandbox_manager_module.bind_thread_to_existing_thread_lease(
-        "thread-child",
-        "thread-parent",
-        db_path=Path("/tmp/fake-sandbox.db"),
-        terminal_repo=terminal_repo,
-        lease_repo=lease_repo,
-    )
-
-    assert initial_cwd == "/terminal/latest"
-    assert terminal_repo.created[0]["initial_cwd"] == "/terminal/latest"
+    try:
+        sandbox_manager_module.bind_thread_to_existing_thread_lease(
+            "thread-child",
+            "thread-parent",
+            db_path=Path("/tmp/fake-sandbox.db"),
+            terminal_repo=terminal_repo,
+            lease_repo=lease_repo,
+        )
+    except ValueError as exc:
+        assert str(exc) == "thread reuse cwd is required"
+    else:
+        raise AssertionError("expected bind_thread_to_existing_thread_lease to fail loudly without cwd")
 
 
 def test_setup_mounts_reads_volume_from_active_storage_repo(tmp_path):

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -726,3 +726,51 @@ def test_make_sandbox_monitor_repo_returns_supabase(monkeypatch):
         assert repo.__class__.__name__ == "SupabaseSandboxMonitorRepo"
     finally:
         repo.close()
+
+
+def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
+    lease_repo = SimpleNamespace(
+        find_by_instance=lambda **kwargs: {
+            "lease_id": "lease-live",
+            "provider_name": kwargs["provider_name"],
+            "current_instance_id": kwargs["instance_id"],
+        },
+        close=lambda: None,
+    )
+
+    lease = sandbox_manager_module.resolve_existing_sandbox_lease(
+        {
+            "provider_name": "daytona",
+            "provider_env_id": "sandbox-env-1",
+            "config": {"legacy_lease_id": "lease-legacy"},
+        },
+        resolve_lease=lambda _lease_id: (_ for _ in ()).throw(AssertionError("legacy fallback should stay unused")),
+        lease_repo=lease_repo,
+    )
+
+    assert lease == {
+        "lease_id": "lease-live",
+        "provider_name": "daytona",
+        "current_instance_id": "sandbox-env-1",
+    }
+
+
+def test_resolve_existing_sandbox_lease_falls_back_to_legacy_lease_id_when_instance_lookup_misses() -> None:
+    lease_repo = SimpleNamespace(
+        find_by_instance=lambda **_kwargs: None,
+        close=lambda: None,
+    )
+    seen_lease_ids: list[str] = []
+
+    lease = sandbox_manager_module.resolve_existing_sandbox_lease(
+        {
+            "provider_name": "daytona",
+            "provider_env_id": "sandbox-env-1",
+            "config": {"legacy_lease_id": "lease-legacy"},
+        },
+        resolve_lease=lambda lease_id: seen_lease_ids.append(lease_id) or {"lease_id": lease_id},
+        lease_repo=lease_repo,
+    )
+
+    assert seen_lease_ids == ["lease-legacy"]
+    assert lease == {"lease_id": "lease-legacy"}

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -837,6 +837,45 @@ def test_get_sandbox_routes_bind_mounts_to_provider_thread_state():
     assert capability._session is session
 
 
+def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
+    manager = _new_test_manager()
+    terminal = SimpleNamespace(
+        terminal_id="term-1",
+        lease_id="lease-1",
+        get_state=lambda: SimpleNamespace(cwd="/tmp", env_delta={}, state_version=0),
+        update_state=lambda _state: None,
+    )
+    lease = SimpleNamespace(
+        lease_id="lease-1",
+        provider_name="agentbay",
+        observed_state="running",
+        recipe=None,
+        get_instance=lambda: SimpleNamespace(instance_id="instance-1"),
+    )
+    sync_calls: list[tuple[str, str, Path]] = []
+    expected_path = Path("/tmp/workspace-files")
+
+    manager.provider = SimpleNamespace(name="agentbay")
+    manager.provider_capability = SimpleNamespace(runtime_kind="agentbay", eager_instance_binding=False)
+    manager._get_active_terminal = lambda _thread_id: terminal
+    manager._get_lease = lambda _lease_id: lease
+    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager._ensure_bound_instance = lambda _lease: None
+    manager._setup_mounts = lambda _thread_id: {"source_path": expected_path, "remote_path": "/workspace"}
+    manager._sync_to_sandbox = (
+        lambda thread_id, instance_id, source=None, files=None: sync_calls.append((thread_id, instance_id, source))
+    )
+    manager._fire_session_ready = lambda *_args, **_kwargs: None
+    manager.session_manager = SimpleNamespace(
+        get=lambda _thread_id, _terminal_id: None,
+        create=lambda **_kwargs: SimpleNamespace(terminal=terminal, lease=lease, status="active"),
+    )
+
+    manager.get_sandbox("thread-1")
+
+    assert sync_calls == [("thread-1", "instance-1", expected_path)]
+
+
 def test_resume_session_rebinds_live_session_lease_after_resume():
     manager = _new_test_manager()
     terminal = SimpleNamespace(terminal_id="term-1", lease_id="lease-1")

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import pytest
 
 import sandbox.manager as sandbox_manager_module
+from config.user_paths import user_home_path
 from sandbox.manager import SandboxManager
 from sandbox.providers.local import LocalSessionProvider
 from sandbox.volume_source import DaytonaVolume, HostVolume
@@ -40,8 +41,8 @@ class _FakeVolumeRepo:
 class _FakeVolume:
     def __init__(self) -> None:
         self.mount_calls: list[tuple[str, str]] = []
-        self.upload_calls: list[tuple[str, str]] = []
-        self.download_calls: list[tuple[str, str]] = []
+        self.upload_calls: list[tuple[str, str, Path, str]] = []
+        self.download_calls: list[tuple[str, str, Path, str]] = []
         self.cleared: list[str] = []
 
     def resolve_mount_path(self) -> str:
@@ -53,11 +54,11 @@ class _FakeVolume:
     def mount_managed_volume(self, thread_id: str, volume_name: str, remote_path: str) -> None:
         self.mount_calls.append((thread_id, remote_path))
 
-    def sync_upload(self, thread_id: str, session_id: str, source, remote_path: str, files=None) -> None:
-        self.upload_calls.append((thread_id, session_id))
+    def sync_upload(self, thread_id: str, session_id: str, source_path: Path, remote_path: str, files=None) -> None:
+        self.upload_calls.append((thread_id, session_id, source_path, remote_path))
 
-    def sync_download(self, thread_id: str, session_id: str, source, remote_path: str) -> None:
-        self.download_calls.append((thread_id, session_id))
+    def sync_download(self, thread_id: str, session_id: str, source_path: Path, remote_path: str) -> None:
+        self.download_calls.append((thread_id, session_id, source_path, remote_path))
 
     def clear_sync_state(self, thread_id: str) -> None:
         self.cleared.append(thread_id)
@@ -198,7 +199,6 @@ def _new_test_manager() -> Any:
 
 
 def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_truth(monkeypatch):
-    terminal_repo = _FakeTerminalRepo(row=None)
     lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
 
     def build_provider(name: str):
@@ -213,14 +213,11 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
     cwd = sandbox_manager_module.resolve_existing_lease_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
-        terminal_repo=terminal_repo,
         lease_repo=lease_repo,
     )
 
     assert cwd == "/providers/local"
-    assert terminal_repo.requested_lease_ids == ["lease-1"]
     assert lease_repo.requested_ids == ["lease-1"]
-    assert terminal_repo.closed is False
     assert lease_repo.closed is False
 
 
@@ -682,6 +679,34 @@ def test_sync_uploads_skips_local_volume_sync_when_lease_has_no_volume_id():
 
     assert manager.sync_uploads("thread-1") is True
     assert manager.volume.upload_calls == []
+
+
+def test_sync_paths_use_workspace_file_channel_root_instead_of_volume_source(monkeypatch):
+    manager = _new_test_manager()
+    manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
+    manager.volume = _FakeVolume()
+    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(volume_id="volume-1")
+    manager.resolve_volume_source = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume source should stay unused"))
+
+    class _ThreadRepo:
+        def get_by_id(self, _thread_id: str):
+            return {"current_workspace_id": "ws-1"}
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "build_storage_container",
+        lambda: SimpleNamespace(thread_repo=lambda: _ThreadRepo()),
+    )
+
+    manager._sync_to_sandbox("thread-1", "instance-1")
+    manager._sync_from_sandbox("thread-1", "instance-1")
+
+    expected_root = user_home_path("file_channels", "ws-1").expanduser().resolve()
+    assert manager.volume.upload_calls == [("thread-1", "instance-1", expected_root, "/workspace")]
+    assert manager.volume.download_calls == [("thread-1", "instance-1", expected_root, "/workspace")]
 
 
 def test_get_sandbox_local_provider_does_not_require_volume_bootstrap(tmp_path, monkeypatch):

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -222,25 +222,22 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
     assert lease_repo.closed is False
 
 
-def test_resolve_existing_lease_cwd_keeps_latest_terminal_cwd_when_present(monkeypatch):
-    terminal_repo = _FakeTerminalRepo(row={"cwd": "/terminal/latest"})
+def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_provider_default(monkeypatch):
     lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
     monkeypatch.setattr(
         sandbox_manager_module,
         "_build_provider_from_name",
-        lambda _name: (_ for _ in ()).throw(AssertionError("provider default should not be used")),
+        lambda name: SimpleNamespace(default_cwd=f"/providers/{name}"),
     )
 
     cwd = sandbox_manager_module.resolve_existing_lease_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
-        terminal_repo=terminal_repo,
         lease_repo=lease_repo,
     )
 
-    assert cwd == "/terminal/latest"
-    assert terminal_repo.requested_lease_ids == ["lease-1"]
-    assert lease_repo.requested_ids == []
+    assert cwd == "/providers/local"
+    assert lease_repo.requested_ids == ["lease-1"]
 
 
 def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider_default_exists(monkeypatch):

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -852,7 +852,7 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
         recipe=None,
         get_instance=lambda: SimpleNamespace(instance_id="instance-1"),
     )
-    sync_calls: list[tuple[str, str, Path]] = []
+    sync_calls: list[tuple[str, str, Path | None]] = []
     expected_path = Path("/tmp/workspace-files")
 
     manager.provider = SimpleNamespace(name="agentbay")
@@ -862,9 +862,7 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
     manager._assert_lease_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     manager._setup_mounts = lambda _thread_id: {"source_path": expected_path, "remote_path": "/workspace"}
-    manager._sync_to_sandbox = (
-        lambda thread_id, instance_id, source=None, files=None: sync_calls.append((thread_id, instance_id, source))
-    )
+    manager._sync_to_sandbox = lambda thread_id, instance_id, source=None, files=None: sync_calls.append((thread_id, instance_id, source))
     manager._fire_session_ready = lambda *_args, **_kwargs: None
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: None,

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -107,15 +107,51 @@ class _FakeTerminalRepo:
         self.closed = True
 
 
+class _FakeBindTerminalRepo:
+    def __init__(self, latest_by_lease: dict[str, Any] | None = None, active_by_thread: dict[str, Any] | None = None) -> None:
+        self._latest_by_lease = latest_by_lease
+        self._active_by_thread = active_by_thread or {}
+        self.closed = False
+        self.requested_lease_ids: list[str] = []
+        self.requested_active_threads: list[str] = []
+        self.created: list[dict[str, Any]] = []
+
+    def get_latest_by_lease(self, lease_id: str):
+        self.requested_lease_ids.append(lease_id)
+        return self._latest_by_lease
+
+    def get_active(self, thread_id: str):
+        self.requested_active_threads.append(thread_id)
+        return self._active_by_thread.get(thread_id)
+
+    def create(self, *, terminal_id: str, thread_id: str, lease_id: str, initial_cwd: str) -> None:
+        self.created.append(
+            {
+                "terminal_id": terminal_id,
+                "thread_id": thread_id,
+                "lease_id": lease_id,
+                "initial_cwd": initial_cwd,
+            }
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class _FakeLeaseRepo:
     def __init__(self, row: dict[str, Any] | None = None) -> None:
         self._row = row
         self.closed = False
         self.requested_ids: list[str] = []
+        self.instance_queries: list[tuple[str, str]] = []
 
     def get(self, lease_id: str):
         self.requested_ids.append(lease_id)
         return self._row
+
+    def find_by_instance(self, *, provider_name: str, instance_id: str):
+        self.instance_queries.append((provider_name, instance_id))
+        return None
 
     def close(self) -> None:
         self.closed = True
@@ -205,6 +241,59 @@ def test_resolve_existing_lease_cwd_keeps_latest_terminal_cwd_when_present(monke
     assert cwd == "/terminal/latest"
     assert terminal_repo.requested_lease_ids == ["lease-1"]
     assert lease_repo.requested_ids == []
+
+
+def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider_default_exists(monkeypatch):
+    terminal_repo = _FakeBindTerminalRepo(latest_by_lease={"cwd": "/terminal/latest"})
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "_build_provider_from_name",
+        lambda name: SimpleNamespace(default_cwd=f"/providers/{name}"),
+    )
+
+    initial_cwd, lease = sandbox_manager_module.bind_thread_to_existing_sandbox(
+        "thread-1",
+        {
+            "provider_name": "local",
+            "provider_env_id": "env-1",
+            "config": {"legacy_lease_id": "legacy-lease"},
+        },
+        resolve_lease=lambda _lease_id: {"lease_id": "lease-1"},
+        db_path=Path("/tmp/fake-sandbox.db"),
+        terminal_repo=terminal_repo,
+        lease_repo=lease_repo,
+    )
+
+    assert initial_cwd == "/providers/local"
+    assert lease["lease_id"] == "lease-1"
+    assert terminal_repo.created[0]["initial_cwd"] == "/providers/local"
+
+
+def test_bind_thread_to_existing_thread_lease_keeps_latest_terminal_cwd_continuity(monkeypatch):
+    terminal_repo = _FakeBindTerminalRepo(
+        latest_by_lease={"cwd": "/terminal/latest"},
+        active_by_thread={"thread-parent": {"lease_id": "lease-1"}},
+    )
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "_build_provider_from_name",
+        lambda _name: (_ for _ in ()).throw(AssertionError("provider default should stay unused for continuity path")),
+    )
+
+    initial_cwd = sandbox_manager_module.bind_thread_to_existing_thread_lease(
+        "thread-child",
+        "thread-parent",
+        db_path=Path("/tmp/fake-sandbox.db"),
+        terminal_repo=terminal_repo,
+        lease_repo=lease_repo,
+    )
+
+    assert initial_cwd == "/terminal/latest"
+    assert terminal_repo.created[0]["initial_cwd"] == "/terminal/latest"
 
 
 def test_setup_mounts_reads_volume_from_active_storage_repo(tmp_path):

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import pytest
+
 import sandbox.manager as sandbox_manager_module
 from sandbox.manager import SandboxManager
 from sandbox.providers.local import LocalSessionProvider
@@ -237,6 +239,24 @@ def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_prov
     )
 
     assert cwd == "/providers/local"
+    assert lease_repo.requested_ids == ["lease-1"]
+
+
+def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavailable(monkeypatch):
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "missing-provider"})
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "_build_provider_from_name",
+        lambda _name: None,
+    )
+
+    with pytest.raises(ValueError, match="provider default cwd is required"):
+        sandbox_manager_module.resolve_existing_lease_cwd(
+            "lease-1",
+            db_path=Path("/tmp/fake-sandbox.db"),
+            lease_repo=lease_repo,
+        )
+
     assert lease_repo.requested_ids == ["lease-1"]
 
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -93,6 +93,34 @@ class _FakeLeaseStore:
         self.volume_updates.append((lease_id, volume_id))
 
 
+class _FakeTerminalRepo:
+    def __init__(self, row: dict[str, Any] | None = None) -> None:
+        self._row = row
+        self.closed = False
+        self.requested_lease_ids: list[str] = []
+
+    def get_latest_by_lease(self, lease_id: str):
+        self.requested_lease_ids.append(lease_id)
+        return self._row
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeLeaseRepo:
+    def __init__(self, row: dict[str, Any] | None = None) -> None:
+        self._row = row
+        self.closed = False
+        self.requested_ids: list[str] = []
+
+    def get(self, lease_id: str):
+        self.requested_ids.append(lease_id)
+        return self._row
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class _FakeSessionManager:
     def __init__(self, active_rows) -> None:
         self._active_rows = active_rows
@@ -129,6 +157,54 @@ def _new_test_manager() -> Any:
     manager = cast(Any, object.__new__(SandboxManager))
     manager.db_path = Path("/tmp/fake-sandbox.db")
     return manager
+
+
+def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_truth(monkeypatch):
+    terminal_repo = _FakeTerminalRepo(row=None)
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+
+    def build_provider(name: str):
+        return SimpleNamespace(default_cwd=f"/providers/{name}") if name == "local" else None
+
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "_build_provider_from_name",
+        build_provider,
+    )
+
+    cwd = sandbox_manager_module.resolve_existing_lease_cwd(
+        "lease-1",
+        db_path=Path("/tmp/fake-sandbox.db"),
+        terminal_repo=terminal_repo,
+        lease_repo=lease_repo,
+    )
+
+    assert cwd == "/providers/local"
+    assert terminal_repo.requested_lease_ids == ["lease-1"]
+    assert lease_repo.requested_ids == ["lease-1"]
+    assert terminal_repo.closed is False
+    assert lease_repo.closed is False
+
+
+def test_resolve_existing_lease_cwd_keeps_latest_terminal_cwd_when_present(monkeypatch):
+    terminal_repo = _FakeTerminalRepo(row={"cwd": "/terminal/latest"})
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+    monkeypatch.setattr(
+        sandbox_manager_module,
+        "_build_provider_from_name",
+        lambda _name: (_ for _ in ()).throw(AssertionError("provider default should not be used")),
+    )
+
+    cwd = sandbox_manager_module.resolve_existing_lease_cwd(
+        "lease-1",
+        db_path=Path("/tmp/fake-sandbox.db"),
+        terminal_repo=terminal_repo,
+        lease_repo=lease_repo,
+    )
+
+    assert cwd == "/terminal/latest"
+    assert terminal_repo.requested_lease_ids == ["lease-1"]
+    assert lease_repo.requested_ids == []
 
 
 def test_setup_mounts_reads_volume_from_active_storage_repo(tmp_path):


### PR DESCRIPTION
## Summary
- move file channel CRUD and thread create off the lease.volume_id / sandbox_volumes caller spine
- rewrite existing-sandbox and thread-reuse bind paths to prefer workspace-shaped cwd truth and fail loud when provider/workspace truth is missing
- rewrite sync source to use workspace-owned local staging paths instead of volume metadata

## Verification
- `uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q`
- `uv run python -m ruff check sandbox/manager.py sandbox/volume.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py`
- `git diff --check`

## Notes
- this PR does not remove lease as a runtime object
- current primary residual is mount/source transitional residue in `sandbox/manager.py::_setup_mounts(...)`
