### PR TITLE
Retire live staging wording in agent user comment

### DIFF
--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -326,7 +326,7 @@ def create_agent_user(
         user_repo.create(row)
 
     # @@@agent-user-before-config - new schema roots agent_configs on agent_user_id.
-    # The user row must exist before the config write, otherwise live staging
+    # The user row must exist before the config write, otherwise the live DB
     # rejects the insert on the forward reference.
     if agent_config_repo:
         if owner_user_id is None:


### PR DESCRIPTION
## Summary
- replace the stale `live staging` comment in agent user config creation with `live DB`
- no behavior, schema, API, or test contract change

## Verification
- `uv run ruff check backend/web/services/agent_user_service.py`
- `git diff --check`
- `git grep -n "live staging"` returns no matches