### PR TITLE
test: prune legacy lease poison fakes

### DIFF
--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -26,12 +26,6 @@ class _FakeMonitorRepo:
         self._runtime_session_ids = runtime_session_ids
         self.batch_calls: list[list[str]] = []
 
-    def query_lease_instance_id(self, lease_id: str) -> str | None:
-        raise AssertionError(f"unexpected per-lease runtime-session probe: {lease_id}")
-
-    def query_lease_instance_ids(self, lease_ids: list[str]) -> dict[str, str | None]:
-        raise AssertionError(f"unexpected lease batch runtime-session probe: {lease_ids}")
-
     def query_sandbox_instance_ids(self, sandbox_ids: list[str]) -> dict[str, str | None]:
         self.batch_calls.append(list(sandbox_ids))
         return {sandbox_id: self._runtime_session_ids.get(sandbox_id) for sandbox_id in sandbox_ids}

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -449,14 +449,10 @@ def test_list_resource_providers_uses_canonical_sandbox_visible_parent_projectio
         },
     ]
 
-    class _SandboxThreadOnlyRepo(_FakeRepo):
-        def query_lease_threads(self, lease_id: str):
-            raise AssertionError(f"unexpected lease-shaped visible-parent projection: {lease_id}")
-
     monkeypatch.setattr(
         resource_projection_service,
         "make_sandbox_monitor_repo",
-        lambda: _SandboxThreadOnlyRepo(rows, sandbox_threads={"sandbox-1": ["subagent-deadbeef", "thread-parent"]}),
+        lambda: _FakeRepo(rows, sandbox_threads={"sandbox-1": ["subagent-deadbeef", "thread-parent"]}),
     )
     monkeypatch.setattr(
         resource_projection_service,
@@ -509,14 +505,10 @@ def test_list_resource_providers_no_longer_uses_lease_shaped_visible_parent_proj
         },
     ]
 
-    class _NoLeaseFallbackRepo(_FakeRepo):
-        def query_lease_threads(self, lease_id: str):
-            raise AssertionError(f"lease-shaped visible-parent projection should be gone: {lease_id}")
-
     monkeypatch.setattr(
         resource_projection_service,
         "make_sandbox_monitor_repo",
-        lambda: _NoLeaseFallbackRepo(rows),
+        lambda: _FakeRepo(rows),
     )
     monkeypatch.setattr(
         resource_projection_service,
@@ -683,12 +675,6 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_leases(mon
             super().__init__(rows, instance_ids={"sandbox-a": "runtime-a", "sandbox-b": "runtime-b"})
             self.batch_calls: list[list[str]] = []
 
-        def query_lease_instance_id(self, lease_id: str):
-            raise AssertionError(f"unexpected per-lease lookup: {lease_id}")
-
-        def query_lease_instance_ids(self, lease_ids: list[str]):
-            raise AssertionError(f"unexpected lease batch lookup: {lease_ids}")
-
         def query_sandbox_instance_ids(self, sandbox_ids: list[str]):
             self.batch_calls.append(list(sandbox_ids))
             return super().query_sandbox_instance_ids(sandbox_ids)
@@ -721,14 +707,11 @@ def test_visible_resource_session_stats_uses_sandbox_keyed_runtime_lookup(monkey
         },
     ]
 
-    class _BatchOnlyRepo(_FakeRepo):
-        def __init__(self):
-            super().__init__(rows, instance_ids={"sandbox-a": "runtime-a"})
-
-        def query_lease_instance_ids(self, lease_ids: list[str]):
-            raise AssertionError(f"unexpected lease batch lookup: {lease_ids}")
-
-    monkeypatch.setattr(resource_projection_service, "make_sandbox_monitor_repo", lambda: _BatchOnlyRepo())
+    monkeypatch.setattr(
+        resource_projection_service,
+        "make_sandbox_monitor_repo",
+        lambda: _FakeRepo(rows, instance_ids={"sandbox-a": "runtime-a"}),
+    )
     monkeypatch.setattr(resource_projection_service, "list_resource_snapshots_by_sandbox", lambda _sessions: {})
 
     stats = resource_projection_service.visible_resource_session_stats()

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -60,12 +60,6 @@ class _CanonicalOnlyResourceRepo:
     def query_sandbox_instance_id(self, sandbox_id: str):
         return self._instance_ids.get(sandbox_id)
 
-    def query_lease(self, _lease_id: str):
-        raise AssertionError("resource runtime-target helper should not use query_lease as single source")
-
-    def query_lease_instance_id(self, _lease_id: str):
-        raise AssertionError("resource runtime-target helper should not use query_lease_instance_id as single source")
-
     def close(self):
         return None
 


### PR DESCRIPTION
## Summary
- remove legacy query_lease/query_lease_instance poison methods from monitor/resource fake repos
- keep sandbox-keyed runtime lookup, visible-parent projection, probe, and stats behavior assertions
- no production code, frontend monitor, schema/API/live DB, lower LeaseRepo/SandboxLease, or provider-event matched_lease_id change

## Proof
- uv run python -m pytest tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py -q
- uv run ruff check tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
- uv run ruff format --check tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
- git diff --check