### PR TITLE
test: prune sync state shape guards

### DIFF
--- a/tests/Unit/sandbox/test_sync_state.py
+++ b/tests/Unit/sandbox/test_sync_state.py
@@ -1,26 +1,6 @@
 from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
 
 
-def test_process_local_sync_backing_exposes_only_batch_list_and_clear() -> None:
-    backing = ProcessLocalSyncFileBacking()
-
-    assert hasattr(backing, "track_files_batch")
-    assert hasattr(backing, "get_all_files")
-    assert hasattr(backing, "clear_thread")
-    assert not hasattr(backing, "track_file")
-    assert not hasattr(backing, "get_file_info")
-
-
-def test_sync_state_exposes_only_batch_list_and_clear_protocol() -> None:
-    state = SyncState(repo=ProcessLocalSyncFileBacking())
-
-    assert hasattr(state, "track_files_batch")
-    assert hasattr(state, "get_all_files")
-    assert hasattr(state, "clear_thread")
-    assert not hasattr(state, "track_file")
-    assert not hasattr(state, "get_file_info")
-
-
 def test_sync_state_defaults_to_process_local_backing() -> None:
     state = SyncState()
 


### PR DESCRIPTION
## Summary
- delete two low-value SyncState interface-shape tests that only used hasattr/not hasattr
- keep the default ProcessLocalSyncFileBacking behavior check

## Verification
- uv run python -m pytest tests/Unit/sandbox/test_sync_state.py -q
- uv run ruff check tests/Unit/sandbox/test_sync_state.py
- uv run ruff format --check tests/Unit/sandbox/test_sync_state.py
- git diff --check