### PR TITLE
fix: create supabase lease bridge as detached

### DIFF
--- a/storage/providers/supabase/lease_repo.py
+++ b/storage/providers/supabase/lease_repo.py
@@ -169,7 +169,7 @@ class SupabaseLeaseRepo:
                 "provider_env_id": None,
                 "sandbox_template_id": recipe_id,
                 "desired_state": "running",
-                "observed_state": "running",
+                "observed_state": "detached",
                 "status": "ready",
                 "observed_at": now,
                 "last_error": None,

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -122,8 +122,11 @@ def test_supabase_lease_repo_create_writes_container_sandbox_bridge():
     assert row["owner_user_id"] == "owner-1"
     assert row["provider_name"] == "local"
     assert row["sandbox_template_id"] == "local:default"
-    assert row["observed_state"] == "running"
+    assert row["provider_env_id"] is None
+    assert row["observed_state"] == "detached"
     assert row["status"] == "ready"
+    assert created["current_instance_id"] is None
+    assert created["_instance"] is None
     assert row["config"]["legacy_lease_id"] == "lease-1"
     assert row["config"]["lease_compat"]["recipe_json"] == '{"id":"local:default"}'
     assert row["config"]["lease_compat"]["needs_refresh"] == 0


### PR DESCRIPTION
Fixes one lower-runtime truth mismatch in the Supabase LeaseRepo bridge.\n\nScope:\n- storage/providers/supabase/lease_repo.py\n- tests/Unit/storage/test_supabase_lease_repo.py\n\nBehavior:\n- SupabaseLeaseRepo.create keeps desired_state=running but now writes observed_state=detached while provider_env_id is null.\n- adopt_instance remains the boundary that records provider_env_id and flips observed runtime state to running/paused.\n- No storage contract rename, no SandboxLease/manager changes, no provider-event/schema/live DB/marketplace changes.\n\nProof:\n- RED: tests/Unit/storage/test_supabase_lease_repo.py::test_supabase_lease_repo_create_writes_container_sandbox_bridge failed because observed_state was running.\n- GREEN: uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py::test_supabase_lease_repo_create_writes_container_sandbox_bridge -q\n- GREEN: uv run python -m pytest tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py -q\n- GREEN: uv run ruff check storage/providers/supabase/lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py\n- GREEN: uv run ruff format --check storage/providers/supabase/lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py\n- GREEN: git diff --check