### PR TITLE
Fail loudly on provider session enumeration errors

### DIFF
--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -416,7 +416,9 @@ def load_provider_orphan_sessions(managers: dict) -> list[dict]:
             if str(row.get("current_instance_id") or "").strip()
         }
         raw_provider_sessions = list_provider_sessions()
-        provider_sessions = raw_provider_sessions if isinstance(raw_provider_sessions, list) else []
+        if not isinstance(raw_provider_sessions, list):
+            raise TypeError(f"{provider_slug}.list_provider_sessions must return list")
+        provider_sessions = raw_provider_sessions
 
         inspect_visible = manager.provider_capability.inspect_visible
         for ps in provider_sessions:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -951,12 +951,10 @@ class SandboxManager:
         list_provider_sessions = getattr(self.provider, "list_provider_sessions", None)
         provider_sessions = []
         if callable(list_provider_sessions):
-            try:
-                raw_provider_sessions = list_provider_sessions()
-                provider_sessions = raw_provider_sessions if isinstance(raw_provider_sessions, list) else []
-            except Exception:
-                logger.warning("Failed to list provider sessions for %s", self.provider.name, exc_info=True)
-                provider_sessions = []
+            raw_provider_sessions = list_provider_sessions()
+            if not isinstance(raw_provider_sessions, list):
+                raise TypeError(f"{self.provider.name}.list_provider_sessions must return list")
+            provider_sessions = raw_provider_sessions
 
         for ps in provider_sessions:
             instance_id = getattr(ps, "session_id", None)

--- a/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
+++ b/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from backend.web.services import monitor_service, sandbox_service
 
 
@@ -68,3 +70,14 @@ def test_load_provider_orphan_sessions_excludes_lease_backed_provider_runtimes()
             "inspect_visible": False,
         },
     ]
+
+
+def test_load_provider_orphan_sessions_rejects_non_list_provider_result():
+    manager = SimpleNamespace(
+        provider=SimpleNamespace(name="daytona", list_provider_sessions=lambda: (_provider_runtime("orphan"),)),
+        lease_store=SimpleNamespace(list_by_provider=lambda _provider_name: []),
+        provider_capability=SimpleNamespace(inspect_visible=False),
+    )
+
+    with pytest.raises(TypeError, match="daytona.list_provider_sessions must return list"):
+        sandbox_service.load_provider_orphan_sessions({"daytona": manager})

--- a/tests/Unit/sandbox/test_sandbox_manager_sessions.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_sessions.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from sandbox.manager import SandboxManager
+
+
+def _manager_for_provider(provider: SimpleNamespace) -> SandboxManager:
+    manager = object.__new__(SandboxManager)
+    manager.provider = provider
+    manager.provider_capability = SimpleNamespace(inspect_visible=True)
+    manager.terminal_store = SimpleNamespace(list_all=lambda: [])
+    manager.session_manager = SimpleNamespace(list_all=lambda: [])
+    manager.lease_store = SimpleNamespace(list_by_provider=lambda _provider_name: [])
+    return manager
+
+
+def test_list_sessions_propagates_provider_session_errors() -> None:
+    def _raise_provider_error():
+        raise RuntimeError("provider boom")
+
+    manager = _manager_for_provider(SimpleNamespace(name="daytona", list_provider_sessions=_raise_provider_error))
+
+    with pytest.raises(RuntimeError, match="provider boom"):
+        manager.list_sessions()
+
+
+def test_list_sessions_rejects_non_list_provider_session_result() -> None:
+    manager = _manager_for_provider(
+        SimpleNamespace(name="daytona", list_provider_sessions=lambda: (SimpleNamespace(session_id="runtime-1"),))
+    )
+
+    with pytest.raises(TypeError, match="daytona.list_provider_sessions must return list"):
+        manager.list_sessions()


### PR DESCRIPTION
## Summary
- stop hiding provider session enumeration failures in SandboxManager.list_sessions
- reject non-list provider session results in SandboxManager and backend provider-orphan runtime loading
- add focused tests for provider errors and wrong return types

## Scope
- sandbox/manager.py
- backend/web/services/sandbox_service.py
- tests/Unit/sandbox/test_sandbox_manager_sessions.py
- tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py

## Non-scope
- LeaseRepo/SandboxLease
- terminal/runtime internals
- provider SDK APIs
- monitor route shape
- DB/schema
- upload/download

## Verification
- RED: `uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_sessions.py tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py -q` -> 3 failed, proving errors/wrong result types were hidden
- GREEN after rebase onto `c726e1e9`: `uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_sessions.py tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py tests/Integration/test_monitor_resources_route.py -q` -> 40 passed
- `uv run ruff check sandbox/manager.py backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_manager_sessions.py tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py`
- `uv run ruff format --check sandbox/manager.py backend/web/services/sandbox_service.py tests/Unit/sandbox/test_sandbox_manager_sessions.py tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py`
- `git diff --check origin/dev...HEAD`

## Baseline
- Rebases cleanly on shared dev `c726e1e9`, whose dev CI is green.