### PR TITLE
Fix resource projection sandbox fixture

### DIFF
--- a/tests/Integration/test_schema_redesign_baseline_contract.py
+++ b/tests/Integration/test_schema_redesign_baseline_contract.py
@@ -80,13 +80,15 @@ def test_resource_projection_sessions_do_not_leak_member_ids(monkeypatch) -> Non
 
     monkeypatch.setattr(
         resource_projection_service.sandbox_service,
-        "list_user_leases",
+        "list_user_sandboxes",
         lambda owner_user_id, **_kwargs: [
             {
+                "sandbox_id": "sandbox-1",
                 "lease_id": "lease-1",
                 "provider_name": "daytona_selfhost",
                 "recipe": {"id": "daytona:default", "provider_type": "daytona", "name": "Daytona Default"},
                 "cwd": "/workspace",
+                "runtime_session_id": "provider-session-1",
                 "thread_ids": ["thread-1"],
                 "agents": [
                     {
@@ -100,6 +102,11 @@ def test_resource_projection_sessions_do_not_leak_member_ids(monkeypatch) -> Non
                 "created_at": "2026-04-08T10:00:00Z",
             }
         ],
+    )
+    monkeypatch.setattr(
+        resource_projection_service.sandbox_service,
+        "list_user_leases",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("resource overview must not read lease wrapper")),
     )
     monkeypatch.setattr(
         resource_projection_service.resource_service,


### PR DESCRIPTION
## Scope
- Test-only fix for dev CI red after a8cc3a61.
- Updates test_resource_projection_sessions_do_not_leak_member_ids to patch sandbox_service.list_user_sandboxes, matching the current resource overview call path.
- Adds an assertion guard that list_user_leases must not be used by this test path.

## Root Cause
- a8cc3a61 correctly moved sandbox_service.list_user_sandboxes off the public list_user_leases compatibility wrapper.
- This baseline test still patched list_user_leases, so resource_projection_service.list_user_resource_providers fell through into the real list_user_sandboxes path with object() repos and failed in CI.

## Verification
- uv run python -m pytest tests/Integration/test_schema_redesign_baseline_contract.py::test_resource_projection_sessions_do_not_leak_member_ids -q -> 1 passed.
- uv run python -m pytest tests/Integration/test_sandbox_router_user_shell.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_schema_redesign_baseline_contract.py tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_resource_probe.py -q -> 83 passed.
- uv run ruff check tests/Integration/test_schema_redesign_baseline_contract.py -> passed.
- uv run ruff format --check tests/Integration/test_schema_redesign_baseline_contract.py -> 1 file already formatted.
- git diff --check -> clean.