### PR TITLE
fix: use contacts tab for contact detail back

### DIFF
--- a/frontend/app/src/pages/contacts/ContactDetailPage.test.tsx
+++ b/frontend/app/src/pages/contacts/ContactDetailPage.test.tsx
@@ -43,6 +43,34 @@ describe("ContactDetailPage", () => {
     navigate.mockReset();
   });
 
+  it("uses the contacts tab as the back target for direct-open contact detail", async () => {
+    authFetch.mockResolvedValueOnce(okJson([
+      {
+        user_id: "human-2",
+        name: "Ada",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "visit",
+        can_chat: true,
+      },
+    ]));
+
+    render(
+      <MemoryRouter initialEntries={["/contacts/users/human-2"]}>
+        <Routes>
+          <Route path="/contacts/users/:userId" element={<ContactDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Ada" })).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    expect(navigate).toHaveBeenCalledWith("/contacts/users");
+  });
+
   it("renders a contact profile from the user candidate surface without leaking agent config panels", async () => {
     authFetch.mockResolvedValueOnce(okJson([
       {

--- a/frontend/app/src/pages/contacts/ContactDetailPage.tsx
+++ b/frontend/app/src/pages/contacts/ContactDetailPage.tsx
@@ -100,7 +100,7 @@ export default function ContactDetailPage() {
   return (
     <div className="h-full flex flex-col bg-background">
       <div className="flex items-center gap-3 px-4 py-3 border-b shrink-0">
-        <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+        <Button variant="ghost" size="icon" onClick={() => navigate("/contacts/users")}>
           <ArrowLeft className="h-4 w-4" />
         </Button>
         {isAgent ? <Bot className="h-5 w-5 text-primary" /> : <User className="h-5 w-5 text-primary" />}


### PR DESCRIPTION
## Summary
- route contact detail back actions to the canonical contacts tab
- stop relying on browser history for direct-open contact detail pages

## Verification
- cd frontend/app && npm test -- --run src/pages/contacts/ContactDetailPage.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check
- Playwright CLI: direct-open /contacts/users/m_dWeAuzVyw3QS then click back lands on /contacts/users with console Errors: 0