### PR TITLE
fix: persist existing sandbox defaults with sandbox ids

### DIFF
--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -105,6 +105,7 @@ def list_user_leases(
                 lease_id,
                 {
                     "lease_id": lease_id,
+                    "sandbox_id": str(row.get("sandbox_id") or "").strip() or None,
                     "provider_name": str(row.get("provider_name") or "local"),
                     "recipe_id": str(row.get("recipe_id") or "") or None,
                     "recipe": row.get("recipe_json"),
@@ -118,6 +119,8 @@ def list_user_leases(
             )
             if include_runtime_session_id and runtime_session_id and not group.get("runtime_session_id"):
                 group["runtime_session_id"] = runtime_session_id
+            if not group.get("sandbox_id"):
+                group["sandbox_id"] = str(row.get("sandbox_id") or "").strip() or None
             thread_id = str(row.get("thread_id") or "").strip()
             if not _is_user_visible_lease_thread(thread_id) or thread_id in group["thread_ids"]:
                 continue

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -398,6 +398,7 @@ function parseUserLeases(value: unknown): UserLeaseSummary[] {
   return leases.map((lease) => {
     const data = asRecord(lease);
     const lease_id = data ? recordString(data, "lease_id") : undefined;
+    const sandbox_id = data?.sandbox_id;
     const provider_name = data ? recordString(data, "provider_name") : undefined;
     const recipe_id = data ? recordString(data, "recipe_id") : undefined;
     const recipe_name = data ? recordString(data, "recipe_name") : undefined;
@@ -406,6 +407,7 @@ function parseUserLeases(value: unknown): UserLeaseSummary[] {
     if (
       !data ||
       !lease_id ||
+      !isStringOrNullish(sandbox_id) ||
       !provider_name ||
       !recipe_id ||
       !recipe_name ||
@@ -422,7 +424,7 @@ function parseUserLeases(value: unknown): UserLeaseSummary[] {
       if (!agentData || !thread_id || !agent_name) throw new Error("Malformed user leases");
       return { ...agentData, thread_id, agent_name };
     });
-    return { ...data, lease_id, provider_name, recipe_id, recipe_name, thread_ids, agents: admittedAgents } as UserLeaseSummary;
+    return { ...data, lease_id, sandbox_id, provider_name, recipe_id, recipe_name, thread_ids, agents: admittedAgents } as UserLeaseSummary;
   });
 }
 

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -158,6 +158,7 @@ export interface AccountResourceLimit {
 
 export interface UserLeaseSummary {
   lease_id: string;
+  sandbox_id?: string | null;
   provider_name: string;
   recipe_id: string;
   recipe_name: string;

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -553,6 +553,71 @@ describe("NewChatPage", () => {
     });
   });
 
+  it("persists existing-sandbox defaults with the selected sandbox-shaped id instead of the lease id", async () => {
+    clientMocks.getDefaultThreadConfig.mockResolvedValue({
+      source: "derived",
+      config: {
+        create_mode: "existing",
+        provider_config: "daytona_selfhost",
+        existing_sandbox_id: null,
+        model: "leon:large",
+        workspace: "/workspace/reused-1",
+      },
+    });
+    clientMocks.listMyLeases.mockResolvedValue([
+      {
+        lease_id: "lease-1",
+        sandbox_id: "sandbox-1",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-1",
+        recipe_name: "Existing One",
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/reused-1",
+        thread_ids: [],
+        agents: [],
+      } as UserLeaseSummary,
+      {
+        lease_id: "lease-2",
+        sandbox_id: "sandbox-2",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-2",
+        recipe_name: "Existing Two",
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/reused-2",
+        thread_ids: [],
+        agents: [],
+      } as UserLeaseSummary,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("centered-input-box");
+    fireEvent.click(screen.getByRole("button", { name: "下一步" }));
+    fireEvent.click(screen.getByRole("button", { name: /Daytona .* Existing Two/ }));
+    fireEvent.click(screen.getByRole("button", { name: "确认" }));
+
+    await waitFor(() => {
+      expect(clientMocks.saveDefaultThreadConfig).toHaveBeenCalledWith(
+        "m_xVuNpKJNxblZ",
+        expect.objectContaining({
+          create_mode: "existing",
+          existing_sandbox_id: "sandbox-2",
+          workspace: "/workspace/reused-2",
+        }),
+      );
+    });
+  });
+
   it("blocks advancing a new sandbox selection when backend account resources say the provider is exhausted", async () => {
     sandboxTypesForTest = [{ name: "daytona_selfhost", provider: "daytona", available: true }];
     clientMocks.fetchAccountResourceLimits.mockResolvedValue([

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -233,7 +233,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         const leases = await listMyLeases(ac.signal);
         if (cancelled) return;
         setLeaseOptions(leases);
-        setSelectedExistingSandboxId((current) => current || leases[0]?.lease_id || "");
+        setSelectedExistingSandboxId((current) => current || (leases[0] ? leaseSandboxId(leases[0]) : ""));
       } catch (err) {
         if (cancelled) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
@@ -268,7 +268,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         } satisfies SandboxTemplateSnapshot,
       }))
   ), [librarySandboxTemplates]);
-  const selectedLease = leaseOptions.find((lease) => lease.lease_id === selectedExistingSandboxId) ?? null;
+  const selectedLease = leaseOptions.find((lease) => leaseSandboxId(lease) === selectedExistingSandboxId) ?? null;
   const sandboxResourceByProvider = useMemo(() => {
     const map = new Map<string, AccountResourceLimit>();
     for (const item of accountResources) {
@@ -296,8 +296,8 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   }, [sandboxTemplateOptions, selectedSandboxTemplateId]);
 
   useEffect(() => {
-    if (!selectedExistingSandboxId && leaseOptions[0]?.lease_id) {
-      setSelectedExistingSandboxId(leaseOptions[0].lease_id);
+    if (!selectedExistingSandboxId && leaseOptions[0]) {
+      setSelectedExistingSandboxId(leaseSandboxId(leaseOptions[0]));
     }
   }, [leaseOptions, selectedExistingSandboxId]);
 
@@ -442,7 +442,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   function buildConfigSnapshot(): ConfigSnapshot {
     return {
       createMode,
-      selectedExistingSandboxId: selectedExistingSandboxId || leaseOptions[0]?.lease_id || "",
+      selectedExistingSandboxId: selectedExistingSandboxId || (leaseOptions[0] ? leaseSandboxId(leaseOptions[0]) : ""),
       selectedSandboxTemplateId,
       selectedSandboxTemplateFeatures: { ...selectedSandboxTemplateFeatures },
       selectedWorkspace: activeWorkspace,
@@ -846,13 +846,14 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                           </div>
                           <div className="max-h-[320px] space-y-2 overflow-y-auto pr-1">
                             {filteredLeaseOptions.map((lease) => {
-                              const isActive = selectedExistingSandboxId === lease.lease_id;
+                              const leaseSandboxKey = leaseSandboxId(lease);
+                              const isActive = selectedExistingSandboxId === leaseSandboxKey;
                               const stateMeta = leaseStateMeta(lease.observed_state);
                               return (
                                 <button
                                   key={lease.lease_id}
                                   type="button"
-                                  onClick={() => setSelectedExistingSandboxId(lease.lease_id)}
+                                  onClick={() => setSelectedExistingSandboxId(leaseSandboxKey)}
                                   className={cn(
                                     "w-full rounded-2xl border p-3 text-left transition-colors",
                                     isActive ? "border-primary/40 bg-primary/5" : "border-border bg-background hover:bg-accent/40",
@@ -932,3 +933,6 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
     </div>
   );
 }
+  function leaseSandboxId(lease: UserLeaseSummary): string {
+    return String(lease.sandbox_id || "").trim() || lease.lease_id;
+  }

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -15,10 +15,12 @@ def _lease_row(
     desired_state: str = "running",
     created_at: str = "2026-04-07T10:00:00Z",
     cwd: str = "/tmp/app",
+    sandbox_id: str | None = None,
     **extra,
 ):
     return {
         "lease_id": lease_id,
+        "sandbox_id": sandbox_id or lease_id.replace("lease", "sandbox", 1),
         "provider_name": provider_name,
         "recipe_id": recipe_id or f"{provider_name}:default",
         "recipe_json": None,
@@ -196,6 +198,7 @@ def test_list_user_leases_visible_thread_contract(
     assert len(leases) == 1
     lease = leases[0]
     assert lease["lease_id"] == "lease-1"
+    assert lease["sandbox_id"] == "sandbox-1"
     assert lease["thread_ids"] == expected_thread_ids
     assert lease["agents"] == expected_agents
     assert lease["recipe_id"] == expected_recipe_id


### PR DESCRIPTION
## Summary
- expose sandbox ids on user lease summaries from the backend lease shell
- use sandbox-shaped ids throughout existing-sandbox default-config persistence in NewChatPage
- cover both the backend lease contract and the frontend persist flow with regressions

## Verification
- `./.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_user_leases.py -k visible_thread_contract` -> 2 passed, 13 deselected
- `cd frontend/app && npm test -- --run src/pages/NewChatPage.test.tsx` -> 12 passed
- `cd frontend/app && npm run lint`
- `cd frontend/app && npm run build`
- `git diff --check origin/dev...HEAD`
- Playwright CLI YATU on rebased branch backend: cold open `/chat/hire/new/m_dKjuBBLbR1bw` -> `配置` -> `Existing sandbox` -> `下一步` -> select existing sandbox -> `确认`; observed `/api/threads/default-config` status 200, backend log `POST /api/threads/default-config` 200, console errors 0

## Rebase
- Updated onto `origin/dev` after #671 at `63a6cfac`; branch head is `fa847286`.