### PR TITLE
Format resource snapshot repo

### DIFF
--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -20,10 +20,7 @@ def _raise_if_snapshot_schema_drift(err: Exception) -> None:
     message = str(err)
     if f"{_SCHEMA}.{_TABLE}" not in message or "lease_resource_snapshots" not in message:
         return
-    raise RuntimeError(
-        "container.resource_snapshots is missing; "
-        "stale lease_resource_snapshots residue is not a fallback"
-    ) from err
+    raise RuntimeError("container.resource_snapshots is missing; stale lease_resource_snapshots residue is not a fallback") from err
 
 
 def _t(client: Any) -> Any:


### PR DESCRIPTION
## Summary
- apply ruff formatting to storage/providers/supabase/resource_snapshot_repo.py
- fixes the current dev Python lint failure where ruff format --check reported this file would be reformatted

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m pytest tests/Unit/storage/test_supabase_resource_snapshot_repo.py
- git diff --check HEAD~1 HEAD