### PR TITLE
refactor: align resource snapshot substrate target

### DIFF
--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from storage.providers.supabase import _query as q
+
+_REPO = "resource snapshot repo"
+_SCHEMA = "container"
+_TABLE = "resource_snapshots"
+
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
@@ -12,12 +18,16 @@ def _now_iso() -> str:
 
 def _raise_if_snapshot_schema_drift(err: Exception) -> None:
     message = str(err)
-    if "staging.sandbox_resource_snapshots" not in message or "staging.lease_resource_snapshots" not in message:
+    if f"{_SCHEMA}.{_TABLE}" not in message or "staging.lease_resource_snapshots" not in message:
         return
     raise RuntimeError(
         "live schema still exposes staging.lease_resource_snapshots; "
-        "land sandbox_resource_snapshots instead of falling back to the old lease table"
+        "land container.resource_snapshots instead of falling back to the old lease table"
     ) from err
+
+
+def _t(client: Any) -> Any:
+    return q.schema_table(client, _SCHEMA, _TABLE, _REPO)
 
 
 def upsert_sandbox_resource_snapshot(
@@ -41,7 +51,7 @@ def upsert_sandbox_resource_snapshot(
         raise RuntimeError("upsert_sandbox_resource_snapshot requires a client")
     now = _now_iso()
     try:
-        client.table("sandbox_resource_snapshots").upsert(
+        _t(client).upsert(
             {
                 "sandbox_id": sandbox_id,
                 "provider_name": provider_name,
@@ -76,11 +86,10 @@ def list_snapshots_by_sandbox_ids(
     unique_ids = sorted({sid for sid in sandbox_ids if sid})
     if not unique_ids:
         return {}
-    from storage.providers.supabase import _query as q
 
     try:
         rows = q.rows_in_chunks(
-            lambda: client.table("sandbox_resource_snapshots").select("*"),
+            lambda: _t(client).select("*"),
             "sandbox_id",
             unique_ids,
             "resource_snapshot",
@@ -94,7 +103,7 @@ def list_snapshots_by_sandbox_ids(
 
 class SupabaseResourceSnapshotRepo:
     def __init__(self, client: Any) -> None:
-        self._client = client
+        self._client = q.validate_client(client, _REPO)
 
     def close(self) -> None:
         return None

--- a/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
+++ b/tests/Unit/storage/test_supabase_resource_snapshot_repo.py
@@ -35,7 +35,12 @@ class _FakeTable:
 class _FakeClient:
     def __init__(self) -> None:
         self.table_obj = _FakeTable()
+        self.last_schema_name: str | None = None
         self.last_table_name: str | None = None
+
+    def schema(self, name):
+        self.last_schema_name = name
+        return self
 
     def table(self, name):
         self.last_table_name = name
@@ -54,7 +59,8 @@ def test_supabase_resource_snapshot_repo_upserts_for_sandbox_without_lease_shape
     )
 
     assert client.table_obj.upsert_payload is not None
-    assert client.last_table_name == "sandbox_resource_snapshots"
+    assert client.last_schema_name == "container"
+    assert client.last_table_name == "resource_snapshots"
     assert client.table_obj.upsert_payload["sandbox_id"] == "sandbox-1"
     assert "lease_id" not in client.table_obj.upsert_payload
     assert client.table_obj.upsert_payload["provider_name"] == "daytona"
@@ -72,7 +78,8 @@ def test_supabase_resource_snapshot_repo_lists_snapshots_by_sandbox_ids() -> Non
     )
 
     assert rows == {"sandbox-1": {"sandbox_id": "sandbox-1", "cpu_used": 1.0}}
-    assert client.last_table_name == "sandbox_resource_snapshots"
+    assert client.last_schema_name == "container"
+    assert client.last_table_name == "resource_snapshots"
     assert ("sandbox_id", ["sandbox-1", "sandbox-2"]) in client.table_obj.in_calls
 
 
@@ -107,7 +114,7 @@ def test_supabase_resource_snapshot_repo_instance_no_longer_exposes_lease_shaped
 def test_supabase_resource_snapshot_repo_fails_loudly_when_live_schema_still_uses_lease_table_name() -> None:
     client = _FakeClient()
     client.table_obj.error = RuntimeError(
-        "Could not find the table 'staging.sandbox_resource_snapshots' in the schema cache; "
+        "Could not find the table 'container.resource_snapshots' in the schema cache; "
         "Perhaps you meant the table 'staging.lease_resource_snapshots'"
     )
     repo = SupabaseResourceSnapshotRepo(client)
@@ -119,12 +126,12 @@ def test_supabase_resource_snapshot_repo_fails_loudly_when_live_schema_still_use
 def test_supabase_resource_snapshot_repo_write_fails_loudly_when_live_schema_still_uses_lease_table_name() -> None:
     client = _FakeClient()
     client.table_obj.error = RuntimeError(
-        "Could not find the table 'staging.sandbox_resource_snapshots' in the schema cache; "
+        "Could not find the table 'container.resource_snapshots' in the schema cache; "
         "Perhaps you meant the table 'staging.lease_resource_snapshots'"
     )
     repo = SupabaseResourceSnapshotRepo(client)
 
-    with pytest.raises(RuntimeError, match="land sandbox_resource_snapshots instead of falling back"):
+    with pytest.raises(RuntimeError, match="land container\\.resource_snapshots instead of falling back"):
         repo.upsert_resource_snapshot_for_sandbox(
             sandbox_id="sandbox-1",
             provider_name="daytona",


### PR DESCRIPTION
## Summary
- move resource snapshot storage substrate onto admitted target 
- keep sandbox-shaped outward row key and fail loud on old lease-shaped live schema drift
- limit the first cut to the Supabase resource snapshot repo plus owner tests

## Verification
- ============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/lexicalmathical/worktrees/leonai--dev-runnable-closure
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, langsmith-0.6.4, timeout-2.4.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 8 items

tests/Unit/storage/test_supabase_resource_snapshot_repo.py ........      [100%]

============================== 8 passed in 0.03s ===============================
- ============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/lexicalmathical/worktrees/leonai--dev-runnable-closure
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, langsmith-0.6.4, timeout-2.4.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 14 items

tests/Unit/monitor/test_monitor_resource_probe.py ..............         [100%]

============================== 14 passed in 0.09s ==============================
- ============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/lexicalmathical/worktrees/leonai--dev-runnable-closure
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, langsmith-0.6.4, timeout-2.4.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 18 items / 16 deselected / 2 selected

tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py ..       [100%]

======================= 2 passed, 16 deselected in 0.08s =======================
- All checks passed!
- 
