### PR TITLE
fix: abort stale marketplace explore fetches

### DIFF
--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -88,7 +88,12 @@ export default function MarketplacePage() {
 
   // Fetch explore items when filters change
   useEffect(() => {
-    if (tab === "explore") fetchItems();
+    if (tab !== "explore") return;
+    const controller = new AbortController();
+    void fetchItems(controller.signal);
+    return () => {
+      controller.abort();
+    };
   }, [tab, filters, fetchItems]);
 
   // Debounced search

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -11,6 +11,8 @@ function LocationProbe() {
   return <output aria-label="location">{location.pathname + location.search}</output>;
 }
 
+let fetchItemsMock: ReturnType<typeof vi.fn>;
+
 vi.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => false,
 }));
@@ -33,7 +35,7 @@ vi.mock("@/store/marketplace-store", () => ({
       updates: [],
       filters: { type: null, sort: "downloads" },
       setFilter: vi.fn(),
-      fetchItems: vi.fn(),
+      fetchItems: fetchItemsMock,
       checkUpdates: vi.fn(),
   }),
 }));
@@ -55,6 +57,7 @@ afterEach(() => {
 describe("MarketplacePage wording contract", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    fetchItemsMock = vi.fn();
     appStoreFetchLibrary.mockReset();
     appStoreDeleteResource.mockReset();
     appStoreAddResource.mockReset();
@@ -230,5 +233,29 @@ describe("MarketplacePage wording contract", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Explore" })).toBeTruthy();
+  });
+
+  it("aborts the explore fetch when navigation leaves the marketplace page", () => {
+    const seenSignals: AbortSignal[] = [];
+    fetchItemsMock.mockImplementation((signal?: AbortSignal) => {
+      if (signal) seenSignals.push(signal);
+      return Promise.resolve();
+    });
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/marketplace"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(fetchItemsMock).toHaveBeenCalledOnce();
+    expect(seenSignals).toHaveLength(1);
+    expect(seenSignals[0].aborted).toBe(false);
+
+    unmount();
+
+    expect(seenSignals[0].aborted).toBe(true);
   });
 });

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -67,7 +67,7 @@ interface MarketplaceState {
   error: string | null;
   filters: MarketplaceFilters;
   setFilter: <K extends keyof MarketplaceFilters>(key: K, value: MarketplaceFilters[K]) => void;
-  fetchItems: () => Promise<void>;
+  fetchItems: (signal?: AbortSignal) => Promise<void>;
 
   // Detail
   detail: MarketplaceItemDetail | null;
@@ -147,7 +147,7 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
     });
   },
 
-  fetchItems: async () => {
+  fetchItems: async (signal) => {
     set({ error: null, loading: true });
     try {
       const { type, q, sort, page } = get().filters;
@@ -157,9 +157,10 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       params.set("sort", sort);
       params.set("page", String(page));
       params.set("page_size", "20");
-      const data = await backendApi<{ items: MarketplaceItemSummary[]; total: number }>(`/items?${params}`);
+      const data = await backendApi<{ items: MarketplaceItemSummary[]; total: number }>(`/items?${params}`, { signal });
       set({ items: data.items, total: data.total });
     } catch (e) {
+      if (signal?.aborted) return;
       // @@@marketplace-route-teardown - explore fetches can resolve after the
       // user already left /marketplace. Only log if the marketplace route is
       // still active; otherwise this is stale UI noise.


### PR DESCRIPTION
## Summary
- abort in-flight marketplace explore fetches when the marketplace page unmounts
- thread the abort signal through the marketplace store fetch path
- cover the cleanup behavior with a page-level regression test

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx src/store/marketplace-store.test.ts
- cd frontend/app && npm run lint
- git diff --check