### PR TITLE
Fix bak gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ node_modules/
 .next/
 .langgraph_api/
 *.log
- *.bak
+*.bak
 
 # Archives
 *.zip


### PR DESCRIPTION
## Summary
- fix the .gitignore backup-file pattern from leading-space " *.bak" to "*.bak"
- make ordinary .bak files ignored as intended

## Scope
- .gitignore only
- no product code, docs, schema, runtime, or tests

## Verification
- git check-ignore -v scratch.bak " scratch.bak" foo.log docs/superpowers/specs/x.md
- git diff --check