### PR TITLE
Refactor: fail loud on missing thread workspace bridge

### DIFF
--- a/backend/web/services/thread_launch_config_service.py
+++ b/backend/web/services/thread_launch_config_service.py
@@ -76,8 +76,7 @@ def _derive_default_config(
             current_workspace_id=thread["current_workspace_id"],
             owner_user_id=owner_user_id,
         )
-        if config is not None:
-            return config
+        return config
 
     provider_names = [str(item["name"]) for item in providers]
     provider_config = "local" if "local" in provider_names else (provider_names[0] if provider_names else "local")
@@ -125,40 +124,43 @@ def _resolve_workspace_backed_existing_config(
     app: Any,
     current_workspace_id: str,
     owner_user_id: str,
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     workspace_repo = getattr(app.state, "workspace_repo", None)
     get_by_id = getattr(workspace_repo, "get_by_id", None)
-    if callable(get_by_id):
-        workspace = get_by_id(current_workspace_id)
-        if workspace is not None:
-            sandbox_id = _required_bridge_text(workspace, "sandbox_id", "workspace")
-            workspace_owner_user_id = _required_bridge_text(workspace, "owner_user_id", "workspace")
-            if workspace_owner_user_id != owner_user_id:
-                raise PermissionError(f"workspace owner mismatch: expected {owner_user_id}, got {workspace_owner_user_id}")
-            sandbox_repo = getattr(app.state, "sandbox_repo", None)
-            sandbox_get_by_id = getattr(sandbox_repo, "get_by_id", None)
-            if not callable(sandbox_get_by_id):
-                raise RuntimeError("sandbox_repo must support get_by_id")
-            sandbox = sandbox_get_by_id(sandbox_id)
-            if sandbox is None:
-                raise RuntimeError(f"sandbox not found: {sandbox_id}")
-            sandbox_owner_user_id = _required_bridge_text(sandbox, "owner_user_id", "sandbox")
-            if sandbox_owner_user_id != owner_user_id:
-                raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
-            sandbox_template = _resolve_workspace_backed_sandbox_template(
-                app=app,
-                owner_user_id=owner_user_id,
-                sandbox=sandbox,
-            )
-            return {
-                "create_mode": "existing",
-                "provider_config": _required_bridge_text(sandbox, "provider_name", "sandbox"),
-                "sandbox_template": sandbox_template,
-                "existing_sandbox_id": _required_bridge_text(sandbox, "id", "sandbox"),
-                "model": None,
-                "workspace": _required_bridge_text(workspace, "workspace_path", "workspace"),
-            }
-    return None
+    if not callable(get_by_id):
+        raise RuntimeError("workspace_repo must support get_by_id")
+
+    workspace = get_by_id(current_workspace_id)
+    if workspace is None:
+        raise RuntimeError(f"workspace not found: {current_workspace_id}")
+
+    sandbox_id = _required_bridge_text(workspace, "sandbox_id", "workspace")
+    workspace_owner_user_id = _required_bridge_text(workspace, "owner_user_id", "workspace")
+    if workspace_owner_user_id != owner_user_id:
+        raise PermissionError(f"workspace owner mismatch: expected {owner_user_id}, got {workspace_owner_user_id}")
+    sandbox_repo = getattr(app.state, "sandbox_repo", None)
+    sandbox_get_by_id = getattr(sandbox_repo, "get_by_id", None)
+    if not callable(sandbox_get_by_id):
+        raise RuntimeError("sandbox_repo must support get_by_id")
+    sandbox = sandbox_get_by_id(sandbox_id)
+    if sandbox is None:
+        raise RuntimeError(f"sandbox not found: {sandbox_id}")
+    sandbox_owner_user_id = _required_bridge_text(sandbox, "owner_user_id", "sandbox")
+    if sandbox_owner_user_id != owner_user_id:
+        raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
+    sandbox_template = _resolve_workspace_backed_sandbox_template(
+        app=app,
+        owner_user_id=owner_user_id,
+        sandbox=sandbox,
+    )
+    return {
+        "create_mode": "existing",
+        "provider_config": _required_bridge_text(sandbox, "provider_name", "sandbox"),
+        "sandbox_template": sandbox_template,
+        "existing_sandbox_id": _required_bridge_text(sandbox, "id", "sandbox"),
+        "model": None,
+        "workspace": _required_bridge_text(workspace, "workspace_path", "workspace"),
+    }
 
 
 def _resolve_workspace_backed_sandbox_template(

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -174,16 +173,6 @@ def _recipe_library_entry(provider_type: str) -> dict[str, object]:
         "created_at": 0,
         "updated_at": 0,
     }
-
-
-def test_launch_config_service_does_not_expose_lease_shell_builder() -> None:
-    assert not hasattr(thread_launch_config_service, "build_existing_launch_config")
-
-
-def test_launch_config_service_comments_do_not_describe_workspace_bridge_as_lease_lookup() -> None:
-    source = inspect.getsource(thread_launch_config_service)
-
-    assert "live lease lookup" not in source
 
 
 def test_build_new_launch_config_uses_sandbox_template_id() -> None:
@@ -449,12 +438,13 @@ def test_resolve_default_config_fails_loudly_when_workspace_backed_template_sour
         )
 
 
-def test_resolve_default_config_derives_existing_from_sandbox_backed_current_workspace_id() -> None:
+@pytest.mark.parametrize("missing_workspace_id", ["lease-2", "missing-workspace"])
+def test_resolve_default_config_fails_loudly_when_thread_workspace_bridge_is_missing(missing_workspace_id: str) -> None:
     thread_repo = _FakeThreadRepo()
     thread_repo.rows["agent-user-1-1"] = {
         "thread_id": "agent-user-1-1",
         "agent_user_id": "agent-user-1",
-        "current_workspace_id": "lease-2",
+        "current_workspace_id": missing_workspace_id,
         "is_main": True,
         "branch_index": 0,
         "created_at": 1.0,
@@ -483,25 +473,44 @@ def test_resolve_default_config_derives_existing_from_sandbox_backed_current_wor
             "list_library",
             return_value=[_recipe_library_entry("local")],
         ),
+        pytest.raises(RuntimeError, match=f"workspace not found: {missing_workspace_id}"),
     ):
-        result = thread_launch_config_service.resolve_default_config(
+        thread_launch_config_service.resolve_default_config(
             app=app,
             owner_user_id="owner-1",
             agent_user_id="agent-user-1",
         )
 
-    assert result == {
-        "source": "derived",
-        "config": {
-            "create_mode": "new",
-            "provider_config": "local",
-            "sandbox_template_id": "local:default",
-            "sandbox_template": default_recipe_snapshot("local"),
-            "existing_sandbox_id": None,
-            "model": None,
-            "workspace": None,
-        },
+
+def test_resolve_default_config_fails_loudly_when_workspace_repo_cannot_read_bridge() -> None:
+    thread_repo = _FakeThreadRepo()
+    thread_repo.rows["agent-user-1-1"] = {
+        "thread_id": "agent-user-1-1",
+        "agent_user_id": "agent-user-1",
+        "current_workspace_id": "ws-unsupported",
+        "is_main": True,
+        "branch_index": 0,
+        "created_at": 1.0,
     }
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=thread_repo,
+            user_repo=SimpleNamespace(),
+            recipe_repo=object(),
+            workspace_repo=object(),
+        )
+    )
+
+    with (
+        patch.object(thread_launch_config_service.sandbox_service, "available_sandbox_types", return_value=[]),
+        patch.object(thread_launch_config_service, "list_library", return_value=[]),
+        pytest.raises(RuntimeError, match="workspace_repo must support get_by_id"),
+    ):
+        thread_launch_config_service.resolve_default_config(
+            app=app,
+            owner_user_id="owner-1",
+            agent_user_id="agent-user-1",
+        )
 
 
 def test_resolve_default_config_fails_loudly_for_malformed_workspace_bridge() -> None:
@@ -543,56 +552,6 @@ def test_resolve_default_config_fails_loudly_for_malformed_workspace_bridge() ->
             owner_user_id="owner-1",
             agent_user_id="agent-user-1",
         )
-
-
-def test_resolve_default_config_falls_back_to_new_default_when_thread_workspace_bridge_is_missing() -> None:
-    thread_repo = _FakeThreadRepo()
-    thread_repo.rows["agent-user-1-1"] = {
-        "thread_id": "agent-user-1-1",
-        "agent_user_id": "agent-user-1",
-        "current_workspace_id": "missing-lease",
-        "is_main": True,
-        "branch_index": 0,
-    }
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            thread_repo=thread_repo,
-            user_repo=SimpleNamespace(),
-            recipe_repo=object(),
-            workspace_repo=_FakeWorkspaceRepo(),
-        )
-    )
-
-    with (
-        patch.object(
-            thread_launch_config_service.sandbox_service,
-            "available_sandbox_types",
-            return_value=[{"name": "local", "available": True}],
-        ),
-        patch.object(
-            thread_launch_config_service,
-            "list_library",
-            return_value=[_recipe_library_entry("local")],
-        ),
-    ):
-        result = thread_launch_config_service.resolve_default_config(
-            app=app,
-            owner_user_id="owner-1",
-            agent_user_id="agent-user-1",
-        )
-
-    assert result == {
-        "source": "derived",
-        "config": {
-            "create_mode": "new",
-            "provider_config": "local",
-            "sandbox_template_id": "local:default",
-            "sandbox_template": default_recipe_snapshot("local"),
-            "existing_sandbox_id": None,
-            "model": None,
-            "workspace": None,
-        },
-    }
 
 
 def test_find_owned_agent_returns_none_for_foreign_agent() -> None:


### PR DESCRIPTION
## Summary
- make thread launch default resolution fail loudly when a thread has current_workspace_id but workspace lookup is missing or unsupported
- remove the stale fallback path that silently derived a new sandbox default for bridge-bearing thread metadata
- delete low-value thread launch source-shape guards and consolidate the old fallback tests into fail-loud behavior coverage

## Verification
- RED: missing-workspace test failed before implementation because no RuntimeError was raised
- uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q
- uv run ruff check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py
- uv run ruff format --check backend/web/services/thread_launch_config_service.py tests/Integration/test_thread_launch_config_contract.py
- git diff --check origin/dev...HEAD
- rg -n "falls_back_to_new_default|falls back to new default|build_existing_launch_config|live lease lookup|sandbox_backed_current_workspace_id" tests/Integration/test_thread_launch_config_contract.py backend/web/services/thread_launch_config_service.py (no matches)