### PR TITLE
test: demote agent registry proof callsites

### DIFF
--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -162,7 +162,7 @@ def test_taskstop_terminates_real_background_bash_run(tmp_path):
         )
         agent_service = AgentService(
             tool_registry=registry,
-            agent_registry=_fake_agent_registry(),
+            agent_registry=None,
             workspace_root=Path(tmp_path),
             model_name="gpt-test",
             shared_runs=shared_runs,
@@ -244,7 +244,7 @@ def test_sendmessage_search_hint_uses_queue_naming(tmp_path):
     registry = ToolRegistry()
     AgentService(
         tool_registry=registry,
-        agent_registry=_fake_agent_registry(),
+        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
     )
@@ -420,7 +420,7 @@ async def test_background_agent_progress_notification_reaches_parent_next_turn(t
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=_fake_agent_registry(),
+        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -467,7 +467,7 @@ async def test_background_agent_completion_notification_waits_for_followthrough_
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=_fake_agent_registry(),
+        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -521,7 +521,7 @@ async def test_mixed_success_and_init_failure_background_agents_queue_both_termi
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=_fake_agent_registry(),
+        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,


### PR DESCRIPTION
## Summary
- stop injecting a fake AgentRegistry in non-lookup integration proof callsites
- keep explicit fake-registry usage only where the test is actually proving running lookup behavior
- align background cleanup / notification integration proof with the current runtime default path

## Verification
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'taskstop_terminates_real_background_bash_run or sendmessage_search_hint_uses_queue_naming or background_agent_progress_notification_reaches_parent_next_turn or background_agent_completion_notification_waits_for_followthrough_run or mixed_success_and_init_failure_background_agents_queue_both_terminal_notifications'
- uv run ruff check tests/Integration/test_background_task_cleanup.py
- git diff --check
