### PR TITLE
refactor: drop child continuity registry residue

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -43,14 +43,6 @@ class _InMemoryAgentRegistryRepo:
     def list_running_by_name(self, name: str) -> list[tuple[str, str, str, str, str | None, str | None]]:
         return [row for row in self._rows.values() if row[1] == name and row[3] == "running"]
 
-    def get_latest_by_name_and_parent(
-        self,
-        name: str,
-        parent_agent_id: str | None,
-    ) -> tuple[str, str, str, str, str | None, str | None] | None:
-        matches = [row for row in self._rows.values() if row[1] == name and row[4] == parent_agent_id]
-        return matches[-1] if matches else None
-
     def update_status(self, agent_id: str, status: str) -> None:
         row = self._rows.get(agent_id)
         if row is None:
@@ -105,19 +97,6 @@ class AgentRegistry:
             )
             for row in rows
         ]
-
-    async def get_latest_by_name_and_parent(self, name: str, parent_agent_id: str | None) -> AgentEntry | None:
-        row = self._repo.get_latest_by_name_and_parent(name, parent_agent_id)
-        if row is None:
-            return None
-        return AgentEntry(
-            agent_id=row[0],
-            name=row[1],
-            thread_id=row[2],
-            status=row[3],
-            parent_agent_id=row[4],
-            subagent_type=row[5],
-        )
 
     async def update_status(self, agent_id: str, status: str) -> None:
         async with self._lock:

--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -48,10 +48,6 @@ class _FakeAgentRegistry:
     async def get_by_id(self, agent_id: str) -> AgentEntry | None:
         return self._entries.get(agent_id)
 
-    async def get_latest_by_name_and_parent(self, name: str, parent_agent_id: str | None) -> AgentEntry | None:
-        matches = [e for e in self._entries.values() if e.name == name and e.parent_agent_id == parent_agent_id]
-        return matches[-1] if matches else None
-
     async def list_running(self) -> list[AgentEntry]:
         return [e for e in self._entries.values() if e.status == "running"]
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -112,12 +112,6 @@ class _FakeAgentRegistryRepo:
             return
         self._rows[agent_id] = (row[0], row[1], row[2], status, row[4], row[5])
 
-    def get_latest_by_name_and_parent(
-        self, name: str, parent_agent_id: str | None
-    ) -> tuple[str, str, str, str, str | None, str | None] | None:
-        matches = [row for row in self._rows.values() if row[1] == name and row[4] == parent_agent_id]
-        return matches[-1] if matches else None
-
     def list_running(self) -> list[tuple[str, str, str, str, str | None, str | None]]:
         return [row for row in self._rows.values() if row[3] == "running"]
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -44,16 +44,14 @@ class _CapturingRegistry(ToolRegistry):
 
 class _FakeAgentRegistry(AgentRegistry):
     def __init__(self) -> None:
-        self._latest_by_name_parent: dict[tuple[str, str | None], AgentEntry] = {}
+        self.entry = None
+        self.last_status = None
 
     async def register(self, entry):
         self.entry = entry
 
     async def update_status(self, agent_id: str, status: str):
         self.last_status = (agent_id, status)
-
-    async def get_latest_by_name_and_parent(self, name: str, parent_agent_id: str | None):
-        return self._latest_by_name_parent.get((name, parent_agent_id))
 
 
 class _FakeThreadRepo:
@@ -159,6 +157,12 @@ async def test_agent_registry_defaults_to_process_local_in_memory_repo() -> None
     updated = await registry.get_by_id("agent-1")
     assert updated is not None
     assert updated.status == "completed"
+
+
+def test_agent_registry_no_longer_exposes_child_continuity_lookup() -> None:
+    registry = AgentRegistry()
+
+    assert hasattr(registry, "get_latest_by_name_and_parent") is False
 
 
 class _FakeChildAgent:
@@ -1469,7 +1473,7 @@ async def test_handle_agent_does_not_register_child_thread_when_parent_bridge_is
 
 
 @pytest.mark.asyncio
-async def test_handle_agent_mints_fresh_child_thread_even_when_completed_child_exists(monkeypatch, tmp_path):
+async def test_handle_agent_mints_fresh_child_thread_without_child_continuity_lookup(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
 
     thread_repo = _FakeThreadRepo(
@@ -1501,14 +1505,6 @@ async def test_handle_agent_mints_fresh_child_thread_even_when_completed_child_e
         }
     )
     registry = _FakeAgentRegistry()
-    registry._latest_by_name_parent[("worker-1", "parent-thread")] = AgentEntry(
-        agent_id="old-agent",
-        name="worker-1",
-        thread_id="subagent-existing",
-        status="completed",
-        parent_agent_id="parent-thread",
-        subagent_type="general",
-    )
     service = _make_service(
         tmp_path,
         agent_registry=registry,


### PR DESCRIPTION
## Summary
- remove the dead child-continuity lookup from AgentRegistry and its in-memory backing
- drop matching residue from focused test doubles
- keep the already-landed service behavior cut isolated from this substrate cleanup

## Verification
- uv run python -m pytest tests/Unit/core/test_agent_service.py -k 'no_longer_exposes_child_continuity_lookup or without_child_continuity_lookup or handle_agent'
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run ruff check core/agents/registry.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_leon_agent.py
- git diff --check