### PR TITLE
Move recipe repo to container sandbox recipes

### DIFF
--- a/storage/providers/supabase/recipe_repo.py
+++ b/storage/providers/supabase/recipe_repo.py
@@ -9,7 +9,7 @@ from typing import Any
 from storage.providers.supabase import _query as q
 
 _REPO = "recipe repo"
-_TABLE = "library_recipes"
+_TABLE = "sandbox_recipes"
 
 
 class SupabaseRecipeRepo:
@@ -111,4 +111,4 @@ class SupabaseRecipeRepo:
         }
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, "container", _TABLE, _REPO)

--- a/tests/Unit/storage/test_supabase_recipe_repo.py
+++ b/tests/Unit/storage/test_supabase_recipe_repo.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from storage.providers.supabase.recipe_repo import SupabaseRecipeRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_supabase_recipe_repo_reads_container_sandbox_recipes() -> None:
+    tables = {
+        "container.sandbox_recipes": [
+            {
+                "owner_user_id": "owner-1",
+                "recipe_id": "local:default",
+                "kind": "custom",
+                "provider_type": "local",
+                "data_json": '{"id":"local:default"}',
+                "created_at": 1000,
+                "updated_at": 2000,
+            }
+        ]
+    }
+    repo = SupabaseRecipeRepo(FakeSupabaseClient(tables=tables))
+
+    rows = repo.list_by_owner("owner-1")
+
+    assert rows == [
+        {
+            "owner_user_id": "owner-1",
+            "recipe_id": "local:default",
+            "kind": "custom",
+            "provider_type": "local",
+            "data": {"id": "local:default"},
+            "created_at": 1000,
+            "updated_at": 2000,
+        }
+    ]
+    assert "library_recipes" not in tables
+
+
+def test_supabase_recipe_repo_writes_container_sandbox_recipes() -> None:
+    tables: dict[str, list[dict]] = {"container.sandbox_recipes": []}
+    repo = SupabaseRecipeRepo(FakeSupabaseClient(tables=tables))
+
+    row = repo.upsert(
+        owner_user_id="owner-1",
+        recipe_id="local:default",
+        kind="custom",
+        provider_type="local",
+        data={"id": "local:default"},
+        created_at=1000,
+    )
+
+    stored = tables["container.sandbox_recipes"][0]
+    assert row["recipe_id"] == "local:default"
+    assert stored["owner_user_id"] == "owner-1"
+    assert stored["data_json"] == '{"id": "local:default"}'
+    assert "library_recipes" not in tables


### PR DESCRIPTION
## Summary
- move SupabaseRecipeRepo from bare library_recipes to container.sandbox_recipes
- add focused storage tests proving reads/writes use the container schema target
- keep staging.library_recipes in place for post-merge archive/drop; target table was created/backfilled in the real DB with 56 rows and drift_count=0

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_recipe_repo.py tests/Unit/backend/test_auth_service_token_verification.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q
- uv run ruff check storage/providers/supabase/recipe_repo.py tests/Unit/storage/test_supabase_recipe_repo.py
- uv run ruff format --check storage/providers/supabase/recipe_repo.py tests/Unit/storage/test_supabase_recipe_repo.py
- git diff --check

## DB/Ops
- created/backfilled container.sandbox_recipes from staging.library_recipes: 56 rows, drift_count=0
- synced ~/share/ops/schema.sql to define container.sandbox_recipes and remove bare library_recipes DDL
- no staging drop in this PR