### PR TITLE
fix(frontend): label existing sandbox picker honestly

### DIFF
--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -610,6 +610,49 @@ describe("NewChatPage", () => {
     });
   });
 
+  it("labels the existing runtime picker as sandboxes instead of leases", async () => {
+    clientMocks.getDefaultThreadConfig.mockResolvedValue({
+      source: "derived",
+      config: {
+        create_mode: "existing",
+        provider_config: "daytona_selfhost",
+        existing_sandbox_id: null,
+        model: "leon:large",
+        workspace: "/workspace/reused-1",
+      },
+    });
+    clientMocks.listMyLeases.mockResolvedValue([
+      {
+        lease_id: "lease-1",
+        sandbox_id: "sandbox-1",
+        provider_name: "daytona_selfhost",
+        recipe_id: "recipe-1",
+        recipe_name: "Existing One",
+        observed_state: "running",
+        desired_state: "running",
+        cwd: "/workspace/reused-1",
+        thread_ids: [],
+        agents: [],
+      } as UserLeaseSummary,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/chat/hire/m_xVuNpKJNxblZ"]}>
+        <Routes>
+          <Route element={<ContextOutlet />}>
+            <Route path="/chat/hire/:agentId" element={<NewChatPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("centered-input-box");
+    fireEvent.click(screen.getByRole("button", { name: "下一步" }));
+
+    expect(screen.queryByText("My Sandboxes")).not.toBeNull();
+    expect(screen.queryByText("My Leases")).toBeNull();
+  });
+
   it("keeps provider-switch defaults sandbox-shaped when reselecting an existing lease", async () => {
     sandboxTypesForTest = [
       { name: "daytona_selfhost", provider: "daytona", available: true },

--- a/frontend/app/src/pages/NewChatPage.tsx
+++ b/frontend/app/src/pages/NewChatPage.tsx
@@ -826,7 +826,7 @@ export default function NewChatPage({ mode = "agent" }: { mode?: "agent" | "new"
                       {createMode === "existing" && (
                         <div className="space-y-2">
                           <div className="flex items-center justify-between gap-3">
-                            <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">My Leases</div>
+                            <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">My Sandboxes</div>
                             <div className="text-xs text-muted-foreground">{existingCount} available</div>
                           </div>
                           <div className="max-h-[320px] space-y-2 overflow-y-auto pr-1">


### PR DESCRIPTION
## Summary\n- Rename the existing runtime picker heading from "My Leases" to "My Sandboxes".\n- Add a focused NewChatPage regression test locking the visible wording.\n\n## Verification\n- cd frontend/app && npm test -- --run src/pages/NewChatPage.test.tsx -t "labels the existing runtime picker"\n- cd frontend/app && npm test -- --run src/pages/NewChatPage.test.tsx src/api/client.test.ts\n- cd frontend/app && npm run lint\n- git diff --check\n\n## Scope\nFrontend-only wording realignment after staging.sandbox_leases table closure. No backend, API, runtime, or DB changes.