### PR TITLE
refactor: narrow sync state wrapper

### DIFF
--- a/sandbox/sync/state.py
+++ b/sandbox/sync/state.py
@@ -20,17 +20,11 @@ class SyncState:
     def close(self) -> None:
         self._repo.close()
 
-    def track_file(self, thread_id: str, relative_path: str, checksum: str, timestamp: int):
-        self._repo.track_file(thread_id, relative_path, checksum, timestamp)
-
     def track_files_batch(self, thread_id: str, file_records: list[tuple[str, str, int]]):
         """Batch insert/update multiple files in a single transaction.
         file_records: list of (relative_path, checksum, timestamp)
         """
         self._repo.track_files_batch(thread_id, file_records)
-
-    def get_file_info(self, thread_id: str, relative_path: str) -> dict | None:
-        return self._repo.get_file_info(thread_id, relative_path)
 
     def get_all_files(self, thread_id: str) -> dict[str, str]:
         """Batch fetch all tracked files for a thread. Returns {relative_path: checksum}."""

--- a/tests/Unit/sandbox/test_sync_state.py
+++ b/tests/Unit/sandbox/test_sync_state.py
@@ -1,4 +1,4 @@
-from sandbox.sync.state import ProcessLocalSyncFileBacking
+from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
 
 
 def test_process_local_sync_backing_exposes_only_batch_list_and_clear() -> None:
@@ -9,3 +9,13 @@ def test_process_local_sync_backing_exposes_only_batch_list_and_clear() -> None:
     assert hasattr(backing, "clear_thread")
     assert not hasattr(backing, "track_file")
     assert not hasattr(backing, "get_file_info")
+
+
+def test_sync_state_exposes_only_batch_list_and_clear_protocol() -> None:
+    state = SyncState(repo=ProcessLocalSyncFileBacking())
+
+    assert hasattr(state, "track_files_batch")
+    assert hasattr(state, "get_all_files")
+    assert hasattr(state, "clear_thread")
+    assert not hasattr(state, "track_file")
+    assert not hasattr(state, "get_file_info")


### PR DESCRIPTION
## Summary
- remove  and  from 
- keep the wrapper aligned with the already-narrowed process-local backing
- add a focused unit test that locks the reduced wrapper protocol

## Verification
- uv run python -m pytest tests/Unit/sandbox/test_sync_state.py -q
- uv run python -m pytest tests/Unit/sandbox/test_sync_manager.py -q
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'clear_thread' -q
- uv run ruff check sandbox/sync/state.py tests/Unit/sandbox/test_sync_state.py tests/Unit/sandbox/test_sync_manager.py
- git diff --check