### PR TITLE
Remove root agent compatibility shim

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,7 +1,0 @@
-# Backward compat - deprecated, use core.runtime.agent instead
-from core.runtime.agent import (  # noqa: F401
-    LeonAgent,
-    create_leon_agent,
-)
-
-__all__ = ["LeonAgent", "create_leon_agent"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ packages = [
     "eval",
     "eval.harness",
 ]
-py-modules = ["agent"]
 
 [tool.setuptools.package-data]
 "config.defaults.agents" = ["*.md"]

--- a/tests/Unit/core/test_root_agent_entrypoint.py
+++ b/tests/Unit/core/test_root_agent_entrypoint.py
@@ -1,14 +1,12 @@
-import importlib
 import re
 from pathlib import Path
 
 
-def test_root_agent_shim_aliases_canonical_runtime_entrypoint():
-    root_agent = importlib.import_module("agent")
-    runtime_agent = importlib.import_module("core.runtime.agent")
+def test_root_agent_compatibility_shim_is_removed():
+    repo_root = Path(__file__).resolve().parents[3]
 
-    assert root_agent.LeonAgent is runtime_agent.LeonAgent
-    assert root_agent.create_leon_agent is runtime_agent.create_leon_agent
+    assert not (repo_root / "agent.py").exists()
+    assert 'py-modules = ["agent"]' not in (repo_root / "pyproject.toml").read_text(encoding="utf-8")
 
 
 def test_internal_entrypoints_import_canonical_runtime_agent():


### PR DESCRIPTION
## Summary
- delete deprecated root agent.py compatibility shim
- stop publishing agent as a setuptools py-module
- invert the root entrypoint guard so canonical imports stay on core.runtime.agent / langgraph_app.py

## Scope
- No runtime agent behavior change
- No langgraph_app.py change
- No backend/API/schema/sandbox/monitor/file-channel change

## Tests
- RED: uv run python -m pytest tests/Unit/core/test_root_agent_entrypoint.py -q failed on existing agent.py
- GREEN: uv run python -m pytest tests/Unit/core/test_root_agent_entrypoint.py tests/Unit/core/test_runtime_agent.py tests/Unit/core/test_agent_model_clients.py tests/Unit/core/test_agent_extraction_model.py -q -> 10 passed
- uv run ruff check tests/Unit/core/test_root_agent_entrypoint.py && uv run ruff format --check tests/Unit/core/test_root_agent_entrypoint.py
- production/config/docs/examples scan found no root agent imports or py-modules agent publication
- git diff --check