### PR TITLE
Route chat and thread delivery through agent runtime port

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -130,6 +130,10 @@ async def lifespan(app: FastAPI):
     app.state.thread_event_buffers = {}
     app.state.subagent_buffers = {}
 
+    from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
+
+    app.state.agent_runtime_gateway = NativeAgentRuntimeGateway(app)
+
     from backend.web.services.display_builder import DisplayBuilder
 
     app.state.display_builder = DisplayBuilder()

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1038,7 +1038,7 @@ async def send_message(
 
     from backend.protocols.agent_runtime import AgentThreadInputEnvelope
     from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
-    from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
+    from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
 
     message = payload.message
     # @@@attachment-wire - sync files to sandbox and prepend paths
@@ -1053,7 +1053,7 @@ async def send_message(
             agent=agent,
         )
 
-    return await NativeAgentRuntimeGateway(app).dispatch_thread_input(
+    return await get_agent_runtime_gateway(app).dispatch_thread_input(
         AgentThreadInputEnvelope(
             thread_id=thread_id,
             content=message,
@@ -1174,7 +1174,7 @@ async def resolve_thread_permission_request(
     followup: dict[str, Any] | None = None
     if is_ask_user_question and payload.decision == "allow" and pending_request is not None and answers is not None:
         from backend.protocols.agent_runtime import AgentThreadInputEnvelope
-        from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
+        from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
 
         answered_payload = _build_ask_user_question_answered_payload(
             pending_request,
@@ -1182,7 +1182,7 @@ async def resolve_thread_permission_request(
             annotations=getattr(payload, "annotations", None),
         )
 
-        followup = await NativeAgentRuntimeGateway(app).dispatch_thread_input(
+        followup = await get_agent_runtime_gateway(app).dispatch_thread_input(
             AgentThreadInputEnvelope(
                 thread_id=thread_id,
                 content=_format_ask_user_question_followup(

--- a/backend/web/services/agent_runtime_port.py
+++ b/backend/web/services/agent_runtime_port.py
@@ -1,0 +1,17 @@
+"""Agent runtime port used by web routes and chat delivery."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from backend.protocols.agent_runtime import AgentChatDeliveryEnvelope, AgentGatewayDeliveryResult, AgentThreadInputEnvelope
+
+
+class AgentRuntimeGatewayPort(Protocol):
+    async def dispatch_chat(self, envelope: AgentChatDeliveryEnvelope) -> AgentGatewayDeliveryResult: ...
+
+    async def dispatch_thread_input(self, envelope: AgentThreadInputEnvelope) -> dict[str, Any]: ...
+
+
+def get_agent_runtime_gateway(app: Any) -> AgentRuntimeGatewayPort:
+    return app.state.agent_runtime_gateway

--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -14,7 +14,7 @@ from backend.protocols.agent_runtime import (
     AgentChatMessage,
     AgentChatRecipient,
 )
-from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
+from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
 from storage.contracts import UserRow
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ def make_chat_delivery_fn(app: Any):
                 }
             },
         )
-        await NativeAgentRuntimeGateway(app).dispatch_chat(envelope)
+        await get_agent_runtime_gateway(app).dispatch_chat(envelope)
 
     def _deliver(
         recipient_id: str,

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -515,7 +515,9 @@ def _make_streaming_app(
     if include_route_locks:
         state.thread_locks = {}
         state.thread_locks_guard = asyncio.Lock()
-    return SimpleNamespace(state=state), queue_manager
+    app = SimpleNamespace(state=state)
+    state.agent_runtime_gateway = NativeAgentRuntimeGateway(app)
+    return app, queue_manager
 
 
 def _make_direct_streaming_context(

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -2080,7 +2080,7 @@ async def test_cancel_task_route_marks_bash_run_cancelled_and_forces_process_sto
     response = await threads_router.cancel_task(
         thread_id,
         "cmd-cancel-route",
-        SimpleNamespace(app=app),
+        cast(Any, SimpleNamespace(app=app)),
     )
 
     assert response == {"success": True}

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from contextlib import contextmanager
@@ -166,17 +167,17 @@ class _FakeRecipeRepo:
 async def test_send_message_passes_enable_trajectory_to_agent_runtime_gateway() -> None:
     captured: list[Any] = []
 
-    async def dispatch_thread_input(_gateway: Any, envelope: Any) -> dict[str, str]:
-        captured.append(envelope)
-        return {"status": "started", "thread_id": "thread-1"}
+    class _Gateway:
+        async def dispatch_thread_input(self, envelope: Any) -> dict[str, str]:
+            captured.append(envelope)
+            return {"status": "started", "thread_id": "thread-1"}
 
-    with patch("backend.web.services.agent_runtime_gateway.NativeAgentRuntimeGateway.dispatch_thread_input", dispatch_thread_input):
-        result = await threads_router.send_message(
-            "thread-1",
-            SendMessageRequest(message="hello", enable_trajectory=True),
-            user_id="owner-1",
-            app=SimpleNamespace(),
-        )
+    result = await threads_router.send_message(
+        "thread-1",
+        SendMessageRequest(message="hello", enable_trajectory=True),
+        user_id="owner-1",
+        app=SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=_Gateway())),
+    )
 
     assert result == {"status": "started", "thread_id": "thread-1"}
     assert captured[0].enable_trajectory is True
@@ -387,12 +388,8 @@ class _FakeAskUserQuestionAgent(_FakePermissionAgent):
         return True
 
 
-class _NullLock:
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
+class _NullLock(asyncio.Lock):
+    pass
 
 
 def _make_threads_app(
@@ -1228,7 +1225,6 @@ async def test_resolve_thread_permission_request_persists_resolution():
 @pytest.mark.asyncio
 async def test_resolve_ask_user_question_request_starts_followup_run_with_answers():
     agent = _FakeAskUserQuestionAgent()
-    app = SimpleNamespace()
     payload = ResolvePermissionRequest.model_validate(
         {
             "decision": "allow",
@@ -1246,20 +1242,20 @@ async def test_resolve_ask_user_question_request_starts_followup_run_with_answer
 
     captured: list[Any] = []
 
-    async def dispatch_thread_input(_gateway: Any, envelope: Any) -> dict[str, str]:
-        captured.append(envelope)
-        return {"status": "started", "routing": "direct", "thread_id": "thread-1"}
+    class _Gateway:
+        async def dispatch_thread_input(self, envelope: Any) -> dict[str, str]:
+            captured.append(envelope)
+            return {"status": "started", "routing": "direct", "thread_id": "thread-1"}
 
-    with patch("backend.web.services.agent_runtime_gateway.NativeAgentRuntimeGateway.dispatch_thread_input", dispatch_thread_input):
-        result = await threads_router.resolve_thread_permission_request(
-            "thread-1",
-            "perm-ask",
-            payload,
-            user_id="owner-1",
-            agent=agent,
-            app=app,
-            thread_lock=_NullLock(),
-        )
+    result = await threads_router.resolve_thread_permission_request(
+        "thread-1",
+        "perm-ask",
+        payload,
+        user_id="owner-1",
+        agent=agent,
+        app=SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=_Gateway())),
+        thread_lock=_NullLock(),
+    )
 
     assert result == {
         "ok": True,

--- a/tests/Unit/backend/web/services/test_agent_runtime_port.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_port.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_agent_runtime_port_requires_lifespan_registration() -> None:
+    from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
+
+    with pytest.raises(AttributeError, match="agent_runtime_gateway"):
+        get_agent_runtime_gateway(SimpleNamespace(state=SimpleNamespace()))

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import inspect
+
+from backend.web.routers import threads as threads_router
+from backend.web.services import chat_delivery_hook
+
+
+def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> None:
+    delivery_source = inspect.getsource(chat_delivery_hook)
+    threads_source = inspect.getsource(threads_router)
+
+    assert "NativeAgentRuntimeGateway" not in delivery_source
+    assert "NativeAgentRuntimeGateway" not in threads_source
+    assert "get_agent_runtime_gateway" in delivery_source
+    assert "get_agent_runtime_gateway" in threads_source


### PR DESCRIPTION
## Summary
- Add an explicit `agent_runtime_port` seam and register the native gateway in app lifespan.
- Route Chat delivery hook and direct thread input through `get_agent_runtime_gateway(app)` instead of constructing `NativeAgentRuntimeGateway` at call sites.
- Update direct router/integration tests to inject the runtime port and keep missing port registration fail-loud.

## Verification
- `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py -q`
- `uv run ruff format --check backend/web/services/agent_runtime_port.py backend/web/services/chat_delivery_hook.py backend/web/routers/threads.py backend/web/core/lifespan.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py`
- `uv run ruff check backend/web/services/agent_runtime_port.py backend/web/services/chat_delivery_hook.py backend/web/routers/threads.py backend/web/core/lifespan.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py`
- `uv run python -m pyright backend/web/services/agent_runtime_port.py backend/web/services/chat_delivery_hook.py backend/web/routers/threads.py backend/web/core/lifespan.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py`
- `git diff --check`