### PR TITLE
refactor: drop agent registry read residue

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -74,19 +74,6 @@ class AgentRegistry:
                 subagent_type=entry.subagent_type,
             )
 
-    async def get_by_id(self, agent_id: str) -> AgentEntry | None:
-        row = self._repo.get_by_id(agent_id)
-        if row is None:
-            return None
-        return AgentEntry(
-            agent_id=row[0],
-            name=row[1],
-            thread_id=row[2],
-            status=row[3],
-            parent_agent_id=row[4],
-            subagent_type=row[5],
-        )
-
     async def list_running_by_name(self, name: str) -> list[AgentEntry]:
         rows = self._repo.list_running_by_name(name)
         return [
@@ -108,17 +95,3 @@ class AgentRegistry:
     async def remove(self, agent_id: str) -> None:
         async with self._lock:
             self._repo.remove(agent_id)
-
-    async def list_running(self) -> list[AgentEntry]:
-        rows = self._repo.list_running()
-        return [
-            AgentEntry(
-                agent_id=r[0],
-                name=r[1],
-                thread_id=r[2],
-                status=r[3],
-                parent_agent_id=r[4],
-                subagent_type=r[5],
-            )
-            for r in rows
-        ]

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -172,20 +172,19 @@ async def test_agent_registry_defaults_to_process_local_in_memory_repo() -> None
 
     await registry.register(entry)
 
-    assert await registry.get_by_id("agent-1") == entry
     assert await registry.list_running_by_name("general") == [entry]
 
-    await registry.update_status("agent-1", "completed")
+    await registry.remove("agent-1")
 
-    updated = await registry.get_by_id("agent-1")
-    assert updated is not None
-    assert updated.status == "completed"
+    assert await registry.list_running_by_name("general") == []
 
 
 def test_agent_registry_no_longer_exposes_child_continuity_lookup() -> None:
     registry = AgentRegistry()
 
     assert hasattr(registry, "get_latest_by_name_and_parent") is False
+    assert hasattr(registry, "get_by_id") is False
+    assert hasattr(registry, "list_running") is False
 
 
 class _FakeChildAgent:
@@ -1569,7 +1568,7 @@ async def test_handle_agent_blocking_path_does_not_duplicate_completed_status(mo
 
     assert raw.content == "(Agent completed with no text output)"
     assert registry.status_updates == []
-    assert await registry.get_by_id(registry.entry.agent_id) is None
+    assert await registry.list_running_by_name("worker-1") == []
 
 
 @pytest.mark.asyncio
@@ -1586,7 +1585,7 @@ async def test_handle_agent_blocking_path_removes_registry_entry_on_finish(monke
     )
 
     assert raw.content == "(Agent completed with no text output)"
-    assert await registry.get_by_id(registry.entry.agent_id) is None
+    assert await registry.list_running_by_name("worker-1") == []
     assert await registry.list_running_by_name("worker-1") == []
 
 
@@ -1615,7 +1614,7 @@ async def test_handle_agent_blocking_path_does_not_duplicate_error_status(monkey
 
     assert "Agent failed: boom" in raw.content
     assert registry.status_updates == []
-    assert await registry.get_by_id(registry.entry.agent_id) is None
+    assert await registry.list_running_by_name("worker-1") == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove `get_by_id(...)` and `list_running(...)` from the `AgentRegistry` public wrapper
- keep the active public surface narrowed to `register(...)`, `list_running_by_name(...)`, and `remove(...)`
- update focused agent-service tests to prove the read residue is no longer part of the runtime contract

## Test Plan
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run ruff check core/agents/registry.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_leon_agent.py
- git diff --check