### PR TITLE
fix: show contacts sidebar loading before agent bootstrap

### DIFF
--- a/frontend/app/src/pages/contacts/ContactList.test.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.test.tsx
@@ -62,6 +62,7 @@ describe("ContactList", () => {
           avatar_url: "/api/users/agent-1/avatar",
         },
       ],
+      agentsLoaded: true,
       ensureAgents,
     });
   });
@@ -75,6 +76,20 @@ describe("ContactList", () => {
 
     expect(ensureAgents).not.toHaveBeenCalled();
     expect(screen.getByText("Morel")).toBeTruthy();
+  });
+
+  it("shows agent loading instead of empty state before panel bootstrap completes", () => {
+    useAppStore.setState({ agentList: [], agentsLoaded: false });
+
+    render(
+      <MemoryRouter>
+        <ContactList />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("加载 Agent...")).toBeTruthy();
+    expect(screen.queryByText("暂无 Agent")).toBeNull();
+    expect(screen.queryByText("无匹配结果")).toBeNull();
   });
 
   it("shows backend-approved external contacts from the user candidate surface", async () => {

--- a/frontend/app/src/pages/contacts/ContactList.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.tsx
@@ -36,6 +36,7 @@ export default function ContactList() {
   const tab: Tab = location.pathname.startsWith("/contacts/users") ? "contacts" : "agents";
 
   const agentsState = useAppStore((s) => s.agentList);
+  const agentsLoaded = useAppStore((s) => s.agentsLoaded);
   const myUserId = useAuthStore((s) => s.userId);
 
   // Filter user-created agents.
@@ -133,7 +134,11 @@ export default function ContactList() {
       {/* List */}
       <div className="flex-1 min-h-0 overflow-y-auto px-2 pt-2 space-y-0.5 custom-scrollbar">
         {tab === "agents" ? (
-          filtered.length === 0 ? (
+          !agentsLoaded ? (
+            <div className="flex flex-col items-center justify-center py-12 px-4">
+              <p className="text-xs text-muted-foreground">加载 Agent...</p>
+            </div>
+          ) : filtered.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 px-4">
               <p className="text-xs text-muted-foreground">
                 {search ? "无匹配结果" : "暂无 Agent"}


### PR DESCRIPTION
## Summary
- show a loading state in the contacts sidebar while owned agents are still bootstrapping
- stop rendering the misleading "暂无 Agent" empty state before panel agent data arrives
- cover the sidebar contract with a regression test

## Verification
- cd frontend/app && npm test -- --run src/pages/contacts/ContactList.test.tsx src/components/agent-shell-contract.test.tsx src/router.test.tsx src/pages/AgentDetailPage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI: cold-open /contacts and verify sidebar shows "加载 Agent..." instead of "暂无 Agent" before agent list hydration