### PR TITLE
Route social repos through chat schema

### DIFF
--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -63,6 +63,21 @@ def schema_table(client: Any, schema: str, table: str, repo: str) -> Any:
     return table_method(table)
 
 
+def schema_rpc(client: Any, schema: str, function_name: str, params: dict[str, Any], repo: str) -> Any:
+    """Return a schema-qualified RPC query, failing loudly if unsupported."""
+    scoped = _preserve_postgrest_session(client, schema)
+    schema_method = getattr(client, "schema", None)
+    if scoped is None and not callable(schema_method):
+        raise RuntimeError(f"Supabase {repo} requires client.schema({schema!r}) support for {schema}.{function_name}.")
+    if scoped is None:
+        assert callable(schema_method)
+        scoped = schema_method(schema)
+    rpc_method = getattr(scoped, "rpc", None)
+    if not callable(rpc_method):
+        raise RuntimeError(f"Supabase {repo} schema({schema!r}) result must expose rpc(name, params).")
+    return rpc_method(function_name, params)
+
+
 def rows(response: Any, repo: str, operation: str) -> list[dict[str, Any]]:
     """Extract and validate the `.data` list from a supabase-py response."""
     if isinstance(response, dict):

--- a/storage/providers/supabase/chat_repo.py
+++ b/storage/providers/supabase/chat_repo.py
@@ -49,12 +49,12 @@ class SupabaseChatRepo:
         return [by_id[chat_id] for chat_id in chat_ids if chat_id in by_id]
 
     def delete(self, chat_id: str) -> None:
-        self._client.table("messages").delete().eq("chat_id", chat_id).execute()
-        self._client.table("chat_members").delete().eq("chat_id", chat_id).execute()
+        q.schema_table(self._client, "chat", "messages", _REPO_CHAT).delete().eq("chat_id", chat_id).execute()
+        q.schema_table(self._client, "chat", "chat_members", _REPO_CHAT).delete().eq("chat_id", chat_id).execute()
         self._t().delete().eq("id", chat_id).execute()
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE_CHATS)
+        return q.schema_table(self._client, "chat", _TABLE_CHATS, _REPO_CHAT)
 
 
 def _row_to_chat(r: dict[str, Any]) -> ChatRow:

--- a/storage/providers/supabase/contact_repo.py
+++ b/storage/providers/supabase/contact_repo.py
@@ -72,4 +72,4 @@ class SupabaseContactRepo:
         )
 
     def _t(self) -> Any:
-        return self._client.table(_TABLE)
+        return q.schema_table(self._client, "chat", _TABLE, _REPO)

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -13,6 +13,8 @@ from storage.providers.supabase import _query as q
 
 logger = logging.getLogger(__name__)
 
+_SCHEMA = "chat"
+
 
 class SupabaseChatMemberRepo:
     """chat_members table for Supabase messaging."""
@@ -24,24 +26,24 @@ class SupabaseChatMemberRepo:
         pass
 
     def add_member(self, chat_id: str, user_id: str) -> None:
-        self._client.table("chat_members").upsert(
+        self._t().upsert(
             {"chat_id": chat_id, "user_id": user_id, "role": "member", "joined_at": time.time()},
             on_conflict="chat_id,user_id",
         ).execute()
 
     def list_members(self, chat_id: str) -> list[dict[str, Any]]:
-        res = self._client.table("chat_members").select("*").eq("chat_id", chat_id).execute()
+        res = self._t().select("*").eq("chat_id", chat_id).execute()
         return res.data or []
 
     def list_chats_for_user(self, user_id: str) -> list[str]:
-        res = self._client.table("chat_members").select("chat_id").eq("user_id", user_id).execute()
+        res = self._t().select("chat_id").eq("user_id", user_id).execute()
         return [r["chat_id"] for r in (res.data or [])]
 
     def list_members_for_chats(self, chat_ids: list[str]) -> list[dict[str, Any]]:
         if not chat_ids:
             return []
         return q.rows_in_chunks(
-            lambda: self._client.table("chat_members").select("chat_id,user_id,last_read_seq"),
+            lambda: self._t().select("chat_id,user_id,last_read_seq"),
             "chat_id",
             chat_ids,
             "chat member repo",
@@ -49,7 +51,7 @@ class SupabaseChatMemberRepo:
         )
 
     def is_member(self, chat_id: str, user_id: str) -> bool:
-        res = self._client.table("chat_members").select("user_id").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
+        res = self._t().select("user_id").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
         return bool(res.data)
 
     def find_chat_between(self, user_a: str, user_b: str) -> str | None:
@@ -65,20 +67,19 @@ class SupabaseChatMemberRepo:
         return None
 
     def update_last_read(self, chat_id: str, user_id: str, last_read_seq: int) -> None:
-        self._client.table("chat_members").update({"last_read_seq": last_read_seq}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
+        self._t().update({"last_read_seq": last_read_seq}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
 
     def last_read_seq(self, chat_id: str, user_id: str) -> int:
-        member_res = (
-            self._client.table("chat_members").select("last_read_seq").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
-        )
+        member_res = self._t().select("last_read_seq").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
         if not member_res.data:
             return 0
         return int(member_res.data[0].get("last_read_seq") or 0)
 
     def update_mute(self, chat_id: str, user_id: str, muted: bool, mute_until: str | None = None) -> None:
-        self._client.table("chat_members").update({"muted": muted, "mute_until": mute_until}).eq("chat_id", chat_id).eq(
-            "user_id", user_id
-        ).execute()
+        self._t().update({"muted": muted, "mute_until": mute_until}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "chat_members", "chat member repo")
 
 
 class SupabaseMessagesRepo:
@@ -93,7 +94,13 @@ class SupabaseMessagesRepo:
     def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
         """Insert a new message. Returns the created row."""
         if expected_read_seq is None:
-            seq_response = self._client.rpc("increment_chat_message_seq", {"p_chat_id": row["chat_id"]}).execute()
+            seq_response = q.schema_rpc(
+                self._client,
+                _SCHEMA,
+                "increment_chat_message_seq",
+                {"p_chat_id": row["chat_id"]},
+                "messages repo",
+            ).execute()
             seq_data = seq_response.data
             if not seq_data:
                 raise RuntimeError("Supabase messages repo expected increment_chat_message_seq RPC data.")
@@ -108,7 +115,7 @@ class SupabaseMessagesRepo:
             # the conversation from the same stale history.
             next_seq = int(expected_read_seq) + 1
             update_res = (
-                self._client.table("chats")
+                self._chats_t()
                 .update({"next_message_seq": next_seq})
                 .eq("id", row["chat_id"])
                 .eq("next_message_seq", int(expected_read_seq))
@@ -118,17 +125,17 @@ class SupabaseMessagesRepo:
                 raise RuntimeError(f"Chat advanced after your last read. Call read_messages(chat_id='{row['chat_id']}') first.")
             seq = next_seq
         payload = {**row, "seq": int(seq)}
-        res = self._client.table("messages").insert(payload).execute()
+        res = self._t().insert(payload).execute()
         return res.data[0] if res.data else payload
 
     def get_by_id(self, message_id: str) -> dict[str, Any] | None:
-        res = self._client.table("messages").select("*").eq("id", message_id).limit(1).execute()
+        res = self._t().select("*").eq("id", message_id).limit(1).execute()
         return res.data[0] if res.data else None
 
     def list_by_chat(
         self, chat_id: str, *, limit: int = 50, before: str | None = None, viewer_id: str | None = None
     ) -> list[dict[str, Any]]:
-        q = self._client.table("messages").select("*").eq("chat_id", chat_id).is_("deleted_at", "null")
+        q = self._t().select("*").eq("chat_id", chat_id).is_("deleted_at", "null")
         if before:
             q = q.lt("seq", int(before))
         res = q.order("seq", desc=True).limit(limit).execute()
@@ -144,7 +151,7 @@ class SupabaseMessagesRepo:
         latest_by_chat: dict[str, dict[str, Any]] = {}
         rows = q.rows_in_chunks(
             lambda: q.order(
-                self._client.table("messages").select("*").is_("deleted_at", "null"),
+                self._t().select("*").is_("deleted_at", "null"),
                 "seq",
                 desc=True,
                 repo="messages repo",
@@ -165,7 +172,7 @@ class SupabaseMessagesRepo:
         """Messages after user's last_read_seq, excluding own, not deleted."""
         last_read_seq = self._last_read_seq(chat_id, user_id)
 
-        q = self._client.table("messages").select("*").eq("chat_id", chat_id).neq("sender_user_id", user_id).is_("deleted_at", "null")
+        q = self._t().select("*").eq("chat_id", chat_id).neq("sender_user_id", user_id).is_("deleted_at", "null")
         if last_read_seq > 0:
             q = q.gt("seq", last_read_seq)
         res = q.order("seq", desc=False).execute()
@@ -176,13 +183,7 @@ class SupabaseMessagesRepo:
         """Count unread messages using a COUNT query to avoid materializing rows."""
         last_read_seq = self._last_read_seq(chat_id, user_id)
 
-        q = (
-            self._client.table("messages")
-            .select("id", count="exact")
-            .eq("chat_id", chat_id)
-            .neq("sender_user_id", user_id)
-            .is_("deleted_at", "null")
-        )
+        q = self._t().select("id", count="exact").eq("chat_id", chat_id).neq("sender_user_id", user_id).is_("deleted_at", "null")
         if last_read_seq > 0:
             q = q.gt("seq", last_read_seq)
         res = q.execute()
@@ -195,7 +196,7 @@ class SupabaseMessagesRepo:
         min_last_read_seq = min(last_read_by_chat.values())
 
         def unread_query():
-            query = self._client.table("messages").select("chat_id,seq").neq("sender_user_id", user_id).is_("deleted_at", "null")
+            query = self._t().select("chat_id,seq").neq("sender_user_id", user_id).is_("deleted_at", "null")
             if min_last_read_seq > 0:
                 query = query.gt("seq", min_last_read_seq)
             return query
@@ -208,9 +209,7 @@ class SupabaseMessagesRepo:
         return counts
 
     def _last_read_seq(self, chat_id: str, user_id: str) -> int:
-        member_res = (
-            self._client.table("chat_members").select("last_read_seq").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
-        )
+        member_res = self._members_t().select("last_read_seq").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()
         if not member_res.data:
             return 0
         return int(member_res.data[0].get("last_read_seq") or 0)
@@ -229,7 +228,7 @@ class SupabaseMessagesRepo:
                     return False
             except (ValueError, AttributeError):
                 pass
-        self._client.table("messages").update({"retracted_at": now_iso(), "content": "[已撤回]"}).eq("id", message_id).execute()
+        self._t().update({"retracted_at": now_iso(), "content": "[已撤回]"}).eq("id", message_id).execute()
         return True
 
     def delete_for(self, message_id: str, user_id: str) -> None:
@@ -240,10 +239,10 @@ class SupabaseMessagesRepo:
         deleted_for = list(msg.get("deleted_for") or [])
         if user_id not in deleted_for:
             deleted_for.append(user_id)
-        self._client.table("messages").update({"deleted_for": deleted_for}).eq("id", message_id).execute()
+        self._t().update({"deleted_for": deleted_for}).eq("id", message_id).execute()
 
     def search(self, query: str, *, chat_id: str, limit: int = 50) -> list[dict[str, Any]]:
-        q = self._client.table("messages").select("*").ilike("content", f"%{query}%").is_("deleted_at", "null")
+        q = self._t().select("*").ilike("content", f"%{query}%").is_("deleted_at", "null")
         q = q.eq("chat_id", chat_id)
         res = q.order("seq", desc=False).limit(limit).execute()
         return res.data or []
@@ -251,13 +250,22 @@ class SupabaseMessagesRepo:
     def list_by_time_range(
         self, chat_id: str, *, after: str | None = None, before: str | None = None, limit: int = 100
     ) -> list[dict[str, Any]]:
-        q = self._client.table("messages").select("*").eq("chat_id", chat_id).is_("deleted_at", "null")
+        q = self._t().select("*").eq("chat_id", chat_id).is_("deleted_at", "null")
         if after:
             q = q.gte("created_at", after)
         if before:
             q = q.lte("created_at", before)
         res = q.order("created_at", desc=False).limit(limit).execute()
         return res.data or []
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "messages", "messages repo")
+
+    def _chats_t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "chats", "messages repo")
+
+    def _members_t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "chat_members", "messages repo")
 
 
 class SupabaseRelationshipRepo:
@@ -283,15 +291,7 @@ class SupabaseRelationshipRepo:
 
     def get(self, user_a: str, user_b: str) -> dict[str, Any] | None:
         user_low, user_high = self._ordered(user_a, user_b)
-        res = (
-            self._client.table("relationships")
-            .select("*")
-            .eq("user_low", user_low)
-            .eq("user_high", user_high)
-            .eq("kind", "hire_visit")
-            .limit(1)
-            .execute()
-        )
+        res = self._t().select("*").eq("user_low", user_low).eq("user_high", user_high).eq("kind", "hire_visit").limit(1).execute()
         if not res.data:
             return None
         return self._normalize(res.data[0])
@@ -301,15 +301,7 @@ class SupabaseRelationshipRepo:
         if len(parts) != 3:
             return None
         kind, user_low, user_high = parts
-        res = (
-            self._client.table("relationships")
-            .select("*")
-            .eq("user_low", user_low)
-            .eq("user_high", user_high)
-            .eq("kind", kind)
-            .limit(1)
-            .execute()
-        )
+        res = self._t().select("*").eq("user_low", user_low).eq("user_high", user_high).eq("kind", kind).limit(1).execute()
         if not res.data:
             return None
         return self._normalize(res.data[0])
@@ -328,17 +320,10 @@ class SupabaseRelationshipRepo:
         if existing:
             relationship_updates = {"state": state, "initiator_user_id": initiator_user_id}
             if state == "none":
-                (
-                    self._client.table("relationships")
-                    .delete()
-                    .eq("user_low", user_low)
-                    .eq("user_high", user_high)
-                    .eq("kind", "hire_visit")
-                    .execute()
-                )
+                (self._t().delete().eq("user_low", user_low).eq("user_high", user_high).eq("kind", "hire_visit").execute())
                 return self._normalize({**existing, "updated_at": now, **relationship_updates})
             res = (
-                self._client.table("relationships")
+                self._t()
                 .update({"updated_at": now, **relationship_updates})
                 .eq("user_low", user_low)
                 .eq("user_high", user_high)
@@ -356,10 +341,13 @@ class SupabaseRelationshipRepo:
             "state": state,
             "initiator_user_id": initiator_user_id,
         }
-        res = self._client.table("relationships").insert(row).execute()
+        res = self._t().insert(row).execute()
         return self._normalize(res.data[0] if res.data else row)
 
     def list_for_user(self, user_id: str) -> list[dict[str, Any]]:
         # Single query with OR filter
-        res = self._client.table("relationships").select("*").or_(f"user_low.eq.{user_id},user_high.eq.{user_id}").execute()
+        res = self._t().select("*").or_(f"user_low.eq.{user_id},user_high.eq.{user_id}").execute()
         return [self._normalize(raw) for raw in (res.data or [])]
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "relationships", "relationship repo")

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -2,12 +2,84 @@ from __future__ import annotations
 
 import pytest
 
-from storage.contracts import ChatRow
+from storage.contracts import ChatRow, ContactEdgeRow
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
+from storage.providers.supabase.contact_repo import SupabaseContactRepo
 from storage.providers.supabase.messaging_repo import (
     SupabaseChatMemberRepo,
     SupabaseMessagesRepo,
+    SupabaseRelationshipRepo,
 )
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_supabase_chat_stack_uses_chat_schema_for_root_tables() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.chats": [{"id": "chat-1", "next_message_seq": 0}],
+        "chat.chat_members": [{"chat_id": "chat-1", "user_id": "user-1", "last_read_seq": 0}],
+        "chat.messages": [],
+    }
+    client = FakeSupabaseClient(tables=tables)
+
+    SupabaseChatRepo(client).create(
+        ChatRow(
+            id="chat-2",
+            type="direct",
+            created_by_user_id="user-1",
+            title=None,
+            status="active",
+            next_message_seq=0,
+            created_at=123.0,
+        )
+    )
+    SupabaseChatMemberRepo(client).add_member("chat-2", "user-2")
+    message = SupabaseMessagesRepo(client).create(
+        {
+            "id": "msg-1",
+            "chat_id": "chat-1",
+            "sender_user_id": "user-1",
+            "content": "hello",
+            "created_at": 123.0,
+        },
+        expected_read_seq=0,
+    )
+
+    assert message["seq"] == 1
+    assert any(row["id"] == "chat-2" for row in tables["chat.chats"])
+    assert any(row["user_id"] == "user-2" for row in tables["chat.chat_members"])
+    assert any(row["id"] == "msg-1" for row in tables["chat.messages"])
+    assert "chats" not in tables
+    assert "chat_members" not in tables
+    assert "messages" not in tables
+
+
+def test_supabase_contact_and_relationship_repos_use_chat_schema() -> None:
+    tables: dict[str, list[dict]] = {"chat.contacts": [], "chat.relationships": []}
+    client = FakeSupabaseClient(tables=tables)
+
+    SupabaseContactRepo(client).upsert(
+        ContactEdgeRow(
+            source_user_id="user-1",
+            target_user_id="user-2",
+            kind="normal",
+            state="active",
+            muted=False,
+            blocked=False,
+            created_at=123.0,
+        )
+    )
+    relationship = SupabaseRelationshipRepo(client).upsert(
+        "user-1",
+        "user-2",
+        state="pending",
+        initiator_user_id="user-1",
+    )
+
+    assert tables["chat.contacts"][0]["source_user_id"] == "user-1"
+    assert relationship["id"] == "hire_visit:user-1:user-2"
+    assert tables["chat.relationships"][0]["initiator_user_id"] == "user-1"
+    assert "contacts" not in tables
+    assert "relationships" not in tables
 
 
 class _FakeResponse:
@@ -89,22 +161,30 @@ class _FakeTable:
 
 
 class _FakeClient:
-    def __init__(self) -> None:
-        self.tables: dict[str, _FakeTable] = {}
-        self.table_calls: list[str] = []
-        self.rpc_calls: list[tuple[str, dict[str, object]]] = []
-        self.rpc_data = [{"increment_chat_message_seq": 7}]
+    def __init__(self, *, schema_name: str | None = None, root: _FakeClient | None = None) -> None:
+        self._schema_name = schema_name
+        self._root = root or self
+        if root is None:
+            self.tables: dict[str, _FakeTable] = {}
+            self.table_calls: list[str] = []
+            self.rpc_calls: list[tuple[str, dict[str, object]]] = []
+            self.rpc_data = [{"increment_chat_message_seq": 7}]
 
     def table(self, name: str):
-        self.table_calls.append(name)
-        table = self.tables.get(name)
+        resolved = f"{self._schema_name}.{name}" if self._schema_name else name
+        self._root.table_calls.append(resolved)
+        table = self._root.tables.get(resolved)
         if table is None:
-            table = _FakeTable(name)
-            self.tables[name] = table
+            table = _FakeTable(resolved)
+            self._root.tables[resolved] = table
         return table
 
+    def schema(self, name: str):
+        return _FakeClient(schema_name=name, root=self._root)
+
     def rpc(self, name: str, params: dict[str, object]):
-        self.rpc_calls.append((name, params))
+        resolved = f"{self._schema_name}.{name}" if self._schema_name else name
+        self._root.rpc_calls.append((resolved, params))
 
         class _Rpc:
             def __init__(self, data):
@@ -113,7 +193,7 @@ class _FakeClient:
             def execute(self):
                 return _FakeResponse(data=self._data)
 
-        return _Rpc(self.rpc_data)
+        return _Rpc(self._root.rpc_data)
 
 
 def test_supabase_chat_repo_create_persists_chat_root_fields() -> None:
@@ -132,7 +212,7 @@ def test_supabase_chat_repo_create_persists_chat_root_fields() -> None:
         )
     )
 
-    payload = client.tables["chats"].insert_payload
+    payload = client.tables["chat.chats"].insert_payload
     assert payload is not None
     assert payload["type"] == "group"
     assert payload["created_by_user_id"] == "user-1"
@@ -141,7 +221,7 @@ def test_supabase_chat_repo_create_persists_chat_root_fields() -> None:
 
 def test_supabase_chat_repo_get_by_id_hydrates_chat_root_fields() -> None:
     client = _FakeClient()
-    client.table("chats").rows = [
+    client.schema("chat").table("chats").rows = [
         {
             "id": "chat-1",
             "type": "direct",
@@ -169,13 +249,13 @@ def test_supabase_chat_repo_delete_removes_child_rows_before_chat_root() -> None
 
     repo.delete("chat-1")
 
-    assert client.table_calls == ["messages", "chat_members", "chats"]
-    assert client.tables["messages"].delete_count == 1
-    assert client.tables["chat_members"].delete_count == 1
-    assert client.tables["chats"].delete_count == 1
-    assert ("chat_id", "chat-1") in client.tables["messages"].eq_calls
-    assert ("chat_id", "chat-1") in client.tables["chat_members"].eq_calls
-    assert ("id", "chat-1") in client.tables["chats"].eq_calls
+    assert client.table_calls == ["chat.messages", "chat.chat_members", "chat.chats"]
+    assert client.tables["chat.messages"].delete_count == 1
+    assert client.tables["chat.chat_members"].delete_count == 1
+    assert client.tables["chat.chats"].delete_count == 1
+    assert ("chat_id", "chat-1") in client.tables["chat.messages"].eq_calls
+    assert ("chat_id", "chat-1") in client.tables["chat.chat_members"].eq_calls
+    assert ("id", "chat-1") in client.tables["chat.chats"].eq_calls
 
 
 def test_supabase_chat_member_repo_updates_last_read_seq() -> None:
@@ -184,7 +264,7 @@ def test_supabase_chat_member_repo_updates_last_read_seq() -> None:
 
     repo.update_last_read("chat-1", "user-1", 7)
 
-    table = client.tables["chat_members"]
+    table = client.tables["chat.chat_members"]
     assert table.update_payload == {"last_read_seq": 7}
     assert ("chat_id", "chat-1") in table.eq_calls
     assert ("user_id", "user-1") in table.eq_calls
@@ -196,17 +276,17 @@ def test_supabase_chat_member_repo_add_member_persists_numeric_joined_at() -> No
 
     repo.add_member("chat-1", "user-1")
 
-    payload = client.tables["chat_members"].upsert_payload
+    payload = client.tables["chat.chat_members"].upsert_payload
     assert payload is not None
     assert payload["chat_id"] == "chat-1"
     assert payload["user_id"] == "user-1"
-    assert client.tables["chat_members"].on_conflict == "chat_id,user_id"
+    assert client.tables["chat.chat_members"].on_conflict == "chat_id,user_id"
     assert isinstance(payload["joined_at"], float)
 
 
 def test_supabase_messages_repo_create_allocates_seq_and_uses_message_root_fields() -> None:
     client = _FakeClient()
-    client.table("messages").rows = [
+    client.schema("chat").table("messages").rows = [
         {
             "id": "msg-1",
             "chat_id": "chat-1",
@@ -230,8 +310,8 @@ def test_supabase_messages_repo_create_allocates_seq_and_uses_message_root_field
         }
     )
 
-    assert client.rpc_calls == [("increment_chat_message_seq", {"p_chat_id": "chat-1"})]
-    payload = client.tables["messages"].insert_payload
+    assert client.rpc_calls == [("chat.increment_chat_message_seq", {"p_chat_id": "chat-1"})]
+    payload = client.tables["chat.messages"].insert_payload
     assert payload is not None
     assert payload["seq"] == 7
     assert payload["sender_user_id"] == "user-1"
@@ -242,7 +322,7 @@ def test_supabase_messages_repo_create_allocates_seq_and_uses_message_root_field
 def test_supabase_messages_repo_create_accepts_scalar_rpc_seq() -> None:
     client = _FakeClient()
     client.rpc_data = 8
-    client.table("messages").rows = [
+    client.schema("chat").table("messages").rows = [
         {
             "id": "msg-2",
             "chat_id": "chat-2",
@@ -266,7 +346,7 @@ def test_supabase_messages_repo_create_accepts_scalar_rpc_seq() -> None:
         }
     )
 
-    payload = client.tables["messages"].insert_payload
+    payload = client.tables["chat.messages"].insert_payload
     assert payload is not None
     assert payload["seq"] == 8
     assert row["seq"] == 8
@@ -274,8 +354,8 @@ def test_supabase_messages_repo_create_accepts_scalar_rpc_seq() -> None:
 
 def test_supabase_messages_repo_create_with_expected_read_seq_uses_chat_cas() -> None:
     client = _FakeClient()
-    client.table("chats").rows = [{"id": "chat-1", "next_message_seq": 6}]
-    client.table("messages").rows = [
+    client.schema("chat").table("chats").rows = [{"id": "chat-1", "next_message_seq": 6}]
+    client.schema("chat").table("messages").rows = [
         {
             "id": "msg-7",
             "chat_id": "chat-1",
@@ -301,11 +381,11 @@ def test_supabase_messages_repo_create_with_expected_read_seq_uses_chat_cas() ->
     )
 
     assert client.rpc_calls == []
-    chats = client.tables["chats"]
+    chats = client.tables["chat.chats"]
     assert chats.update_payload == {"next_message_seq": 7}
     assert ("id", "chat-1") in chats.eq_calls
     assert ("next_message_seq", 6) in chats.eq_calls
-    payload = client.tables["messages"].insert_payload
+    payload = client.tables["chat.messages"].insert_payload
     assert payload is not None
     assert payload["seq"] == 7
     assert row["seq"] == 7
@@ -313,7 +393,7 @@ def test_supabase_messages_repo_create_with_expected_read_seq_uses_chat_cas() ->
 
 def test_supabase_messages_repo_create_with_stale_expected_read_seq_fails_loudly() -> None:
     client = _FakeClient()
-    client.table("chats").rows = []
+    client.schema("chat").table("chats").rows = []
     repo = SupabaseMessagesRepo(client)
 
     with pytest.raises(RuntimeError, match="Chat advanced after your last read. Call read_messages\\(chat_id='chat-1'\\) first\\."):
@@ -332,26 +412,26 @@ def test_supabase_messages_repo_create_with_stale_expected_read_seq_fails_loudly
 
 def test_supabase_messages_repo_list_by_chat_uses_seq_ordering() -> None:
     client = _FakeClient()
-    client.table("messages").rows = [{"id": "msg-6", "seq": 6}, {"id": "msg-7", "seq": 7}]
+    client.schema("chat").table("messages").rows = [{"id": "msg-6", "seq": 6}, {"id": "msg-7", "seq": 7}]
     repo = SupabaseMessagesRepo(client)
 
     repo.list_by_chat("chat-1", limit=20, before="7")
 
-    table = client.tables["messages"]
+    table = client.tables["chat.messages"]
     assert ("seq", 7) in table.lt_calls
     assert table.order_calls == [("seq", True)]
 
 
 def test_supabase_messages_repo_count_unread_uses_last_read_seq_and_sender_user_id() -> None:
     client = _FakeClient()
-    client.table("chat_members").rows = [{"last_read_seq": 5}]
-    client.table("messages").count = 2
+    client.schema("chat").table("chat_members").rows = [{"last_read_seq": 5}]
+    client.schema("chat").table("messages").count = 2
     repo = SupabaseMessagesRepo(client)
 
     count = repo.count_unread("chat-1", "user-1")
 
     assert count == 2
-    assert ("last_read_seq", None) in client.tables["chat_members"].select_calls
-    assert ("seq", 5) in client.tables["messages"].gt_calls
-    assert ("sender_user_id", "user-1") in client.tables["messages"].neq_calls
-    assert ("sender_id", "user-1") not in client.tables["messages"].neq_calls
+    assert ("last_read_seq", None) in client.tables["chat.chat_members"].select_calls
+    assert ("seq", 5) in client.tables["chat.messages"].gt_calls
+    assert ("sender_user_id", "user-1") in client.tables["chat.messages"].neq_calls
+    assert ("sender_id", "user-1") not in client.tables["chat.messages"].neq_calls


### PR DESCRIPTION
## Summary
- route Supabase chat, message, chat member, contact, and relationship repos through schema-qualified chat.* tables
- add schema-qualified RPC helper and use chat.increment_chat_message_seq for message seq allocation
- add schema-boundary tests proving no bare social table writes

## DB prep already executed
- created/backfilled chat.chats/chat_members/messages/contacts/relationships from staging
- counts: 78/235/725/19/1 on both sides, drift 0
- created chat.increment_chat_message_seq
- exposed chat through PGRST_DB_SCHEMAS on the remote Supabase rest container

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_relationship_router.py tests/Integration/test_conversations_router.py -q
- uv run ruff check storage/providers/supabase/_query.py storage/providers/supabase/chat_repo.py storage/providers/supabase/contact_repo.py storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
- uv run ruff format --check storage/providers/supabase/_query.py storage/providers/supabase/chat_repo.py storage/providers/supabase/contact_repo.py storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
- git diff --check