### PR TITLE
Chore: name uploads as thread files

### DIFF
--- a/frontend/app/src/api/client.test.ts
+++ b/frontend/app/src/api/client.test.ts
@@ -341,7 +341,7 @@ describe("thread api client contract", () => {
     await expect(api.readSandboxFile("thread-1", "/workspace/app.py")).rejects.toThrow("Malformed sandbox file read");
   });
 
-  it("uploadSandboxFile rejects malformed upload results", async () => {
+  it("uploadThreadFile rejects malformed upload results", async () => {
     authFetch.mockResolvedValue(okJson({
       thread_id: "thread-1",
       relative_path: "avatar.png",
@@ -350,8 +350,8 @@ describe("thread api client contract", () => {
       sha256: "abc",
     }));
 
-    await expect(api.uploadSandboxFile("thread-1", { file: new File(["png"], "avatar.png") })).rejects.toThrow(
-      "Malformed sandbox upload result",
+    await expect(api.uploadThreadFile("thread-1", { file: new File(["png"], "avatar.png") })).rejects.toThrow(
+      "Malformed thread file upload result",
     );
   });
 

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -14,8 +14,8 @@ import type {
   SandboxFileEntry,
   SandboxFileResult,
   SandboxFilesListResult,
-  SandboxUploadResult,
   ThreadFileChannelBinding,
+  ThreadFileUploadResult,
 } from "./types";
 
 import { authFetch } from "../store/auth-store";
@@ -525,10 +525,10 @@ function parseSandboxFileRead(value: unknown): SandboxFileResult {
   return { thread_id, path, content, size };
 }
 
-export async function uploadSandboxFile(
+export async function uploadThreadFile(
   threadId: string,
   opts: { file: File; path?: string },
-): Promise<SandboxUploadResult> {
+): Promise<ThreadFileUploadResult> {
   const query = new URLSearchParams();
   if (opts.path) query.set("path", opts.path);
   const form = new FormData();
@@ -542,10 +542,10 @@ export async function uploadSandboxFile(
     const body = await response.text();
     throw new Error(`API ${response.status}: ${body || response.statusText}`);
   }
-  return parseSandboxUploadResult(await response.json());
+  return parseThreadFileUploadResult(await response.json());
 }
 
-function parseSandboxUploadResult(value: unknown): SandboxUploadResult {
+function parseThreadFileUploadResult(value: unknown): ThreadFileUploadResult {
   const payload = asRecord(value);
   const thread_id = payload ? recordString(payload, "thread_id") : undefined;
   const relative_path = payload ? recordString(payload, "relative_path") : undefined;
@@ -553,12 +553,12 @@ function parseSandboxUploadResult(value: unknown): SandboxUploadResult {
   const size_bytes = payload?.size_bytes;
   const sha256 = payload ? recordString(payload, "sha256") : undefined;
   if (!payload || !thread_id || !relative_path || !absolute_path || typeof size_bytes !== "number" || !sha256) {
-    throw new Error("Malformed sandbox upload result");
+    throw new Error("Malformed thread file upload result");
   }
   return { thread_id, relative_path, absolute_path, size_bytes, sha256 };
 }
 
-export function getSandboxDownloadUrl(
+export function getThreadFileDownloadUrl(
   threadId: string,
   path: string,
 ): string {

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -369,7 +369,7 @@ export interface ChatMessage {
   created_at: number;
 }
 
-export interface SandboxUploadResult {
+export interface ThreadFileUploadResult {
   thread_id: string;
   relative_path: string;
   absolute_path: string;

--- a/frontend/app/src/components/chat-area/UserBubble.tsx
+++ b/frontend/app/src/components/chat-area/UserBubble.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { useParams } from "react-router-dom";
 import { FileText } from "lucide-react";
 import type { UserMessage } from "../../api";
-import { getSandboxDownloadUrl } from "../../api";
+import { getThreadFileDownloadUrl } from "../../api";
 import ActorAvatar from "../ActorAvatar";
 import { formatTime } from "./utils";
 
@@ -34,7 +34,7 @@ export const UserBubble = memo(function UserBubble(props: UserBubbleProps) {
             {attachments.map((filename) => (
               <a
                 key={filename}
-                href={getSandboxDownloadUrl(threadId, filename)}
+                href={getThreadFileDownloadUrl(threadId, filename)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-1.5 px-2.5 py-1.5 bg-muted hover:bg-accent rounded-lg text-xs transition-colors duration-fast cursor-pointer"

--- a/frontend/app/src/pages/ChatPage.tsx
+++ b/frontend/app/src/pages/ChatPage.tsx
@@ -4,7 +4,7 @@ import { Check, ShieldAlert, X } from "lucide-react";
 import { toast } from "sonner";
 import ChatArea from "../components/ChatArea";
 import type { AskUserAnswer, AskUserQuestionPrompt, PermissionRequest } from "../api";
-import { isAssistantTurn, uploadSandboxFile } from "../api";
+import { isAssistantTurn, uploadThreadFile } from "../api";
 import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { Button } from "../components/ui/button";
 import ComputerPanel from "../components/computer-panel";
@@ -278,7 +278,7 @@ function ChatPageInner({ threadId }: { threadId: string }) {
       const toastId = toast.loading(`Uploading ${attachedFiles.length} file(s)...`);
       try {
         await Promise.all(attachedFiles.map((file) =>
-          uploadSandboxFile(threadId, { file, path: file.name }),
+          uploadThreadFile(threadId, { file, path: file.name }),
         ));
         toast.success(`Uploaded ${attachedFiles.length} file(s)`, { id: toastId });
         setAttachedFiles([]);


### PR DESCRIPTION
## Scope
- Rename frontend thread upload/download API helpers from sandbox-file wording to thread-file-channel wording.
- `uploadSandboxFile` -> `uploadThreadFile`; `getSandboxDownloadUrl` -> `getThreadFileDownloadUrl`; `SandboxUploadResult` -> `ThreadFileUploadResult`.
- No backend route, runtime, DB, schema, or product behavior change.

## Why
Uploads are staged in the thread file channel and only synced into the sandbox when a message is sent. The old frontend names implied direct sandbox workspace writes, which made the abstraction look more unified than the actual boundary.

## Verification
- RED/fact check: old names existed before the change via `rg uploadSandboxFile|getSandboxDownloadUrl|SandboxUploadResult frontend/app/src`.
- `rg -n "uploadSandboxFile|getSandboxDownloadUrl|SandboxUploadResult|parseSandboxUploadResult|Malformed sandbox upload" frontend/app/src || true` -> no matches.
- `npm run test -- src/api/client.test.ts` -> 29 passed.
- `npm run lint` -> passed.
- `npm run build` -> passed, with existing large chunk warning.
- `git diff --check` -> clean.
