### PR TITLE
docs: clarify thread workspace bridge comment

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -605,7 +605,7 @@ def _materialize_workspace_for_sandbox(
     workspace_id = f"workspace-{uuid.uuid4().hex}"
     now = time.time()
     # @@@workspace-bridge-write - Phase 2 only cuts thread create writes to a real
-    # workspace row; sandbox identity can stay lease-backed until container.sandboxes lands.
+    # workspace row; lower lease_id remains a terminal/runtime bridge, not the workspace authority.
     workspace_repo.create(
         WorkspaceRow(
             id=workspace_id,


### PR DESCRIPTION
## Summary
- clarify the thread workspace bridge comment so it no longer implies sandbox identity is waiting on container.sandboxes
- keep lower lease_id described as terminal/runtime bridge detail, not workspace authority

## Scope
- comment-only change in backend/web/routers/threads.py
- no API/DB/schema/runtime behavior change
- no Resources leaseId contract change

## Verification
- uv run ruff check backend/web/routers/threads.py
- uv run ruff format --check backend/web/routers/threads.py
- git diff --check
- rg -n "container\.sandboxes lands|sandbox identity can stay lease-backed" backend/web/routers/threads.py -S || true