### PR TITLE
refactor: read file operations from agent schema

### DIFF
--- a/storage/providers/supabase/file_operation_repo.py
+++ b/storage/providers/supabase/file_operation_repo.py
@@ -64,4 +64,4 @@ class SupabaseFileOperationRepo:
         return len(pre)
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, "agent", _TABLE, _REPO)

--- a/tests/Unit/storage/test_file_operation_repo.py
+++ b/tests/Unit/storage/test_file_operation_repo.py
@@ -1,0 +1,23 @@
+from storage.providers.supabase.file_operation_repo import SupabaseFileOperationRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_supabase_file_operation_repo_uses_agent_schema() -> None:
+    tables: dict[str, list[dict]] = {"agent.file_operations": []}
+    repo = SupabaseFileOperationRepo(client=FakeSupabaseClient(tables=tables))
+
+    op_id = repo.record(
+        thread_id="thread-1",
+        checkpoint_id="checkpoint-1",
+        operation_type="write",
+        file_path="/tmp/example.txt",
+        before_content=None,
+        after_content="hello",
+        changes=[{"line": 1}],
+    )
+
+    assert tables["agent.file_operations"][0]["id"] == op_id
+    assert tables["agent.file_operations"][0]["thread_id"] == "thread-1"
+    assert repo.delete_thread_operations("thread-1") == 1
+    assert tables["agent.file_operations"] == []
+    assert "file_operations" not in tables


### PR DESCRIPTION
## Summary
- switch SupabaseFileOperationRepo to schema-qualified agent.file_operations
- add focused repo test proving no bare file_operations access

## DB prep
- created/backfilled agent.file_operations from staging.file_operations before app cut
- report: /Users/lexicalmathical/share/ops/backups/agent-file-operations-target-backfill-20260417T074230Z/report.json
- source/target: 18 -> 18, id drift 0

## Verification
- RED first: tests/Unit/storage/test_file_operation_repo.py failed because old repo wrote bare file_operations while test expected agent.file_operations
- uv run python -m pytest tests/Unit/storage/test_file_operation_repo.py -q
- uv run python -m pytest tests/Unit/storage/test_file_operation_repo.py tests/Unit/core/test_agent_pool.py tests/Integration/test_e2e_summary_persistence.py -q
- uv run ruff check storage/providers/supabase/file_operation_repo.py tests/Unit/storage/test_file_operation_repo.py
- uv run ruff format --check storage/providers/supabase/file_operation_repo.py tests/Unit/storage/test_file_operation_repo.py
- git diff --check

No staging.file_operations drop in this PR; drop waits for merge + mechanism/backend proof.