### PR TITLE
Remove existing sandbox legacy lease fallback

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -354,12 +354,7 @@ def _resolve_owned_existing_sandbox_request_lease(
         raise HTTPException(403, "Not authorized")
     return resolve_existing_sandbox_lease(
         sandbox,
-        resolve_lease=lambda lease_id: sandbox_service.resolve_owned_lease(
-            owner_user_id,
-            lease_id,
-            thread_repo=app.state.thread_repo,
-            user_repo=app.state.user_repo,
-        ),
+        lease_repo=getattr(app.state, "lease_repo", None),
     )
 
 
@@ -798,13 +793,8 @@ def _create_owned_thread(
         bound_cwd, owned_lease = bind_thread_to_existing_sandbox(
             new_thread_id,
             sandbox,
-            resolve_lease=lambda lease_id: sandbox_service.resolve_owned_lease(
-                owner_user_id,
-                lease_id,
-                thread_repo=app.state.thread_repo,
-                user_repo=app.state.user_repo,
-            ),
             cwd=bind_cwd,
+            lease_repo=getattr(app.state, "lease_repo", None),
         )
         selected_lease_id = _request_bridge_text(owned_lease, "lease_id", label="lease")
         if owned_lease is None:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -140,7 +140,6 @@ def bind_thread_to_existing_lease(
 def resolve_existing_sandbox_lease(
     sandbox: Any,
     *,
-    resolve_lease: Callable[[str], dict[str, Any] | None],
     db_path: Path | None = None,
     lease_repo: Any | None = None,
 ) -> dict[str, Any] | None:
@@ -150,37 +149,32 @@ def resolve_existing_sandbox_lease(
     provider_env_id = str(
         (sandbox.get("provider_env_id") if isinstance(sandbox, dict) else getattr(sandbox, "provider_env_id", None)) or ""
     ).strip()
-    if provider_name and provider_env_id:
-        # @@@existing-sandbox-live-lease-first
-        # Existing-sandbox reuse should resolve the live lease from sandbox runtime identity first.
-        # legacy_lease_id stays only as the compatibility fallback when the live provider-env binding
-        # has not been materialized yet.
-        target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-        _lease_repo = lease_repo
-        own_lease_repo = _lease_repo is None
-        if _lease_repo is None:
-            _lease_repo = make_lease_repo(db_path=target_db)
-        try:
-            lease = _lease_repo.find_by_instance(provider_name=provider_name, instance_id=provider_env_id)
-            if lease is not None:
-                return lease
-        finally:
-            if own_lease_repo:
-                _lease_repo.close()
-    config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
-    if not isinstance(config, dict):
-        raise RuntimeError("sandbox.config must be an object")
-    legacy_lease_id = str(config.get("legacy_lease_id") or "").strip()
-    if not legacy_lease_id:
-        raise RuntimeError("sandbox.config.legacy_lease_id is required")
-    return resolve_lease(legacy_lease_id)
+    if not provider_name:
+        raise RuntimeError("sandbox.provider_name is required")
+    if not provider_env_id:
+        raise RuntimeError("sandbox.provider_env_id is required")
+
+    # @@@existing-sandbox-runtime-identity - existing-sandbox reuse must bind
+    # through live runtime identity; legacy_lease_id is not a resolution fallback.
+    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    _lease_repo = lease_repo
+    own_lease_repo = _lease_repo is None
+    if _lease_repo is None:
+        _lease_repo = make_lease_repo(db_path=target_db)
+    try:
+        lease = _lease_repo.find_by_instance(provider_name=provider_name, instance_id=provider_env_id)
+        if lease is not None:
+            return lease
+    finally:
+        if own_lease_repo:
+            _lease_repo.close()
+    raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
 
 
 def bind_thread_to_existing_sandbox(
     thread_id: str,
     sandbox: Any,
     *,
-    resolve_lease: Callable[[str], dict[str, Any] | None],
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
@@ -188,14 +182,11 @@ def bind_thread_to_existing_sandbox(
 ) -> tuple[str, dict[str, Any]]:
     lease = resolve_existing_sandbox_lease(
         sandbox,
-        resolve_lease=resolve_lease,
         db_path=db_path,
         lease_repo=lease_repo,
     )
     if lease is None:
-        config = sandbox.get("config") if isinstance(sandbox, dict) else getattr(sandbox, "config", None)
-        legacy_lease_id = str((config or {}).get("legacy_lease_id") or "").strip()
-        raise RuntimeError(f"lease not found: {legacy_lease_id}")
+        raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
     lease_id = str(lease.get("lease_id") or "").strip()
     if not lease_id:
         raise RuntimeError("lease.lease_id is required")

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -122,6 +122,20 @@ class _FakeSandboxRepo:
         self.by_id[row.id] = row
 
 
+class _FakeLeaseRepo:
+    def __init__(self, row: dict[str, object] | None = None) -> None:
+        self._row = row
+        self.instance_queries: list[tuple[str, str]] = []
+
+    def find_by_instance(self, *, provider_name: str, instance_id: str):
+        self.instance_queries.append((provider_name, instance_id))
+        if self._row is None:
+            return None
+        row_provider = str(self._row.get("provider_name") or "").strip()
+        row_instance = str(self._row.get("provider_env_id") or self._row.get("current_instance_id") or "").strip()
+        return self._row if row_provider == provider_name and row_instance == instance_id else None
+
+
 def _make_threads_app():
     return SimpleNamespace(
         state=SimpleNamespace(
@@ -130,6 +144,7 @@ def _make_threads_app():
             recipe_repo=_FakeRecipeRepo(),
             workspace_repo=_FakeWorkspaceRepo(),
             sandbox_repo=_FakeSandboxRepo(),
+            lease_repo=_FakeLeaseRepo(),
             thread_sandbox={},
             thread_cwd={},
         )
@@ -627,8 +642,18 @@ async def test_create_thread_existing_lease_binds_without_launch_config_save() -
     app.state.sandbox_repo.by_id["sandbox-1"] = {
         "id": "sandbox-1",
         "owner_user_id": "owner-1",
+        "provider_name": "daytona_selfhost",
+        "provider_env_id": "instance-1",
         "config": {"legacy_lease_id": "lease-1"},
     }
+    app.state.lease_repo = _FakeLeaseRepo(
+        {
+            "lease_id": "lease-1",
+            "provider_name": "daytona_selfhost",
+            "provider_env_id": "instance-1",
+            "recipe": {"id": "daytona:recipe-1"},
+        }
+    )
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -95,6 +95,56 @@ class _FakeSandboxRepo:
         self.by_id[row.id] = row
 
 
+class _FakeLeaseRepo:
+    def __init__(self, row: dict[str, Any] | None = None) -> None:
+        self._row = row
+        self.instance_queries: list[tuple[str, str]] = []
+
+    def find_by_instance(self, *, provider_name: str, instance_id: str):
+        self.instance_queries.append((provider_name, instance_id))
+        if self._row is None:
+            return None
+        row_provider = str(self._row.get("provider_name") or "").strip()
+        row_instance = str(self._row.get("provider_env_id") or self._row.get("current_instance_id") or "").strip()
+        return self._row if row_provider == provider_name and row_instance == instance_id else None
+
+
+def _existing_sandbox_row(
+    *,
+    provider_name: str = "local",
+    provider_env_id: str = "instance-1",
+    legacy_lease_id: str = "lease-1",
+) -> dict[str, Any]:
+    return {
+        "id": "sandbox-1",
+        "owner_user_id": "owner-1",
+        "provider_name": provider_name,
+        "provider_env_id": provider_env_id,
+        "config": {"legacy_lease_id": legacy_lease_id},
+    }
+
+
+def _existing_sandbox_lease_repo(
+    *,
+    lease_id: str = "lease-1",
+    sandbox_id: str = "sandbox-1",
+    provider_name: str = "local",
+    provider_env_id: str = "instance-1",
+    cwd: str = "/workspace/reused",
+    recipe: dict[str, Any] | None = None,
+) -> _FakeLeaseRepo:
+    return _FakeLeaseRepo(
+        {
+            "lease_id": lease_id,
+            "sandbox_id": sandbox_id,
+            "provider_name": provider_name,
+            "provider_env_id": provider_env_id,
+            "cwd": cwd,
+            "recipe": recipe,
+        }
+    )
+
+
 class _FakeAuthService:
     def __init__(self) -> None:
         self.tokens: list[str] = []
@@ -366,6 +416,7 @@ def _make_threads_app(
             recipe_repo=state_overrides.pop("recipe_repo", _FakeRecipeRepo()),
             workspace_repo=state_overrides.pop("workspace_repo", _FakeWorkspaceRepo()),
             sandbox_repo=state_overrides.pop("sandbox_repo", _FakeSandboxRepo()),
+            lease_repo=state_overrides.pop("lease_repo", _FakeLeaseRepo()),
             **state_overrides,
         )
     )
@@ -599,12 +650,14 @@ async def test_create_thread_route_rejects_lease_shaped_existing_identity():
 async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() -> None:
     workspace_repo = _FakeWorkspaceRepo()
     sandbox_repo = _FakeSandboxRepo()
-    sandbox_repo.by_id["sandbox-1"] = {
-        "id": "sandbox-1",
-        "owner_user_id": "owner-1",
-        "config": {"legacy_lease_id": "lease-1"},
-    }
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
+    sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row()
+    app = _make_threads_app(
+        thread_sandbox={},
+        thread_cwd={},
+        workspace_repo=workspace_repo,
+        sandbox_repo=sandbox_repo,
+        lease_repo=_existing_sandbox_lease_repo(recipe=None),
+    )
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -654,11 +707,7 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
 async def test_create_thread_route_existing_sandbox_prefers_existing_workspace_path_for_bind_cwd() -> None:
     workspace_repo = _FakeWorkspaceRepo()
     sandbox_repo = _FakeSandboxRepo()
-    sandbox_repo.by_id["sandbox-1"] = {
-        "id": "sandbox-1",
-        "owner_user_id": "owner-1",
-        "config": {"legacy_lease_id": "lease-1"},
-    }
+    sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row()
     existing_workspace = SimpleNamespace(
         id="workspace-existing",
         sandbox_id="sandbox-1",
@@ -666,7 +715,13 @@ async def test_create_thread_route_existing_sandbox_prefers_existing_workspace_p
         workspace_path="/workspace/existing",
     )
     workspace_repo.by_sandbox_id["sandbox-1"] = [existing_workspace]
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
+    app = _make_threads_app(
+        thread_sandbox={},
+        thread_cwd={},
+        workspace_repo=workspace_repo,
+        sandbox_repo=sandbox_repo,
+        lease_repo=_existing_sandbox_lease_repo(recipe=None),
+    )
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -770,12 +825,14 @@ async def test_create_thread_route_persists_current_workspace_id_for_new_sandbox
 async def test_create_thread_route_existing_sandbox_binds_without_launch_config_save() -> None:
     workspace_repo = _FakeWorkspaceRepo()
     sandbox_repo = _FakeSandboxRepo()
-    sandbox_repo.by_id["sandbox-1"] = {
-        "id": "sandbox-1",
-        "owner_user_id": "owner-1",
-        "config": {"legacy_lease_id": "lease-1"},
-    }
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
+    sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row()
+    app = _make_threads_app(
+        thread_sandbox={},
+        thread_cwd={},
+        workspace_repo=workspace_repo,
+        sandbox_repo=sandbox_repo,
+        lease_repo=_existing_sandbox_lease_repo(recipe={"id": "local:default"}),
+    )
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -820,12 +877,14 @@ async def test_create_thread_route_existing_sandbox_binds_without_launch_config_
 async def test_create_thread_route_accepts_sandbox_shaped_existing_identity() -> None:
     workspace_repo = _FakeWorkspaceRepo()
     sandbox_repo = _FakeSandboxRepo()
-    sandbox_repo.by_id["sandbox-1"] = {
-        "id": "sandbox-1",
-        "owner_user_id": "owner-1",
-        "config": {"legacy_lease_id": "lease-1"},
-    }
-    app = _make_threads_app(thread_sandbox={}, thread_cwd={}, workspace_repo=workspace_repo, sandbox_repo=sandbox_repo)
+    sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row()
+    app = _make_threads_app(
+        thread_sandbox={},
+        thread_cwd={},
+        workspace_repo=workspace_repo,
+        sandbox_repo=sandbox_repo,
+        lease_repo=_existing_sandbox_lease_repo(recipe={"id": "local:default"}),
+    )
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",
@@ -1196,11 +1255,8 @@ async def test_create_thread_route_rejects_unavailable_provider():
 @pytest.mark.asyncio
 async def test_create_thread_route_rejects_unavailable_provider_for_existing_lease():
     app = _make_threads_app(thread_sandbox={}, thread_cwd={})
-    app.state.sandbox_repo.by_id["sandbox-1"] = {
-        "id": "sandbox-1",
-        "owner_user_id": "owner-1",
-        "config": {"legacy_lease_id": "lease-1"},
-    }
+    app.state.sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row(provider_name="daytona")
+    app.state.lease_repo = _existing_sandbox_lease_repo(provider_name="daytona", recipe=None)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -113,7 +113,16 @@ class _FakeLeaseRepo:
 
     def find_by_instance(self, *, provider_name: str, instance_id: str):
         self.instance_queries.append((provider_name, instance_id))
-        return None
+        if self._row is None:
+            return None
+        row_provider = str(self._row.get("provider_name") or "").strip()
+        row_instance = str(
+            self._row.get("provider_env_id")
+            or self._row.get("current_instance_id")
+            or (self._row.get("_instance") or {}).get("instance_id")
+            or ""
+        ).strip()
+        return self._row if row_provider == provider_name and row_instance == instance_id else None
 
     def close(self) -> None:
         self.closed = True
@@ -158,7 +167,7 @@ def _new_test_manager() -> Any:
 
 
 def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_truth(monkeypatch):
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
 
     def build_provider(name: str):
         return SimpleNamespace(default_cwd=f"/providers/{name}") if name == "local" else None
@@ -181,7 +190,7 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
 
 
 def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_provider_default(monkeypatch):
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
     monkeypatch.setattr(
         sandbox_manager_module,
         "_build_provider_from_name",
@@ -218,7 +227,7 @@ def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavaila
 
 def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider_default_exists(monkeypatch):
     terminal_repo = _FakeBindTerminalRepo(latest_by_lease={"cwd": "/terminal/latest"})
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
 
     monkeypatch.setattr(
         sandbox_manager_module,
@@ -233,7 +242,6 @@ def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider
             "provider_env_id": "env-1",
             "config": {"legacy_lease_id": "legacy-lease"},
         },
-        resolve_lease=lambda _lease_id: {"lease_id": "lease-1"},
         db_path=Path("/tmp/fake-sandbox.db"),
         terminal_repo=terminal_repo,
         lease_repo=lease_repo,
@@ -1012,7 +1020,6 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
             "provider_env_id": "sandbox-env-1",
             "config": {"legacy_lease_id": "lease-legacy"},
         },
-        resolve_lease=lambda _lease_id: (_ for _ in ()).throw(AssertionError("legacy fallback should stay unused")),
         lease_repo=lease_repo,
     )
 
@@ -1023,22 +1030,18 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
     }
 
 
-def test_resolve_existing_sandbox_lease_falls_back_to_legacy_lease_id_when_instance_lookup_misses() -> None:
+def test_resolve_existing_sandbox_lease_fails_when_instance_lookup_misses() -> None:
     lease_repo = SimpleNamespace(
         find_by_instance=lambda **_kwargs: None,
         close=lambda: None,
     )
-    seen_lease_ids: list[str] = []
 
-    lease = sandbox_manager_module.resolve_existing_sandbox_lease(
-        {
-            "provider_name": "daytona",
-            "provider_env_id": "sandbox-env-1",
-            "config": {"legacy_lease_id": "lease-legacy"},
-        },
-        resolve_lease=lambda lease_id: seen_lease_ids.append(lease_id) or {"lease_id": lease_id},
-        lease_repo=lease_repo,
-    )
-
-    assert seen_lease_ids == ["lease-legacy"]
-    assert lease == {"lease_id": "lease-legacy"}
+    with pytest.raises(RuntimeError, match="sandbox provider_env_id did not resolve to a lease"):
+        sandbox_manager_module.resolve_existing_sandbox_lease(
+            {
+                "provider_name": "daytona",
+                "provider_env_id": "sandbox-env-1",
+                "config": {"legacy_lease_id": "lease-legacy"},
+            },
+            lease_repo=lease_repo,
+        )


### PR DESCRIPTION
## Scope
- Existing-sandbox reuse now requires canonical sandbox runtime identity: provider_name + provider_env_id.
- Removed the legacy_lease_id resolution fallback from sandbox.manager.resolve_existing_sandbox_lease / bind_thread_to_existing_sandbox.
- Threads router passes the app lease_repo into existing-sandbox preview/bind so tests and runtime use the same provider-env lookup path.
- Updated existing-sandbox route fixtures to carry provider_env_id and resolve leases through find_by_instance.

## TDD / Verification
- RED: focused unit test failed because the old implementation still called the legacy lease resolver when find_by_instance missed.
- GREEN: uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py tests/Unit/backend/web/services/test_thread_state_service.py -q -> 88 passed.
- uv run ruff check sandbox/manager.py backend/web/routers/threads.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -> passed.
- uv run ruff format --check sandbox/manager.py backend/web/routers/threads.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -> 5 files already formatted.
- git diff --check -> clean.

## Stopline
- No DB/schema mutation.
- No monitor/runtime lease contract rename.
- No fallback or compatibility resolver was added.