### PR TITLE
fix: use canonical installed routes for library back

### DIFF
--- a/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
@@ -43,7 +43,14 @@ describe("LibraryItemDetailPage", () => {
         created_at: 1,
         updated_at: 1,
       }],
-      librarySkills: [],
+      librarySkills: [{
+        id: "skill-lib-1",
+        name: "Skill One",
+        desc: "skill desc",
+        type: "skill",
+        created_at: 1,
+        updated_at: 1,
+      }],
       librarySandboxTemplates: [{
         id: "daytona:default",
         name: "Daytona Default",
@@ -66,6 +73,53 @@ describe("LibraryItemDetailPage", () => {
       fetchResourceContent,
       updateResource,
     });
+  });
+
+  it("uses the canonical installed route for the back button on sandbox detail pages", async () => {
+    render(
+      <MemoryRouter initialEntries={["/library/sandbox-template/daytona:default"]}>
+        <Routes>
+          <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Daytona Default" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=installed&sub=sandbox-template");
+  });
+
+  it("uses the canonical installed route for the back button on agent detail pages", async () => {
+    render(
+      <MemoryRouter initialEntries={["/library/agent/agent-lib-1"]}>
+        <Routes>
+          <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Explorer" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=installed&sub=agent");
+  });
+
+  it("uses the canonical installed route for the back button on skill detail pages", async () => {
+    fetchResourceContent.mockResolvedValue("# Skill doc");
+
+    render(
+      <MemoryRouter initialEntries={["/library/skill/skill-lib-1"]}>
+        <Routes>
+          <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Skill One" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=installed&sub=skill");
   });
 
   it("uses bootstrapped library state instead of refetching the whole list", async () => {

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -11,6 +11,12 @@ function detailLibraryType(value: string | undefined): DetailLibraryType | null 
   return value === "skill" || value === "agent" || value === "sandbox-template" ? value : null;
 }
 
+function installedDetailReturnTarget(type: DetailLibraryType | null): string {
+  if (type === "skill") return "/marketplace?tab=installed&sub=skill";
+  if (type === "agent") return "/marketplace?tab=installed&sub=agent";
+  return "/marketplace?tab=installed&sub=sandbox-template";
+}
+
 export default function LibraryItemDetailPage() {
   const { type, id } = useParams<{ type: string; id: string }>();
   const navigate = useNavigate();
@@ -94,7 +100,7 @@ export default function LibraryItemDetailPage() {
       <div className="max-w-3xl mx-auto py-6 px-4 md:px-6">
         {/* Back */}
         <button
-          onClick={() => navigate(-1)}
+          onClick={() => navigate(installedDetailReturnTarget(libraryType))}
           className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors duration-fast mb-6"
         >
           <ArrowLeft className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary
- route library detail back actions to canonical installed marketplace tabs by library type
- stop relying on browser history for direct-open library detail pages

## Verification
- cd frontend/app && npm test -- --run src/pages/LibraryItemDetailPage.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI: direct-open /library/sandbox-template/daytona:default then click 返回 lands on /marketplace?tab=installed&sub=sandbox-template with console Errors: 0