### PR TITLE
Test: prune low-value source shape guards

### DIFF
--- a/tests/Integration/test_thread_files_channel_shell.py
+++ b/tests/Integration/test_thread_files_channel_shell.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,35 +8,6 @@ from fastapi import HTTPException
 from fastapi.responses import FileResponse
 
 from backend.web.routers import thread_files as thread_files_router
-from backend.web.services import file_channel_service
-
-
-def test_file_channel_service_no_longer_imports_storage_factory() -> None:
-    file_channel_source = inspect.getsource(file_channel_service)
-
-    assert "backend.web.core.storage_factory" not in file_channel_source
-    assert "backend.web.utils.helpers" in file_channel_source
-    assert "SQLiteTerminalRepo" not in file_channel_source
-    assert "SQLiteLeaseRepo" not in file_channel_source
-    assert "build_chat_session_repo" not in file_channel_source
-    assert "touch_thread_activity" not in file_channel_source
-
-
-def test_helpers_no_longer_import_storage_factory() -> None:
-    helpers_source = Path("backend/web/utils/helpers.py").read_text(encoding="utf-8")
-
-    assert "backend.web.core.storage_factory" not in helpers_source
-    assert "storage.runtime" in helpers_source
-    assert "resolve_role_db_path" not in helpers_source
-    assert "sandbox.control_plane_repos" in helpers_source
-
-
-def test_thread_file_delete_handler_uses_file_channel_language() -> None:
-    router_source = Path("backend/web/routers/thread_files.py").read_text(encoding="utf-8")
-
-    assert "delete_workspace_file" not in router_source
-    assert "Delete a file from workspace." not in router_source
-    assert "delete_channel_file" in router_source
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/backend/web/services/test_file_channel_service.py
+++ b/tests/Unit/backend/web/services/test_file_channel_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -68,9 +67,3 @@ def test_save_file_does_not_touch_chat_session_activity(monkeypatch):
     result = file_channel_service.save_file(thread_id="thread-1", relative_path="note.txt", content=b"hello")
 
     assert result == {"path": "note.txt", "size": 5, "thread_id": "thread-1"}
-
-
-def test_file_channel_service_does_not_describe_channel_crud_as_volume_source() -> None:
-    source = inspect.getsource(file_channel_service)
-
-    assert "File CRUD — delegates to VolumeSource" not in source

--- a/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_binding_service.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from inspect import signature
-from pathlib import Path
 
 import pytest
 
@@ -154,22 +152,6 @@ def test_workspace_without_sandbox_fails_loudly() -> None:
         )
 
     assert "sandbox_id" in str(excinfo.value)
-
-
-def test_service_signature_does_not_expose_unused_purpose_dimension() -> None:
-    assert "purpose" not in signature(resolve_thread_runtime_binding).parameters
-
-
-def test_service_does_not_import_removed_runtime_glue() -> None:
-    source = Path("backend/web/services/thread_runtime_binding_service.py").read_text()
-    removed_cwd_token = "leg" + "acy_cwd"
-
-    assert "terminal_repo" not in source
-    assert "lease_repo" not in source
-    assert "chat_session" not in source
-    assert "sandbox_volume" not in source
-    assert "sync_file" not in source
-    assert removed_cwd_token not in source
 
 
 def test_resolves_binding_with_thin_workspace_shape() -> None:

--- a/tests/Unit/backend/web/test_web_config.py
+++ b/tests/Unit/backend/web/test_web_config.py
@@ -5,10 +5,3 @@ from backend.web.core import config
 
 def test_local_workspace_root_defaults_to_user_home() -> None:
     assert config.LOCAL_WORKSPACE_ROOT == Path.home().resolve()
-
-
-def test_db_path_comment_does_not_label_current_sqlite_default_as_removed() -> None:
-    source = Path(config.__file__).read_text()
-    removed_db_path_token = "Leg" + "acy DB_PATH"
-
-    assert removed_db_path_token not in source

--- a/tests/Unit/sandbox/test_sandbox_service_session_mutation.py
+++ b/tests/Unit/sandbox/test_sandbox_service_session_mutation.py
@@ -57,12 +57,3 @@ def test_mutate_sandbox_session_destroys_provider_orphan_without_fake_lease(monk
     assert payload["mode"] == "provider_orphan_direct"
     assert payload["lease_id"] is None
     assert manager.provider.destroyed == [("sandbox-1", True)]
-
-
-def test_sandbox_service_cleanup_comments_do_not_describe_owner_action_as_lease_destroy() -> None:
-    source = Path(sandbox_service.__file__) if sandbox_service.__file__ else None
-    assert source is not None
-    text = source.read_text(encoding="utf-8")
-
-    assert "Destroy a lease through the manager-owned lease state machine" not in text
-    assert "cleanup must target the lease state machine directly" not in text


### PR DESCRIPTION
## Summary
- delete source-text/import/comment/signature guard tests that police implementation shape instead of product behavior
- keep the remaining file-channel, runtime-binding, config, and sandbox mutation behavior tests
- no production code, runtime behavior, API/schema, or live DB change

## Verification
- uv run python -m pytest tests/Integration/test_thread_files_channel_shell.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py tests/Unit/backend/web/test_web_config.py tests/Unit/sandbox/test_sandbox_service_session_mutation.py -q
- uv run ruff check tests/Integration/test_thread_files_channel_shell.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py tests/Unit/backend/web/test_web_config.py tests/Unit/sandbox/test_sandbox_service_session_mutation.py
- uv run ruff format --check tests/Integration/test_thread_files_channel_shell.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Unit/backend/web/services/test_thread_runtime_binding_service.py tests/Unit/backend/web/test_web_config.py tests/Unit/sandbox/test_sandbox_service_session_mutation.py
- git diff --check origin/dev...HEAD