### PR TITLE
fix: finish auth hydration signal after persisted restore

### DIFF
--- a/frontend/app/src/store/auth-store.test.ts
+++ b/frontend/app/src/store/auth-store.test.ts
@@ -60,4 +60,31 @@ describe("authFetch header contract", () => {
     expect(headers.get("Content-Type")).toBeNull();
     expect(headers.get("Authorization")).toBe("Bearer token-1");
   });
+
+  it("marks auth state hydrated after persisted session restore", async () => {
+    const persisted = JSON.stringify({
+      state: {
+        token: "persisted-token",
+        user: { id: "u-1", name: "tester", type: "human", avatar: null },
+        agent: null,
+        userId: "u-1",
+        setupInfo: null,
+      },
+      version: 0,
+    });
+    const storage = {
+      getItem: vi.fn((key: string) => (key === "leon-auth" ? persisted : null)),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    vi.stubGlobal("localStorage", storage);
+    vi.stubGlobal("window", { __MYCEL_CONFIG__: {}, localStorage: storage });
+    vi.resetModules();
+
+    const mod = await import("./auth-store");
+    await Promise.resolve();
+
+    expect(mod.useAuthStore.getState().token).toBe("persisted-token");
+    expect(mod.useAuthStore.getState().hydrated).toBe(true);
+  });
 });

--- a/frontend/app/src/store/auth-store.ts
+++ b/frontend/app/src/store/auth-store.ts
@@ -29,6 +29,7 @@ interface AuthState {
   userId: string | null;
   setupInfo: { userId: string; defaultName: string } | null;
 
+  markHydrated: () => void;
   login: (identifier: string, password: string) => Promise<void>;
   sendOtp: (email: string, password: string, inviteCode: string) => Promise<void>;
   verifyOtp: (email: string, token: string) => Promise<{ tempToken: string }>;
@@ -67,6 +68,10 @@ export const useAuthStore = create<AuthState>()(
       agent: null,
       userId: null,
       setupInfo: null,
+
+      markHydrated: () => {
+        set({ hydrated: true });
+      },
 
       login: async (identifier, password) => {
         const data = await apiPost("login", { identifier, password });
@@ -113,9 +118,16 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: "leon-auth",
+      partialize: (state) => ({
+        token: state.token,
+        user: state.user,
+        agent: state.agent,
+        userId: state.userId,
+        setupInfo: state.setupInfo,
+      }),
       onRehydrateStorage: () => {
-        return () => {
-          useAuthStore.setState({ hydrated: true });
+        return (state) => {
+          state?.markHydrated();
         };
       },
     },


### PR DESCRIPTION
## Summary
- mark auth state hydrated after persisted session restore
- persist only auth data fields, not runtime action state
- keep RootLayout hydration gate honest on cold chat entry

## Verification
- cd frontend/app && npm test -- --run src/store/auth-store.test.ts src/pages/RootLayout.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- Playwright CLI cold-open `http://127.0.0.1:5191/chat/hire/new/m_dKjuBBLbR1bw` now renders instead of blank page