### PR TITLE
refactor: demote agent registry default wiring

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -10,8 +10,6 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any
 
-from storage.runtime import build_agent_registry_repo
-
 
 @dataclass
 class AgentEntry:
@@ -23,12 +21,52 @@ class AgentEntry:
     subagent_type: str | None = None
 
 
+class _InMemoryAgentRegistryRepo:
+    def __init__(self) -> None:
+        self._rows: dict[str, tuple[str, str, str, str, str | None, str | None]] = {}
+
+    def register(
+        self,
+        *,
+        agent_id: str,
+        name: str,
+        thread_id: str,
+        status: str,
+        parent_agent_id: str | None,
+        subagent_type: str | None,
+    ) -> None:
+        self._rows[agent_id] = (agent_id, name, thread_id, status, parent_agent_id, subagent_type)
+
+    def get_by_id(self, agent_id: str) -> tuple[str, str, str, str, str | None, str | None] | None:
+        return self._rows.get(agent_id)
+
+    def list_running_by_name(self, name: str) -> list[tuple[str, str, str, str, str | None, str | None]]:
+        return [row for row in self._rows.values() if row[1] == name and row[3] == "running"]
+
+    def get_latest_by_name_and_parent(
+        self,
+        name: str,
+        parent_agent_id: str | None,
+    ) -> tuple[str, str, str, str, str | None, str | None] | None:
+        matches = [row for row in self._rows.values() if row[1] == name and row[4] == parent_agent_id]
+        return matches[-1] if matches else None
+
+    def update_status(self, agent_id: str, status: str) -> None:
+        row = self._rows.get(agent_id)
+        if row is None:
+            return
+        self._rows[agent_id] = (row[0], row[1], row[2], status, row[4], row[5])
+
+    def list_running(self) -> list[tuple[str, str, str, str, str | None, str | None]]:
+        return [row for row in self._rows.values() if row[3] == "running"]
+
+
 class AgentRegistry:
-    """Supabase-backed registry mapping agent_ids to thread IDs."""
+    """Registry mapping agent_ids to thread IDs."""
 
     def __init__(self, repo: Any = None):
         self._lock = asyncio.Lock()
-        self._repo = repo or build_agent_registry_repo()
+        self._repo = repo or _InMemoryAgentRegistryRepo()
 
     async def register(self, entry: AgentEntry) -> None:
         async with self._lock:

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -351,6 +351,25 @@ def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing
         agent.close()
 
 
+@_patch_env_api_key()
+def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch, tmp_path, _patch_runtime_storage_container):
+    from core.runtime.agent import LeonAgent
+
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=_mock_model("registry wiring")),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+    ):
+        agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
+
+    try:
+        assert agent._agent_registry._repo is not _patch_runtime_storage_container.agent_registry_repo()
+        assert agent._agent_registry._repo.__class__.__name__ == "_InMemoryAgentRegistryRepo"
+    finally:
+        agent.close()
+
+
 # ---------------------------------------------------------------------------
 # Integration Tests
 # ---------------------------------------------------------------------------

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -137,6 +137,30 @@ def test_fake_thread_repo_create_requires_current_workspace_id() -> None:
         )
 
 
+@pytest.mark.asyncio
+async def test_agent_registry_defaults_to_process_local_in_memory_repo() -> None:
+    registry = AgentRegistry()
+    entry = AgentEntry(
+        agent_id="agent-1",
+        name="general",
+        thread_id="thread-1",
+        status="running",
+        parent_agent_id="parent-1",
+        subagent_type="general",
+    )
+
+    await registry.register(entry)
+
+    assert await registry.get_by_id("agent-1") == entry
+    assert await registry.list_running_by_name("general") == [entry]
+
+    await registry.update_status("agent-1", "completed")
+
+    updated = await registry.get_by_id("agent-1")
+    assert updated is not None
+    assert updated.status == "completed"
+
+
 class _FakeChildAgent:
     def __init__(self, workspace_root: Path, model_name: str):
         self.workspace_root = workspace_root


### PR DESCRIPTION
## Summary
- switch default AgentRegistry construction to a process-local in-memory backing
- keep explicit repo injection intact for targeted proofs and follow-up demotion work
- add focused coverage proving LeonAgent no longer defaults to the persistent agent registry repo

## Verification
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run ruff check core/agents/registry.py tests/Unit/core/test_agent_service.py tests/Integration/test_leon_agent.py
- git diff --check