### PR TITLE
refactor: remove agent registry entries on run finish

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -49,6 +49,9 @@ class _InMemoryAgentRegistryRepo:
             return
         self._rows[agent_id] = (row[0], row[1], row[2], status, row[4], row[5])
 
+    def remove(self, agent_id: str) -> None:
+        self._rows.pop(agent_id, None)
+
     def list_running(self) -> list[tuple[str, str, str, str, str | None, str | None]]:
         return [row for row in self._rows.values() if row[3] == "running"]
 
@@ -101,6 +104,10 @@ class AgentRegistry:
     async def update_status(self, agent_id: str, status: str) -> None:
         async with self._lock:
             self._repo.update_status(agent_id, status)
+
+    async def remove(self, agent_id: str) -> None:
+        async with self._lock:
+            self._repo.remove(agent_id)
 
     async def list_running(self) -> list[AgentEntry]:
         rows = self._repo.list_running()

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -993,7 +993,7 @@ class AgentService:
                                                 output_parts.append(text)
                                                 latest_progress = self._summarize_progress(text, description or agent_name)
 
-            await self._agent_registry.update_status(task_id, "completed")
+            await self._agent_registry.remove(task_id)
             result = "\n".join(output_parts) or "(Agent completed with no text output)"
             if progress_stop is not None:
                 progress_stop.set()
@@ -1036,7 +1036,7 @@ class AgentService:
             if progress_task is not None:
                 await progress_task
             logger.exception("[AgentService] Agent %s failed", agent_name)
-            await self._agent_registry.update_status(task_id, "error")
+            await self._agent_registry.remove(task_id)
             # Notify frontend: task error
             if emit_fn is not None:
                 try:

--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -51,6 +51,9 @@ class _FakeAgentRegistry:
     async def list_running(self) -> list[AgentEntry]:
         return [e for e in self._entries.values() if e.status == "running"]
 
+    async def remove(self, agent_id: str) -> None:
+        self._entries.pop(agent_id, None)
+
 
 def _fake_agent_registry() -> AgentRegistry:
     return cast(AgentRegistry, _FakeAgentRegistry())

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -112,6 +112,9 @@ class _FakeAgentRegistryRepo:
             return
         self._rows[agent_id] = (row[0], row[1], row[2], status, row[4], row[5])
 
+    def remove(self, agent_id: str) -> None:
+        self._rows.pop(agent_id, None)
+
     def list_running(self) -> list[tuple[str, str, str, str, str | None, str | None]]:
         return [row for row in self._rows.values() if row[3] == "running"]
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -47,13 +47,34 @@ class _FakeAgentRegistry(AgentRegistry):
         self.entry = None
         self.last_status = None
         self.status_updates: list[tuple[str, str]] = []
+        self._entries: dict[str, AgentEntry] = {}
 
     async def register(self, entry):
         self.entry = entry
+        self._entries[entry.agent_id] = entry
 
     async def update_status(self, agent_id: str, status: str):
         self.last_status = (agent_id, status)
         self.status_updates.append((agent_id, status))
+        if agent_id in self._entries:
+            current = self._entries[agent_id]
+            self._entries[agent_id] = AgentEntry(
+                agent_id=current.agent_id,
+                name=current.name,
+                thread_id=current.thread_id,
+                status=status,
+                parent_agent_id=current.parent_agent_id,
+                subagent_type=current.subagent_type,
+            )
+
+    async def get_by_id(self, agent_id: str) -> AgentEntry | None:
+        return self._entries.get(agent_id)
+
+    async def list_running_by_name(self, name: str) -> list[AgentEntry]:
+        return [entry for entry in self._entries.values() if entry.name == name and entry.status == "running"]
+
+    async def remove(self, agent_id: str) -> None:
+        self._entries.pop(agent_id, None)
 
 
 class _FakeThreadRepo:
@@ -1547,7 +1568,26 @@ async def test_handle_agent_blocking_path_does_not_duplicate_completed_status(mo
     )
 
     assert raw.content == "(Agent completed with no text output)"
-    assert registry.status_updates == [(registry.entry.agent_id, "completed")]
+    assert registry.status_updates == []
+    assert await registry.get_by_id(registry.entry.agent_id) is None
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_blocking_path_removes_registry_entry_on_finish(monkeypatch, tmp_path):
+    _patch_create_leon_agent(monkeypatch)
+
+    registry = _FakeAgentRegistry()
+    service = _make_service(tmp_path, agent_registry=registry)
+
+    raw = await service._handle_agent(
+        prompt="do work",
+        name="worker-1",
+        run_in_background=False,
+    )
+
+    assert raw.content == "(Agent completed with no text output)"
+    assert await registry.get_by_id(registry.entry.agent_id) is None
+    assert await registry.list_running_by_name("worker-1") == []
 
 
 @pytest.mark.asyncio
@@ -1574,7 +1614,8 @@ async def test_handle_agent_blocking_path_does_not_duplicate_error_status(monkey
     )
 
     assert "Agent failed: boom" in raw.content
-    assert registry.status_updates == [(registry.entry.agent_id, "error")]
+    assert registry.status_updates == []
+    assert await registry.get_by_id(registry.entry.agent_id) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace run-finish completed/error status writes with direct registry removal
- keep queue/notification terminal status behavior unchanged
- add focused proof that finished runs no longer leave registry entries behind

## Verification
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run ruff check core/agents/registry.py core/agents/service.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_leon_agent.py
- git diff --check
