### PR TITLE
Refactor chat delivery dispatcher

### DIFF
--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -1,0 +1,102 @@
+"""Agent delivery dispatch for Chat messages."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from enum import Enum
+from typing import Any
+
+from backend.web.utils.serializers import avatar_url
+from messaging.delivery.actions import DeliveryAction
+from messaging.display_user import resolve_messaging_display_user
+
+logger = logging.getLogger(__name__)
+
+
+class ChatDeliveryDispatcher:
+    """Dispatch durable Chat messages to Agent recipients."""
+
+    def __init__(
+        self,
+        chat_member_repo: Any,
+        user_repo: Any,
+        delivery_resolver: Any | None = None,
+        delivery_fn: Callable | None = None,
+    ) -> None:
+        self._chat_members_repo = chat_member_repo
+        self._user_repo = user_repo
+        self._delivery_resolver = delivery_resolver
+        self._delivery_fn = delivery_fn
+
+    def set_delivery_fn(self, fn: Callable) -> None:
+        self._delivery_fn = fn
+
+    def dispatch(
+        self,
+        chat_id: str,
+        sender_id: str,
+        content: str,
+        mentions: list[str],
+        signal: str | None = None,
+    ) -> None:
+        mention_set = set(mentions)
+        members = self._chat_members_repo.list_members(chat_id)
+        sender_user = self._resolve_display_user(sender_id)
+        sender_name = sender_user.display_name if sender_user else "unknown"
+        sender_avatar_url = avatar_url(sender_user.id if sender_user else sender_id, bool(sender_user.avatar if sender_user else None))
+        sender_raw_type = getattr(sender_user, "type", None) if sender_user else None
+        sender_type = sender_raw_type.value if isinstance(sender_raw_type, Enum) else sender_raw_type
+        sender_owner_id = sender_user.id if sender_user and sender_type == "human" else getattr(sender_user, "owner_user_id", None)
+
+        for member in members:
+            uid = member.get("user_id")
+            if not uid or uid == sender_id:
+                continue
+            recipient = self._resolve_display_user(uid)
+            if not recipient:
+                continue
+            member_raw_type = getattr(recipient, "type", None)
+            member_type = member_raw_type.value if isinstance(member_raw_type, Enum) else member_raw_type
+            if member_type == "human":
+                continue
+
+            # @@@same-owner-group-delivery - explicit group membership among the same owner
+            # must reach sibling actors even when no relationship row exists yet.
+            if sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id:
+                self._deliver(uid, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
+                continue
+
+            if self._delivery_resolver:
+                is_mentioned = uid in mention_set
+                action = self._delivery_resolver.resolve(uid, chat_id, sender_id, is_mentioned=is_mentioned)
+                if action != DeliveryAction.DELIVER:
+                    logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])
+                    continue
+
+            self._deliver(uid, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
+
+    def _resolve_display_user(self, social_user_id: str) -> Any | None:
+        return resolve_messaging_display_user(
+            user_repo=self._user_repo,
+            social_user_id=social_user_id,
+        )
+
+    def _deliver(
+        self,
+        recipient_id: str,
+        recipient: Any,
+        content: str,
+        sender_name: str,
+        chat_id: str,
+        sender_id: str,
+        sender_avatar_url: str | None,
+        *,
+        signal: str | None,
+    ) -> None:
+        if not self._delivery_fn:
+            return
+        try:
+            self._delivery_fn(recipient_id, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
+        except Exception:
+            logger.exception("[messaging] delivery failed for member %s", recipient_id)

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -14,11 +14,11 @@ import time
 import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from enum import Enum
 from typing import Any
 
 from backend.web.utils.serializers import avatar_url
 from messaging.contracts import ContentType, MessageType
+from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.display_user import resolve_messaging_display_user
 
 logger = logging.getLogger(__name__)
@@ -36,14 +36,19 @@ class MessagingService:
         thread_repo: Any | None = None,
         delivery_resolver: Any | None = None,
         delivery_fn: Callable | None = None,
+        delivery_dispatcher: ChatDeliveryDispatcher | None = None,
         event_bus: Any | None = None,
     ) -> None:
         self._chats = chat_repo
         self._chat_members_repo = chat_member_repo
         self._messages = messages_repo
         self._user_repo = user_repo
-        self._delivery_resolver = delivery_resolver
-        self._delivery_fn = delivery_fn
+        self._delivery_dispatcher = delivery_dispatcher or ChatDeliveryDispatcher(
+            chat_member_repo=chat_member_repo,
+            user_repo=user_repo,
+            delivery_resolver=delivery_resolver,
+            delivery_fn=delivery_fn,
+        )
         self._event_bus = event_bus
 
     def _normalize_message_row(self, row: dict[str, Any]) -> dict[str, Any]:
@@ -105,7 +110,7 @@ class MessagingService:
         return member_info
 
     def set_delivery_fn(self, fn: Callable) -> None:
-        self._delivery_fn = fn
+        self._delivery_dispatcher.set_delivery_fn(fn)
 
     # ------------------------------------------------------------------
     # Chat lifecycle
@@ -204,63 +209,9 @@ class MessagingService:
 
         # Deliver to agent recipients
         if message_type in ("human", "ai"):
-            self._deliver_to_agents(chat_id, sender_id, content, mentions or [], signal=signal)
+            self._delivery_dispatcher.dispatch(chat_id, sender_id, content, mentions or [], signal=signal)
 
         return created
-
-    def _deliver_to_agents(
-        self,
-        chat_id: str,
-        sender_id: str,
-        content: str,
-        mentions: list[str],
-        signal: str | None = None,
-    ) -> None:
-        mention_set = set(mentions)
-        members = self._chat_members_repo.list_members(chat_id)
-        sender_user = self._resolve_display_user(sender_id)
-        sender_name = sender_user.display_name if sender_user else "unknown"
-        sender_avatar_url = avatar_url(sender_user.id if sender_user else sender_id, bool(sender_user.avatar if sender_user else None))
-        sender_raw_type = getattr(sender_user, "type", None) if sender_user else None
-        sender_type = sender_raw_type.value if isinstance(sender_raw_type, Enum) else sender_raw_type
-        sender_owner_id = sender_user.id if sender_user and sender_type == "human" else getattr(sender_user, "owner_user_id", None)
-
-        for member in members:
-            uid = member.get("user_id")
-            if not uid or uid == sender_id:
-                continue
-            m = self._resolve_display_user(uid)
-            if not m:
-                continue
-            member_raw_type = getattr(m, "type", None)
-            member_type = member_raw_type.value if isinstance(member_raw_type, Enum) else member_raw_type
-            if member_type == "human":
-                continue
-
-            # @@@same-owner-group-delivery - explicit group membership among the same owner
-            # must reach sibling actors even when no relationship row exists yet.
-            if sender_owner_id and getattr(m, "owner_user_id", None) == sender_owner_id:
-                if self._delivery_fn:
-                    try:
-                        self._delivery_fn(uid, m, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
-                    except Exception:
-                        logger.exception("[messaging] delivery failed for member %s", uid)
-                continue
-
-            from messaging.delivery.actions import DeliveryAction
-
-            if self._delivery_resolver:
-                is_mentioned = uid in mention_set
-                action = self._delivery_resolver.resolve(uid, chat_id, sender_id, is_mentioned=is_mentioned)
-                if action != DeliveryAction.DELIVER:
-                    logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])
-                    continue
-
-            if self._delivery_fn:
-                try:
-                    self._delivery_fn(uid, m, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
-                except Exception:
-                    logger.exception("[messaging] delivery failed for member %s", uid)
 
     # ------------------------------------------------------------------
     # Lifecycle operations

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -12,6 +12,7 @@ from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope
 from messaging.delivery.actions import DeliveryAction
+from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.display_user import resolve_messaging_display_user
 from messaging.relationships.service import RelationshipService
@@ -91,10 +92,8 @@ def test_messaging_display_user_resolver_does_not_read_removed_thread_user_id() 
 
 def test_deliver_to_agents_does_not_require_main_thread_id():
     delivered: list[tuple[str, str]] = []
-    service = MessagingService(
-        chat_repo=SimpleNamespace(),
+    dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "agent-user-1"}]),
-        messages_repo=SimpleNamespace(),
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
@@ -105,7 +104,7 @@ def test_deliver_to_agents_does_not_require_main_thread_id():
         delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
     )
 
-    service._deliver_to_agents("chat-1", "human-user-1", "hello", [])
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
 
     assert delivered == [("agent-user-1", "agent-user-1")]
 
@@ -1045,10 +1044,8 @@ def test_chat_tool_search_uses_messaging_service_direct_chat_lookup_without_memb
 
 def test_deliver_to_agents_routes_delivery_by_agent_user_id() -> None:
     delivered: list[tuple[str, str]] = []
-    service = MessagingService(
-        chat_repo=SimpleNamespace(),
+    dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "agent-user-1"}]),
-        messages_repo=SimpleNamespace(),
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
@@ -1059,7 +1056,7 @@ def test_deliver_to_agents_routes_delivery_by_agent_user_id() -> None:
         delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
     )
 
-    service._deliver_to_agents("chat-1", "human-user-1", "hello", [])
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
 
     assert delivered == [("agent-user-1", "agent-user-1")]
 
@@ -1077,8 +1074,7 @@ def test_same_owner_group_chat_kickoff_delivers_without_relationship() -> None:
         ),
         relationship_repo=SimpleNamespace(get=lambda _a, _b: None),
     )
-    service = MessagingService(
-        chat_repo=SimpleNamespace(),
+    dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(
             list_members=lambda _chat_id: [
                 {"user_id": "human-user-1"},
@@ -1086,7 +1082,6 @@ def test_same_owner_group_chat_kickoff_delivers_without_relationship() -> None:
                 {"user_id": "agent-user-2"},
             ]
         ),
-        messages_repo=SimpleNamespace(),
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None, owner_user_id=None)
@@ -1102,7 +1097,7 @@ def test_same_owner_group_chat_kickoff_delivers_without_relationship() -> None:
         delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
     )
 
-    service._deliver_to_agents("chat-1", "human-user-1", "hello", [])
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
 
     assert delivered == [("agent-user-1", "agent-user-1"), ("agent-user-2", "agent-user-2")]
 
@@ -1187,8 +1182,7 @@ def test_same_owner_agent_turn_delivers_to_sibling_actor_without_relationship() 
         ),
         relationship_repo=SimpleNamespace(get=lambda _a, _b: None),
     )
-    service = MessagingService(
-        chat_repo=SimpleNamespace(),
+    dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(
             list_members=lambda _chat_id: [
                 {"user_id": "human-user-1"},
@@ -1196,7 +1190,6 @@ def test_same_owner_agent_turn_delivers_to_sibling_actor_without_relationship() 
                 {"user_id": "agent-user-2"},
             ]
         ),
-        messages_repo=SimpleNamespace(),
         user_repo=SimpleNamespace(
             get_by_id=lambda uid: (
                 SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None, owner_user_id=None)
@@ -1212,7 +1205,7 @@ def test_same_owner_agent_turn_delivers_to_sibling_actor_without_relationship() 
         delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
     )
 
-    service._deliver_to_agents("chat-1", "agent-user-1", "hello", [])
+    dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])
 
     assert delivered == [("agent-user-2", "agent-user-2")]
 

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from messaging.delivery.actions import DeliveryAction
+from messaging.delivery.dispatcher import ChatDeliveryDispatcher
+
+
+def _user_repo() -> SimpleNamespace:
+    def get_by_id(uid: str) -> Any | None:
+        users = {
+            "human-user-1": SimpleNamespace(
+                id="human-user-1",
+                display_name="Human",
+                type="human",
+                avatar=None,
+                owner_user_id=None,
+            ),
+            "outside-human-user": SimpleNamespace(
+                id="outside-human-user",
+                display_name="Outside",
+                type="human",
+                avatar=None,
+                owner_user_id=None,
+            ),
+            "agent-user-1": SimpleNamespace(
+                id="agent-user-1",
+                display_name="Morel",
+                type="agent",
+                avatar=None,
+                owner_user_id="human-user-1",
+            ),
+            "agent-user-2": SimpleNamespace(
+                id="agent-user-2",
+                display_name="Toad",
+                type="agent",
+                avatar=None,
+                owner_user_id="human-user-1",
+            ),
+        }
+        return users.get(uid)
+
+    return SimpleNamespace(get_by_id=get_by_id)
+
+
+def _member_repo(user_ids: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(list_members=lambda _chat_id: [{"user_id": uid} for uid in user_ids])
+
+
+def test_dispatcher_delivers_to_agent_user_ids() -> None:
+    delivered: list[tuple[str, str]] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
+        user_repo=_user_repo(),
+        delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert delivered == [("agent-user-1", "agent-user-1")]
+
+
+def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
+        user_repo=_user_repo(),
+        delivery_resolver=SimpleNamespace(
+            resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner path must not call resolver"))
+        ),
+        delivery_fn=lambda recipient_id, *_args, **_kwargs: delivered.append(recipient_id),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert delivered == ["agent-user-1", "agent-user-2"]
+
+
+def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
+        user_repo=_user_repo(),
+        delivery_resolver=SimpleNamespace(
+            resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner sibling path must not call resolver"))
+        ),
+        delivery_fn=lambda recipient_id, *_args, **_kwargs: delivered.append(recipient_id),
+    )
+
+    dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])
+
+    assert delivered == ["agent-user-2"]
+
+
+@pytest.mark.parametrize("action", [DeliveryAction.NOTIFY, DeliveryAction.DROP])
+def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["outside-human-user", "agent-user-1"]),
+        user_repo=_user_repo(),
+        delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: action),
+        delivery_fn=lambda recipient_id, *_args, **_kwargs: delivered.append(recipient_id),
+    )
+
+    dispatcher.dispatch("chat-1", "outside-human-user", "hello", [])
+
+    assert delivered == []
+
+
+def test_dispatcher_continues_after_delivery_function_failure() -> None:
+    delivered: list[str] = []
+
+    def deliver(recipient_id: str, *_args: Any, **_kwargs: Any) -> None:
+        if recipient_id == "agent-user-1":
+            raise RuntimeError("agent offline")
+        delivered.append(recipient_id)
+
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
+        user_repo=_user_repo(),
+        delivery_fn=deliver,
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert delivered == ["agent-user-2"]


### PR DESCRIPTION
## Summary
- Extract Agent-recipient Chat delivery from MessagingService into messaging.delivery.ChatDeliveryDispatcher.
- Keep MessagingService.send responsible for durable message creation/event publish, then delegate delivery dispatch.
- Move direct delivery behavior tests off the removed private _deliver_to_agents method and add focused dispatcher coverage.

## Verification
- uv run pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py tests/Unit/backend/test_message_routing.py -q
- uv run ruff check .
- uv run pyright messaging/service.py messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py

## Notes
- No schema, auth, route, UI, or deployment changes.
- Full pyright on the touched integration test file still reports pre-existing errors unrelated to this slice; the production files and new dispatcher unit test are clean under pyright.