### PR TITLE
Move observability repos to observability schema

### DIFF
--- a/storage/providers/supabase/eval_batch_repo.py
+++ b/storage/providers/supabase/eval_batch_repo.py
@@ -22,7 +22,7 @@ class SupabaseEvaluationBatchRepo:
 
     def create_batch(self, batch: dict[str, Any]) -> dict[str, Any]:
         rows = q.rows(
-            self._client.table(_BATCH_TABLE).insert(batch).execute(),
+            self._t(_BATCH_TABLE).insert(batch).execute(),
             _REPO,
             "create_batch",
         )
@@ -32,7 +32,7 @@ class SupabaseEvaluationBatchRepo:
 
     def get_batch(self, batch_id: str) -> dict | None:
         rows = q.rows(
-            self._client.table(_BATCH_TABLE).select("*").eq("batch_id", batch_id).execute(),
+            self._t(_BATCH_TABLE).select("*").eq("batch_id", batch_id).execute(),
             _REPO,
             "get_batch",
         )
@@ -41,7 +41,7 @@ class SupabaseEvaluationBatchRepo:
         return self._map_batch(rows[0])
 
     def list_batches(self, limit: int = 50) -> list[dict[str, Any]]:
-        query = self._client.table(_BATCH_TABLE).select("*")
+        query = self._t(_BATCH_TABLE).select("*")
         query = q.order(query, "created_at", desc=True, repo=_REPO, operation="list_batches")
         query = q.limit(query, limit, _REPO, "list_batches")
         return [self._map_batch(row) for row in q.rows(query.execute(), _REPO, "list_batches")]
@@ -58,7 +58,7 @@ class SupabaseEvaluationBatchRepo:
         if not updates:
             return self.get_batch(batch_id)
         rows = q.rows(
-            self._client.table(_BATCH_TABLE).update(updates).eq("batch_id", batch_id).execute(),
+            self._t(_BATCH_TABLE).update(updates).eq("batch_id", batch_id).execute(),
             _REPO,
             "update_batch",
         )
@@ -68,7 +68,7 @@ class SupabaseEvaluationBatchRepo:
 
     def create_batch_run(self, batch_run: dict[str, Any]) -> dict[str, Any]:
         rows = q.rows(
-            self._client.table(_BATCH_RUN_TABLE).insert(batch_run).execute(),
+            self._t(_BATCH_RUN_TABLE).insert(batch_run).execute(),
             _REPO,
             "create_batch_run",
         )
@@ -77,13 +77,13 @@ class SupabaseEvaluationBatchRepo:
         return self._map_batch_run(rows[0])
 
     def list_batch_runs(self, batch_id: str) -> list[dict[str, Any]]:
-        query = self._client.table(_BATCH_RUN_TABLE).select("*").eq("batch_id", batch_id)
+        query = self._t(_BATCH_RUN_TABLE).select("*").eq("batch_id", batch_id)
         query = q.order(query, "item_key", desc=False, repo=_REPO, operation="list_batch_runs")
         return [self._map_batch_run(row) for row in q.rows(query.execute(), _REPO, "list_batch_runs")]
 
     def get_batch_run_by_eval_run_id(self, eval_run_id: str) -> dict[str, Any] | None:
         rows = q.rows(
-            self._client.table(_BATCH_RUN_TABLE).select("*").eq("eval_run_id", eval_run_id).execute(),
+            self._t(_BATCH_RUN_TABLE).select("*").eq("eval_run_id", eval_run_id).execute(),
             _REPO,
             "get_batch_run_by_eval_run_id",
         )
@@ -92,7 +92,7 @@ class SupabaseEvaluationBatchRepo:
         return self._map_batch_run(rows[0])
 
     def list_batch_runs_by_thread_id(self, thread_id: str) -> list[dict[str, Any]]:
-        query = self._client.table(_BATCH_RUN_TABLE).select("*").eq("thread_id", thread_id)
+        query = self._t(_BATCH_RUN_TABLE).select("*").eq("thread_id", thread_id)
         query = q.order(query, "started_at", desc=True, repo=_REPO, operation="list_batch_runs_by_thread_id")
         return [self._map_batch_run(row) for row in q.rows(query.execute(), _REPO, "list_batch_runs_by_thread_id")]
 
@@ -119,13 +119,13 @@ class SupabaseEvaluationBatchRepo:
         )
         if not updates:
             rows = q.rows(
-                self._client.table(_BATCH_RUN_TABLE).select("*").eq("batch_run_id", batch_run_id).execute(),
+                self._t(_BATCH_RUN_TABLE).select("*").eq("batch_run_id", batch_run_id).execute(),
                 _REPO,
                 "update_batch_run get",
             )
             return self._map_batch_run(rows[0]) if rows else None
         rows = q.rows(
-            self._client.table(_BATCH_RUN_TABLE).update(updates).eq("batch_run_id", batch_run_id).execute(),
+            self._t(_BATCH_RUN_TABLE).update(updates).eq("batch_run_id", batch_run_id).execute(),
             _REPO,
             "update_batch_run",
         )
@@ -145,6 +145,9 @@ class SupabaseEvaluationBatchRepo:
             "updated_at": row.get("updated_at"),
             "summary_json": row.get("summary_json") or {},
         }
+
+    def _t(self, table_name: str) -> Any:
+        return q.schema_table(self._client, "observability", table_name, _REPO)
 
     def _map_batch_run(self, row: dict[str, Any]) -> dict[str, Any]:
         return {

--- a/storage/providers/supabase/eval_repo.py
+++ b/storage/providers/supabase/eval_repo.py
@@ -227,4 +227,4 @@ class SupabaseEvalRepo:
         ]
 
     def _t(self, table_name: str) -> Any:
-        return self._client.table(table_name)
+        return q.schema_table(self._client, "observability", table_name, _REPO)

--- a/storage/providers/supabase/provider_event_repo.py
+++ b/storage/providers/supabase/provider_event_repo.py
@@ -13,7 +13,7 @@ _TABLE = "provider_events"
 
 
 class SupabaseProviderEventRepo:
-    """Provider event persistence backed by Supabase (table: provider_events, BIGSERIAL event_id)."""
+    """Provider event persistence backed by Supabase (table: observability.provider_events)."""
 
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
@@ -22,7 +22,7 @@ class SupabaseProviderEventRepo:
         return None
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, "observability", _TABLE, _REPO)
 
     def record(
         self,

--- a/tests/Unit/eval/test_repo_lifecycle.py
+++ b/tests/Unit/eval/test_repo_lifecycle.py
@@ -40,3 +40,20 @@ def test_supabase_eval_repo_updates_same_row_across_run_lifecycle() -> None:
     assert runs[0]["status"] == "completed"
     assert runs[0]["finished_at"] == "2026-04-08T12:01:00Z"
     assert repo.get_trajectory_json("run-1") == '{"id":"run-1"}'
+
+
+def test_supabase_eval_repo_uses_observability_schema_tables() -> None:
+    tables: dict[str, list[dict]] = {"observability.eval_runs": []}
+    client = FakeSupabaseClient(tables=tables)
+    repo = SupabaseEvalRepo(client)
+
+    repo.upsert_run_header(
+        run_id="run-1",
+        thread_id="thread-1",
+        started_at="2026-04-08T12:00:00Z",
+        user_message="hello",
+        status="running",
+    )
+
+    assert tables["observability.eval_runs"][0]["id"] == "run-1"
+    assert "eval_runs" not in tables

--- a/tests/Unit/storage/test_supabase_eval_batch_repo.py
+++ b/tests/Unit/storage/test_supabase_eval_batch_repo.py
@@ -68,7 +68,7 @@ class _FakeTable:
 class _FakeClient:
     def __init__(self):
         self.tables = {
-            "evaluation_batches": _FakeTable(
+            "observability.evaluation_batches": _FakeTable(
                 [
                     {
                         "batch_id": "batch-1",
@@ -83,11 +83,19 @@ class _FakeClient:
                     }
                 ]
             ),
-            "evaluation_batch_runs": _FakeTable([]),
+            "observability.evaluation_batch_runs": _FakeTable([]),
         }
+        self._schema_name = None
 
     def table(self, _name):
-        return self.tables[_name]
+        resolved = f"{self._schema_name}.{_name}" if self._schema_name else _name
+        return self.tables[resolved]
+
+    def schema(self, schema_name):
+        scoped = _FakeClient()
+        scoped.tables = self.tables
+        scoped._schema_name = schema_name
+        return scoped
 
 
 def test_supabase_eval_batch_repo_maps_batch_rows():
@@ -216,3 +224,25 @@ def test_supabase_eval_batch_repo_lists_batch_runs_by_thread_id():
 
     assert repo.list_batch_runs_by_thread_id("thread-1") == [first]
     assert repo.list_batch_runs_by_thread_id("missing-thread") == []
+
+
+def test_supabase_eval_batch_repo_uses_observability_schema_tables():
+    client = _FakeClient()
+    repo = SupabaseEvaluationBatchRepo(client)
+
+    repo.create_batch(
+        {
+            "batch_id": "batch-2",
+            "kind": "scenario_batch",
+            "submitted_by_user_id": "user-1",
+            "agent_user_id": "agent-1",
+            "config_json": {},
+            "status": "pending",
+            "created_at": None,
+            "updated_at": None,
+            "summary_json": {},
+        }
+    )
+
+    assert any(row["batch_id"] == "batch-2" for row in client.tables["observability.evaluation_batches"].rows)
+    assert "evaluation_batches" not in client.tables

--- a/tests/Unit/storage/test_supabase_provider_event_repo.py
+++ b/tests/Unit/storage/test_supabase_provider_event_repo.py
@@ -1,0 +1,18 @@
+from storage.providers.supabase.provider_event_repo import SupabaseProviderEventRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_supabase_provider_event_repo_uses_observability_schema_table() -> None:
+    tables: dict[str, list[dict]] = {"observability.provider_events": []}
+    repo = SupabaseProviderEventRepo(FakeSupabaseClient(tables=tables))
+
+    repo.record(
+        provider_name="daytona",
+        instance_id="instance-1",
+        event_type="started",
+        payload={"ok": True},
+        matched_lease_id="lease-1",
+    )
+
+    assert tables["observability.provider_events"][0]["provider_name"] == "daytona"
+    assert "provider_events" not in tables


### PR DESCRIPTION
## Summary
- route SupabaseEvalRepo to observability.eval_* tables
- route SupabaseEvaluationBatchRepo to observability.evaluation_* tables
- route SupabaseProviderEventRepo to observability.provider_events
- add schema-qualified regression tests for all three repo surfaces

## DB prerequisite already executed
- created/backfilled observability targets from staging sources
- backfill report: /Users/lexicalmathical/share/ops/backups/observability-target-backfill-20260417T070125Z/report.json
- no staging observability tables are dropped by this PR

## Verification
- uv run python -m pytest tests/Unit/eval/test_repo_lifecycle.py tests/Unit/storage/test_supabase_eval_batch_repo.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Unit/storage/test_eval_batch_runtime_wiring.py tests/Integration/test_monitor_resources_route.py -q
- uv run ruff check storage/providers/supabase/eval_repo.py storage/providers/supabase/eval_batch_repo.py storage/providers/supabase/provider_event_repo.py tests/Unit/eval/test_repo_lifecycle.py tests/Unit/storage/test_supabase_eval_batch_repo.py tests/Unit/storage/test_supabase_provider_event_repo.py
- uv run ruff format --check storage/providers/supabase/eval_repo.py storage/providers/supabase/eval_batch_repo.py storage/providers/supabase/provider_event_repo.py tests/Unit/eval/test_repo_lifecycle.py tests/Unit/storage/test_supabase_eval_batch_repo.py tests/Unit/storage/test_supabase_provider_event_repo.py
- git diff --check