### PR TITLE
Clarify filesystem backend runtime wording

### DIFF
--- a/sandbox/interfaces/filesystem.py
+++ b/sandbox/interfaces/filesystem.py
@@ -48,7 +48,7 @@ class FileSystemBackend(ABC):
 
     Implementations:
     - LocalBackend: direct local filesystem access
-    - Remote capability wrapper: delegates to SandboxProvider via lease/runtime
+    - Remote capability wrapper: delegates to SandboxProvider via sandbox provider/runtime
     """
 
     is_remote: bool = False

--- a/tests/Unit/filesystem/test_filesystem_service.py
+++ b/tests/Unit/filesystem/test_filesystem_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import inspect
 import threading
 import time
 from pathlib import Path, PurePosixPath
 
+import sandbox.interfaces.filesystem as filesystem_interface
 from core.runtime.registry import ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope
 from core.tools.filesystem.service import FileSystemService, _ReadFileStateCache
@@ -27,6 +29,13 @@ def _make_service(
 def _require_text_result(result: str | ToolResultEnvelope) -> str:
     assert isinstance(result, str)
     return result
+
+
+def test_filesystem_backend_remote_backend_docstring_uses_sandbox_runtime_language() -> None:
+    source = inspect.getsource(filesystem_interface.FileSystemBackend)
+
+    assert "lease/runtime" not in source
+    assert "sandbox provider/runtime" in source
 
 
 def test_edit_rejects_if_last_read_was_partial_view(tmp_path: Path):


### PR DESCRIPTION
## Summary
- clarify FileSystemBackend remote implementation wording from lease/runtime to sandbox provider/runtime
- add a source contract so the stale wording does not return

## Scope
- sandbox/interfaces/filesystem.py
- tests/Unit/filesystem/test_filesystem_service.py

## Non-scope
- filesystem behavior
- command execution
- upload/download semantics
- SandboxProvider APIs
- LeaseRepo/SandboxLease
- terminal/runtime internals
- DB/schema

## Verification
- RED: `uv run python -m pytest tests/Unit/filesystem/test_filesystem_service.py -q` failed on `lease/runtime` in FileSystemBackend source
- GREEN: `uv run python -m pytest tests/Unit/filesystem/test_filesystem_service.py -q` -> 16 passed
- `uv run ruff check sandbox/interfaces/filesystem.py tests/Unit/filesystem/test_filesystem_service.py`
- `uv run ruff format --check sandbox/interfaces/filesystem.py tests/Unit/filesystem/test_filesystem_service.py`
- `git diff --check`