### PR TITLE
Fix monitor sandbox thread binding query

### DIFF
--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -269,11 +269,13 @@ class SupabaseSandboxMonitorRepo:
         ordered_ids = [str(sandbox_id or "").strip() for sandbox_id in sandbox_ids if str(sandbox_id or "").strip()]
         if not ordered_ids:
             return {}
+        sandbox_id_set = set(ordered_ids)
 
-        workspaces = q.rows_in_chunks(
-            lambda: q.schema_table(self._client, "container", "workspaces", _REPO).select("id,sandbox_id,updated_at,created_at"),
-            "sandbox_id",
-            ordered_ids,
+        # @@@monitor-binding-query - remote PostgREST can 502 on large sandbox_id IN
+        # filters here; monitor already loaded all sandboxes, so filter the small
+        # workspace/thread projections locally instead of making this endpoint fragile.
+        workspaces = q.rows(
+            q.schema_table(self._client, "container", "workspaces", _REPO).select("id,sandbox_id,updated_at,created_at").execute(),
             _REPO,
             "query_sandboxes workspaces",
         )
@@ -281,15 +283,14 @@ class SupabaseSandboxMonitorRepo:
         for row in sorted(workspaces, key=lambda x: x.get("updated_at") or x.get("created_at") or ""):
             workspace_id = str(row.get("id") or "").strip()
             sandbox_id = str(row.get("sandbox_id") or "").strip()
-            if workspace_id and sandbox_id:
+            if workspace_id and sandbox_id in sandbox_id_set:
                 workspace_to_sandbox[workspace_id] = sandbox_id
         if not workspace_to_sandbox:
             return {}
+        workspace_id_set = set(workspace_to_sandbox)
 
-        threads = q.rows_in_chunks(
-            lambda: q.schema_table(self._client, "agent", "threads", _REPO).select("id,current_workspace_id,updated_at,created_at"),
-            "current_workspace_id",
-            list(workspace_to_sandbox),
+        threads = q.rows(
+            q.schema_table(self._client, "agent", "threads", _REPO).select("id,current_workspace_id,updated_at,created_at").execute(),
             _REPO,
             "query_sandboxes threads",
         )
@@ -298,7 +299,7 @@ class SupabaseSandboxMonitorRepo:
             thread_id = str(row.get("id") or "").strip()
             workspace_id = str(row.get("current_workspace_id") or "").strip()
             sandbox_id = workspace_to_sandbox.get(workspace_id)
-            if thread_id and sandbox_id:
+            if thread_id and workspace_id in workspace_id_set and sandbox_id:
                 result[sandbox_id] = thread_id
         return result
 

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -32,6 +32,25 @@ class _MaxInFilterClient(FakeSupabaseClient):
         return query
 
 
+class _NoWorkspaceSandboxInQuery(FakeSupabaseQuery):
+    def in_(self, column: str, values: list[object]):
+        if self._table_name == "container.workspaces" and column == "sandbox_id":
+            raise AssertionError("query_sandboxes should not use sandbox_id IN against container.workspaces")
+        return super().in_(column, values)
+
+
+class _NoWorkspaceSandboxInClient(FakeSupabaseClient):
+    def table(self, table_name: str):
+        resolved_table = f"{self._schema_name}.{table_name}" if self._schema_name else table_name
+        query = _NoWorkspaceSandboxInQuery(resolved_table, self._tables)
+        if resolved_table in self._auto_seq_tables:
+            query._auto_seq = True
+        return query
+
+    def schema(self, schema_name: str):
+        return _NoWorkspaceSandboxInClient(self._tables, self._auto_seq_tables, schema_name=schema_name)
+
+
 def _repo(tables: dict) -> SupabaseSandboxMonitorRepo:
     return SupabaseSandboxMonitorRepo(FakeSupabaseClient(tables))
 
@@ -548,7 +567,28 @@ def test_query_sandboxes_reads_container_sandboxes_with_workspace_binding() -> N
     ]
 
 
-def test_query_sandboxes_chunks_workspace_thread_binding_lookup() -> None:
+def test_query_sandboxes_does_not_depend_on_workspace_sandbox_id_in_filter() -> None:
+    repo = SupabaseSandboxMonitorRepo(
+        _NoWorkspaceSandboxInClient(
+            {
+                "container.sandboxes": [
+                    _sandbox(
+                        "sandbox-1",
+                        provider_env_id="instance-1",
+                        updated_at="2026-04-05T10:10:00",
+                        legacy_lease_id="lease-1",
+                    )
+                ],
+                "container.workspaces": [_workspace("workspace-1", "sandbox-1")],
+                "agent.threads": [_thread("thread-1", "workspace-1")],
+            }
+        )
+    )
+
+    assert repo.query_sandboxes()[0]["thread_id"] == "thread-1"
+
+
+def test_query_sandboxes_handles_many_workspace_thread_bindings() -> None:
     sandboxes = [
         _sandbox(
             f"sandbox-{index}",


### PR DESCRIPTION
## Summary
- avoid fragile PostgREST sandbox_id IN lookup when binding monitor sandboxes to threads
- filter workspace/thread projections locally while preserving latest-binding behavior
- add regression coverage for query_sandboxes without workspace sandbox_id IN

## Verification
- uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Integration/test_monitor_resources_route.py tests/Unit/sandbox/test_sandbox_user_leases.py -q
- uv run ruff check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- uv run ruff format --check storage/providers/supabase/sandbox_monitor_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py
- git diff --check
- YATU: local Supabase backend on 8010, login 200, /api/monitor/sandboxes 200, POST /api/threads 200, /api/threads/{id}/runtime 200, /api/monitor/threads 200, abstract_terminals +1 on create and 0 after DELETE cleanup