### PR TITLE
Move message queue repo to agent schema

### DIFF
--- a/storage/providers/supabase/queue_repo.py
+++ b/storage/providers/supabase/queue_repo.py
@@ -13,7 +13,7 @@ _SENDER_USER_ID = "sender_user_id"
 
 
 class SupabaseQueueRepo:
-    """Message queue backed by Supabase (table: message_queue, BIGSERIAL id)."""
+    """Message queue backed by Supabase (table: agent.message_queue, BIGSERIAL id)."""
 
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
@@ -22,7 +22,7 @@ class SupabaseQueueRepo:
         return None
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, "agent", _TABLE, _REPO)
 
     def _hydrate_item(self, row: dict[str, Any]) -> QueueItem:
         return QueueItem(

--- a/tests/Unit/storage/test_supabase_queue_repo.py
+++ b/tests/Unit/storage/test_supabase_queue_repo.py
@@ -4,8 +4,25 @@ from storage.providers.supabase.queue_repo import SupabaseQueueRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
 
+class _RecordingSupabaseClient(FakeSupabaseClient):
+    def __init__(self, tables: dict):
+        super().__init__(tables=tables)
+        self.table_names: list[str] = []
+
+    def table(self, table_name: str):
+        resolved_table = f"{self._schema_name}.{table_name}" if self._schema_name else table_name
+        self.table_names.append(resolved_table)
+        return super().table(table_name)
+
+    def schema(self, schema_name: str):
+        scoped = _RecordingSupabaseClient(self._tables)
+        scoped._schema_name = schema_name
+        scoped.table_names = self.table_names
+        return scoped
+
+
 def test_supabase_queue_repo_enqueue_persists_sender_user_id() -> None:
-    tables = {"message_queue": []}
+    tables = {"agent.message_queue": []}
     repo = SupabaseQueueRepo(client=FakeSupabaseClient(tables=tables))
 
     repo.enqueue(
@@ -17,7 +34,7 @@ def test_supabase_queue_repo_enqueue_persists_sender_user_id() -> None:
         sender_name="Alice",
     )
 
-    row = tables["message_queue"][0]
+    row = tables["agent.message_queue"][0]
     assert row["thread_id"] == "thread-1"
     assert row["sender_user_id"] == "user-1"
     assert "sender_id" not in row
@@ -25,7 +42,7 @@ def test_supabase_queue_repo_enqueue_persists_sender_user_id() -> None:
 
 def test_supabase_queue_repo_dequeue_maps_sender_user_id_to_sender_id() -> None:
     tables = {
-        "message_queue": [
+        "agent.message_queue": [
             {
                 "id": 1,
                 "thread_id": "thread-1",
@@ -43,12 +60,12 @@ def test_supabase_queue_repo_dequeue_maps_sender_user_id_to_sender_id() -> None:
 
     assert item is not None
     assert item.sender_id == "user-1"
-    assert tables["message_queue"] == []
+    assert tables["agent.message_queue"] == []
 
 
 def test_supabase_queue_repo_drain_all_maps_sender_user_id_to_sender_id() -> None:
     tables = {
-        "message_queue": [
+        "agent.message_queue": [
             {
                 "id": 1,
                 "thread_id": "thread-1",
@@ -74,4 +91,13 @@ def test_supabase_queue_repo_drain_all_maps_sender_user_id_to_sender_id() -> Non
     items = repo.drain_all("thread-1")
 
     assert [item.sender_id for item in items] == ["user-1", "user-2"]
-    assert tables["message_queue"] == []
+    assert tables["agent.message_queue"] == []
+
+
+def test_supabase_queue_repo_uses_agent_schema_table() -> None:
+    client = _RecordingSupabaseClient({"agent.message_queue": []})
+    repo = SupabaseQueueRepo(client=client)
+
+    repo.enqueue("thread-1", "hello")
+
+    assert client.table_names == ["agent.message_queue"]


### PR DESCRIPTION
## Summary
- route SupabaseQueueRepo to agent.message_queue
- update queue repo tests to assert schema-qualified access

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_queue_repo.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Integration/test_threads_router.py -k "queue or steer_message" -q
- uv run ruff check storage/providers/supabase/queue_repo.py tests/Unit/storage/test_supabase_queue_repo.py
- uv run ruff format --check storage/providers/supabase/queue_repo.py tests/Unit/storage/test_supabase_queue_repo.py
- git diff --check