### PR TITLE
test: drop agent registry runtime patch surface

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -46,7 +46,6 @@ from config.observation_loader import ObservationLoader  # noqa: E402
 from config.observation_schema import ObservationConfig  # noqa: E402
 
 # Multi-agent services
-from core.agents.registry import AgentRegistry as _AgentRegistry  # noqa: E402
 from core.agents.service import AgentService  # noqa: E402
 from core.model_params import normalize_model_kwargs  # noqa: E402
 
@@ -84,8 +83,6 @@ from core.tools.web.service import WebService  # noqa: E402
 from storage.container import StorageContainer  # noqa: E402
 
 logger = logging.getLogger(__name__)
-
-AgentRegistry = _AgentRegistry
 
 if TYPE_CHECKING:
     from sandbox import Sandbox

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -338,6 +338,7 @@ def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing
 
 @_patch_env_api_key()
 def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch, tmp_path, _patch_runtime_storage_container):
+    import core.runtime.agent as runtime_agent
     from core.runtime.agent import LeonAgent
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
@@ -359,6 +360,7 @@ def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch,
         assert agent._agent_registry is None
         assert agent._agent_service._agent_registry is None
         assert "agent_registry" not in captured
+        assert hasattr(runtime_agent, "AgentRegistry") is False
     finally:
         agent.close()
 
@@ -964,10 +966,6 @@ def test_leon_agent_chat_tool_wiring_rejects_user_id_only_runtime_shape(monkeypa
         def __init__(self, *args, **kwargs) -> None:
             return None
 
-    class _NoopRegistry:
-        def __init__(self, *args, **kwargs) -> None:
-            return None
-
     class _FakeChatToolService:
         def __init__(self, *args, **kwargs) -> None:
             raise AssertionError("chat tool should not initialize from user_id-only runtime shape")
@@ -975,7 +973,6 @@ def test_leon_agent_chat_tool_wiring_rejects_user_id_only_runtime_shape(monkeypa
     monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
-    monkeypatch.setattr("core.runtime.agent.AgentRegistry", _NoopRegistry)
     monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
     monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _FakeChatToolService)
 
@@ -1076,10 +1073,6 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
         def __init__(self, *args, **kwargs) -> None:
             return None
 
-    class _NoopRegistry:
-        def __init__(self, *args, **kwargs) -> None:
-            return None
-
     class _FakeChatToolService:
         def __init__(self, *args, **kwargs) -> None:
             captured.update(kwargs)
@@ -1087,7 +1080,6 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
-    monkeypatch.setattr("core.runtime.agent.AgentRegistry", _NoopRegistry)
     monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
     monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _FakeChatToolService)
 


### PR DESCRIPTION
Summary:
- remove the dead AgentRegistry re-export from core.runtime.agent
- stop monkeypatching that runtime patch surface in focused leon_agent integration tests
- keep runtime behavior unchanged

Testing:
- uv run python -m pytest tests/Integration/test_leon_agent.py -k 'defaults_to_process_local_agent_registry or chat_tool_wiring_rejects_user_id_only_runtime_shape or chat_tool_wiring_does_not_pass_dead_repo_dependencies'
- uv run ruff check core/runtime/agent.py tests/Integration/test_leon_agent.py
- git diff --check