### PR TITLE
chore: remove thread detail lease summary

### DIFF
--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -111,12 +111,24 @@ def _derive_thread_summary_from_sessions(sessions: list[dict[str, Any]]) -> dict
     summary = {
         "sandbox_id": latest.get("sandbox_id"),
         "provider_name": latest.get("provider_name"),
-        "lease_id": latest.get("lease_id"),
         "current_instance_id": latest.get("current_instance_id"),
         "desired_state": latest.get("desired_state"),
         "observed_state": latest.get("observed_state"),
     }
     return summary if any(value is not None for value in summary.values()) else None
+
+
+def _normalize_thread_summary(summary: dict[str, Any] | None) -> dict[str, Any] | None:
+    if summary is None:
+        return None
+    payload = {
+        "sandbox_id": summary.get("sandbox_id"),
+        "provider_name": summary.get("provider_name"),
+        "current_instance_id": summary.get("current_instance_id"),
+        "desired_state": summary.get("desired_state"),
+        "observed_state": summary.get("observed_state"),
+    }
+    return payload if any(value is not None for value in payload.values()) else None
 
 
 def _normalize_thread_owner(owner: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -767,6 +779,7 @@ async def get_monitor_thread_detail(app: Any, thread_id: str) -> dict[str, Any]:
 
     if summary is None:
         summary = _derive_thread_summary_from_sessions(sessions)
+    summary = _normalize_thread_summary(summary)
 
     owners = _thread_owners(
         [thread_id],

--- a/frontend/monitor/src/pages/MonitorRelationShell.test.ts
+++ b/frontend/monitor/src/pages/MonitorRelationShell.test.ts
@@ -11,7 +11,6 @@ describe("monitor relation shell", () => {
     const shell = buildThreadRelationShell({
       provider_name: "daytona",
       sandbox_id: "sandbox-1",
-      lease_id: "lease-1",
       current_instance_id: "runtime-1",
     });
 

--- a/frontend/monitor/src/pages/ThreadDetailPage.contract.test.js
+++ b/frontend/monitor/src/pages/ThreadDetailPage.contract.test.js
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("ThreadDetailPage summary contract", () => {
+  it("does not expose lease_id on the thread summary read surface", () => {
+    const source = readFileSync(resolve(import.meta.dirname, "ThreadDetailPage.tsx"), "utf8");
+    const legacyLeaseToken = "lease_" + "id";
+
+    expect(source).not.toContain(legacyLeaseToken);
+  });
+});

--- a/frontend/monitor/src/pages/ThreadDetailPage.tsx
+++ b/frontend/monitor/src/pages/ThreadDetailPage.tsx
@@ -19,7 +19,6 @@ type ThreadDetailPayload = {
   summary?: {
     provider_name?: string | null;
     sandbox_id?: string | null;
-    lease_id?: string | null;
     current_instance_id?: string | null;
     desired_state?: string | null;
     observed_state?: string | null;

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -747,6 +747,7 @@ async def test_get_monitor_thread_detail_exposes_trajectory_state(monkeypatch):
     assert payload["thread"]["thread_id"] == "thread-1"
     assert payload["owner"]["display_name"] == "Ada"
     assert payload["summary"]["sandbox_id"] == "sandbox-1"
+    assert "lease_id" not in payload["summary"]
     assert payload["trajectory"]["run_id"] == "run-1"
     assert payload["trajectory"]["conversation"][0]["role"] == "human"
     assert payload["trajectory"]["events"][0]["event_type"] == "tool_call"
@@ -793,7 +794,6 @@ async def test_get_monitor_thread_detail_derives_summary_from_session_state_when
     assert payload["summary"] == {
         "sandbox_id": "sandbox-1",
         "provider_name": "daytona",
-        "lease_id": "lease-1",
         "current_instance_id": "runtime-1",
         "desired_state": "paused",
         "observed_state": "paused",


### PR DESCRIPTION
## Scope
- Remove `summary.lease_id` from `/api/monitor/threads/{thread_id}` read surface by normalizing ThreadDetail summaries to sandbox/runtime state only.
- Remove the frontend `ThreadDetailPage` summary `lease_id` type and stale relation-shell fixture input.
- Add backend and frontend contract coverage that locks the ThreadDetail summary against the legacy lease field.

## Non-scope
- No LeaseRepo, schema, runtime, terminal/session internals, resource_service generic helper, operation target contract, or raw monitor row `lease_id` changes.
- This does not rename lower bridge internals that still deliberately speak lease for runtime cleanup compatibility.

## Verification
- RED before implementation: backend ThreadDetail summary contract still exposed `lease_id`; frontend source contract found `lease_id` in `ThreadDetailPage.tsx`.
- `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py tests/Integration/test_monitor_resources_route.py tests/Integration/test_resource_overview_contract_split.py -q` -> 71 passed.
- `npm --prefix frontend/monitor run test -- ThreadDetailPage.contract.test.js MonitorRelationShell ThreadDetailPage` -> 6 passed.
- `npm --prefix frontend/monitor run build` -> passed.
- `uv run ruff check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py` -> passed.
- `uv run ruff format --check backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py` -> passed.
- `git diff --check` -> passed.