### PR TITLE
test: clarify sandbox manager orchestration wording

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -1,6 +1,6 @@
 """Sandbox session manager.
 
-Orchestrates: Thread → ChatSession → Runtime → Terminal → Lease → Instance
+Orchestrates: Thread → ChatSession → Runtime with lower sandbox bindings.
 """
 
 import logging
@@ -225,8 +225,8 @@ def bind_thread_to_existing_thread_lease(
     if source_terminal is None:
         return None
     # @@@subagent-lease-reuse
-    # Child threads need their own terminal/session state, but must attach
-    # to the parent's existing lease instead of silently provisioning a new one.
+    # Child threads need their own terminal/session state while reusing the
+    # parent's lower sandbox binding instead of silently provisioning a new one.
     return bind_thread_to_existing_lease(
         thread_id,
         str(source_terminal["lease_id"]),

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -339,6 +339,17 @@ def test_sandbox_volume_doc_does_not_claim_volume_source_is_db_truth():
     assert "VolumeSource is per-thread, passed to operations or resolved from DB" not in source
 
 
+def test_sandbox_manager_doc_names_current_runtime_binding_shape():
+    source = inspect.getsource(sandbox_manager_module)
+
+    stale_chain = "Terminal \u2192 " + "Lease \u2192 Instance"
+    stale_parent_binding = "parent's existing " + "lease"
+
+    assert stale_chain not in source
+    assert stale_parent_binding not in source
+    assert "Thread \u2192 ChatSession \u2192 Runtime" in source
+
+
 def test_setup_mounts_uses_workspace_source_without_remote_volume_metadata(monkeypatch, tmp_path):
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")


### PR DESCRIPTION
## Summary\n- describe sandbox manager orchestration as thread/runtime with lower sandbox bindings instead of Terminal -> Lease -> Instance\n- update the subagent reuse comment to say lower sandbox binding rather than parent's existing lease\n- add a source assertion for the current wording contract\n\n## Verification\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py::test_sandbox_manager_doc_names_current_runtime_binding_shape -q (RED before implementation: failed on old Terminal -> Lease -> Instance wording)\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_manager_sessions.py -q\n- uv run python -m pytest tests/Integration/test_monitor_resources_route.py -q\n- uv run ruff check sandbox/manager.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_manager_sessions.py tests/Integration/test_monitor_resources_route.py\n- uv run ruff format --check sandbox/manager.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_manager_sessions.py tests/Integration/test_monitor_resources_route.py\n- git diff --check\n\nNon-scope: function names, LeaseRepo/SandboxLease/terminal runtime behavior, API/schema/provider SDK.