### PR TITLE
Remove agent E501 lint exception

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1421,8 +1421,10 @@ class LeonAgent:
                     f"- For 1:1 chat tools, use participant_id for the other user's social id.\n"
                     f"- When you receive a chat notification, you MUST read it with read_messages() before deciding what to do.\n"
                     f"- If that notification already gives you a chat_id, prefer using that exact chat_id directly.\n"
-                    f"- If you reply to the other party, you MUST call send_message(). Never claim you replied unless send_message() succeeded.\n"
-                    f"- Your normal text output goes to your owner's thread, not to the chat — only send_message() delivers to the other party.\n"
+                    f"- If you reply to the other party, you MUST call send_message(). "
+                    f"Never claim you replied unless send_message() succeeded.\n"
+                    f"- Your normal text output goes to your owner's thread, not to the chat — "
+                    f"only send_message() delivers to the other party.\n"
                 )
         return prompt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ known-third-party = ["httpx", "supabase", "supabase_auth"]
 "tests/*.py" = ["E402", "E501"]
 "examples/*.py" = ["E402", "N806"]
 # Long lines inside string literals (SQL / markdown rules) that cannot be broken
-"core/runtime/agent.py" = ["E501"]
 "storage/providers/sqlite/terminal_repo.py" = ["E501"]
 # Marketplace skills are third-party code; suppress unfixable lint errors
 ".claude/skills/**/*.py" = ["E402", "E712", "E721", "F821", "F841", "N805", "UP042"]


### PR DESCRIPTION
## Summary
- split two overlong chat-identity prompt string literals in core/runtime/agent.py without changing the concatenated prompt text
- remove the now-unneeded core/runtime/agent.py E501 per-file ignore from pyproject.toml

## Scope
- core/runtime/agent.py and pyproject.toml only
- no runtime behavior, API, schema, model config, or sandbox bridge change

## Verification
- uv run ruff check core/runtime/agent.py --select E501 --isolated --line-length 140
- uv run ruff check core/runtime/agent.py pyproject.toml
- uv run ruff format --check core/runtime/agent.py
- uv run python -m pytest tests/Unit/core/test_runtime_agent.py tests/Unit/core/test_agent_model_clients.py tests/Unit/core/test_agent_extraction_model.py -q
- uv run python prompt text equivalence check for the Chat Identity block
- git diff --check