### PR TITLE
Refactor native agent runtime handlers

### DIFF
--- a/backend/web/services/agent_runtime_chat_handler.py
+++ b/backend/web/services/agent_runtime_chat_handler.py
@@ -1,0 +1,117 @@
+"""Native Chat delivery handler for the Agent runtime."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from backend.protocols import agent_runtime as agent_runtime_protocol
+from core.runtime.middleware.monitor import AgentState
+
+logger = logging.getLogger(__name__)
+
+
+class NativeAgentChatDeliveryHandler:
+    """Routes Chat messages into native Mycel Agent threads."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    async def dispatch(
+        self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
+    ) -> agent_runtime_protocol.AgentGatewayDeliveryResult:
+        from langchain_core.runnables.config import var_child_runnable_config
+
+        var_child_runnable_config.set(None)
+
+        # @@@thread-delivery-route - delivery target must come from the recipient social handle,
+        # never from the template default-thread shortcut.
+        thread_id = self._select_runtime_thread_id(envelope.recipient.agent_user_id)
+        logger.info(
+            "[agent-runtime-gateway] dispatch_chat: recipient=%s user=%s thread=%s from=%s",
+            envelope.recipient.agent_user_id,
+            envelope.recipient.agent_user_id,
+            thread_id,
+            envelope.sender.display_name,
+        )
+
+        if not thread_id:
+            logger.warning("Recipient %s has no thread, skipping delivery", envelope.recipient.agent_user_id)
+            return agent_runtime_protocol.AgentGatewayDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
+
+        from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
+        from backend.web.services.streaming_service import _ensure_thread_handlers
+        from core.runtime.middleware.queue.formatters import format_chat_notification
+
+        sandbox_type = resolve_thread_sandbox(self._app, thread_id)
+        agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
+        _ensure_thread_handlers(agent, thread_id, self._app)
+
+        typing_tracker = getattr(self._app.state, "typing_tracker", None)
+        if typing_tracker is not None:
+            typing_tracker.start_chat(thread_id, envelope.chat.chat_id, envelope.recipient.agent_user_id)
+
+        unread_count = self._app.state.messaging_service.count_unread(envelope.chat.chat_id, envelope.recipient.agent_user_id)
+        formatted = format_chat_notification(
+            envelope.sender.display_name,
+            envelope.chat.chat_id,
+            unread_count,
+            signal=envelope.message.signal,
+        )
+
+        self._app.state.queue_manager.enqueue(
+            formatted,
+            thread_id,
+            "chat",
+            source="external",
+            sender_id=envelope.sender.user_id,
+            sender_name=envelope.sender.display_name,
+            sender_avatar_url=envelope.sender.avatar_url,
+        )
+        return agent_runtime_protocol.AgentGatewayDeliveryResult(status="accepted", thread_id=thread_id)
+
+    def _select_runtime_thread_id(self, recipient_id: str) -> str | None:
+        thread = self._app.state.thread_repo.get_by_user_id(recipient_id)
+        active_thread_id = self._resolve_unique_active_thread_id(recipient_id, thread)
+        if active_thread_id is not None:
+            return active_thread_id
+        if thread is None:
+            return None
+        return thread["id"]
+
+    def _resolve_unique_active_thread_id(self, recipient_id: str, thread: dict[str, Any] | None) -> str | None:
+        agent_user_id = str((thread or {}).get("agent_user_id") or recipient_id).strip()
+        if not agent_user_id:
+            return None
+
+        active_thread_ids: list[str] = []
+        live_child_threads: list[tuple[int, str]] = []
+        for candidate in self._app.state.thread_repo.list_by_agent_user(agent_user_id):
+            thread_id = str(candidate.get("id") or "").strip()
+            if not thread_id:
+                continue
+            # @@@active-thread-delivery-precedence - fresh chat delivery should prefer a
+            # recipient's latest live child thread over the default-main thread, even when the
+            # main thread is still marked ACTIVE from stale work or older child threads still exist.
+            for pool_key, agent in self._app.state.agent_pool.items():
+                if not str(pool_key).startswith(f"{thread_id}:"):
+                    continue
+                state = agent.runtime.current_state
+                if state in {
+                    AgentState.READY,
+                    AgentState.ACTIVE,
+                    AgentState.IDLE,
+                    AgentState.SUSPENDED,
+                    AgentState.INITIALIZING,
+                } and not bool(candidate.get("is_main")):
+                    live_child_threads.append((int(candidate.get("branch_index") or -1), thread_id))
+                if state == AgentState.ACTIVE:
+                    active_thread_ids.append(thread_id)
+                    break
+
+        if live_child_threads:
+            return max(live_child_threads)[1]
+        unique_active_thread_ids = list(dict.fromkeys(active_thread_ids))
+        if len(unique_active_thread_ids) == 1:
+            return unique_active_thread_ids[0]
+        return None

--- a/backend/web/services/agent_runtime_gateway.py
+++ b/backend/web/services/agent_runtime_gateway.py
@@ -1,197 +1,32 @@
-"""Agent-runtime gateway for service-to-service dispatch."""
+"""Agent Runtime Gateway facade for service-to-service dispatch."""
 
 from __future__ import annotations
 
-import asyncio
-import logging
 from typing import Any
 
 from backend.protocols import agent_runtime as agent_runtime_protocol
-from core.runtime.middleware.monitor import AgentState
-
-logger = logging.getLogger(__name__)
+from backend.web.services.agent_runtime_chat_handler import NativeAgentChatDeliveryHandler
+from backend.web.services.agent_runtime_thread_handler import NativeAgentThreadInputHandler
 
 
 class NativeAgentRuntimeGateway:
     """In-process Agent-side gateway for native Mycel runtime dispatch."""
 
-    def __init__(self, app: Any) -> None:
-        self._app = app
+    def __init__(
+        self,
+        app: Any,
+        *,
+        chat_handler: Any | None = None,
+        thread_input_handler: Any | None = None,
+    ) -> None:
+        self._chat_handler = chat_handler or NativeAgentChatDeliveryHandler(app)
+        self._thread_input_handler = thread_input_handler or NativeAgentThreadInputHandler(app)
 
     async def dispatch_chat(
         self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
     ) -> agent_runtime_protocol.AgentGatewayDeliveryResult:
-        from langchain_core.runnables.config import var_child_runnable_config
-
-        var_child_runnable_config.set(None)
-
-        # @@@thread-delivery-route - delivery target must come from the recipient social handle,
-        # never from the template default-thread shortcut.
-        thread_id = self._select_runtime_thread_id(envelope.recipient.agent_user_id)
-        logger.info(
-            "[agent-runtime-gateway] dispatch_chat: recipient=%s user=%s thread=%s from=%s",
-            envelope.recipient.agent_user_id,
-            envelope.recipient.agent_user_id,
-            thread_id,
-            envelope.sender.display_name,
-        )
-
-        if not thread_id:
-            logger.warning("Recipient %s has no thread, skipping delivery", envelope.recipient.agent_user_id)
-            return agent_runtime_protocol.AgentGatewayDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
-
-        from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
-        from backend.web.services.streaming_service import _ensure_thread_handlers
-        from core.runtime.middleware.queue.formatters import format_chat_notification
-
-        sandbox_type = resolve_thread_sandbox(self._app, thread_id)
-        agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
-        _ensure_thread_handlers(agent, thread_id, self._app)
-
-        typing_tracker = getattr(self._app.state, "typing_tracker", None)
-        if typing_tracker is not None:
-            typing_tracker.start_chat(thread_id, envelope.chat.chat_id, envelope.recipient.agent_user_id)
-
-        unread_count = self._app.state.messaging_service.count_unread(envelope.chat.chat_id, envelope.recipient.agent_user_id)
-        formatted = format_chat_notification(
-            envelope.sender.display_name,
-            envelope.chat.chat_id,
-            unread_count,
-            signal=envelope.message.signal,
-        )
-
-        self._app.state.queue_manager.enqueue(
-            formatted,
-            thread_id,
-            "chat",
-            source="external",
-            sender_id=envelope.sender.user_id,
-            sender_name=envelope.sender.display_name,
-            sender_avatar_url=envelope.sender.avatar_url,
-        )
-        return agent_runtime_protocol.AgentGatewayDeliveryResult(status="accepted", thread_id=thread_id)
+        return await self._chat_handler.dispatch(envelope)
 
     async def dispatch_thread_input(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
         """Route direct thread input through the Agent-side gateway."""
-        from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
-        from backend.web.services.resource_cache import clear_resource_overview_cache
-        from backend.web.services.streaming_service import start_agent_run
-
-        thread_id = envelope.thread_id
-        startup_cancel = None
-        existing_task = self._app.state.thread_tasks.get(thread_id)
-        if existing_task is None or existing_task.done():
-            startup_cancel = asyncio.get_running_loop().create_future()
-            self._app.state.thread_tasks[thread_id] = startup_cancel
-
-        try:
-            sandbox_type = resolve_thread_sandbox(self._app, thread_id)
-            agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
-            qm = self._app.state.queue_manager
-
-            if startup_cancel is not None and startup_cancel.cancelled():
-                return {"status": "cancelled", "routing": "cancelled", "thread_id": thread_id}
-
-            state = agent.runtime.current_state
-            logger.debug("[agent-runtime-gateway] thread=%s state=%s source=%s", thread_id[:15], state, envelope.source)
-
-            if agent.runtime.current_state == AgentState.ACTIVE:
-                qm.enqueue(
-                    envelope.content,
-                    thread_id,
-                    "steer",
-                    source=envelope.source,
-                    sender_name=envelope.sender_name,
-                    sender_avatar_url=envelope.sender_avatar_url,
-                    is_steer=True,
-                )
-                logger.debug("[agent-runtime-gateway] thread input enqueued")
-                return {"status": "injected", "routing": "steer", "thread_id": thread_id}
-
-            locks = self._app.state.thread_locks
-            async with self._app.state.thread_locks_guard:
-                lock = locks.setdefault(thread_id, asyncio.Lock())
-            async with lock:
-                if not agent.runtime.transition(AgentState.ACTIVE):
-                    qm.enqueue(
-                        envelope.content,
-                        thread_id,
-                        "steer",
-                        source=envelope.source,
-                        sender_name=envelope.sender_name,
-                        sender_avatar_url=envelope.sender_avatar_url,
-                        is_steer=True,
-                    )
-                    logger.debug("[agent-runtime-gateway] thread input enqueued after transition race")
-                    return {"status": "injected", "routing": "steer", "thread_id": thread_id}
-                logger.debug("[agent-runtime-gateway] thread input starts run")
-                meta = {
-                    "source": envelope.source,
-                    "sender_name": envelope.sender_name,
-                    "sender_avatar_url": envelope.sender_avatar_url,
-                }
-                if envelope.message_metadata:
-                    meta.update(envelope.message_metadata)
-                if envelope.attachments:
-                    meta["attachments"] = envelope.attachments
-                run_id = start_agent_run(
-                    agent,
-                    thread_id,
-                    envelope.content,
-                    self._app,
-                    enable_trajectory=envelope.enable_trajectory,
-                    message_metadata=meta,
-                )
-                # @@@monitor-resource-cache-run-start - a fresh run can create or resume a sandbox runtime immediately.
-                # Drop the cached monitor snapshot so the next /api/monitor/resources read reflects the live topology.
-                clear_resource_overview_cache()
-            return {"status": "started", "routing": "direct", "run_id": run_id, "thread_id": thread_id}
-        finally:
-            if startup_cancel is not None and self._app.state.thread_tasks.get(thread_id) is startup_cancel:
-                self._app.state.thread_tasks.pop(thread_id, None)
-
-    def _select_runtime_thread_id(self, recipient_id: str) -> str | None:
-        thread = self._app.state.thread_repo.get_by_user_id(recipient_id)
-        active_thread_id = self._resolve_unique_active_thread_id(recipient_id, thread)
-        if active_thread_id is not None:
-            return active_thread_id
-        if thread is None:
-            return None
-        return thread["id"]
-
-    def _resolve_unique_active_thread_id(self, recipient_id: str, thread: dict[str, Any] | None) -> str | None:
-        agent_user_id = str((thread or {}).get("agent_user_id") or recipient_id).strip()
-        if not agent_user_id:
-            return None
-
-        active_thread_ids: list[str] = []
-        live_child_threads: list[tuple[int, str]] = []
-        for candidate in self._app.state.thread_repo.list_by_agent_user(agent_user_id):
-            thread_id = str(candidate.get("id") or "").strip()
-            if not thread_id:
-                continue
-            # @@@active-thread-delivery-precedence - fresh chat delivery should prefer a
-            # recipient's latest live child thread over the default-main thread, even when the
-            # main thread is still marked ACTIVE from stale work or older child threads still exist.
-            for pool_key, agent in self._app.state.agent_pool.items():
-                if not str(pool_key).startswith(f"{thread_id}:"):
-                    continue
-                state = agent.runtime.current_state
-                if state in {
-                    AgentState.READY,
-                    AgentState.ACTIVE,
-                    AgentState.IDLE,
-                    AgentState.SUSPENDED,
-                    AgentState.INITIALIZING,
-                } and not bool(candidate.get("is_main")):
-                    live_child_threads.append((int(candidate.get("branch_index") or -1), thread_id))
-                if state == AgentState.ACTIVE:
-                    active_thread_ids.append(thread_id)
-                    break
-
-        if live_child_threads:
-            return max(live_child_threads)[1]
-        unique_active_thread_ids = list(dict.fromkeys(active_thread_ids))
-        if len(unique_active_thread_ids) == 1:
-            return unique_active_thread_ids[0]
-        return None
+        return await self._thread_input_handler.dispatch(envelope)

--- a/backend/web/services/agent_runtime_thread_handler.py
+++ b/backend/web/services/agent_runtime_thread_handler.py
@@ -1,0 +1,97 @@
+"""Native direct Thread input handler for the Agent runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from backend.protocols import agent_runtime as agent_runtime_protocol
+from core.runtime.middleware.monitor import AgentState
+
+logger = logging.getLogger(__name__)
+
+
+class NativeAgentThreadInputHandler:
+    """Routes direct thread input into native Mycel Agent runs."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    async def dispatch(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
+        from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
+        from backend.web.services.resource_cache import clear_resource_overview_cache
+        from backend.web.services.streaming_service import start_agent_run
+
+        thread_id = envelope.thread_id
+        startup_cancel = None
+        existing_task = self._app.state.thread_tasks.get(thread_id)
+        if existing_task is None or existing_task.done():
+            startup_cancel = asyncio.get_running_loop().create_future()
+            self._app.state.thread_tasks[thread_id] = startup_cancel
+
+        try:
+            sandbox_type = resolve_thread_sandbox(self._app, thread_id)
+            agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
+            qm = self._app.state.queue_manager
+
+            if startup_cancel is not None and startup_cancel.cancelled():
+                return {"status": "cancelled", "routing": "cancelled", "thread_id": thread_id}
+
+            state = agent.runtime.current_state
+            logger.debug("[agent-runtime-gateway] thread=%s state=%s source=%s", thread_id[:15], state, envelope.source)
+
+            if agent.runtime.current_state == AgentState.ACTIVE:
+                qm.enqueue(
+                    envelope.content,
+                    thread_id,
+                    "steer",
+                    source=envelope.source,
+                    sender_name=envelope.sender_name,
+                    sender_avatar_url=envelope.sender_avatar_url,
+                    is_steer=True,
+                )
+                logger.debug("[agent-runtime-gateway] thread input enqueued")
+                return {"status": "injected", "routing": "steer", "thread_id": thread_id}
+
+            locks = self._app.state.thread_locks
+            async with self._app.state.thread_locks_guard:
+                lock = locks.setdefault(thread_id, asyncio.Lock())
+            async with lock:
+                if not agent.runtime.transition(AgentState.ACTIVE):
+                    qm.enqueue(
+                        envelope.content,
+                        thread_id,
+                        "steer",
+                        source=envelope.source,
+                        sender_name=envelope.sender_name,
+                        sender_avatar_url=envelope.sender_avatar_url,
+                        is_steer=True,
+                    )
+                    logger.debug("[agent-runtime-gateway] thread input enqueued after transition race")
+                    return {"status": "injected", "routing": "steer", "thread_id": thread_id}
+                logger.debug("[agent-runtime-gateway] thread input starts run")
+                meta = {
+                    "source": envelope.source,
+                    "sender_name": envelope.sender_name,
+                    "sender_avatar_url": envelope.sender_avatar_url,
+                }
+                if envelope.message_metadata:
+                    meta.update(envelope.message_metadata)
+                if envelope.attachments:
+                    meta["attachments"] = envelope.attachments
+                run_id = start_agent_run(
+                    agent,
+                    thread_id,
+                    envelope.content,
+                    self._app,
+                    enable_trajectory=envelope.enable_trajectory,
+                    message_metadata=meta,
+                )
+                # @@@monitor-resource-cache-run-start - a fresh run can create or resume a sandbox runtime immediately.
+                # Drop the cached monitor snapshot so the next /api/monitor/resources read reflects the live topology.
+                clear_resource_overview_cache()
+            return {"status": "started", "routing": "direct", "run_id": run_id, "thread_id": thread_id}
+        finally:
+            if startup_cancel is not None and self._app.state.thread_tasks.get(thread_id) is startup_cancel:
+                self._app.state.thread_tasks.pop(thread_id, None)

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from backend.protocols.agent_runtime import AgentGatewayDeliveryResult
+from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
+
+
+@dataclass
+class _FakeChatHandler:
+    called_with: object | None = None
+
+    async def dispatch(self, envelope):
+        self.called_with = envelope
+        return AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
+
+
+@dataclass
+class _FakeThreadInputHandler:
+    called_with: object | None = None
+
+    async def dispatch(self, envelope):
+        self.called_with = envelope
+        return {"status": "started", "thread_id": "thread-1"}
+
+
+@pytest.mark.asyncio
+async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> None:
+    from backend.protocols.agent_runtime import (
+        AgentChatActor,
+        AgentChatContext,
+        AgentChatDeliveryEnvelope,
+        AgentChatMessage,
+        AgentChatRecipient,
+        AgentThreadInputEnvelope,
+    )
+
+    chat_handler = _FakeChatHandler()
+    thread_input_handler = _FakeThreadInputHandler()
+    gateway = NativeAgentRuntimeGateway(
+        app=object(),
+        chat_handler=chat_handler,
+        thread_input_handler=thread_input_handler,
+    )
+    chat_envelope = AgentChatDeliveryEnvelope(
+        chat=AgentChatContext(chat_id="chat-1"),
+        sender=AgentChatActor(user_id="human-1", user_type="human", display_name="Human"),
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel"),
+        message=AgentChatMessage(content="hello"),
+    )
+    thread_envelope = AgentThreadInputEnvelope(thread_id="thread-1", content="hello")
+
+    chat_result = await gateway.dispatch_chat(chat_envelope)
+    thread_result = await gateway.dispatch_thread_input(thread_envelope)
+
+    assert chat_result == AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
+    assert thread_result == {"status": "started", "thread_id": "thread-1"}
+    assert chat_handler.called_with is chat_envelope
+    assert thread_input_handler.called_with is thread_envelope
+
+
+def test_split_handler_modules_are_the_behavior_owners() -> None:
+    from backend.web.services.agent_runtime_chat_handler import NativeAgentChatDeliveryHandler
+    from backend.web.services.agent_runtime_thread_handler import NativeAgentThreadInputHandler
+
+    assert NativeAgentChatDeliveryHandler.__name__ == "NativeAgentChatDeliveryHandler"
+    assert NativeAgentThreadInputHandler.__name__ == "NativeAgentThreadInputHandler"


### PR DESCRIPTION
## Summary
- split native Agent Runtime Gateway behavior into dedicated Chat delivery and Thread input handlers
- keep NativeAgentRuntimeGateway as a facade over those handlers
- add TDD coverage proving the gateway delegates through split handlers

## Verification
- .venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff format --check backend/web/services/agent_runtime_gateway.py backend/web/services/agent_runtime_chat_handler.py backend/web/services/agent_runtime_thread_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
- uv run ruff check backend/web/services/agent_runtime_gateway.py backend/web/services/agent_runtime_chat_handler.py backend/web/services/agent_runtime_thread_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
- uv run python -m pyright backend/web/services/agent_runtime_gateway.py backend/web/services/agent_runtime_chat_handler.py backend/web/services/agent_runtime_thread_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
- git diff --check