### PR TITLE
refactor: drop agent registry wrapper residue

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -1,14 +1,8 @@
-"""Agent Registry — Supabase-backed agent_id -> thread_id mapping.
-
-@@@id-based — all lookups use agent_id, never name.
-Name is stored for display only.
-"""
+"""Agent registry shared row types."""
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass
@@ -19,63 +13,3 @@ class AgentEntry:
     status: str
     parent_agent_id: str | None = None
     subagent_type: str | None = None
-
-
-class _InMemoryAgentRegistryRepo:
-    def __init__(self) -> None:
-        self._rows: dict[str, tuple[str, str, str, str, str | None, str | None]] = {}
-
-    def register(
-        self,
-        *,
-        agent_id: str,
-        name: str,
-        thread_id: str,
-        status: str,
-        parent_agent_id: str | None,
-        subagent_type: str | None,
-    ) -> None:
-        self._rows[agent_id] = (agent_id, name, thread_id, status, parent_agent_id, subagent_type)
-
-    def list_running_by_name(self, name: str) -> list[tuple[str, str, str, str, str | None, str | None]]:
-        return [row for row in self._rows.values() if row[1] == name and row[3] == "running"]
-
-    def remove(self, agent_id: str) -> None:
-        self._rows.pop(agent_id, None)
-
-
-class AgentRegistry:
-    """Registry mapping agent_ids to thread IDs."""
-
-    def __init__(self, repo: Any = None):
-        self._lock = asyncio.Lock()
-        self._repo = repo or _InMemoryAgentRegistryRepo()
-
-    async def register(self, entry: AgentEntry) -> None:
-        async with self._lock:
-            self._repo.register(
-                agent_id=entry.agent_id,
-                name=entry.name,
-                thread_id=entry.thread_id,
-                status=entry.status,
-                parent_agent_id=entry.parent_agent_id,
-                subagent_type=entry.subagent_type,
-            )
-
-    async def list_running_by_name(self, name: str) -> list[AgentEntry]:
-        rows = self._repo.list_running_by_name(name)
-        return [
-            AgentEntry(
-                agent_id=row[0],
-                name=row[1],
-                thread_id=row[2],
-                status=row[3],
-                parent_agent_id=row[4],
-                subagent_type=row[5],
-            )
-            for row in rows
-        ]
-
-    async def remove(self, agent_id: str) -> None:
-        async with self._lock:
-            self._repo.remove(agent_id)

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -46,7 +46,6 @@ from config.observation_loader import ObservationLoader  # noqa: E402
 from config.observation_schema import ObservationConfig  # noqa: E402
 
 # Multi-agent services
-from core.agents.registry import AgentRegistry as _AgentRegistry  # noqa: E402
 from core.agents.service import AgentService  # noqa: E402
 from core.model_params import normalize_model_kwargs  # noqa: E402
 
@@ -84,8 +83,6 @@ from core.tools.web.service import WebService  # noqa: E402
 from storage.container import StorageContainer  # noqa: E402
 
 logger = logging.getLogger(__name__)
-
-AgentRegistry = _AgentRegistry
 
 if TYPE_CHECKING:
     from sandbox import Sandbox

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -338,6 +338,7 @@ def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing
 
 @_patch_env_api_key()
 def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch, tmp_path, _patch_runtime_storage_container):
+    import core.agents.registry as agent_registry_module
     import core.runtime.agent as runtime_agent
     from core.runtime.agent import LeonAgent
 
@@ -361,6 +362,7 @@ def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch,
         assert agent._agent_service._agent_registry is None
         assert "agent_registry" not in captured
         assert hasattr(runtime_agent, "AgentRegistry") is False
+        assert hasattr(agent_registry_module, "AgentRegistry") is False
     finally:
         agent.close()
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -338,6 +338,7 @@ def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing
 
 @_patch_env_api_key()
 def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch, tmp_path, _patch_runtime_storage_container):
+    import core.runtime.agent as runtime_agent
     from core.runtime.agent import LeonAgent
 
     monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
@@ -359,6 +360,7 @@ def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch,
         assert agent._agent_registry is None
         assert agent._agent_service._agent_registry is None
         assert "agent_registry" not in captured
+        assert hasattr(runtime_agent, "AgentRegistry") is False
     finally:
         agent.close()
 
@@ -964,10 +966,6 @@ def test_leon_agent_chat_tool_wiring_rejects_user_id_only_runtime_shape(monkeypa
         def __init__(self, *args, **kwargs) -> None:
             return None
 
-    class _NoopRegistry:
-        def __init__(self, *args, **kwargs) -> None:
-            return None
-
     class _FakeChatToolService:
         def __init__(self, *args, **kwargs) -> None:
             raise AssertionError("chat tool should not initialize from user_id-only runtime shape")
@@ -975,7 +973,6 @@ def test_leon_agent_chat_tool_wiring_rejects_user_id_only_runtime_shape(monkeypa
     monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
-    monkeypatch.setattr("core.runtime.agent.AgentRegistry", _NoopRegistry)
     monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
     monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _FakeChatToolService)
 
@@ -1076,10 +1073,6 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
         def __init__(self, *args, **kwargs) -> None:
             return None
 
-    class _NoopRegistry:
-        def __init__(self, *args, **kwargs) -> None:
-            return None
-
     class _FakeChatToolService:
         def __init__(self, *args, **kwargs) -> None:
             captured.update(kwargs)
@@ -1087,7 +1080,6 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
     monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
-    monkeypatch.setattr("core.runtime.agent.AgentRegistry", _NoopRegistry)
     monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
     monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _FakeChatToolService)
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from core.agents.registry import AgentEntry, AgentRegistry
 from core.agents.service import (
     AGENT_DISALLOWED,
     AGENT_SCHEMA,
@@ -121,44 +120,6 @@ def test_fake_thread_repo_create_requires_current_workspace_id() -> None:
             branch_index=0,
             owner_user_id="owner-1",
         )
-
-
-@pytest.mark.asyncio
-async def test_agent_registry_defaults_to_process_local_in_memory_repo() -> None:
-    registry = AgentRegistry()
-    entry = AgentEntry(
-        agent_id="agent-1",
-        name="general",
-        thread_id="thread-1",
-        status="running",
-        parent_agent_id="parent-1",
-        subagent_type="general",
-    )
-
-    await registry.register(entry)
-
-    assert await registry.list_running_by_name("general") == [entry]
-
-    await registry.remove("agent-1")
-
-    assert await registry.list_running_by_name("general") == []
-
-
-def test_agent_registry_no_longer_exposes_child_continuity_lookup() -> None:
-    registry = AgentRegistry()
-
-    assert hasattr(registry, "get_latest_by_name_and_parent") is False
-    assert hasattr(registry, "get_by_id") is False
-    assert hasattr(registry, "list_running") is False
-    assert hasattr(registry, "update_status") is False
-
-
-def test_process_local_agent_registry_backing_no_longer_exposes_dead_methods() -> None:
-    registry = AgentRegistry()
-
-    assert hasattr(registry._repo, "get_by_id") is False
-    assert hasattr(registry._repo, "update_status") is False
-    assert hasattr(registry._repo, "list_running") is False
 
 
 class _FakeChildAgent:


### PR DESCRIPTION
Summary:
- remove the dead AgentRegistry wrapper and its top-level wrapper-self tests
- keep AgentEntry as the remaining shared row type
- leave storage agent-registry substrate tests intact

Testing:
- uv run python -m pytest tests/Integration/test_leon_agent.py -k defaults_to_process_local_agent_registry
- uv run python -m pytest tests/Unit/core/test_agent_service.py -k 'make_service_defaults_to_no_injected_agent_registry or cleanup_background_runs_cancels_pending_agent_and_shell_runs or cleanup_background_runs_does_not_relabel_completed_agent_run or fresh_child_thread_without_child_continuity_lookup or duplicate_completed_status or duplicate_error_status'
- uv run python -m pytest tests/Unit/storage/test_supabase_agent_registry_repo.py
- uv run ruff check core/agents/registry.py tests/Integration/test_leon_agent.py tests/Unit/core/test_agent_service.py tests/Unit/storage/test_supabase_agent_registry_repo.py
- git diff --check