### PR TITLE
Route owner sandbox reads through canonical service

### DIFF
--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -17,10 +17,6 @@ def _runtime_http_error(exc: RuntimeError) -> HTTPException:
     return HTTPException(status, message)
 
 
-def _canonical_sandbox_summary(row: dict[str, Any]) -> dict[str, Any]:
-    return {key: value for key, value in row.items() if key != "lease_id"}
-
-
 async def _mutate_session_action(session_id: str, action: str, provider: str | None) -> dict[str, Any]:
     try:
         return await asyncio.to_thread(
@@ -55,13 +51,12 @@ async def list_my_sandboxes(
 ) -> dict[str, Any]:
     thread_repo = getattr(request.app.state, "thread_repo", None)
     user_repo = getattr(request.app.state, "user_repo", None)
-    lease_rows = await asyncio.to_thread(
-        sandbox_service.list_user_leases,
+    sandboxes = await asyncio.to_thread(
+        sandbox_service.list_user_sandboxes,
         user_id,
         thread_repo=thread_repo,
         user_repo=user_repo,
     )
-    sandboxes = [_canonical_sandbox_summary(row) for row in lease_rows]
     return {"sandboxes": sandboxes}
 
 

--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -165,6 +165,20 @@ def list_user_leases(
         monitor_repo.close()
 
 
+def _sandbox_summary(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in row.items() if key != "lease_id"}
+
+
+def list_user_sandboxes(
+    user_id: str,
+    *,
+    thread_repo: Any = None,
+    user_repo: Any = None,
+) -> list[dict[str, Any]]:
+    lease_rows = list_user_leases(user_id, thread_repo=thread_repo, user_repo=user_repo)
+    return [_sandbox_summary(row) for row in lease_rows]
+
+
 def count_user_visible_leases_by_provider(
     user_id: str,
     *,

--- a/tests/Integration/test_sandbox_router_user_shell.py
+++ b/tests/Integration/test_sandbox_router_user_shell.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from backend.web.routers import sandbox as sandbox_router
+from backend.web.services import sandbox_service
 
 
 def test_sandbox_router_does_not_expose_local_folder_picker() -> None:
@@ -19,7 +20,10 @@ def test_sandbox_router_does_not_expose_local_folder_picker() -> None:
 async def test_list_my_sandboxes_uses_canonical_sandbox_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
 
-    def fake_list_user_leases(user_id: str, *, thread_repo=None, user_repo=None) -> list[dict[str, object]]:
+    def fail_list_user_leases(*_args, **_kwargs) -> list[dict[str, object]]:
+        raise AssertionError("owner-facing sandbox route must not call list_user_leases")
+
+    def fake_list_user_sandboxes(user_id: str, *, thread_repo=None, user_repo=None) -> list[dict[str, object]]:
         seen.update(
             {
                 "user_id": user_id,
@@ -27,12 +31,13 @@ async def test_list_my_sandboxes_uses_canonical_sandbox_envelope(monkeypatch: py
                 "user_repo": user_repo,
             }
         )
-        return [{"lease_id": "lease-1", "sandbox_id": "sandbox-1"}]
+        return [{"sandbox_id": "sandbox-1"}]
 
     thread_repo = SimpleNamespace()
     user_repo = SimpleNamespace()
     request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(thread_repo=thread_repo, user_repo=user_repo)))
-    monkeypatch.setattr(sandbox_router.sandbox_service, "list_user_leases", fake_list_user_leases)
+    monkeypatch.setattr(sandbox_router.sandbox_service, "list_user_leases", fail_list_user_leases)
+    monkeypatch.setattr(sandbox_router.sandbox_service, "list_user_sandboxes", fake_list_user_sandboxes, raising=False)
 
     result = await sandbox_router.list_my_sandboxes(user_id="owner-1", request=request)
 
@@ -42,3 +47,21 @@ async def test_list_my_sandboxes_uses_canonical_sandbox_envelope(monkeypatch: py
         "thread_repo": thread_repo,
         "user_repo": user_repo,
     }
+
+
+def test_list_user_sandboxes_projects_internal_lease_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_list_user_leases(user_id: str, *, thread_repo=None, user_repo=None) -> list[dict[str, object]]:
+        assert user_id == "owner-1"
+        assert thread_repo is not None
+        assert user_repo is not None
+        return [{"lease_id": "lease-1", "sandbox_id": "sandbox-1", "provider_name": "local"}]
+
+    monkeypatch.setattr(sandbox_service, "list_user_leases", fake_list_user_leases)
+
+    result = sandbox_service.list_user_sandboxes(
+        "owner-1",
+        thread_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(),
+    )
+
+    assert result == [{"sandbox_id": "sandbox-1", "provider_name": "local"}]


### PR DESCRIPTION
## Summary
- add sandbox_service.list_user_sandboxes as the canonical owner-facing projection over current internal lease rows
- route /api/sandbox/sandboxes/mine through list_user_sandboxes instead of calling list_user_leases directly
- keep runtime lease repo, monitor lease compatibility, and existing-sandbox bridge unchanged

## TDD
- RED: tests/Integration/test_sandbox_router_user_shell.py failed because the route still called list_user_leases and list_user_sandboxes did not exist
- GREEN: added canonical service projection and changed the route to use it

## Verification
- uv run python -m pytest tests/Integration/test_sandbox_router_user_shell.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_resource_overview_contract_split.py -q
- uv run ruff check backend/web/services/sandbox_service.py backend/web/routers/sandbox.py tests/Integration/test_sandbox_router_user_shell.py
- uv run ruff format --check backend/web/services/sandbox_service.py backend/web/routers/sandbox.py tests/Integration/test_sandbox_router_user_shell.py
- git diff --check HEAD~1 HEAD