### PR TITLE
test: prune auth router mock-only checks

### DIFF
--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -12,33 +12,15 @@ from backend.web.routers import messaging as chats_router
 class _FakeAuthService:
     def __init__(self) -> None:
         self.send_otp_calls: list[tuple[str, str, str]] = []
-        self.verify_otp_calls: list[tuple[str, str]] = []
-        self.complete_register_calls: list[tuple[str, str]] = []
         self.login_calls: list[tuple[str, str]] = []
-        self.verify_otp_result = {"temp_token": "temp-otp"}
-        self.complete_register_result = {"token": "tok-register"}
         self.login_result = {"token": "tok-login"}
         self.send_otp_error: Exception | None = None
-        self.verify_otp_error: Exception | None = None
-        self.complete_register_error: Exception | None = None
         self.login_error: Exception | None = None
 
     def send_otp(self, email: str, password: str, invite_code: str) -> None:
         self.send_otp_calls.append((email, password, invite_code))
         if self.send_otp_error is not None:
             raise self.send_otp_error
-
-    def verify_register_otp(self, email: str, token: str) -> dict:
-        self.verify_otp_calls.append((email, token))
-        if self.verify_otp_error is not None:
-            raise self.verify_otp_error
-        return self.verify_otp_result
-
-    def complete_register(self, temp_token: str, invite_code: str) -> dict:
-        self.complete_register_calls.append((temp_token, invite_code))
-        if self.complete_register_error is not None:
-            raise self.complete_register_error
-        return self.complete_register_result
 
     def login(self, identifier: str, password: str) -> dict:
         self.login_calls.append((identifier, password))
@@ -78,45 +60,6 @@ async def test_send_otp_maps_value_error_to_bad_request():
 
 
 @pytest.mark.asyncio
-async def test_verify_otp_calls_auth_service_directly():
-    service = _FakeAuthService()
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
-
-    result = await auth_router.verify_otp(
-        auth_router.VerifyOtpRequest(email="fresh@example.com", token="123456"),
-        app,
-    )
-
-    assert result == {"temp_token": "temp-otp"}
-    assert service.verify_otp_calls == [("fresh@example.com", "123456")]
-
-
-@pytest.mark.asyncio
-async def test_complete_register_calls_auth_service_directly():
-    service = _FakeAuthService()
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
-
-    result = await auth_router.complete_register(
-        auth_router.CompleteRegisterRequest(temp_token="temp-otp", invite_code="invite-1"),
-        app,
-    )
-
-    assert result == {"token": "tok-register"}
-    assert service.complete_register_calls == [("temp-otp", "invite-1")]
-
-
-@pytest.mark.asyncio
-async def test_login_calls_auth_service_directly():
-    service = _FakeAuthService()
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
-
-    result = await auth_router.login(auth_router.LoginRequest(identifier="fresh@example.com", password="pass1234"), app)
-
-    assert result == {"token": "tok-login"}
-    assert service.login_calls == [("fresh@example.com", "pass1234")]
-
-
-@pytest.mark.asyncio
 async def test_login_maps_value_error_to_unauthorized():
     service = _FakeAuthService()
     service.login_error = ValueError("Invalid username or password")
@@ -127,38 +70,6 @@ async def test_login_maps_value_error_to_unauthorized():
 
     assert exc_info.value.status_code == 401
     assert "Invalid username or password" in str(exc_info.value.detail)
-
-
-@pytest.mark.asyncio
-async def test_call_auth_service_returns_service_result():
-    service = _FakeAuthService()
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
-
-    result = await auth_router._call_auth_service(
-        app,
-        400,
-        lambda service: service.verify_register_otp("fresh@example.com", "123456"),
-    )
-
-    assert result == {"temp_token": "temp-otp"}
-    assert service.verify_otp_calls == [("fresh@example.com", "123456")]
-
-
-@pytest.mark.asyncio
-async def test_call_auth_service_maps_value_error_to_given_status():
-    service = _FakeAuthService()
-    service.complete_register_error = ValueError("邀请码无效")
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
-
-    with pytest.raises(HTTPException) as exc_info:
-        await auth_router._call_auth_service(
-            app,
-            400,
-            lambda service: service.complete_register("temp-otp", "invite-1"),
-        )
-
-    assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == "邀请码无效"
 
 
 class _ChatEventBus:


### PR DESCRIPTION
## Summary
- delete repeated auth-router tests that only assert direct calls into a fake service
- delete private _call_auth_service helper tests now covered by endpoint-level HTTP error mapping
- shrink the fake auth service to the remaining send_otp/login router behavior checks

## Verification
- uv run python -m pytest tests/Integration/test_auth_router.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/test_auth_user_resolution.py -q
- uv run ruff check tests/Integration/test_auth_router.py
- uv run ruff format --check tests/Integration/test_auth_router.py
- git diff --check