### PR TITLE
Fix user sandbox summaries to not require lease ids

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -272,10 +272,9 @@ describe("thread api client contract", () => {
     await expect(api.listSandboxTypes()).rejects.toThrow("Malformed sandbox types");
   });
 
-  it("listMySandboxes reads the canonical sandbox list endpoint", async () => {
+  it("listMySandboxes reads canonical sandbox summaries without lease identities", async () => {
     authFetch.mockResolvedValue(okJson({
       sandboxes: [{
-        lease_id: "lease-1",
         sandbox_id: "sandbox-1",
         provider_name: "local",
         recipe_id: "recipe-1",
@@ -285,14 +284,16 @@ describe("thread api client contract", () => {
       }],
     }));
 
-    await expect(api.listMySandboxes()).resolves.toMatchObject([{ sandbox_id: "sandbox-1" }]);
+    const result = await api.listMySandboxes();
+
+    expect(result).toMatchObject([{ sandbox_id: "sandbox-1" }]);
+    expect(result[0]).not.toHaveProperty("lease_id");
     expect(authFetch).toHaveBeenCalledWith("/api/sandbox/sandboxes/mine", { signal: undefined });
   });
 
   it("listMySandboxes rejects sandbox summaries without sandbox identities", async () => {
     authFetch.mockResolvedValue(okJson({
       sandboxes: [{
-        lease_id: "lease-1",
         provider_name: "local",
         recipe_id: "recipe-1",
         recipe_name: "Local",
@@ -307,7 +308,6 @@ describe("thread api client contract", () => {
   it("listMySandboxes rejects malformed sandbox participant identities", async () => {
     authFetch.mockResolvedValue(okJson({
       sandboxes: [{
-        lease_id: "lease-1",
         sandbox_id: "sandbox-1",
         provider_name: "local",
         recipe_id: "recipe-1",

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -387,7 +387,6 @@ function parseUserSandboxSummaries(value: unknown): UserSandboxSummary[] {
   if (!Array.isArray(sandboxes)) throw new Error("Malformed user sandboxes");
   return sandboxes.map((sandbox) => {
     const data = asRecord(sandbox);
-    const lease_id = data ? recordString(data, "lease_id") : undefined;
     const sandbox_id = data ? recordString(data, "sandbox_id") : undefined;
     const provider_name = data ? recordString(data, "provider_name") : undefined;
     const recipe_id = data ? recordString(data, "recipe_id") : undefined;
@@ -396,7 +395,6 @@ function parseUserSandboxSummaries(value: unknown): UserSandboxSummary[] {
     const agents = data?.agents;
     if (
       !data ||
-      !lease_id ||
       !sandbox_id ||
       !provider_name ||
       !recipe_id ||
@@ -414,7 +412,18 @@ function parseUserSandboxSummaries(value: unknown): UserSandboxSummary[] {
       if (!agentData || !thread_id || !agent_name) throw new Error("Malformed user sandboxes");
       return { ...agentData, thread_id, agent_name };
     });
-    return { ...data, lease_id, sandbox_id, provider_name, recipe_id, recipe_name, thread_ids, agents: admittedAgents } as UserSandboxSummary;
+    return {
+      sandbox_id,
+      provider_name,
+      recipe_id,
+      recipe_name,
+      recipe: data.recipe,
+      observed_state: data.observed_state,
+      desired_state: data.desired_state,
+      cwd: data.cwd,
+      thread_ids,
+      agents: admittedAgents,
+    } as UserSandboxSummary;
   });
 }
 

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -157,7 +157,6 @@ export interface AccountResourceLimit {
 }
 
 export interface UserSandboxSummary {
-  lease_id: string;
   sandbox_id: string;
   provider_name: string;
   recipe_id: string;

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -502,7 +502,6 @@ describe("NewChatPage", () => {
     });
     clientMocks.listMySandboxes.mockResolvedValue([
       {
-        lease_id: "lease-1",
         sandbox_id: "sandbox-1",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-1",
@@ -514,7 +513,6 @@ describe("NewChatPage", () => {
         agents: [],
       },
       {
-        lease_id: "lease-2",
         sandbox_id: "sandbox-2",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-2",
@@ -565,7 +563,6 @@ describe("NewChatPage", () => {
     });
     clientMocks.listMySandboxes.mockResolvedValue([
       {
-        lease_id: "lease-1",
         sandbox_id: "sandbox-1",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-1",
@@ -577,7 +574,6 @@ describe("NewChatPage", () => {
         agents: [],
       } as UserSandboxSummary,
       {
-        lease_id: "lease-2",
         sandbox_id: "sandbox-2",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-2",
@@ -623,7 +619,6 @@ describe("NewChatPage", () => {
     });
     clientMocks.listMySandboxes.mockResolvedValue([
       {
-        lease_id: "lease-1",
         sandbox_id: "sandbox-1",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-1",
@@ -689,7 +684,6 @@ describe("NewChatPage", () => {
     });
     clientMocks.listMySandboxes.mockResolvedValue([
       {
-        lease_id: "lease-daytona",
         sandbox_id: "sandbox-daytona",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-daytona",
@@ -701,7 +695,6 @@ describe("NewChatPage", () => {
         agents: [],
       } as UserSandboxSummary,
       {
-        lease_id: "lease-local",
         sandbox_id: "sandbox-local",
         provider_name: "local",
         recipe_id: "recipe-local",
@@ -748,7 +741,6 @@ describe("NewChatPage", () => {
     });
     clientMocks.listMySandboxes.mockResolvedValue([
       {
-        lease_id: "lease-1",
         sandbox_id: "sandbox-1",
         provider_name: "daytona_selfhost",
         recipe_id: "recipe-1",


### PR DESCRIPTION
## Summary
- remove lease_id from the canonical UserSandboxSummary frontend type
- make listMySandboxes parse /api/sandbox/sandboxes/mine without requiring or returning lease_id
- update NewChatPage sandbox summary test data to stay sandbox-shaped

## Verification
- RED: npm test -- client.test.ts -t "listMySandboxes reads canonical sandbox summaries without lease identities" failed with Malformed user sandboxes before the parser/type change
- npm test -- client.test.ts NewChatPage.test.tsx
- npm run build
- npm run lint
- git diff --check