### PR TITLE
Chore: name resource provider orphan runtimes

### DIFF
--- a/backend/web/services/resource_common.py
+++ b/backend/web/services/resource_common.py
@@ -255,11 +255,13 @@ def thread_owners(thread_ids: list[str], user_repo: Any = None, thread_repo: Any
 
 def aggregate_provider_telemetry(
     *,
-    provider_sessions: list[dict[str, Any]],
+    provider_orphan_runtimes: list[dict[str, Any]],
     running_count: int,
     snapshot_by_sandbox: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    sandbox_ids = sorted({str(session.get("sandbox_id") or "").strip() for session in provider_sessions if session.get("sandbox_id")})
+    sandbox_ids = sorted(
+        {str(runtime.get("sandbox_id") or "").strip() for runtime in provider_orphan_runtimes if runtime.get("sandbox_id")}
+    )
     snapshots = [snapshot_by_sandbox[sandbox_id] for sandbox_id in sandbox_ids if sandbox_id in snapshot_by_sandbox]
 
     freshness = "stale"

--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -293,12 +293,12 @@ def list_resource_providers() -> dict[str, Any]:
         if not effective_available:
             unavailable_reason = str(item.get("reason") or capability_error or "provider unavailable")
 
-        provider_sessions = grouped.get(config_name, [])
+        provider_orphan_runtimes = grouped.get(config_name, [])
         normalized_sessions: list[dict[str, Any]] = []
         seen_session_ids: set[str] = set()
         running_count = 0
         seen_running_sandboxes: set[str] = set()
-        for session in provider_sessions:
+        for session in provider_orphan_runtimes:
             observed_state = session.get("observed_state")
             desired_state = session.get("desired_state")
             thread_id = str(session.get("thread_id") or "")
@@ -335,11 +335,11 @@ def list_resource_providers() -> dict[str, Any]:
 
         provider_type = _resolve_provider_type(provider_name)
         telemetry = _aggregate_provider_telemetry(
-            provider_sessions=provider_sessions,
+            provider_orphan_runtimes=provider_orphan_runtimes,
             running_count=running_count,
             snapshot_by_sandbox={
                 str(session.get("sandbox_id") or "").strip(): snapshot_by_sandbox[str(session.get("sandbox_id") or "").strip()]
-                for session in provider_sessions
+                for session in provider_orphan_runtimes
                 if str(session.get("sandbox_id") or "").strip() in snapshot_by_sandbox
             },
         )

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -101,6 +101,14 @@ def test_resource_projection_comments_use_sandbox_row_language() -> None:
     assert "detached leases that have neither a bound runtime" not in text
 
 
+def test_resource_projection_internal_orphan_runtime_grouping_uses_runtime_language() -> None:
+    projection_source = Path(resource_projection_service.__file__).read_text(encoding="utf-8")
+    common_source = Path(resource_common.__file__).read_text(encoding="utf-8")
+
+    assert "provider_sessions" not in projection_source
+    assert "provider_sessions" not in common_source
+
+
 def test_resource_projection_identity_no_longer_falls_back_to_lease_id() -> None:
     session = {
         "session_id": "provider-session-1",
@@ -873,8 +881,8 @@ def test_list_resource_providers_passes_sandbox_keyed_snapshots_to_provider_tele
 
     captured: dict[str, object] = {}
 
-    def _fake_aggregate_provider_telemetry(*, provider_sessions, running_count, snapshot_by_sandbox):
-        captured["provider_sessions"] = provider_sessions
+    def _fake_aggregate_provider_telemetry(*, provider_orphan_runtimes, running_count, snapshot_by_sandbox):
+        captured["provider_orphan_runtimes"] = provider_orphan_runtimes
         captured["running_count"] = running_count
         captured["snapshot_keys"] = sorted(snapshot_by_sandbox.keys())
         return {


### PR DESCRIPTION
## Summary\n- rename internal Resources projection provider orphan runtime rows from provider_sessions to provider_orphan_runtimes\n- update aggregate_provider_telemetry parameter naming without changing payload/behavior\n- add a source assertion to keep this internal projection naming aligned with the public provider-orphan-runtime contract\n\n## Non-scope\n- provider SDK list_provider_sessions substrate\n- sandbox_service.load_provider_orphan_sessions\n- public API/payload shape\n- behavior/schema/runtime/LeaseRepo/webhooks\n\n## Tests\n- RED: test_resource_projection_internal_orphan_runtime_grouping_uses_runtime_language failed on provider_sessions in production source\n- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_monitor_resources_route.py -q\n- uv run ruff check backend/web/services/resource_projection_service.py backend/web/services/resource_common.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py\n- uv run ruff format --check backend/web/services/resource_projection_service.py backend/web/services/resource_common.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py\n- git diff --check