### PR TITLE
fix: honor legacy subagent marketplace tab

### DIFF
--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -25,8 +25,10 @@ function isTab(value: string | null): value is Tab {
   return value === "explore" || value === "installed";
 }
 
-function isInstalledSubTab(value: string | null): value is InstalledSubTab {
-  return value === "agent-user" || value === "skill" || value === "agent" || value === "sandbox-template";
+function normalizeInstalledSubTab(value: string | null): InstalledSubTab | null {
+  if (value === "subagent") return "agent";
+  if (value === "agent-user" || value === "skill" || value === "agent" || value === "sandbox-template") return value;
+  return null;
 }
 
 const typeFilters: { id: TypeFilter; label: string }[] = [
@@ -51,7 +53,7 @@ export default function MarketplacePage() {
   const rawTab = searchParams.get("tab");
   const rawInstalledSubTab = searchParams.get("sub");
   const tab = isTab(rawTab) ? rawTab : "explore";
-  const installedSubTab = isInstalledSubTab(rawInstalledSubTab) ? rawInstalledSubTab : "agent-user";
+  const installedSubTab = normalizeInstalledSubTab(rawInstalledSubTab) ?? "agent-user";
 
   const setTab = (t: Tab) => setSearchParams((p) => { p.set("tab", t); p.delete("sub"); return p; }, { replace: true });
   const setInstalledSubTab = (s: InstalledSubTab) => setSearchParams((p) => { p.set("sub", s); return p; }, { replace: true });

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -142,6 +142,20 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.getByText("暂无已安装的 Subagent")).toBeTruthy();
   });
 
+  it("treats legacy installed subagent query key as the Subagent tab", () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=subagent"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: /Subagent/ })).toBeTruthy();
+    expect(screen.getByText("暂无已安装的 Subagent")).toBeTruthy();
+    expect(screen.queryByText("暂无已安装的 Agent")).toBeNull();
+  });
+
   it("does not bootstrap installed libraries because RootLayout owns panel loading", () => {
     render(
       <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=agent"]}>


### PR DESCRIPTION
## Summary\n- treat legacy installed marketplace query key sub=subagent as the Subagent installed tab instead of silently falling back to agent-user\n- keep the current installed subtab truth unchanged (agent remains the canonical internal tab id)\n- add wording coverage for the legacy query key so the route stops regressing\n\n## Verification\n- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx\n- cd frontend/app && npm run lint\n- git diff --check\n- Playwright CLI: /marketplace?tab=installed&sub=subagent now shows "暂无已安装的 Subagent" instead of Agent fallback\n