### PR TITLE
chore: add frontend app typecheck script

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
- add a frontend/app typecheck npm script that runs the same tsc command used by CI
- keep the change limited to operator ergonomics; no product/runtime behavior changes

## Scope
- frontend/app/package.json only

## Verification
- RED: npm --prefix frontend/app run typecheck failed because the script was missing
- GREEN: npm --prefix frontend/app run typecheck
- npm --prefix frontend/app run build
- git diff --check