### PR TITLE
Show monitor source markers

### DIFF
--- a/frontend/monitor/src/pages/LeaseDetailPage.test.ts
+++ b/frontend/monitor/src/pages/LeaseDetailPage.test.ts
@@ -5,12 +5,14 @@ import { buildLeaseDetailShell } from "./LeaseDetailPage";
 describe("lease detail page shell", () => {
   it("becomes a compatibility redirect shell after sandbox detail parity lands", () => {
     const shell = buildLeaseDetailShell({
+      source: "lease_compatibility",
       lease: { lease_id: "lease-1", sandbox_id: "sandbox-1" },
       triage: { description: "Lease state and cleanup readiness." },
       cleanup: { reason: "Canonical sandbox detail is ready." },
     });
 
     expect(shell.title).toBe("Lease compatibility redirect");
+    expect(shell.sourceLabel).toBe("Source: lease_compatibility");
     expect(shell.description).toBe("Legacy lease-shaped detail route now redirects to canonical sandbox detail.");
     expect(shell.canonicalHref).toBe("/sandboxes/sandbox-1");
     expect(shell.compatibilityOnly).toBe(true);

--- a/frontend/monitor/src/pages/LeaseDetailPage.tsx
+++ b/frontend/monitor/src/pages/LeaseDetailPage.tsx
@@ -5,6 +5,7 @@ import { useMonitorData } from "../app/fetch";
 import ErrorState from "../components/ErrorState";
 
 type LeaseDetailPayload = {
+  source: string;
   lease: {
     lease_id: string;
     sandbox_id?: string | null;
@@ -21,10 +22,11 @@ type LeaseDetailPayload = {
   } | null;
 };
 
-export function buildLeaseDetailShell(data: Pick<LeaseDetailPayload, "lease" | "triage" | "cleanup">) {
+export function buildLeaseDetailShell(data: Pick<LeaseDetailPayload, "source" | "lease" | "triage" | "cleanup">) {
   const sandboxId = String(data.lease.sandbox_id ?? "").trim();
   return {
     title: "Lease compatibility redirect",
+    sourceLabel: `Source: ${data.source}`,
     description: "Legacy lease-shaped detail route now redirects to canonical sandbox detail.",
     reason: data.cleanup?.reason ?? data.triage?.description ?? "Canonical sandbox detail is now the source of truth.",
     canonicalHref: sandboxId ? `/sandboxes/${sandboxId}` : null,
@@ -53,6 +55,7 @@ export default function LeaseDetailPage() {
     <div className="page">
       <h1>{shell.title}</h1>
       <p className="description">{shell.description}</p>
+      <p className="count">{shell.sourceLabel}</p>
       <section className="surface-section">
         <h2>Compatibility Route</h2>
         <p className="description">{shell.reason}</p>

--- a/frontend/monitor/src/pages/LeasesPage.test.ts
+++ b/frontend/monitor/src/pages/LeasesPage.test.ts
@@ -7,6 +7,7 @@ describe("leases page shell", () => {
     const shell = buildLeaseWorkbenchShell({
       title: "All Leases",
       count: 1,
+      source: "lease_compatibility",
       triage: {
         summary: {
           active_drift: 0,
@@ -32,6 +33,7 @@ describe("leases page shell", () => {
 
     expect(shell.triageTitle).toBe("Lease Triage");
     expect(shell.workbenchTitle).toBe("Lease Workbench");
+    expect(shell.sourceLabel).toBe("Source: lease_compatibility");
     expect(shell.rows[0].href).toBe("/sandboxes/sandbox-1");
     expect(shell.rows[0].compatibilityLeaseId).toBe("lease-1");
   });

--- a/frontend/monitor/src/pages/LeasesPage.tsx
+++ b/frontend/monitor/src/pages/LeasesPage.tsx
@@ -8,6 +8,7 @@ import { useMonitorData } from "../app/fetch";
 type LeasesPayload = {
   title: string;
   count: number;
+  source: string;
   triage?: {
     summary?: {
       active_drift?: number;
@@ -49,6 +50,7 @@ export function buildLeaseWorkbenchShell(data: LeasesPayload) {
   return {
     triageTitle: "Lease Triage",
     workbenchTitle: "Lease Workbench",
+    sourceLabel: `Source: ${data.source}`,
     triageCards,
     rows: data.items.map((item) => ({
       ...item,
@@ -75,7 +77,9 @@ export default function LeasesPage() {
   return (
     <div className="page">
       <h1>{data.title}</h1>
-      <p className="count">Total: {data.count}</p>
+      <p className="count">
+        Total: {data.count} · {shell.sourceLabel}
+      </p>
       <section className="surface-section">
         <h2>{shell.triageTitle}</h2>
         <div className="surface-grid">

--- a/frontend/monitor/src/pages/SandboxDetailPage.test.ts
+++ b/frontend/monitor/src/pages/SandboxDetailPage.test.ts
@@ -5,6 +5,7 @@ import { buildSandboxDetailShell } from "./SandboxDetailPage";
 describe("sandbox detail page shell", () => {
   it("uses sandbox-shaped shell with cleanup parity lane", () => {
     const shell = buildSandboxDetailShell({
+      source: "sandbox_canonical",
       sandbox: {
         sandbox_id: "sandbox-1",
         provider_name: "docker",
@@ -44,6 +45,7 @@ describe("sandbox detail page shell", () => {
     });
 
     expect(shell.title).toBe("Sandbox sandbox-1");
+    expect(shell.sourceLabel).toBe("Source: sandbox_canonical");
     expect(shell.surfaceHref).toBe("/sandboxes");
     expect(shell.cleanupIncluded).toBe(true);
     expect(shell.cleanupTitle).toBe("Cleanup");

--- a/frontend/monitor/src/pages/SandboxDetailPage.tsx
+++ b/frontend/monitor/src/pages/SandboxDetailPage.tsx
@@ -6,6 +6,7 @@ import ErrorState from "../components/ErrorState";
 import StateBadge from "../components/StateBadge";
 
 export type SandboxDetailPayload = {
+  source: string;
   sandbox: {
     sandbox_id: string;
     provider_name?: string | null;
@@ -70,6 +71,7 @@ const CLEANUP_STATUS_CLASS_BY_STATUS: Record<string, string> = {
 export function buildSandboxDetailShell(data: SandboxDetailPayload) {
   return {
     title: `Sandbox ${data.sandbox.sandbox_id}`,
+    sourceLabel: `Source: ${data.source}`,
     description: data.triage?.description ?? "Sandbox state and current read-only relations.",
     surfaceHref: "/sandboxes",
     cleanupIncluded: true,
@@ -128,6 +130,7 @@ export default function SandboxDetailPage() {
     <div className="page">
       <h1>{shell.title}</h1>
       <p className="description">{shell.description}</p>
+      <p className="count">{shell.sourceLabel}</p>
       <section className="surface-section">
         <h2>State</h2>
         <div className="surface-grid">

--- a/frontend/monitor/src/pages/SandboxesPage.test.ts
+++ b/frontend/monitor/src/pages/SandboxesPage.test.ts
@@ -7,6 +7,7 @@ describe("sandboxes page shell", () => {
     const shell = buildSandboxWorkbenchShell({
       title: "All Sandboxes",
       count: 2,
+      source: "sandbox_canonical",
       triage: {
         summary: {
           active_drift: 1,
@@ -31,6 +32,7 @@ describe("sandboxes page shell", () => {
 
     expect(shell.triageTitle).toBe("Sandbox Triage");
     expect(shell.workbenchTitle).toBe("Sandbox Workbench");
+    expect(shell.sourceLabel).toBe("Source: sandbox_canonical");
     expect(shell.rows[0].href).toBe("/sandboxes/sandbox-1");
   });
 });

--- a/frontend/monitor/src/pages/SandboxesPage.tsx
+++ b/frontend/monitor/src/pages/SandboxesPage.tsx
@@ -8,6 +8,7 @@ import { useMonitorData } from "../app/fetch";
 export type SandboxesPayload = {
   title: string;
   count: number;
+  source: string;
   triage?: {
     summary?: {
       active_drift?: number;
@@ -48,6 +49,7 @@ export function buildSandboxWorkbenchShell(data: SandboxesPayload) {
   return {
     triageTitle: "Sandbox Triage",
     workbenchTitle: "Sandbox Workbench",
+    sourceLabel: `Source: ${data.source}`,
     triageCards,
     rows: data.items.map((item) => ({
       ...item,
@@ -73,7 +75,9 @@ export default function SandboxesPage() {
   return (
     <div className="page">
       <h1>{data.title}</h1>
-      <p className="count">Total: {data.count}</p>
+      <p className="count">
+        Total: {data.count} · {shell.sourceLabel}
+      </p>
       <section className="surface-section">
         <h2>{shell.triageTitle}</h2>
         <div className="surface-grid">


### PR DESCRIPTION
## Summary
- surface backend monitor source markers on sandbox and lease list pages
- surface the same source markers on sandbox and lease detail shells
- keep source required in frontend monitor payloads so missing backend truth fails at build/test time

## Verification
- npm test -- --run src/pages/SandboxesPage.test.ts src/pages/LeasesPage.test.ts src/pages/SandboxDetailPage.test.ts src/pages/LeaseDetailPage.test.ts
- npm run build
- git diff --check HEAD~1 HEAD