### PR TITLE
Drop lease volume_id runtime field

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -56,7 +56,6 @@ REQUIRED_LEASE_COLUMNS = {
     "needs_refresh",
     "refresh_hint_at",
     "status",
-    "volume_id",
     "created_at",
     "updated_at",
 }
@@ -130,7 +129,6 @@ class SandboxLease(ABC):
         last_error: str | None = None,
         needs_refresh: bool = False,
         refresh_hint_at: datetime | None = None,
-        volume_id: str | None = None,
         bind_mounts: list[dict[str, str]] | None = None,
     ):
         self.lease_id = lease_id
@@ -147,7 +145,6 @@ class SandboxLease(ABC):
         self.last_error = last_error
         self.needs_refresh = needs_refresh
         self.refresh_hint_at = refresh_hint_at
-        self.volume_id = volume_id
         self.bind_mounts = bind_mounts
 
     def get_instance(self) -> SandboxInstance | None:
@@ -212,7 +209,6 @@ class SQLiteLease(SandboxLease):
         last_error: str | None = None,
         needs_refresh: bool = False,
         refresh_hint_at: datetime | None = None,
-        volume_id: str | None = None,
     ):
         super().__init__(
             lease_id=lease_id,
@@ -229,7 +225,6 @@ class SQLiteLease(SandboxLease):
             last_error=last_error,
             needs_refresh=needs_refresh,
             refresh_hint_at=refresh_hint_at,
-            volume_id=volume_id,
         )
         self.db_path = resolve_sandbox_db_path(db_path)
         self._detached_instance: SandboxInstance | None = None
@@ -718,7 +713,6 @@ class SQLiteLease(SandboxLease):
         self.observed_at = other.observed_at
         self.last_error = other.last_error
         self.needs_refresh = other.needs_refresh
-        self.volume_id = other.volume_id
         self.refresh_hint_at = other.refresh_hint_at
 
     def apply(
@@ -1150,5 +1144,4 @@ def lease_from_row(row: dict, db_path: Path) -> SQLiteLease:
         last_error=row.get("last_error"),
         needs_refresh=bool(row.get("needs_refresh")),
         refresh_hint_at=refresh_hint_at,
-        volume_id=row.get("volume_id"),
     )

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -308,14 +308,8 @@ class SandboxManager:
 
     def _destroy_daytona_managed_volume(self, lease_id: str) -> None:
         # @@@daytona-managed-volume-ref - daytona managed volumes now derive their backend
-        # ref from lease identity directly, so cleanup no longer depends on lease.volume_id.
+        # ref from lease identity directly, so cleanup no longer depends on lease volume metadata.
         self.provider.delete_managed_volume(f"leon-volume-{lease_id}")
-
-    def _assert_no_legacy_volume_id(self, lease, *, action: str) -> None:
-        # @@@legacy-volume-stopline - after sandbox_volumes collapse, non-daytona runtime may only
-        # encounter volume_id as stale storage residue. Treat it as explicit data drift, not fallback input.
-        if self._requires_volume_bootstrap() and self.provider_capability.runtime_kind != "daytona_pty" and lease.volume_id:
-            raise ValueError(f"legacy volume_id is not allowed for non-daytona runtime {action}")
 
     def _setup_mounts(self, thread_id: str) -> dict:
         """Mount the lease's volume into the sandbox. Pure sandbox-layer operation."""
@@ -329,7 +323,6 @@ class SandboxManager:
         source_path = self._resolve_sync_source_path(thread_id)
 
         if self.provider_capability.runtime_kind != "daytona_pty":
-            self._assert_no_legacy_volume_id(lease, action="mount")
             self.volume.mount(thread_id, source_path, remote_path)
             return {"source_path": source_path, "remote_path": remote_path}
 
@@ -432,7 +425,7 @@ class SandboxManager:
 
     def _skip_volume_sync_for_local_lease(self, lease) -> bool:
         # @@@local-no-volume-sync - local sessions execute directly in host cwd, so upload/download
-        # must always no-op there. Legacy volume_id residue is not allowed to reactivate volume-backed sync.
+        # must always no-op there rather than reactivating volume-backed sync.
         return lease is not None and not self._requires_volume_bootstrap()
 
     def _sync_to_sandbox(self, thread_id: str, instance_id: str, source=None, files: list[str] | None = None) -> None:
@@ -881,8 +874,6 @@ class SandboxManager:
         lease.destroy_instance(self.provider)
         if self.provider_capability.runtime_kind == "daytona_pty":
             self._destroy_daytona_managed_volume(lease_id)
-        else:
-            self._assert_no_legacy_volume_id(lease, action="cleanup")
         self.lease_store.delete(lease_id)
         return True
 

--- a/storage/providers/sqlite/lease_repo.py
+++ b/storage/providers/sqlite/lease_repo.py
@@ -58,7 +58,7 @@ class SQLiteLeaseRepo:
                        current_instance_id, instance_created_at,
                        desired_state, observed_state, version,
                        observed_at, last_error, needs_refresh,
-                       refresh_hint_at, status, volume_id,
+                       refresh_hint_at, status,
                        created_at, updated_at
                 FROM sandbox_leases
                 WHERE lease_id = ?
@@ -441,7 +441,6 @@ class SQLiteLeaseRepo:
                 needs_refresh INTEGER NOT NULL DEFAULT 0,
                 refresh_hint_at TIMESTAMP,
                 status TEXT DEFAULT 'active',
-                volume_id TEXT,
                 created_at TIMESTAMP NOT NULL,
                 updated_at TIMESTAMP NOT NULL
             )

--- a/storage/providers/supabase/lease_repo.py
+++ b/storage/providers/supabase/lease_repo.py
@@ -45,7 +45,7 @@ class SupabaseLeaseRepo:
             .select(
                 "lease_id,provider_name,recipe_id,workspace_key,recipe_json,"
                 "current_instance_id,instance_created_at,desired_state,observed_state,version,"
-                "observed_at,last_error,needs_refresh,refresh_hint_at,status,volume_id,"
+                "observed_at,last_error,needs_refresh,refresh_hint_at,status,"
                 "created_at,updated_at"
             )
             .eq("lease_id", lease_id)

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -276,7 +276,7 @@ def test_setup_mounts_uses_workspace_sync_source_for_non_daytona_runtime(tmp_pat
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: SimpleNamespace(volume_id=None)
+    manager._get_lease = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     result = manager._setup_mounts("thread-1")
 
@@ -304,32 +304,31 @@ def test_deserialize_historical_daytona_source_downgrades_to_host_volume(tmp_pat
     assert source.host_path == (tmp_path / "staging").resolve()
 
 
-def test_setup_mounts_provisions_missing_remote_volume_metadata(monkeypatch, tmp_path):
+def test_setup_mounts_uses_workspace_source_without_remote_volume_metadata(monkeypatch, tmp_path):
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
-    lease = SimpleNamespace(lease_id="lease-1", volume_id=None)
+    lease = SimpleNamespace(lease_id="lease-1")
     manager._get_lease = lambda _lease_id: lease
     manager.lease_store = _FakeLeaseStore()
     monkeypatch.setenv("LEON_SANDBOX_VOLUME_ROOT", str(tmp_path / "volumes"))
 
     result = manager._setup_mounts("thread-1")
 
-    assert lease.volume_id is None
     assert result == {"source_path": Path(tmp_path) / "channel-root", "remote_path": "/workspace"}
     assert manager.volume.mount_sources == [Path(tmp_path) / "channel-root"]
 
 
-def test_setup_mounts_daytona_does_not_require_volume_id(monkeypatch, tmp_path):
+def test_setup_mounts_daytona_uses_lease_id_for_managed_volume(monkeypatch, tmp_path):
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="daytona_pty")
     manager.provider = _FakeDaytonaProvider()
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
-    lease = SimpleNamespace(lease_id="lease-1", volume_id=None)
+    lease = SimpleNamespace(lease_id="lease-1")
     manager._get_lease = lambda _lease_id: lease
     manager.lease_store = _FakeLeaseStore()
     monkeypatch.setenv("LEON_SANDBOX_VOLUME_ROOT", str(tmp_path / "volumes"))
@@ -354,7 +353,6 @@ def test_destroy_thread_resources_daytona_does_not_require_volume_row(tmp_path):
     class _Lease:
         lease_id = "lease-1"
         observed_state = "detached"
-        volume_id = "volume-1"
 
         def get_instance(self):
             return None
@@ -456,7 +454,7 @@ def test_enforce_idle_timeouts_accepts_aware_supabase_timestamps():
     assert manager.enforce_idle_timeouts() == 0
 
 
-def test_destroy_thread_resources_skips_local_sync_even_with_legacy_volume_id():
+def test_destroy_thread_resources_skips_local_sync_without_volume_metadata():
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="local")
     manager.provider = SimpleNamespace(name="local")
@@ -482,7 +480,6 @@ def test_destroy_thread_resources_skips_local_sync_even_with_legacy_volume_id():
     class _Lease:
         lease_id = "lease-1"
         observed_state = "running"
-        volume_id = "legacy-volume-1"
 
         def get_instance(self):
             return SimpleNamespace(instance_id="instance-1")
@@ -516,7 +513,6 @@ def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_termi
     class _Lease:
         lease_id = "lease-1"
         observed_state = "running"
-        volume_id = None
 
         def get_instance(self):
             return SimpleNamespace(instance_id="instance-1")
@@ -565,7 +561,6 @@ def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
     class _Lease:
         lease_id = "lease-1"
         observed_state = "detached"
-        volume_id = None
 
         def get_instance(self):
             return None
@@ -598,7 +593,7 @@ def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
     assert deleted_leases == []
 
 
-def test_destroy_thread_resources_deletes_daytona_managed_volume_without_volume_id(tmp_path):
+def test_destroy_thread_resources_deletes_daytona_managed_volume_from_lease_id(tmp_path):
     manager = _new_test_manager()
     provider = _FakeDaytonaProvider()
     manager.provider_capability = SimpleNamespace(runtime_kind="daytona_pty")
@@ -612,7 +607,6 @@ def test_destroy_thread_resources_deletes_daytona_managed_volume_without_volume_
     class _Lease:
         lease_id = "lease-1"
         observed_state = "detached"
-        volume_id = None
 
         def get_instance(self):
             return None
@@ -645,7 +639,7 @@ def test_destroy_thread_resources_deletes_daytona_managed_volume_without_volume_
     assert all_terminals == []
 
 
-def test_destroy_thread_resources_derives_daytona_volume_name_without_serialized_daytona_source(tmp_path):
+def test_destroy_thread_resources_derives_daytona_volume_name_from_lease_id(tmp_path):
     manager = _new_test_manager()
     provider = _FakeDaytonaProvider()
     manager.provider_capability = SimpleNamespace(runtime_kind="daytona_pty")
@@ -659,7 +653,6 @@ def test_destroy_thread_resources_derives_daytona_volume_name_without_serialized
     class _Lease:
         lease_id = "lease-1"
         observed_state = "detached"
-        volume_id = "volume-1"
 
         def get_instance(self):
             return None
@@ -691,13 +684,13 @@ def test_destroy_thread_resources_derives_daytona_volume_name_without_serialized
     assert deleted_leases == ["lease-1"]
 
 
-def test_sync_uploads_skips_local_volume_sync_even_with_legacy_volume_id():
+def test_sync_uploads_skips_local_volume_sync_without_volume_metadata():
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="local")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: SimpleNamespace(volume_id="legacy-volume-1")
-    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(volume_id="legacy-volume-1")
+    manager._get_lease = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: SimpleNamespace(
@@ -709,43 +702,11 @@ def test_sync_uploads_skips_local_volume_sync_even_with_legacy_volume_id():
     assert manager.volume.upload_calls == []
 
 
-def test_non_daytona_runtime_rejects_legacy_volume_id_during_mount_setup(tmp_path):
-    manager = _new_test_manager()
-    manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
-    manager.volume = _FakeVolume()
-    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
-    manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
-    manager._get_lease = lambda _lease_id: SimpleNamespace(volume_id="legacy-volume-1")
-
-    with pytest.raises(ValueError, match="legacy volume_id is not allowed"):
-        manager._setup_mounts("thread-1")
-
-
-def test_non_daytona_runtime_rejects_legacy_volume_id_during_destroy():
-    manager = _new_test_manager()
-    manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
-    manager.provider = SimpleNamespace(name="agentbay")
-    manager.terminal_store = SimpleNamespace(list_all=lambda: [])
-
-    class _Lease:
-        lease_id = "lease-1"
-        volume_id = "legacy-volume-1"
-
-        def destroy_instance(self, _provider):
-            return None
-
-    manager._get_lease = lambda _lease_id: _Lease()
-    manager.lease_store = SimpleNamespace(delete=lambda _lease_id: (_ for _ in ()).throw(AssertionError("lease delete should not happen")))
-
-    with pytest.raises(ValueError, match="legacy volume_id is not allowed"):
-        manager.destroy_lease_resources("lease-1")
-
-
 def test_sync_paths_use_workspace_file_channel_root_instead_of_volume_source(monkeypatch):
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
-    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(volume_id="volume-1")
+    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager.resolve_volume_source = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume source should stay unused"))
 
     class _ThreadRepo:

--- a/tests/Unit/storage/test_sqlite_lease_repo.py
+++ b/tests/Unit/storage/test_sqlite_lease_repo.py
@@ -1,0 +1,11 @@
+from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+
+
+def test_sqlite_lease_repo_schema_does_not_create_legacy_volume_id(tmp_path):
+    repo = SQLiteLeaseRepo(tmp_path / "sandbox.db")
+    try:
+        cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_leases)").fetchall()}
+    finally:
+        repo.close()
+
+    assert "volume_id" not in cols

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -25,6 +25,7 @@ def test_supabase_lease_repo_adopt_instance_fails_loudly_if_bootstrap_reload_mis
 class _FakeTable:
     def __init__(self) -> None:
         self.insert_payload = None
+        self.selected_cols = None
         self.eq_calls: list[tuple[str, object]] = []
         self.rows = [
             {
@@ -53,7 +54,8 @@ class _FakeTable:
         self.insert_payload = payload
         return self
 
-    def select(self, _cols):
+    def select(self, cols):
+        self.selected_cols = cols
         return self
 
     def eq(self, key, value):
@@ -106,6 +108,16 @@ def test_supabase_lease_repo_create_does_not_write_legacy_volume_id():
 
     payload = client.tables["sandbox_leases"].insert_payload
     assert "volume_id" not in payload
+
+
+def test_supabase_lease_repo_get_does_not_select_legacy_volume_id():
+    client = _FakeClient()
+    repo = SupabaseLeaseRepo(client)
+
+    result = repo.get("lease-1")
+
+    assert result is not None
+    assert "volume_id" not in client.tables["sandbox_leases"].selected_cols
 
 
 def test_supabase_lease_repo_adopt_instance_persists_integer_refresh_flag():


### PR DESCRIPTION
## Summary
- stop lease repos/domain from selecting or creating the legacy sandbox_leases.volume_id runtime field
- remove manager fail-loud guard that still treated volume_id as a runtime signal
- keep Daytona provider SDK volume_id parameter untouched; that is provider API shape, not the lease column

## Fresh DB fact
- staging.sandbox_leases currently has 148 rows, 142 with volume_id set after staging.sandbox_volumes was dropped
- this PR is app-side prep only: it does not mutate DB data or drop the column

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_sqlite_lease_repo.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_service_session_mutation.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py -q
- uv run python -m pytest tests/Unit/storage tests/Unit/sandbox -q
- uv run ruff check .
- uv run ruff format --check .
- git diff --check