### PR TITLE
refactor: demote child continuity thread reuse

### DIFF
--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -632,11 +632,7 @@ class AgentService:
         task_id = uuid.uuid4().hex[:8]
         agent_name = name or f"agent-{task_id}"
         parent_thread_id = get_current_thread_id()
-        existing_child = None
-        lookup_existing_child = getattr(self._agent_registry, "get_latest_by_name_and_parent", None)
-        if name and parent_thread_id and lookup_existing_child is not None:
-            existing_child = await lookup_existing_child(name, parent_thread_id)
-        thread_id = existing_child.thread_id if existing_child is not None and existing_child.status != "running" else f"subagent-{task_id}"
+        thread_id = f"subagent-{task_id}"
 
         # Register in AgentRegistry immediately
         entry = AgentEntry(

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1469,7 +1469,7 @@ async def test_handle_agent_does_not_register_child_thread_when_parent_bridge_is
 
 
 @pytest.mark.asyncio
-async def test_handle_agent_reuses_existing_completed_child_thread_for_same_parent_and_name(monkeypatch, tmp_path):
+async def test_handle_agent_mints_fresh_child_thread_even_when_completed_child_exists(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
 
     thread_repo = _FakeThreadRepo(
@@ -1477,6 +1477,8 @@ async def test_handle_agent_reuses_existing_completed_child_thread_for_same_pare
             "parent-thread": {
                 "id": "parent-thread",
                 "agent_user_id": "agent-user-1",
+                "owner_user_id": "owner-1",
+                "current_workspace_id": "workspace-1",
                 "sandbox_type": "daytona_selfhost",
                 "cwd": "/home/daytona",
                 "model": "gpt-parent",
@@ -1487,6 +1489,8 @@ async def test_handle_agent_reuses_existing_completed_child_thread_for_same_pare
             "subagent-existing": {
                 "id": "subagent-existing",
                 "agent_user_id": "agent-user-1",
+                "owner_user_id": "owner-1",
+                "current_workspace_id": "workspace-1",
                 "sandbox_type": "daytona_selfhost",
                 "cwd": "/home/daytona",
                 "model": "gpt-test",
@@ -1521,8 +1525,9 @@ async def test_handle_agent_reuses_existing_completed_child_thread_for_same_pare
         )
 
         payload = _agent_tool_json(raw)
-        assert payload["thread_id"] == "subagent-existing"
-        assert len(thread_repo.created) == 0
+        assert payload["thread_id"] != "subagent-existing"
+        assert payload["thread_id"].startswith("subagent-")
+        assert len(thread_repo.created) == 1
     finally:
         await service.cleanup_background_runs()
         set_current_thread_id("")


### PR DESCRIPTION
## Summary
- stop reusing completed child threads by default in AgentService
- always mint a fresh subagent thread id from _handle_agent
- update the focused unit proof to reflect fresh child-thread creation

## Verification
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run ruff check core/agents/service.py tests/Unit/core/test_agent_service.py
- git diff --check