### PR TITLE
fix: honor legacy installed sandbox marketplace tab

### DIFF
--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -27,6 +27,7 @@ function isTab(value: string | null): value is Tab {
 
 function normalizeInstalledSubTab(value: string | null): InstalledSubTab | null {
   if (value === "subagent") return "agent";
+  if (value === "sandbox") return "sandbox-template";
   if (value === "agent-user" || value === "skill" || value === "agent" || value === "sandbox-template") return value;
   return null;
 }

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -165,6 +165,18 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
   });
 
+  it("treats legacy installed sandbox query key as the Sandbox tab", () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=sandbox"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
+  });
+
   it("disables check-updates when no installed agents have marketplace source metadata", () => {
     appStoreState = {
       ...appStoreState,


### PR DESCRIPTION
## Summary
- normalize the legacy installed marketplace query key `sub=sandbox` to the canonical sandbox tab
- stop silently falling back to the agent-user installed tab for that route
- cover the legacy sandbox query contract with a regression test

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI: open /marketplace?tab=installed&sub=sandbox and verify the page no longer shows the agent-only 检查更新 action