### PR TITLE
refactor: drop agent registry constructor seat

### DIFF
--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -3,7 +3,6 @@
 Creates independent LeonAgent instances per spawn. Sub-agents run as asyncio
 tasks; parent blocks until completion by default. `run_in_background=True`
 fires-and-forgets and returns a task_id for polling via TaskOutput.
-Backed by AgentRegistry (SQLite).
 """
 
 from __future__ import annotations
@@ -19,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from config.loader import AgentLoader
-from core.agents.registry import AgentEntry, AgentRegistry
+from core.agents.registry import AgentEntry
 from core.runtime.middleware.queue.formatters import (
     format_agent_message,
     format_background_notification,
@@ -462,7 +461,6 @@ class AgentService:
     def __init__(
         self,
         tool_registry: ToolRegistry,
-        agent_registry: AgentRegistry | None,
         workspace_root: Path,
         model_name: str,
         queue_manager: Any | None = None,
@@ -473,7 +471,7 @@ class AgentService:
         web_app: Any = None,
         child_agent_factory: ChildAgentFactory | None = None,
     ):
-        self._agent_registry = agent_registry
+        self._agent_registry = None
         self._active_agents: dict[str, AgentEntry] = {}
         self._workspace_root = workspace_root
         self._model_name = model_name
@@ -544,20 +542,12 @@ class AgentService:
         )
 
     async def _register_active_entry(self, entry: AgentEntry) -> None:
-        if self._agent_registry is not None:
-            await self._agent_registry.register(entry)
-            return
         self._active_agents[entry.agent_id] = entry
 
     async def _list_running_entries_by_name(self, name: str) -> list[AgentEntry]:
-        if self._agent_registry is not None:
-            return await self._agent_registry.list_running_by_name(name)
         return [entry for entry in self._active_agents.values() if entry.name == name and entry.status == "running"]
 
     async def _remove_active_entry(self, agent_id: str) -> None:
-        if self._agent_registry is not None:
-            await self._agent_registry.remove(agent_id)
-            return
         self._active_agents.pop(agent_id, None)
 
     @staticmethod

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1237,7 +1237,6 @@ class LeonAgent:
         self._agent_registry = None
         self._agent_service = AgentService(
             tool_registry=self._tool_registry,
-            agent_registry=self._agent_registry,
             workspace_root=self.workspace_root,
             model_name=self.model_name,
             thread_repo=self._thread_repo,

--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -124,7 +124,6 @@ def test_taskstop_terminates_real_background_bash_run(tmp_path):
         )
         agent_service = AgentService(
             tool_registry=registry,
-            agent_registry=None,
             workspace_root=Path(tmp_path),
             model_name="gpt-test",
             shared_runs=shared_runs,
@@ -206,7 +205,6 @@ def test_sendmessage_search_hint_uses_queue_naming(tmp_path):
     registry = ToolRegistry()
     AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
     )
@@ -224,7 +222,6 @@ async def test_sendmessage_enqueues_real_agent_notification_for_target_thread(tm
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -258,7 +255,6 @@ async def test_sendmessage_uses_service_local_active_state_when_registry_missing
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -292,7 +288,6 @@ async def test_sendmessage_reaches_target_next_turn_via_steering_middleware(tmp_
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -332,7 +327,6 @@ async def test_sendmessage_rejects_ambiguous_running_agent_names(tmp_path):
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -379,7 +373,6 @@ async def test_background_agent_progress_notification_reaches_parent_next_turn(t
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -426,7 +419,6 @@ async def test_background_agent_completion_notification_waits_for_followthrough_
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,
@@ -480,7 +472,6 @@ async def test_mixed_success_and_init_failure_background_agents_queue_both_termi
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     service = AgentService(
         tool_registry=registry,
-        agent_registry=None,
         workspace_root=Path(tmp_path),
         model_name="gpt-test",
         queue_manager=queue_manager,

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -341,16 +341,24 @@ def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch,
     from core.runtime.agent import LeonAgent
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    captured: dict[str, Any] = {}
+
+    class _CapturingAgentService:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.update(kwargs)
+            self._agent_registry = None
 
     with (
         patch("core.runtime.agent.LeonAgent._create_model", return_value=_mock_model("registry wiring")),
         patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.AgentService", _CapturingAgentService),
     ):
         agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
 
     try:
         assert agent._agent_registry is None
         assert agent._agent_service._agent_registry is None
+        assert "agent_registry" not in captured
     finally:
         agent.close()
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -263,11 +263,9 @@ def _make_tool_request(
 
 def _make_service(tmp_path: Path, **kwargs) -> AgentService:
     tool_registry = kwargs.pop("tool_registry", None) or _CapturingRegistry()
-    agent_registry = kwargs.pop("agent_registry", None)
     model_name = kwargs.pop("model_name", "gpt-test")
     return AgentService(
         tool_registry=tool_registry,
-        agent_registry=agent_registry,
         workspace_root=tmp_path,
         model_name=model_name,
         **kwargs,
@@ -997,7 +995,7 @@ async def test_agent_tool_model_priority_inherits_parent_when_no_env_tool_or_fro
 
 @pytest.mark.asyncio
 async def test_cleanup_background_runs_cancels_pending_agent_and_shell_runs(tmp_path):
-    service = _make_service(tmp_path, agent_registry=None)
+    service = _make_service(tmp_path)
     agent_task = asyncio.create_task(_sleep_forever())
     shell_cmd = _FakeAsyncCommand()
     service._tasks["agent-task"] = _RunningTask(
@@ -1023,7 +1021,7 @@ async def test_cleanup_background_runs_cancels_pending_agent_and_shell_runs(tmp_
 
 @pytest.mark.asyncio
 async def test_cleanup_background_runs_does_not_relabel_completed_agent_run(tmp_path):
-    service = _make_service(tmp_path, agent_registry=None)
+    service = _make_service(tmp_path)
     completed_task = asyncio.create_task(asyncio.sleep(0, result="done"))
     await completed_task
     service._tasks["agent-task"] = _RunningTask(
@@ -1509,7 +1507,6 @@ async def test_handle_agent_mints_fresh_child_thread_without_child_continuity_lo
     )
     service = _make_service(
         tmp_path,
-        agent_registry=None,
         thread_repo=thread_repo,
         user_repo=_FakeUserRepo({"agent-user-1": "Toad"}),
     )
@@ -1535,7 +1532,7 @@ async def test_handle_agent_mints_fresh_child_thread_without_child_continuity_lo
 async def test_handle_agent_blocking_path_does_not_duplicate_completed_status(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
 
-    service = _make_service(tmp_path, agent_registry=None)
+    service = _make_service(tmp_path)
 
     raw = await service._handle_agent(
         prompt="do work",
@@ -1551,7 +1548,7 @@ async def test_handle_agent_blocking_path_does_not_duplicate_completed_status(mo
 async def test_handle_agent_blocking_path_removes_registry_entry_on_finish(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
 
-    service = _make_service(tmp_path, agent_registry=None)
+    service = _make_service(tmp_path)
 
     raw = await service._handle_agent(
         prompt="do work",
@@ -1572,7 +1569,6 @@ async def test_handle_agent_blocking_path_does_not_duplicate_error_status(monkey
 
     service = _make_service(
         tmp_path,
-        agent_registry=None,
         child_agent_factory=lambda *, model_name, workspace_root, **kwargs: _FailingChildAgent(
             Path(workspace_root),
             model_name,


### PR DESCRIPTION
Summary:
- remove the AgentService agent_registry constructor seat from runtime and focused test callsites
- keep service-local active state as the only default runtime path
- leave top-level AgentRegistry abstraction-self tests intact

Testing:
- uv run python -m pytest tests/Integration/test_leon_agent.py -k defaults_to_process_local_agent_registry
- uv run python -m pytest tests/Unit/core/test_agent_service.py -k 'make_service_defaults_to_no_injected_agent_registry or cleanup_background_runs_cancels_pending_agent_and_shell_runs or cleanup_background_runs_does_not_relabel_completed_agent_run or fresh_child_thread_without_child_continuity_lookup or duplicate_completed_status or duplicate_error_status'
- uv run python -m pytest tests/Integration/test_background_task_cleanup.py -k 'sendmessage or background or service_local_active_state_when_registry_missing'
- uv run ruff check core/agents/service.py core/runtime/agent.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py tests/Integration/test_leon_agent.py
- git diff --check