### PR TITLE
test: prune spill buffer write fallback check

### DIFF
--- a/tests/Unit/core/test_spill_buffer.py
+++ b/tests/Unit/core/test_spill_buffer.py
@@ -131,29 +131,6 @@ class TestSpillIfNeeded:
             assert result is value
         fs.write_file.assert_not_called()
 
-    def test_write_failure_graceful_degradation(self):
-        """If write_file raises, a warning is included but no crash."""
-        fs = _make_fs_backend()
-        fs.write_file.side_effect = OSError("disk full")
-
-        large = "B" * 60_000
-        result = _spill(
-            large,
-            threshold_bytes=50_000,
-            tool_call_id="call_fail",
-            fs_backend=fs,
-            workspace_root="/workspace",
-        )
-
-        # Should still return a preview, not raise.
-        assert result.startswith("<persisted-output")
-        assert "Preview" in result
-        # Must include the warning note about write failure.
-        assert "Warning: failed to save full output to disk" in result
-        assert "disk full" in result
-        # Path should indicate write failure.
-        assert "<write failed>" in result
-
     def test_preview_length_capped(self):
         """Preview contains at most PREVIEW_BYTES characters of the original."""
         fs = _make_fs_backend()


### PR DESCRIPTION
## Summary
- delete the spill buffer mock filesystem write-failure graceful-degradation test
- keep passthrough, successful spill, preview cap, wrapper, binary handoff, skip-tool, and threshold behavior coverage

## Verification
- uv run python -m pytest tests/Unit/core/test_spill_buffer.py -q
- uv run ruff check tests/Unit/core/test_spill_buffer.py core/runtime/middleware/spill_buffer
- uv run ruff format --check tests/Unit/core/test_spill_buffer.py core/runtime/middleware/spill_buffer
- git diff --check