### PR TITLE
fix: allow sandbox detail without lease bridge

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -596,8 +596,6 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
     if sandbox is None:
         raise KeyError(f"Sandbox not found: {sandbox_id}")
     lease_id = str(sandbox.get("lease_id") or "").strip()
-    if not lease_id:
-        raise RuntimeError("monitor sandbox detail target missing lease bridge")
 
     threads = repo.query_sandbox_threads(sandbox_id)
     sessions = repo.query_sandbox_sessions(sandbox_id)
@@ -645,7 +643,7 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
             }
             for item in sessions
         ],
-        "cleanup": monitor_operation_service.build_lease_cleanup_truth(
+        "cleanup": _sandbox_detail_cleanup_truth(
             lease_id=lease_id,
             triage=triage,
             provider_name=provider_name,
@@ -664,6 +662,33 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
             threads=live_thread_refs,
         ),
     }
+
+
+def _sandbox_detail_cleanup_truth(
+    *,
+    lease_id: str,
+    triage: dict[str, Any],
+    provider_name: str,
+    runtime_session_id: str | None,
+    sessions: list[dict[str, Any]],
+    threads: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if not lease_id:
+        return {
+            "allowed": False,
+            "recommended_action": None,
+            "reason": "Sandbox has no lease bridge and cannot enter managed cleanup.",
+            "operation": None,
+            "recent_operations": [],
+        }
+    return monitor_operation_service.build_lease_cleanup_truth(
+        lease_id=lease_id,
+        triage=triage,
+        provider_name=provider_name,
+        runtime_session_id=runtime_session_id,
+        sessions=sessions,
+        threads=threads,
+    )
 
 
 def get_monitor_sandbox_detail(sandbox_id: str) -> dict[str, Any]:

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -587,6 +587,30 @@ def test_get_monitor_sandbox_detail_exposes_cleanup_state(monkeypatch):
     assert payload["cleanup"] == _cleanup_state("Lease is orphan cleanup residue and can enter managed cleanup.")
 
 
+def test_get_monitor_sandbox_detail_allows_missing_lease_bridge_for_readonly_detail(monkeypatch):
+    _use_monitor_repo(
+        monkeypatch,
+        FakeLeaseRepo(
+            lease=_lease_row(lease_id=None, provider_name="local", observed_state="running", desired_state="running"),
+            threads=[],
+            sessions=[],
+            runtime_session_id="runtime-1",
+        ),
+    )
+
+    payload = monitor_service.get_monitor_sandbox_detail("sandbox-1")
+
+    assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
+    assert payload["runtime"]["runtime_session_id"] == "runtime-1"
+    assert payload["cleanup"] == {
+        "allowed": False,
+        "recommended_action": None,
+        "reason": "Sandbox has no lease bridge and cannot enter managed cleanup.",
+        "operation": None,
+        "recent_operations": [],
+    }
+
+
 def test_get_monitor_lease_detail_exposes_cleanup_state(monkeypatch):
     _use_monitor_repo(monkeypatch, FakeLeaseRepo(lease=_detached_lease()))
 


### PR DESCRIPTION
## Summary
- allow monitor sandbox detail to render a sandbox row even when it has no legacy lease bridge
- keep cleanup unavailable for no-lease-bridge sandboxes instead of routing them into lease cleanup truth
- add regression coverage for the stale legacy-bridge read-contract cut

## Verification
- RED: `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py -k "missing_lease_bridge_for_readonly_detail" -q` failed with `RuntimeError: monitor sandbox detail target missing lease bridge` before the fix
- GREEN: `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py -k "missing_lease_bridge_for_readonly_detail" -q` -> 1 passed, 44 deselected
- `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py -q` -> 74 passed
- `uv run python -m pytest tests/Integration/test_monitor_resources_route.py -q` -> 34 passed
- `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Integration/test_monitor_resources_route.py -q` -> 108 passed
- `uv run ruff check . && uv run ruff format --check .`
- `git diff --check`