### PR TITLE
fix: use contacts route for agent detail back

### DIFF
--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -217,7 +217,7 @@ export default function AgentDetail() {
     <div className="h-full flex flex-col">
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b shrink-0">
-        <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+        <Button variant="ghost" size="icon" onClick={() => navigate("/contacts")}>
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <Bot className="h-5 w-5 text-primary" />

--- a/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
@@ -14,6 +14,18 @@ const { getAgentById, fetchAgent, updateAgent, updateAgentConfig } = vi.hoisted(
   updateAgentConfig: vi.fn(),
 }));
 
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
 const agentFixture = {
   id: "agent-1",
   name: "Agent One",
@@ -65,6 +77,22 @@ describe("AgentDetailPage wording contract", () => {
   beforeEach(() => {
     getAgentById.mockReturnValue(agentFixture);
     fetchAgent.mockResolvedValue(agentFixture);
+    navigateMock.mockReset();
+  });
+
+  it("uses the contacts page as the back target for direct-open agent detail", async () => {
+    render(
+      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
+        <Routes>
+          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Agent One")).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    expect(navigateMock).toHaveBeenCalledWith("/contacts");
   });
 
   it("uses Agent wording for the subagent module label", () => {


### PR DESCRIPTION
## Summary
- route agent detail back actions to the canonical contacts page
- stop relying on browser history for direct-open agent detail pages

## Verification
- cd frontend/app && npm test -- --run src/pages/AgentDetailPage.wording.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI: direct-open /contacts/agents/m_dKjuBBLbR1bw then click back lands on /contacts with console Errors: 0