### PR TITLE
Remove empty resource lease snapshot slot

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -130,7 +130,6 @@ def _load_visible_resource_runtime() -> tuple[
     list[dict[str, Any]],
     dict[str, str | None],
     dict[str, dict[str, Any]],
-    dict[str, dict[str, Any]],
 ]:
     repo = make_sandbox_monitor_repo()
     try:
@@ -140,8 +139,7 @@ def _load_visible_resource_runtime() -> tuple[
         repo.close()
 
     snapshot_by_sandbox = list_resource_snapshots_by_sandbox(sessions)
-    snapshot_by_lease: dict[str, dict[str, Any]] = {}
-    return sessions, runtime_session_ids, snapshot_by_lease, snapshot_by_sandbox
+    return sessions, runtime_session_ids, snapshot_by_sandbox
 
 
 def _backfill_runtime_session_ids(sandboxes: list[dict[str, Any]]) -> None:
@@ -285,7 +283,7 @@ def _project_user_visible_resource_sessions(repo: Any, rows: list[dict[str, Any]
 
 
 def list_resource_providers() -> dict[str, Any]:
-    sessions, runtime_session_ids, snapshot_by_lease, snapshot_by_sandbox = _load_visible_resource_runtime()
+    sessions, runtime_session_ids, snapshot_by_sandbox = _load_visible_resource_runtime()
 
     grouped: dict[str, list[dict[str, Any]]] = {}
     for session in sessions:
@@ -402,7 +400,7 @@ def list_resource_providers() -> dict[str, Any]:
 
 
 def visible_resource_session_stats() -> dict[str, dict[str, int]]:
-    sessions, runtime_session_ids, _snapshot_by_lease, snapshot_by_sandbox = _load_visible_resource_runtime()
+    sessions, runtime_session_ids, snapshot_by_sandbox = _load_visible_resource_runtime()
     stats: dict[str, dict[str, int]] = {}
     seen_session_ids: set[str] = set()
     seen_running_sandboxes: set[tuple[str, str]] = set()

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -802,7 +802,7 @@ def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_tele
     assert payload["providers"][0]["telemetry"]["cpu"]["used"] == 11
 
 
-def test_load_visible_resource_runtime_uses_sandbox_snapshot_wrapper(monkeypatch):
+def test_load_visible_resource_runtime_returns_only_sandbox_keyed_snapshots(monkeypatch):
     rows = [
         {
             "provider": "daytona_selfhost",
@@ -823,9 +823,8 @@ def test_load_visible_resource_runtime_uses_sandbox_snapshot_wrapper(monkeypatch
         lambda sessions: {"sandbox-a": {"sandbox_id": "sandbox-a", "cpu_used": 11}},
     )
 
-    sessions, runtime_session_ids, snapshot_by_lease, snapshot_by_sandbox = resource_projection_service._load_visible_resource_runtime()
+    sessions, runtime_session_ids, snapshot_by_sandbox = resource_projection_service._load_visible_resource_runtime()
 
     assert [session["sandbox_id"] for session in sessions] == ["sandbox-a"]
     assert runtime_session_ids == {"sandbox-a": None}
-    assert snapshot_by_lease == {}
     assert snapshot_by_sandbox == {"sandbox-a": {"sandbox_id": "sandbox-a", "cpu_used": 11}}


### PR DESCRIPTION
## Summary
- Remove the always-empty `snapshot_by_lease` return slot from `_load_visible_resource_runtime`.
- Update resource overview callers to consume only sessions, runtime session ids, and sandbox-keyed snapshots.
- Keep existing sandbox-keyed snapshot regression coverage and assert the helper no longer exposes the lease-shaped slot.

## Test Plan
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py -q`
- `uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py`
- `uv run ruff format --check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py`
- `git diff --check`
- `rg -n "snapshot_by_lease|_snapshot_by_lease" backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py || true`
