### PR TITLE
Clean up AgentBay comment E501 suppressions

### DIFF
--- a/sandbox/providers/agentbay.py
+++ b/sandbox/providers/agentbay.py
@@ -82,7 +82,8 @@ class AgentBayProvider(SandboxProvider):
         self.default_context_path = default_context_path
         self.image_id = image_id
         self._sessions: dict[str, Any] = {}
-        # @@@agentbay-runtime-capability-override - account tier may disable pause/resume; keep provider-type defaults, override per configured instance only.  # noqa: E501
+        # @@@agentbay-runtime-capability-override - account tier may disable pause/resume;
+        # keep provider-type defaults, override per configured instance only.
         can_pause = self.CAPABILITY.can_pause if supports_pause is None else supports_pause
         can_resume = self.CAPABILITY.can_resume if supports_resume is None else supports_resume
         self._capability = replace(self.CAPABILITY, can_pause=can_pause, can_resume=can_resume)
@@ -141,7 +142,8 @@ class AgentBayProvider(SandboxProvider):
 
     def pause_session(self, session_id: str) -> bool:
         session = self._get_session(session_id)
-        # @@@agentbay-benefit-level - Some AgentBay accounts reject pause/resume with BenefitLevel.NotSupport; keep fail-loud and do not fallback.  # noqa: E501
+        # @@@agentbay-benefit-level - Some AgentBay accounts reject pause/resume with
+        # BenefitLevel.NotSupport; keep fail-loud and do not fallback.
         result = session.beta_pause()
         if result.success:
             return True


### PR DESCRIPTION
## Summary
- split two overlong AgentBay @@@ comments across normal comment lines
- remove the local E501 suppressions from those comments
- keep AgentBay provider behavior unchanged

## Verification
- uv run python -m pytest tests/Unit/sandbox/test_agentbay_provider.py tests/Unit/platform/test_agentbay_capability_override.py -q
- uv run ruff check sandbox/providers/agentbay.py --select E501 --isolated --line-length 140
- uv run ruff check sandbox/providers/agentbay.py
- uv run ruff format --check sandbox/providers/agentbay.py
- git diff --check origin/dev...HEAD