### PR TITLE
fix: abort chat sse on browser pagehide

### DIFF
--- a/frontend/app/src/pages/ChatConversationPage.test.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ChatConversationPage from "./ChatConversationPage";
+import { useAuthStore } from "../store/auth-store";
+
+const authFetchMocks = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+  streamChatEvents: vi.fn(),
+  useOutletContext: vi.fn(),
+}));
+
+vi.mock("zustand/middleware", async () => {
+  const actual = await vi.importActual<typeof import("zustand/middleware")>("zustand/middleware");
+  return {
+    ...actual,
+    persist: ((initializer: unknown) => initializer) as typeof actual.persist,
+  };
+});
+
+vi.mock("../store/auth-store", async () => {
+  const actual = await vi.importActual<typeof import("../store/auth-store")>("../store/auth-store");
+  return {
+    ...actual,
+    authFetch: authFetchMocks.authFetch,
+  };
+});
+
+vi.mock("../api/chat-events", () => ({
+  streamChatEvents: authFetchMocks.streamChatEvents,
+  parseChatMessageEventData: vi.fn(),
+  parseChatTypingUserId: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useOutletContext: authFetchMocks.useOutletContext,
+  };
+});
+
+vi.mock("../components/chat-area/UserBubble", () => ({
+  UserBubble: () => null,
+}));
+
+vi.mock("../components/chat-area/ChatBubble", () => ({
+  ChatBubble: () => null,
+}));
+
+describe("ChatConversationPage SSE teardown", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    authFetchMocks.authFetch.mockReset();
+    authFetchMocks.streamChatEvents.mockReset();
+    authFetchMocks.useOutletContext.mockReset();
+    authFetchMocks.useOutletContext.mockReturnValue({
+      setSidebarCollapsed: vi.fn(),
+      refreshChatList: vi.fn(),
+    });
+
+    useAuthStore.setState({
+      hydrated: true,
+      token: "token-1",
+      user: { id: "user-1", name: "tester", type: "human", avatar: null },
+      agent: null,
+      userId: "user-1",
+      setupInfo: null,
+      markHydrated: vi.fn(),
+      login: vi.fn(),
+      sendOtp: vi.fn(),
+      verifyOtp: vi.fn(),
+      completeRegister: vi.fn(),
+      clearSetupInfo: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    authFetchMocks.authFetch.mockImplementation(async (url: string) => {
+      if (url === "/api/chats/chat-1") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "chat-1",
+            title: "chat title",
+            members: [{ id: "user-1", name: "tester", type: "human" }],
+          }),
+        };
+      }
+      if (url === "/api/chats/chat-1/messages?limit=100") {
+        return {
+          ok: true,
+          json: async () => [],
+        };
+      }
+      if (url === "/api/chats/chat-1/read") {
+        return {
+          ok: true,
+          json: async () => ({}),
+        };
+      }
+      throw new Error(`Unexpected authFetch url: ${url}`);
+    });
+  });
+
+  it("suppresses unload-time SSE network errors after pagehide aborts the stream", async () => {
+    let rejectStream: ((reason?: unknown) => void) | null = null;
+    let seenSignal: AbortSignal | undefined;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    authFetchMocks.streamChatEvents.mockImplementation(
+      async (_chatId: string, _onEvent: unknown, signal?: AbortSignal) =>
+        new Promise<void>((_, reject) => {
+          seenSignal = signal;
+          rejectStream = reject;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/chat/visit/chat-1"]}>
+        <Routes>
+          <Route path="/chat/visit/:chatId" element={<ChatConversationPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(authFetchMocks.streamChatEvents).toHaveBeenCalled();
+    });
+
+    window.dispatchEvent(new Event("pagehide"));
+    expect(seenSignal?.aborted).toBe(true);
+
+    if (!rejectStream) {
+      throw new Error("expected stream reject handler to be captured");
+    }
+    const reject = rejectStream as (reason?: unknown) => void;
+    reject(new TypeError("network error"));
+    await waitFor(() => {
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -116,6 +116,9 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
   // SSE for real-time messages
   useEffect(() => {
     const ac = new AbortController();
+    // @@@pagehide-abort — browser-level navigation can destroy the page before React unmount finishes
+    const handlePageHide = () => ac.abort();
+    window.addEventListener("pagehide", handlePageHide);
 
     void streamChatEvents(
       chatId,
@@ -165,6 +168,7 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
     });
 
     return () => {
+      window.removeEventListener("pagehide", handlePageHide);
       ac.abort();
       refreshChatList(); // refresh sidebar on leave
     };


### PR DESCRIPTION
## Summary
- abort the chat SSE stream on browser pagehide before the page tears down
- add a page-level regression test for unload-time SSE network noise
- keep the existing chat teardown behavior unchanged for in-app navigation

## Verification
- cd frontend/app && npm test -- --run src/pages/ChatConversationPage.test.tsx src/api/chat-events.test.ts src/pages/NewChatPage.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- Playwright CLI: chat context then browser-level goto /settings no longer logs `[ChatSSE] connection failed`