### PR TITLE
Refactor provider event lower runtime match

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -31,8 +31,8 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
     try:
         lease_row = await asyncio.to_thread(lease_repo.find_by_instance, provider_name=provider_name, instance_id=instance_id)
         lease = lease_from_row(lease_row, resolve_sandbox_db_path()) if lease_row else None
-        matched_lease_id = lease.lease_id if lease else None
         matched_sandbox_id = str((lease_row or {}).get("sandbox_id") or "").strip() or None
+        lower_runtime_handle = lease.lease_id if lease else None
 
         # @@@webhook-invalidation-only - Webhook is optimization only: persist event + mark lease stale.
         await asyncio.to_thread(
@@ -41,8 +41,8 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
             instance_id=instance_id,
             event_type=event_type,
             payload=payload,
-            matched_lease_id=matched_lease_id,
             matched_sandbox_id=matched_sandbox_id,
+            lower_runtime_handle=lower_runtime_handle,
         )
     finally:
         lease_repo.close()

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -83,8 +83,8 @@ class ProviderEventRepo(Protocol):
         instance_id: str,
         event_type: str,
         payload: dict[str, Any],
-        matched_lease_id: str | None,
         matched_sandbox_id: str | None,
+        lower_runtime_handle: str | None,
     ) -> None: ...
     def list_recent(self, limit: int = 100) -> list[dict[str, Any]]: ...
 

--- a/storage/providers/supabase/provider_event_repo.py
+++ b/storage/providers/supabase/provider_event_repo.py
@@ -31,8 +31,8 @@ class SupabaseProviderEventRepo:
         instance_id: str,
         event_type: str,
         payload: dict[str, Any],
-        matched_lease_id: str | None,
         matched_sandbox_id: str | None,
+        lower_runtime_handle: str | None,
     ) -> None:
         self._t().insert(
             {
@@ -40,8 +40,8 @@ class SupabaseProviderEventRepo:
                 "instance_id": instance_id,
                 "event_type": event_type,
                 "payload_json": json.dumps(payload, ensure_ascii=False),
-                "matched_lease_id": matched_lease_id,
                 "matched_sandbox_id": matched_sandbox_id,
+                "matched_lease_id": lower_runtime_handle,
                 "created_at": datetime.now().isoformat(),
             }
         ).execute()

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -57,8 +57,8 @@ async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch
             "instance_id": "inst-1",
             "event_type": "provider.updated",
             "payload": {"instance_id": "inst-1", "event": "provider.updated"},
-            "matched_lease_id": None,
             "matched_sandbox_id": None,
+            "lower_runtime_handle": None,
         }
     ]
 
@@ -140,8 +140,8 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_le
             "instance_id": "inst-2",
             "event_type": "provider.running",
             "payload": {"instance_id": "inst-2", "event": "provider.running"},
-            "matched_lease_id": "lease-1",
             "matched_sandbox_id": "sandbox-1",
+            "lower_runtime_handle": "lease-1",
         }
     ]
     assert lease.applied == [

--- a/tests/Unit/storage/test_supabase_provider_event_repo.py
+++ b/tests/Unit/storage/test_supabase_provider_event_repo.py
@@ -11,8 +11,8 @@ def test_supabase_provider_event_repo_uses_observability_schema_table() -> None:
         instance_id="instance-1",
         event_type="started",
         payload={"ok": True},
-        matched_lease_id="lease-1",
         matched_sandbox_id="sandbox-1",
+        lower_runtime_handle="lease-1",
     )
 
     row = tables["observability.provider_events"][0]


### PR DESCRIPTION
## Summary
- hide the old provider_events.matched_lease_id column behind SupabaseProviderEventRepo
- move the ProviderEventRepo contract and webhook router call site to lower_runtime_handle + matched_sandbox_id
- keep public webhook event listing stripping the old DB column

## Verification
- RED: updated webhooks/provider-event repo tests failed on old matched_lease_id contract
- uv run python -m pytest tests/Integration/test_webhooks_router_contract.py tests/Unit/storage/test_supabase_provider_event_repo.py -q
- uv run python -m pytest tests/Integration/test_webhooks_router_contract.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Unit/storage/test_supabase_lease_repo.py -q
- uv run ruff check backend/web/routers/webhooks.py storage/contracts.py storage/providers/supabase/provider_event_repo.py tests/Integration/test_webhooks_router_contract.py tests/Unit/storage/test_supabase_provider_event_repo.py
- uv run ruff format --check backend/web/routers/webhooks.py storage/contracts.py storage/providers/supabase/provider_event_repo.py tests/Integration/test_webhooks_router_contract.py tests/Unit/storage/test_supabase_provider_event_repo.py
- uv run pyright backend/web/routers/webhooks.py storage/providers/supabase/provider_event_repo.py storage/contracts.py
- git diff --check