### PR TITLE
fix: keep provider switch sandbox ids shaped

### DIFF
--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -125,6 +125,7 @@ describe("NewChatPage", () => {
   });
 
   beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
     handleGetDefaultThread.mockReset();
     handleGetDefaultThread.mockResolvedValue(null);
     handleCreateThread.mockReset();
@@ -615,6 +616,96 @@ describe("NewChatPage", () => {
           create_mode: "existing",
           existing_sandbox_id: "sandbox-2",
           workspace: "/workspace/reused-2",
+        }),
+      );
+    });
+  });
+
+  it("keeps provider-switch defaults sandbox-shaped when reselecting an existing lease", async () => {
+    sandboxTypesForTest = [
+      { name: "daytona_selfhost", provider: "daytona", available: true },
+      { name: "local", provider: "local", available: true },
+    ];
+    clientMocks.fetchAccountResourceLimits.mockResolvedValue([
+      {
+        resource: "sandbox",
+        provider_name: "daytona_selfhost",
+        label: "Daytona",
+        limit: 2,
+        used: 1,
+        remaining: 1,
+        can_create: true,
+      },
+      {
+        resource: "sandbox",
+        provider_name: "local",
+        label: "Local",
+        limit: 2,
+        used: 1,
+        remaining: 1,
+        can_create: true,
+      },
+    ]);
+    clientMocks.getDefaultThreadConfig.mockResolvedValue({
+      source: "derived",
+      config: {
+        create_mode: "existing",
+        provider_config: "daytona_selfhost",
+        existing_sandbox_id: "sandbox-daytona",
+        model: "leon:large",
+        workspace: "/workspace/daytona",
+      },
+    });
+    clientMocks.listMyLeases.mockResolvedValue([
+      {
+        lease_id: "lease-daytona",
+        sandbox_id: "sandbox-daytona",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-daytona",
+        recipe_name: "Daytona Existing",
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/daytona",
+        thread_ids: [],
+        agents: [],
+      } as UserLeaseSummary,
+      {
+        lease_id: "lease-local",
+        sandbox_id: "sandbox-local",
+        provider_name: "local",
+        recipe_id: "recipe-local",
+        recipe_name: "Local Existing",
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/local",
+        thread_ids: [],
+        agents: [],
+      } as UserLeaseSummary,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("centered-input-box");
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    fireEvent.click(await screen.findByRole("option", { name: "Local" }));
+    fireEvent.click(screen.getByRole("button", { name: "下一步" }));
+    fireEvent.click(screen.getByRole("button", { name: "确认" }));
+
+    await waitFor(() => {
+      expect(clientMocks.saveDefaultThreadConfig).toHaveBeenCalledWith(
+        "m_xVuNpKJNxblZ",
+        expect.objectContaining({
+          create_mode: "existing",
+          existing_sandbox_id: "sandbox-local",
+          workspace: "/workspace/local",
         }),
       );
     });

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -703,13 +703,13 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                             const nextProviderType = providerConfigOptions.find((item) => item.value === nextProviderConfig)?.providerType
                               || providerTypeFromName(nextProviderConfig);
                             setSelectedProviderConfig(nextProviderConfig);
-                          const nextSandboxTemplates = sandboxTemplateOptions.filter((item) => item.sandboxTemplate.provider_type === nextProviderType);
-                          if (nextSandboxTemplates.length > 0 && !nextSandboxTemplates.some((item) => item.value === selectedSandboxTemplateId)) {
-                            setSelectedSandboxTemplateId(nextSandboxTemplates[0].value);
-                          }
+                            const nextSandboxTemplates = sandboxTemplateOptions.filter((item) => item.sandboxTemplate.provider_type === nextProviderType);
+                            if (nextSandboxTemplates.length > 0 && !nextSandboxTemplates.some((item) => item.value === selectedSandboxTemplateId)) {
+                              setSelectedSandboxTemplateId(nextSandboxTemplates[0].value);
+                            }
                             const nextLease = leaseOptions.find((lease) => lease.provider_name === nextProviderConfig);
                             if (createMode === "existing") {
-                              setSelectedExistingSandboxId(nextLease?.lease_id || "");
+                              setSelectedExistingSandboxId(nextLease ? leaseSandboxId(nextLease) : "");
                             }
                           }}
                         >


### PR DESCRIPTION
## Summary
- keep provider switch reselection on sandbox-shaped ids for existing leases
- preserve workspace lookup by selecting the matching sandbox id instead of the lease id
- add a regression test for switching providers in existing-sandbox mode

## Verification
- RED: `npm test -- --run src/pages/NewChatPage.test.tsx -t "keeps provider-switch defaults sandbox-shaped"` failed with `existing_sandbox_id: "lease-local"` and `workspace: null`
- GREEN: `npm test -- --run src/pages/NewChatPage.test.tsx -t "keeps provider-switch defaults sandbox-shaped"`
- `npm test -- --run src/pages/NewChatPage.test.tsx src/api/client.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`