### PR TITLE
fix: decouple agent publish from marketplace hub

### DIFF
--- a/frontend/app/src/components/PublishDialog.test.tsx
+++ b/frontend/app/src/components/PublishDialog.test.tsx
@@ -67,30 +67,22 @@ afterEach(() => {
 });
 
 describe("PublishDialog", () => {
-  it("fails loudly when marketplace publish fails", async () => {
+  it("publishes locally without requiring marketplace availability", async () => {
     publishAgent.mockResolvedValue(undefined);
-    publishAgentUserToMarketplace.mockRejectedValue(new Error("Marketplace Hub unavailable"));
+    const onOpenChange = vi.fn();
 
-    render(<PublishDialog open onOpenChange={vi.fn()} agentId="agent-1" />);
+    render(<PublishDialog open onOpenChange={onOpenChange} agentId="agent-1" />);
 
     fireEvent.click(screen.getByRole("button", { name: "发布 v1.0.1" }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("发布失败：Marketplace Hub unavailable");
+      expect(publishAgent).toHaveBeenCalledWith("agent-1", "patch");
     });
-    expect(toast.success).not.toHaveBeenCalled();
-  });
-
-  it("publishes agent users without exposing the hub member type to the dialog", async () => {
-    publishAgent.mockResolvedValue(undefined);
-    publishAgentUserToMarketplace.mockResolvedValue({});
-
-    render(<PublishDialog open onOpenChange={vi.fn()} agentId="agent-1" />);
-
-    fireEvent.click(screen.getByRole("button", { name: "发布 v1.0.1" }));
-
     await waitFor(() => {
-      expect(publishAgentUserToMarketplace).toHaveBeenCalledWith("agent-1", "patch", "", [], "public");
+      expect(toast.success).toHaveBeenCalledWith("Morel v1.0.1 已发布");
     });
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(publishAgentUserToMarketplace).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/app/src/components/PublishDialog.tsx
+++ b/frontend/app/src/components/PublishDialog.tsx
@@ -4,10 +4,8 @@ import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { useAppStore } from "@/store/app-store";
-import { useMarketplaceStore } from "@/store/marketplace-store";
 import { toast } from "sonner";
 
 interface Props {
@@ -29,10 +27,7 @@ export default function PublishDialog({ open, onOpenChange, agentId }: Props) {
   const agent = useAppStore(s => s.getAgentById(agentId));
   const publishAgent = useAppStore(s => s.publishAgent);
   const [bumpType, setBumpType] = useState<BumpType>("patch");
-  const [notes, setNotes] = useState("");
-  const [tags, setTags] = useState("");
   const [publishing, setPublishing] = useState(false);
-  const publishAgentUserToMarketplace = useMarketplaceStore(s => s.publishAgentUserToMarketplace);
 
   if (!agent) return null;
 
@@ -42,7 +37,6 @@ export default function PublishDialog({ open, onOpenChange, agentId }: Props) {
     try {
       setPublishing(true);
       await publishAgent(agentId, bumpType);
-      await publishAgentUserToMarketplace(agentId, bumpType, notes, tags.split(",").map(t => t.trim()).filter(Boolean), "public");
       toast.success(`${agent.name} v${newVersion} 已发布`);
       onOpenChange(false);
     } catch (err) {
@@ -99,26 +93,6 @@ export default function PublishDialog({ open, onOpenChange, agentId }: Props) {
           <div className="p-3 rounded-lg bg-muted text-center">
             <p className="text-xs text-muted-foreground">新版本号</p>
             <p className="text-lg font-mono font-semibold text-primary mt-0.5">v{newVersion}</p>
-          </div>
-
-          <div className="space-y-2">
-            <Label className="text-sm">发布说明 <span className="text-muted-foreground text-xs">（可选）</span></Label>
-            <Textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder="描述此版本的变更..."
-              rows={3}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label className="text-sm">Tags <span className="text-muted-foreground text-xs">(comma separated)</span></Label>
-            <input
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-              placeholder="e.g. coding, research, writing"
-              className="w-full px-3 py-2 rounded-lg bg-card border border-border text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40"
-            />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- make agent detail publish dialog perform only the local panel publish
- remove marketplace-only release notes/tags fields from that dialog
- add a regression test proving local publish no longer touches marketplace

## Verification
- cd frontend/app && npm test -- --run src/components/PublishDialog.test.tsx src/pages/AgentDetailPage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- real YATU: create disposable agent, publish from /contacts/agents/:id, confirm status becomes 在岗 and no /api/marketplace/publish-agent-user request fires