### PR TITLE
Fail loud on missing default terminal

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -558,9 +558,6 @@ class SandboxManager:
     def create_background_command_session(self, thread_id: str, initial_cwd: str) -> Any:
         default_row = self.terminal_store.get_default(thread_id)
         if default_row is None:
-            # Fallback: pointer row may predate default_terminal_id tracking; try active terminal
-            default_row = self.terminal_store.get_active(thread_id)
-        if default_row is None:
             raise RuntimeError(f"Thread {thread_id} has no default terminal")
         default_terminal = terminal_from_row(default_row, self.db_path)
         lease = self._get_lease(default_terminal.lease_id)

--- a/sandbox/sync/manager.py
+++ b/sandbox/sync/manager.py
@@ -9,15 +9,13 @@ class SyncManager:
         self.strategy = self._select_strategy()
 
     def _select_strategy(self) -> SyncStrategy:
-        from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
+        from sandbox.sync.state import SyncState
         from sandbox.sync.strategy import IncrementalSyncStrategy, NoOpStrategy
 
         runtime_kind = self.provider_capability.runtime_kind
         if runtime_kind in ("local", "docker_pty"):
             return NoOpStrategy()
-        # @@@sync-process-local-first-cut - remote runtimes now get a process-local checksum backing
-        # so incremental sync no longer defaults to a persisted sync_files repo on the first cut.
-        state = SyncState(repo=ProcessLocalSyncFileBacking())
+        state = SyncState()
         return IncrementalSyncStrategy(state)
 
     def upload(

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -939,6 +939,73 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
     assert sync_calls == [("thread-1", "instance-1", expected_path)]
 
 
+def test_background_command_requires_default_terminal_without_active_terminal_substitute():
+    manager = _new_test_manager()
+
+    manager.terminal_store = SimpleNamespace(
+        get_default=lambda _thread_id: None,
+        get_active=lambda _thread_id: (_ for _ in ()).throw(AssertionError("active terminal was queried unexpectedly")),
+    )
+
+    with pytest.raises(RuntimeError, match="Thread thread-1 has no default terminal"):
+        manager.create_background_command_session("thread-1", "/workspace")
+
+
+def test_background_command_inherits_default_terminal_environment(monkeypatch):
+    manager = _new_test_manager()
+    default_state = SimpleNamespace(cwd="/default", env_delta={"TOKEN": "value"}, state_version=7)
+    created_terminal = SimpleNamespace(updated_state=None)
+    default_terminal = SimpleNamespace(lease_id="lease-1", get_state=lambda: default_state)
+    created_rows: list[dict[str, str]] = []
+    created_sessions: list[dict[str, Any]] = []
+
+    def from_row(row, _db_path):
+        if row["terminal_id"] == "term-default":
+            return default_terminal
+        return created_terminal
+
+    def create_terminal(**kwargs):
+        created_rows.append(kwargs)
+        return {
+            "terminal_id": kwargs["terminal_id"],
+            "thread_id": kwargs["thread_id"],
+            "lease_id": kwargs["lease_id"],
+            "cwd": kwargs["initial_cwd"],
+            "env_delta_json": "{}",
+            "state_version": 0,
+        }
+
+    def update_state(state):
+        created_terminal.updated_state = state
+
+    created_terminal.update_state = update_state
+    manager.terminal_store = SimpleNamespace(
+        get_default=lambda _thread_id: {
+            "terminal_id": "term-default",
+            "thread_id": "thread-1",
+            "lease_id": "lease-1",
+            "cwd": "/default",
+            "env_delta_json": '{"TOKEN": "value"}',
+            "state_version": 7,
+        },
+        create=create_terminal,
+    )
+    manager._get_lease = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager.session_manager = SimpleNamespace(create=lambda **kwargs: created_sessions.append(kwargs) or kwargs)
+    monkeypatch.setattr(sandbox_manager_module, "terminal_from_row", from_row)
+
+    session = manager.create_background_command_session("thread-1", "/workspace/task")
+
+    assert created_rows[0]["thread_id"] == "thread-1"
+    assert created_rows[0]["lease_id"] == "lease-1"
+    assert created_rows[0]["initial_cwd"] == "/workspace/task"
+    assert created_terminal.updated_state.cwd == "/workspace/task"
+    assert created_terminal.updated_state.env_delta == {"TOKEN": "value"}
+    assert created_terminal.updated_state.state_version == 7
+    assert session is created_sessions[0]
+
+
 def test_resume_session_rebinds_live_session_lease_after_resume():
     manager = _new_test_manager()
     terminal = SimpleNamespace(terminal_id="term-1", lease_id="lease-1")

--- a/tests/Unit/sandbox/test_sync_manager.py
+++ b/tests/Unit/sandbox/test_sync_manager.py
@@ -7,3 +7,18 @@ def test_sync_manager_uses_process_local_backing_for_remote_runtime() -> None:
     manager = sync_manager_module.SyncManager(provider_capability=SimpleNamespace(runtime_kind="remote_pty"))
 
     assert type(manager.strategy).__name__ == "IncrementalSyncStrategy"
+
+
+def test_sync_manager_uses_sync_state_default_backing_for_remote_runtime(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _SyncStateProbe:
+        def __init__(self, repo=None) -> None:
+            captured["repo"] = repo
+
+    monkeypatch.setattr("sandbox.sync.state.SyncState", _SyncStateProbe)
+
+    manager = sync_manager_module.SyncManager(provider_capability=SimpleNamespace(runtime_kind="remote_pty"))
+
+    assert type(manager.strategy).__name__ == "IncrementalSyncStrategy"
+    assert captured["repo"] is None


### PR DESCRIPTION
## Summary
- remove background-command substitution from missing default terminal to active terminal
- keep default-terminal inheritance behavior pinned with unit coverage
- let SyncState own remote sync default backing instead of explicitly constructing ProcessLocalSyncFileBacking in SyncManager

## Non-scope
- no storage/supabase, schema, API, live DB, provider-event matched_lease_id, or frontend changes
- no terminal repo pointer-repair behavior changes

## Verification
- uv run python -m pytest tests/Unit/sandbox/test_sync_manager.py tests/Unit/sandbox/test_sync_state.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q
- uv run ruff check sandbox/manager.py sandbox/sync/manager.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sync_manager.py tests/Unit/sandbox/test_sync_state.py
- uv run ruff format --check sandbox/manager.py sandbox/sync/manager.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sync_manager.py tests/Unit/sandbox/test_sync_state.py
- git diff --check f79578c3..HEAD
- target stale-token scan clean