### PR TITLE
fix: quiet chat event abort teardown noise

### DIFF
--- a/frontend/app/src/api/chat-events.test.ts
+++ b/frontend/app/src/api/chat-events.test.ts
@@ -82,4 +82,32 @@ describe("chat event stream", () => {
       created_at: 1,
     })).toThrow("mentioned_ids must be a string array");
   });
+
+  it("treats abort-time reader network errors as clean teardown, not a stream failure", async () => {
+    const cancel = vi.fn();
+    let rejectRead: ((reason?: unknown) => void) | null = null;
+    const read = vi.fn(() =>
+      new Promise<never>((_, reject) => {
+        rejectRead = reject;
+      }),
+    );
+    authFetch.mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read,
+          cancel,
+        }),
+      },
+    });
+
+    const ac = new AbortController();
+    const stream = api.streamChatEvents("chat-1", () => undefined, ac.signal);
+    await Promise.resolve();
+    ac.abort();
+    rejectRead?.(new TypeError("network error"));
+
+    await expect(stream).resolves.toBeUndefined();
+    expect(cancel).toHaveBeenCalled();
+  });
 });

--- a/frontend/app/src/api/chat-events.test.ts
+++ b/frontend/app/src/api/chat-events.test.ts
@@ -85,9 +85,13 @@ describe("chat event stream", () => {
 
   it("treats abort-time reader network errors as clean teardown, not a stream failure", async () => {
     const cancel = vi.fn();
-    let rejectRead: ((reason?: unknown) => void) | null = null;
+    let capturedReject = false;
+    let rejectRead: (reason?: unknown) => void = () => {
+      throw new Error("expected read reject handler to be captured");
+    };
     const read = vi.fn(() =>
-      new Promise<never>((_, reject) => {
+      new Promise<void>((_, reject: (reason?: unknown) => void) => {
+        capturedReject = true;
         rejectRead = reject;
       }),
     );
@@ -105,7 +109,10 @@ describe("chat event stream", () => {
     const stream = api.streamChatEvents("chat-1", () => undefined, ac.signal);
     await Promise.resolve();
     ac.abort();
-    rejectRead?.(new TypeError("network error"));
+    if (!capturedReject) {
+      throw new Error("expected read reject handler to be captured");
+    }
+    rejectRead(new TypeError("network error"));
 
     await expect(stream).resolves.toBeUndefined();
     expect(cancel).toHaveBeenCalled();

--- a/frontend/app/src/api/chat-events.ts
+++ b/frontend/app/src/api/chat-events.ts
@@ -7,6 +7,12 @@ export interface ChatStreamEvent {
   data: unknown;
 }
 
+function isAbortTeardownError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof TypeError && error.message === "network error";
+}
+
 function requiredString(value: Record<string, unknown>, key: string): string {
   const field = value[key];
   if (typeof field !== "string") {
@@ -84,7 +90,14 @@ export async function streamChatEvents(
 
   try {
     while (!signal?.aborted) {
-      const { done, value } = await reader.read();
+      let chunk: ReadableStreamReadResult<Uint8Array>;
+      try {
+        chunk = await reader.read();
+      } catch (error) {
+        if (signal?.aborted && isAbortTeardownError(error)) break;
+        throw error;
+      }
+      const { done, value } = chunk;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       const chunks = buffer.split(/\r?\n\r?\n/);


### PR DESCRIPTION
## Summary
- treat aborted chat event reader errors as clean teardown instead of connection failures
- keep the stream test coverage around abort-time reader errors

## Verification
- cd frontend/app && npm test -- --run src/api/chat-events.test.ts src/pages/NewChatPage.test.tsx
- cd frontend/app && npm run lint
- git diff --check
- real product: open live chat, navigate in-app to /settings, confirm console errors stay at 0