### PR TITLE
Demote terminal session runtime persistence

### DIFF
--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import (
-    build_chat_session_repo,
     build_lease_repo,
-    build_terminal_repo,
     uses_supabase_runtime_defaults,
 )
 
@@ -20,8 +18,6 @@ def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
 
 
 def make_chat_session_repo(db_path: Path | None = None):
-    if _use_strategy_control_plane_repo(db_path):
-        return build_chat_session_repo()
     from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 
     return SQLiteChatSessionRepo(db_path=resolve_sandbox_db_path(db_path))
@@ -36,8 +32,6 @@ def make_lease_repo(db_path: Path | None = None):
 
 
 def make_terminal_repo(db_path: Path | None = None):
-    if _use_strategy_control_plane_repo(db_path):
-        return build_terminal_repo()
     from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
     return SQLiteTerminalRepo(db_path=resolve_sandbox_db_path(db_path))

--- a/storage/container.py
+++ b/storage/container.py
@@ -8,7 +8,6 @@ from typing import Any
 from .contracts import (
     AgentConfigRepo,
     ChatRepo,
-    ChatSessionRepo,
     CheckpointRepo,
     ContactRepo,
     EvalRepo,
@@ -23,7 +22,6 @@ from .contracts import (
     RunEventRepo,
     SandboxRepo,
     SummaryRepo,
-    TerminalRepo,
     ThreadLaunchPrefRepo,
     ThreadRepo,
     ToolTaskRepo,
@@ -43,8 +41,6 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "queue_repo": ("storage.providers.supabase.queue_repo", "SupabaseQueueRepo"),
     "provider_event_repo": ("storage.providers.supabase.provider_event_repo", "SupabaseProviderEventRepo"),
     "lease_repo": ("storage.providers.supabase.lease_repo", "SupabaseLeaseRepo"),
-    "terminal_repo": ("storage.providers.supabase.terminal_repo", "SupabaseTerminalRepo"),
-    "chat_session_repo": ("storage.providers.supabase.chat_session_repo", "SupabaseChatSessionRepo"),
     "tool_task_repo": ("storage.providers.supabase.tool_task_repo", "SupabaseToolTaskRepo"),
     "resource_snapshot_repo": ("storage.providers.supabase.resource_snapshot_repo", "SupabaseResourceSnapshotRepo"),
     "user_repo": ("storage.providers.supabase.user_repo", "SupabaseUserRepo"),
@@ -104,12 +100,6 @@ class StorageContainer:
 
     def lease_repo(self) -> LeaseRepo:
         return self._build("lease_repo")
-
-    def terminal_repo(self) -> TerminalRepo:
-        return self._build("terminal_repo")
-
-    def chat_session_repo(self) -> ChatSessionRepo:
-        return self._build("chat_session_repo")
 
     def tool_task_repo(self) -> ToolTaskRepo:
         return self._build("tool_task_repo")

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Any
 
 from storage.container import StorageContainer
+from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 
 _WEB_SUPABASE_CLIENT_FACTORY = "backend.web.core.supabase_factory:create_supabase_client"
 
@@ -86,10 +87,18 @@ def build_lease_repo(*, supabase_client: Any | None = None, supabase_client_fact
 
 
 def build_chat_session_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    if supabase_client is None and supabase_client_factory is None:
+        from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
+
+        return SQLiteChatSessionRepo(db_path=resolve_role_db_path(SQLiteDBRole.SANDBOX))
     return _build_storage_repo("chat_session_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
 def build_terminal_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    if supabase_client is None and supabase_client_factory is None:
+        from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
+
+        return SQLiteTerminalRepo(db_path=resolve_role_db_path(SQLiteDBRole.SANDBOX))
     return _build_storage_repo("terminal_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 

--- a/tests/Unit/storage/test_runtime_terminal_session_demotion.py
+++ b/tests/Unit/storage/test_runtime_terminal_session_demotion.py
@@ -1,0 +1,45 @@
+from sandbox import control_plane_repos
+from storage import runtime
+from storage.container import _REPO_REGISTRY, StorageContainer
+from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
+from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
+
+
+def test_default_terminal_and_chat_session_builders_use_local_runtime_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.missing:factory")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
+
+    def reject_supabase_repo(repo_method: str, **_kwargs):
+        raise AssertionError(f"{repo_method} should not use Supabase staging persistence by default")
+
+    monkeypatch.setattr(runtime, "_build_storage_repo", reject_supabase_repo)
+
+    terminal_repo = runtime.build_terminal_repo()
+    chat_session_repo = runtime.build_chat_session_repo()
+    try:
+        assert isinstance(terminal_repo, SQLiteTerminalRepo)
+        assert isinstance(chat_session_repo, SQLiteChatSessionRepo)
+    finally:
+        terminal_repo.close()
+        chat_session_repo.close()
+
+
+def test_control_plane_terminal_and_chat_session_repos_do_not_route_through_supabase_defaults(monkeypatch, tmp_path):
+    monkeypatch.setenv("LEON_SUPABASE_CLIENT_FACTORY", "tests.missing:factory")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
+
+    terminal_repo = control_plane_repos.make_terminal_repo()
+    chat_session_repo = control_plane_repos.make_chat_session_repo()
+    try:
+        assert isinstance(terminal_repo, SQLiteTerminalRepo)
+        assert isinstance(chat_session_repo, SQLiteChatSessionRepo)
+    finally:
+        terminal_repo.close()
+        chat_session_repo.close()
+
+
+def test_storage_container_does_not_register_terminal_session_supabase_defaults():
+    assert "terminal_repo" not in _REPO_REGISTRY
+    assert "chat_session_repo" not in _REPO_REGISTRY
+    assert not hasattr(StorageContainer, "terminal_repo")
+    assert not hasattr(StorageContainer, "chat_session_repo")


### PR DESCRIPTION
## Summary
- stop default terminal/chat session runtime builders from constructing Supabase staging repos
- keep terminal/session control-plane runtime state on local SQLite sandbox store under Supabase defaults
- remove terminal_repo/chat_session_repo from StorageContainer's Supabase default registry

## Verification
- RED first: tests/Unit/storage/test_runtime_terminal_session_demotion.py failed because default builders and control-plane repos still routed through Supabase staging persistence
- uv run python -m pytest tests/Unit/storage/test_runtime_terminal_session_demotion.py tests/Unit/backend/web/utils/test_helpers.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_lifecycle.py -q => 74 passed, 1 skipped
- uv run python -m pytest tests/Integration/test_leon_agent.py -k clear_thread -q => 3 passed, 35 deselected, 1 existing mock-model warning
- uv run ruff check storage/runtime.py storage/container.py sandbox/control_plane_repos.py tests/Unit/storage/test_runtime_terminal_session_demotion.py
- uv run ruff format --check storage/runtime.py storage/container.py sandbox/control_plane_repos.py tests/Unit/storage/test_runtime_terminal_session_demotion.py
- git diff --check

## Notes
- This is app-side demotion only. It does not drop staging.abstract_terminals, staging.thread_terminal_pointers, staging.chat_sessions, terminal_commands, or terminal_command_chunks.
- Explicit Supabase provider classes remain for low-level tests and follow-up migration checks; default runtime/container paths no longer expose them.