### PR TITLE
test: drop dead terminal client mock

### DIFF
--- a/frontend/app/src/components/computer-panel/use-remote-workspace-root.test.tsx
+++ b/frontend/app/src/components/computer-panel/use-remote-workspace-root.test.tsx
@@ -4,20 +4,17 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRemoteWorkspaceRoot } from "./use-remote-workspace-root";
 
-const { getThreadFileChannel, getThreadTerminal } = vi.hoisted(() => ({
+const { getThreadFileChannel } = vi.hoisted(() => ({
   getThreadFileChannel: vi.fn(),
-  getThreadTerminal: vi.fn(),
 }));
 
 vi.mock("../../api", () => ({
   getThreadFileChannel,
-  getThreadTerminal,
 }));
 
 describe("useRemoteWorkspaceRoot", () => {
   beforeEach(() => {
     getThreadFileChannel.mockReset();
-    getThreadTerminal.mockReset();
   });
 
   it("reads remote workspace root from file channel binding instead of terminal state", async () => {
@@ -32,6 +29,5 @@ describe("useRemoteWorkspaceRoot", () => {
 
     await expect(view.result.current.refreshWorkspaceRoot()).resolves.toBe("/workspace");
     expect(getThreadFileChannel).toHaveBeenCalledWith("thread-1");
-    expect(getThreadTerminal).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- remove the stale `getThreadTerminal` test mock from `useRemoteWorkspaceRoot` after the thread terminal route/client removal
- keep the test focused on the current file-channel workspace-root contract

## Verification
- `cd frontend/app && npm test -- --run src/components/computer-panel/use-remote-workspace-root.test.tsx src/api/client.test.ts` -> 31 passed
- `rg "getThreadTerminal|fetchThreadTerminal|ThreadTerminal|/api/threads/.*/terminal|/terminal\b|/session\b|getThreadSession|fetchThreadSession|ThreadSession" frontend/app/src backend tests -n` -> only negative route/API assertions and non-route session/terminal wording remain
- `cd frontend/app && npm run lint`
- `cd frontend/app && npm run build`
- `git diff --check`