### PR TITLE
Fix resource running count to use sandbox identity

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -217,6 +217,13 @@ def _resource_session_identity(session: dict[str, Any]) -> str:
     return f"{lease_id}:{thread_id or 'unbound'}"
 
 
+def _resource_running_identity(session: dict[str, Any]) -> str:
+    sandbox_id = str(session.get("sandbox_id") or "").strip()
+    if sandbox_id:
+        return sandbox_id
+    return str(session.get("lease_id") or "").strip()
+
+
 def _resource_display_status(
     *,
     observed_state: str | None,
@@ -303,7 +310,7 @@ def list_resource_providers() -> dict[str, Any]:
         normalized_sessions: list[dict[str, Any]] = []
         seen_session_ids: set[str] = set()
         running_count = 0
-        seen_running_leases: set[str] = set()
+        seen_running_sandboxes: set[str] = set()
         for session in provider_sessions:
             observed_state = session.get("observed_state")
             desired_state = session.get("desired_state")
@@ -318,9 +325,10 @@ def list_resource_providers() -> dict[str, Any]:
                 runtime_session_id=runtime_session_id,
                 session_metrics=session_metrics,
             )
-            if normalized == "running" and lease_id not in seen_running_leases:
+            running_identity = _resource_running_identity(session)
+            if normalized == "running" and running_identity and running_identity not in seen_running_sandboxes:
                 running_count += 1
-                seen_running_leases.add(lease_id)
+                seen_running_sandboxes.add(running_identity)
             owner = owners.get(thread_id, {"agent_name": "未绑定Agent", "avatar_url": None})
             session_identity = _resource_session_identity(session)
             if session_identity in seen_session_ids:
@@ -397,7 +405,7 @@ def visible_resource_session_stats() -> dict[str, dict[str, int]]:
     sessions, runtime_session_ids, _snapshot_by_lease, snapshot_by_sandbox = _load_visible_resource_runtime()
     stats: dict[str, dict[str, int]] = {}
     seen_session_ids: set[str] = set()
-    seen_running_leases: set[tuple[str, str]] = set()
+    seen_running_sandboxes: set[tuple[str, str]] = set()
     for session in sessions:
         provider_instance = str(session.get("provider") or "local")
         provider_stats = stats.setdefault(provider_instance, {"sessions": 0, "running": 0})
@@ -406,7 +414,6 @@ def visible_resource_session_stats() -> dict[str, dict[str, int]]:
             seen_session_ids.add(session_identity)
             provider_stats["sessions"] += 1
 
-        lease_id = str(session.get("lease_id") or "")
         sandbox_id = str(session.get("sandbox_id") or "").strip()
         runtime_session_id = runtime_session_ids.get(sandbox_id)
         normalized = _resource_display_status(
@@ -415,9 +422,10 @@ def visible_resource_session_stats() -> dict[str, dict[str, int]]:
             runtime_session_id=runtime_session_id,
             session_metrics=_to_session_metrics(snapshot_by_sandbox.get(sandbox_id)),
         )
-        running_identity = (provider_instance, lease_id)
-        if normalized == "running" and lease_id and running_identity not in seen_running_leases:
-            seen_running_leases.add(running_identity)
+        running_identity = _resource_running_identity(session)
+        scoped_running_identity = (provider_instance, running_identity)
+        if normalized == "running" and running_identity and scoped_running_identity not in seen_running_sandboxes:
+            seen_running_sandboxes.add(scoped_running_identity)
             provider_stats["running"] += 1
 
     return stats

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -183,6 +183,56 @@ def test_list_resource_providers_deduplicates_terminal_derived_rows(monkeypatch)
     ]
 
 
+def test_list_resource_providers_counts_running_sandboxes_once_when_lease_residue_duplicates(monkeypatch):
+    rows = [
+        {
+            "provider": "local",
+            "session_id": None,
+            "thread_id": "thread-1",
+            "sandbox_id": "sandbox-1",
+            "lease_id": "lease-old",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-04T00:00:00",
+        },
+        {
+            "provider": "local",
+            "session_id": None,
+            "thread_id": "thread-1",
+            "sandbox_id": "sandbox-1",
+            "lease_id": "lease-new",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-04T00:00:01",
+        },
+    ]
+
+    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _FakeRepo(rows))
+    monkeypatch.setattr(
+        resource_projection_service,
+        "available_sandbox_types",
+        lambda: [{"name": "local", "available": True}],
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_resolve_instance_capabilities",
+        lambda _config_name: (resource_common.empty_capabilities(), None),
+    )
+    monkeypatch.setattr(
+        resource_projection_service,
+        "_thread_owners",
+        lambda thread_ids: {tid: {"agent_user_id": "agent-1", "agent_name": "Toad", "avatar_url": None} for tid in thread_ids},
+    )
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
+
+    payload = resource_projection_service.list_resource_providers()
+    local = payload["providers"][0]
+
+    assert local["telemetry"]["running"]["used"] == 1
+    assert payload["summary"]["running_sessions"] == 1
+    assert [session["id"] for session in local["sessions"]] == ["sandbox-1:thread-1"]
+
+
 def test_list_resource_providers_resolves_owner_metadata_from_runtime_storage(monkeypatch):
     rows = [
         {
@@ -616,6 +666,38 @@ def test_visible_resource_session_stats_uses_sandbox_keyed_runtime_lookup(monkey
             raise AssertionError(f"unexpected lease batch lookup: {lease_ids}")
 
     monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _BatchOnlyRepo())
+    monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
+
+    stats = resource_projection_service.visible_resource_session_stats()
+
+    assert stats == {"daytona_selfhost": {"sessions": 1, "running": 1}}
+
+
+def test_visible_resource_session_stats_counts_running_sandbox_once_when_lease_residue_duplicates(monkeypatch):
+    rows = [
+        {
+            "provider": "daytona_selfhost",
+            "session_id": None,
+            "thread_id": "thread-a",
+            "sandbox_id": "sandbox-a",
+            "lease_id": "lease-old",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-08T00:00:00",
+        },
+        {
+            "provider": "daytona_selfhost",
+            "session_id": None,
+            "thread_id": "thread-a",
+            "sandbox_id": "sandbox-a",
+            "lease_id": "lease-new",
+            "observed_state": "running",
+            "desired_state": "running",
+            "created_at": "2026-04-08T00:00:01",
+        },
+    ]
+
+    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _FakeRepo(rows))
     monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     stats = resource_projection_service.visible_resource_session_stats()


### PR DESCRIPTION
## Summary
- Count resource overview running instances by canonical sandbox id first, falling back to lease id only for lease-only compatibility rows.
- Apply the same sandbox-first running identity to `visible_resource_session_stats`.
- Add regression coverage for duplicate lease-shaped rows pointing at the same sandbox.

## Test Plan
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py -q`
- `uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py`
- `uv run ruff format --check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py`
- `git diff --check`
