### PR TITLE
fix: use explore route for marketplace detail back

### DIFF
--- a/frontend/app/src/pages/MarketplaceDetailPage.test.tsx
+++ b/frontend/app/src/pages/MarketplaceDetailPage.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import MarketplaceDetailPage from "./MarketplaceDetailPage";
+
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock("@/components/marketplace/LineageTree", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/marketplace/InstallDialog", () => ({
+  default: () => null,
+}));
+
+const marketplaceState = {
+  detail: {
+    id: "item-1",
+    slug: "item-one",
+    type: "skill",
+    name: "Skill One",
+    description: "skill description",
+    avatar_url: null,
+    publisher_user_id: "publisher-1",
+    publisher_username: "owner",
+    parent_id: null,
+    download_count: 0,
+    visibility: "public",
+    featured: false,
+    tags: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    versions: [],
+    parent: null,
+  },
+  detailLoading: false,
+  fetchDetail: vi.fn(),
+  lineage: { ancestors: [], children: [] },
+  fetchLineage: vi.fn(),
+  clearDetail: vi.fn(),
+  error: null,
+  versionSnapshot: null,
+  snapshotLoading: false,
+  fetchVersionSnapshot: vi.fn(),
+  clearSnapshot: vi.fn(),
+};
+
+vi.mock("@/store/marketplace-store", () => ({
+  useMarketplaceStore: (selector: (state: typeof marketplaceState) => unknown) => selector(marketplaceState),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("MarketplaceDetailPage", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+  });
+
+  it("uses the marketplace explore route as the back target for direct-open detail", async () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace/item-1"]}>
+        <Routes>
+          <Route path="/marketplace/:id" element={<MarketplaceDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Skill One" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=explore");
+  });
+});

--- a/frontend/app/src/pages/MarketplaceDetailPage.tsx
+++ b/frontend/app/src/pages/MarketplaceDetailPage.tsx
@@ -70,7 +70,7 @@ export default function MarketplaceDetailPage() {
       <div className="max-w-3xl mx-auto py-6 px-4 md:px-6">
         {/* Back button */}
         <button
-          onClick={() => navigate(-1)}
+          onClick={() => navigate("/marketplace?tab=explore")}
           className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors duration-fast mb-6"
         >
           <ArrowLeft className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary
- route marketplace detail back actions to the canonical explore marketplace route
- stop relying on browser history for direct-open marketplace detail pages

## Verification
- cd frontend/app && npm test -- --run src/pages/MarketplaceDetailPage.test.tsx
- cd frontend/app && npm run lint
- cd frontend/app && npm run build
- git diff --check

## YATU note
- Attempted direct-open marketplace detail in Playwright CLI, but the local product path is currently blocked by existing Marketplace Hub 503s on /api/marketplace/items/:id and /lineage. No product success claim is made for that blocked path.