### PR TITLE
fix: gate auth pages until persisted session hydrates

### DIFF
--- a/frontend/app/src/pages/RootLayout.test.tsx
+++ b/frontend/app/src/pages/RootLayout.test.tsx
@@ -69,6 +69,7 @@ describe("RootLayout setup-name contract", () => {
       configurable: true,
     });
     useAuthStore.setState({
+      hydrated: true,
       token: "token-1",
       user: { id: "user-1", name: "old", type: "human", avatar: null },
       agent: null,
@@ -129,6 +130,7 @@ describe("RootLayout agent wording contract", () => {
       configurable: true,
     });
     useAuthStore.setState({
+      hydrated: true,
       token: "token-1",
       user: { id: "user-1", name: "tester", type: "human", avatar: null },
       agent: null,
@@ -208,19 +210,68 @@ describe("RootLayout agent wording contract", () => {
   });
 });
 
+describe("RootLayout auth hydration gate", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    vi.stubGlobal("localStorage", storage);
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    useAuthStore.setState({
+      token: null,
+      user: null,
+      agent: null,
+      userId: null,
+      setupInfo: null,
+      hydrated: false,
+      login: vi.fn(),
+      sendOtp: vi.fn(),
+      verifyOtp: vi.fn(),
+      completeRegister: vi.fn(),
+      clearSetupInfo: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
+  it("does not render LoginForm before auth persistence finishes hydrating", () => {
+    render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <Routes>
+          <Route path="*" element={<RootLayout />}>
+            <Route path="chat" element={<div>chat-page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByPlaceholderText("邮箱或 Mycel ID")).toBeNull();
+    expect(screen.queryByText("chat-page")).toBeNull();
+  });
+});
+
 describe("LoginForm", () => {
   beforeEach(() => {
     useAuthStore.setState({
       token: null,
       user: null,
       agent: null,
+      userId: null,
       setupInfo: null,
+      hydrated: true,
       login: vi.fn(async () => {
         useAuthStore.setState({
           token: "token",
           user: { id: "u-1", name: "tester", type: "human", avatar: null },
           agent: null,
+          userId: "u-1",
           setupInfo: null,
+          hydrated: true,
         });
       }),
       sendOtp: vi.fn(async () => undefined),

--- a/frontend/app/src/pages/RootLayout.tsx
+++ b/frontend/app/src/pages/RootLayout.tsx
@@ -24,8 +24,10 @@ const mobileNavItems = [
 
 // @@@auth-guard — wrapper that shows LoginForm when not authenticated
 export default function RootLayout() {
+  const hydrated = useAuthStore(s => s.hydrated);
   const token = useAuthStore(s => s.token);
   const setupInfo = useAuthStore(s => s.setupInfo);
+  if (!hydrated) return null;
   if (!token) return <LoginForm />;
   if (setupInfo) return <SetupNameStep userId={setupInfo.userId} defaultName={setupInfo.defaultName} />;
   return <AuthenticatedLayout />;

--- a/frontend/app/src/store/auth-store.ts
+++ b/frontend/app/src/store/auth-store.ts
@@ -22,6 +22,7 @@ interface AuthIdentity {
 }
 
 interface AuthState {
+  hydrated: boolean;
   token: string | null;
   user: AuthIdentity | null;
   agent: AuthIdentity | null;
@@ -60,6 +61,7 @@ async function apiPost(endpoint: string, body: Record<string, string>) {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
+      hydrated: false,
       token: null,
       user: null,
       agent: null,
@@ -69,6 +71,7 @@ export const useAuthStore = create<AuthState>()(
       login: async (identifier, password) => {
         const data = await apiPost("login", { identifier, password });
         set({
+          hydrated: true,
           token: data.token,
           user: data.user,
           agent: data.agent,
@@ -91,6 +94,7 @@ export const useAuthStore = create<AuthState>()(
           invite_code: inviteCode,
         });
         set({
+          hydrated: true,
           token: data.token,
           user: data.user,
           agent: data.agent ?? null,
@@ -104,11 +108,16 @@ export const useAuthStore = create<AuthState>()(
       },
 
       logout: () => {
-        set({ token: null, user: null, agent: null, userId: null, setupInfo: null });
+        set({ hydrated: true, token: null, user: null, agent: null, userId: null, setupInfo: null });
       },
     }),
     {
       name: "leon-auth",
+      onRehydrateStorage: () => {
+        return () => {
+          useAuthStore.setState({ hydrated: true });
+        };
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- add an explicit auth hydration truth to the persisted auth store
- block RootLayout from mounting auth-protected routes before persisted session restore finishes
- cover the hydration gate with RootLayout/auth-store tests

## Verification
- cd frontend/app && npm test -- --run src/pages/RootLayout.test.tsx src/store/auth-store.test.ts
- cd frontend/app && npm run lint
- git diff --check
- Playwright CLI: cold-open /chat/visit/... no longer logs ChatSSE/conversations startup noise
