### PR TITLE
fix: honor legacy skill-template marketplace tab

### DIFF
--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -27,6 +27,7 @@ function isTab(value: string | null): value is Tab {
 
 function normalizeInstalledSubTab(value: string | null): InstalledSubTab | null {
   if (value === "subagent") return "agent";
+  if (value === "skill-template") return "skill";
   if (value === "sandbox") return "sandbox-template";
   if (value === "agent-user" || value === "skill" || value === "agent" || value === "sandbox-template") return value;
   return null;

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -165,6 +165,19 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
   });
 
+  it("treats legacy installed skill-template query key as the Skill tab", () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=skill-template"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
+    expect(screen.getByText("暂无已安装的 Skill")).toBeTruthy();
+  });
+
   it("treats legacy installed sandbox query key as the Sandbox tab", () => {
     render(
       <MemoryRouter initialEntries={["/marketplace?tab=installed&sub=sandbox"]}>


### PR DESCRIPTION
## Summary
- normalize legacy installed marketplace sub=skill-template to the canonical skill tab
- add a wording regression so the installed skill tab no longer exposes the agent-only update action

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplacePage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI: /marketplace?tab=installed&sub=skill-template no longer shows 检查更新