### PR TITLE
Fix checkpoint saver search path pinning

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -50,12 +50,10 @@ async def lifespan(app: FastAPI):
         supabase_client=_supabase_client,
         public_supabase_client=_public_supabase_client,
     )
-    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-
-    from core.runtime.langgraph_checkpoint_store import LangGraphCheckpointStore, agent_checkpoint_conn_string
+    from core.runtime.langgraph_checkpoint_store import LangGraphCheckpointStore, agent_checkpoint_saver_from_conn_string
 
     pg_url = os.environ["LEON_POSTGRES_URL"]
-    app.state._thread_checkpoint_saver_ctx = AsyncPostgresSaver.from_conn_string(agent_checkpoint_conn_string(pg_url))
+    app.state._thread_checkpoint_saver_ctx = agent_checkpoint_saver_from_conn_string(pg_url)
     app.state._thread_checkpoint_saver = await app.state._thread_checkpoint_saver_ctx.__aenter__()
     await app.state._thread_checkpoint_saver.setup()
     app.state.thread_checkpoint_store = LangGraphCheckpointStore(app.state._thread_checkpoint_saver)

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1342,13 +1342,11 @@ class LeonAgent:
         if not pg_url:
             raise RuntimeError("LEON_POSTGRES_URL is required for checkpointer initialization")
 
-        from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-
-        from core.runtime.langgraph_checkpoint_store import agent_checkpoint_conn_string
+        from core.runtime.langgraph_checkpoint_store import agent_checkpoint_saver_from_conn_string
 
         # from_conn_string is an async context manager; enter it and keep
         # the reference so the connection pool stays open for the agent's lifetime.
-        self._pg_saver_ctx = AsyncPostgresSaver.from_conn_string(agent_checkpoint_conn_string(pg_url))
+        self._pg_saver_ctx = agent_checkpoint_saver_from_conn_string(pg_url)
         self.checkpointer = await self._pg_saver_ctx.__aenter__()
         await self.checkpointer.setup()
 

--- a/core/runtime/langgraph_checkpoint_store.py
+++ b/core/runtime/langgraph_checkpoint_store.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any, cast
 from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
 
 from .checkpoint_store import ThreadCheckpointState
 
@@ -26,6 +32,21 @@ def agent_checkpoint_conn_string(conn_string: str) -> str:
     if not saw_options:
         merged_query.append(("options", "-csearch_path=agent"))
     return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(merged_query, quote_via=quote), parts.fragment))
+
+
+@asynccontextmanager
+async def agent_checkpoint_saver_from_conn_string(conn_string: str) -> AsyncIterator[AsyncPostgresSaver]:
+    shaped_conn_string = agent_checkpoint_conn_string(conn_string)
+    async with await AsyncConnection.connect(
+        shaped_conn_string,
+        autocommit=True,
+        prepare_threshold=0,
+        row_factory=dict_row,
+    ) as conn:
+        # @@@checkpoint-search-path - Supavisor may ignore libpq options, so pin
+        # the live connection before LangGraph setup creates unqualified tables.
+        await conn.execute("SET search_path TO agent")
+        yield AsyncPostgresSaver(conn=conn)
 
 
 class LangGraphCheckpointStore:

--- a/tests/Unit/core/test_langgraph_checkpoint_store.py
+++ b/tests/Unit/core/test_langgraph_checkpoint_store.py
@@ -1,3 +1,6 @@
+import pytest
+
+import core.runtime.langgraph_checkpoint_store as checkpoint_store
 from core.runtime.langgraph_checkpoint_store import agent_checkpoint_conn_string
 
 
@@ -17,3 +20,45 @@ def test_agent_checkpoint_conn_string_merges_existing_libpq_options() -> None:
     conn = agent_checkpoint_conn_string("postgresql://user:pass@db.example/postgres?options=-cstatement_timeout%3D5000")
 
     assert conn == "postgresql://user:pass@db.example/postgres?options=-cstatement_timeout%3D5000%20-csearch_path%3Dagent"
+
+
+@pytest.mark.asyncio
+async def test_agent_checkpoint_saver_sets_agent_search_path_on_open_connection(monkeypatch) -> None:
+    opened: dict[str, object] = {}
+
+    class _FakeConnection:
+        def __init__(self) -> None:
+            self.executed: list[str] = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            return None
+
+        async def execute(self, sql: str):
+            self.executed.append(sql)
+
+    class _FakeAsyncConnection:
+        @staticmethod
+        async def connect(conn_string: str, **kwargs):
+            conn = _FakeConnection()
+            opened["conn"] = conn
+            opened["conn_string"] = conn_string
+            opened["kwargs"] = kwargs
+            return conn
+
+    class _FakeSaver:
+        def __init__(self, *, conn, serde=None):
+            self.conn = conn
+            self.serde = serde
+
+    monkeypatch.setattr(checkpoint_store, "AsyncConnection", _FakeAsyncConnection)
+    monkeypatch.setattr(checkpoint_store, "AsyncPostgresSaver", _FakeSaver)
+
+    async with checkpoint_store.agent_checkpoint_saver_from_conn_string("postgresql://user:pass@db.example/postgres") as saver:
+        assert saver.conn is opened["conn"]
+
+    assert opened["conn_string"] == "postgresql://user:pass@db.example/postgres?options=-csearch_path%3Dagent"
+    assert opened["kwargs"]["autocommit"] is True
+    assert opened["conn"].executed == ["SET search_path TO agent"]


### PR DESCRIPTION
## Summary
- add a shared LangGraph checkpoint saver helper that sets `search_path` on the opened Postgres connection
- route web lifespan and LeonAgent checkpointer initialization through that helper
- keep the existing conn-string shaping, but do not rely on Supavisor honoring libpq `options`

## Root cause
Fresh DB audit after #686 showed `public.checkpoint_*` reappeared. Direct proof showed `agent_checkpoint_conn_string()` produced `options=-csearch_path=agent`, but a real Supavisor/psycopg connection still reported `SHOW search_path = "$user", public, extensions`. Explicit `SET search_path TO agent` on the live connection reports `search_path=agent` and `current_schema=agent`.

## Verification
- `uv run python -m pytest tests/Unit/core/test_langgraph_checkpoint_store.py tests/Unit/core/test_runtime_agent.py tests/Unit/storage/test_supabase_checkpoint_repo.py -q`
- `uv run ruff check core/runtime/langgraph_checkpoint_store.py core/runtime/agent.py backend/web/core/lifespan.py tests/Unit/core/test_langgraph_checkpoint_store.py`
- `uv run ruff format --check core/runtime/langgraph_checkpoint_store.py core/runtime/agent.py backend/web/core/lifespan.py tests/Unit/core/test_langgraph_checkpoint_store.py`
- `git diff --check`
- real Supavisor probe through `agent_checkpoint_saver_from_conn_string(...)`: `SHOW search_path -> agent`, `current_schema() -> agent`
