### PR TITLE
Split sandbox capability stale wording guard

### DIFF
--- a/tests/Unit/core/test_capability_async.py
+++ b/tests/Unit/core/test_capability_async.py
@@ -93,11 +93,15 @@ def test_command_wrapper_supports_execute_async():
 
 def test_capability_doc_names_agent_facing_runtime_binding_surface():
     source = inspect.getsource(capability_module)
+    guard_source = inspect.getsource(test_capability_doc_names_agent_facing_runtime_binding_surface)
     stale_chain = "Terminal \u2192 " + "Lease"
-    stale_interface_label = "same interface " + "as before"
+    stale_interface_label = "same " + "interface " + "as before"
+    stale_interface_partial = "same " + "interface "
 
     assert stale_chain not in source
     assert stale_interface_label not in source
+    assert stale_interface_partial not in source
+    assert stale_interface_partial not in guard_source
     assert "agent-facing thread/runtime/sandbox binding surface" in source
 
 


### PR DESCRIPTION
## Summary
- split the SandboxCapability stale wording guard so the test no longer contains the partial stale literal `same interface `
- add guard-source coverage so the test catches future self-pollution

## Scope
- tests/Unit/core/test_capability_async.py only

## Non-scope
- no production code
- no command/filesystem behavior
- no runtime/API/schema/provider SDK change

## Verification
- RED: capability async test failed while the guard still contained the partial stale literal
- GREEN: uv run python -m pytest tests/Unit/core/test_capability_async.py tests/Unit/core/test_root_agent_entrypoint.py -q
- GREEN: uv run ruff check tests/Unit/core/test_capability_async.py tests/Unit/core/test_root_agent_entrypoint.py
- GREEN: uv run ruff format --check tests/Unit/core/test_capability_async.py tests/Unit/core/test_root_agent_entrypoint.py
- GREEN: git diff --check
- GREEN: stale scan for same-interface / Terminal-Lease wording in capability test and source

## Base
- based on shared dev 9b7425ba
