### PR TITLE
fix: suppress expected marketplace hub noise

### DIFF
--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -53,6 +53,24 @@ describe("useMarketplaceStore", () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
+  it("keeps marketplace explore outage user-facing without logging expected hub 503 noise", async () => {
+    window.history.replaceState({}, "", "/marketplace");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "hub down",
+    } as Response);
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().fetchItems();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(useMarketplaceStore.getState().error).toBe("Marketplace Hub unavailable");
+  });
+
   it("does not log a failed detail fetch once navigation already left the marketplace detail route", async () => {
     window.history.replaceState({}, "", "/marketplace/item-1");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -164,7 +164,9 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
       // user already left /marketplace. Only log if the marketplace route is
       // still active; otherwise this is stale UI noise.
       if (!isActiveMarketplaceRoute()) return;
-      console.error("Failed to fetch marketplace items:", e);
+      if (!isMarketplaceUnavailableError(e)) {
+        console.error("Failed to fetch marketplace items:", e);
+      }
       set({ error: e instanceof Error ? e.message : "Unknown error" });
     } finally {
       set({ loading: false });


### PR DESCRIPTION
## Summary
- keep marketplace hub outage user-facing without duplicating it as an app-level console error
- add a store regression test for the expected 503 path

## Verification
- cd frontend/app && npm test -- --run src/store/marketplace-store.test.ts
- cd frontend/app && npm run lint
- git diff --check
- real product: /marketplace now shows only the browser 503 line, not the extra frontend console error