### PR TITLE
fix: disable dead installed marketplace update check

### DIFF
--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -112,6 +112,7 @@ export default function MarketplacePage() {
 
   // Installed agent users with marketplace source info
   const installedAgentUsers: InstalledAgentUser[] = agentList.filter((agent) => !agent.builtin);
+  const updateCheckableAgentUsers = installedAgentUsers.filter((agent) => agent.source?.marketplace_item_id);
   const filteredAgentUsers = installedAgentUsers.filter((agent) =>
     !installedSearch || agent.name.toLowerCase().includes(installedSearch.toLowerCase())
   );
@@ -143,8 +144,9 @@ export default function MarketplacePage() {
   const installedSubTabLoaded = installedSubTab === "agent-user" ? agentsLoaded : librariesLoaded[installedSubTab];
 
   const handleCheckUpdates = async () => {
+    if (updateCheckableAgentUsers.length === 0) return;
     // source field comes from meta.json; agent users without it cannot be checked
-    const payload = installedAgentUsers.flatMap((agent) => {
+    const payload = updateCheckableAgentUsers.flatMap((agent) => {
       const source = agent.source;
       if (!source?.marketplace_item_id) return [];
       return [{
@@ -227,6 +229,7 @@ export default function MarketplacePage() {
           {tab === "installed" && installedSubTab === "agent-user" && (
             <button
               onClick={handleCheckUpdates}
+              disabled={updateCheckableAgentUsers.length === 0}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors duration-fast"
             >
               <RefreshCw className="w-3.5 h-3.5" />

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -165,6 +165,33 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
   });
 
+  it("disables check-updates when no installed agents have marketplace source metadata", () => {
+    appStoreState = {
+      ...appStoreState,
+      agentList: [{
+        id: "agent-1",
+        name: "Local Agent",
+        description: "local only",
+        status: "active",
+        version: "1.0.0",
+        config: { prompt: "", rules: [], tools: [], mcps: [], skills: [], subAgents: [] },
+        created_at: 1,
+        updated_at: 1,
+        builtin: false,
+      }],
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=agent-user"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "检查更新" }).hasAttribute("disabled")).toBe(true);
+  });
+
   it("uses Subagent wording for marketplace agent resources", () => {
     render(
       <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=agent"]}>


### PR DESCRIPTION
## Summary
- disable the installed marketplace update button when no installed agent has marketplace source metadata
- ignore local-only installed agents when building the update-check payload
- add a wording regression test for the disabled state

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI YATU: /marketplace?tab=installed shows 检查更新 disabled and console Errors: 0