### PR TITLE
Remove single chat runtime handler entrypoint

### DIFF
--- a/backend/web/services/agent_runtime_gateway.py
+++ b/backend/web/services/agent_runtime_gateway.py
@@ -17,13 +17,10 @@ class NativeAgentRuntimeGateway:
         self,
         app: Any,
         *,
-        chat_handler: Any | None = None,
         chat_handlers: Mapping[str, Any] | None = None,
         thread_input_handler: Any | None = None,
     ) -> None:
-        if chat_handler is not None and chat_handlers is not None:
-            raise ValueError("Use either chat_handler or chat_handlers, not both")
-        self._chat_handlers = dict(chat_handlers or {"mycel": chat_handler or NativeAgentChatDeliveryHandler(app)})
+        self._chat_handlers = dict(chat_handlers or {"mycel": NativeAgentChatDeliveryHandler(app)})
         self._thread_input_handler = thread_input_handler or NativeAgentThreadInputHandler(app)
 
     async def dispatch_chat(

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
@@ -41,7 +42,7 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
     thread_input_handler = _FakeThreadInputHandler()
     gateway = NativeAgentRuntimeGateway(
         app=object(),
-        chat_handler=chat_handler,
+        chat_handlers={"mycel": chat_handler},
         thread_input_handler=thread_input_handler,
     )
     chat_envelope = AgentChatDeliveryEnvelope(
@@ -67,6 +68,16 @@ def test_split_handler_modules_are_the_behavior_owners() -> None:
 
     assert NativeAgentChatDeliveryHandler.__name__ == "NativeAgentChatDeliveryHandler"
     assert NativeAgentThreadInputHandler.__name__ == "NativeAgentThreadInputHandler"
+
+
+def test_gateway_rejects_single_chat_handler_entrypoint() -> None:
+    constructor: Any = NativeAgentRuntimeGateway
+    with pytest.raises(TypeError, match="chat_handler"):
+        constructor(
+            app=object(),
+            chat_handler=_FakeChatHandler(),
+            thread_input_handler=_FakeThreadInputHandler(),
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the stale single `chat_handler=` constructor entrypoint from `NativeAgentRuntimeGateway`
- keep runtime-source routing explicit through `chat_handlers={runtime_source: handler}`
- preserve the default native `mycel` handler path and unregistered-source fail-loud behavior

## Non-scope
- no schema/auth/route/UI/deploy changes
- no external runtime implementation, inbox, SSE, idempotency, or delivery-state table
- no Monitor/Sandbox changes

## Verification
- RED: `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py -q` failed because `chat_handler=` was still accepted
- GREEN: `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_router.py tests/Integration/test_threads_router.py -q` -> 68 passed
- `uv run ruff format --check backend/web/services/agent_runtime_gateway.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py`
- `uv run ruff check backend/web/services/agent_runtime_gateway.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py`
- `uv run python -m pyright backend/web/services/agent_runtime_gateway.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py` -> 0 errors
- `git diff --check`