### PR TITLE
fix: restore contacts agents list route

### DIFF
--- a/frontend/app/src/router.test.tsx
+++ b/frontend/app/src/router.test.tsx
@@ -36,5 +36,6 @@ describe("router removed route contract", () => {
     expect(routePaths.has("hire/new/:agentId")).toBe(true);
     expect(routePaths.has("hire/:agentId")).toBe(true);
     expect(routePaths.has("contacts")).toBe(true);
+    expect(routePaths.has("agents")).toBe(true);
   });
 });

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -39,6 +39,7 @@ export const router = createBrowserRouter([
         element: <ContactsLayout />,
         children: [
           { index: true, element: <AgentsPage /> },
+          { path: 'agents', element: <AgentsPage /> },
           { path: 'agents/:id', element: <AgentDetailPage /> },
           { path: 'users', element: null },
           { path: 'users/:userId', element: <ContactDetailPage /> },


### PR DESCRIPTION
## Summary
- restore the missing `/contacts/agents` list route
- keep `/contacts` index and `/contacts/agents/:id` detail behavior unchanged
- add a router contract check so the list route cannot silently disappear again

## Verification
- cd frontend/app && npm test -- --run src/router.test.tsx src/components/agent-shell-contract.test.tsx src/pages/AgentDetailPage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- Playwright CLI: direct-open `http://127.0.0.1:5191/contacts/agents` no longer hits React Router 404 and console stays clean