### PR TITLE
Fix sandbox mine endpoint to hide lease ids

### DIFF
--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -17,6 +17,10 @@ def _runtime_http_error(exc: RuntimeError) -> HTTPException:
     return HTTPException(status, message)
 
 
+def _sandbox_summary(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in row.items() if key != "lease_id"}
+
+
 async def _mutate_session_action(session_id: str, action: str, provider: str | None) -> dict[str, Any]:
     try:
         return await asyncio.to_thread(
@@ -57,7 +61,7 @@ async def list_my_sandboxes(
         thread_repo=thread_repo,
         user_repo=user_repo,
     )
-    return {"sandboxes": sandboxes}
+    return {"sandboxes": [_sandbox_summary(sandbox) for sandbox in sandboxes]}
 
 
 @router.get("/sessions/{session_id}/metrics")

--- a/tests/Integration/test_sandbox_router_user_shell.py
+++ b/tests/Integration/test_sandbox_router_user_shell.py
@@ -36,7 +36,7 @@ async def test_list_my_sandboxes_uses_canonical_sandbox_envelope(monkeypatch: py
 
     result = await sandbox_router.list_my_sandboxes(user_id="owner-1", request=request)
 
-    assert result == {"sandboxes": [{"lease_id": "lease-1", "sandbox_id": "sandbox-1"}]}
+    assert result == {"sandboxes": [{"sandbox_id": "sandbox-1"}]}
     assert seen == {
         "user_id": "owner-1",
         "thread_repo": thread_repo,


### PR DESCRIPTION
## Summary
- project /api/sandbox/sandboxes/mine rows into canonical sandbox summaries at the router boundary
- stop exposing lease_id in the sandboxes envelope
- keep lower-level lease/runtime service data unchanged

## Verification
- RED: uv run python -m pytest tests/Integration/test_sandbox_router_user_shell.py -q failed because /sandboxes/mine still returned lease_id
- uv run python -m pytest tests/Integration/test_sandbox_router_user_shell.py -q
- uv run ruff check backend/web/routers/sandbox.py tests/Integration/test_sandbox_router_user_shell.py
- npm test -- client.test.ts NewChatPage.test.tsx
- git diff --check