### PR TITLE
test: guard canonical root agent entrypoint imports

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -25,7 +25,7 @@ if env_file.exists():
             key, value = line.split("=", 1)
             os.environ[key] = value
 
-from agent import create_leon_agent
+from core.runtime.agent import create_leon_agent
 
 
 class Colors:

--- a/langgraph_app.py
+++ b/langgraph_app.py
@@ -4,7 +4,7 @@ LangGraph Dev 入口文件
 用于 langgraph dev 命令的独立入口，不污染 agent.py
 """
 
-from agent import create_leon_agent
+from core.runtime.agent import create_leon_agent
 
 # 创建 agent 实例供 langgraph dev 使用
 agent = create_leon_agent(agent="default").agent

--- a/tests/Integration/test_e2e_summary_persistence.py
+++ b/tests/Integration/test_e2e_summary_persistence.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(
     reason="LEON_E2E_AGENT not set (requires working LLM API key for real agent calls)",
 )
 
-from agent import create_leon_agent
+from core.runtime.agent import create_leon_agent
 from sandbox.thread_context import set_current_thread_id
 
 

--- a/tests/Unit/core/test_root_agent_entrypoint.py
+++ b/tests/Unit/core/test_root_agent_entrypoint.py
@@ -1,0 +1,25 @@
+import importlib
+import re
+from pathlib import Path
+
+
+def test_root_agent_shim_aliases_canonical_runtime_entrypoint():
+    root_agent = importlib.import_module("agent")
+    runtime_agent = importlib.import_module("core.runtime.agent")
+
+    assert root_agent.LeonAgent is runtime_agent.LeonAgent
+    assert root_agent.create_leon_agent is runtime_agent.create_leon_agent
+
+
+def test_internal_entrypoints_import_canonical_runtime_agent():
+    repo_root = Path(__file__).resolve().parents[3]
+    checked_paths = [
+        Path("langgraph_app.py"),
+        Path("examples/chat.py"),
+        Path("tests/Integration/test_e2e_summary_persistence.py"),
+    ]
+    root_agent_import = re.compile(r"^\s*(from agent import|import agent(?:\s|$))", re.MULTILINE)
+
+    offenders = [str(path) for path in checked_paths if root_agent_import.search((repo_root / path).read_text(encoding="utf-8"))]
+
+    assert offenders == []


### PR DESCRIPTION
## Summary

- move internal root agent consumers to the canonical `core.runtime.agent` import path
- keep root `agent.py` as the deprecated compatibility shim
- add a source-level regression test that verifies the shim aliases canonical objects and internal entrypoints do not import from the shim

## Scope

No database, schema, LeaseRepo, monitor/resource projection, local SQLite/runtime, API, or runtime behavior change.

Touched files:
- `langgraph_app.py`
- `examples/chat.py`
- `tests/Integration/test_e2e_summary_persistence.py`
- `tests/Unit/core/test_root_agent_entrypoint.py`

## TDD / Verification

RED:
- `uv run python -m pytest tests/Unit/core/test_root_agent_entrypoint.py -q` failed because `langgraph_app.py`, `examples/chat.py`, and `tests/Integration/test_e2e_summary_persistence.py` still imported from root `agent`.

GREEN:
- `uv run python -m pytest tests/Unit/core/test_root_agent_entrypoint.py -q` -> 2 passed
- `uv run python -m pytest tests/Integration/test_e2e_summary_persistence.py --collect-only -q` -> 3 tests collected
- `uv run ruff check agent.py langgraph_app.py examples/chat.py tests/Integration/test_e2e_summary_persistence.py tests/Unit/core/test_root_agent_entrypoint.py` -> passed
- `git diff --check HEAD~1 HEAD` -> clean
- alias check -> `same_LeonAgent True`, `same_create True`
- internal direct root import scan -> 0 matches

Design DB context:
- root entrypoint preflight recorded locally in mycel-db-design commit `976f4c7`
