### PR TITLE
fix: honor settings model mapping truth

### DIFF
--- a/frontend/app/src/components/ModelMappingSection.test.tsx
+++ b/frontend/app/src/components/ModelMappingSection.test.tsx
@@ -12,6 +12,21 @@ afterEach(() => {
 });
 
 describe("ModelMappingSection", () => {
+  it("shows mapped model even when enabled model pool is empty", () => {
+    render(
+      <ModelMappingSection
+        virtualModels={[{ id: "leon:mini", name: "Mini", description: "virtual", icon: "V" }]}
+        availableModels={[{ id: "gpt-5.4", name: "GPT-5.4" }]}
+        modelMapping={{ "leon:mini": "gpt-5.4" }}
+        enabledModels={[]}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("请在下方模型池中启用模型")).toBeNull();
+    expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("gpt-5.4");
+  });
+
   it("does not log a failed mapping save once navigation already left /settings", async () => {
     window.history.replaceState({}, "", "/settings");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/frontend/app/src/components/ModelMappingSection.tsx
+++ b/frontend/app/src/components/ModelMappingSection.tsx
@@ -65,7 +65,9 @@ export default function ModelMappingSection({
     }
   };
 
-  const enabledModelsList = availableModels.filter((m) => enabledModels.includes(m.id));
+  const mappingTargets = new Set(Object.values(modelMapping).filter(Boolean));
+  const selectableModelIds = new Set([...enabledModels, ...mappingTargets]);
+  const enabledModelsList = availableModels.filter((m) => selectableModelIds.has(m.id));
 
   return (
     <div className="space-y-4 relative">


### PR DESCRIPTION
## Summary
- make settings virtual-model cards honor existing `model_mapping` targets even when `enabled_models` is empty
- stop the false empty-pool warning in `/settings` when the backend has already settled leon:* mappings onto real models
- keep the fix frontend-only with no backend contract change

## Test Plan
- `cd frontend/app && npm test -- --run src/components/ModelMappingSection.test.tsx src/pages/SettingsPage.test.tsx`
- `cd frontend/app && npm run lint`
- `cd frontend/app && npm run build`
- `git diff --check`
- manual product check on brother frontend `5189` against canonical backend `8017`:
  - open `/settings`
  - verify all four leon:* virtual cards show `gpt-5.4` selected
  - verify the false text `请在下方模型池中启用模型` is gone
