### PR TITLE
test: prune sqlite lease docstring guard

### DIFF
--- a/tests/Unit/storage/test_sqlite_lease_repo.py
+++ b/tests/Unit/storage/test_sqlite_lease_repo.py
@@ -1,13 +1,6 @@
 from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
 
 
-def test_sqlite_lease_repo_docstring_names_lower_runtime_bridge() -> None:
-    doc = SQLiteLeaseRepo.__doc__ or ""
-
-    assert "Container-backed lower sandbox runtime bridge" in doc
-    assert "Sandbox lease CRUD" not in doc
-
-
 def test_sqlite_lease_repo_schema_does_not_create_removed_volume_id(tmp_path):
     repo = SQLiteLeaseRepo(tmp_path / "sandbox.db")
     try:


### PR DESCRIPTION
## Summary
- delete a low-value SQLiteLeaseRepo docstring wording guard
- keep the real SQLite schema test that opens the DB and verifies removed volume_id is not created

## Verification
- uv run python -m pytest tests/Unit/storage/test_sqlite_lease_repo.py -q
- uv run ruff check tests/Unit/storage/test_sqlite_lease_repo.py
- uv run ruff format --check tests/Unit/storage/test_sqlite_lease_repo.py
- git diff --check origin/dev..HEAD