### PR TITLE
refactor: route checkpoint repo to agent schema

### DIFF
--- a/storage/providers/supabase/checkpoint_repo.py
+++ b/storage/providers/supabase/checkpoint_repo.py
@@ -7,6 +7,7 @@ from typing import Any
 from storage.providers.supabase import _query as q
 
 _REPO = "checkpoint repo"
+_SCHEMA = "agent"
 _TABLES = ("checkpoints", "checkpoint_writes", "checkpoint_blobs")
 
 
@@ -19,21 +20,24 @@ class SupabaseCheckpointRepo:
     def close(self) -> None:
         return None
 
+    def _table(self, name: str) -> Any:
+        return q.schema_table(self._client, _SCHEMA, name, _REPO)
+
     def list_thread_ids(self) -> list[str]:
-        response = self._client.table("checkpoints").select("thread_id").execute()
+        response = self._table("checkpoints").select("thread_id").execute()
         rows = q.rows(response, _REPO, "list_thread_ids")
         return sorted({str(row["thread_id"]) for row in rows if row.get("thread_id")})
 
     def delete_thread_data(self, thread_id: str) -> None:
         for table in _TABLES:
-            self._client.table(table).delete().eq("thread_id", thread_id).execute()
+            self._table(table).delete().eq("thread_id", thread_id).execute()
 
     def delete_checkpoints_by_ids(self, thread_id: str, checkpoint_ids: list[str]) -> None:
         if not checkpoint_ids:
             return
         for table in _TABLES:
             q.execute_in_chunks(
-                lambda table=table: self._client.table(table).delete().eq("thread_id", thread_id),
+                lambda table=table: self._table(table).delete().eq("thread_id", thread_id),
                 "checkpoint_id",
                 checkpoint_ids,
                 _REPO,

--- a/tests/Unit/storage/test_supabase_checkpoint_repo.py
+++ b/tests/Unit/storage/test_supabase_checkpoint_repo.py
@@ -1,0 +1,62 @@
+from storage.providers.supabase.checkpoint_repo import SupabaseCheckpointRepo
+
+
+class _FakeTable:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.eq_calls: list[tuple[str, object]] = []
+        self.delete_calls = 0
+
+    def select(self, _cols):
+        return self
+
+    def delete(self):
+        self.delete_calls += 1
+        return self
+
+    def eq(self, key, value):
+        self.eq_calls.append((key, value))
+        return self
+
+    def execute(self):
+        return type("Resp", (), {"data": self.rows})()
+
+
+class _FakeClient:
+    def __init__(self, rows=None):
+        self.table_obj = _FakeTable(rows)
+        self.table_names: list[str] = []
+
+    def schema(self, name):
+        self.table_names.append(f"schema:{name}")
+        return self
+
+    def table(self, name):
+        self.table_names.append(name)
+        return self.table_obj
+
+
+def test_supabase_checkpoint_repo_reads_agent_schema_checkpoints_table() -> None:
+    client = _FakeClient([{"thread_id": "thread-2"}, {"thread_id": "thread-1"}, {"thread_id": "thread-1"}])
+    repo = SupabaseCheckpointRepo(client)
+
+    thread_ids = repo.list_thread_ids()
+
+    assert thread_ids == ["thread-1", "thread-2"]
+    assert client.table_names == ["schema:agent", "checkpoints"]
+
+
+def test_supabase_checkpoint_repo_deletes_agent_schema_checkpoint_family() -> None:
+    client = _FakeClient()
+    repo = SupabaseCheckpointRepo(client)
+
+    repo.delete_thread_data("thread-1")
+
+    assert client.table_names == [
+        "schema:agent",
+        "checkpoints",
+        "schema:agent",
+        "checkpoint_writes",
+        "schema:agent",
+        "checkpoint_blobs",
+    ]


### PR DESCRIPTION
## Summary\n- make SupabaseCheckpointRepo read/write the checkpoint family from the agent schema\n- keep checkpoint table shapes unchanged\n- add focused unit proof for the schema-qualified checkpoint family\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_supabase_checkpoint_repo.py\n- uv run ruff check storage/providers/supabase/checkpoint_repo.py tests/Unit/storage/test_supabase_checkpoint_repo.py\n- git diff --check