### PR TITLE
fix: show sandbox cleanup history

### DIFF
--- a/backend/web/services/monitor_operation_service.py
+++ b/backend/web/services/monitor_operation_service.py
@@ -83,6 +83,7 @@ def _can_close_stale_active_sessions(*, category: str, sessions: list[dict[str, 
 def build_lease_cleanup_truth(
     *,
     lease_id: str,
+    sandbox_id: str | None = None,
     triage: dict[str, Any] | None,
     provider_name: str | None,
     runtime_session_id: str | None,
@@ -120,7 +121,11 @@ def build_lease_cleanup_truth(
         allowed = False
         reason = "Sandbox is not in a managed cleanup state."
 
-    operations = _operations_for_target("lease", lease_id)
+    sandbox_key = str(sandbox_id or "").strip()
+    if sandbox_key:
+        operations = _operations_for_target("sandbox", sandbox_key)
+    else:
+        operations = _operations_for_target("lease", lease_id)
     latest = operations[0] if operations else None
 
     return {
@@ -139,6 +144,7 @@ def request_lease_cleanup(lease_detail: dict[str, Any]) -> dict[str, Any]:
     threads = lease_detail.get("threads") or []
     cleanup = lease_detail.get("cleanup") or build_lease_cleanup_truth(
         lease_id=str(lease.get("lease_id") or ""),
+        sandbox_id=str(lease.get("sandbox_id") or ""),
         triage=lease_detail.get("triage"),
         provider_name=str(provider.get("id") or lease.get("provider_name") or ""),
         runtime_session_id=str(runtime.get("runtime_session_id") or ""),

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -647,6 +647,7 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
             for item in sessions
         ],
         "cleanup": _sandbox_detail_cleanup_truth(
+            sandbox_id=str(sandbox.get("sandbox_id") or "").strip(),
             lease_id=lease_id,
             triage=triage,
             provider_name=provider_name,
@@ -669,6 +670,7 @@ def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
 
 def _sandbox_detail_cleanup_truth(
     *,
+    sandbox_id: str,
     lease_id: str,
     triage: dict[str, Any],
     provider_name: str,
@@ -686,6 +688,7 @@ def _sandbox_detail_cleanup_truth(
         }
     return monitor_operation_service.build_lease_cleanup_truth(
         lease_id=lease_id,
+        sandbox_id=sandbox_id,
         triage=triage,
         provider_name=provider_name,
         runtime_session_id=runtime_session_id,
@@ -816,6 +819,7 @@ def request_monitor_sandbox_cleanup(sandbox_id: str) -> dict[str, Any]:
         "sessions": payload.get("sessions") or [],
         "cleanup": monitor_operation_service.build_lease_cleanup_truth(
             lease_id=lease_id,
+            sandbox_id=sandbox_id,
             triage=payload.get("triage"),
             provider_name=str(provider.get("id") or sandbox.get("provider_name") or ""),
             runtime_session_id=str(runtime.get("runtime_session_id") or ""),

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -555,6 +555,29 @@ def test_request_monitor_sandbox_cleanup_uses_canonical_sandbox_target(monkeypat
     assert calls == [("lease-1", "daytona", True)]
 
 
+def test_get_monitor_sandbox_detail_shows_recent_sandbox_cleanup_operation(monkeypatch):
+    calls: list[tuple[str, str, bool]] = []
+    repo = FakeSandboxMonitorRepo(
+        sandbox=_detached_sandbox(),
+        threads=[{"thread_id": "thread-historical"}],
+        runtime_session_id="runtime-1",
+    )
+    _use_monitor_repo(monkeypatch, repo)
+    monkeypatch.setattr(
+        "backend.web.services.sandbox_service.destroy_sandbox_lease",
+        _record_destroy(calls),
+        raising=False,
+    )
+
+    created = monitor_service.request_monitor_sandbox_cleanup("sandbox-1")
+    detail = monitor_service.get_monitor_sandbox_detail("sandbox-1")
+
+    assert detail["cleanup"]["operation"]["operation_id"] == created["operation"]["operation_id"]
+    assert detail["cleanup"]["operation"]["target_type"] == "sandbox"
+    assert detail["cleanup"]["recent_operations"][0]["target_type"] == "sandbox"
+    assert calls == [("lease-1", "daytona", True)]
+
+
 def test_get_monitor_operation_detail_uses_canonical_sandbox_source(monkeypatch):
     class CanonicalOnlyRepo(FakeSandboxMonitorRepo):
         def query_lease(self, _lease_id):


### PR DESCRIPTION
## Scope
- Make sandbox cleanup truth look up recent cleanup operations by canonical `target_type=sandbox` / `target_id=sandbox_id` when a sandbox id is available.
- Preserve lower/direct compatibility by keeping lease-target lookup only for callers that do not provide a sandbox id.
- Add regression coverage proving `get_monitor_sandbox_detail` shows the operation created by `request_monitor_sandbox_cleanup`.

## Non-scope
- No LeaseRepo, schema, runtime, terminal internals, route rename, operation kind rename, resource projection grouping, or broad lease wording cleanup.
- `kind` / `recommended_action` remain `lease_cleanup` as the explicit operation bridge.

## TDD
- RED: `test_get_monitor_sandbox_detail_shows_recent_sandbox_cleanup_operation` failed because `detail["cleanup"]["operation"]` was `None` after creating a sandbox-target cleanup operation.
- GREEN: cleanup truth now uses the sandbox operation index when `sandbox_id` is present.

## Verification
- `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py -q -k "recent_sandbox_cleanup_operation or sandbox_cleanup_uses_canonical_sandbox_target or exposes_cleanup_state or operation_detail"` -> 6 passed.
- `uv run python -m pytest tests/Unit/monitor/test_monitor_detail_contracts.py tests/Integration/test_monitor_resources_route.py -q` -> 64 passed.
- `uv run ruff check backend/web/services/monitor_operation_service.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py` -> passed.
- `uv run ruff format --check backend/web/services/monitor_operation_service.py backend/web/services/monitor_service.py tests/Unit/monitor/test_monitor_detail_contracts.py` -> passed.
- `git diff --check` -> passed.