### PR TITLE
refactor: use process-local sync backing

### DIFF
--- a/sandbox/sync/manager.py
+++ b/sandbox/sync/manager.py
@@ -9,13 +9,15 @@ class SyncManager:
         self.strategy = self._select_strategy()
 
     def _select_strategy(self) -> SyncStrategy:
-        from sandbox.sync.state import SyncState
+        from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
         from sandbox.sync.strategy import IncrementalSyncStrategy, NoOpStrategy
 
         runtime_kind = self.provider_capability.runtime_kind
         if runtime_kind in ("local", "docker_pty"):
             return NoOpStrategy()
-        state = SyncState()
+        # @@@sync-process-local-first-cut - remote runtimes now get a process-local checksum backing
+        # so incremental sync no longer defaults to a persisted sync_files repo on the first cut.
+        state = SyncState(repo=ProcessLocalSyncFileBacking())
         return IncrementalSyncStrategy(state)
 
     def upload(

--- a/sandbox/sync/state.py
+++ b/sandbox/sync/state.py
@@ -57,3 +57,32 @@ class SyncState:
             if current_checksum != known[relative]:
                 changed.append(relative)
         return changed
+
+
+class ProcessLocalSyncFileBacking:
+    def __init__(self) -> None:
+        self._rows: dict[str, dict[str, tuple[str, int]]] = {}
+
+    def close(self) -> None:
+        return None
+
+    def track_file(self, thread_id: str, relative_path: str, checksum: str, timestamp: int) -> None:
+        self._rows.setdefault(thread_id, {})[relative_path] = (checksum, timestamp)
+
+    def track_files_batch(self, thread_id: str, file_records: list[tuple[str, str, int]]) -> None:
+        for relative_path, checksum, timestamp in file_records:
+            self.track_file(thread_id, relative_path, checksum, timestamp)
+
+    def get_file_info(self, thread_id: str, relative_path: str) -> dict | None:
+        info = self._rows.get(thread_id, {}).get(relative_path)
+        if info is None:
+            return None
+        return {"checksum": info[0], "last_synced": info[1]}
+
+    def get_all_files(self, thread_id: str) -> dict[str, str]:
+        return {path: checksum for path, (checksum, _timestamp) in self._rows.get(thread_id, {}).items()}
+
+    def clear_thread(self, thread_id: str) -> int:
+        removed = len(self._rows.get(thread_id, {}))
+        self._rows.pop(thread_id, None)
+        return removed

--- a/tests/Unit/sandbox/test_sync_manager.py
+++ b/tests/Unit/sandbox/test_sync_manager.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+import pytest
+
+import sandbox.sync.manager as sync_manager_module
+
+
+def test_sync_manager_uses_process_local_backing_for_remote_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_build_sync_file_repo():
+        raise AssertionError("persisted sync_file repo should stay unused for remote runtime first cut")
+
+    monkeypatch.setattr(sync_manager_module, "build_sync_file_repo", fail_build_sync_file_repo, raising=False)
+
+    manager = sync_manager_module.SyncManager(provider_capability=SimpleNamespace(runtime_kind="remote_pty"))
+
+    assert type(manager.strategy).__name__ == "IncrementalSyncStrategy"


### PR DESCRIPTION
## Summary
- move remote SyncManager off the default persisted sync_files repo on the first cut
- add a process-local checksum backing in sync state
- prove remote runtime can initialize incremental sync without Supabase sync repo wiring

## Testing
- uv run python -m pytest tests/Unit/sandbox/test_sync_manager.py -q
- uv run python -m pytest tests/Unit/backend/web/utils/test_helpers.py -q
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'clear_thread' -q
- uv run ruff check sandbox/sync/state.py sandbox/sync/manager.py tests/Unit/sandbox/test_sync_manager.py
- git diff --check
