### PR TITLE
Move agent config Supabase repo to agent schema

### DIFF
--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -313,10 +313,13 @@ def create_agent_user(
     # The user row must exist before the config write, otherwise live staging
     # rejects the insert on the forward reference.
     if agent_config_repo:
+        if owner_user_id is None:
+            raise RuntimeError("owner_user_id is required when creating repo-backed agent configs")
         _save_config_to_repo(
             agent_config_repo,
             agent_config_id,
             agent_user_id=agent_user_id,
+            owner_user_id=owner_user_id,
             name=name,
             description=description,
             status="draft",
@@ -390,6 +393,7 @@ def _save_config_to_repo(
     agent_config_id: str,
     *,
     agent_user_id: str,
+    owner_user_id: str,
     name: str,
     description: str = "",
     model: str | None = None,
@@ -407,6 +411,7 @@ def _save_config_to_repo(
         agent_config_id,
         {
             "agent_user_id": agent_user_id,
+            "owner_user_id": owner_user_id,
             "name": name,
             "description": description,
             "model": model,
@@ -708,6 +713,7 @@ def install_from_snapshot(
         agent_config_repo,
         agent_config_id,
         agent_user_id=user_id,
+        owner_user_id=owner_user_id,
         name=agent_name,
         description=agent_description,
         model=agent_model,

--- a/backend/web/services/auth_service.py
+++ b/backend/web/services/auth_service.py
@@ -267,6 +267,7 @@ class AuthService:
                 agent_config_id,
                 {
                     "agent_user_id": agent_id,
+                    "owner_user_id": owner_user_id,
                     "name": agent_def["name"],
                     "description": agent_def["description"],
                     "status": "active",

--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -198,11 +198,15 @@ def publish(
     user = user_repo.get_by_id(user_id)
     if user is None or user.agent_config_id is None:
         raise RuntimeError(f"Agent user {user_id} is missing agent_config_id")
+    owner_user_id = getattr(user, "owner_user_id", None)
+    if owner_user_id is None:
+        raise RuntimeError(f"Agent user {user_id} is missing owner_user_id")
     agent_config_repo.save_config(
         user.agent_config_id,
         {
             "id": user.agent_config_id,
             "agent_user_id": user_id,
+            "owner_user_id": owner_user_id,
             "name": bundle.agent.name,
             "description": bundle.agent.description,
             "model": bundle.agent.model,

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
 from storage.providers.supabase import _query as q
@@ -52,6 +53,9 @@ class SupabaseAgentConfigRepo:
 
     def save_config(self, agent_config_id: str, data: dict[str, Any]) -> None:
         payload = {"id": agent_config_id, **{k: v for k, v in data.items() if k != "id"}}
+        for timestamp_key in ("created_at", "updated_at"):
+            if timestamp_key in payload:
+                payload[timestamp_key] = _coerce_timestamptz(payload[timestamp_key])
         if "tools" in payload:
             payload["tools_json"] = payload.pop("tools")
         if "runtime" in payload:
@@ -160,3 +164,9 @@ class SupabaseAgentConfigRepo:
 
     def delete_sub_agent(self, sub_agent_id: str) -> None:
         self._table("agent_sub_agents").delete().eq("id", sub_agent_id).execute()
+
+
+def _coerce_timestamptz(value: Any) -> Any:
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(value / 1000, UTC).isoformat()
+    return value

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -8,6 +8,7 @@ from typing import Any
 from storage.providers.supabase import _query as q
 
 _REPO = "agent_config repo"
+_SCHEMA = "agent"
 
 
 class SupabaseAgentConfigRepo:
@@ -17,13 +18,16 @@ class SupabaseAgentConfigRepo:
     def close(self) -> None:
         return None
 
+    def _table(self, table: str) -> Any:
+        return q.schema_table(self._client, _SCHEMA, table, _REPO)
+
     # ------------------------------------------------------------------
     # agent_configs (1:1 with agent_config id)
     # ------------------------------------------------------------------
 
     def get_config(self, agent_config_id: str) -> dict[str, Any] | None:
         rows = q.rows(
-            self._client.table("agent_configs").select("*").eq("id", agent_config_id).execute(),
+            self._table("agent_configs").select("*").eq("id", agent_config_id).execute(),
             _REPO,
             "get_config",
         )
@@ -67,10 +71,10 @@ class SupabaseAgentConfigRepo:
             else:
                 meta["compact"] = compact
         payload["meta_json"] = meta
-        self._client.table("agent_configs").upsert(payload).execute()
+        self._table("agent_configs").upsert(payload).execute()
 
     def delete_config(self, agent_config_id: str) -> None:
-        self._client.table("agent_configs").delete().eq("id", agent_config_id).execute()
+        self._table("agent_configs").delete().eq("id", agent_config_id).execute()
 
     # ------------------------------------------------------------------
     # agent_rules
@@ -78,7 +82,7 @@ class SupabaseAgentConfigRepo:
 
     def list_rules(self, agent_config_id: str) -> list[dict[str, Any]]:
         rows = q.rows(
-            self._client.table("agent_rules").select("*").eq("agent_config_id", agent_config_id).execute(),
+            self._table("agent_rules").select("*").eq("agent_config_id", agent_config_id).execute(),
             _REPO,
             "list_rules",
         )
@@ -87,11 +91,11 @@ class SupabaseAgentConfigRepo:
     def save_rule(self, agent_config_id: str, filename: str, content: str, rule_id: str | None = None) -> dict[str, Any]:
         rid = rule_id or str(uuid.uuid4())
         payload = {"id": rid, "agent_config_id": agent_config_id, "filename": filename, "content": content}
-        self._client.table("agent_rules").upsert(payload).execute()
+        self._table("agent_rules").upsert(payload).execute()
         return payload
 
     def delete_rule(self, rule_id: str) -> None:
-        self._client.table("agent_rules").delete().eq("id", rule_id).execute()
+        self._table("agent_rules").delete().eq("id", rule_id).execute()
 
     # ------------------------------------------------------------------
     # agent_skills
@@ -99,7 +103,7 @@ class SupabaseAgentConfigRepo:
 
     def list_skills(self, agent_config_id: str) -> list[dict[str, Any]]:
         rows = q.rows(
-            self._client.table("agent_skills").select("*").eq("agent_config_id", agent_config_id).execute(),
+            self._table("agent_skills").select("*").eq("agent_config_id", agent_config_id).execute(),
             _REPO,
             "list_skills",
         )
@@ -112,11 +116,11 @@ class SupabaseAgentConfigRepo:
         payload: dict[str, Any] = {"id": sid, "agent_config_id": agent_config_id, "name": name, "content": content}
         if meta:
             payload["meta_json"] = meta
-        self._client.table("agent_skills").upsert(payload, on_conflict="agent_config_id,name").execute()
+        self._table("agent_skills").upsert(payload, on_conflict="agent_config_id,name").execute()
         return payload
 
     def delete_skill(self, skill_id: str) -> None:
-        self._client.table("agent_skills").delete().eq("id", skill_id).execute()
+        self._table("agent_skills").delete().eq("id", skill_id).execute()
 
     # ------------------------------------------------------------------
     # agent_sub_agents
@@ -124,7 +128,7 @@ class SupabaseAgentConfigRepo:
 
     def list_sub_agents(self, agent_config_id: str) -> list[dict[str, Any]]:
         rows = q.rows(
-            self._client.table("agent_sub_agents").select("*").eq("agent_config_id", agent_config_id).execute(),
+            self._table("agent_sub_agents").select("*").eq("agent_config_id", agent_config_id).execute(),
             _REPO,
             "list_sub_agents",
         )
@@ -151,8 +155,8 @@ class SupabaseAgentConfigRepo:
             payload["tools_json"] = tools
         if system_prompt is not None:
             payload["system_prompt"] = system_prompt
-        self._client.table("agent_sub_agents").upsert(payload, on_conflict="agent_config_id,name").execute()
+        self._table("agent_sub_agents").upsert(payload, on_conflict="agent_config_id,name").execute()
         return payload
 
     def delete_sub_agent(self, sub_agent_id: str) -> None:
-        self._client.table("agent_sub_agents").delete().eq("id", sub_agent_id).execute()
+        self._table("agent_sub_agents").delete().eq("id", sub_agent_id).execute()

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -361,6 +361,7 @@ def test_create_initial_agents_keeps_avatar_column_null_under_file_backed_avatar
     assert [row.id for row in created_users] == ["agent-toad", "agent-morel"]
     assert [row.display_name for row in created_users] == ["Toad", "Morel"]
     assert [item[0] for item in saved_configs] == ["cfg-toad", "cfg-morel"]
+    assert [item[1]["owner_user_id"] for item in saved_configs] == ["owner-1", "owner-1"]
     assert updates == []
     assert [(row.source_user_id, row.target_user_id, row.kind, row.state) for row in contact_edges] == [
         ("owner-1", "agent-toad", "normal", "active"),

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -277,7 +277,7 @@ def test_publish_uses_repo_bundle_when_member_dir_is_absent(tmp_path, monkeypatc
     saved: dict[str, object] = {}
     captured: dict[str, object] = {}
 
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1"))
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1", owner_user_id="owner-1"))
 
     class _AgentConfigRepo:
         def get_config(self, agent_config_id: str):
@@ -348,6 +348,7 @@ def test_publish_uses_repo_bundle_when_member_dir_is_absent(tmp_path, monkeypatc
     assert payload["snapshot"]["rules"] == [{"name": "default", "content": "Rule content"}]
     assert payload["snapshot"]["skills"][0]["meta"] == {"name": "Search", "desc": "Repo Search"}
     assert saved["agent_config_id"] == "cfg-1"
+    assert saved["data"]["owner_user_id"] == "owner-1"
     assert saved["data"]["version"] == "0.1.1"
     assert saved["data"]["status"] == "active"
     assert saved["data"]["meta"]["source"]["marketplace_item_id"] == "item-123"
@@ -371,7 +372,7 @@ def test_publish_prefers_repo_lineage_even_when_stale_member_dir_exists(tmp_path
     }
     (member_dir / "meta.json").write_text(json.dumps(stale_meta, indent=2), encoding="utf-8")
 
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1"))
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1", owner_user_id="owner-1"))
 
     class _AgentConfigRepo:
         def get_config(self, agent_config_id: str):
@@ -435,6 +436,7 @@ def test_publish_prefers_repo_lineage_even_when_stale_member_dir_exists(tmp_path
     assert payload["parent_version"] == "0.1.0"
     assert payload["snapshot"]["meta"]["source"] == {"marketplace_item_id": "item-parent", "installed_version": "0.1.0"}
     assert saved["agent_config_id"] == "cfg-1"
+    assert saved["data"]["owner_user_id"] == "owner-1"
     assert saved["data"]["meta"]["source"]["marketplace_item_id"] == "item-123"
     assert saved["data"]["meta"]["source"]["installed_version"] == "0.1.1"
     assert json.loads((member_dir / "meta.json").read_text(encoding="utf-8")) == stale_meta

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -72,6 +72,7 @@ def test_supabase_agent_config_repo_save_config_uses_agent_config_id_payload() -
         {
             "id": "cfg-1",
             "agent_user_id": "user-agent-1",
+            "owner_user_id": "owner-1",
             "name": "Toad",
             "tools": ["search"],
             "runtime": {"tools:search": {"enabled": True}},
@@ -84,6 +85,7 @@ def test_supabase_agent_config_repo_save_config_uses_agent_config_id_payload() -
     payload = client.tables["agent.agent_configs"].upsert_payload
     assert payload is not None
     assert payload["id"] == "cfg-1"
+    assert payload["owner_user_id"] == "owner-1"
     assert "member_id" not in payload
     assert payload["tools_json"] == ["search"]
     assert payload["runtime_json"] == {"tools:search": {"enabled": True}}
@@ -97,6 +99,27 @@ def test_supabase_agent_config_repo_save_config_uses_agent_config_id_payload() -
     assert "mcp" not in payload
     assert "meta" not in payload
     assert "compact" not in payload
+
+
+def test_supabase_agent_config_repo_converts_millisecond_timestamps_for_timestamptz() -> None:
+    client = _FakeClient()
+    repo = SupabaseAgentConfigRepo(client)
+
+    repo.save_config(
+        "cfg-1",
+        {
+            "agent_user_id": "user-agent-1",
+            "owner_user_id": "owner-1",
+            "name": "Toad",
+            "created_at": 123000,
+            "updated_at": 456000,
+        },
+    )
+
+    payload = client.tables["agent.agent_configs"].upsert_payload
+    assert payload is not None
+    assert payload["created_at"] == "1970-01-01T00:02:03+00:00"
+    assert payload["updated_at"] == "1970-01-01T00:07:36+00:00"
 
 
 def test_supabase_agent_config_repo_get_config_normalizes_json_columns() -> None:

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -1,4 +1,5 @@
 from storage.providers.supabase.agent_config_repo import SupabaseAgentConfigRepo
+from tests.fakes.supabase import FakeSupabaseClient
 
 
 class _FakeTable:
@@ -35,15 +36,20 @@ class _FakeTable:
 
 
 class _FakeClient:
-    def __init__(self) -> None:
-        self.tables: dict[str, _FakeTable] = {}
+    def __init__(self, tables: dict[str, _FakeTable] | None = None, schema_name: str | None = None) -> None:
+        self.tables: dict[str, _FakeTable] = tables if tables is not None else {}
+        self.schema_name = schema_name
 
     def table(self, name):
-        table = self.tables.get(name)
+        resolved = f"{self.schema_name}.{name}" if self.schema_name else name
+        table = self.tables.get(resolved)
         if table is None:
             table = _FakeTable()
-            self.tables[name] = table
+            self.tables[resolved] = table
         return table
+
+    def schema(self, name):
+        return _FakeClient(self.tables, schema_name=name)
 
 
 def test_supabase_agent_config_repo_get_config_filters_on_agent_config_id() -> None:
@@ -53,8 +59,8 @@ def test_supabase_agent_config_repo_get_config_filters_on_agent_config_id() -> N
     row = repo.get_config("cfg-1")
 
     assert row is not None
-    assert ("id", "cfg-1") in client.tables["agent_configs"].eq_calls
-    assert ("member_id", "cfg-1") not in client.tables["agent_configs"].eq_calls
+    assert ("id", "cfg-1") in client.tables["agent.agent_configs"].eq_calls
+    assert ("member_id", "cfg-1") not in client.tables["agent.agent_configs"].eq_calls
 
 
 def test_supabase_agent_config_repo_save_config_uses_agent_config_id_payload() -> None:
@@ -75,7 +81,7 @@ def test_supabase_agent_config_repo_save_config_uses_agent_config_id_payload() -
         },
     )
 
-    payload = client.tables["agent_configs"].upsert_payload
+    payload = client.tables["agent.agent_configs"].upsert_payload
     assert payload is not None
     assert payload["id"] == "cfg-1"
     assert "member_id" not in payload
@@ -95,8 +101,8 @@ def test_supabase_agent_config_repo_save_config_uses_agent_config_id_payload() -
 
 def test_supabase_agent_config_repo_get_config_normalizes_json_columns() -> None:
     client = _FakeClient()
-    client.tables["agent_configs"] = _FakeTable()
-    client.tables["agent_configs"].rows = [
+    client.tables["agent.agent_configs"] = _FakeTable()
+    client.tables["agent.agent_configs"].rows = [
         {
             "id": "cfg-1",
             "agent_user_id": "user-agent-1",
@@ -128,7 +134,7 @@ def test_supabase_agent_config_repo_save_skill_conflicts_on_agent_config_id_and_
 
     repo.save_skill("cfg-1", "Search", "search skill", meta={"enabled": True})
 
-    table = client.tables["agent_skills"]
+    table = client.tables["agent.agent_skills"]
     assert table.upsert_payload is not None
     assert table.upsert_payload["agent_config_id"] == "cfg-1"
     assert table.upsert_conflict == "agent_config_id,name"
@@ -141,8 +147,8 @@ def test_supabase_agent_config_repo_list_rules_filters_on_agent_config_id() -> N
 
     repo.list_rules("cfg-1")
 
-    assert ("agent_config_id", "cfg-1") in client.tables["agent_rules"].eq_calls
-    assert ("member_id", "cfg-1") not in client.tables["agent_rules"].eq_calls
+    assert ("agent_config_id", "cfg-1") in client.tables["agent.agent_rules"].eq_calls
+    assert ("member_id", "cfg-1") not in client.tables["agent.agent_rules"].eq_calls
 
 
 def test_supabase_agent_config_repo_save_sub_agent_uses_tools_json() -> None:
@@ -151,7 +157,36 @@ def test_supabase_agent_config_repo_save_sub_agent_uses_tools_json() -> None:
 
     repo.save_sub_agent("cfg-1", "Scout", tools=["search"])
 
-    table = client.tables["agent_sub_agents"]
+    table = client.tables["agent.agent_sub_agents"]
     assert table.upsert_payload is not None
     assert table.upsert_payload["agent_config_id"] == "cfg-1"
     assert table.upsert_payload["tools_json"] == ["search"]
+
+
+def test_supabase_agent_config_repo_uses_agent_schema_tables() -> None:
+    tables: dict[str, list[dict]] = {
+        "agent.agent_configs": [
+            {
+                "id": "cfg-1",
+                "agent_user_id": "user-agent-1",
+                "name": "Toad",
+                "description": "target schema config",
+            }
+        ],
+        "agent.agent_rules": [{"id": "rule-1", "agent_config_id": "cfg-1", "filename": "RULE.md", "content": "rule"}],
+    }
+    repo = SupabaseAgentConfigRepo(FakeSupabaseClient(tables))
+
+    config = repo.get_config("cfg-1")
+    repo.save_skill("cfg-1", "Search", "skill")
+    repo.save_sub_agent("cfg-1", "Scout")
+
+    assert config is not None
+    assert config["id"] == "cfg-1"
+    assert repo.list_rules("cfg-1")[0]["id"] == "rule-1"
+    assert "agent.agent_skills" in tables
+    assert "agent.agent_sub_agents" in tables
+    assert "agent_configs" not in tables
+    assert "agent_rules" not in tables
+    assert "agent_skills" not in tables
+    assert "agent_sub_agents" not in tables


### PR DESCRIPTION
## Summary
- move SupabaseAgentConfigRepo reads/writes to agent.agent_configs, agent.agent_rules, agent.agent_skills, and agent.agent_sub_agents through schema-qualified query roots
- update unit fakes/tests so the repo fails if it falls back to unqualified/default-schema agent_config tables
- prerequisite DB target landing/backfill already executed on live Supabase: agent.agent_configs=33, child tables=0, staging/agent config id drift=0

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_agent_config_repo.py -q
- uv run python -m pytest tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/backend/test_auth_service_token_verification.py tests/Integration/test_marketplace_router_user_shell.py -q
- uv run python -m pytest tests/Unit/core/test_agent_pool.py tests/Unit/platform/test_marketplace_client.py -q
- uv run ruff check storage/providers/supabase/agent_config_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py
- uv run ruff format storage/providers/supabase/agent_config_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py --check
- git diff --check

## Follow-up
After this merges and is verified, archive/drop staging.agent_configs, staging.agent_rules, staging.agent_skills, and staging.agent_sub_agents.