### PR TITLE
refactor: clarify supabase lease bridge state naming

### DIFF
--- a/storage/providers/supabase/lease_repo.py
+++ b/storage/providers/supabase/lease_repo.py
@@ -39,7 +39,7 @@ def _config(row: dict[str, Any]) -> dict[str, Any]:
     return dict(value)
 
 
-def _compat(row: dict[str, Any]) -> dict[str, Any]:
+def _bridge_state(row: dict[str, Any]) -> dict[str, Any]:
     value = _config(row).get(_LEASE_COMPAT)
     if value is None:
         raise RuntimeError(f"container sandbox missing config.{_LEASE_COMPAT}: {row.get('id')}")
@@ -57,7 +57,7 @@ def _lease_id(row: dict[str, Any]) -> str:
     return str(value)
 
 
-def _has_lease_compat(row: dict[str, Any]) -> bool:
+def _has_lease_bridge_state(row: dict[str, Any]) -> bool:
     return _config(row).get(_LEASE_COMPAT) is not None
 
 
@@ -82,25 +82,25 @@ def _instance_from_lease(row: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _lease_from_sandbox(row: dict[str, Any]) -> dict[str, Any]:
-    compat = _compat(row)
+    bridge_state = _bridge_state(row)
     result = {
         "sandbox_id": row.get("id"),
         "lease_id": _lease_id(row),
         "provider_name": row.get("provider_name"),
-        "recipe_id": compat.get("recipe_id") or row.get("sandbox_template_id"),
-        "workspace_key": compat.get("workspace_key"),
-        "recipe_json": compat.get("recipe_json"),
+        "recipe_id": bridge_state.get("recipe_id") or row.get("sandbox_template_id"),
+        "workspace_key": bridge_state.get("workspace_key"),
+        "recipe_json": bridge_state.get("recipe_json"),
         "current_instance_id": row.get("provider_env_id"),
-        "instance_created_at": compat.get("instance_created_at"),
+        "instance_created_at": bridge_state.get("instance_created_at"),
         "desired_state": row.get("desired_state"),
         "observed_state": row.get("observed_state"),
         "instance_status": row.get("observed_state"),
-        "version": int(compat.get("version") or 0),
+        "version": int(bridge_state.get("version") or 0),
         "observed_at": row.get("observed_at"),
         "last_error": row.get("last_error"),
-        "needs_refresh": _int_flag(compat.get("needs_refresh")),
-        "refresh_hint_at": compat.get("refresh_hint_at"),
-        "status": compat.get("status") or "active",
+        "needs_refresh": _int_flag(bridge_state.get("needs_refresh")),
+        "refresh_hint_at": bridge_state.get("refresh_hint_at"),
+        "status": bridge_state.get("status") or "active",
         "created_at": row.get("created_at"),
         "updated_at": row.get("updated_at"),
     }
@@ -110,9 +110,9 @@ def _lease_from_sandbox(row: dict[str, Any]) -> dict[str, Any]:
 
 def _patched_config(row: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
     config = _config(row)
-    compat = _compat(row)
-    compat.update(updates)
-    config[_LEASE_COMPAT] = compat
+    bridge_state = _bridge_state(row)
+    bridge_state.update(updates)
+    config[_LEASE_COMPAT] = bridge_state
     return config
 
 
@@ -352,7 +352,7 @@ class SupabaseLeaseRepo:
 
     def list_all(self) -> list[dict[str, Any]]:
         return sorted(
-            [_lease_from_sandbox(row) for row in self._sandbox_rows() if _has_lease_compat(row)],
+            [_lease_from_sandbox(row) for row in self._sandbox_rows() if _has_lease_bridge_state(row)],
             key=lambda row: row.get("created_at") or "",
             reverse=True,
         )

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -2,6 +2,7 @@ import inspect
 
 import pytest
 
+import storage.providers.supabase.lease_repo as lease_repo_module
 from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
@@ -22,6 +23,13 @@ def test_supabase_lease_repo_names_container_bridge_without_adapter_label():
 
     assert "Lease-compatible adapter" not in source
     assert "Container-backed LeaseRepo bridge" in source
+
+
+def test_supabase_lease_repo_internal_bridge_state_not_named_as_compat_helper():
+    source = inspect.getsource(lease_repo_module)
+
+    assert "def _compat(" not in source
+    assert "compat =" not in source
 
 
 def _sandbox_row(
@@ -139,7 +147,7 @@ def test_supabase_lease_repo_create_writes_container_sandbox_bridge():
     assert "volume_id" not in row
 
 
-def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and_compat_state():
+def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and_bridge_state():
     tables = {"container.sandboxes": [_sandbox_row(provider_env_id=None, observed_state="detached", version=0, needs_refresh=0)]}
     repo = SupabaseLeaseRepo(client=_client(tables))
 
@@ -158,7 +166,7 @@ def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and
     assert updated["_instance"]["instance_id"] == "inst-1"
 
 
-def test_supabase_lease_repo_persist_metadata_updates_container_and_compat_fields():
+def test_supabase_lease_repo_persist_metadata_updates_container_and_bridge_state_fields():
     tables = {"container.sandboxes": [_sandbox_row(provider_env_id=None, observed_state="detached", version=0, needs_refresh=0)]}
     repo = SupabaseLeaseRepo(client=_client(tables))
 
@@ -177,16 +185,16 @@ def test_supabase_lease_repo_persist_metadata_updates_container_and_compat_field
     )
 
     row = tables["container.sandboxes"][0]
-    compat = row["config"]["lease_compat"]
+    bridge_state = row["config"]["lease_compat"]
     assert updated["lease_id"] == "lease-1"
     assert row["sandbox_template_id"] == "local:python"
     assert row["observed_state"] == "unknown"
     assert row["last_error"] == "provider boom"
-    assert compat["recipe_json"] == '{"id":"local:python"}'
-    assert compat["version"] == 3
-    assert compat["needs_refresh"] == 1
-    assert compat["refresh_hint_at"] == "2026-04-07T00:00:06+00:00"
-    assert compat["status"] == "recovering"
+    assert bridge_state["recipe_json"] == '{"id":"local:python"}'
+    assert bridge_state["version"] == 3
+    assert bridge_state["needs_refresh"] == 1
+    assert bridge_state["refresh_hint_at"] == "2026-04-07T00:00:06+00:00"
+    assert bridge_state["status"] == "recovering"
 
 
 def test_supabase_lease_repo_observe_status_detaches_instance_from_container_sandbox():
@@ -200,26 +208,26 @@ def test_supabase_lease_repo_observe_status_detaches_instance_from_container_san
     )
 
     row = tables["container.sandboxes"][0]
-    compat = row["config"]["lease_compat"]
+    bridge_state = row["config"]["lease_compat"]
     assert updated["lease_id"] == "lease-1"
     assert row["provider_env_id"] is None
     assert row["observed_state"] == "detached"
-    assert compat["status"] == "expired"
-    assert compat["needs_refresh"] == 0
-    assert compat["refresh_hint_at"] is None
-    assert compat["instance_created_at"] is None
+    assert bridge_state["status"] == "expired"
+    assert bridge_state["needs_refresh"] == 0
+    assert bridge_state["refresh_hint_at"] is None
+    assert bridge_state["instance_created_at"] is None
     assert updated["_instance"] is None
 
 
-def test_supabase_lease_repo_mark_needs_refresh_updates_compat_only():
+def test_supabase_lease_repo_mark_needs_refresh_updates_bridge_state_only():
     tables = {"container.sandboxes": [_sandbox_row(needs_refresh=0, refresh_hint_at=None)]}
     repo = SupabaseLeaseRepo(client=_client(tables))
 
     assert repo.mark_needs_refresh("lease-1", hint_at="2026-04-07T00:00:06+00:00") is True
 
-    compat = tables["container.sandboxes"][0]["config"]["lease_compat"]
-    assert compat["needs_refresh"] == 1
-    assert compat["refresh_hint_at"] == "2026-04-07T00:00:06+00:00"
+    bridge_state = tables["container.sandboxes"][0]["config"]["lease_compat"]
+    assert bridge_state["needs_refresh"] == 1
+    assert bridge_state["refresh_hint_at"] == "2026-04-07T00:00:06+00:00"
 
 
 def test_supabase_lease_repo_delete_removes_container_sandbox_bridge():

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -20,16 +20,19 @@ def _client(tables: dict[str, list[dict]] | None = None) -> _RejectBareSandboxLe
 
 def test_supabase_lease_repo_names_container_bridge_without_adapter_label():
     source = inspect.getsource(SupabaseLeaseRepo)
+    stale_adapter_label = "Lease-" + "compatible adapter"
 
-    assert "Lease-compatible adapter" not in source
+    assert stale_adapter_label not in source
     assert "Container-backed LeaseRepo bridge" in source
 
 
 def test_supabase_lease_repo_internal_bridge_state_not_named_as_compat_helper():
     source = inspect.getsource(lease_repo_module)
+    stale_helper = "def _" + "compat("
+    stale_local_name = "compat " + "="
 
-    assert "def _compat(" not in source
-    assert "compat =" not in source
+    assert stale_helper not in source
+    assert stale_local_name not in source
 
 
 def _sandbox_row(


### PR DESCRIPTION
## Summary
- rename Supabase LeaseRepo internal lease_compat helper/local names from compat to bridge_state
- keep the real config[lease_compat] and config[legacy_lease_id] field names unchanged
- update storage tests and add a source guard against reintroducing the internal _compat helper naming

## Scope
- storage/providers/supabase/lease_repo.py
- tests/Unit/storage/test_supabase_lease_repo.py

## Non-scope
- schema/API/runtime behavior
- lower LeaseRepo contract changes
- legacy_lease_id or lease_compat field renames
- monitor/resource routes

## Proof
- RED: uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py -q failed at test_supabase_lease_repo_internal_bridge_state_not_named_as_compat_helper while def _compat still existed
- GREEN: uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/storage/test_supabase_sandbox_repo.py tests/Unit/storage/test_supabase_resource_snapshot_repo.py -q -> 25 passed
- uv run ruff check storage/providers/supabase/lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py
- uv run ruff format --check storage/providers/supabase/lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py
- git diff --check