### PR TITLE
Stop returning lease id from provider webhook

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -77,7 +77,6 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
         "instance_id": instance_id,
         "event_type": event_type,
         "matched": True,
-        "lease_id": lease.lease_id,
     }
 
 

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -85,15 +85,21 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_le
             return None
 
     class _EventRepo:
-        def record(self, **_kwargs):
-            return None
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def record(self, **kwargs):
+            self.calls.append(kwargs)
 
         def close(self) -> None:
             return None
 
     class _Container:
+        def __init__(self, event_repo: _EventRepo) -> None:
+            self._event_repo = event_repo
+
         def provider_event_repo(self) -> _EventRepo:
-            return _EventRepo()
+            return self._event_repo
 
     class _Lease:
         lease_id = "lease-1"
@@ -116,11 +122,12 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_le
             self.provider = object()
 
     expected_db_path = tmp_path / "sandbox.db"
+    event_repo = _EventRepo()
     lease = _Lease()
 
     monkeypatch.setattr(webhooks, "resolve_sandbox_db_path", lambda: expected_db_path, raising=False)
     monkeypatch.setattr(webhooks, "make_lease_repo", lambda: _LeaseRepo())
-    monkeypatch.setattr(webhooks, "_get_container", lambda: _Container())
+    monkeypatch.setattr(webhooks, "_get_container", lambda: _Container(event_repo))
     monkeypatch.setattr(webhooks, "init_providers_and_managers", lambda: ({}, {"local": _Manager()}))
 
     def _fake_lease_from_row(row, db_path):
@@ -136,7 +143,16 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_le
     )
 
     assert payload["matched"] is True
-    assert payload["lease_id"] == "lease-1"
+    assert "lease_id" not in payload
+    assert event_repo.calls == [
+        {
+            "provider_name": "local",
+            "instance_id": "inst-2",
+            "event_type": "provider.running",
+            "payload": {"instance_id": "inst-2", "event": "provider.running"},
+            "matched_lease_id": "lease-1",
+        }
+    ]
     assert lease.applied == [
         {
             "provider": lease.applied[0]["provider"],


### PR DESCRIPTION
## Summary
- Remove legacy lease_id from matched provider webhook HTTP responses
- Keep provider_events.matched_lease_id recording intact for internal event correlation
- Add contract coverage that matched webhook responses stay lease-id-free while internal event correlation remains present

## Verification
- RED observed before implementation: tests/Integration/test_webhooks_router_contract.py failed because matched response still contained lease_id
- uv run python -m pytest tests/Integration/test_webhooks_router_contract.py -q
- uv run python -m pytest tests/Integration/test_webhooks_router_contract.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_thread_state_service.py -q
- uv run ruff check backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py
- uv run ruff format --check backend/web/routers/webhooks.py tests/Integration/test_webhooks_router_contract.py
- git diff --check