### PR TITLE
Remove unused bridge config helper

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -318,18 +318,6 @@ def _request_bridge_text(row: Any, key: str, *, label: str) -> str:
     return str(value)
 
 
-def _request_bridge_config_text(row: Any, key: str, *, label: str) -> str:
-    config = row.get("config") if isinstance(row, dict) else getattr(row, "config", None)
-    if not isinstance(config, dict):
-        raise RuntimeError(f"{label}.config must be an object")
-    value = config.get(key)
-    if isinstance(value, str):
-        value = value.strip()
-    if value is None or value == "":
-        raise RuntimeError(f"{label}.config.{key} is required")
-    return str(value)
-
-
 def _resolve_owned_existing_sandbox_request_lease(
     app: Any,
     owner_user_id: str,


### PR DESCRIPTION
## Scope
- Removes unused backend/web/routers/threads.py::_request_bridge_config_text.
- No behavior/API/schema/runtime change.
- This is cleanup after existing-sandbox reuse stopped resolving through config.legacy_lease_id fallback.

## Verification
- rg -n "_request_bridge_config_text" . || true -> no matches.
- uv run python -m pytest tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -q -> 55 passed.
- uv run ruff check backend/web/routers/threads.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -> passed.
- uv run ruff format --check backend/web/routers/threads.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -> 3 files already formatted.
- git diff --check -> clean.