### PR TITLE
Refactor agent runtime payloads into protocols

### DIFF
--- a/backend/protocols/README.md
+++ b/backend/protocols/README.md
@@ -1,0 +1,16 @@
+# Backend Protocols
+
+This package holds transport payload contracts that cross backend or API
+boundaries.
+
+Keep this package narrow:
+
+- Put HTTP/SSE/polling/server-to-server payloads here when multiple backends or
+  transports share the same semantic shape.
+- Do not put database row models, repository protocols, provider configs, or
+  service-private helper types here.
+- Add sibling protocol modules only when a real split lane needs them; do not
+  add filler files to make the directory look populated.
+
+The durable design ruling is recorded in
+`mycel-db-design/program/doc/core/shared-protocol-package-boundary-ruling-2026-04-18.md`.

--- a/backend/protocols/__init__.py
+++ b/backend/protocols/__init__.py
@@ -1,0 +1,1 @@
+"""Transport protocol contracts shared across backend boundaries."""

--- a/backend/protocols/agent_runtime.py
+++ b/backend/protocols/agent_runtime.py
@@ -1,0 +1,75 @@
+"""Agent runtime transport protocol contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class AgentChatContext:
+    chat_id: str
+    title: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentChatActor:
+    user_id: str
+    user_type: str
+    display_name: str
+    avatar_url: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentChatRecipient:
+    agent_user_id: str
+    runtime_source: str
+
+
+@dataclass(frozen=True)
+class AgentChatMessage:
+    content: str
+    content_type: str = "text"
+    message_id: str | None = None
+    signal: str | None = None
+    created_at: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentChatTransport:
+    delivery_id: str | None = None
+    correlation_id: str | None = None
+    idempotency_key: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentChatDeliveryEnvelope:
+    chat: AgentChatContext
+    sender: AgentChatActor
+    recipient: AgentChatRecipient
+    message: AgentChatMessage
+    transport: AgentChatTransport = AgentChatTransport()
+    protocol_version: Literal["agent.chat.delivery.v1"] = "agent.chat.delivery.v1"
+    event_type: Literal["chat.message"] = "chat.message"
+    extensions: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class AgentThreadInputEnvelope:
+    thread_id: str
+    content: str
+    source: str = "owner"
+    enable_trajectory: bool = False
+    sender_name: str | None = None
+    sender_avatar_url: str | None = None
+    attachments: list[str] | None = None
+    message_metadata: dict[str, Any] | None = None
+    protocol_version: Literal["agent.thread.input.v1"] = "agent.thread.input.v1"
+    event_type: Literal["thread.input"] = "thread.input"
+
+
+@dataclass(frozen=True)
+class AgentGatewayDeliveryResult:
+    status: Literal["accepted", "skipped"]
+    thread_id: str | None
+    reason: str | None = None

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1036,8 +1036,9 @@ async def send_message(
     if not payload.message.strip():
         raise HTTPException(status_code=400, detail="message cannot be empty")
 
+    from backend.protocols.agent_runtime import AgentThreadInputEnvelope
     from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
-    from backend.web.services.agent_runtime_gateway import AgentThreadInputEnvelope, NativeAgentRuntimeGateway
+    from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 
     message = payload.message
     # @@@attachment-wire - sync files to sandbox and prepend paths
@@ -1172,7 +1173,8 @@ async def resolve_thread_permission_request(
 
     followup: dict[str, Any] | None = None
     if is_ask_user_question and payload.decision == "allow" and pending_request is not None and answers is not None:
-        from backend.web.services.agent_runtime_gateway import AgentThreadInputEnvelope, NativeAgentRuntimeGateway
+        from backend.protocols.agent_runtime import AgentThreadInputEnvelope
+        from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 
         answered_payload = _build_ask_user_question_answered_payload(
             pending_request,

--- a/backend/web/services/agent_runtime_gateway.py
+++ b/backend/web/services/agent_runtime_gateway.py
@@ -4,81 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
+from backend.protocols import agent_runtime as agent_runtime_protocol
 from core.runtime.middleware.monitor import AgentState
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class AgentChatContext:
-    chat_id: str
-    title: str | None = None
-
-
-@dataclass(frozen=True)
-class AgentChatActor:
-    user_id: str
-    user_type: str
-    display_name: str
-    avatar_url: str | None = None
-
-
-@dataclass(frozen=True)
-class AgentChatRecipient:
-    agent_user_id: str
-    runtime_source: str
-
-
-@dataclass(frozen=True)
-class AgentChatMessage:
-    content: str
-    content_type: str = "text"
-    message_id: str | None = None
-    signal: str | None = None
-    created_at: str | None = None
-
-
-@dataclass(frozen=True)
-class AgentChatTransport:
-    delivery_id: str | None = None
-    correlation_id: str | None = None
-    idempotency_key: str | None = None
-
-
-@dataclass(frozen=True)
-class AgentChatDeliveryEnvelope:
-    chat: AgentChatContext
-    sender: AgentChatActor
-    recipient: AgentChatRecipient
-    message: AgentChatMessage
-    transport: AgentChatTransport = AgentChatTransport()
-    protocol_version: Literal["agent.chat.delivery.v1"] = "agent.chat.delivery.v1"
-    event_type: Literal["chat.message"] = "chat.message"
-    extensions: dict[str, Any] | None = None
-
-
-@dataclass(frozen=True)
-class AgentThreadInputEnvelope:
-    thread_id: str
-    content: str
-    source: str = "owner"
-    enable_trajectory: bool = False
-    sender_name: str | None = None
-    sender_avatar_url: str | None = None
-    attachments: list[str] | None = None
-    message_metadata: dict[str, Any] | None = None
-    protocol_version: Literal["agent.thread.input.v1"] = "agent.thread.input.v1"
-    event_type: Literal["thread.input"] = "thread.input"
-
-
-@dataclass(frozen=True)
-class AgentGatewayDeliveryResult:
-    status: Literal["accepted", "skipped"]
-    thread_id: str | None
-    reason: str | None = None
 
 
 class NativeAgentRuntimeGateway:
@@ -87,7 +18,9 @@ class NativeAgentRuntimeGateway:
     def __init__(self, app: Any) -> None:
         self._app = app
 
-    async def dispatch_chat(self, envelope: AgentChatDeliveryEnvelope) -> AgentGatewayDeliveryResult:
+    async def dispatch_chat(
+        self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
+    ) -> agent_runtime_protocol.AgentGatewayDeliveryResult:
         from langchain_core.runnables.config import var_child_runnable_config
 
         var_child_runnable_config.set(None)
@@ -105,7 +38,7 @@ class NativeAgentRuntimeGateway:
 
         if not thread_id:
             logger.warning("Recipient %s has no thread, skipping delivery", envelope.recipient.agent_user_id)
-            return AgentGatewayDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
+            return agent_runtime_protocol.AgentGatewayDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
 
         from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
         from backend.web.services.streaming_service import _ensure_thread_handlers
@@ -136,9 +69,9 @@ class NativeAgentRuntimeGateway:
             sender_name=envelope.sender.display_name,
             sender_avatar_url=envelope.sender.avatar_url,
         )
-        return AgentGatewayDeliveryResult(status="accepted", thread_id=thread_id)
+        return agent_runtime_protocol.AgentGatewayDeliveryResult(status="accepted", thread_id=thread_id)
 
-    async def dispatch_thread_input(self, envelope: AgentThreadInputEnvelope) -> dict[str, Any]:
+    async def dispatch_thread_input(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
         """Route direct thread input through the Agent-side gateway."""
         from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
         from backend.web.services.resource_cache import clear_resource_overview_cache

--- a/backend/web/services/chat_delivery_adapter.py
+++ b/backend/web/services/chat_delivery_adapter.py
@@ -7,14 +7,14 @@ import logging
 from enum import Enum
 from typing import Any
 
-from backend.web.services.agent_runtime_gateway import (
+from backend.protocols.agent_runtime import (
     AgentChatActor,
     AgentChatContext,
     AgentChatDeliveryEnvelope,
     AgentChatMessage,
     AgentChatRecipient,
-    NativeAgentRuntimeGateway,
 )
+from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from storage.contracts import UserRow
 
 logger = logging.getLogger(__name__)

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -6,14 +6,14 @@ from typing import Any, cast
 
 import pytest
 
-from backend.web.services.agent_runtime_gateway import (
+from backend.protocols.agent_runtime import (
     AgentChatActor,
     AgentChatContext,
     AgentChatDeliveryEnvelope,
     AgentChatMessage,
     AgentChatRecipient,
-    NativeAgentRuntimeGateway,
 )
+from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from backend.web.utils.serializers import avatar_url
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -12,10 +12,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
+from backend.protocols.agent_runtime import AgentThreadInputEnvelope
 from backend.web.models.requests import SendMessageRequest
 from backend.web.routers import threads as threads_router
 from backend.web.routers.threads import get_thread_history, get_thread_messages
-from backend.web.services.agent_runtime_gateway import AgentThreadInputEnvelope, NativeAgentRuntimeGateway
+from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from backend.web.services.display_builder import DisplayBuilder
 from backend.web.services.event_buffer import ThreadEventBuffer
 from backend.web.services.streaming_service import (

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -5,14 +5,14 @@ from typing import Any
 
 import pytest
 
-from backend.web.services.agent_runtime_gateway import (
+from backend.protocols.agent_runtime import (
     AgentChatActor,
     AgentChatContext,
     AgentChatDeliveryEnvelope,
     AgentChatMessage,
     AgentChatRecipient,
-    NativeAgentRuntimeGateway,
 )
+from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
 
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_agent_runtime_protocol_types_live_outside_web_service_layer() -> None:
+    protocol_module = importlib.import_module("backend.protocols.agent_runtime")
+    gateway_module = importlib.import_module("backend.web.services.agent_runtime_gateway")
+
+    assert protocol_module.AgentChatDeliveryEnvelope.__module__ == "backend.protocols.agent_runtime"
+    assert protocol_module.AgentThreadInputEnvelope.__module__ == "backend.protocols.agent_runtime"
+    assert not hasattr(gateway_module, "AgentChatDeliveryEnvelope")
+    assert not hasattr(gateway_module, "AgentThreadInputEnvelope")

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from backend.web.services.agent_runtime_gateway import AgentThreadInputEnvelope, NativeAgentRuntimeGateway
+from backend.protocols.agent_runtime import AgentThreadInputEnvelope
+from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
 
 


### PR DESCRIPTION
## Summary
- Move Agent Runtime Gateway transport envelopes into `backend.protocols.agent_runtime`.
- Keep `NativeAgentRuntimeGateway` as runtime dispatch service only; callers now import protocol DTOs from the neutral protocol package.
- Add a structure test and protocol package README to preserve the boundary.

## Verification
- `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_chat_delivery_adapter.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py -q`
- `uv run ruff format --check backend/protocols backend/web/services/agent_runtime_gateway.py backend/web/services/chat_delivery_adapter.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_chat_delivery_adapter.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff check backend/protocols backend/web/services/agent_runtime_gateway.py backend/web/services/chat_delivery_adapter.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_chat_delivery_adapter.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run python -m pyright backend/protocols backend/web/services/agent_runtime_gateway.py backend/web/services/chat_delivery_adapter.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_chat_delivery_adapter.py`
- `git diff --check`