### PR TITLE
refactor: drop cleanup agent status residue

### DIFF
--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -1290,7 +1290,6 @@ class AgentService:
                     await running.task
                 except asyncio.CancelledError:
                     pass
-                await self._agent_registry.update_status(running.agent_id, "error")
             self._tasks.pop(task_id, None)
             return
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -996,7 +996,8 @@ async def test_agent_tool_model_priority_inherits_parent_when_no_env_tool_or_fro
 
 @pytest.mark.asyncio
 async def test_cleanup_background_runs_cancels_pending_agent_and_shell_runs(tmp_path):
-    service = _make_service(tmp_path)
+    registry = _FakeAgentRegistry()
+    service = _make_service(tmp_path, agent_registry=registry)
     agent_task = asyncio.create_task(_sleep_forever())
     shell_cmd = _FakeAsyncCommand()
     service._tasks["agent-task"] = _RunningTask(
@@ -1014,6 +1015,7 @@ async def test_cleanup_background_runs_cancels_pending_agent_and_shell_runs(tmp_
     await service.cleanup_background_runs()
 
     assert agent_task.cancelled() is True
+    assert registry.status_updates == []
     assert shell_cmd.terminated is True
     assert shell_cmd.wait_calls == 1
     assert service._tasks == {}


### PR DESCRIPTION
## Summary
- stop writing registry error status during cancelled _RunningTask cleanup
- keep task cancellation, await, and _tasks pop behavior unchanged
- add focused proof that cleanup no longer leaves a registry status write

## Verification
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run ruff check core/agents/service.py tests/Unit/core/test_agent_service.py
- git diff --check
