### PR TITLE
fix: scope installed update action to agent tab

### DIFF
--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -222,7 +222,7 @@ export default function MarketplacePage() {
               </h3>
             )}
           </div>
-          {tab === "installed" && (
+          {tab === "installed" && installedSubTab === "agent-user" && (
             <button
               onClick={handleCheckUpdates}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors duration-fast"

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -129,6 +129,42 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.getByLabelText("location").textContent).not.toContain("sub=member");
   });
 
+  it("shows 检查更新 only on the installed Agent tab", () => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=agent-user"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "检查更新" })).toBeTruthy();
+
+    unmount();
+
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=skill"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
+  });
+
+  it("does not show 检查更新 on the installed Sandbox tab", () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=sandbox-template"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
+  });
+
   it("uses Subagent wording for marketplace agent resources", () => {
     render(
       <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=agent"]}>


### PR DESCRIPTION
## Summary
- show the installed-page 更新 action only on the Agent subtab
- keep Skill and Sandbox installed subtabs free of an agent-user-only action
- lock the header contract with wording tests

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx
- git diff --check
- real Playwright CLI check on 5191: agent-user shows 检查更新; skill and sandbox-template do not