### PR TITLE
test: cover missing agent config fail-loud startup

### DIFF
--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -651,6 +651,32 @@ async def test_leon_agent_agent_config_id_ignores_conflicting_stale_member_shell
         agent.close()
 
 
+@_patch_env_api_key()
+def test_leon_agent_agent_config_id_missing_config_does_not_fallback_to_bundle_dir(tmp_path):
+    from core.runtime.agent import LeonAgent
+
+    bundle_dir = tmp_path / "agent-bundles" / "stale"
+    bundle_dir.mkdir(parents=True)
+    (bundle_dir / "agent.md").write_text(
+        "---\nname: Stale Bundle\ndescription: must not load\n---\nYou are stale.\n",
+        encoding="utf-8",
+    )
+
+    class _Repo:
+        def get_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-missing"
+            return None
+
+    with pytest.raises(RuntimeError, match="Agent config bundle not found: cfg-missing"):
+        LeonAgent(
+            workspace_root=str(tmp_path),
+            agent_config_id="cfg-missing",
+            agent_config_repo=_Repo(),
+            bundle_dir=str(bundle_dir),
+            api_key="sk-test-integration",
+        )
+
+
 @pytest.mark.asyncio
 @_patch_env_api_key()
 async def test_leon_agent_announces_mcp_instruction_delta_once_and_reannounces_on_change(tmp_path):


### PR DESCRIPTION
## Summary
- add LeonAgent regression coverage for missing repo-backed agent_config_id
- assert an explicit bundle_dir is not used as a fallback when agent_config_id lookup fails

## Verification
- uv run python -m pytest tests/Integration/test_leon_agent.py tests/Unit/core/test_agent_pool.py tests/Config/test_loader.py -q
- uv run ruff check tests/Integration/test_leon_agent.py
- git diff --check HEAD~1 HEAD

Note: the new focused test passed immediately; this is test-only coverage for existing fail-loud behavior, not a production bug fix.