### PR TITLE
refactor: drop agent registry status wrapper

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -88,10 +88,6 @@ class AgentRegistry:
             for row in rows
         ]
 
-    async def update_status(self, agent_id: str, status: str) -> None:
-        async with self._lock:
-            self._repo.update_status(agent_id, status)
-
     async def remove(self, agent_id: str) -> None:
         async with self._lock:
             self._repo.remove(agent_id)

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -185,6 +185,7 @@ def test_agent_registry_no_longer_exposes_child_continuity_lookup() -> None:
     assert hasattr(registry, "get_latest_by_name_and_parent") is False
     assert hasattr(registry, "get_by_id") is False
     assert hasattr(registry, "list_running") is False
+    assert hasattr(registry, "update_status") is False
 
 
 class _FakeChildAgent:


### PR DESCRIPTION
## Summary
- remove dead `update_status(...)` from the `AgentRegistry` public wrapper
- prove the public active surface stays narrowed to `register(...)`, `list_running_by_name(...)`, and `remove(...)`
- keep this cut at the app wrapper level without widening into storage-contract cleanup

## Test Plan
- uv run python -m pytest tests/Unit/core/test_agent_service.py -k 'no_longer_exposes_child_continuity_lookup'
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background'
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run ruff check core/agents/registry.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_leon_agent.py
- git diff --check