### PR TITLE
fix: send sandbox id for existing sandbox threads

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -74,14 +74,14 @@ describe("thread api client contract", () => {
     await api.createThread({
       sandbox: "local",
       agentUserId: "agent-1",
-      existingSandboxId: "lease-1",
+      existingSandboxId: "sandbox-1",
     });
 
     expect(authFetch).toHaveBeenCalledWith(
       "/api/threads",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ sandbox: "local", agent_user_id: "agent-1", existing_sandbox_id: "lease-1" }),
+        body: JSON.stringify({ sandbox: "local", agent_user_id: "agent-1", existing_sandbox_id: "sandbox-1" }),
       }),
     );
   });
@@ -192,7 +192,7 @@ describe("thread api client contract", () => {
     await api.saveDefaultThreadConfig("agent-1", {
       create_mode: "existing",
       provider_config: "daytona_selfhost",
-      existing_sandbox_id: "lease-1",
+      existing_sandbox_id: "sandbox-1",
       model: "gpt-5.4",
       workspace: "/workspace/reused",
     });
@@ -205,7 +205,7 @@ describe("thread api client contract", () => {
           agent_user_id: "agent-1",
           create_mode: "existing",
           provider_config: "daytona_selfhost",
-          existing_sandbox_id: "lease-1",
+          existing_sandbox_id: "sandbox-1",
           model: "gpt-5.4",
           workspace: "/workspace/reused",
         }),

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -498,7 +498,7 @@ describe("NewChatPage", () => {
       config: {
         create_mode: "existing",
         provider_config: "daytona_selfhost",
-        existing_sandbox_id: "lease-2",
+        existing_sandbox_id: "sandbox-2",
         model: "leon:large",
         workspace: "/workspace/reused-2",
       },
@@ -506,6 +506,7 @@ describe("NewChatPage", () => {
     clientMocks.listMyLeases.mockResolvedValue([
       {
         lease_id: "lease-1",
+        sandbox_id: "sandbox-1",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-1",
         recipe_name: "Existing One",
@@ -517,6 +518,7 @@ describe("NewChatPage", () => {
       },
       {
         lease_id: "lease-2",
+        sandbox_id: "sandbox-2",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-2",
         recipe_name: "Existing Two",
@@ -548,7 +550,7 @@ describe("NewChatPage", () => {
         undefined,
         "m_xVuNpKJNxblZ",
         "leon:large",
-        "lease-2",
+        "sandbox-2",
       );
     });
   });

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -391,7 +391,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
         undefined,
         decodedAgentId,
         model,
-        selectedLease.lease_id,
+        leaseSandboxId(selectedLease),
       );
     } else {
       if (!selectedSandboxTemplateSnapshot) {

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -1150,7 +1150,7 @@ async def test_save_default_thread_config_runs_sync_repo_work_off_event_loop(mon
 
 
 @pytest.mark.asyncio
-async def test_save_default_thread_config_accepts_sandbox_shaped_existing_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_save_default_thread_config_rejects_lease_shaped_existing_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     app = _make_threads_app()
     payload = threads_router.SaveThreadLaunchConfigRequest(
         agent_user_id="agent-user-1",


### PR DESCRIPTION
## Summary
- send the selected sandbox-shaped id when creating a thread from an existing sandbox
- update frontend API/NewChat tests to use sandbox-shaped `existing_sandbox_id` examples
- rename the backend route test that intentionally rejects lease-shaped existing identities

## Verification
- RED: `npm test -- --run src/api/client.test.ts src/pages/NewChatPage.test.tsx` failed because NewChatPage still passed `lease-2` to `handleCreateThread`
- GREEN: `npm test -- --run src/api/client.test.ts src/pages/NewChatPage.test.tsx` -> 39 passed
- `uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py -k "default_thread_config or save_default_thread_config"` -> 8 passed
- `npm run lint`
- `uv run ruff check tests/Integration/test_thread_launch_config_contract.py && uv run ruff format --check tests/Integration/test_thread_launch_config_contract.py`
- `npm run build`
- `git diff --check`
- Playwright CLI YATU: `/chat/hire/new/m_dKjuBBLbR1bw` -> `配置` -> `Existing sandbox` -> select existing sandbox -> `确认` -> send message; observed `/api/threads` POST body with `existing_sandbox_id":"sandbox-f6ecdcb8a7ac5fd6a61c2e97c8a970c0"` and response 200; console errors 0

## Notes
- Playwright generated transient `.playwright-cli` files during YATU; removed before commit.