### PR TITLE
refactor: drop thread config helper shell

### DIFF
--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -88,7 +88,7 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
         if pool_key in pool:
             return pool[pool_key]
 
-        # For local sandbox, check if thread has custom cwd (live map → persisted thread config).
+        # For local sandbox, check if thread has custom cwd (live map → persisted thread row).
         workspace_root = None
         thread_data = app_obj.state.thread_repo.get_by_id(thread_id) if hasattr(app_obj.state, "thread_repo") else None
         if sandbox_type == "local":
@@ -132,7 +132,7 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
             if get_models_config is not None:
                 models_config_override = get_models_config(owner_user_id)
 
-        # @@@agent-vs-agent-user - thread_config.agent stores an agent user id (e.g. "__leon__") for display,
+        # @@@agent-vs-agent-user - thread row agent_user_id resolves an agent user for display,
         # NOT an agent type name ("bash", "general", etc.). Never pass it to create_leon_agent.
         agent_name = agent  # explicit caller-provided type only; None → default Leon agent
         bundle_dir = None

--- a/backend/web/services/resource_common.py
+++ b/backend/web/services/resource_common.py
@@ -243,7 +243,7 @@ def thread_owners(thread_ids: list[str], user_repo: Any = None, thread_repo: Any
         if not agent_ref:
             owners[thread_id] = {"agent_user_id": None, "agent_name": "未绑定Agent", "avatar_url": None}
             continue
-        # @@@agent-name-resolution - thread_config.agent may be agent user id or direct display name.
+        # @@@agent-name-resolution - current thread agent ref may resolve to an agent user id or direct display name.
         meta = agent_user_meta.get(agent_ref, {})
         owners[thread_id] = {
             "agent_user_id": agent_ref,

--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -88,8 +88,8 @@ def _get_thread_repo(thread_repo=None):
     return _cached_thread_repo
 
 
-def load_thread_config(thread_id: str, thread_repo=None) -> dict[str, Any] | None:
-    """Load thread data. Returns dict or None."""
+def load_thread_row(thread_id: str, thread_repo=None) -> dict[str, Any] | None:
+    """Load the current thread row. Returns dict or None."""
     return _get_thread_repo(thread_repo).get_by_id(thread_id)
 
 
@@ -111,7 +111,7 @@ def resolve_local_workspace_path(
         if thread_cwd_map:
             thread_cwd = thread_cwd_map.get(thread_id)
         if not thread_cwd:
-            tc = load_thread_config(thread_id)
+            tc = load_thread_row(thread_id)
             if tc:
                 thread_cwd = tc.get("cwd")
     # @@@workspace-base-normalize - relative LOCAL_WORKSPACE_ROOT must be normalized, or target.relative_to(base) always fails.

--- a/tests/Unit/backend/web/utils/test_helpers.py
+++ b/tests/Unit/backend/web/utils/test_helpers.py
@@ -91,3 +91,18 @@ def test_get_lease_timestamps_uses_runtime_repo_factory_without_db_path(monkeypa
 
     assert helpers.get_lease_timestamps("lease-1") == ("lease-created", "lease-updated")
     assert lease_repo.closed
+
+
+def test_load_thread_row_returns_current_thread_row(monkeypatch) -> None:
+    thread_repo = _ThreadRepo()
+    thread_repo.row = {"id": "thread-1", "cwd": "/workspace"}
+    thread_repo.requested_ids = []
+
+    def get_by_id(thread_id: str):
+        thread_repo.requested_ids.append(thread_id)
+        return thread_repo.row
+
+    thread_repo.get_by_id = get_by_id
+
+    assert helpers.load_thread_row("thread-1", thread_repo=thread_repo) == {"id": "thread-1", "cwd": "/workspace"}
+    assert thread_repo.requested_ids == ["thread-1"]


### PR DESCRIPTION
## Summary
- rename the old thread_config helper to current thread-row truth
- update the only live helper call site
- clean the obvious thread_config wording residue in adjacent comments

## Testing
- uv run python -m pytest tests/Unit/backend/web/utils/test_helpers.py -q
- uv run ruff check backend/web/utils/helpers.py backend/web/services/agent_pool.py backend/web/services/resource_common.py tests/Unit/backend/web/utils/test_helpers.py
- git diff --check
