### PR TITLE
fix: hide cold owned agents from group chat picker

### DIFF
--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -182,6 +182,7 @@ async def list_chat_candidates(
         raise HTTPException(503, str(exc)) from exc
 
     items = []
+    thread_repo = getattr(app.state, "thread_repo", None)
 
     for user in users:
         if user.id == user_id:
@@ -212,19 +213,21 @@ async def list_chat_candidates(
             )
         else:
             owner = user_map.get(user.owner_user_id) if user.owner_user_id else None
-            items.append(
-                {
-                    "user_id": user.id,
-                    "name": user.display_name,
-                    "type": user.type.value,
-                    "avatar_url": avatar_url(user.id, bool(user.avatar)),
-                    "owner_name": owner.display_name if owner else None,
-                    "agent_name": user.display_name,
-                    "is_owned": is_owned,
-                    "relationship_state": relationship_state,
-                    "can_chat": can_chat,
-                }
-            )
+            default_thread = thread_repo.get_default_thread(user.id) if is_owned and thread_repo is not None else None
+            item = {
+                "user_id": user.id,
+                "name": user.display_name,
+                "type": user.type.value,
+                "avatar_url": avatar_url(user.id, bool(user.avatar)),
+                "owner_name": owner.display_name if owner else None,
+                "agent_name": user.display_name,
+                "is_owned": is_owned,
+                "relationship_state": relationship_state,
+                "can_chat": can_chat,
+            }
+            if is_owned:
+                item["default_thread_id"] = default_thread["id"] if default_thread else None
+            items.append(item)
     return items
 
 

--- a/frontend/app/src/api/users.ts
+++ b/frontend/app/src/api/users.ts
@@ -9,6 +9,7 @@ export type UserChatCandidate = {
   is_owned: boolean;
   relationship_state: string;
   can_chat: boolean;
+  default_thread_id?: string | null;
 };
 
 let inflightUserChatCandidates: Promise<UserChatCandidate[]> | null = null;
@@ -37,6 +38,7 @@ export function parseUserChatCandidates(value: unknown): UserChatCandidate[] {
       is_owned: row.is_owned,
       relationship_state: row.relationship_state,
       can_chat: row.can_chat,
+      default_thread_id: typeof row.default_thread_id === "string" ? row.default_thread_id : null,
     };
   });
 }

--- a/frontend/app/src/components/NewChatDialog.test.tsx
+++ b/frontend/app/src/components/NewChatDialog.test.tsx
@@ -216,4 +216,49 @@ describe("NewChatDialog", () => {
       );
     });
   });
+
+  it("hides owned agents without a default thread from the group-chat picker", async () => {
+    authFetch.mockResolvedValueOnce(okJson([
+      {
+        user_id: "agent-ready",
+        name: "Ready Agent",
+        type: "agent",
+        avatar_url: null,
+        owner_name: "Me",
+        is_owned: true,
+        relationship_state: "none",
+        can_chat: true,
+        default_thread_id: "thread-ready",
+      },
+      {
+        user_id: "agent-cold",
+        name: "Cold Agent",
+        type: "agent",
+        avatar_url: null,
+        owner_name: "Me",
+        is_owned: true,
+        relationship_state: "none",
+        can_chat: true,
+        default_thread_id: null,
+      },
+      {
+        user_id: "human-2",
+        name: "Ada",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]));
+
+    renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "创建群聊" }));
+
+    expect(await screen.findByRole("button", { name: /Ready Agent/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Ada/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Cold Agent/ })).toBeNull();
+  });
 });

--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -54,7 +54,12 @@ export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps
 
   const groupCandidates = useMemo(() => {
     const query = filter.trim().toLowerCase();
-    const items = chatCandidates.filter((item) => item.user_id !== myUserId && (item.is_owned || item.can_chat));
+    const items = chatCandidates.filter((item) => {
+      if (item.user_id === myUserId) return false;
+      // @@@owned-agent-group-ingress - group-chat POST only accepts owned agents
+      // once they have a real default thread backing their actor identity.
+      return item.is_owned ? Boolean(item.default_thread_id) : item.can_chat;
+    });
     if (!query) return items;
     return items.filter((item) => [item.name, item.owner_name ?? "", item.type].join(" ").toLowerCase().includes(query));
   }, [chatCandidates, filter, myUserId]);

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -55,11 +55,14 @@ def _users_app(
     *,
     relationships: dict[str, str] | None = None,
     contact_repo: object | None = None,
+    default_threads: dict[str, dict[str, object] | None] | None = None,
 ) -> SimpleNamespace:
     relationships = relationships or {}
+    default_threads = default_threads or {}
     return SimpleNamespace(
         state=SimpleNamespace(
             user_repo=SimpleNamespace(list_all=lambda: users),
+            thread_repo=SimpleNamespace(get_default_thread=lambda agent_user_id: default_threads.get(agent_user_id)),
             relationship_service=SimpleNamespace(
                 list_for_user=lambda _user_id: [
                     SimpleNamespace(other_user_id=other_user_id, state=state) for other_user_id, state in relationships.items()
@@ -138,6 +141,24 @@ async def test_list_chat_candidates_marks_owned_agents_as_chat_candidates_withou
     assert result[0]["is_owned"] is True
     assert result[0]["relationship_state"] == "none"
     assert result[0]["can_chat"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_chat_candidates_exposes_default_thread_id_for_owned_agents_only():
+    app = _users_app(
+        [_human("u1", "owner"), _agent("a-owned-ready", "Ready Agent", "u1"), _agent("a-owned-cold", "Cold Agent", "u1")],
+        default_threads={
+            "a-owned-ready": {"id": "thread-ready"},
+            "a-owned-cold": None,
+        },
+    )
+
+    result = await users_router.list_chat_candidates(user_id="u1", app=app)
+
+    ready = next(item for item in result if item["user_id"] == "a-owned-ready")
+    cold = next(item for item in result if item["user_id"] == "a-owned-cold")
+    assert ready["default_thread_id"] == "thread-ready"
+    assert cold["default_thread_id"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose `default_thread_id` for owned chat candidates that already have a representative thread
- hide cold owned agents from the group-chat picker until they have that thread truth
- keep backend validation loud; no fallback/compat layer added

## Root cause
Frontend group-chat selection treated every owned agent as selectable.
Backend group-chat creation only admits actor user ids that already resolve through the thread truth gate.
That mismatch let cold owned agents appear in the picker and then fail with `400 Agent participant ids must be actor user_ids, not agent_user_id`.

## Verification
- `./.venv/bin/python -m pytest -q tests/Integration/test_users_router.py`
- `cd frontend/app && npm test -- --run src/components/NewChatDialog.test.tsx src/pages/contacts/ContactDetailPage.test.tsx`
- `cd frontend/app && npm run lint`
- `git diff --check`
- real product check on branch-local backend `8017` + frontend `5189`:
  - `/api/users/chat-candidates` now returns `default_thread_id` for ready owned agents and `null` for the cold owned agent
  - group-chat dialog hides `BROTHER_CREATE_AGENT_177634`
  - dialog still shows `YATUAgent1776251627` and `BROTHER_PUBLISH_FIX_177670`
  - `POST /api/chats` succeeds for the two ready owned agents and navigates into the new group chat

## Explicit non-goal
- latest shared `dev` still has a pre-existing `ChatSSE` console noise on page load; this PR does not touch that lane
