### PR TITLE
refactor: read summaries from agent schema

### DIFF
--- a/storage/providers/supabase/summary_repo.py
+++ b/storage/providers/supabase/summary_repo.py
@@ -97,7 +97,7 @@ class SupabaseSummaryRepo:
         self._t().delete().eq("thread_id", thread_id).execute()
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, "agent", _TABLE, _REPO)
 
     def _required(self, row: dict[str, Any], field: str, operation: str) -> Any:
         value = row.get(field)

--- a/tests/Unit/storage/test_summary_repo.py
+++ b/tests/Unit/storage/test_summary_repo.py
@@ -5,7 +5,7 @@ from tests.fakes.supabase import FakeSupabaseClient
 
 
 def test_supabase_summary_repo_save_list_get_and_delete():
-    tables: dict[str, list[dict]] = {"summaries": []}
+    tables: dict[str, list[dict]] = {"agent.summaries": []}
     repo = SupabaseSummaryRepo(client=FakeSupabaseClient(tables=tables))
 
     repo.ensure_tables()
@@ -41,12 +41,13 @@ def test_supabase_summary_repo_save_list_get_and_delete():
     listed = repo.list_summaries("t-1")
     assert [row["summary_id"] for row in listed] == ["s-2", "s-1"]
 
-    active_count = sum(1 for row in tables["summaries"] if row["is_active"])
+    active_count = sum(1 for row in tables["agent.summaries"] if row["is_active"])
     assert active_count == 1
 
     repo.delete_thread_summaries("t-1")
     assert repo.list_summaries("t-1") == []
     assert repo.get_latest_summary_row("t-1") is None
+    assert "summaries" not in tables
 
 
 def test_supabase_summary_repo_requires_compatible_client():


### PR DESCRIPTION
## Summary
- switch SupabaseSummaryRepo to schema-qualified agent.summaries
- update focused repo test to prove no bare summaries table access

## DB prep
- created/backfilled agent.summaries from staging.summaries before app cut
- report: /Users/lexicalmathical/share/ops/backups/agent-summaries-target-backfill-20260417T072930Z/report.json
- source/target: 8 -> 8, id drift 0

## Verification
- RED first: tests/Unit/storage/test_summary_repo.py failed because old repo wrote bare summaries while test expected agent.summaries
- uv run python -m pytest tests/Unit/storage/test_summary_repo.py -q
- uv run python -m pytest tests/Unit/storage/test_summary_repo.py tests/Unit/core/test_memory_compaction_config.py tests/Integration/test_memory_middleware_integration.py tests/Integration/test_e2e_summary_persistence.py -q
- uv run ruff check storage/providers/supabase/summary_repo.py tests/Unit/storage/test_summary_repo.py
- uv run ruff format --check storage/providers/supabase/summary_repo.py tests/Unit/storage/test_summary_repo.py
- git diff --check

No staging.summaries drop in this PR; drop waits for merge + backend/API YATU.