### PR TITLE
Clarify sandbox capability architecture wording

### DIFF
--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -1,8 +1,8 @@
-"""SandboxCapability - Wrapper that hides new architecture from agents.
+"""SandboxCapability - Agent-facing sandbox binding surface.
 
 This module provides the capability object that agents interact with.
-It wraps the new architecture (ChatSession → Runtime → Terminal → Lease)
-while maintaining the same interface as before.
+It wraps the agent-facing thread/runtime/sandbox binding surface while
+keeping lower runtime identity details behind the capability interface.
 """
 
 from __future__ import annotations
@@ -26,7 +26,8 @@ class SandboxCapability:
     """Agent-facing capability object.
 
     Wraps ChatSession and provides access to command execution and filesystem.
-    Agents see the same interface as before - all complexity is hidden.
+    Agents interact through command and filesystem handles; lower runtime
+    binding details stay behind this capability object.
 
     Usage:
         sandbox = sandbox_manager.get_sandbox(thread_id)

--- a/tests/Unit/core/test_capability_async.py
+++ b/tests/Unit/core/test_capability_async.py
@@ -1,8 +1,10 @@
 import asyncio
+import inspect
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
+import sandbox.capability as capability_module
 from sandbox.base import LocalSandbox
 from sandbox.capability import SandboxCapability
 from sandbox.interfaces.executor import AsyncCommand, ExecuteResult
@@ -87,6 +89,16 @@ async def _run_async_command_flow():
 
 def test_command_wrapper_supports_execute_async():
     asyncio.run(_run_async_command_flow())
+
+
+def test_capability_doc_names_agent_facing_runtime_binding_surface():
+    source = inspect.getsource(capability_module)
+    stale_chain = "Terminal \u2192 " + "Lease"
+    stale_interface_label = "same interface " + "as before"
+
+    assert stale_chain not in source
+    assert stale_interface_label not in source
+    assert "agent-facing thread/runtime/sandbox binding surface" in source
 
 
 def test_local_sandbox_rebuilds_stale_closed_capability_before_execute_async(tmp_path):


### PR DESCRIPTION
## Summary
- reword SandboxCapability docs around the agent-facing thread/runtime/sandbox binding surface
- remove stale Terminal -> Lease / same-interface wording from capability source
- add a source contract test for the wording boundary

## Scope
- sandbox/capability.py
- tests/Unit/core/test_capability_async.py

## Non-scope
- no command/filesystem behavior change
- no session/terminal/lease internals change
- no API/schema/provider SDK change

## Verification
- RED: new source assertion failed against the previous Terminal -> Lease wording
- GREEN: uv run python -m pytest tests/Unit/core/test_capability_async.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py -q
- GREEN: uv run ruff check sandbox/capability.py tests/Unit/core/test_capability_async.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py
- GREEN: uv run ruff format --check sandbox/capability.py tests/Unit/core/test_capability_async.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py
- GREEN: git diff --check
- GREEN: stale wording scan against sandbox/capability.py and tests/Unit/core/test_capability_async.py

## Base
- based on shared dev cadbccfb
