### PR TITLE
Read marketplace from hub schema

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -69,6 +69,7 @@ async def lifespan(app: FastAPI):
     app.state.user_settings_repo = storage_container.user_settings_repo()
     app.state.agent_config_repo = storage_container.agent_config_repo()
     app.state.contact_repo = storage_container.contact_repo()
+    app.state.marketplace_hub_repo = storage_container.marketplace_hub_repo()
     app.state._supabase_client = _supabase_client
     app.state._public_supabase_client = _public_supabase_client
     app.state._supabase_auth_client_factory = create_supabase_auth_client

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -13,6 +13,7 @@ from backend.web.models.marketplace import (
     UpgradeFromMarketplaceRequest,
 )
 from backend.web.services import marketplace_client
+from storage.contracts import MarketplaceHubNotFoundError, MarketplaceHubUnsupportedSortError
 
 router = APIRouter(prefix="/api/marketplace", tags=["marketplace"])
 
@@ -31,16 +32,26 @@ async def _verify_user_ownership(agent_user_id: str, user_id: str, user_repo: An
     await asyncio.to_thread(_check)
 
 
+async def _read_marketplace_hub(callable_: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    try:
+        return await asyncio.to_thread(callable_, *args, **kwargs)
+    except MarketplaceHubNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=exc.args[0]) from exc
+    except MarketplaceHubUnsupportedSortError as exc:
+        raise HTTPException(status_code=400, detail=exc.args[0]) from exc
+
+
 @router.get("/items")
 async def list_marketplace_items(
+    request: Request,
     type: str | None = None,
     q: str | None = None,
     sort: str = "downloads",
     page: int = 1,
     page_size: int = 20,
 ) -> dict[str, Any]:
-    return await asyncio.to_thread(
-        marketplace_client.list_items,
+    return await _read_marketplace_hub(
+        request.app.state.marketplace_hub_repo.list_items,
         type=type,
         q=q,
         sort=sort,
@@ -50,18 +61,18 @@ async def list_marketplace_items(
 
 
 @router.get("/items/{item_id}")
-async def get_marketplace_item_detail(item_id: str) -> dict[str, Any]:
-    return await asyncio.to_thread(marketplace_client.get_item_detail, item_id)
+async def get_marketplace_item_detail(item_id: str, request: Request) -> dict[str, Any]:
+    return await _read_marketplace_hub(request.app.state.marketplace_hub_repo.get_item_detail, item_id)
 
 
 @router.get("/items/{item_id}/lineage")
-async def get_marketplace_item_lineage(item_id: str) -> dict[str, Any]:
-    return await asyncio.to_thread(marketplace_client.get_item_lineage, item_id)
+async def get_marketplace_item_lineage(item_id: str, request: Request) -> dict[str, Any]:
+    return await _read_marketplace_hub(request.app.state.marketplace_hub_repo.get_item_lineage, item_id)
 
 
 @router.get("/items/{item_id}/versions/{version}")
-async def get_marketplace_item_version_snapshot(item_id: str, version: str) -> dict[str, Any]:
-    return await asyncio.to_thread(marketplace_client.get_item_version_snapshot, item_id, version)
+async def get_marketplace_item_version_snapshot(item_id: str, version: str, request: Request) -> dict[str, Any]:
+    return await _read_marketplace_hub(request.app.state.marketplace_hub_repo.get_item_version_snapshot, item_id, version)
 
 
 @router.post("/publish-agent-user")

--- a/frontend/app/src/components/marketplace/InstallDialog.wording.test.tsx
+++ b/frontend/app/src/components/marketplace/InstallDialog.wording.test.tsx
@@ -52,7 +52,6 @@ describe("InstallDialog wording contract", () => {
           parent_id: null,
           download_count: 0,
           visibility: "public",
-          featured: false,
           tags: [],
           created_at: "2026-04-08T00:00:00Z",
           updated_at: "2026-04-08T00:00:00Z",

--- a/frontend/app/src/components/marketplace/MarketplaceCard.tsx
+++ b/frontend/app/src/components/marketplace/MarketplaceCard.tsx
@@ -1,4 +1,4 @@
-import { Download, GitFork, Star } from "lucide-react";
+import { Download, GitFork } from "lucide-react";
 import type { MarketplaceItemSummary } from "@/store/marketplace-store";
 import { typeBadgeColors } from "./constants";
 import { marketplaceTypeLabel } from "@/lib/marketplace-types";
@@ -23,9 +23,6 @@ export default function MarketplaceCard({ item, onClick, installed, hasUpdate }:
         <span className={`text-2xs px-1.5 py-0.5 rounded-full font-medium shrink-0 ${typeBadgeColors[item.type] || "bg-muted text-muted-foreground"}`}>
           {marketplaceTypeLabel(item.type)}
         </span>
-        {item.featured && (
-          <Star className="w-3 h-3 text-warning fill-warning shrink-0" />
-        )}
       </div>
       <p className="text-xs text-muted-foreground line-clamp-2">
         {item.description || "No description"}

--- a/frontend/app/src/components/marketplace/MarketplaceCard.wording.test.tsx
+++ b/frontend/app/src/components/marketplace/MarketplaceCard.wording.test.tsx
@@ -23,7 +23,6 @@ describe("MarketplaceCard wording contract", () => {
           parent_id: null,
           download_count: 0,
           visibility: "public",
-          featured: false,
           tags: [],
           created_at: "2026-04-13T00:00:00Z",
           updated_at: "2026-04-13T00:00:00Z",

--- a/frontend/app/src/pages/MarketplaceDetailPage.test.tsx
+++ b/frontend/app/src/pages/MarketplaceDetailPage.test.tsx
@@ -39,7 +39,6 @@ const marketplaceState = {
     parent_id: null,
     download_count: 0,
     visibility: "public",
-    featured: false,
     tags: [],
     created_at: "2026-04-01T00:00:00Z",
     updated_at: "2026-04-01T00:00:00Z",

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Box, Search, Store, Package, TrendingUp, Clock, Star, RefreshCw, Zap, Users, Trash2, Plus, X } from "lucide-react";
+import { Box, Search, Store, Package, TrendingUp, Clock, RefreshCw, Zap, Users, Trash2, Plus, X } from "lucide-react";
 import { useMarketplaceStore } from "@/store/marketplace-store";
 import { useAppStore } from "@/store/app-store";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -38,7 +38,6 @@ const typeFilters: { id: TypeFilter; label: string }[] = [
 const sortOptions = [
   { id: "downloads", label: "Popular", icon: TrendingUp },
   { id: "newest", label: "Newest", icon: Clock },
-  { id: "featured", label: "Featured", icon: Star },
 ];
 
 export default function MarketplacePage() {

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -15,7 +15,6 @@ export interface MarketplaceItemSummary {
   parent_id: string | null;
   download_count: number;
   visibility: string;
-  featured: boolean;
   tags: string[];
   created_at: string;
   updated_at: string;

--- a/storage/container.py
+++ b/storage/container.py
@@ -15,6 +15,7 @@ from .contracts import (
     FileOperationRepo,
     InviteCodeRepo,
     LeaseRepo,
+    MarketplaceHubRepo,
     ProviderEventRepo,
     QueueRepo,
     RecipeRepo,
@@ -52,6 +53,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "user_settings_repo": ("storage.providers.supabase.user_settings_repo", "SupabaseUserSettingsRepo"),
     "agent_config_repo": ("storage.providers.supabase.agent_config_repo", "SupabaseAgentConfigRepo"),
     "contact_repo": ("storage.providers.supabase.contact_repo", "SupabaseContactRepo"),
+    "marketplace_hub_repo": ("storage.providers.supabase.marketplace_hub_repo", "SupabaseMarketplaceHubRepo"),
 }
 
 
@@ -134,6 +136,9 @@ class StorageContainer:
 
     def contact_repo(self) -> ContactRepo:
         return self._build("contact_repo")
+
+    def marketplace_hub_repo(self) -> MarketplaceHubRepo:
+        return self._build("marketplace_hub_repo")
 
     def purge_thread(self, thread_id: str) -> None:
         """Delete all data for a thread across all repos."""

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -89,6 +89,32 @@ class ProviderEventRepo(Protocol):
     def list_recent(self, limit: int = 100) -> list[dict[str, Any]]: ...
 
 
+class MarketplaceHubNotFoundError(KeyError):
+    """Marketplace Hub row was explicitly absent."""
+
+
+class MarketplaceHubUnsupportedSortError(ValueError):
+    """Marketplace Hub sort is not part of the current schema contract."""
+
+
+class MarketplaceHubRepo(Protocol):
+    """Read model for local Hub marketplace explore/detail surfaces."""
+
+    def close(self) -> None: ...
+    def list_items(
+        self,
+        *,
+        type: str | None = None,
+        q: str | None = None,
+        sort: str = "downloads",
+        page: int = 1,
+        page_size: int = 20,
+    ) -> dict[str, Any]: ...
+    def get_item_detail(self, item_id: str) -> dict[str, Any]: ...
+    def get_item_lineage(self, item_id: str) -> dict[str, Any]: ...
+    def get_item_version_snapshot(self, item_id: str, version: str) -> dict[str, Any]: ...
+
+
 class ChatSessionRepo(Protocol):
     """Chat session + terminal command persistence."""
 

--- a/storage/providers/supabase/marketplace_hub_repo.py
+++ b/storage/providers/supabase/marketplace_hub_repo.py
@@ -1,0 +1,175 @@
+"""Supabase read model for local Hub marketplace surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from storage.contracts import MarketplaceHubNotFoundError, MarketplaceHubUnsupportedSortError
+from storage.providers.supabase import _query as sq
+
+_REPO = "marketplace hub repo"
+_SCHEMA = "hub"
+
+
+class SupabaseMarketplaceHubRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = sq.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def list_items(
+        self,
+        *,
+        type: str | None = None,
+        q: str | None = None,
+        sort: str = "downloads",
+        page: int = 1,
+        page_size: int = 20,
+    ) -> dict[str, Any]:
+        rows = self._published_items()
+        if type:
+            rows = [row for row in rows if row.get("type") == type]
+        if q:
+            needle = q.strip().lower()
+            rows = [row for row in rows if needle in _search_text(row)]
+
+        rows = _sort_items(rows, sort)
+        total = len(rows)
+        start = max(page - 1, 0) * page_size
+        end = start + page_size
+        publishers = self._publishers_for(rows[start:end])
+        return {
+            "items": [self._summary(row, publishers) for row in rows[start:end]],
+            "total": total,
+        }
+
+    def get_item_detail(self, item_id: str) -> dict[str, Any]:
+        row = self._item(item_id)
+        publishers = self._publishers_for([row])
+        versions = self._versions(item_id)
+        return {
+            **self._summary(row, publishers),
+            "versions": [
+                {
+                    "id": str(version["id"]),
+                    "version": str(version["version"]),
+                    "release_notes": version.get("changelog"),
+                    "created_at": str(version["created_at"]),
+                }
+                for version in versions
+            ],
+            "parent": None,
+        }
+
+    def get_item_lineage(self, item_id: str) -> dict[str, Any]:
+        self._item(item_id)
+        return {"ancestors": [], "children": []}
+
+    def get_item_version_snapshot(self, item_id: str, version: str) -> dict[str, Any]:
+        rows = sq.rows(
+            self._table("marketplace_versions")
+            .select("id, item_id, version, content, changelog, status, created_at")
+            .eq("item_id", item_id)
+            .eq("version", version)
+            .eq("status", "active")
+            .execute(),
+            _REPO,
+            "get_item_version_snapshot",
+        )
+        if not rows:
+            raise MarketplaceHubNotFoundError(f"Marketplace item version not found: {item_id}@{version}")
+        return {"snapshot": rows[0]["content"]}
+
+    def _published_items(self) -> list[dict[str, Any]]:
+        rows = sq.rows(
+            self._table("marketplace_items")
+            .select(
+                "id, publisher_id, slug, type, name, description, tags, is_public, status, "
+                "latest_version, install_count, created_at, updated_at"
+            )
+            .eq("status", "published")
+            .eq("is_public", True)
+            .execute(),
+            _REPO,
+            "list_items",
+        )
+        return [dict(row) for row in rows]
+
+    def _item(self, item_id: str) -> dict[str, Any]:
+        rows = sq.rows(
+            self._table("marketplace_items")
+            .select(
+                "id, publisher_id, slug, type, name, description, tags, is_public, status, "
+                "latest_version, install_count, created_at, updated_at"
+            )
+            .eq("id", item_id)
+            .eq("status", "published")
+            .eq("is_public", True)
+            .execute(),
+            _REPO,
+            "get_item",
+        )
+        if not rows:
+            raise MarketplaceHubNotFoundError(f"Marketplace item not found: {item_id}")
+        return dict(rows[0])
+
+    def _versions(self, item_id: str) -> list[dict[str, Any]]:
+        query = (
+            self._table("marketplace_versions")
+            .select("id, item_id, version, content, changelog, status, created_at")
+            .eq("item_id", item_id)
+            .eq("status", "active")
+        )
+        rows = sq.rows(sq.order(query, "created_at", desc=True, repo=_REPO, operation="list_versions").execute(), _REPO, "list_versions")
+        return [dict(row) for row in rows]
+
+    def _publishers_for(self, rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        publisher_ids = sorted({str(row["publisher_id"]) for row in rows})
+        if not publisher_ids:
+            return {}
+        result = sq.rows_in_chunks(
+            lambda: self._table("marketplace_publishers").select("id, user_id, display_name, avatar_url, created_at"),
+            "id",
+            publisher_ids,
+            _REPO,
+            "publishers_for_items",
+        )
+        return {str(row["id"]): dict(row) for row in result}
+
+    def _summary(self, row: dict[str, Any], publishers: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        publisher = publishers.get(str(row["publisher_id"]))
+        if publisher is None:
+            raise RuntimeError(f"Marketplace item {row['id']} references missing publisher {row['publisher_id']}")
+        return {
+            "id": str(row["id"]),
+            "slug": str(row["slug"]),
+            "type": str(row["type"]),
+            "name": str(row["name"]),
+            "description": row.get("description"),
+            "avatar_url": publisher.get("avatar_url"),
+            "publisher_user_id": str(publisher["user_id"]),
+            "publisher_username": str(publisher["display_name"]),
+            "parent_id": row.get("parent_id"),
+            "download_count": int(row.get("install_count") or 0),
+            "visibility": "public" if row.get("is_public") else "unlisted",
+            "tags": list(row.get("tags") or []),
+            "created_at": str(row["created_at"]),
+            "updated_at": str(row["updated_at"]),
+        }
+
+    def _table(self, table: str) -> Any:
+        return sq.schema_table(self._client, _SCHEMA, table, _REPO)
+
+
+def _search_text(row: dict[str, Any]) -> str:
+    values = [row.get("name"), row.get("slug"), row.get("description"), " ".join(row.get("tags") or [])]
+    return " ".join(str(value).lower() for value in values if value)
+
+
+def _sort_items(rows: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
+    if sort == "newest":
+        return sorted(rows, key=lambda row: str(row.get("created_at") or ""), reverse=True)
+    if sort == "downloads":
+        return sorted(rows, key=lambda row: int(row.get("install_count") or 0), reverse=True)
+    raise MarketplaceHubUnsupportedSortError(f"Marketplace Hub sort is not supported by hub schema: {sort}")

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -139,6 +139,15 @@ def build_provider_event_repo(*, supabase_client: Any | None = None, supabase_cl
     return _build_storage_repo("provider_event_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
+def build_marketplace_hub_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo(
+        "marketplace_hub_repo",
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+        default_supabase_client_factory=_WEB_SUPABASE_CLIENT_FACTORY,
+    )
+
+
 def build_checkpoint_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
     return _build_storage_repo("checkpoint_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 

--- a/tests/Integration/test_marketplace_router_user_shell.py
+++ b/tests/Integration/test_marketplace_router_user_shell.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 
 from backend.web.models.marketplace import PublishAgentUserToMarketplaceRequest, UpgradeFromMarketplaceRequest
 from backend.web.routers import marketplace as marketplace_router
+from storage.contracts import MarketplaceHubNotFoundError, MarketplaceHubUnsupportedSortError
 
 
 def test_marketplace_router_exposes_agent_user_marketplace_routes() -> None:
@@ -116,62 +117,111 @@ async def test_download_from_marketplace_uses_user_and_agent_config_repos(monkey
 
 
 @pytest.mark.asyncio
-async def test_list_marketplace_items_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_list_marketplace_items_reads_local_hub_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
 
     monkeypatch.setattr(
         marketplace_router.marketplace_client,
         "list_items",
-        lambda **kwargs: seen.update(kwargs) or {"items": [{"id": "item-1"}], "total": 1},
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("marketplace read path must not require external Hub HTTP")),
         raising=False,
     )
+    hub_repo = SimpleNamespace(
+        list_items=lambda **kwargs: seen.update(kwargs) or {"items": [{"id": "item-1"}], "total": 1},
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(marketplace_hub_repo=hub_repo)))
 
-    result = await marketplace_router.list_marketplace_items(type="skill", q="search", sort="newest", page=2, page_size=10)
+    result = await marketplace_router.list_marketplace_items(
+        request=request,
+        type="skill",
+        q="search",
+        sort="newest",
+        page=2,
+        page_size=10,
+    )
 
     assert result == {"items": [{"id": "item-1"}], "total": 1}
     assert seen == {"type": "skill", "q": "search", "sort": "newest", "page": 2, "page_size": 10}
 
 
 @pytest.mark.asyncio
-async def test_get_marketplace_item_detail_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_marketplace_item_detail_reads_local_hub_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         marketplace_router.marketplace_client,
         "get_item_detail",
-        lambda item_id: {"id": item_id, "name": "Repo Item"},
+        lambda _item_id: (_ for _ in ()).throw(AssertionError("marketplace read path must not require external Hub HTTP")),
         raising=False,
     )
+    hub_repo = SimpleNamespace(get_item_detail=lambda item_id: {"id": item_id, "name": "Repo Item"})
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(marketplace_hub_repo=hub_repo)))
 
-    result = await marketplace_router.get_marketplace_item_detail("item-1")
+    result = await marketplace_router.get_marketplace_item_detail("item-1", request=request)
 
     assert result == {"id": "item-1", "name": "Repo Item"}
 
 
 @pytest.mark.asyncio
-async def test_get_marketplace_item_lineage_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_marketplace_item_lineage_reads_local_hub_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         marketplace_router.marketplace_client,
         "get_item_lineage",
-        lambda item_id: {"ancestors": [], "children": [{"id": item_id}]},
+        lambda _item_id: (_ for _ in ()).throw(AssertionError("marketplace read path must not require external Hub HTTP")),
         raising=False,
     )
+    hub_repo = SimpleNamespace(get_item_lineage=lambda item_id: {"ancestors": [], "children": [{"id": item_id}]})
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(marketplace_hub_repo=hub_repo)))
 
-    result = await marketplace_router.get_marketplace_item_lineage("item-1")
+    result = await marketplace_router.get_marketplace_item_lineage("item-1", request=request)
 
     assert result == {"ancestors": [], "children": [{"id": "item-1"}]}
 
 
 @pytest.mark.asyncio
-async def test_get_marketplace_item_version_snapshot_forwards_into_marketplace_client(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_marketplace_item_version_snapshot_reads_local_hub_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         marketplace_router.marketplace_client,
         "get_item_version_snapshot",
-        lambda item_id, version: {"snapshot": {"meta": {"id": item_id, "version": version}}},
+        lambda _item_id, _version: (_ for _ in ()).throw(AssertionError("marketplace read path must not require external Hub HTTP")),
         raising=False,
     )
+    hub_repo = SimpleNamespace(
+        get_item_version_snapshot=lambda item_id, version: {"snapshot": {"meta": {"id": item_id, "version": version}}},
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(marketplace_hub_repo=hub_repo)))
 
-    result = await marketplace_router.get_marketplace_item_version_snapshot("item-1", "1.2.3")
+    result = await marketplace_router.get_marketplace_item_version_snapshot("item-1", "1.2.3", request=request)
 
     assert result == {"snapshot": {"meta": {"id": "item-1", "version": "1.2.3"}}}
+
+
+@pytest.mark.asyncio
+async def test_get_marketplace_item_detail_maps_missing_hub_row_to_404() -> None:
+    hub_repo = SimpleNamespace(
+        get_item_detail=lambda _item_id: (_ for _ in ()).throw(MarketplaceHubNotFoundError("Marketplace item not found: missing-item")),
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(marketplace_hub_repo=hub_repo)))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await marketplace_router.get_marketplace_item_detail("missing-item", request=request)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Marketplace item not found: missing-item"
+
+
+@pytest.mark.asyncio
+async def test_list_marketplace_items_maps_unsupported_hub_sort_to_400() -> None:
+    hub_repo = SimpleNamespace(
+        list_items=lambda **_kwargs: (_ for _ in ()).throw(
+            MarketplaceHubUnsupportedSortError("Marketplace Hub sort is not supported by hub schema: featured")
+        ),
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(marketplace_hub_repo=hub_repo)))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await marketplace_router.list_marketplace_items(request=request, sort="featured")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Marketplace Hub sort is not supported by hub schema: featured"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/storage/test_supabase_marketplace_hub_repo.py
+++ b/tests/Unit/storage/test_supabase_marketplace_hub_repo.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from storage.contracts import MarketplaceHubNotFoundError, MarketplaceHubUnsupportedSortError
+from storage.providers.supabase.marketplace_hub_repo import SupabaseMarketplaceHubRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def _repo() -> SupabaseMarketplaceHubRepo:
+    return SupabaseMarketplaceHubRepo(
+        FakeSupabaseClient(
+            tables={
+                "hub.marketplace_publishers": [
+                    {
+                        "id": "publisher-1",
+                        "user_id": "system",
+                        "display_name": "Mycel Official",
+                        "avatar_url": None,
+                        "created_at": "2026-03-31T05:07:12+00:00",
+                    }
+                ],
+                "hub.marketplace_items": [
+                    {
+                        "id": "item-1",
+                        "publisher_id": "publisher-1",
+                        "slug": "architecture-patterns",
+                        "type": "skill",
+                        "name": "architecture-patterns",
+                        "description": "Architecture patterns",
+                        "tags": ["backend"],
+                        "is_public": True,
+                        "status": "published",
+                        "latest_version": "1.0.0",
+                        "install_count": 4,
+                        "created_at": "2026-03-31T05:13:49+00:00",
+                        "updated_at": "2026-03-31T05:13:49+00:00",
+                    },
+                    {
+                        "id": "item-hidden",
+                        "publisher_id": "publisher-1",
+                        "slug": "hidden",
+                        "type": "skill",
+                        "name": "hidden",
+                        "description": "Hidden draft",
+                        "tags": [],
+                        "is_public": True,
+                        "status": "draft",
+                        "latest_version": "1.0.0",
+                        "install_count": 99,
+                        "created_at": "2026-03-31T05:13:50+00:00",
+                        "updated_at": "2026-03-31T05:13:50+00:00",
+                    },
+                ],
+                "hub.marketplace_versions": [
+                    {
+                        "id": "version-1",
+                        "item_id": "item-1",
+                        "version": "1.0.0",
+                        "changelog": "Initial release",
+                        "content": {"content": "# Architecture Patterns", "meta": {"name": "architecture-patterns"}},
+                        "status": "active",
+                        "created_at": "2026-03-31T05:13:50+00:00",
+                    }
+                ],
+            }
+        )
+    )
+
+
+def test_list_items_projects_published_hub_rows_to_marketplace_payload() -> None:
+    payload = _repo().list_items(type="skill", q="architecture", sort="downloads", page=1, page_size=20)
+
+    assert payload == {
+        "items": [
+            {
+                "id": "item-1",
+                "slug": "architecture-patterns",
+                "type": "skill",
+                "name": "architecture-patterns",
+                "description": "Architecture patterns",
+                "avatar_url": None,
+                "publisher_user_id": "system",
+                "publisher_username": "Mycel Official",
+                "parent_id": None,
+                "download_count": 4,
+                "visibility": "public",
+                "tags": ["backend"],
+                "created_at": "2026-03-31T05:13:49+00:00",
+                "updated_at": "2026-03-31T05:13:49+00:00",
+            }
+        ],
+        "total": 1,
+    }
+
+
+def test_item_detail_includes_versions_and_snapshot() -> None:
+    repo = _repo()
+
+    detail = repo.get_item_detail("item-1")
+    snapshot = repo.get_item_version_snapshot("item-1", "1.0.0")
+
+    assert detail["versions"] == [
+        {
+            "id": "version-1",
+            "version": "1.0.0",
+            "release_notes": "Initial release",
+            "created_at": "2026-03-31T05:13:50+00:00",
+        }
+    ]
+    assert detail["parent"] is None
+    assert snapshot == {"snapshot": {"content": "# Architecture Patterns", "meta": {"name": "architecture-patterns"}}}
+
+
+def test_missing_item_fails_loudly() -> None:
+    with pytest.raises(MarketplaceHubNotFoundError, match="Marketplace item not found: missing"):
+        _repo().get_item_detail("missing")
+
+
+def test_unsupported_featured_sort_fails_loudly() -> None:
+    with pytest.raises(MarketplaceHubUnsupportedSortError, match="sort is not supported"):
+        _repo().list_items(sort="featured")


### PR DESCRIPTION
## Summary
- route marketplace explore/detail/version/lineage reads through the local Supabase hub read repo instead of the external Hub HTTP client
- add storage contract/container/runtime/lifespan wiring for `MarketplaceHubRepo` over `hub.marketplace_publishers/items/versions`
- remove the unsupported Featured marketplace contract from the app UI/types and fail clearly for `sort=featured`

## Scope
- Restores marketplace explore/detail/version read path.
- Does not move publish/download/upgrade/check-updates off the existing external Hub adapter; that remains the next marketplace lane.
- Ops hub schema/seed/expose changes were applied out-of-repo under `~/share/ops`, not committed here.

## Verification
- `uv run python -m pytest tests/Unit/storage/test_supabase_marketplace_hub_repo.py tests/Integration/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_client.py -q` -> 34 passed
- `uv run ruff check ...` -> all checks passed
- `uv run ruff format --check ...` -> 8 files already formatted
- `npm --prefix frontend/app run typecheck` -> passed
- `npm --prefix frontend/app run test -- --run src/pages/MarketplacePage.wording.test.tsx src/components/marketplace/MarketplaceCard.wording.test.tsx src/components/marketplace/InstallDialog.wording.test.tsx src/pages/MarketplaceDetailPage.test.tsx` -> 4 files / 20 tests passed
- `git diff --check` -> clean
- Backend YATU on 127.0.0.1:8017: `/api/marketplace/items?sort=downloads&page=1&page_size=1` -> 200 / total 853; `sort=featured` -> 400
- Frontend Playwright CLI YATU on 127.0.0.1:5189: real login, `/marketplace` shows `architecture-patterns`, no `Marketplace Hub unavailable`, no `Featured`, network `/api/marketplace/items?...` -> 200
