### PR TITLE
chore: name thread file channel delete handler

### DIFF
--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -226,11 +226,11 @@ async def download_file(
 
 
 @router.delete("/files")
-async def delete_workspace_file(
+async def delete_channel_file(
     thread_id: str,
     path: str = Query(...),
 ) -> dict[str, Any]:
-    """Delete a file from workspace."""
+    """Delete a file from the thread file channel."""
     await _call_channel_file_service(
         file_channel_service.delete_channel_file,
         thread_id=thread_id,

--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -32,6 +32,14 @@ def test_helpers_no_longer_import_storage_factory() -> None:
     assert "sandbox.control_plane_repos" in helpers_source
 
 
+def test_thread_file_delete_handler_uses_file_channel_language() -> None:
+    router_source = Path("backend/web/routers/thread_files.py").read_text(encoding="utf-8")
+
+    assert "delete_workspace_file" not in router_source
+    assert "Delete a file from workspace." not in router_source
+    assert "delete_channel_file" in router_source
+
+
 @pytest.mark.asyncio
 async def test_call_channel_file_service_maps_value_error_to_400():
     def fake_method(*_args: object, **_kwargs: object):
@@ -78,13 +86,13 @@ async def test_download_file_returns_file_response(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
-async def test_delete_workspace_file_returns_ok_payload(monkeypatch: pytest.MonkeyPatch):
+async def test_delete_channel_file_returns_ok_payload(monkeypatch: pytest.MonkeyPatch):
     async def fake_call(method, *args: object, **kwargs: object):
         return None
 
     monkeypatch.setattr(thread_files_router, "_call_channel_file_service", fake_call)
 
-    result = await thread_files_router.delete_workspace_file("thread-1", path="notes.txt")
+    result = await thread_files_router.delete_channel_file("thread-1", path="notes.txt")
 
     assert result == {"ok": True, "path": "notes.txt"}
 


### PR DESCRIPTION
## Summary
- rename the internal thread-files delete handler from workspace wording to thread file-channel wording
- keep the public delete route and response payload unchanged
- add a source assertion that blocks the old delete_workspace_file handler name/docstring

## Verification
- RED: uv run python -m pytest tests/Integration/test_thread_files_channel_shell.py -q failed on old delete_workspace_file naming and missing delete_channel_file
- GREEN: uv run python -m pytest tests/Integration/test_thread_files_channel_shell.py -q => 10 passed
- npm --prefix frontend/app run test -- client => 29 passed
- uv run ruff check backend/web/routers/thread_files.py tests/Integration/test_thread_files_channel_shell.py
- uv run ruff format --check backend/web/routers/thread_files.py tests/Integration/test_thread_files_channel_shell.py
- git diff --check