### PR TITLE
Demote Supabase sandbox_instances table

### DIFF
--- a/storage/providers/supabase/lease_repo.py
+++ b/storage/providers/supabase/lease_repo.py
@@ -9,11 +9,24 @@ from storage.providers.supabase import _query as q
 
 _REPO = "lease repo"
 _LEASES_TABLE = "sandbox_leases"
-_INSTANCES_TABLE = "sandbox_instances"
 
 
 def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _instance_from_lease(row: dict[str, Any]) -> dict[str, Any] | None:
+    current_instance_id = row.get("current_instance_id")
+    if not current_instance_id:
+        return None
+    return {
+        "instance_id": current_instance_id,
+        "lease_id": row.get("lease_id"),
+        "provider_session_id": current_instance_id,
+        "status": row.get("observed_state"),
+        "created_at": row.get("instance_created_at"),
+        "last_seen_at": row.get("observed_at"),
+    }
 
 
 class SupabaseLeaseRepo:
@@ -36,9 +49,6 @@ class SupabaseLeaseRepo:
     def _leases(self) -> Any:
         return self._client.table(_LEASES_TABLE)
 
-    def _instances(self) -> Any:
-        return self._client.table(_INSTANCES_TABLE)
-
     def get(self, lease_id: str) -> dict[str, Any] | None:
         rows = q.rows(
             self._leases()
@@ -57,21 +67,7 @@ class SupabaseLeaseRepo:
             return None
         result = dict(rows[0])
 
-        # Attach instance data as _instance key
-        current_instance_id = result.get("current_instance_id")
-        if current_instance_id:
-            inst_rows = q.rows(
-                self._instances()
-                .select("instance_id,lease_id,provider_session_id,status,created_at,last_seen_at")
-                .eq("instance_id", current_instance_id)
-                .execute(),
-                _REPO,
-                "get instance",
-            )
-            result["_instance"] = dict(inst_rows[0]) if inst_rows else None
-        else:
-            result["_instance"] = None
-
+        result["_instance"] = _instance_from_lease(result)
         return result
 
     def create(
@@ -162,18 +158,6 @@ class SupabaseLeaseRepo:
             }
         ).eq("lease_id", lease_id).execute()
 
-        # Upsert instance row
-        self._instances().upsert(
-            {
-                "instance_id": instance_id,
-                "lease_id": lease_id,
-                "provider_session_id": instance_id,
-                "status": normalized,
-                "created_at": now,
-                "last_seen_at": now,
-            }
-        ).execute()
-
         return self._require_lease(self.get(lease_id), lease_id=lease_id, operation="adopt_instance")
 
     def observe_status(
@@ -188,8 +172,6 @@ class SupabaseLeaseRepo:
         existing = self._require_lease(self.get(lease_id), lease_id=lease_id, operation="observe_status")
         now = observed_at.isoformat() if isinstance(observed_at, datetime) else (observed_at or _utc_now_iso())
         normalized = parse_lease_instance_state(status).value
-        current_instance_id = existing.get("current_instance_id")
-
         self._leases().update(
             {
                 "current_instance_id": None if normalized == "detached" else existing.get("current_instance_id"),
@@ -205,14 +187,6 @@ class SupabaseLeaseRepo:
                 "updated_at": _utc_now_iso(),
             }
         ).eq("lease_id", lease_id).execute()
-
-        if current_instance_id:
-            self._instances().update(
-                {
-                    "status": "stopped" if normalized == "detached" else normalized,
-                    "last_seen_at": now,
-                }
-            ).eq("instance_id", current_instance_id).execute()
 
         return self._require_lease(self.get(lease_id), lease_id=lease_id, operation="observe_status")
 
@@ -272,7 +246,6 @@ class SupabaseLeaseRepo:
         return len(updated) > 0
 
     def delete(self, lease_id: str) -> None:
-        self._instances().delete().eq("lease_id", lease_id).execute()
         self._leases().delete().eq("lease_id", lease_id).execute()
 
     def list_all(self) -> list[dict[str, Any]]:

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -165,43 +165,11 @@ class SupabaseSandboxMonitorRepo:
             if str(sandbox.get("id") or "").strip() in ordered_ids
         }
 
-        instance_by_lease: dict[str, str | None] = {}
-        lease_ids = []
-        for sandbox_id in ordered_ids:
-            sandbox = sandbox_rows.get(sandbox_id)
-            if sandbox is None:
-                continue
-            lease = self._lease_row_from_sandbox(sandbox)
-            lease_id = str(lease.get("lease_id") or "").strip()
-            if not lease_id:
-                continue
-            lease_ids.append(lease_id)
-            instance_by_lease[lease_id] = None
-
-        if lease_ids:
-            instances = q.rows_in_chunks(
-                lambda: self._client.table("sandbox_instances").select("lease_id,provider_session_id"),
-                "lease_id",
-                lease_ids,
-                _REPO,
-                "query_sandbox_instance_ids instances",
-            )
-            for row in instances:
-                lease_id = str(row.get("lease_id") or "").strip()
-                provider_session_id = str(row.get("provider_session_id") or "").strip()
-                if lease_id and provider_session_id:
-                    instance_by_lease[lease_id] = provider_session_id
-
         result: dict[str, str | None] = {}
         for sandbox_id in ordered_ids:
             sandbox = sandbox_rows.get(sandbox_id)
             if sandbox is None:
                 result[sandbox_id] = None
-                continue
-            lease = self._lease_row_from_sandbox(sandbox)
-            lease_id = str(lease.get("lease_id") or "").strip()
-            result[sandbox_id] = instance_by_lease.get(lease_id)
-            if result[sandbox_id]:
                 continue
             provider_env_id = str(sandbox.get("provider_env_id") or "").strip()
             result[sandbox_id] = provider_env_id or None

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -603,7 +603,7 @@ def test_lease_instance_protocol_shell_is_removed() -> None:
     assert not hasattr(repo, "query_lease_instance_ids")
 
 
-def test_query_sandbox_instance_id_prefers_provider_session_id() -> None:
+def test_query_sandbox_instance_id_uses_sandbox_provider_env_id() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -616,12 +616,12 @@ def test_query_sandbox_instance_id_prefers_provider_session_id() -> None:
                 )
             ],
             "sandbox_instances": [
-                {"lease_id": "lease-1", "provider_session_id": "provider-session-1"},
+                {"lease_id": "lease-1", "provider_session_id": "instance-lease"},
             ],
         }
     )
 
-    assert repo.query_sandbox_instance_id("sandbox-1") == "provider-session-1"
+    assert repo.query_sandbox_instance_id("sandbox-1") == "instance-sandbox"
 
 
 def test_query_sandbox_instance_id_falls_back_without_legacy_lease_bridge() -> None:
@@ -655,7 +655,7 @@ def test_query_sandbox_instance_ids_chunks_large_lookup() -> None:
                     )
                     for index in range(175)
                 ],
-                "sandbox_instances": [{"lease_id": "lease-174", "provider_session_id": "provider-session-174"}],
+                "sandbox_instances": [{"lease_id": "lease-174", "provider_session_id": "sandbox-instance-sandbox-174"}],
             }
         )
     )
@@ -663,10 +663,10 @@ def test_query_sandbox_instance_ids_chunks_large_lookup() -> None:
     result = repo.query_sandbox_instance_ids(sandbox_ids)
 
     assert result["sandbox-0"] == "sandbox-instance-sandbox-0"
-    assert result["sandbox-174"] == "provider-session-174"
+    assert result["sandbox-174"] == "sandbox-instance-sandbox-174"
 
 
-def test_query_sandbox_instance_ids_uses_legacy_bridge() -> None:
+def test_query_sandbox_instance_ids_use_sandbox_provider_env_id() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -674,14 +674,14 @@ def test_query_sandbox_instance_ids_uses_legacy_bridge() -> None:
                 _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", legacy_lease_id="lease-2"),
             ],
             "sandbox_instances": [
-                {"lease_id": "lease-2", "provider_session_id": "provider-session-2"},
+                {"lease_id": "lease-2", "provider_session_id": "stale-instance-2"},
             ],
         }
     )
 
     assert repo.query_sandbox_instance_ids(["sandbox-1", "sandbox-2"]) == {
         "sandbox-1": "sandbox-instance-1",
-        "sandbox-2": "provider-session-2",
+        "sandbox-2": "sandbox-instance-2",
     }
 
 
@@ -693,7 +693,7 @@ def test_query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge() 
                 _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", legacy_lease_id="lease-2"),
             ],
             "sandbox_instances": [
-                {"lease_id": "lease-2", "provider_session_id": "provider-session-2"},
+                {"lease_id": "lease-2", "provider_session_id": "stale-instance-2"},
             ],
         }
     )
@@ -702,7 +702,7 @@ def test_query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge() 
 
     assert repo.query_sandbox_instance_ids(["sandbox-1", "sandbox-2"]) == {
         "sandbox-1": "sandbox-instance-1",
-        "sandbox-2": "provider-session-2",
+        "sandbox-2": "sandbox-instance-2",
     }
 
 
@@ -713,24 +713,24 @@ def test_query_sandbox_instance_id_no_longer_roundtrips_through_lease_bridge() -
                 _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", legacy_lease_id="lease-1"),
             ],
             "sandbox_instances": [
-                {"lease_id": "lease-1", "provider_session_id": "provider-session-1"},
+                {"lease_id": "lease-1", "provider_session_id": "instance-lease"},
             ],
         }
     )
 
     assert not hasattr(repo, "query_lease_instance_id")
 
-    assert repo.query_sandbox_instance_id("sandbox-1") == "provider-session-1"
+    assert repo.query_sandbox_instance_id("sandbox-1") == "sandbox-instance-1"
 
 
-def test_list_probe_targets_prefers_provider_session_id() -> None:
+def test_list_probe_targets_use_sandbox_provider_env_id() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
                 _sandbox(
                     "sandbox-running",
                     provider_name="daytona_selfhost",
-                    provider_env_id="instance-lease",
+                    provider_env_id="instance-sandbox",
                     observed_state="detached",
                     updated_at="2026-04-05T10:10:00",
                     legacy_lease_id="lease-running",
@@ -754,7 +754,7 @@ def test_list_probe_targets_prefers_provider_session_id() -> None:
                 ),
             ],
             "sandbox_instances": [
-                {"lease_id": "lease-running", "provider_session_id": "provider-session-1"},
+                {"lease_id": "lease-running", "provider_session_id": "instance-lease"},
             ],
         }
     )
@@ -771,7 +771,7 @@ def test_list_probe_targets_prefers_provider_session_id() -> None:
             "sandbox_id": "sandbox-running",
             "legacy_lease_id": "lease-running",
             "provider_name": "daytona_selfhost",
-            "instance_id": "provider-session-1",
+            "instance_id": "instance-sandbox",
             "observed_state": "detached",
         },
     ]
@@ -802,7 +802,7 @@ def test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge()
                 _sandbox(
                     "sandbox-running",
                     provider_name="daytona_selfhost",
-                    provider_env_id="instance-lease",
+                    provider_env_id="instance-sandbox",
                     observed_state="detached",
                     updated_at="2026-04-05T10:10:00",
                     legacy_lease_id="lease-running",
@@ -817,7 +817,7 @@ def test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge()
                 ),
             ],
             "sandbox_instances": [
-                {"lease_id": "lease-running", "provider_session_id": "provider-session-1"},
+                {"lease_id": "lease-running", "provider_session_id": "instance-lease"},
             ],
         }
     )
@@ -836,7 +836,7 @@ def test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge()
             "sandbox_id": "sandbox-running",
             "legacy_lease_id": "lease-running",
             "provider_name": "daytona_selfhost",
-            "instance_id": "provider-session-1",
+            "instance_id": "instance-sandbox",
             "observed_state": "detached",
         },
     ]
@@ -850,7 +850,7 @@ def test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge()
     ],
     ids=["query-sandbox-instance-id", "list-probe-targets"],
 )
-def test_instance_lookup_failures_are_loud(include_updated_at, caller) -> None:
+def test_instance_lookup_does_not_read_removed_instances_table(include_updated_at, caller) -> None:
     tables = {
         "container.sandboxes": [
             _sandbox(
@@ -865,8 +865,20 @@ def test_instance_lookup_failures_are_loud(include_updated_at, caller) -> None:
     }
     repo = SupabaseSandboxMonitorRepo(_BrokenSandboxInstancesClient(tables))
 
-    with pytest.raises(RuntimeError, match="sandbox_instances exploded"):
-        caller(repo)
+    result = caller(repo)
+
+    if include_updated_at:
+        assert result == [
+            {
+                "sandbox_id": "sandbox-1",
+                "legacy_lease_id": "lease-1",
+                "provider_name": "daytona_selfhost",
+                "instance_id": "instance-lease",
+                "observed_state": "detached",
+            }
+        ]
+    else:
+        assert result == "instance-lease"
 
 
 def test_resource_session_row_source_shell_is_removed() -> None:

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -4,6 +4,13 @@ from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
 
+class _RejectSandboxInstancesClient(FakeSupabaseClient):
+    def table(self, table_name: str):
+        if table_name == "sandbox_instances":
+            raise AssertionError("sandbox_instances table should not be accessed")
+        return super().table(table_name)
+
+
 def test_supabase_lease_repo_adopt_instance_fails_loudly_if_bootstrap_reload_missing():
     repo = SupabaseLeaseRepo(client=FakeSupabaseClient(tables={"sandbox_leases": [], "sandbox_instances": []}))
     rows = iter([None, None])
@@ -20,6 +27,45 @@ def test_supabase_lease_repo_adopt_instance_fails_loudly_if_bootstrap_reload_mis
             provider_name="test-provider",
             instance_id="inst-123",
         )
+
+
+def test_supabase_lease_repo_get_synthesizes_instance_from_lease_row_without_instances_table():
+    tables = {
+        "sandbox_leases": [
+            {
+                "lease_id": "lease-1",
+                "provider_name": "local",
+                "recipe_id": None,
+                "workspace_key": None,
+                "recipe_json": None,
+                "current_instance_id": "inst-1",
+                "instance_created_at": "2026-04-07T00:00:01+00:00",
+                "desired_state": "running",
+                "observed_state": "running",
+                "version": 0,
+                "observed_at": "2026-04-07T00:00:05+00:00",
+                "last_error": None,
+                "needs_refresh": 0,
+                "refresh_hint_at": None,
+                "status": "active",
+                "created_at": "2026-04-07T00:00:00+00:00",
+                "updated_at": "2026-04-07T00:00:05+00:00",
+            }
+        ]
+    }
+    repo = SupabaseLeaseRepo(client=_RejectSandboxInstancesClient(tables=tables))
+
+    lease = repo.get("lease-1")
+
+    assert lease is not None
+    assert lease["_instance"] == {
+        "instance_id": "inst-1",
+        "lease_id": "lease-1",
+        "provider_session_id": "inst-1",
+        "status": "running",
+        "created_at": "2026-04-07T00:00:01+00:00",
+        "last_seen_at": "2026-04-07T00:00:05+00:00",
+    }
 
 
 class _FakeTable:
@@ -44,7 +90,6 @@ class _FakeTable:
                 "needs_refresh": 0,
                 "refresh_hint_at": None,
                 "status": "active",
-                "volume_id": None,
                 "created_at": "2026-04-07T00:00:00",
                 "updated_at": "2026-04-07T00:00:00",
             }
@@ -139,7 +184,6 @@ def test_supabase_lease_repo_adopt_instance_persists_integer_refresh_flag():
                 "needs_refresh": 0,
                 "refresh_hint_at": None,
                 "status": "active",
-                "volume_id": None,
                 "created_at": "2026-04-07T00:00:00+00:00",
                 "updated_at": "2026-04-07T00:00:00+00:00",
             }
@@ -158,6 +202,45 @@ def test_supabase_lease_repo_adopt_instance_persists_integer_refresh_flag():
     lease_row = tables["sandbox_leases"][0]
     assert lease_row["needs_refresh"] == 1
     assert type(lease_row["needs_refresh"]) is int
+
+
+def test_supabase_lease_repo_adopt_instance_updates_lease_without_instances_table():
+    tables = {
+        "sandbox_leases": [
+            {
+                "lease_id": "lease-1",
+                "provider_name": "local",
+                "recipe_id": None,
+                "workspace_key": None,
+                "recipe_json": None,
+                "current_instance_id": None,
+                "instance_created_at": None,
+                "desired_state": "running",
+                "observed_state": "detached",
+                "version": 0,
+                "observed_at": "2026-04-07T00:00:00+00:00",
+                "last_error": None,
+                "needs_refresh": 0,
+                "refresh_hint_at": None,
+                "status": "active",
+                "created_at": "2026-04-07T00:00:00+00:00",
+                "updated_at": "2026-04-07T00:00:00+00:00",
+            }
+        ]
+    }
+    repo = SupabaseLeaseRepo(client=_RejectSandboxInstancesClient(tables=tables))
+
+    updated = repo.adopt_instance(
+        lease_id="lease-1",
+        provider_name="local",
+        instance_id="inst-1",
+        status="running",
+    )
+
+    lease_row = tables["sandbox_leases"][0]
+    assert lease_row["current_instance_id"] == "inst-1"
+    assert lease_row["observed_state"] == "running"
+    assert updated["_instance"]["instance_id"] == "inst-1"
 
 
 def test_supabase_lease_repo_persist_metadata_updates_error_refresh_fields():
@@ -179,7 +262,6 @@ def test_supabase_lease_repo_persist_metadata_updates_error_refresh_fields():
                 "needs_refresh": 0,
                 "refresh_hint_at": None,
                 "status": "active",
-                "volume_id": None,
                 "created_at": "2026-04-07T00:00:00+00:00",
                 "updated_at": "2026-04-07T00:00:00+00:00",
             }
@@ -213,7 +295,7 @@ def test_supabase_lease_repo_persist_metadata_updates_error_refresh_fields():
     assert lease_row["status"] == "recovering"
 
 
-def test_supabase_lease_repo_observe_status_detaches_instance_and_clears_refresh_fields():
+def test_supabase_lease_repo_observe_status_detaches_instance_without_instances_table():
     tables = {
         "sandbox_leases": [
             {
@@ -232,23 +314,12 @@ def test_supabase_lease_repo_observe_status_detaches_instance_and_clears_refresh
                 "needs_refresh": 1,
                 "refresh_hint_at": "2026-04-07T00:00:02+00:00",
                 "status": "active",
-                "volume_id": None,
                 "created_at": "2026-04-07T00:00:00+00:00",
                 "updated_at": "2026-04-07T00:00:00+00:00",
             }
         ],
-        "sandbox_instances": [
-            {
-                "instance_id": "inst-1",
-                "lease_id": "lease-1",
-                "provider_session_id": "inst-1",
-                "status": "running",
-                "created_at": "2026-04-07T00:00:01+00:00",
-                "last_seen_at": "2026-04-07T00:00:01+00:00",
-            }
-        ],
     }
-    repo = SupabaseLeaseRepo(client=FakeSupabaseClient(tables=tables))
+    repo = SupabaseLeaseRepo(client=_RejectSandboxInstancesClient(tables=tables))
 
     updated = repo.observe_status(
         lease_id="lease-1",
@@ -257,7 +328,6 @@ def test_supabase_lease_repo_observe_status_detaches_instance_and_clears_refresh
     )
 
     lease_row = tables["sandbox_leases"][0]
-    instance_row = tables["sandbox_instances"][0]
     assert updated["lease_id"] == "lease-1"
     assert lease_row["current_instance_id"] is None
     assert lease_row["observed_state"] == "detached"
@@ -266,4 +336,20 @@ def test_supabase_lease_repo_observe_status_detaches_instance_and_clears_refresh
     assert lease_row["needs_refresh"] == 0
     assert type(lease_row["needs_refresh"]) is int
     assert lease_row["version"] == 1
-    assert instance_row["status"] == "stopped"
+    assert updated["_instance"] is None
+
+
+def test_supabase_lease_repo_delete_removes_lease_without_instances_table():
+    tables = {
+        "sandbox_leases": [
+            {
+                "lease_id": "lease-1",
+                "provider_name": "local",
+            }
+        ]
+    }
+    repo = SupabaseLeaseRepo(client=_RejectSandboxInstancesClient(tables=tables))
+
+    repo.delete("lease-1")
+
+    assert tables["sandbox_leases"] == []


### PR DESCRIPTION
## Summary
- stop Supabase lease repo from reading/writing/deleting staging.sandbox_instances
- synthesize the legacy lease _instance shape from sandbox_leases.current_instance_id
- resolve monitor probe instance ids from container.sandboxes.provider_env_id instead of sandbox_instances
- add tests that fail if Supabase code touches sandbox_instances
- rebased after #680 / d27d8d20 and preserved the volume_id app demotion

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py -q
  - 42 passed
- uv run ruff check storage/providers/supabase/lease_repo.py storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format --check storage/providers/supabase/lease_repo.py storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check

Design ledger: /Users/lexicalmathical/Codebase/mycel-db-design/program/doc/core/staging-sandbox-instances-app-demotion-preflight-2026-04-17.md