### PR TITLE
Refactor provider orphan runtime monitor contract

### DIFF
--- a/backend/web/routers/monitor.py
+++ b/backend/web/routers/monitor.py
@@ -61,9 +61,9 @@ def sandboxes_snapshot():
     return monitor_service.list_monitor_sandboxes()
 
 
-@router.get("/provider-sessions")
-def provider_sessions_snapshot():
-    return monitor_service.list_monitor_provider_sessions()
+@router.get("/provider-orphan-runtimes")
+def provider_orphan_runtimes_snapshot():
+    return monitor_service.list_monitor_provider_orphan_runtimes()
 
 
 @router.get("/threads")
@@ -89,9 +89,9 @@ def sandbox_cleanup_action(sandbox_id: str):
     return _or_404(monitor_service.request_monitor_sandbox_cleanup, sandbox_id)
 
 
-@router.post("/provider-sessions/{provider_id}/{session_id}/cleanup")
-def provider_session_cleanup_action(provider_id: str, session_id: str):
-    return monitor_service.request_monitor_provider_session_cleanup(provider_id, session_id)
+@router.post("/provider-orphan-runtimes/{provider_id}/{runtime_id}/cleanup")
+def provider_orphan_runtime_cleanup_action(provider_id: str, runtime_id: str):
+    return monitor_service.request_monitor_provider_orphan_runtime_cleanup(provider_id, runtime_id)
 
 
 @router.get("/operations/{operation_id}")

--- a/backend/web/services/monitor_service.py
+++ b/backend/web/services/monitor_service.py
@@ -579,19 +579,19 @@ def list_monitor_sandboxes() -> dict[str, Any]:
         repo.close()
 
 
-def list_monitor_provider_sessions() -> dict[str, Any]:
+def list_monitor_provider_orphan_runtimes() -> dict[str, Any]:
     _, managers = sandbox_service.init_providers_and_managers()
-    sessions = []
+    runtimes = []
     for item in sandbox_service.load_provider_orphan_sessions(managers):
-        sessions.append(
+        runtimes.append(
             {
-                "session_id": str(item.get("session_id") or ""),
+                "runtime_id": str(item.get("session_id") or ""),
                 "provider": str(item.get("provider") or ""),
                 "status": str(item.get("status") or "unknown"),
                 "source": "provider_orphan",
             }
         )
-    return {"count": len(sessions), "sessions": sessions}
+    return {"count": len(runtimes), "runtimes": runtimes}
 
 
 def _build_monitor_sandbox_detail(repo: Any, sandbox_id: str) -> dict[str, Any]:
@@ -830,13 +830,14 @@ def request_monitor_sandbox_cleanup(sandbox_id: str) -> dict[str, Any]:
     return monitor_operation_service.request_lease_cleanup(lease_detail)
 
 
-def request_monitor_provider_session_cleanup(provider_name: str, session_id: str) -> dict[str, Any]:
+def request_monitor_provider_orphan_runtime_cleanup(provider_name: str, runtime_id: str) -> dict[str, Any]:
     provider = str(provider_name or "").strip()
-    session = str(session_id or "").strip()
-    for item in list_monitor_provider_sessions().get("sessions", []):
-        if str(item.get("provider") or "").strip() == provider and str(item.get("session_id") or "").strip() == session:
-            return monitor_operation_service.request_provider_session_cleanup(provider, session, item)
-    raise KeyError(f"Provider session not found: {provider}:{session}")
+    runtime = str(runtime_id or "").strip()
+    for item in list_monitor_provider_orphan_runtimes().get("runtimes", []):
+        if str(item.get("provider") or "").strip() == provider and str(item.get("runtime_id") or "").strip() == runtime:
+            session_truth = {**item, "session_id": runtime}
+            return monitor_operation_service.request_provider_session_cleanup(provider, runtime, session_truth)
+    raise KeyError(f"Provider orphan runtime not found: {provider}:{runtime}")
 
 
 def get_monitor_operation_detail(operation_id: str) -> dict[str, Any]:

--- a/frontend/monitor/src/ResourcesPage.tsx
+++ b/frontend/monitor/src/ResourcesPage.tsx
@@ -13,9 +13,9 @@ import {
 
 import {
   browseMonitorSandbox,
-  cleanupMonitorProviderSession,
+  cleanupMonitorProviderOrphanRuntime,
   fetchJsonOrThrow,
-  fetchMonitorProviderSessions,
+  fetchMonitorProviderOrphanRuntimes,
   fetchMonitorResources,
   readMonitorSandboxFile,
   refreshMonitorResources,
@@ -25,7 +25,7 @@ import type {
   BrowseItem,
   ProviderCapabilities,
   ProviderInfo,
-  ProviderOrphanSession,
+  ProviderOrphanRuntime,
   ResourceOverviewResponse,
   ResourceSession,
   SessionMetrics,
@@ -296,7 +296,7 @@ export default function ResourcesPage() {
   const [loading, setLoading] = React.useState(true);
   const [refreshing, setRefreshing] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const [providerOrphans, setProviderOrphans] = React.useState<ProviderOrphanSession[]>([]);
+  const [providerOrphans, setProviderOrphans] = React.useState<ProviderOrphanRuntime[]>([]);
   const [providerOrphansLoading, setProviderOrphansLoading] = React.useState(false);
   const [providerOrphansError, setProviderOrphansError] = React.useState<string | null>(null);
   const [providerCleanupPendingId, setProviderCleanupPendingId] = React.useState<string | null>(null);
@@ -317,8 +317,8 @@ export default function ResourcesPage() {
     setProviderOrphansLoading(true);
     setProviderOrphansError(null);
     try {
-      const payload = await fetchMonitorProviderSessions();
-      setProviderOrphans(payload.sessions);
+      const payload = await fetchMonitorProviderOrphanRuntimes();
+      setProviderOrphans(payload.runtimes);
     } catch (exc) {
       setProviderOrphansError(exc instanceof Error ? exc.message : "Provider 运行时检查失败");
     } finally {
@@ -386,12 +386,12 @@ export default function ResourcesPage() {
   }, [applyPayload, loadProviderOrphans, providers.length]);
 
   const cleanupProviderOrphan = React.useCallback(
-    async (session: ProviderOrphanSession) => {
-      const pendingId = `${session.provider}:${session.session_id}`;
+    async (runtime: ProviderOrphanRuntime) => {
+      const pendingId = `${runtime.provider}:${runtime.runtime_id}`;
       setProviderCleanupPendingId(pendingId);
       setProviderCleanupMessage(null);
       try {
-        const result = await cleanupMonitorProviderSession(session.provider, session.session_id);
+        const result = await cleanupMonitorProviderOrphanRuntime(runtime.provider, runtime.runtime_id);
         setProviderCleanupMessage(result.message ?? "Provider 运行时清理已完成");
         await loadProviderOrphans();
       } catch (exc) {
@@ -440,7 +440,7 @@ export default function ResourcesPage() {
   }, [loadSnapshot]);
 
   const selected = providers.find((provider) => provider.id === selectedId) ?? null;
-  const selectedProviderOrphans = selected ? providerOrphans.filter((session) => session.provider === selected.id) : [];
+  const selectedProviderOrphans = selected ? providerOrphans.filter((runtime) => runtime.provider === selected.id) : [];
   const runningSessionCount = countProviderSessions(providers, "running");
   const pausedSessionCount = countProviderSessions(providers, "paused");
   const stoppedSessionCount = countProviderSessions(providers, "stopped");
@@ -520,7 +520,7 @@ export default function ResourcesPage() {
             key={provider.id}
             provider={provider}
             selected={provider.id === selectedId}
-            orphanCount={providerOrphans.filter((session) => session.provider === provider.id).length}
+            orphanCount={providerOrphans.filter((runtime) => runtime.provider === provider.id).length}
             onSelect={() => setSelectedId(provider.id)}
           />
         ))}
@@ -644,12 +644,12 @@ function ProviderDetail({
   onCleanupProviderOrphan,
 }: {
   provider: ProviderInfo;
-  providerOrphans: ProviderOrphanSession[];
+  providerOrphans: ProviderOrphanRuntime[];
   providerOrphansLoading: boolean;
   providerOrphansError: string | null;
   providerCleanupPendingId: string | null;
   providerCleanupMessage: string | null;
-  onCleanupProviderOrphan: (session: ProviderOrphanSession) => Promise<void>;
+  onCleanupProviderOrphan: (runtime: ProviderOrphanRuntime) => Promise<void>;
 }) {
   const [selectedGroup, setSelectedGroup] = React.useState<SandboxGroup | null>(null);
   const [statusFilter, setStatusFilter] = React.useState<SandboxGroup["status"] | "all">("all");
@@ -745,7 +745,7 @@ function ProviderDetail({
             </div>
 
             <ProviderOrphanSection
-              sessions={providerOrphans}
+              runtimes={providerOrphans}
               loading={providerOrphansLoading}
               error={providerOrphansError}
               cleanupPendingId={providerCleanupPendingId}
@@ -813,21 +813,21 @@ function ProviderDetail({
 }
 
 function ProviderOrphanSection({
-  sessions,
+  runtimes,
   loading,
   error,
   cleanupPendingId,
   cleanupMessage,
   onCleanup,
 }: {
-  sessions: ProviderOrphanSession[];
+  runtimes: ProviderOrphanRuntime[];
   loading: boolean;
   error: string | null;
   cleanupPendingId: string | null;
   cleanupMessage: string | null;
-  onCleanup: (session: ProviderOrphanSession) => Promise<void>;
+  onCleanup: (runtime: ProviderOrphanRuntime) => Promise<void>;
 }) {
-  if (!loading && !error && sessions.length === 0) {
+  if (!loading && !error && runtimes.length === 0) {
     return null;
   }
 
@@ -835,7 +835,7 @@ function ProviderOrphanSection({
     <div className="provider-section provider-orphan-panel">
       <div className="provider-section__header">
         <h3>未绑定运行时</h3>
-        <span>{sessions.length} 个</span>
+        <span>{runtimes.length} 个</span>
       </div>
       <p className="provider-orphan-note">
         这些运行时存在于 provider，但没有 sandbox/thread 绑定。暂停态可以直接走 Monitor 清理；运行中或未知状态先保留。
@@ -843,18 +843,18 @@ function ProviderOrphanSection({
       {loading && <p className="provider-empty-state">正在检查 provider 运行时...</p>}
       {error && <p className="provider-orphan-error">{error}</p>}
       {cleanupMessage && <p className="provider-orphan-message">{cleanupMessage}</p>}
-      {sessions.length > 0 && (
+      {runtimes.length > 0 && (
         <div className="provider-orphan-list">
-          {sessions.map((session) => {
-            const pendingId = `${session.provider}:${session.session_id}`;
-            const cleanupAllowed = session.status === "paused";
+          {runtimes.map((runtime) => {
+            const pendingId = `${runtime.provider}:${runtime.runtime_id}`;
+            const cleanupAllowed = runtime.status === "paused";
             return (
               <div key={pendingId} className="provider-orphan-row">
                 <div className="provider-orphan-row__main">
-                  <span className={`provider-status-dot provider-status-dot--${session.status}`} />
+                  <span className={`provider-status-dot provider-status-dot--${runtime.status}`} />
                   <div>
-                    <div className="provider-orphan-row__id">{session.session_id}</div>
-                    <div className="provider-orphan-row__meta">{session.status}</div>
+                    <div className="provider-orphan-row__id">{runtime.runtime_id}</div>
+                    <div className="provider-orphan-row__meta">{runtime.status}</div>
                   </div>
                 </div>
                 <button
@@ -862,7 +862,7 @@ function ProviderOrphanSection({
                   className="provider-orphan-cleanup-button"
                   disabled={!cleanupAllowed || cleanupPendingId === pendingId}
                   title={cleanupAllowed ? "清理暂停态未绑定运行时" : "运行中或未知状态需要先确认归属"}
-                  onClick={() => void onCleanup(session)}
+                  onClick={() => void onCleanup(runtime)}
                 >
                   {cleanupPendingId === pendingId ? "清理中..." : cleanupAllowed ? "清理" : "先保留"}
                 </button>

--- a/frontend/monitor/src/resources/api.test.ts
+++ b/frontend/monitor/src/resources/api.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   browseMonitorSandbox,
-  cleanupMonitorProviderSession,
-  fetchMonitorProviderSessions,
+  cleanupMonitorProviderOrphanRuntime,
+  fetchMonitorProviderOrphanRuntimes,
   readMonitorSandboxFile,
 } from "./api";
 
@@ -12,39 +12,39 @@ describe("monitor resource API", () => {
     vi.unstubAllGlobals();
   });
 
-  it("fetches provider orphan sessions through the monitor API", async () => {
+  it("fetches provider orphan runtimes through the monitor API", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         count: 1,
-        sessions: [{ session_id: "sandbox-1", provider: "daytona_selfhost", status: "paused", source: "provider_orphan" }],
+        runtimes: [{ runtime_id: "sandbox-1", provider: "daytona_selfhost", status: "paused", source: "provider_orphan" }],
       }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const payload = await fetchMonitorProviderSessions();
+    const payload = await fetchMonitorProviderOrphanRuntimes();
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/monitor/provider-sessions", {
+    expect(fetchMock).toHaveBeenCalledWith("/api/monitor/provider-orphan-runtimes", {
       headers: { "Content-Type": "application/json" },
     });
-    expect(payload.sessions[0].session_id).toBe("sandbox-1");
+    expect(payload.runtimes[0].runtime_id).toBe("sandbox-1");
   });
 
-  it("rejects malformed provider orphan payloads", async () => {
+  it("rejects malformed provider orphan runtime payloads", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({ sessions: null }),
+        json: async () => ({ runtimes: null }),
       }),
     );
 
-    await expect(fetchMonitorProviderSessions()).rejects.toThrow(
-      "Unexpected /api/monitor/provider-sessions response shape",
+    await expect(fetchMonitorProviderOrphanRuntimes()).rejects.toThrow(
+      "Unexpected /api/monitor/provider-orphan-runtimes response shape",
     );
   });
 
-  it("cleans provider orphan sessions through the monitor API", async () => {
+  it("cleans provider orphan runtimes through the monitor API", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -55,9 +55,9 @@ describe("monitor resource API", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const payload = await cleanupMonitorProviderSession("daytona_selfhost", "sandbox/1");
+    const payload = await cleanupMonitorProviderOrphanRuntime("daytona_selfhost", "sandbox/1");
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/monitor/provider-sessions/daytona_selfhost/sandbox%2F1/cleanup", {
+    expect(fetchMock).toHaveBeenCalledWith("/api/monitor/provider-orphan-runtimes/daytona_selfhost/sandbox%2F1/cleanup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
     });

--- a/frontend/monitor/src/resources/api.ts
+++ b/frontend/monitor/src/resources/api.ts
@@ -1,4 +1,4 @@
-import type { BrowseItem, ProviderOrphanSessionsResponse, ResourceOverviewResponse } from "./types";
+import type { BrowseItem, ProviderOrphanRuntimesResponse, ResourceOverviewResponse } from "./types";
 
 function ensureProviderCardContract(payload: ResourceOverviewResponse): ResourceOverviewResponse {
   if (!payload || !payload.summary || !Array.isArray(payload.providers)) {
@@ -7,9 +7,9 @@ function ensureProviderCardContract(payload: ResourceOverviewResponse): Resource
   return payload;
 }
 
-function ensureProviderOrphanContract(payload: ProviderOrphanSessionsResponse): ProviderOrphanSessionsResponse {
-  if (!payload || !Array.isArray(payload.sessions)) {
-    throw new Error("Unexpected /api/monitor/provider-sessions response shape");
+function ensureProviderOrphanRuntimeContract(payload: ProviderOrphanRuntimesResponse): ProviderOrphanRuntimesResponse {
+  if (!payload || !Array.isArray(payload.runtimes)) {
+    throw new Error("Unexpected /api/monitor/provider-orphan-runtimes response shape");
   }
   return payload;
 }
@@ -41,16 +41,16 @@ export async function refreshMonitorResources(): Promise<ResourceOverviewRespons
   return ensureProviderCardContract(payload);
 }
 
-export async function fetchMonitorProviderSessions(): Promise<ProviderOrphanSessionsResponse> {
-  const payload = await fetchJsonOrThrow<ProviderOrphanSessionsResponse>("/api/monitor/provider-sessions", {
+export async function fetchMonitorProviderOrphanRuntimes(): Promise<ProviderOrphanRuntimesResponse> {
+  const payload = await fetchJsonOrThrow<ProviderOrphanRuntimesResponse>("/api/monitor/provider-orphan-runtimes", {
     headers: { "Content-Type": "application/json" },
   });
-  return ensureProviderOrphanContract(payload);
+  return ensureProviderOrphanRuntimeContract(payload);
 }
 
-export async function cleanupMonitorProviderSession(
+export async function cleanupMonitorProviderOrphanRuntime(
   providerId: string,
-  sessionId: string,
+  runtimeId: string,
 ): Promise<{
   accepted: boolean;
   message?: string | null;
@@ -60,10 +60,13 @@ export async function cleanupMonitorProviderSession(
     summary?: string | null;
   } | null;
 }> {
-  return fetchJsonOrThrow(`/api/monitor/provider-sessions/${encodeURIComponent(providerId)}/${encodeURIComponent(sessionId)}/cleanup`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-  });
+  return fetchJsonOrThrow(
+    `/api/monitor/provider-orphan-runtimes/${encodeURIComponent(providerId)}/${encodeURIComponent(runtimeId)}/cleanup`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    },
+  );
 }
 
 export async function browseMonitorSandbox(sandboxId: string, path: string): Promise<{

--- a/frontend/monitor/src/resources/types.ts
+++ b/frontend/monitor/src/resources/types.ts
@@ -83,16 +83,16 @@ export interface ResourceOverviewResponse {
   };
 }
 
-export interface ProviderOrphanSession {
-  session_id: string;
+export interface ProviderOrphanRuntime {
+  runtime_id: string;
   provider: string;
   status: string;
   source: "provider_orphan";
 }
 
-export interface ProviderOrphanSessionsResponse {
+export interface ProviderOrphanRuntimesResponse {
   count: number;
-  sessions: ProviderOrphanSession[];
+  runtimes: ProviderOrphanRuntime[];
 }
 
 export interface BrowseItem {

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -136,9 +136,11 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
         ("get", "/api/monitor/leases"),
         ("get", "/api/monitor/leases/lease-1"),
         ("post", "/api/monitor/leases/lease-1/cleanup"),
+        ("get", "/api/monitor/provider-sessions"),
+        ("post", "/api/monitor/provider-sessions/daytona_selfhost/session-1/cleanup"),
     ],
 )
-def test_monitor_legacy_lease_routes_are_not_exposed(method, path):
+def test_monitor_legacy_monitor_routes_are_not_exposed(method, path):
     response = _request(method, path)
 
     assert response.status_code == 404
@@ -148,14 +150,14 @@ def test_monitor_legacy_lease_routes_are_not_exposed(method, path):
     ("method", "path", "service_name", "payload"),
     [
         ("get", "/api/monitor/sandboxes", "list_monitor_sandboxes", {"summary": {}, "groups": [], "items": []}),
-        ("get", "/api/monitor/provider-sessions", "list_monitor_provider_sessions", {"sessions": [], "count": 0}),
+        ("get", "/api/monitor/provider-orphan-runtimes", "list_monitor_provider_orphan_runtimes", {"runtimes": [], "count": 0}),
         ("get", "/api/monitor/providers/daytona", "get_monitor_provider_detail", {"provider": {"id": "daytona"}}),
         ("get", "/api/monitor/sandboxes/sandbox-1", "get_monitor_sandbox_detail", {"sandbox": {"sandbox_id": "sandbox-1"}}),
         ("post", "/api/monitor/sandboxes/sandbox-1/cleanup", "request_monitor_sandbox_cleanup", {"accepted": True}),
         (
             "post",
-            "/api/monitor/provider-sessions/daytona_selfhost/session-1/cleanup",
-            "request_monitor_provider_session_cleanup",
+            "/api/monitor/provider-orphan-runtimes/daytona_selfhost/session-1/cleanup",
+            "request_monitor_provider_orphan_runtime_cleanup",
             {"accepted": True},
         ),
         ("get", "/api/monitor/operations/op-1", "get_monitor_operation_detail", {"operation": {"operation_id": "op-1"}}),

--- a/tests/Unit/backend/web/services/test_monitor_provider_sessions.py
+++ b/tests/Unit/backend/web/services/test_monitor_provider_sessions.py
@@ -17,12 +17,12 @@ def _provider_session(session_id: str, status: str = "paused"):
     return SimpleNamespace(session_id=session_id, status=status)
 
 
-def test_monitor_provider_sessions_does_not_refresh_all_lease_sessions(monkeypatch):
+def test_monitor_provider_orphan_runtimes_do_not_refresh_all_lease_sessions(monkeypatch):
     manager = _FailingManager()
 
     monkeypatch.setattr(sandbox_service, "init_providers_and_managers", lambda: ({}, {"daytona": manager}))
 
-    assert monitor_service.list_monitor_provider_sessions() == {"count": 0, "sessions": []}
+    assert monitor_service.list_monitor_provider_orphan_runtimes() == {"count": 0, "runtimes": []}
 
 
 def test_load_provider_orphan_sessions_excludes_lease_backed_provider_sessions():

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -618,16 +618,16 @@ def test_get_monitor_operation_detail_uses_canonical_sandbox_source(monkeypatch)
     assert payload["sandbox_id"] == "sandbox-1"
 
 
-def test_request_monitor_provider_session_cleanup_uses_sandbox_manager(monkeypatch):
+def test_request_monitor_provider_orphan_runtime_cleanup_uses_sandbox_manager(monkeypatch):
     calls: list[tuple[str, str, str, str | None]] = []
     monkeypatch.setattr(
         monitor_service,
-        "list_monitor_provider_sessions",
+        "list_monitor_provider_orphan_runtimes",
         lambda: {
             "count": 1,
-            "sessions": [
+            "runtimes": [
                 {
-                    "session_id": "sandbox-1",
+                    "runtime_id": "sandbox-1",
                     "provider": "daytona_selfhost",
                     "status": "paused",
                     "source": "provider_orphan",
@@ -653,7 +653,7 @@ def test_request_monitor_provider_session_cleanup_uses_sandbox_manager(monkeypat
         raising=False,
     )
 
-    payload = monitor_service.request_monitor_provider_session_cleanup("daytona_selfhost", "sandbox-1")
+    payload = monitor_service.request_monitor_provider_orphan_runtime_cleanup("daytona_selfhost", "sandbox-1")
 
     assert payload["accepted"] is True
     assert payload["message"] == "Provider session cleanup completed."
@@ -665,16 +665,16 @@ def test_request_monitor_provider_session_cleanup_uses_sandbox_manager(monkeypat
     assert calls == [("sandbox-1", "destroy", "daytona_selfhost", "daytona_selfhost")]
 
 
-def test_request_monitor_provider_session_cleanup_rejects_running_orphan(monkeypatch):
+def test_request_monitor_provider_orphan_runtime_cleanup_rejects_running_orphan(monkeypatch):
     calls: list[tuple[str, str, str | None]] = []
     monkeypatch.setattr(
         monitor_service,
-        "list_monitor_provider_sessions",
+        "list_monitor_provider_orphan_runtimes",
         lambda: {
             "count": 1,
-            "sessions": [
+            "runtimes": [
                 {
-                    "session_id": "sandbox-1",
+                    "runtime_id": "sandbox-1",
                     "provider": "daytona_selfhost",
                     "status": "running",
                     "source": "provider_orphan",
@@ -693,7 +693,7 @@ def test_request_monitor_provider_session_cleanup_rejects_running_orphan(monkeyp
         raising=False,
     )
 
-    payload = monitor_service.request_monitor_provider_session_cleanup("daytona_selfhost", "sandbox-1")
+    payload = monitor_service.request_monitor_provider_orphan_runtime_cleanup("daytona_selfhost", "sandbox-1")
 
     assert payload["accepted"] is False
     assert payload["operation"] is None
@@ -701,7 +701,7 @@ def test_request_monitor_provider_session_cleanup_rejects_running_orphan(monkeyp
     assert calls == []
 
 
-def test_list_monitor_provider_sessions_returns_provider_orphans(monkeypatch):
+def test_list_monitor_provider_orphan_runtimes_returns_provider_orphans(monkeypatch):
     monkeypatch.setattr(monitor_service.sandbox_service, "init_providers_and_managers", lambda: ({}, {"daytona": object()}))
     monkeypatch.setattr(
         monitor_service.sandbox_service,
@@ -711,13 +711,13 @@ def test_list_monitor_provider_sessions_returns_provider_orphans(monkeypatch):
         ],
     )
 
-    payload = monitor_service.list_monitor_provider_sessions()
+    payload = monitor_service.list_monitor_provider_orphan_runtimes()
 
     assert payload == {
         "count": 1,
-        "sessions": [
+        "runtimes": [
             {
-                "session_id": "orphan-1",
+                "runtime_id": "orphan-1",
                 "provider": "daytona",
                 "status": "running",
                 "source": "provider_orphan",


### PR DESCRIPTION
## Summary
- replace public monitor provider orphan route from /api/monitor/provider-sessions* to /api/monitor/provider-orphan-runtimes*
- rename frontend API/types from ProviderOrphanSession(s) to ProviderOrphanRuntime(s)
- keep lower provider SDK list_provider_sessions and monitor_operation_service provider_session_cleanup substrate unchanged
- do not add compatibility/fallback routes for the old provider-sessions surface

## Verification
- TDD RED observed before implementation: old /api/monitor/provider-sessions still returned 200, new service/API functions were absent
- uv run python -m pytest tests/Integration/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/backend/web/services/test_monitor_provider_sessions.py -q => 69 passed
- npm --prefix frontend/monitor run test -- ResourcesPage MonitorRelationShell resources/api.test.ts => 12 passed
- npm --prefix frontend/monitor run build => passed
- uv run ruff check/format --check touched backend/test files => passed
- git diff --check HEAD~1 HEAD => clean
- old provider-sessions scan only finds 404 regression tests

## Non-scope
- LeaseRepo/schema/runtime/terminal/webhooks/resource projection
- lower provider SDK list_provider_sessions substrate
- monitor_operation_service provider_session_cleanup operation kind/target