### PR TITLE
Clarify resource projection visible parent naming

### DIFF
--- a/backend/web/services/resource_projection_service.py
+++ b/backend/web/services/resource_projection_service.py
@@ -250,7 +250,7 @@ def _project_user_visible_resource_sessions(repo: Any, rows: list[dict[str, Any]
             projected.extend(visible_rows)
             continue
 
-        # @@@resource-visible-thread-fallback - visible resource cards are now
+        # @@@resource-visible-parent-projection - visible resource cards are now
         # sandbox-first. If the raw monitor row lands on a hidden/subagent
         # thread, only sandbox truth can authorize a visible-parent projection.
         # Rows without sandbox truth are no longer eligible for

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -128,6 +128,13 @@ def test_resource_projection_unbound_identity_is_not_named_as_fallback() -> None
     assert "unbound-runtime fallback" not in source
 
 
+def test_resource_projection_visible_parent_path_is_not_named_as_fallback() -> None:
+    source = Path(resource_projection_service.__file__).read_text(encoding="utf-8")
+
+    assert "resource-visible-thread-fallback" not in source
+    assert "visible-thread fallback" not in source
+
+
 def test_list_resource_providers_no_longer_uses_lease_shaped_row_source_shell(monkeypatch) -> None:
     class _Repo(_FakeRepo):
         def list_sessions_with_leases(self):
@@ -477,7 +484,7 @@ def test_list_resource_providers_projects_hidden_rows_by_sandbox_not_lease(monke
     ]
 
 
-def test_list_resource_providers_uses_canonical_sandbox_thread_fallback(monkeypatch):
+def test_list_resource_providers_uses_canonical_sandbox_visible_parent_projection(monkeypatch):
     rows = [
         {
             "provider": "daytona_selfhost",
@@ -493,7 +500,7 @@ def test_list_resource_providers_uses_canonical_sandbox_thread_fallback(monkeypa
 
     class _SandboxThreadOnlyRepo(_FakeRepo):
         def query_lease_threads(self, lease_id: str):
-            raise AssertionError(f"unexpected lease-shaped visible-thread fallback: {lease_id}")
+            raise AssertionError(f"unexpected lease-shaped visible-parent projection: {lease_id}")
 
     monkeypatch.setattr(
         resource_projection_service,
@@ -537,7 +544,7 @@ def test_list_resource_providers_uses_canonical_sandbox_thread_fallback(monkeypa
     ]
 
 
-def test_list_resource_providers_no_longer_uses_lease_shaped_visible_thread_fallback_without_sandbox_id(monkeypatch):
+def test_list_resource_providers_no_longer_uses_lease_shaped_visible_parent_projection_without_sandbox_id(monkeypatch):
     rows = [
         {
             "provider": "daytona_selfhost",
@@ -553,7 +560,7 @@ def test_list_resource_providers_no_longer_uses_lease_shaped_visible_thread_fall
 
     class _NoLeaseFallbackRepo(_FakeRepo):
         def query_lease_threads(self, lease_id: str):
-            raise AssertionError(f"lease-shaped visible-thread fallback should be gone: {lease_id}")
+            raise AssertionError(f"lease-shaped visible-parent projection should be gone: {lease_id}")
 
     monkeypatch.setattr(
         resource_projection_service,


### PR DESCRIPTION
## Scope
- Rename resource projection visible-thread fallback wording to visible-parent projection wording.
- Add a source assertion so this sandbox-authorized projection path is not described as fallback behavior.

## Non-scope
- No behavior or payload shape change.
- No monitor route/API/schema/runtime/LeaseRepo/terminal/provider-session change.

## Verification
- RED: uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -q failed on the new assertion against resource-visible-thread-fallback.
- Rebased onto origin/dev 6fd3d471 after mainline dev CI passed.
- uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_overview_cache.py tests/Integration/test_resource_overview_contract_split.py -q => 39 passed.
- uv run ruff check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py => passed.
- uv run ruff format --check backend/web/services/resource_projection_service.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py => 2 files already formatted.
- git diff --check origin/dev...HEAD => clean.