### PR TITLE
refactor: demote sync files constructor seat

### DIFF
--- a/sandbox/sync/state.py
+++ b/sandbox/sync/state.py
@@ -1,8 +1,6 @@
 import hashlib
 from pathlib import Path
 
-from storage.runtime import build_sync_file_repo
-
 
 def _calculate_checksum(file_path: Path) -> str:
     """Calculate SHA256 checksum of file."""
@@ -15,7 +13,7 @@ def _calculate_checksum(file_path: Path) -> str:
 
 class SyncState:
     def __init__(self, repo=None):
-        self._repo = repo or build_sync_file_repo()
+        self._repo = repo or ProcessLocalSyncFileBacking()
 
     def close(self) -> None:
         self._repo.close()

--- a/tests/Unit/sandbox/test_sync_state.py
+++ b/tests/Unit/sandbox/test_sync_state.py
@@ -19,3 +19,9 @@ def test_sync_state_exposes_only_batch_list_and_clear_protocol() -> None:
     assert hasattr(state, "clear_thread")
     assert not hasattr(state, "track_file")
     assert not hasattr(state, "get_file_info")
+
+
+def test_sync_state_defaults_to_process_local_backing() -> None:
+    state = SyncState()
+
+    assert isinstance(state._repo, ProcessLocalSyncFileBacking)


### PR DESCRIPTION
## Summary\n- default SyncState to process-local sync backing instead of persisted sync_file_repo\n- keep the batch/list/clear protocol unchanged\n- extend sync-state tests to prove the process-local default\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sync_state.py tests/Unit/backend/web/utils/test_helpers.py -k 'sync_state or delete_thread_in_db_uses_runtime_repo_factories_without_db_path'\n- uv run ruff check sandbox/sync/state.py tests/Unit/sandbox/test_sync_state.py tests/Unit/backend/web/utils/test_helpers.py\n- git diff --check