### PR TITLE
fix: quiet chat event abort teardown noise

### DIFF
--- a/frontend/app/src/api/chat-events.test.ts
+++ b/frontend/app/src/api/chat-events.test.ts
@@ -82,4 +82,32 @@ describe("chat event stream", () => {
       created_at: 1,
     })).toThrow("mentioned_ids must be a string array");
   });
+
+  it("treats abort-time reader network errors as clean teardown, not a stream failure", async () => {
+    const cancel = vi.fn();
+    let rejectRead: ((reason?: unknown) => void) | null = null;
+    const read = vi.fn(() =>
+      new Promise<never>((_, reject) => {
+        rejectRead = reject;
+      }),
+    );
+    authFetch.mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read,
+          cancel,
+        }),
+      },
+    });
+
+    const ac = new AbortController();
+    const stream = api.streamChatEvents("chat-1", () => undefined, ac.signal);
+    await Promise.resolve();
+    ac.abort();
+    rejectRead?.(new TypeError("network error"));
+
+    await expect(stream).resolves.toBeUndefined();
+    expect(cancel).toHaveBeenCalled();
+  });
 });

--- a/frontend/app/src/api/chat-events.ts
+++ b/frontend/app/src/api/chat-events.ts
@@ -7,6 +7,12 @@ export interface ChatStreamEvent {
   data: unknown;
 }
 
+function isAbortTeardownError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof TypeError && error.message === "network error";
+}
+
 function requiredString(value: Record<string, unknown>, key: string): string {
   const field = value[key];
   if (typeof field !== "string") {
@@ -84,7 +90,14 @@ export async function streamChatEvents(
 
   try {
     while (!signal?.aborted) {
-      const { done, value } = await reader.read();
+      let chunk: ReadableStreamReadResult<Uint8Array>;
+      try {
+        chunk = await reader.read();
+      } catch (error) {
+        if (signal?.aborted && isAbortTeardownError(error)) break;
+        throw error;
+      }
+      const { done, value } = chunk;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       const chunks = buffer.split(/\r?\n\r?\n/);


### PR DESCRIPTION
## Summary
- treat abort-time SSE reader network errors as clean teardown inside `streamChatEvents`
- add a regression test for aborting an active chat stream while `reader.read()` rejects with `TypeError("network error")`
- keep the fix at the API helper boundary instead of patching page-level route transitions

## Verification
- `cd frontend/app && npm test -- --run src/api/chat-events.test.ts src/pages/NewChatPage.test.tsx`
- `cd frontend/app && npm run lint`
- `git diff --check`
- real product on branch-local frontend `5189` + canonical backend `8017`:
  - open an active chat at `/chat/visit/057dac43-a793-40d3-b9dd-cbbfd4e1569e`
  - navigate in-app from the live chat page to `/settings`
  - console remained `Errors: 0, Warnings: 0`
