### PR TITLE
test: clarify thread workspace fixture ids

### DIFF
--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1352,7 +1352,7 @@ async def test_handle_agent_registers_subagent_thread_metadata_before_return(mon
                 "id": "parent-thread",
                 "agent_user_id": "agent-user-1",
                 "owner_user_id": "owner-1",
-                "current_workspace_id": "lease-parent",
+                "current_workspace_id": "workspace-parent",
                 "sandbox_type": "daytona_selfhost",
                 "cwd": "/home/daytona",
                 "model": "gpt-parent",
@@ -1384,7 +1384,7 @@ async def test_handle_agent_registers_subagent_thread_metadata_before_return(mon
         assert child_thread is not None
         assert child_thread["agent_user_id"] == "agent-user-1"
         assert child_thread["owner_user_id"] == "owner-1"
-        assert child_thread["current_workspace_id"] == "lease-parent"
+        assert child_thread["current_workspace_id"] == "workspace-parent"
         assert child_thread["sandbox_type"] == "daytona_selfhost"
         assert child_thread["cwd"] == "/home/daytona"
         assert child_thread["is_main"] is False

--- a/tests/Unit/storage/test_supabase_thread_repo.py
+++ b/tests/Unit/storage/test_supabase_thread_repo.py
@@ -78,7 +78,7 @@ def test_supabase_thread_repo_create_writes_integer_main_flag():
         is_main=True,
         branch_index=0,
         owner_user_id="owner-1",
-        current_workspace_id="lease-1",
+        current_workspace_id="workspace-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -97,7 +97,7 @@ def test_supabase_thread_repo_create_defaults_active_status():
         is_main=True,
         branch_index=0,
         owner_user_id="owner-1",
-        current_workspace_id="lease-1",
+        current_workspace_id="workspace-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -118,7 +118,7 @@ def test_supabase_thread_repo_create_serializes_epoch_timestamps_for_agent_schem
         is_main=True,
         branch_index=0,
         owner_user_id="owner-1",
-        current_workspace_id="lease-1",
+        current_workspace_id="workspace-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -139,7 +139,7 @@ def test_supabase_thread_repo_create_defaults_updated_at_to_created_at_for_agent
         is_main=True,
         branch_index=0,
         owner_user_id="owner-1",
-        current_workspace_id="lease-1",
+        current_workspace_id="workspace-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -160,7 +160,7 @@ def test_supabase_thread_repo_create_uses_agent_user_id_not_member_id() -> None:
         is_main=True,
         branch_index=0,
         owner_user_id="owner-1",
-        current_workspace_id="lease-1",
+        current_workspace_id="workspace-1",
     )
 
     assert client.table_obj.insert_payload is not None
@@ -180,11 +180,11 @@ def test_supabase_thread_repo_create_writes_current_workspace_id() -> None:
         is_main=True,
         branch_index=0,
         owner_user_id="owner-1",
-        current_workspace_id="lease-1",
+        current_workspace_id="workspace-1",
     )
 
     assert client.table_obj.insert_payload is not None
-    assert client.table_obj.insert_payload["current_workspace_id"] == "lease-1"
+    assert client.table_obj.insert_payload["current_workspace_id"] == "workspace-1"
 
 
 def test_supabase_thread_repo_create_requires_current_workspace_id() -> None:
@@ -232,7 +232,7 @@ def test_supabase_thread_repo_create_requires_explicit_owner_user_id() -> None:
             created_at=1.0,
             is_main=True,
             branch_index=0,
-            current_workspace_id="lease-1",
+            current_workspace_id="workspace-1",
         )
 
 


### PR DESCRIPTION
## Summary
- replace misleading current_workspace_id=lease-* fixture values with workspace-* in thread repo and agent service tests
- keep the explicit legacy lease-backed workspace integration test unchanged

## Verification
- uv run python -m pytest tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/core/test_agent_service.py -q
- uv run ruff check tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/core/test_agent_service.py
- uv run ruff format --check tests/Unit/storage/test_supabase_thread_repo.py tests/Unit/core/test_agent_service.py
- git diff --check