### PR TITLE
fix: align installed sandbox route key

### DIFF
--- a/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
@@ -7,11 +7,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LibraryItemDetailPage from "./LibraryItemDetailPage";
 import { useAppStore } from "@/store/app-store";
 
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}));
+
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => navigateMock,
   };
 });
 
@@ -26,6 +30,7 @@ describe("LibraryItemDetailPage", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    navigateMock.mockReset();
     fetchLibrary = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     fetchResourceContent = vi.fn<(type: string, id: string) => Promise<string>>().mockResolvedValue("# Agent doc");
     updateResource = vi.fn<(type: string, id: string, fields: Record<string, unknown>) => Promise<void>>().mockResolvedValue(undefined);
@@ -103,6 +108,43 @@ describe("LibraryItemDetailPage", () => {
         desc: "Updated sandbox template",
         features: { lark_cli: false },
       });
+    });
+  });
+
+  it("returns sandbox detail deletions to the sandbox installed subtab", async () => {
+    const deleteResource = vi.fn<(type: string, id: string) => Promise<void>>().mockResolvedValue(undefined);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    useAppStore.setState({
+      deleteResource,
+      librarySandboxTemplates: [{
+        id: "daytona:custom",
+        name: "Daytona Custom",
+        desc: "Custom recipe",
+        type: "sandbox-template",
+        provider_name: "daytona_selfhost",
+        provider_type: "daytona",
+        features: { lark_cli: false },
+        feature_options: [],
+        builtin: false,
+        created_at: 0,
+        updated_at: 0,
+      }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/library/sandbox-template/daytona:custom"]}>
+        <Routes>
+          <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Daytona Custom" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "删除" }));
+
+    await waitFor(() => {
+      expect(deleteResource).toHaveBeenCalledWith("sandbox-template", "daytona:custom");
+      expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=installed&sub=sandbox");
     });
   });
 });

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -123,7 +123,7 @@ export default function LibraryItemDetailPage() {
         )}
 
         {isSandboxTemplate && item ? (
-          <SandboxTemplateEditor item={item} onDeleted={() => navigate("/marketplace?tab=installed&sub=sandbox-template")} />
+          <SandboxTemplateEditor item={item} onDeleted={() => navigate("/marketplace?tab=installed&sub=sandbox")} />
         ) : (
           <div className="surface-card p-4">
           <div className="flex items-center gap-2 mb-3">


### PR DESCRIPTION
## Summary
- make the installed marketplace sandbox tab use the outward route key `sub=sandbox`
- keep sandbox-template as the internal library resource key only
- update wording tests to lock the outward route contract

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx
- cd frontend/app && npm run lint && npm run build
- git diff --check
- Playwright CLI YATU: /marketplace?tab=installed&sub=sandbox settles on sandbox templates, not the agent-user list, with console Errors: 0