### PR TITLE
test: split monitor resource stale wording guard

### DIFF
--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -96,9 +96,14 @@ def test_storage_runtime_no_longer_exposes_lease_shaped_snapshot_read_shell() ->
 def test_resource_projection_comments_use_sandbox_row_language() -> None:
     source = Path(resource_projection_service.__file__)
     text = source.read_text(encoding="utf-8")
+    guard_source = Path(__file__).read_text(encoding="utf-8")
+    stale_residue_comment = "lease ids remain " + "compatibility residue for enrichment joins"
+    stale_detached_comment = "detached leases that have neither " + "a bound runtime"
 
-    assert "lease ids remain compatibility residue for enrichment joins" not in text
-    assert "detached leases that have neither a bound runtime" not in text
+    assert stale_residue_comment not in text
+    assert stale_residue_comment not in guard_source
+    assert stale_detached_comment not in text
+    assert stale_detached_comment not in guard_source
 
 
 def test_resource_projection_internal_orphan_runtime_grouping_uses_runtime_language() -> None:


### PR DESCRIPTION
## Scope
- `tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py` only.
- Split stale resource projection comment guard strings so the test no longer contains the full old phrases it is policing.
- Add guard-source assertions for both stale phrases to catch future self-pollution.

## Non-scope
- No production code change.
- No resource grouping/projection behavior change.
- No monitor UI/runtime behavior change.
- No backend/API/schema/runtime change.

## Proof
- RED: before splitting, the self-source assertion failed because the test itself contained the stale `lease ids remain compatibility residue for enrichment joins` phrase.
- GREEN: `uv run python -m pytest tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_monitor_resources_route.py -q` -> 63 passed.
- GREEN: `uv run ruff check tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_monitor_resources_route.py && uv run ruff format --check tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Integration/test_monitor_resources_route.py` -> passed.
- GREEN: `git diff --check` -> clean.
- GREEN: `rg -n "lease ids remain compatibility residue|detached leases that have neither a bound runtime" tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py backend/web/services/resource_projection_service.py || true` -> no matches.
