### PR TITLE
Rename dashboard running sandbox card

### DIFF
--- a/frontend/monitor/src/pages/DashboardPage.test.ts
+++ b/frontend/monitor/src/pages/DashboardPage.test.ts
@@ -23,6 +23,12 @@ const payload: DashboardPayload = {
 describe("dashboard summary shell", () => {
   it("uses sandbox-shaped labels and canonical sandbox links", () => {
     expect(buildDashboardSurfaces(payload)).toContainEqual({
+      label: "Running Sandboxes",
+      value: 4,
+      to: "/resources",
+    });
+    expect(buildDashboardSurfaces(payload).map((surface) => surface.label)).not.toContain("Running Sessions");
+    expect(buildDashboardSurfaces(payload)).toContainEqual({
       label: "Tracked Sandboxes",
       value: 3,
       to: "/sandboxes",

--- a/frontend/monitor/src/pages/DashboardPage.tsx
+++ b/frontend/monitor/src/pages/DashboardPage.tsx
@@ -23,7 +23,7 @@ export type DashboardPayload = {
 
 export function buildDashboardSurfaces(data: DashboardPayload) {
   return [
-    { label: "Running Sessions", value: data.workload.running_sessions, to: "/resources" },
+    { label: "Running Sandboxes", value: data.workload.running_sessions, to: "/resources" },
     { label: "Evaluations Running", value: data.workload.evaluations_running, to: "/evaluation" },
     { label: "Tracked Sandboxes", value: data.infra.sandboxes_total, to: "/sandboxes" },
   ];


### PR DESCRIPTION
## Summary
- rename the owner-facing Dashboard workload card from Running Sessions to Running Sandboxes
- keep the backend/API field name running_sessions unchanged

## Scope
- frontend-only Dashboard wording
- no backend/API/schema/runtime change

## Proof
- npm --prefix frontend/monitor run test -- DashboardPage
- npm --prefix frontend/monitor run build
- git diff --check