### PR TITLE
chore: clarify sandbox visibility comment

### DIFF
--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -221,8 +221,8 @@ def _is_user_visible_sandbox_thread(thread_id: str | None) -> bool:
 
 
 def _is_user_visible_sandbox_state(sandbox_row: dict[str, Any]) -> bool:
-    # @@@user-visible-lease-scope - product-facing lease surfaces should only
-    # expose leases the user can still act on, not historical stopped/destroying
+    # @@@user-visible-sandbox-scope - product-facing sandbox summaries should only
+    # expose sandboxes the user can still act on, not historical stopped/destroying
     # residue from monitor storage.
     status = map_lease_to_session_status(sandbox_row.get("observed_state"), sandbox_row.get("desired_state"))
     return status in {"running", "paused"}

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -105,6 +105,7 @@ def test_user_visible_sandbox_helpers_use_sandbox_runtime_language() -> None:
     assert "_apply_lease_recipe" not in source
     assert "_is_user_visible_lease_thread" not in source
     assert "_is_user_visible_lease_state" not in source
+    assert "user-visible-lease-scope" not in source
 
 
 class _FakeThreadRepo:


### PR DESCRIPTION
## Summary
- Rename the stale sandbox visibility @@@ marker from lease wording to sandbox wording.
- Extend the existing sandbox_service source assertion so the stale marker cannot return.

## Scope
- Comment/test language only.
- No API, schema, runtime, LeaseRepo, provider-session, or monitor cleanup behavior change.

## Verification
- RED observed: uv run python -m pytest tests/Unit/sandbox/test_sandbox_user_leases.py::test_user_visible_sandbox_helpers_use_sandbox_runtime_language -q failed on existing user-visible-lease-scope marker.
- GREEN focused: uv run python -m pytest tests/Unit/sandbox/test_sandbox_user_leases.py::test_user_visible_sandbox_helpers_use_sandbox_runtime_language -q passed.
- GREEN unit file: uv run python -m pytest tests/Unit/sandbox/test_sandbox_user_leases.py -q passed.
- uv run ruff check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py passed.
- uv run ruff format --check backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_user_leases.py passed.
- git diff --check passed.