### PR TITLE
fix: block stale existing sandbox defaults

### DIFF
--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -711,6 +711,51 @@ describe("NewChatPage", () => {
     });
   });
 
+  it("blocks saving an existing-sandbox default when the configured sandbox id is not in my leases", async () => {
+    clientMocks.getDefaultThreadConfig.mockResolvedValue({
+      source: "last_successful",
+      config: {
+        create_mode: "existing",
+        provider_config: "daytona_selfhost",
+        existing_sandbox_id: "sandbox-missing",
+        model: "leon:large",
+        workspace: "/workspace/missing",
+      },
+    });
+    clientMocks.listMyLeases.mockResolvedValue([
+      {
+        lease_id: "lease-1",
+        sandbox_id: "sandbox-1",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-1",
+        recipe_name: "Existing One",
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/reused-1",
+        thread_ids: [],
+        agents: [],
+      } as UserLeaseSummary,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("centered-input-box");
+    fireEvent.click(screen.getByRole("button", { name: "下一步" }));
+
+    const confirm = screen.getByRole("button", { name: "确认" }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+    fireEvent.click(confirm);
+    expect(clientMocks.saveDefaultThreadConfig).not.toHaveBeenCalled();
+  });
+
   it("blocks advancing a new sandbox selection when backend account resources say the provider is exhausted", async () => {
     sandboxTypesForTest = [{ name: "daytona_selfhost", provider: "daytona", available: true }];
     clientMocks.fetchAccountResourceLimits.mockResolvedValue([

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -596,7 +596,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
             panelClassName: "max-h-[calc(100vh-4rem)]",
             applyLabel: configStep === 3 ? "确认" : (configStep === 1 ? "下一步" : (localSandboxTemplateSelected ? "下一步" : "确认")),
             applyDisabled: (configStep === 1 && (newSandboxQuotaBlocked || newSandboxProviderUnavailable))
-              || (configStep === 2 && createMode === "existing" && !selectedExistingSandboxId),
+              || (configStep === 2 && createMode === "existing" && !selectedLease),
             showBack: configStep > 1,
             backLabel: "返回上一步",
             onBack: stepBack,


### PR DESCRIPTION
## Summary
- prevent the existing-sandbox config flow from saving a stale `existing_sandbox_id` that is not present in the current lease list
- require the selected sandbox id to resolve to a real `UserLeaseSummary` before confirming step 2
- add a regression test for stale default-config sandbox ids

## Verification
- RED: `npm test -- --run src/pages/NewChatPage.test.tsx -t "blocks saving an existing-sandbox default"` failed because the confirm button was enabled
- GREEN: `npm test -- --run src/pages/NewChatPage.test.tsx -t "blocks saving an existing-sandbox default"`
- `npm test -- --run src/pages/NewChatPage.test.tsx src/api/client.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`