### PR TITLE
Demote monitor session table reads

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -76,25 +76,9 @@ class SupabaseSandboxMonitorRepo:
         return results[0] if results else None
 
     def query_thread_sessions(self, thread_id: str) -> list[dict]:
-        sessions = q.rows(
-            q.order(
-                self._client.table("chat_sessions")
-                .select("chat_session_id,status,started_at,ended_at,close_reason,lease_id")
-                .eq("thread_id", thread_id),
-                "started_at",
-                desc=True,
-                repo=_REPO,
-                operation="query_thread_sessions",
-            ).execute(),
-            _REPO,
-            "query_thread_sessions",
-        )
-        if not sessions:
-            return []
-
-        sandbox_rows = self._sandbox_rows_by_legacy_lease_id("query_thread_sessions")
-        lease_map = {lease_id: self._lease_row_from_sandbox(sandbox) for lease_id, sandbox in sandbox_rows.items()}
-        return [self._session_with_lease(s, lease_map.get(s.get("lease_id") or "")) for s in sessions]
+        # @@@monitor-session-demotion - Supabase no longer owns runtime-local chat
+        # session history; remote monitor session detail must not read staging.chat_sessions.
+        return []
 
     def query_sandboxes(self) -> list[dict]:
         sandboxes = self._ordered_sandboxes("query_sandboxes")
@@ -121,26 +105,9 @@ class SupabaseSandboxMonitorRepo:
         return None
 
     def query_sandbox_sessions(self, sandbox_id: str) -> list[dict]:
-        sandbox = self.query_sandbox(sandbox_id)
-        if sandbox is None:
-            return []
-        lease_id = str(sandbox.get("lease_id") or "").strip()
-        if not lease_id:
-            return []
-        sessions = q.rows(
-            q.order(
-                self._client.table("chat_sessions")
-                .select("chat_session_id,thread_id,status,started_at,ended_at,close_reason,lease_id")
-                .eq("lease_id", lease_id),
-                "started_at",
-                desc=True,
-                repo=_REPO,
-                operation="query_sandbox_sessions",
-            ).execute(),
-            _REPO,
-            "query_sandbox_sessions",
-        )
-        return [self._session_with_lease(session, sandbox, include_thread=True) for session in sessions]
+        # @@@monitor-session-demotion - sandbox detail still has sandbox/thread
+        # facts, but Supabase session rows are no longer admitted remote truth.
+        return []
 
     def query_sandbox_threads(self, sandbox_id: str) -> list[dict]:
         sandbox = self.query_sandbox(sandbox_id)
@@ -176,43 +143,10 @@ class SupabaseSandboxMonitorRepo:
         return result
 
     def query_resource_sessions(self) -> list[dict]:
-        active_sessions = q.rows(
-            self._client.table("chat_sessions").select("chat_session_id,thread_id,lease_id,started_at").neq("status", "closed").execute(),
-            _REPO,
-            "query_resource_sessions active",
-        )
-
-        # @@@sandbox-monitor-session-base - session aggregation surfaces now use
-        # container.sandboxes as the object base and only keep lease ids as the
-        # residue join key for chat_sessions.
         sandbox_rows = self._sandbox_rows_by_legacy_lease_id("query_resource_sessions")
-
-        all_sessions = q.rows(
-            self._client.table("chat_sessions").select("chat_session_id,thread_id,lease_id,status,started_at").execute(),
-            _REPO,
-            "query_resource_sessions all_sessions",
-        )
-        latest_session_thread_by_lease: dict[str, str] = {}
-        for row in sorted(all_sessions, key=lambda x: x.get("started_at") or ""):
-            lease_id = str(row.get("lease_id") or "")
-            thread_id = str(row.get("thread_id") or "")
-            if lease_id and thread_id:
-                latest_session_thread_by_lease[lease_id] = thread_id
-
         result = []
-        seen_leases: set[str] = set()
 
-        for s in active_sessions:
-            lease_id = str(s.get("lease_id") or "")
-            sandbox = sandbox_rows.get(lease_id)
-            if not sandbox:
-                continue
-            seen_leases.add(lease_id)
-            result.append(self._resource_session_row_from_sandbox(sandbox, session_id=s["chat_session_id"], thread_id=s["thread_id"]))
-
-        for lid, sandbox in sandbox_rows.items():
-            if lid in seen_leases:
-                continue
+        for sandbox in sandbox_rows.values():
             thread_ids = self._thread_ids_for_sandbox_id(str(sandbox.get("id") or ""))
             if thread_ids:
                 for thread_id in thread_ids:
@@ -229,7 +163,7 @@ class SupabaseSandboxMonitorRepo:
                 self._resource_session_row_from_sandbox(
                     sandbox,
                     session_id=None,
-                    thread_id=latest_session_thread_by_lease.get(lid),
+                    thread_id=None,
                 )
             )
 

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -11,6 +11,13 @@ class _BrokenSandboxInstancesClient(FakeSupabaseClient):
         return super().table(table_name)
 
 
+class _BrokenChatSessionsClient(FakeSupabaseClient):
+    def table(self, table_name: str):
+        if table_name == "chat_sessions":
+            raise RuntimeError("chat_sessions exploded")
+        return super().table(table_name)
+
+
 class _MaxInFilterQuery(FakeSupabaseQuery):
     def in_(self, column: str, values: list[object]):
         assert len(values) <= 80
@@ -333,7 +340,7 @@ def test_query_sandbox_allows_missing_legacy_lease_bridge() -> None:
     }
 
 
-def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
+def test_query_thread_sessions_ignores_removed_chat_sessions_rows() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -357,25 +364,43 @@ def test_query_thread_sessions_reads_container_sandbox_rows() -> None:
         }
     )
 
-    assert repo.query_thread_sessions("thread-1") == [
+    assert repo.query_thread_sessions("thread-1") == []
+
+
+def test_session_monitor_surfaces_do_not_read_removed_chat_sessions_table() -> None:
+    repo = SupabaseSandboxMonitorRepo(
+        _BrokenChatSessionsClient(
+            {
+                "container.sandboxes": [
+                    _sandbox("sandbox-1", provider_env_id="instance-1", legacy_lease_id="lease-1"),
+                ],
+                "container.workspaces": [
+                    _workspace("workspace-1", "sandbox-1", updated_at="2026-04-05T10:05:00"),
+                ],
+                "agent.threads": [
+                    _thread("thread-1", "workspace-1", updated_at="2026-04-05T10:05:00"),
+                ],
+            }
+        )
+    )
+
+    assert repo.query_thread_sessions("thread-1") == []
+    assert repo.query_sandbox_sessions("sandbox-1") == []
+    assert repo.query_resource_sessions() == [
         {
-            "chat_session_id": "sess-1",
-            "status": "active",
-            "started_at": "2026-04-05T10:01:00",
-            "ended_at": None,
-            "close_reason": None,
+            "provider": "local",
+            "session_id": None,
+            "thread_id": "thread-1",
             "sandbox_id": "sandbox-1",
             "lease_id": "lease-1",
-            "provider_name": "daytona_selfhost",
-            "desired_state": "paused",
-            "observed_state": "paused",
-            "current_instance_id": "instance-1",
-            "last_error": "last boom",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-05T09:00:00",
         }
     ]
 
 
-def test_query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell(monkeypatch) -> None:
+def test_query_sandbox_sessions_no_longer_reads_remote_session_shell(monkeypatch) -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -401,26 +426,10 @@ def test_query_sandbox_sessions_no_longer_roundtrips_through_lease_session_shell
 
     assert not hasattr(repo, "query_lease_sessions")
 
-    assert repo.query_sandbox_sessions("sandbox-1") == [
-        {
-            "chat_session_id": "sess-1",
-            "status": "active",
-            "started_at": "2026-04-05T10:01:00",
-            "ended_at": None,
-            "close_reason": None,
-            "sandbox_id": "sandbox-1",
-            "lease_id": "lease-1",
-            "provider_name": "daytona_selfhost",
-            "desired_state": "paused",
-            "observed_state": "paused",
-            "current_instance_id": "instance-1",
-            "last_error": "last boom",
-            "thread_id": "thread-1",
-        }
-    ]
+    assert repo.query_sandbox_sessions("sandbox-1") == []
 
 
-def test_query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell(monkeypatch) -> None:
+def test_query_thread_sessions_no_longer_reads_lease_or_session_summary_shell(monkeypatch) -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -452,22 +461,7 @@ def test_query_thread_sessions_no_longer_roundtrips_through_lease_summary_shell(
         ),
     )
 
-    assert repo.query_thread_sessions("thread-1") == [
-        {
-            "chat_session_id": "sess-1",
-            "status": "active",
-            "started_at": "2026-04-05T10:01:00",
-            "ended_at": None,
-            "close_reason": None,
-            "sandbox_id": "sandbox-1",
-            "lease_id": "lease-1",
-            "provider_name": "daytona_selfhost",
-            "desired_state": "paused",
-            "observed_state": "paused",
-            "current_instance_id": "instance-1",
-            "last_error": "last boom",
-        }
-    ]
+    assert repo.query_thread_sessions("thread-1") == []
 
 
 def test_query_sandboxes_uses_latest_workspace_thread_binding() -> None:
@@ -887,7 +881,7 @@ def test_resource_session_row_source_shell_is_removed() -> None:
     assert not hasattr(repo, "list_sessions_with_leases")
 
 
-def test_query_resource_sessions_keeps_active_terminal_and_latest_closed_session_rows() -> None:
+def test_query_resource_sessions_uses_sandbox_thread_rows_without_session_rows() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -929,7 +923,7 @@ def test_query_resource_sessions_keeps_active_terminal_and_latest_closed_session
         {
             "provider": "docker",
             "session_id": None,
-            "thread_id": "thread-new",
+            "thread_id": None,
             "sandbox_id": "sandbox-recent",
             "lease_id": "lease-recent",
             "observed_state": "paused",
@@ -958,8 +952,8 @@ def test_query_resource_sessions_keeps_active_terminal_and_latest_closed_session
         },
         {
             "provider": "local",
-            "session_id": "sess-active",
-            "thread_id": "thread-active",
+            "session_id": None,
+            "thread_id": None,
             "sandbox_id": "sandbox-active",
             "lease_id": "lease-active",
             "observed_state": "running",
@@ -1016,8 +1010,8 @@ def test_query_resource_sessions_no_longer_materializes_lease_map(monkeypatch) -
         },
         {
             "provider": "local",
-            "session_id": "sess-active",
-            "thread_id": "thread-active",
+            "session_id": None,
+            "thread_id": None,
             "sandbox_id": "sandbox-active",
             "lease_id": "lease-active",
             "observed_state": "running",


### PR DESCRIPTION
## Summary
- rebase onto dev 9b00c1c7 after #682 landed the default runtime/control-plane/container demotion
- keep only the remaining monitor delta: remove sandbox monitor reads from staging.chat_sessions
- resource-session monitor rows now derive from container.sandboxes/workspaces/threads and expose session_id=null

## Verification
- uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/storage/test_runtime_terminal_session_demotion.py -q
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py --check
- git diff --check