### PR TITLE
chore: clarify monitor resource cache comments

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -76,7 +76,7 @@ def _sidebar_label(*, is_main: bool, branch_index: int) -> str | None:
 
 
 def _invalidate_resource_overview_cache() -> None:
-    # @@@monitor-resource-overview-invalidation - thread/lease mutations change the monitor topology immediately.
+    # @@@monitor-resource-overview-invalidation - thread/sandbox mutations change the monitor topology immediately.
     # Clear the overview snapshot so the next /api/monitor/resources read reflects the fresh binding/state.
     clear_resource_overview_cache()
 

--- a/backend/web/services/message_routing.py
+++ b/backend/web/services/message_routing.py
@@ -96,7 +96,7 @@ async def route_message_to_brain(
                 enable_trajectory=enable_trajectory,
                 message_metadata=meta,
             )
-            # @@@monitor-resource-cache-run-start - a fresh run can create or resume a lease immediately.
+            # @@@monitor-resource-cache-run-start - a fresh run can create or resume a sandbox runtime immediately.
             # Drop the cached monitor snapshot so the next /api/monitor/resources read reflects the live topology.
             clear_resource_overview_cache()
         return {"status": "started", "routing": "direct", "run_id": run_id, "thread_id": thread_id}

--- a/backend/web/services/resource_cache.py
+++ b/backend/web/services/resource_cache.py
@@ -103,9 +103,9 @@ def get_resource_overview_snapshot() -> dict[str, Any]:
         cached = copy.deepcopy(_snapshot_cache)
     if cached is not None:
         _validate_resource_overview_payload(cached)
-        # @@@resource-cache-live-drift - durable session truth lands in sandbox.db after a run
-        # starts; if the cached Resources snapshot no longer matches visible lease/session
-        # counts, refresh synchronously instead of serving a stale zero-sandbox card.
+        # @@@resource-cache-live-drift - durable runtime truth lands after a run
+        # starts; if the cached Resources snapshot no longer matches visible
+        # sandbox/session counts, refresh instead of serving a stale zero-sandbox card.
         if _snapshot_drifted_from_live_sessions(cached):
             return refresh_resource_overview_sync()
         return cached

--- a/backend/web/services/resource_service.py
+++ b/backend/web/services/resource_service.py
@@ -22,9 +22,9 @@ class _SandboxSnapshotRepoAdapter:
     def __init__(self, *, sandbox_id: str) -> None:
         self._sandbox_id = sandbox_id
 
-    # @@@snapshot-write-bridge - resource probe callers are sandbox-shaped now,
-    # but the storage contract is still lease-keyed. Keep the bridge inside the
-    # adapter so service callers stop leaking lease as the outward write subject.
+    # @@@snapshot-write-bridge - resource probe callers are sandbox-shaped now.
+    # Keep storage compatibility inside this adapter so service callers keep
+    # treating sandbox_id as the outward write subject.
     def upsert_resource_snapshot_for_sandbox(self, **kwargs) -> None:
         kwargs.pop("sandbox_id", None)
         upsert_resource_snapshot_for_sandbox(sandbox_id=self._sandbox_id, **kwargs)
@@ -160,7 +160,7 @@ def read_sandbox(sandbox_id: str, path: str) -> dict[str, Any]:
 
 
 def refresh_resource_snapshots() -> dict[str, Any]:
-    """Probe active lease instances and upsert resource snapshots."""
+    """Probe active sandbox runtimes and upsert resource snapshots."""
     repo = make_sandbox_monitor_repo()
     try:
         probe_targets = repo.list_probe_targets()

--- a/tests/Unit/monitor/test_monitor_resource_overview_cache.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_cache.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+from backend.web.routers import threads as threads_router
+from backend.web.services import message_routing
 from backend.web.services import resource_cache as cache
 
 
@@ -167,3 +171,13 @@ def test_resource_overview_cache_refreshes_when_live_session_counts_drift(monkey
     assert payload["providers"][0]["telemetry"]["running"]["used"] == 1
     assert len(payload["providers"][0]["sessions"]) == 1
     assert payload["triage"]["summary"]["healthy_capacity"] == 1
+
+
+def test_monitor_resource_cache_comments_use_sandbox_topology_language() -> None:
+    cache_source = Path(cache.__file__).read_text(encoding="utf-8")
+    routing_source = Path(message_routing.__file__).read_text(encoding="utf-8")
+    threads_source = Path(threads_router.__file__).read_text(encoding="utf-8")
+
+    assert "visible lease/session" not in cache_source
+    assert "create or resume a lease immediately" not in routing_source
+    assert "thread/lease mutations" not in threads_source

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -421,3 +422,10 @@ def test_read_sandbox_uses_canonical_sandbox_instance_lookup(monkeypatch) -> Non
 def test_resource_service_no_longer_exposes_lease_shaped_browse_read_shell() -> None:
     assert not hasattr(resource_service, "sandbox_browse")
     assert not hasattr(resource_service, "sandbox_read")
+
+
+def test_resource_service_comments_use_sandbox_snapshot_language() -> None:
+    source = Path(resource_service.__file__).read_text(encoding="utf-8")
+
+    assert "Probe active lease instances" not in source
+    assert "storage contract is still lease-keyed" not in source


### PR DESCRIPTION
## Summary
- clarify monitor resource cache/probe comments to describe sandbox/runtime topology instead of lease-shaped wording
- add source assertions for the remaining comment-only wording boundaries
- no behavior, API, schema, runtime, or LeaseRepo changes

## Proof
- RED observed before production comment edits: source assertions failed on stale `visible lease/session` and `Probe active lease instances`
- `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Integration/test_monitor_resources_route.py -q` => 54 passed
- `uv run ruff check backend/web/services/resource_service.py backend/web/services/resource_cache.py backend/web/services/message_routing.py backend/web/routers/threads.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_resource_probe.py` => passed
- `uv run ruff format --check backend/web/services/resource_service.py backend/web/services/resource_cache.py backend/web/services/message_routing.py backend/web/routers/threads.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Unit/monitor/test_monitor_resource_probe.py` => passed
- `git diff --check` => clean