### PR TITLE
test: demote last unit registry shadow seat

### DIFF
--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1542,10 +1542,9 @@ async def test_handle_agent_mints_fresh_child_thread_without_child_continuity_lo
             },
         }
     )
-    registry = _FakeAgentRegistry()
     service = _make_service(
         tmp_path,
-        agent_registry=registry,
+        agent_registry=None,
         thread_repo=thread_repo,
         user_repo=_FakeUserRepo({"agent-user-1": "Toad"}),
     )


### PR DESCRIPTION
## Summary
- remove the last explicit fake-registry unit seat from the fresh-child-thread test
- keep the proof focused on fresh child-thread minting rather than registry wiring
- leave remaining explicit AgentRegistry() abstraction-self tests untouched

## Testing
- uv run python -m pytest tests/Unit/core/test_agent_service.py -k 'fresh_child_thread_without_child_continuity_lookup or defaults_to_process_local_in_memory_repo or no_longer_exposes_child_continuity_lookup or no_longer_exposes_dead_methods'
- uv run ruff check tests/Unit/core/test_agent_service.py
- git diff --check