### PR TITLE
Route agent chat delivery by runtime source

### DIFF
--- a/backend/web/services/agent_runtime_gateway.py
+++ b/backend/web/services/agent_runtime_gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from backend.protocols import agent_runtime as agent_runtime_protocol
@@ -17,15 +18,21 @@ class NativeAgentRuntimeGateway:
         app: Any,
         *,
         chat_handler: Any | None = None,
+        chat_handlers: Mapping[str, Any] | None = None,
         thread_input_handler: Any | None = None,
     ) -> None:
-        self._chat_handler = chat_handler or NativeAgentChatDeliveryHandler(app)
+        if chat_handler is not None and chat_handlers is not None:
+            raise ValueError("Use either chat_handler or chat_handlers, not both")
+        self._chat_handlers = dict(chat_handlers or {"mycel": chat_handler or NativeAgentChatDeliveryHandler(app)})
         self._thread_input_handler = thread_input_handler or NativeAgentThreadInputHandler(app)
 
     async def dispatch_chat(
         self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
     ) -> agent_runtime_protocol.AgentGatewayDeliveryResult:
-        return await self._chat_handler.dispatch(envelope)
+        handler = self._chat_handlers.get(envelope.recipient.runtime_source)
+        if handler is None:
+            raise ValueError(f"No Agent chat runtime handler registered for runtime_source={envelope.recipient.runtime_source!r}")
+        return await handler.dispatch(envelope)
 
     async def dispatch_thread_input(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
         """Route direct thread input through the Agent-side gateway."""

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -67,3 +67,58 @@ def test_split_handler_modules_are_the_behavior_owners() -> None:
 
     assert NativeAgentChatDeliveryHandler.__name__ == "NativeAgentChatDeliveryHandler"
     assert NativeAgentThreadInputHandler.__name__ == "NativeAgentThreadInputHandler"
+
+
+@pytest.mark.asyncio
+async def test_gateway_routes_chat_delivery_by_runtime_source() -> None:
+    from backend.protocols.agent_runtime import (
+        AgentChatActor,
+        AgentChatContext,
+        AgentChatDeliveryEnvelope,
+        AgentChatMessage,
+        AgentChatRecipient,
+    )
+
+    external_handler = _FakeChatHandler()
+    gateway = NativeAgentRuntimeGateway(
+        app=object(),
+        chat_handlers={"external-hook": external_handler},
+        thread_input_handler=_FakeThreadInputHandler(),
+    )
+    envelope = AgentChatDeliveryEnvelope(
+        chat=AgentChatContext(chat_id="chat-1"),
+        sender=AgentChatActor(user_id="human-1", user_type="human", display_name="Human"),
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="external-hook"),
+        message=AgentChatMessage(content="hello"),
+    )
+
+    result = await gateway.dispatch_chat(envelope)
+
+    assert result == AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
+    assert external_handler.called_with is envelope
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_unregistered_chat_runtime_source() -> None:
+    from backend.protocols.agent_runtime import (
+        AgentChatActor,
+        AgentChatContext,
+        AgentChatDeliveryEnvelope,
+        AgentChatMessage,
+        AgentChatRecipient,
+    )
+
+    gateway = NativeAgentRuntimeGateway(
+        app=object(),
+        chat_handlers={"mycel": _FakeChatHandler()},
+        thread_input_handler=_FakeThreadInputHandler(),
+    )
+    envelope = AgentChatDeliveryEnvelope(
+        chat=AgentChatContext(chat_id="chat-1"),
+        sender=AgentChatActor(user_id="human-1", user_type="human", display_name="Human"),
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="external-hook"),
+        message=AgentChatMessage(content="hello"),
+    )
+
+    with pytest.raises(ValueError, match="No Agent chat runtime handler registered for runtime_source='external-hook'"):
+        await gateway.dispatch_chat(envelope)


### PR DESCRIPTION
## Summary
- make AgentChatRecipient.runtime_source a real gateway routing key
- default native Chat delivery to the mycel handler only
- fail loudly when no chat runtime handler is registered for a source

## Verification
- .venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff format --check backend/web/services/agent_runtime_gateway.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
- uv run ruff check backend/web/services/agent_runtime_gateway.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
- uv run python -m pyright backend/web/services/agent_runtime_gateway.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
- git diff --check