### PR TITLE
Clarify resource projection secondary identity

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -54,8 +54,8 @@ def _build_provider_card(config_name: str, sandboxes: list[dict[str, Any]]) -> d
         if status == "running":
             running_count += 1
         sandbox_id = str(sandbox.get("sandbox_id") or "").strip() or None
-        fallback_identity = str(sandbox.get("runtime_session_id") or "sandbox").strip()
-        session_identity = f"{sandbox_id}:{thread_id}" if sandbox_id and thread_id else f"{fallback_identity}:{thread_id}"
+        secondary_identity = str(sandbox.get("runtime_session_id") or "sandbox").strip()
+        session_identity = f"{sandbox_id}:{thread_id}" if sandbox_id and thread_id else f"{secondary_identity}:{thread_id}"
         sessions.append(
             resource_service.build_resource_session_payload(
                 session_identity=session_identity,
@@ -199,7 +199,7 @@ def _resource_session_identity(session: dict[str, Any]) -> str:
     sandbox_id = str(session.get("sandbox_id") or "")
     thread_id = str(session.get("thread_id") or "")
     # @@@resource-session-shell - resource session shell is now sandbox-first.
-    # Provider session ids are only an unbound-runtime fallback; bound rows use
+    # Provider session ids are only an unbound-runtime secondary identity; bound rows use
     # sandbox/thread identity on the user-visible Resources surface.
     if sandbox_id and thread_id:
         return f"{sandbox_id}:{thread_id}"

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -121,6 +121,13 @@ def test_resource_projection_identity_no_longer_falls_back_to_lease_id() -> None
     assert resource_projection_service._resource_running_identity(session) == ""
 
 
+def test_resource_projection_unbound_identity_is_not_named_as_fallback() -> None:
+    source = Path(resource_projection_service.__file__).read_text(encoding="utf-8")
+
+    assert "fallback_identity" not in source
+    assert "unbound-runtime fallback" not in source
+
+
 def test_list_resource_providers_no_longer_uses_lease_shaped_row_source_shell(monkeypatch) -> None:
     class _Repo(_FakeRepo):
         def list_sessions_with_leases(self):


### PR DESCRIPTION
## Scope
- Rename the resource projection unbound-runtime internal fallback identity wording to secondary identity.
- Add a source assertion so the old fallback wording does not return in this resource projection surface.

## Non-scope
- No resource payload shape change.
- No monitor route/API/schema/runtime/LeaseRepo/terminal/provider-session change.

## Verification
- Rebased onto origin/dev dafc3f51 after mainline CI passed.
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Integration/test_resource_overview_contract_split.py -q => 38 passed.
- uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py => passed.
- uv run ruff format --check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py => 2 files already formatted.
- git diff --check origin/dev...HEAD => clean.