### PR TITLE
fix: require sandbox ids on lease summaries

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -311,11 +311,27 @@ describe("thread api client contract", () => {
     authFetch.mockResolvedValue(okJson({
       leases: [{
         lease_id: "lease-1",
+        sandbox_id: "sandbox-1",
         provider_name: "local",
         recipe_id: "recipe-1",
         recipe_name: "Local",
         thread_ids: ["thread-1"],
         agents: [{ thread_id: { value: "thread-1" }, agent_name: "Toad" }],
+      }],
+    }));
+
+    await expect(api.listMyLeases()).rejects.toThrow("Malformed user leases");
+  });
+
+  it("listMyLeases rejects lease summaries without sandbox identities", async () => {
+    authFetch.mockResolvedValue(okJson({
+      leases: [{
+        lease_id: "lease-1",
+        provider_name: "local",
+        recipe_id: "recipe-1",
+        recipe_name: "Local",
+        thread_ids: ["thread-1"],
+        agents: [{ thread_id: "thread-1", agent_name: "Toad" }],
       }],
     }));
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -398,7 +398,7 @@ function parseUserLeases(value: unknown): UserLeaseSummary[] {
   return leases.map((lease) => {
     const data = asRecord(lease);
     const lease_id = data ? recordString(data, "lease_id") : undefined;
-    const sandbox_id = data?.sandbox_id;
+    const sandbox_id = data ? recordString(data, "sandbox_id") : undefined;
     const provider_name = data ? recordString(data, "provider_name") : undefined;
     const recipe_id = data ? recordString(data, "recipe_id") : undefined;
     const recipe_name = data ? recordString(data, "recipe_name") : undefined;
@@ -407,7 +407,7 @@ function parseUserLeases(value: unknown): UserLeaseSummary[] {
     if (
       !data ||
       !lease_id ||
-      !isStringOrNullish(sandbox_id) ||
+      !sandbox_id ||
       !provider_name ||
       !recipe_id ||
       !recipe_name ||

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -158,7 +158,7 @@ export interface AccountResourceLimit {
 
 export interface UserLeaseSummary {
   lease_id: string;
-  sandbox_id?: string | null;
+  sandbox_id: string;
   provider_name: string;
   recipe_id: string;
   recipe_name: string;

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -934,5 +934,5 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
   );
 }
   function leaseSandboxId(lease: UserLeaseSummary): string {
-    return String(lease.sandbox_id || "").trim() || lease.lease_id;
+    return lease.sandbox_id;
   }


### PR DESCRIPTION
## Summary
- make `UserLeaseSummary.sandbox_id` required in the frontend contract
- reject `/api/sandbox/leases/mine` responses that omit sandbox identities
- remove the NewChatPage fallback from sandbox id to lease id

## Verification
- RED: `npm test -- --run src/api/client.test.ts -t "listMyLeases rejects lease summaries without sandbox identities"` failed because missing `sandbox_id` was accepted
- GREEN: `npm test -- --run src/api/client.test.ts src/pages/NewChatPage.test.tsx` -> 40 passed
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes
- This is the frontend fail-loud follow-up to the sandbox-shaped existing sandbox contract merged in #664/#672.