### PR TITLE
Clarify sandbox storage runtime wording

### DIFF
--- a/docs/en/memory.mdx
+++ b/docs/en/memory.mdx
@@ -116,7 +116,7 @@ For tools that produce very large outputs (e.g., `Grep` on a large codebase), th
 | Database | Location | Contents |
 |----------|----------|----------|
 | Thread history | `~/.leon/leon.db` | Messages, tool calls, results (LangGraph checkpoints) |
-| Sandbox state | `~/.leon/sandbox.db` | Session leases, metrics |
+| Sandbox state | `~/.leon/sandbox.db` | Sandbox runtime state, terminal bindings, metrics |
 | Chat messages | `~/.leon/chat.db` | Entity-Chat social layer messages |
 
 <Note>

--- a/docs/en/sandbox.mdx
+++ b/docs/en/sandbox.mdx
@@ -191,11 +191,11 @@ flowchart TD
 
 Middleware owns **policy**. The sandbox backend owns **I/O**. Swapping the backend changes where operations run without touching any middleware logic.
 
-Sessions are tracked in SQLite (`~/.leon/sandbox.db`):
+Sandbox runtime state is tracked in SQLite (`~/.leon/sandbox.db`):
 
 | Table | Purpose |
 |-------|---------|
-| `sandbox_leases` | Lease lifecycle — provider, desired/observed state |
+| `sandbox_leases` | Internal sandbox lifecycle bridge — provider, desired/observed state |
 | `sandbox_instances` | Provider-side session IDs |
-| `abstract_terminals` | Virtual terminals bound to Thread + lease |
+| `abstract_terminals` | Virtual terminals bound to Thread + sandbox lifecycle bridge |
 | `sandbox_resource_snapshots` | CPU, memory, disk metrics |

--- a/docs/zh/memory.mdx
+++ b/docs/zh/memory.mdx
@@ -103,7 +103,7 @@ Mycel 的记忆分为两层：
 | 存储 | 位置 | 内容 |
 |------|------|------|
 | Thread 历史 | `~/.leon/leon.db` | 所有消息、工具调用、结果（LangGraph checkpoints） |
-| 沙箱状态 | `~/.leon/sandbox.db` | 会话租约、指标 |
+| 沙箱状态 | `~/.leon/sandbox.db` | 沙箱运行态、终端绑定、指标 |
 | 聊天消息 | `~/.leon/chat.db` | Entity-Chat 社交层消息 |
 
 <Note>

--- a/docs/zh/sandbox.mdx
+++ b/docs/zh/sandbox.mdx
@@ -193,11 +193,11 @@ Agent
 
 中间件负责**策略**（校验、路径规则、安全钩子）。沙箱后端负责**I/O**（操作真正在哪里执行）。切换后端只会改变执行位置，不影响任何中间件逻辑。
 
-会话跟踪存储在 SQLite（`~/.leon/sandbox.db`）：
+沙箱运行态存储在 SQLite（`~/.leon/sandbox.db`）：
 
 | 表 | 用途 |
 |----|------|
-| `sandbox_leases` | 租约生命周期 — 提供商、期望状态/实际状态 |
+| `sandbox_leases` | 内部沙箱生命周期桥 — 提供商、期望状态/实际状态 |
 | `sandbox_instances` | 提供商侧的会话 ID |
-| `abstract_terminals` | 绑定到 Thread + 租约的虚拟终端 |
+| `abstract_terminals` | 绑定到 Thread + 沙箱生命周期桥的虚拟终端 |
 | `sandbox_resource_snapshots` | CPU、内存、磁盘指标 |


### PR DESCRIPTION
## Summary
- keep true internal SQLite table names such as sandbox_leases
- update reader-facing docs to describe sandbox runtime state / lifecycle bridge instead of session leases
- align English and Chinese sandbox + memory docs

## Scope
- Docs only
- No product code, schema, API, LeaseRepo/SandboxLease, or terminal/session runtime change

## Verification
- rg scan for stale reader-facing phrases: Session leases / 租约生命周期 / Thread + lease / 会话租约 returned no matches in docs/en docs/zh
- retained sandbox_leases references only with internal bridge wording
- git diff --check