### PR TITLE
refactor: drop blocking agent status duplicate writes

### DIFF
--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -692,7 +692,6 @@ class AgentService:
         # Default: parent blocks until sub-agent completes (does not block frontend event loop)
         try:
             result = await task
-            await self._agent_registry.update_status(task_id, "completed")
             return tool_success(
                 result,
                 metadata={
@@ -702,7 +701,6 @@ class AgentService:
                 },
             )
         except Exception as e:
-            await self._agent_registry.update_status(task_id, "error")
             return tool_error(
                 f"<tool_use_error>Agent failed: {e}</tool_use_error>",
                 metadata={

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -46,12 +46,14 @@ class _FakeAgentRegistry(AgentRegistry):
     def __init__(self) -> None:
         self.entry = None
         self.last_status = None
+        self.status_updates: list[tuple[str, str]] = []
 
     async def register(self, entry):
         self.entry = entry
 
     async def update_status(self, agent_id: str, status: str):
         self.last_status = (agent_id, status)
+        self.status_updates.append((agent_id, status))
 
 
 class _FakeThreadRepo:
@@ -1527,6 +1529,50 @@ async def test_handle_agent_mints_fresh_child_thread_without_child_continuity_lo
     finally:
         await service.cleanup_background_runs()
         set_current_thread_id("")
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_blocking_path_does_not_duplicate_completed_status(monkeypatch, tmp_path):
+    _patch_create_leon_agent(monkeypatch)
+
+    registry = _FakeAgentRegistry()
+    service = _make_service(tmp_path, agent_registry=registry)
+
+    raw = await service._handle_agent(
+        prompt="do work",
+        name="worker-1",
+        run_in_background=False,
+    )
+
+    assert raw.content == "(Agent completed with no text output)"
+    assert registry.status_updates == [(registry.entry.agent_id, "completed")]
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_blocking_path_does_not_duplicate_error_status(monkeypatch, tmp_path):
+    class _FailingChildAgent(_FakeChildAgent):
+        async def _astream(self, *args, **kwargs):
+            raise RuntimeError("boom")
+            yield
+
+    registry = _FakeAgentRegistry()
+    service = _make_service(
+        tmp_path,
+        agent_registry=registry,
+        child_agent_factory=lambda *, model_name, workspace_root, **kwargs: _FailingChildAgent(
+            Path(workspace_root),
+            model_name,
+        ),
+    )
+
+    raw = await service._handle_agent(
+        prompt="do work",
+        name="worker-1",
+        run_in_background=False,
+    )
+
+    assert "Agent failed: boom" in raw.content
+    assert registry.status_updates == [(registry.entry.agent_id, "error")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove duplicate blocking-path agent_registry status writes from _handle_agent(...)
- keep tool_success/tool_error behavior unchanged while _run_agent(...) remains the lifecycle owner
- add focused tests proving blocking completion/error no longer duplicate-write

## Verification
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run ruff check core/agents/service.py tests/Unit/core/test_agent_service.py
- git diff --check
