### PR TITLE
Fix runtime cleanup without local sandbox db

### DIFF
--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -8,10 +8,20 @@ from fastapi import HTTPException
 from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
 from storage.container import StorageContainer
-from storage.runtime import build_chat_session_repo as make_chat_session_repo
-from storage.runtime import build_lease_repo as make_lease_repo
-from storage.runtime import build_storage_container, build_thread_repo
-from storage.runtime import build_terminal_repo as make_terminal_repo
+from storage.runtime import (
+    build_chat_session_repo as make_chat_session_repo,
+)
+from storage.runtime import (
+    build_lease_repo as make_lease_repo,
+)
+from storage.runtime import (
+    build_storage_container,
+    build_thread_repo,
+    uses_supabase_runtime_defaults,
+)
+from storage.runtime import (
+    build_terminal_repo as make_terminal_repo,
+)
 
 _cached_container: StorageContainer | None = None
 
@@ -137,7 +147,7 @@ def delete_thread_in_db(thread_id: str) -> None:
     _get_container().purge_thread(thread_id)
 
     sandbox_db = resolve_sandbox_db_path()
-    if not sandbox_db.exists():
+    if not uses_supabase_runtime_defaults() and not sandbox_db.exists():
         return
 
     session_repo = make_chat_session_repo()

--- a/tests/Unit/backend/web/utils/test_helpers.py
+++ b/tests/Unit/backend/web/utils/test_helpers.py
@@ -76,6 +76,36 @@ def test_delete_thread_in_db_uses_runtime_repo_factories_without_db_path(monkeyp
     assert type(sync_state.repo).__name__ == "ProcessLocalSyncFileBacking"
 
 
+def test_delete_thread_in_db_cleans_runtime_repos_when_supabase_defaults_without_local_db(monkeypatch, tmp_path):
+    sandbox_db = tmp_path / "missing-sandbox.db"
+    container = _FakeContainer()
+    session_repo = _ThreadRepo()
+    terminal_repo = _ThreadRepo()
+    sync_state_holder: dict[str, _SyncState] = {}
+
+    monkeypatch.setattr(helpers, "_get_container", lambda: container)
+    monkeypatch.setattr(helpers, "resolve_sandbox_db_path", lambda: sandbox_db)
+    monkeypatch.setattr(helpers, "uses_supabase_runtime_defaults", lambda: True)
+    monkeypatch.setattr(helpers, "make_chat_session_repo", lambda: session_repo)
+    monkeypatch.setattr(helpers, "make_terminal_repo", lambda: terminal_repo)
+    monkeypatch.setattr(
+        helpers,
+        "SyncState",
+        lambda **kwargs: sync_state_holder.setdefault("instance", _SyncState(**kwargs)),
+    )
+
+    helpers.delete_thread_in_db("thread-1")
+
+    sync_state = sync_state_holder["instance"]
+    assert container.purged == ["thread-1"]
+    assert session_repo.deleted == ["thread-1"]
+    assert terminal_repo.deleted == ["thread-1"]
+    assert sync_state.cleared == ["thread-1"]
+    assert session_repo.closed
+    assert terminal_repo.closed
+    assert sync_state.closed
+
+
 def test_get_terminal_timestamps_uses_runtime_repo_factory_without_db_path(monkeypatch, tmp_path):
     sandbox_db = tmp_path / "sandbox.db"
     sandbox_db.touch()


### PR DESCRIPTION
## Summary
- keep thread cleanup running remote runtime session/terminal repos under Supabase defaults even when the local sandbox sqlite file is absent
- add regression coverage for delete_thread_in_db on that runtime path

## Verification
- uv run python -m pytest tests/Unit/backend/web/utils/test_helpers.py tests/Unit/backend/web/services/test_thread_runtime_convergence.py tests/Integration/test_threads_router.py -q
- uv run ruff check backend/web/utils/helpers.py tests/Unit/backend/web/utils/test_helpers.py
- uv run ruff format --check backend/web/utils/helpers.py tests/Unit/backend/web/utils/test_helpers.py
- git diff --check