### PR TITLE
refactor: narrow sync files backing protocol

### DIFF
--- a/sandbox/sync/state.py
+++ b/sandbox/sync/state.py
@@ -66,18 +66,9 @@ class ProcessLocalSyncFileBacking:
     def close(self) -> None:
         return None
 
-    def track_file(self, thread_id: str, relative_path: str, checksum: str, timestamp: int) -> None:
-        self._rows.setdefault(thread_id, {})[relative_path] = (checksum, timestamp)
-
     def track_files_batch(self, thread_id: str, file_records: list[tuple[str, str, int]]) -> None:
         for relative_path, checksum, timestamp in file_records:
-            self.track_file(thread_id, relative_path, checksum, timestamp)
-
-    def get_file_info(self, thread_id: str, relative_path: str) -> dict | None:
-        info = self._rows.get(thread_id, {}).get(relative_path)
-        if info is None:
-            return None
-        return {"checksum": info[0], "last_synced": info[1]}
+            self._rows.setdefault(thread_id, {})[relative_path] = (checksum, timestamp)
 
     def get_all_files(self, thread_id: str) -> dict[str, str]:
         return {path: checksum for path, (checksum, _timestamp) in self._rows.get(thread_id, {}).items()}

--- a/tests/Unit/sandbox/test_sync_state.py
+++ b/tests/Unit/sandbox/test_sync_state.py
@@ -1,0 +1,11 @@
+from sandbox.sync.state import ProcessLocalSyncFileBacking
+
+
+def test_process_local_sync_backing_exposes_only_batch_list_and_clear() -> None:
+    backing = ProcessLocalSyncFileBacking()
+
+    assert hasattr(backing, "track_files_batch")
+    assert hasattr(backing, "get_all_files")
+    assert hasattr(backing, "clear_thread")
+    assert not hasattr(backing, "track_file")
+    assert not hasattr(backing, "get_file_info")


### PR DESCRIPTION
## Summary
- remove single-file API residue from the process-local sync backing
- keep the first-cut sync backing on batch/list/clear semantics only
- add focused tests for the narrowed process-local protocol

## Testing
- uv run python -m pytest tests/Unit/sandbox/test_sync_state.py -q
- uv run python -m pytest tests/Unit/sandbox/test_sync_manager.py -q
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'clear_thread' -q
- uv run ruff check sandbox/sync/state.py tests/Unit/sandbox/test_sync_state.py tests/Unit/sandbox/test_sync_manager.py
- git diff --check
