### PR TITLE
test: prune source shape guards

### DIFF
--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -1,6 +1,5 @@
 import subprocess
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -110,34 +109,6 @@ class FakeSandboxMonitorRepo:
 
     def close(self):
         return None
-
-
-def test_monitor_service_no_longer_exposes_lease_bridge_shell() -> None:
-    assert not hasattr(monitor_service, "list_leases")
-    assert not hasattr(monitor_service, "get_monitor_lease_detail")
-    assert not hasattr(monitor_service, "request_monitor_lease_cleanup")
-    assert not hasattr(monitor_service, "_sandbox_cleanup_lease_id")
-
-
-def test_monitor_sandbox_read_surface_uses_sandbox_internal_names() -> None:
-    source = Path(monitor_service.__file__) if monitor_service.__file__ else None
-    assert source is not None
-    text = source.read_text(encoding="utf-8")
-
-    forbidden_tokens = [
-        "lease observation",
-        "LEASE_SEMANTIC_ORDER",
-        "LEASE_SEMANTIC_META",
-        "LEASE_TRIAGE_ORDER",
-        "LEASE_TRIAGE_META",
-        "_classify_lease_semantics",
-        "_classify_lease_triage",
-        "_lease_groups",
-        "Sandbox has no lease bridge",
-        "query_sandbox_cleanup_lease_id",
-    ]
-    for token in forbidden_tokens:
-        assert token not in text
 
 
 def _use_monitor_repo(monkeypatch, repo):

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -279,8 +279,6 @@ def test_query_sandbox_threads_no_longer_roundtrips_through_lease_thread_shell(m
         }
     )
 
-    assert not hasattr(repo, "query_lease_threads")
-
     assert repo.query_sandbox_threads("sandbox-1") == [
         {"thread_id": "thread-2"},
         {"thread_id": "thread-1"},
@@ -431,8 +429,6 @@ def test_query_sandbox_sessions_no_longer_reads_remote_session_shell(monkeypatch
             ],
         }
     )
-
-    assert not hasattr(repo, "query_lease_sessions")
 
     assert repo.query_sandbox_sessions("sandbox-1") == []
 
@@ -711,8 +707,6 @@ def test_query_sandbox_instance_ids_no_longer_roundtrips_through_lease_bridge() 
         }
     )
 
-    assert not hasattr(repo, "query_lease_instance_ids")
-
     assert repo.query_sandbox_instance_ids(["sandbox-1", "sandbox-2"]) == {
         "sandbox-1": "sandbox-instance-1",
         "sandbox-2": "sandbox-instance-2",
@@ -730,8 +724,6 @@ def test_query_sandbox_instance_id_no_longer_roundtrips_through_lease_bridge() -
             ],
         }
     )
-
-    assert not hasattr(repo, "query_lease_instance_id")
 
     assert repo.query_sandbox_instance_id("sandbox-1") == "sandbox-instance-1"
 
@@ -832,8 +824,6 @@ def test_list_probe_targets_no_longer_roundtrips_through_lease_instance_bridge()
             ],
         }
     )
-
-    assert not hasattr(repo, "query_lease_instance_ids")
 
     assert repo.list_probe_targets() == [
         {

--- a/tests/Unit/sandbox/test_sandbox_user_leases.py
+++ b/tests/Unit/sandbox/test_sandbox_user_leases.py
@@ -270,7 +270,6 @@ def test_user_runtime_rows_no_longer_roundtrips_through_lease_summary_shell(monk
     thread_repo, user_repo = _single_agent_repos("thread-a")
     monitor_repo = _FakeMonitorRepo(rows)
 
-    assert not hasattr(monitor_repo, "list_leases_with_threads")
     monkeypatch.setattr(sandbox_service, "make_sandbox_monitor_repo", lambda: monitor_repo)
 
     sandboxes = sandbox_service._list_user_runtime_rows(
@@ -341,7 +340,6 @@ def test_count_user_visible_sandboxes_by_provider_no_longer_roundtrips_through_l
     )
     monitor_repo = _FakeMonitorRepo(rows)
 
-    assert not hasattr(monitor_repo, "list_leases_with_threads")
     monkeypatch.setattr(sandbox_service, "make_sandbox_monitor_repo", lambda **kwargs: monitor_repo)
 
     counts = sandbox_service.count_user_visible_sandboxes_by_provider(

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -1,8 +1,5 @@
-import inspect
-
 import pytest
 
-import storage.providers.supabase.lease_repo as lease_repo_module
 from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
@@ -16,23 +13,6 @@ class _RejectBareSandboxLeasesClient(FakeSupabaseClient):
 
 def _client(tables: dict[str, list[dict]] | None = None) -> _RejectBareSandboxLeasesClient:
     return _RejectBareSandboxLeasesClient(tables={} if tables is None else tables)
-
-
-def test_supabase_lease_repo_names_container_bridge_without_adapter_label():
-    source = inspect.getsource(SupabaseLeaseRepo)
-    stale_adapter_label = "Lease-" + "compatible adapter"
-
-    assert stale_adapter_label not in source
-    assert "Container-backed LeaseRepo bridge" in source
-
-
-def test_supabase_lease_repo_internal_bridge_state_not_named_as_compat_helper():
-    source = inspect.getsource(lease_repo_module)
-    stale_helper = "def _" + "compat("
-    stale_local_name = "compat " + "="
-
-    assert stale_helper not in source
-    assert stale_local_name not in source
 
 
 def _sandbox_row(


### PR DESCRIPTION
## Summary
- delete two pure inspect.getsource wording guards from SupabaseLeaseRepo tests
- remove low-value old query_lease* / list_leases_with_threads attribute-shape assertions while keeping behavior assertions
- delete monitor detail pure absence/source-token guard tests

## Scope
- tests/Unit/storage/test_supabase_lease_repo.py
- tests/Unit/monitor/test_monitor_sandbox_repo.py
- tests/Unit/sandbox/test_sandbox_user_leases.py
- tests/Unit/monitor/test_monitor_detail_contracts.py
- no production code, storage contract, lower LeaseRepo/SandboxLease internals, provider-event matched_lease_id, schema/API/live DB change

## Proof
- uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/monitor/test_monitor_detail_contracts.py -q
- uv run ruff check tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/monitor/test_monitor_detail_contracts.py
- uv run ruff format --check tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/sandbox/test_sandbox_user_leases.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check