### PR TITLE
chore: name monitor cleanup messages as sandboxes

### DIFF
--- a/backend/web/services/monitor_operation_service.py
+++ b/backend/web/services/monitor_operation_service.py
@@ -97,28 +97,28 @@ def build_lease_cleanup_truth(
 
     if has_active_sessions and not can_close_stale_active_sessions:
         allowed = False
-        reason = "Lease still has active sessions and cannot enter managed cleanup."
+        reason = "Sandbox still has active sessions and cannot enter managed cleanup."
     elif has_thread_bindings and category != "detached_residue":
         allowed = False
-        reason = "Lease still has thread bindings and cannot enter managed cleanup."
+        reason = "Sandbox still has thread bindings and cannot enter managed cleanup."
     elif not provider:
         allowed = False
-        reason = "Lease has no provider and cannot enter managed cleanup."
+        reason = "Sandbox has no provider and cannot enter managed cleanup."
     elif category not in _ALLOWED_LEASE_CLEANUP_TRIAGE:
         allowed = False
-        reason = "Lease is not in a managed cleanup state."
+        reason = "Sandbox is not in a managed cleanup state."
     elif category == "orphan_cleanup":
         allowed = True
         if can_close_stale_active_sessions:
-            reason = "Lease has only stale active sessions and can close them before cleanup."
+            reason = "Sandbox has only stale active sessions and can close them before cleanup."
         else:
-            reason = "Lease is orphan cleanup residue and can enter managed cleanup."
+            reason = "Sandbox is orphan cleanup residue and can enter managed cleanup."
     elif category == "detached_residue":
         allowed = True
-        reason = "Lease is detached residue and can detach stale thread bindings before cleanup."
+        reason = "Sandbox is detached residue and can detach stale thread bindings before cleanup."
     else:
         allowed = False
-        reason = "Lease is not in a managed cleanup state."
+        reason = "Sandbox is not in a managed cleanup state."
 
     operations = _operations_for_target("lease", lease_id)
     latest = operations[0] if operations else None
@@ -213,10 +213,10 @@ def request_lease_cleanup(lease_detail: dict[str, Any]) -> dict[str, Any]:
         "runtime_state_after": None,
         "destroy_result": result,
     }
-    _append_event(operation, status="succeeded", message="Lease cleanup completed.")
+    _append_event(operation, status="succeeded", message="Sandbox cleanup completed.")
     return {
         "accepted": True,
-        "message": "Lease cleanup completed.",
+        "message": "Sandbox cleanup completed.",
         "operation": _operation_view(operation),
         "current_truth": {
             "lease_id": lease_id,
@@ -252,7 +252,7 @@ def request_provider_session_cleanup(provider_name: str, session_id: str, sessio
         kind="provider_session_cleanup",
         target_type="provider_session",
         target_id=target_id,
-        reason="Provider session is not lease-backed and can enter managed cleanup.",
+        reason="Provider session is not sandbox-backed and can enter managed cleanup.",
         target={
             "target_type": "provider_session",
             "provider_id": provider,

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -157,19 +157,19 @@ LEASE_SEMANTIC_ORDER = [
 LEASE_SEMANTIC_META = {
     "orphan_diverged": {
         "title": "Orphaned + Diverged",
-        "description": "Lease lost thread binding while desired and observed state still disagree.",
+        "description": "Sandbox lost thread binding while desired and observed state still disagree.",
     },
     "diverged": {
         "title": "Diverged",
-        "description": "Lease is still attached to a thread, but runtime state has not converged.",
+        "description": "Sandbox is still attached to a thread, but runtime state has not converged.",
     },
     "orphan": {
         "title": "Orphans",
-        "description": "Lease has no active thread binding. Usually cleanup or historical residue.",
+        "description": "Sandbox has no active thread binding. Usually cleanup or historical residue.",
     },
     "healthy": {
         "title": "Healthy",
-        "description": "Lease has a thread binding and desired state matches observed state.",
+        "description": "Sandbox has a thread binding and desired state matches observed state.",
     },
 }
 
@@ -184,25 +184,25 @@ LEASE_TRIAGE_ORDER = [
 LEASE_TRIAGE_META = {
     "active_drift": {
         "title": "Active Drift",
-        "description": "Leases whose desired and observed state still disagree recently enough to warrant attention.",
+        "description": "Sandboxes whose desired and observed state still disagree recently enough to warrant attention.",
         "tone": "warning",
     },
     "detached_residue": {
         "title": "Detached Residue",
         "description": (
-            "Leases still marked desired=running but observed=detached long after the runtime "
+            "Sandboxes still marked desired=running but observed=detached long after the runtime "
             "stopped moving. Usually cleanup debt, not live pressure."
         ),
         "tone": "danger",
     },
     "orphan_cleanup": {
         "title": "Orphan Cleanup",
-        "description": "Lease rows that have already lost thread binding and mainly represent cleanup backlog or historical residue.",
+        "description": "Sandboxes that have already lost thread binding and mainly represent cleanup backlog or historical residue.",
         "tone": "warning",
     },
     "healthy_capacity": {
         "title": "Healthy Capacity",
-        "description": "Leases with attached thread context and converged runtime state.",
+        "description": "Sandboxes with attached thread context and converged runtime state.",
         "tone": "success",
     },
 }

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -499,7 +499,7 @@ def test_get_monitor_sandbox_detail_exposes_cleanup_state(monkeypatch):
     payload = monitor_service.get_monitor_sandbox_detail("sandbox-1")
 
     assert payload["sandbox"]["sandbox_id"] == "sandbox-1"
-    assert payload["cleanup"] == _cleanup_state("Lease is orphan cleanup residue and can enter managed cleanup.")
+    assert payload["cleanup"] == _cleanup_state("Sandbox is orphan cleanup residue and can enter managed cleanup.")
 
 
 def test_get_monitor_sandbox_detail_allows_missing_lease_bridge_for_readonly_detail(monkeypatch):
@@ -545,7 +545,7 @@ def test_request_monitor_sandbox_cleanup_uses_canonical_sandbox_target(monkeypat
     payload = monitor_service.request_monitor_sandbox_cleanup("sandbox-1")
 
     assert payload["accepted"] is True
-    assert payload["message"] == "Lease cleanup completed."
+    assert payload["message"] == "Sandbox cleanup completed."
     assert payload["operation"]["target_type"] == "sandbox"
     assert payload["operation"]["target_id"] == "sandbox-1"
     assert payload["operation"]["result_truth"]["sandbox_state_before"] == "detached"


### PR DESCRIPTION
## Summary
- Renames monitor sandbox cleanup/triage user-facing messages from lease wording to sandbox wording.
- Keeps lease bridge internals, operation kind, recommended_action, LeaseRepo, DB/schema, and runtime behavior unchanged.
- Adds/updates monitor detail contract assertions for sandbox cleanup wording.

## Test Plan
- uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py -q -k 'exposes_cleanup_state or uses_canonical_sandbox_target'
- uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py -q
- uv run ruff check backend/web/services/monitor_service.py backend/web/services/monitor_operation_service.py tests/Unit/monitor/test_monitor_detail_contracts.py
- uv run ruff format --check backend/web/services/monitor_service.py backend/web/services/monitor_operation_service.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check
- rg -n 'Lease (still|has|is|rows|lost)|Leases (whose|still|with)|Lease cleanup completed|lease-backed' backend/web/services/monitor_service.py backend/web/services/monitor_operation_service.py tests/Unit/monitor/test_monitor_detail_contracts.py -S || true