### PR TITLE
Move user settings repo to identity schema

### DIFF
--- a/storage/providers/supabase/user_settings_repo.py
+++ b/storage/providers/supabase/user_settings_repo.py
@@ -10,6 +10,7 @@ from typing import Any
 from storage.providers.supabase import _query as q
 
 _REPO = "user_settings repo"
+_SCHEMA = "identity"
 _TABLE = "user_settings"
 
 
@@ -21,7 +22,7 @@ class SupabaseUserSettingsRepo:
         return None
 
     def _table(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
 
     def get(self, user_id: str) -> dict[str, Any]:
         rows = q.rows(

--- a/tests/Unit/storage/test_supabase_settings_and_invites.py
+++ b/tests/Unit/storage/test_supabase_settings_and_invites.py
@@ -26,7 +26,7 @@ class _RecordingSupabaseClient(FakeSupabaseClient):
 
 def test_user_settings_recent_workspace_parser_does_not_hide_unexpected_json_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     tables = {
-        "user_settings": [
+        "identity.user_settings": [
             {
                 "user_id": "user-1",
                 "recent_workspaces": '["/workspace"]',
@@ -48,7 +48,7 @@ def test_user_settings_reads_account_resource_limits() -> None:
     repo = SupabaseUserSettingsRepo(
         FakeSupabaseClient(
             tables={
-                "user_settings": [
+                "identity.user_settings": [
                     {
                         "user_id": "user-1",
                         "account_resource_limits": {"sandbox": {"daytona_selfhost": 5}},
@@ -59,6 +59,20 @@ def test_user_settings_reads_account_resource_limits() -> None:
     )
 
     assert repo.get_account_resource_limits("user-1") == {"sandbox": {"daytona_selfhost": 5}}
+
+
+def test_user_settings_repo_uses_identity_schema_for_reads_and_writes() -> None:
+    tables = {"identity.user_settings": [{"user_id": "user-1", "default_model": "leon:large"}]}
+    client = _RecordingSupabaseClient(tables)
+    repo = SupabaseUserSettingsRepo(client)
+
+    assert repo.get("user-1")["default_model"] == "leon:large"
+
+    repo.set_default_model("user-1", "leon:small")
+
+    assert client.table_names == ["identity.user_settings", "identity.user_settings"]
+    assert tables["identity.user_settings"][0]["default_model"] == "leon:small"
+    assert "user_settings" not in tables
 
 
 def test_invite_code_expiry_does_not_hide_non_string_expires_at() -> None:


### PR DESCRIPTION
## Summary
- route SupabaseUserSettingsRepo through identity.user_settings
- strengthen unit coverage so user settings cannot use the bare/default table path

## Database
- created/backfilled identity.user_settings from staging.user_settings before app cut
- source_count=2 target_count=2 drift=0
- report: /Users/lexicalmathical/share/ops/backups/identity-user-settings-target-backfill-20260417T075850Z/report.json
- synced /Users/lexicalmathical/share/ops/schema.sql to define identity.user_settings

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_settings_and_invites.py -q
- uv run python -m pytest tests/Integration/test_settings_persistence_contract.py tests/Integration/test_settings_local_path_shell.py tests/Unit/core/test_agent_pool.py tests/Unit/storage/test_supabase_settings_and_invites.py -q
- uv run ruff check storage/providers/supabase/user_settings_repo.py tests/Unit/storage/test_supabase_settings_and_invites.py
- uv run ruff format --check storage/providers/supabase/user_settings_repo.py tests/Unit/storage/test_supabase_settings_and_invites.py
- git diff --check

No staging.user_settings drop in this PR; that waits for merge + backend/API settings YATU.