### PR TITLE
refactor: demote agent registry default runtime path

### DIFF
--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -462,7 +462,7 @@ class AgentService:
     def __init__(
         self,
         tool_registry: ToolRegistry,
-        agent_registry: AgentRegistry,
+        agent_registry: AgentRegistry | None,
         workspace_root: Path,
         model_name: str,
         queue_manager: Any | None = None,
@@ -474,6 +474,7 @@ class AgentService:
         child_agent_factory: ChildAgentFactory | None = None,
     ):
         self._agent_registry = agent_registry
+        self._active_agents: dict[str, AgentEntry] = {}
         self._workspace_root = workspace_root
         self._model_name = model_name
         self._queue_manager = queue_manager
@@ -541,6 +542,23 @@ class AgentService:
                 is_concurrency_safe=True,
             )
         )
+
+    async def _register_active_entry(self, entry: AgentEntry) -> None:
+        if self._agent_registry is not None:
+            await self._agent_registry.register(entry)
+            return
+        self._active_agents[entry.agent_id] = entry
+
+    async def _list_running_entries_by_name(self, name: str) -> list[AgentEntry]:
+        if self._agent_registry is not None:
+            return await self._agent_registry.list_running_by_name(name)
+        return [entry for entry in self._active_agents.values() if entry.name == name and entry.status == "running"]
+
+    async def _remove_active_entry(self, agent_id: str) -> None:
+        if self._agent_registry is not None:
+            await self._agent_registry.remove(agent_id)
+            return
+        self._active_agents.pop(agent_id, None)
 
     @staticmethod
     def _normalize_child_sandbox(sandbox_type: str | None) -> str | None:
@@ -643,7 +661,7 @@ class AgentService:
             parent_agent_id=parent_thread_id,
             subagent_type=subagent_type,
         )
-        await self._agent_registry.register(entry)
+        await self._register_active_entry(entry)
         self._ensure_subagent_thread_metadata(
             thread_id=thread_id,
             parent_thread_id=parent_thread_id,
@@ -993,7 +1011,7 @@ class AgentService:
                                                 output_parts.append(text)
                                                 latest_progress = self._summarize_progress(text, description or agent_name)
 
-            await self._agent_registry.remove(task_id)
+            await self._remove_active_entry(task_id)
             result = "\n".join(output_parts) or "(Agent completed with no text output)"
             if progress_stop is not None:
                 progress_stop.set()
@@ -1036,7 +1054,7 @@ class AgentService:
             if progress_task is not None:
                 await progress_task
             logger.exception("[AgentService] Agent %s failed", agent_name)
-            await self._agent_registry.remove(task_id)
+            await self._remove_active_entry(task_id)
             # Notify frontend: task error
             if emit_fn is not None:
                 try:
@@ -1225,7 +1243,7 @@ class AgentService:
         if self._queue_manager is None:
             return "<tool_use_error>SendMessage requires queue_manager</tool_use_error>"
 
-        matches = await self._agent_registry.list_running_by_name(target_name)
+        matches = await self._list_running_entries_by_name(target_name)
         if not matches:
             return f"<tool_use_error>Running agent '{target_name}' not found</tool_use_error>"
         if len(matches) > 1:

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -46,7 +46,6 @@ from config.observation_loader import ObservationLoader  # noqa: E402
 from config.observation_schema import ObservationConfig  # noqa: E402
 
 # Multi-agent services
-from core.agents.registry import AgentRegistry  # noqa: E402
 from core.agents.service import AgentService  # noqa: E402
 from core.model_params import normalize_model_kwargs  # noqa: E402
 
@@ -1232,7 +1231,7 @@ class LeonAgent:
         )
 
         # Multi-agent tools (Agent/TaskOutput/TaskStop)
-        self._agent_registry = AgentRegistry()
+        self._agent_registry = None
         self._agent_service = AgentService(
             tool_registry=self._tool_registry,
             agent_registry=self._agent_registry,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -46,6 +46,7 @@ from config.observation_loader import ObservationLoader  # noqa: E402
 from config.observation_schema import ObservationConfig  # noqa: E402
 
 # Multi-agent services
+from core.agents.registry import AgentRegistry as _AgentRegistry  # noqa: E402
 from core.agents.service import AgentService  # noqa: E402
 from core.model_params import normalize_model_kwargs  # noqa: E402
 
@@ -83,6 +84,8 @@ from core.tools.web.service import WebService  # noqa: E402
 from storage.container import StorageContainer  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+AgentRegistry = _AgentRegistry
 
 if TYPE_CHECKING:
     from sandbox import Sandbox

--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -292,6 +292,40 @@ async def test_sendmessage_enqueues_real_agent_notification_for_target_thread(tm
 
 
 @pytest.mark.asyncio
+async def test_sendmessage_uses_service_local_active_state_when_registry_missing(tmp_path):
+    registry = ToolRegistry()
+    queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
+    service = AgentService(
+        tool_registry=registry,
+        agent_registry=None,
+        workspace_root=Path(tmp_path),
+        model_name="gpt-test",
+        queue_manager=queue_manager,
+    )
+    await service._register_active_entry(
+        AgentEntry(
+            agent_id="agent-1",
+            name="worker-1",
+            thread_id="thread-worker-1",
+            status="running",
+        )
+    )
+
+    result = await service._handle_send_message(
+        target_name="worker-1",
+        message="hello from coordinator",
+        sender_name="coordinator",
+    )
+
+    assert result == "Message sent to worker-1."
+    items = queue_manager.drain_all("thread-worker-1")
+    assert len(items) == 1
+    assert items[0].notification_type == "agent"
+    assert items[0].sender_name == "coordinator"
+    assert "hello from coordinator" in items[0].content
+
+
+@pytest.mark.asyncio
 async def test_sendmessage_reaches_target_next_turn_via_steering_middleware(tmp_path):
     registry = ToolRegistry()
     agent_registry = cast(AgentRegistry, _FakeAgentRegistry())

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -349,8 +349,8 @@ def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch,
         agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
 
     try:
-        assert agent._agent_registry._repo is not _patch_runtime_storage_container.agent_registry_repo()
-        assert agent._agent_registry._repo.__class__.__name__ == "_InMemoryAgentRegistryRepo"
+        assert agent._agent_registry is None
+        assert agent._agent_service._agent_registry is None
     finally:
         agent.close()
 


### PR DESCRIPTION
## Summary
- stop constructing `AgentRegistry()` on the default `LeonAgent` runtime path
- let `AgentService` hold a process-local active-entry map when no registry is injected
- keep explicit injected registry paths intact while proving local-state sendmessage still works

## Test Plan
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry'
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'service_local_active_state_when_registry_missing or sendmessage or background'
- uv run python -m pytest tests/Unit/core/test_agent_service.py
- uv run ruff check core/agents/service.py core/runtime/agent.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_leon_agent.py
- git diff --check