### PR TITLE
refactor: demote sync files helper default path

### DIFF
--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import HTTPException
 
 from sandbox.control_plane_repos import resolve_sandbox_db_path
-from sandbox.sync.state import SyncState
+from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
 from storage.container import StorageContainer
 from storage.runtime import build_chat_session_repo as make_chat_session_repo
 from storage.runtime import build_lease_repo as make_lease_repo
@@ -142,7 +142,7 @@ def delete_thread_in_db(thread_id: str) -> None:
 
     session_repo = make_chat_session_repo()
     terminal_repo = make_terminal_repo()
-    sync_state = SyncState()
+    sync_state = SyncState(repo=ProcessLocalSyncFileBacking())
     try:
         session_repo.delete_by_thread(thread_id)
         terminal_repo.delete_by_thread(thread_id)

--- a/tests/Unit/backend/web/utils/test_helpers.py
+++ b/tests/Unit/backend/web/utils/test_helpers.py
@@ -32,9 +32,10 @@ class _ThreadRepo:
 
 
 class _SyncState:
-    def __init__(self) -> None:
+    def __init__(self, repo=None) -> None:
         self.cleared: list[str] = []
         self.closed = False
+        self.repo = repo
 
     def clear_thread(self, thread_id: str) -> int:
         self.cleared.append(thread_id)
@@ -50,16 +51,21 @@ def test_delete_thread_in_db_uses_runtime_repo_factories_without_db_path(monkeyp
     container = _FakeContainer()
     session_repo = _ThreadRepo()
     terminal_repo = _ThreadRepo()
-    sync_state = _SyncState()
+    sync_state_holder: dict[str, _SyncState] = {}
 
     monkeypatch.setattr(helpers, "_get_container", lambda: container)
     monkeypatch.setattr(helpers, "resolve_sandbox_db_path", lambda: sandbox_db)
     monkeypatch.setattr(helpers, "make_chat_session_repo", lambda: session_repo)
     monkeypatch.setattr(helpers, "make_terminal_repo", lambda: terminal_repo)
-    monkeypatch.setattr(helpers, "SyncState", lambda: sync_state)
+    monkeypatch.setattr(
+        helpers,
+        "SyncState",
+        lambda **kwargs: sync_state_holder.setdefault("instance", _SyncState(**kwargs)),
+    )
 
     helpers.delete_thread_in_db("thread-1")
 
+    sync_state = sync_state_holder["instance"]
     assert container.purged == ["thread-1"]
     assert session_repo.deleted == ["thread-1"]
     assert terminal_repo.deleted == ["thread-1"]
@@ -67,6 +73,7 @@ def test_delete_thread_in_db_uses_runtime_repo_factories_without_db_path(monkeyp
     assert session_repo.closed
     assert terminal_repo.closed
     assert sync_state.closed
+    assert type(sync_state.repo).__name__ == "ProcessLocalSyncFileBacking"
 
 
 def test_get_terminal_timestamps_uses_runtime_repo_factory_without_db_path(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- route helper cleanup off persisted sync_files backing by using a process-local sync state backing
- keep the change narrow to delete_thread_in_db and its focused unit proof

## Verification
- uv run python -m pytest tests/Unit/backend/web/utils/test_helpers.py -k delete_thread_in_db_uses_runtime_repo_factories_without_db_path
- uv run python -m pytest tests/Unit/sandbox/test_sync_state.py
- uv run ruff check backend/web/utils/helpers.py tests/Unit/backend/web/utils/test_helpers.py tests/Unit/sandbox/test_sync_state.py
- git diff --check