### PR TITLE
test: clarify sqlite lease repo bridge wording

### DIFF
--- a/storage/providers/sqlite/lease_repo.py
+++ b/storage/providers/sqlite/lease_repo.py
@@ -15,7 +15,7 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolv
 
 
 class SQLiteLeaseRepo:
-    """Sandbox lease CRUD backed by SQLite.
+    """Container-backed lower sandbox runtime bridge backed by SQLite.
 
     Thread-safe: all connection access is serialized via a lock.
     Returns raw dicts — domain object construction is the consumer's job.

--- a/tests/Unit/storage/test_sqlite_lease_repo.py
+++ b/tests/Unit/storage/test_sqlite_lease_repo.py
@@ -1,6 +1,13 @@
 from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
 
 
+def test_sqlite_lease_repo_docstring_names_lower_runtime_bridge() -> None:
+    doc = SQLiteLeaseRepo.__doc__ or ""
+
+    assert "Container-backed lower sandbox runtime bridge" in doc
+    assert "Sandbox lease CRUD" not in doc
+
+
 def test_sqlite_lease_repo_schema_does_not_create_legacy_volume_id(tmp_path):
     repo = SQLiteLeaseRepo(tmp_path / "sandbox.db")
     try:


### PR DESCRIPTION
## Scope
- Clarify SQLiteLeaseRepo docstring as a Container-backed lower sandbox runtime bridge.
- Add a source contract test in tests/Unit/storage/test_sqlite_lease_repo.py.

## Non-scope
- No LeaseRepo name/method changes.
- No SQLite schema or behavior changes.
- No SupabaseLeaseRepo, terminal/session/runtime, API, or frontend changes.

## Verification
- RED: uv run python -m pytest tests/Unit/storage/test_sqlite_lease_repo.py -q failed on the old 'Sandbox lease CRUD' docstring.
- GREEN: uv run python -m pytest tests/Unit/storage/test_sqlite_lease_repo.py -q => 2 passed.
- Related: uv run python -m pytest tests/Unit/storage/test_storage_contracts.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_sqlite_lease_repo.py -q => 14 passed.
- uv run ruff check storage/providers/sqlite/lease_repo.py tests/Unit/storage/test_sqlite_lease_repo.py
- uv run ruff format --check storage/providers/sqlite/lease_repo.py tests/Unit/storage/test_sqlite_lease_repo.py
- git diff --check