### PR TITLE
fix: pin langgraph checkpoints to agent schema

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -52,10 +52,10 @@ async def lifespan(app: FastAPI):
     )
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
-    from core.runtime.langgraph_checkpoint_store import LangGraphCheckpointStore
+    from core.runtime.langgraph_checkpoint_store import LangGraphCheckpointStore, agent_checkpoint_conn_string
 
     pg_url = os.environ["LEON_POSTGRES_URL"]
-    app.state._thread_checkpoint_saver_ctx = AsyncPostgresSaver.from_conn_string(pg_url)
+    app.state._thread_checkpoint_saver_ctx = AsyncPostgresSaver.from_conn_string(agent_checkpoint_conn_string(pg_url))
     app.state._thread_checkpoint_saver = await app.state._thread_checkpoint_saver_ctx.__aenter__()
     await app.state._thread_checkpoint_saver.setup()
     app.state.thread_checkpoint_store = LangGraphCheckpointStore(app.state._thread_checkpoint_saver)

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1344,9 +1344,11 @@ class LeonAgent:
 
         from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
+        from core.runtime.langgraph_checkpoint_store import agent_checkpoint_conn_string
+
         # from_conn_string is an async context manager; enter it and keep
         # the reference so the connection pool stays open for the agent's lifetime.
-        self._pg_saver_ctx = AsyncPostgresSaver.from_conn_string(pg_url)
+        self._pg_saver_ctx = AsyncPostgresSaver.from_conn_string(agent_checkpoint_conn_string(pg_url))
         self.checkpointer = await self._pg_saver_ctx.__aenter__()
         await self.checkpointer.setup()
 

--- a/core/runtime/langgraph_checkpoint_store.py
+++ b/core/runtime/langgraph_checkpoint_store.py
@@ -2,8 +2,30 @@ from __future__ import annotations
 
 import inspect
 from typing import Any, cast
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
 
 from .checkpoint_store import ThreadCheckpointState
+
+
+def agent_checkpoint_conn_string(conn_string: str) -> str:
+    parts = urlsplit(conn_string)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    merged_query: list[tuple[str, str]] = []
+    saw_options = False
+    for key, value in query:
+        if key != "options":
+            merged_query.append((key, value))
+            continue
+        saw_options = True
+        if "search_path" in value:
+            if "search_path=agent" not in value:
+                raise RuntimeError("LEON_POSTGRES_URL must not set checkpointer search_path outside Mycel runtime")
+            merged_query.append((key, value))
+        else:
+            merged_query.append((key, f"{value} -csearch_path=agent"))
+    if not saw_options:
+        merged_query.append(("options", "-csearch_path=agent"))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(merged_query, quote_via=quote), parts.fragment))
 
 
 class LangGraphCheckpointStore:

--- a/tests/Unit/core/test_langgraph_checkpoint_store.py
+++ b/tests/Unit/core/test_langgraph_checkpoint_store.py
@@ -1,0 +1,19 @@
+from core.runtime.langgraph_checkpoint_store import agent_checkpoint_conn_string
+
+
+def test_agent_checkpoint_conn_string_adds_agent_search_path() -> None:
+    conn = agent_checkpoint_conn_string("postgresql://user:pass@db.example/postgres")
+
+    assert conn == "postgresql://user:pass@db.example/postgres?options=-csearch_path%3Dagent"
+
+
+def test_agent_checkpoint_conn_string_preserves_existing_query_params() -> None:
+    conn = agent_checkpoint_conn_string("postgresql://user:pass@db.example/postgres?sslmode=require")
+
+    assert conn == "postgresql://user:pass@db.example/postgres?sslmode=require&options=-csearch_path%3Dagent"
+
+
+def test_agent_checkpoint_conn_string_merges_existing_libpq_options() -> None:
+    conn = agent_checkpoint_conn_string("postgresql://user:pass@db.example/postgres?options=-cstatement_timeout%3D5000")
+
+    assert conn == "postgresql://user:pass@db.example/postgres?options=-cstatement_timeout%3D5000%20-csearch_path%3Dagent"


### PR DESCRIPTION
## Summary
- pin LangGraph Postgres checkpointer connections to the agent schema via libpq search_path
- apply the same connection shaping in web lifespan and LeonAgent checkpointer init
- add unit coverage for connection strings with no query, existing query params, and existing libpq options

## Evidence
- uv run python -m pytest tests/Unit/core/test_runtime_agent.py tests/Unit/storage/test_supabase_checkpoint_repo.py tests/Unit/core/test_langgraph_checkpoint_store.py
- uv run ruff check backend/web/core/lifespan.py core/runtime/agent.py core/runtime/langgraph_checkpoint_store.py tests/Unit/core/test_langgraph_checkpoint_store.py
- uv run ruff format --check backend/web/core/lifespan.py core/runtime/agent.py core/runtime/langgraph_checkpoint_store.py tests/Unit/core/test_langgraph_checkpoint_store.py
- git diff --check

## DB note
Fresh real DB audit showed public.checkpoints/checkpoint_blobs/checkpoint_migrations had reappeared after the earlier public purge. This patch closes the app-side leak; public cleanup should happen after this lands on dev.