### PR TITLE
fix: use canonical sandbox installed return key

### DIFF
--- a/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
@@ -144,7 +144,7 @@ describe("LibraryItemDetailPage", () => {
 
     await waitFor(() => {
       expect(deleteResource).toHaveBeenCalledWith("sandbox-template", "daytona:custom");
-      expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=installed&sub=sandbox");
+      expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=installed&sub=sandbox-template");
     });
   });
 });

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -123,7 +123,7 @@ export default function LibraryItemDetailPage() {
         )}
 
         {isSandboxTemplate && item ? (
-          <SandboxTemplateEditor item={item} onDeleted={() => navigate("/marketplace?tab=installed&sub=sandbox")} />
+          <SandboxTemplateEditor item={item} onDeleted={() => navigate("/marketplace?tab=installed&sub=sandbox-template")} />
         ) : (
           <div className="surface-card p-4">
           <div className="flex items-center gap-2 mb-3">


### PR DESCRIPTION
## Summary
- return sandbox detail deletions to the canonical installed sandbox route key
- stop emitting the legacy sub=sandbox contract from the sandbox detail page

## Verification
- cd frontend/app && npm test -- --run src/pages/LibraryItemDetailPage.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check