### PR TITLE
feat: install marketplace skills onto agents

### DIFF
--- a/backend/web/models/marketplace.py
+++ b/backend/web/models/marketplace.py
@@ -15,6 +15,7 @@ class PublishAgentUserToMarketplaceRequest(BaseModel):
 
 class InstallFromMarketplaceRequest(BaseModel):
     item_id: str
+    agent_user_id: str | None = None
 
 
 class UpgradeFromMarketplaceRequest(BaseModel):

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -104,12 +104,15 @@ async def download_from_marketplace(
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    if req.agent_user_id is not None:
+        await _verify_user_ownership(req.agent_user_id, user_id, user_repo)
     return await asyncio.to_thread(
         marketplace_client.download,
         item_id=req.item_id,
         owner_user_id=user_id,
         user_repo=user_repo,
         agent_config_repo=agent_config_repo,
+        agent_user_id=req.agent_user_id,
     )
 
 

--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -56,6 +56,19 @@ def _hub_error_detail(response: httpx.Response) -> str | None:
     return detail if isinstance(detail, str) and detail else None
 
 
+def _skill_metadata_from_content(content: str) -> dict[str, Any]:
+    if not content.startswith("---\n"):
+        raise ValueError("Skill snapshot must be a SKILL.md document with frontmatter")
+    try:
+        _, frontmatter, _body = content.split("---", 2)
+    except ValueError as exc:
+        raise ValueError("Skill snapshot must be a SKILL.md document with frontmatter") from exc
+    metadata = yaml.safe_load(frontmatter) or {}
+    if not isinstance(metadata, dict) or not metadata.get("name"):
+        raise ValueError("Skill snapshot frontmatter must include name")
+    return metadata
+
+
 def list_items(
     *,
     type: str | None = None,
@@ -242,6 +255,7 @@ def download(
     owner_user_id: str = "system",
     user_repo: Any = None,
     agent_config_repo: Any = None,
+    agent_user_id: str | None = None,
 ) -> dict:
     """Download a marketplace item to local library or install an agent user."""
     result = _hub_api("POST", f"/items/{item_id}/download")
@@ -255,13 +269,44 @@ def download(
     now = int(time.time() * 1000)
 
     if item_type == "skill":
+        content = snapshot.get("content", "")
+        if not isinstance(content, str):
+            raise ValueError("Skill snapshot content must be a string")
+        skill_metadata = _skill_metadata_from_content(content)
+
+        if agent_user_id is not None:
+            if user_repo is None or agent_config_repo is None:
+                raise RuntimeError("user_repo and agent_config_repo are required to install a skill to an agent")
+            user = user_repo.get_by_id(agent_user_id)
+            if user is None or user.owner_user_id != owner_user_id:
+                raise RuntimeError(f"Agent user not found for owner: {agent_user_id}")
+            if not getattr(user, "agent_config_id", None):
+                raise RuntimeError(f"Agent user has no agent_config_id: {agent_user_id}")
+
+            skill_name = str(skill_metadata["name"])
+            agent_config_repo.save_skill(
+                user.agent_config_id,
+                skill_name,
+                content,
+                meta={
+                    "name": skill_name,
+                    "desc": item.get("description", ""),
+                    "source": {
+                        "marketplace_item_id": item_id,
+                        "installed_version": installed_version,
+                        "publisher": item.get("publisher_username", ""),
+                    },
+                },
+            )
+            logger.info("Installed skill %s to agent user %s", skill_name, agent_user_id)
+            return {"resource_id": skill_name, "type": "skill", "version": installed_version, "agent_user_id": agent_user_id}
+
         slug = item.get("slug", item["name"].lower().replace(" ", "-"))
         skill_dir = (LIBRARY_DIR / "skills" / slug).resolve()
         if not skill_dir.is_relative_to((LIBRARY_DIR / "skills").resolve()):
             raise ValueError(f"Invalid slug: {slug}")
         skill_dir.mkdir(parents=True, exist_ok=True)
 
-        content = snapshot.get("content", "")
         (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
 
         meta = snapshot.get("meta", {})

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1201,7 +1201,8 @@ class LeonAgent:
             )
 
         # Skills tools
-        if self.config.skills.enabled and self.config.skills.paths:
+        bundle_skills = self._agent_bundle.skills if hasattr(self, "_agent_bundle") and self._agent_bundle else []
+        if self.config.skills.enabled and (self.config.skills.paths or bundle_skills):
             # Use the agent bundle's skills enabled/disabled state if available.
             enabled_skills = self.config.skills.skills
             if hasattr(self, "_agent_bundle") and self._agent_bundle:
@@ -1212,6 +1213,7 @@ class LeonAgent:
                 registry=self._tool_registry,
                 skill_paths=self.config.skills.paths,
                 enabled_skills=enabled_skills,
+                inline_skills=bundle_skills,
             )
 
         # Task tools (DEFERRED - discoverable via tool_search)

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -26,11 +26,14 @@ class SkillsService:
         registry: ToolRegistry,
         skill_paths: Sequence[str | Path],
         enabled_skills: dict[str, bool] | None = None,
+        inline_skills: Sequence[dict[str, str]] | None = None,
     ):
         self.skill_paths = [Path(p).expanduser().resolve() for p in skill_paths]
         self.enabled_skills = enabled_skills or {}
         self._skills_index: dict[str, Path] = {}
+        self._inline_skills: dict[str, str] = {}
         self._load_skills_index()
+        self._load_inline_skills(inline_skills or [])
         self._register(registry)
 
     def _load_skills_index(self) -> None:
@@ -46,6 +49,18 @@ class SkillsService:
                 except Exception:
                     logger.exception("Failed to load skill metadata from %s", skill_file)
 
+    def _load_inline_skills(self, skills: Sequence[dict[str, str]]) -> None:
+        for skill in skills:
+            content = skill.get("content")
+            if not isinstance(content, str):
+                continue
+            metadata = self._parse_frontmatter(content)
+            if "name" in metadata:
+                # @@@repo-backed-skill-index - DB-backed agent bundles do not have a
+                # stable filesystem directory; keep their SKILL.md content in memory
+                # while exposing the same load_skill surface as disk-backed skills.
+                self._inline_skills[metadata["name"]] = content
+
     @staticmethod
     def _parse_frontmatter(content: str) -> dict[str, str]:
         match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
@@ -59,7 +74,7 @@ class SkillsService:
         return metadata
 
     def _register(self, registry: ToolRegistry) -> None:
-        if not self._skills_index:
+        if not self._skills_index and not self._inline_skills:
             return
 
         registry.register(
@@ -75,7 +90,7 @@ class SkillsService:
         )
 
     def _get_schema(self) -> dict:
-        available_skills = list(self._skills_index.keys())
+        available_skills = sorted({*self._skills_index.keys(), *self._inline_skills.keys()})
         skills_list = "\n".join(f"- {name}" for name in available_skills)
 
         return make_tool_schema(
@@ -89,19 +104,23 @@ class SkillsService:
             properties={
                 "skill_name": {
                     "type": "string",
-                    "description": f"Name of the skill to load. Available: {', '.join(self._skills_index.keys())}",
+                    "description": f"Name of the skill to load. Available: {', '.join(available_skills)}",
                 },
             },
             required=["skill_name"],
         )
 
     def _load_skill(self, skill_name: str) -> str:
-        if skill_name not in self._skills_index:
-            available = ", ".join(self._skills_index.keys())
+        if skill_name not in self._skills_index and skill_name not in self._inline_skills:
+            available = ", ".join(sorted({*self._skills_index.keys(), *self._inline_skills.keys()}))
             return f"Skill '{skill_name}' not found.\nAvailable skills: {available}"
 
         if self.enabled_skills and skill_name in self.enabled_skills and not self.enabled_skills[skill_name]:
             return f"Skill '{skill_name}' is disabled in profile configuration."
+
+        if skill_name in self._inline_skills:
+            content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", self._inline_skills[skill_name], flags=re.DOTALL)
+            return f"Loaded skill: {skill_name}\n\n{content}"
 
         skill_file = self._skills_index[skill_name]
         try:

--- a/frontend/app/src/components/marketplace/InstallDialog.tsx
+++ b/frontend/app/src/components/marketplace/InstallDialog.tsx
@@ -1,9 +1,11 @@
 import { Download } from "lucide-react";
+import { useEffect, useState } from "react";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useMarketplaceStore, type MarketplaceItemDetail } from "@/store/marketplace-store";
+import { useAppStore } from "@/store/app-store";
 import { toast } from "sonner";
 import { marketplaceTypeLabel } from "@/lib/marketplace-types";
 
@@ -16,15 +18,39 @@ interface Props {
 export default function InstallDialog({ open, onOpenChange, item }: Props) {
   const download = useMarketplaceStore((s) => s.download);
   const downloading = useMarketplaceStore((s) => s.downloading);
+  const agentList = useAppStore((s) => s.agentList);
+  const ensureAgents = useAppStore((s) => s.ensureAgents);
+  const [selectedAgentId, setSelectedAgentId] = useState("");
 
   const latestVersion = item.versions?.[0]?.version || "latest";
   const itemTypeLabel = marketplaceTypeLabel(item.type);
+  const isSkill = item.type === "skill";
+  const installableAgents = agentList.filter((agent) => !agent.builtin);
+
+  useEffect(() => {
+    if (!open || !isSkill) return;
+    void ensureAgents();
+  }, [ensureAgents, isSkill, open]);
+
+  useEffect(() => {
+    if (!isSkill || selectedAgentId || installableAgents.length === 0) return;
+    setSelectedAgentId(installableAgents[0].id);
+  }, [installableAgents, isSkill, selectedAgentId]);
 
   const handleDownload = async () => {
     try {
-      const result = await download(item.id);
+      const targetAgentId = isSkill ? selectedAgentId : undefined;
+      if (isSkill && !targetAgentId) {
+        toast.error("请先选择要安装 Skill 的 Agent");
+        return;
+      }
+      const result = await download(item.id, targetAgentId);
       const resultTypeLabel = result.type === "user" ? "Agent" : result.type;
-      toast.success(`${item.name} downloaded to library (${resultTypeLabel})`);
+      toast.success(
+        isSkill
+          ? `${item.name} installed to Agent (${result.resource_id})`
+          : `${item.name} downloaded to library (${resultTypeLabel})`,
+      );
       onOpenChange(false);
     } catch (e) {
       toast.error(`Download failed: ${e instanceof Error ? e.message : "unknown error"}`);
@@ -50,8 +76,24 @@ export default function InstallDialog({ open, onOpenChange, item }: Props) {
 
         <div className="py-3">
           <p className="text-sm text-muted-foreground">
-            这将把该 {itemTypeLabel} 保存到本地库，之后可以在 Agent 配置页中添加使用。
+            {isSkill
+              ? "这将把该 Skill 直接安装到选中的 Agent，随后对话运行时可通过 load_skill 按需加载。"
+              : `这将把该 ${itemTypeLabel} 保存到本地库，之后可以在 Agent 配置页中添加使用。`}
           </p>
+          {isSkill && (
+            <label className="block mt-3 text-xs text-muted-foreground">
+              安装到 Agent
+              <select
+                className="mt-1 w-full rounded-md border border-border bg-background px-2 py-2 text-sm text-foreground"
+                value={selectedAgentId}
+                onChange={(event) => setSelectedAgentId(event.target.value)}
+              >
+                {installableAgents.map((agent) => (
+                  <option key={agent.id} value={agent.id}>{agent.name}</option>
+                ))}
+              </select>
+            </label>
+          )}
           {item.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mt-3">
               {item.tags.map((tag) => (
@@ -65,9 +107,9 @@ export default function InstallDialog({ open, onOpenChange, item }: Props) {
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>取消</Button>
-          <Button onClick={handleDownload} disabled={downloading}>
+          <Button onClick={handleDownload} disabled={downloading || (isSkill && !selectedAgentId)}>
             <Download className="w-3.5 h-3.5 mr-1.5" />
-            {downloading ? "下载中..." : "下载到库"}
+            {downloading ? "下载中..." : isSkill ? "安装到 Agent" : "下载到库"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/app/src/components/marketplace/InstallDialog.wording.test.tsx
+++ b/frontend/app/src/components/marketplace/InstallDialog.wording.test.tsx
@@ -23,6 +23,14 @@ vi.mock("@/store/marketplace-store", () => ({
     }),
 }));
 
+vi.mock("@/store/app-store", () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      agentList: [{ id: "agent-1", name: "Toad", builtin: false }],
+      ensureAgents: vi.fn(),
+    }),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -63,5 +71,36 @@ describe("InstallDialog wording contract", () => {
 
     expect(screen.getByText("这将把该 Agent 保存到本地库，之后可以在 Agent 配置页中添加使用。")).toBeTruthy();
     expect(screen.queryByText(/member/)).toBeNull();
+  });
+
+  it("requires a target Agent for Skill installs", () => {
+    render(
+      <InstallDialog
+        open
+        onOpenChange={vi.fn()}
+        item={{
+          id: "skill-1",
+          slug: "fastapi",
+          description: "desc",
+          avatar_url: null,
+          publisher_user_id: "user-1",
+          name: "FastAPI",
+          type: "skill",
+          publisher_username: "tester",
+          parent_id: null,
+          download_count: 0,
+          visibility: "public",
+          tags: [],
+          created_at: "2026-04-08T00:00:00Z",
+          updated_at: "2026-04-08T00:00:00Z",
+          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
+          parent: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("这将把该 Skill 直接安装到选中的 Agent，随后对话运行时可通过 load_skill 按需加载。")).toBeTruthy();
+    expect(screen.getAllByText("安装到 Agent").length).toBeGreaterThan(0);
+    expect(screen.getByText("Toad")).toBeTruthy();
   });
 });

--- a/frontend/app/src/store/marketplace-store.test.ts
+++ b/frontend/app/src/store/marketplace-store.test.ts
@@ -201,6 +201,22 @@ describe("useMarketplaceStore", () => {
     });
   });
 
+  it("passes agent_user_id when downloading a Skill into an Agent", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ resource_id: "FastAPI", type: "skill", version: "1.0.0", agent_user_id: "agent-1" }),
+    } as Response);
+
+    const { useMarketplaceStore } = await import("./marketplace-store");
+
+    await useMarketplaceStore.getState().download("skill-1", "agent-1");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/marketplace/download");
+    expect(JSON.parse(String(init?.body))).toEqual({ item_id: "skill-1", agent_user_id: "agent-1" });
+  });
+
   it("preserves backend detail when marketplace publish returns an honest 503", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: false,

--- a/frontend/app/src/store/marketplace-store.ts
+++ b/frontend/app/src/store/marketplace-store.ts
@@ -90,7 +90,7 @@ interface MarketplaceState {
 
   // Actions (go through Mycel backend)
   downloading: boolean;
-  download: (itemId: string) => Promise<{ resource_id: string; type: string; version: string }>;
+  download: (itemId: string, agentUserId?: string) => Promise<{ resource_id: string; type: string; version: string; agent_user_id?: string }>;
   upgrade: (userId: string, itemId: string) => Promise<void>;
   publishAgentUserToMarketplace: (userId: string, bumpType: string, releaseNotes: string, tags: string[], visibility: string) => Promise<unknown>;
 }
@@ -259,12 +259,12 @@ export const useMarketplaceStore = create<MarketplaceState>()((set, get) => ({
 
   downloading: false,
 
-  download: async (itemId) => {
+  download: async (itemId, agentUserId) => {
     set({ downloading: true });
     try {
-      const data = await backendApi<{ resource_id: string; type: string; version: string }>("/download", {
+      const data = await backendApi<{ resource_id: string; type: string; version: string; agent_user_id?: string }>("/download", {
         method: "POST",
-        body: JSON.stringify({ item_id: itemId }),
+        body: JSON.stringify({ item_id: itemId, ...(agentUserId ? { agent_user_id: agentUserId } : {}) }),
       });
       return data;
     } finally {

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -574,6 +574,64 @@ async def test_leon_agent_agent_config_id_registers_mcp_resource_tools(tmp_path)
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
+async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path):
+    from core.runtime.agent import LeonAgent
+
+    class _Repo:
+        def get_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return {
+                "id": "cfg-1",
+                "name": "Repo Toad",
+                "description": "Repo-backed agent",
+                "tools": ["*"],
+                "system_prompt": "You are Repo Toad.",
+                "status": "active",
+                "version": "1.0.0",
+                "runtime": {"skills:FastAPI": {"enabled": True, "desc": "Use FastAPI conventions"}},
+                "mcp": {},
+            }
+
+        def list_rules(self, _agent_config_id: str):
+            return []
+
+        def list_sub_agents(self, _agent_config_id: str):
+            return []
+
+        def list_skills(self, _agent_config_id: str):
+            return [
+                {
+                    "name": "FastAPI",
+                    "content": "---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
+                    "meta_json": {"desc": "Build FastAPI services"},
+                }
+            ]
+
+    mock_model = _mock_model("Repo skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+    ):
+        agent = LeonAgent(
+            workspace_root=str(tmp_path),
+            agent_config_id="cfg-1",
+            agent_config_repo=_Repo(),
+            api_key="sk-test-integration",
+        )
+        await agent.ainit()
+
+        skill_tool = agent._tool_registry.get("load_skill")
+        assert skill_tool is not None
+        assert "FastAPI" in skill_tool.get_schema()["description"]
+        assert skill_tool.handler("FastAPI") == "Loaded skill: FastAPI\n\nAlways use APIRouter."
+
+        agent.close()
+
+
+@pytest.mark.asyncio
+@_patch_env_api_key()
 async def test_leon_agent_agent_config_id_ignores_conflicting_stale_member_shell(tmp_path):
     """Repo-rooted live startup must ignore a stale member-dir shell with conflicting MCP state."""
     from core.runtime.agent import LeonAgent

--- a/tests/Integration/test_marketplace_router_user_shell.py
+++ b/tests/Integration/test_marketplace_router_user_shell.py
@@ -96,15 +96,16 @@ async def test_download_from_marketplace_uses_user_and_agent_config_repos(monkey
 
     monkeypatch.setattr(marketplace_router.marketplace_client, "download", lambda **kwargs: seen.update(kwargs) or {"ok": True})
 
+    owner_agent = SimpleNamespace(id="agent-1", owner_user_id="owner-1")
     request = SimpleNamespace(
         app=SimpleNamespace(
             state=SimpleNamespace(
-                user_repo=SimpleNamespace(),
+                user_repo=SimpleNamespace(get_by_id=lambda user_id: owner_agent if user_id == "agent-1" else None),
                 agent_config_repo=SimpleNamespace(),
             )
         )
     )
-    req = SimpleNamespace(item_id="item-1")
+    req = SimpleNamespace(item_id="item-1", agent_user_id="agent-1")
 
     result = await marketplace_router.download_from_marketplace(req=req, user_id="owner-1", request=request)
 
@@ -113,6 +114,7 @@ async def test_download_from_marketplace_uses_user_and_agent_config_repos(monkey
     assert seen["owner_user_id"] == "owner-1"
     assert seen["user_repo"] is request.app.state.user_repo
     assert seen["agent_config_repo"] is request.app.state.agent_config_repo
+    assert seen["agent_user_id"] == "agent-1"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -99,7 +99,7 @@ class TestDownloadSkill:
     def test_writes_skill_md(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
         monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
-        hub_resp = _make_hub_response("skill", "my-skill", content="# My Skill\nDo stuff")
+        hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
             from backend.web.services.marketplace_client import download
@@ -110,12 +110,14 @@ class TestDownloadSkill:
         assert result["resource_id"] == "my-skill"
         skill_md = lib / "skills" / "my-skill" / "SKILL.md"
         assert skill_md.exists()
-        assert skill_md.read_text(encoding="utf-8") == "# My Skill\nDo stuff"
+        assert skill_md.read_text(encoding="utf-8") == "---\nname: My Skill\n---\n# My Skill\nDo stuff"
 
     def test_meta_json_has_source_tracking(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
         monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
-        hub_resp = _make_hub_response("skill", "tracked-skill", version="2.1.0", publisher="alice")
+        hub_resp = _make_hub_response(
+            "skill", "tracked-skill", content="---\nname: Tracked Skill\n---\n# Hello", version="2.1.0", publisher="alice"
+        )
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
             from backend.web.services.marketplace_client import download
@@ -130,7 +132,7 @@ class TestDownloadSkill:
     def test_path_traversal_blocked(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
         monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
-        hub_resp = _make_hub_response("skill", "../../evil")
+        hub_resp = _make_hub_response("skill", "../../evil", content="---\nname: Evil\n---\n# Hello")
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
             from backend.web.services.marketplace_client import download
@@ -140,6 +142,51 @@ class TestDownloadSkill:
 
         # Ensure no files written outside library
         assert not (tmp_path / "evil").exists()
+
+    def test_installs_skill_to_agent_config_when_agent_user_id_is_provided(self):
+        import backend.web.services.marketplace_client as marketplace_client
+
+        saved: list[tuple[str, str, str, dict[str, object] | None]] = []
+        user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1", owner_user_id="owner-1"))
+
+        class _AgentConfigRepo:
+            def save_skill(self, agent_config_id: str, name: str, content: str, meta: dict[str, object] | None = None) -> None:
+                saved.append((agent_config_id, name, content, meta))
+
+        hub_resp = _make_hub_response(
+            "skill",
+            "fastapi",
+            version="1.2.3",
+            publisher="skillsmp",
+            content="---\nname: FastAPI\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter.",
+        )
+
+        with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
+            result = marketplace_client.download(
+                "skillsmp:fastapi",
+                owner_user_id="owner-1",
+                user_repo=user_repo,
+                agent_config_repo=_AgentConfigRepo(),
+                agent_user_id="agent-user-1",
+            )
+
+        assert result == {"resource_id": "FastAPI", "type": "skill", "version": "1.2.3", "agent_user_id": "agent-user-1"}
+        assert saved == [
+            (
+                "cfg-1",
+                "FastAPI",
+                "---\nname: FastAPI\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter.",
+                {
+                    "name": "FastAPI",
+                    "desc": "A test item",
+                    "source": {
+                        "marketplace_item_id": "skillsmp:fastapi",
+                        "installed_version": "1.2.3",
+                        "publisher": "skillsmp",
+                    },
+                },
+            )
+        ]
 
 
 # ── Download — agent ──
@@ -220,8 +267,8 @@ class TestDownloadIdempotency:
         lib = tmp_path / "library"
         monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
 
-        v1 = _make_hub_response("skill", "idem-skill", content="V1", version="1.0.0")
-        v2 = _make_hub_response("skill", "idem-skill", content="V2", version="1.0.1")
+        v1 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\n---\nV1", version="1.0.0")
+        v2 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\n---\nV2", version="1.0.1")
 
         from backend.web.services.marketplace_client import download
 
@@ -233,7 +280,7 @@ class TestDownloadIdempotency:
 
         assert result["version"] == "1.0.1"
         content = (lib / "skills" / "idem-skill" / "SKILL.md").read_text(encoding="utf-8")
-        assert content == "V2"
+        assert content == "---\nname: Idem Skill\n---\nV2"
         meta = json.loads((lib / "skills" / "idem-skill" / "meta.json").read_text(encoding="utf-8"))
         assert meta["source"]["installed_version"] == "1.0.1"
 

--- a/tests/Unit/platform/test_marketplace_models.py
+++ b/tests/Unit/platform/test_marketplace_models.py
@@ -67,6 +67,11 @@ class TestInstallFromMarketplaceRequest:
     def test_valid(self):
         req = InstallFromMarketplaceRequest(item_id="abc-123")
         assert req.item_id == "abc-123"
+        assert req.agent_user_id is None
+
+    def test_accepts_agent_user_id(self):
+        req = InstallFromMarketplaceRequest(item_id="abc-123", agent_user_id="agent-1")
+        assert req.agent_user_id == "agent-1"
 
     def test_missing_item_id_raises(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary
- Add `agent_user_id` to marketplace skill installs, with backend ownership validation before writing agent skills.
- Expose repo-backed agent skills to runtime `SkillsService`, so installed DB skills can be loaded through `load_skill`.
- Update the marketplace install dialog to require/select a target Agent for skill installs and cover the flow with backend, runtime, store, and UI wording tests.

## Test Plan
- `uv run pytest tests/Unit/platform/test_marketplace_client.py tests/Integration/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_models.py tests/Integration/test_leon_agent.py::test_leon_agent_agent_config_id_registers_repo_backed_skills -q` -> 50 passed
- `uv run ruff check backend/web/models/marketplace.py backend/web/routers/marketplace.py backend/web/services/marketplace_client.py core/runtime/agent.py core/tools/skills/service.py tests/Unit/platform/test_marketplace_client.py tests/Integration/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_models.py tests/Integration/test_leon_agent.py` -> passed
- `uv run ruff format --check backend/web/models/marketplace.py backend/web/routers/marketplace.py backend/web/services/marketplace_client.py core/runtime/agent.py core/tools/skills/service.py tests/Unit/platform/test_marketplace_client.py tests/Integration/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_models.py tests/Integration/test_leon_agent.py` -> passed
- `npm run test -- marketplace-store.test.ts InstallDialog.wording.test.ts` -> 14 passed
- `npm run typecheck` -> passed
- `git diff --check` -> passed

## YATU Evidence
- Local backend from this branch on `127.0.0.1:8010`; local frontend on `127.0.0.1:5182`.
- Browser login through UI, opened `/marketplace`, installed Mycel Official `architecture-patterns` into Agent `Agent1775591401`.
- Agent detail skill tab showed `architecture-patterns`; chat with the agent produced a `load_skill` tool call and final marker `ARCH_SKILL_USED_20260418`.
- SkillsMP item list is visible, but install currently fails loudly because deployed Hub returns a skill snapshot without `content`; Hub PR #3 has the adapter work, deployment is still required.
