### PR TITLE
Route users runtime to identity schema

### DIFF
--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -195,7 +195,12 @@ class SupabaseThreadRepo:
 
     def list_by_owner_user_id(self, owner_user_id: str) -> list[dict[str, Any]]:
         """Return all threads owned by this user via a two-step query (users JOIN threads)."""
-        user_response = self._client.table("users").select("id, display_name, avatar").eq("owner_user_id", owner_user_id).execute()
+        user_response = (
+            q.schema_table(self._client, "identity", "users", _REPO)
+            .select("id, display_name, avatar")
+            .eq("owner_user_id", owner_user_id)
+            .execute()
+        )
         user_rows = q.rows(user_response, _REPO, "list_by_owner_user_id:users")
         if not user_rows:
             return []

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -8,6 +8,7 @@ from storage.contracts import UserRow
 from storage.providers.supabase import _query as q
 
 _USER_REPO = "user repo"
+_SCHEMA = "identity"
 _USER_TABLE = "users"
 _COLS = (
     "id",
@@ -99,7 +100,13 @@ class SupabaseUserRepo:
         self._t().update(updates).eq("id", user_id).execute()
 
     def increment_thread_seq(self, user_id: str) -> int:
-        response = self._client.rpc("increment_user_thread_seq", {"p_user_id": user_id}).execute()
+        response = q.schema_rpc(
+            self._client,
+            _SCHEMA,
+            "increment_user_thread_seq",
+            {"p_user_id": user_id},
+            _USER_REPO,
+        ).execute()
         if isinstance(response, dict):
             data = response.get("data")
         else:
@@ -127,4 +134,4 @@ class SupabaseUserRepo:
         return UserRow.model_validate(rows[0])
 
     def _t(self) -> Any:
-        return self._client.table(_USER_TABLE)
+        return q.schema_table(self._client, _SCHEMA, _USER_TABLE, _USER_REPO)

--- a/tests/Unit/storage/test_supabase_thread_repo.py
+++ b/tests/Unit/storage/test_supabase_thread_repo.py
@@ -399,3 +399,60 @@ def test_supabase_thread_repo_reads_agent_threads_schema_table() -> None:
     assert row["id"] == "thread-1"
     assert row["agent_user_id"] == "agent-1"
     assert row["owner_user_id"] == "owner-1"
+
+
+def test_supabase_thread_repo_list_by_owner_reads_identity_users_for_agent_display() -> None:
+    client = FakeSupabaseClient(
+        tables={
+            "identity.users": [
+                {
+                    "id": "agent-1",
+                    "display_name": "Toad",
+                    "avatar": "avatars/agent-1.png",
+                    "owner_user_id": "owner-1",
+                }
+            ],
+            "agent.threads": [
+                {
+                    "id": "thread-1",
+                    "agent_user_id": "agent-1",
+                    "owner_user_id": "owner-1",
+                    "current_workspace_id": "workspace-1",
+                    "sandbox_type": "local",
+                    "model": "leon:mini",
+                    "cwd": "/workspace",
+                    "status": "active",
+                    "run_status": "idle",
+                    "is_main": True,
+                    "branch_index": 0,
+                    "created_at": "2026-04-14T00:00:00+00:00",
+                    "updated_at": "2026-04-14T00:00:00+00:00",
+                    "last_active_at": None,
+                }
+            ],
+        }
+    )
+    repo = SupabaseThreadRepo(client)
+
+    rows = repo.list_by_owner_user_id("owner-1")
+
+    assert rows == [
+        {
+            "id": "thread-1",
+            "agent_user_id": "agent-1",
+            "owner_user_id": "owner-1",
+            "current_workspace_id": "workspace-1",
+            "sandbox_type": "local",
+            "model": "leon:mini",
+            "cwd": "/workspace",
+            "status": "active",
+            "run_status": "idle",
+            "is_main": True,
+            "branch_index": 0,
+            "created_at": "2026-04-14T00:00:00+00:00",
+            "updated_at": "2026-04-14T00:00:00+00:00",
+            "last_active_at": None,
+            "agent_name": "Toad",
+            "agent_avatar": "avatars/agent-1.png",
+        }
+    ]

--- a/tests/Unit/storage/test_supabase_user_repo.py
+++ b/tests/Unit/storage/test_supabase_user_repo.py
@@ -46,18 +46,28 @@ class _FakeTable:
 
 
 class _FakeClient:
-    def __init__(self) -> None:
+    def __init__(self, root: "_FakeClient | None" = None) -> None:
+        self._root = root or self
         self.table_name = None
         self.table_obj = _FakeTable()
         self.rpc_calls: list[tuple[str, dict[str, object]]] = []
+        self.schema_name: str | None = None
 
     def table(self, name):
-        self.table_name = name
+        self._root.table_name = f"{self.schema_name}.{name}" if self.schema_name else name
         return self.table_obj
 
     def rpc(self, name, params):
-        self.rpc_calls.append((name, params))
+        rpc_name = f"{self.schema_name}.{name}" if self.schema_name else name
+        self.rpc_calls.append((rpc_name, params))
         return type("Rpc", (), {"execute": lambda _self: type("Resp", (), {"data": 4})()})()
+
+    def schema(self, name):
+        scoped = _FakeClient(root=self._root)
+        scoped.table_obj = self.table_obj
+        scoped.rpc_calls = self.rpc_calls
+        scoped.schema_name = name
+        return scoped
 
 
 def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
@@ -80,7 +90,7 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
         )
     )
 
-    assert client.table_name == "users"
+    assert client.table_name == "identity.users"
     assert client.table_obj.insert_payload is not None
     assert client.table_obj.insert_payload["type"] == "agent"
     assert client.table_obj.insert_payload["owner_user_id"] == "owner-1"
@@ -119,4 +129,4 @@ def test_supabase_user_repo_increment_thread_seq_uses_user_rpc() -> None:
     seq = repo.increment_thread_seq("user-1")
 
     assert seq == 4
-    assert client.rpc_calls == [("increment_user_thread_seq", {"p_user_id": "user-1"})]
+    assert client.rpc_calls == [("identity.increment_user_thread_seq", {"p_user_id": "user-1"})]


### PR DESCRIPTION
## Summary
- route SupabaseUserRepo table access to identity.users
- route increment_thread_seq through identity.increment_user_thread_seq
- route SupabaseThreadRepo.list_by_owner_user_id agent enrichment through identity.users
- no staging.users/assets DB drop in this PR

## Verification
- RED first: user/thread repo tests failed on bare users / bare increment_user_thread_seq / missing identity.users enrich
- uv run python -m pytest tests/Unit/storage/test_supabase_user_repo.py tests/Unit/storage/test_supabase_thread_repo.py -q => 22 passed
- uv run python -m pytest tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_users_avatar_auth_shell.py tests/Integration/test_users_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q => 96 passed
- companion broader pack: uv run python -m pytest tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_auth_router.py -q => 95 passed
- uv run ruff check storage/providers/supabase/user_repo.py storage/providers/supabase/thread_repo.py tests/Unit/storage/test_supabase_user_repo.py tests/Unit/storage/test_supabase_thread_repo.py
- uv run ruff format --check storage/providers/supabase/user_repo.py storage/providers/supabase/thread_repo.py tests/Unit/storage/test_supabase_user_repo.py tests/Unit/storage/test_supabase_thread_repo.py
- git diff --check
- backend/API YATU on :8010 marker identity-users-yatu-1776420301: login 200, panel agents 200, create agent wrote identity.users=1/staging.users=0, default-config source=derived, avatar upload/get/delete 200, thread create/runtime/delete 200, agent delete 200, final identity.users/staging.users/agent.threads residue 0/0/0

## Stopline
staging.assets and staging.users archive/drop is intentionally not included. That follows only after this PR merges and post-merge backend/API YATU passes.