### PR TITLE
Converge Agent runtime input protocol shape

### DIFF
--- a/backend/protocols/agent_runtime.py
+++ b/backend/protocols/agent_runtime.py
@@ -13,11 +13,12 @@ class AgentChatContext:
 
 
 @dataclass(frozen=True)
-class AgentChatActor:
+class AgentRuntimeActor:
     user_id: str
     user_type: str
     display_name: str
     avatar_url: str | None = None
+    source: str | None = None
 
 
 @dataclass(frozen=True)
@@ -27,16 +28,18 @@ class AgentChatRecipient:
 
 
 @dataclass(frozen=True)
-class AgentChatMessage:
+class AgentRuntimeMessage:
     content: str
     content_type: str = "text"
     message_id: str | None = None
     signal: str | None = None
     created_at: str | None = None
+    attachments: list[str] | None = None
+    metadata: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
-class AgentChatTransport:
+class AgentRuntimeTransport:
     delivery_id: str | None = None
     correlation_id: str | None = None
     idempotency_key: str | None = None
@@ -45,10 +48,10 @@ class AgentChatTransport:
 @dataclass(frozen=True)
 class AgentChatDeliveryEnvelope:
     chat: AgentChatContext
-    sender: AgentChatActor
+    sender: AgentRuntimeActor
     recipient: AgentChatRecipient
-    message: AgentChatMessage
-    transport: AgentChatTransport = AgentChatTransport()
+    message: AgentRuntimeMessage
+    transport: AgentRuntimeTransport = AgentRuntimeTransport()
     protocol_version: Literal["agent.chat.delivery.v1"] = "agent.chat.delivery.v1"
     event_type: Literal["chat.message"] = "chat.message"
     extensions: dict[str, Any] | None = None
@@ -57,13 +60,10 @@ class AgentChatDeliveryEnvelope:
 @dataclass(frozen=True)
 class AgentThreadInputEnvelope:
     thread_id: str
-    content: str
-    source: str = "owner"
+    sender: AgentRuntimeActor
+    message: AgentRuntimeMessage
+    transport: AgentRuntimeTransport = AgentRuntimeTransport()
     enable_trajectory: bool = False
-    sender_name: str | None = None
-    sender_avatar_url: str | None = None
-    attachments: list[str] | None = None
-    message_metadata: dict[str, Any] | None = None
     protocol_version: Literal["agent.thread.input.v1"] = "agent.thread.input.v1"
     event_type: Literal["thread.input"] = "thread.input"
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1036,7 +1036,7 @@ async def send_message(
     if not payload.message.strip():
         raise HTTPException(status_code=400, detail="message cannot be empty")
 
-    from backend.protocols.agent_runtime import AgentThreadInputEnvelope
+    from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
     from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
     from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
 
@@ -1056,10 +1056,9 @@ async def send_message(
     return await get_agent_runtime_gateway(app).dispatch_thread_input(
         AgentThreadInputEnvelope(
             thread_id=thread_id,
-            content=message,
-            source="owner",
+            sender=AgentRuntimeActor(user_id=user_id, user_type="human", display_name="Owner", source="owner"),
+            message=AgentRuntimeMessage(content=message, attachments=payload.attachments or None),
             enable_trajectory=payload.enable_trajectory,
-            attachments=payload.attachments or None,
         )
     )
 
@@ -1173,7 +1172,7 @@ async def resolve_thread_permission_request(
 
     followup: dict[str, Any] | None = None
     if is_ask_user_question and payload.decision == "allow" and pending_request is not None and answers is not None:
-        from backend.protocols.agent_runtime import AgentThreadInputEnvelope
+        from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
         from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
 
         answered_payload = _build_ask_user_question_answered_payload(
@@ -1185,13 +1184,20 @@ async def resolve_thread_permission_request(
         followup = await get_agent_runtime_gateway(app).dispatch_thread_input(
             AgentThreadInputEnvelope(
                 thread_id=thread_id,
-                content=_format_ask_user_question_followup(
-                    pending_request,
-                    answers=answers,
-                    annotations=getattr(payload, "annotations", None),
+                sender=AgentRuntimeActor(
+                    user_id=user_id or "internal",
+                    user_type="system",
+                    display_name="Internal",
+                    source="internal",
                 ),
-                source="internal",
-                message_metadata={"ask_user_question_answered": answered_payload},
+                message=AgentRuntimeMessage(
+                    content=_format_ask_user_question_followup(
+                        pending_request,
+                        answers=answers,
+                        annotations=getattr(payload, "annotations", None),
+                    ),
+                    metadata={"ask_user_question_answered": answered_payload},
+                ),
             ),
         )
 

--- a/backend/web/services/agent_runtime_thread_handler.py
+++ b/backend/web/services/agent_runtime_thread_handler.py
@@ -39,16 +39,16 @@ class NativeAgentThreadInputHandler:
                 return {"status": "cancelled", "routing": "cancelled", "thread_id": thread_id}
 
             state = agent.runtime.current_state
-            logger.debug("[agent-runtime-gateway] thread=%s state=%s source=%s", thread_id[:15], state, envelope.source)
+            logger.debug("[agent-runtime-gateway] thread=%s state=%s source=%s", thread_id[:15], state, envelope.sender.source)
 
             if agent.runtime.current_state == AgentState.ACTIVE:
                 qm.enqueue(
-                    envelope.content,
+                    envelope.message.content,
                     thread_id,
                     "steer",
-                    source=envelope.source,
-                    sender_name=envelope.sender_name,
-                    sender_avatar_url=envelope.sender_avatar_url,
+                    source=envelope.sender.source,
+                    sender_name=envelope.sender.display_name,
+                    sender_avatar_url=envelope.sender.avatar_url,
                     is_steer=True,
                 )
                 logger.debug("[agent-runtime-gateway] thread input enqueued")
@@ -60,30 +60,30 @@ class NativeAgentThreadInputHandler:
             async with lock:
                 if not agent.runtime.transition(AgentState.ACTIVE):
                     qm.enqueue(
-                        envelope.content,
+                        envelope.message.content,
                         thread_id,
                         "steer",
-                        source=envelope.source,
-                        sender_name=envelope.sender_name,
-                        sender_avatar_url=envelope.sender_avatar_url,
+                        source=envelope.sender.source,
+                        sender_name=envelope.sender.display_name,
+                        sender_avatar_url=envelope.sender.avatar_url,
                         is_steer=True,
                     )
                     logger.debug("[agent-runtime-gateway] thread input enqueued after transition race")
                     return {"status": "injected", "routing": "steer", "thread_id": thread_id}
                 logger.debug("[agent-runtime-gateway] thread input starts run")
                 meta = {
-                    "source": envelope.source,
-                    "sender_name": envelope.sender_name,
-                    "sender_avatar_url": envelope.sender_avatar_url,
+                    "source": envelope.sender.source,
+                    "sender_name": envelope.sender.display_name,
+                    "sender_avatar_url": envelope.sender.avatar_url,
                 }
-                if envelope.message_metadata:
-                    meta.update(envelope.message_metadata)
-                if envelope.attachments:
-                    meta["attachments"] = envelope.attachments
+                if envelope.message.metadata:
+                    meta.update(envelope.message.metadata)
+                if envelope.message.attachments:
+                    meta["attachments"] = envelope.message.attachments
                 run_id = start_agent_run(
                     agent,
                     thread_id,
-                    envelope.content,
+                    envelope.message.content,
                     self._app,
                     enable_trajectory=envelope.enable_trajectory,
                     message_metadata=meta,

--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -8,11 +8,11 @@ from enum import Enum
 from typing import Any
 
 from backend.protocols.agent_runtime import (
-    AgentChatActor,
     AgentChatContext,
     AgentChatDeliveryEnvelope,
-    AgentChatMessage,
     AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
 )
 from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
 from storage.contracts import UserRow
@@ -41,14 +41,15 @@ def make_chat_delivery_fn(app: Any):
         recipient_type = raw_recipient_type.value if isinstance(raw_recipient_type, Enum) else str(raw_recipient_type)
         envelope = AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=chat_id),
-            sender=AgentChatActor(
+            sender=AgentRuntimeActor(
                 user_id=sender_id,
                 user_type="unknown",
                 display_name=sender_name,
                 avatar_url=sender_avatar_url,
+                source="chat",
             ),
             recipient=AgentChatRecipient(agent_user_id=recipient_id, runtime_source="mycel"),
-            message=AgentChatMessage(content=content, signal=signal),
+            message=AgentRuntimeMessage(content=content, signal=signal),
             extensions={
                 "mycel": {
                     "recipient_user_id": getattr(recipient_user, "id", recipient_id),

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -7,11 +7,11 @@ from typing import Any, cast
 import pytest
 
 from backend.protocols.agent_runtime import (
-    AgentChatActor,
     AgentChatContext,
     AgentChatDeliveryEnvelope,
-    AgentChatMessage,
     AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
 )
 from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from backend.web.utils.serializers import avatar_url
@@ -1246,9 +1246,9 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
 def _chat_delivery_envelope(*, chat_id: str = "chat-1", signal: str | None = "ping") -> AgentChatDeliveryEnvelope:
     return AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id=chat_id),
-        sender=AgentChatActor(user_id="human-user-1", user_type="human", display_name="Human"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel"),
-        message=AgentChatMessage(content="hello", signal=signal),
+        message=AgentRuntimeMessage(content="hello", signal=signal),
     )
 
 

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from backend.protocols.agent_runtime import AgentThreadInputEnvelope
+from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
 from backend.web.models.requests import SendMessageRequest
 from backend.web.routers import threads as threads_router
 from backend.web.routers.threads import get_thread_history, get_thread_messages
@@ -1224,7 +1224,13 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
     monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", fake_get_or_create_agent)
 
     startup_task = asyncio.create_task(
-        NativeAgentRuntimeGateway(app).dispatch_thread_input(AgentThreadInputEnvelope(thread_id=thread_id, content="start"))
+        NativeAgentRuntimeGateway(app).dispatch_thread_input(
+            AgentThreadInputEnvelope(
+                thread_id=thread_id,
+                sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),
+                message=AgentRuntimeMessage(content="start"),
+            )
+        )
     )
     await asyncio.wait_for(agent_lookup_started.wait(), timeout=2)
     cancel_handle = app.state.thread_tasks[thread_id]

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -1279,8 +1279,8 @@ async def test_resolve_ask_user_question_request_starts_followup_run_with_answer
         )
     ]
     assert len(captured) == 1
-    assert captured[0].source == "internal"
-    assert captured[0].message_metadata == {
+    assert captured[0].sender.source == "internal"
+    assert captured[0].message.metadata == {
         "ask_user_question_answered": {
             "questions": [
                 {
@@ -1302,7 +1302,7 @@ async def test_resolve_ask_user_question_request_starts_followup_run_with_answer
             "annotations": {"source": "ask-user-ui"},
         }
     }
-    followup_message = captured[0].content
+    followup_message = captured[0].message.content
     assert "AskUserQuestion" in followup_message
     assert "Minimal" in followup_message
     assert "Choose a style" in followup_message

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -6,11 +6,11 @@ from typing import Any
 import pytest
 
 from backend.protocols.agent_runtime import (
-    AgentChatActor,
     AgentChatContext,
     AgentChatDeliveryEnvelope,
-    AgentChatMessage,
     AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
 )
 from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
@@ -52,9 +52,9 @@ def _app(
 def _envelope(*, chat_id: str = "chat-1", signal: str | None = "ping") -> AgentChatDeliveryEnvelope:
     return AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id=chat_id),
-        sender=AgentChatActor(user_id="human-user-1", user_type="human", display_name="Human"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel"),
-        message=AgentChatMessage(content="hello", signal=signal),
+        message=AgentRuntimeMessage(content="hello", signal=signal),
     )
 
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -30,11 +30,11 @@ class _FakeThreadInputHandler:
 @pytest.mark.asyncio
 async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> None:
     from backend.protocols.agent_runtime import (
-        AgentChatActor,
         AgentChatContext,
         AgentChatDeliveryEnvelope,
-        AgentChatMessage,
         AgentChatRecipient,
+        AgentRuntimeActor,
+        AgentRuntimeMessage,
         AgentThreadInputEnvelope,
     )
 
@@ -47,11 +47,15 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
     )
     chat_envelope = AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id="chat-1"),
-        sender=AgentChatActor(user_id="human-1", user_type="human", display_name="Human"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel"),
-        message=AgentChatMessage(content="hello"),
+        message=AgentRuntimeMessage(content="hello"),
     )
-    thread_envelope = AgentThreadInputEnvelope(thread_id="thread-1", content="hello")
+    thread_envelope = AgentThreadInputEnvelope(
+        thread_id="thread-1",
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Owner", source="owner"),
+        message=AgentRuntimeMessage(content="hello"),
+    )
 
     chat_result = await gateway.dispatch_chat(chat_envelope)
     thread_result = await gateway.dispatch_thread_input(thread_envelope)
@@ -83,11 +87,11 @@ def test_gateway_rejects_single_chat_handler_entrypoint() -> None:
 @pytest.mark.asyncio
 async def test_gateway_routes_chat_delivery_by_runtime_source() -> None:
     from backend.protocols.agent_runtime import (
-        AgentChatActor,
         AgentChatContext,
         AgentChatDeliveryEnvelope,
-        AgentChatMessage,
         AgentChatRecipient,
+        AgentRuntimeActor,
+        AgentRuntimeMessage,
     )
 
     external_handler = _FakeChatHandler()
@@ -98,9 +102,9 @@ async def test_gateway_routes_chat_delivery_by_runtime_source() -> None:
     )
     envelope = AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id="chat-1"),
-        sender=AgentChatActor(user_id="human-1", user_type="human", display_name="Human"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="external-hook"),
-        message=AgentChatMessage(content="hello"),
+        message=AgentRuntimeMessage(content="hello"),
     )
 
     result = await gateway.dispatch_chat(envelope)
@@ -112,11 +116,11 @@ async def test_gateway_routes_chat_delivery_by_runtime_source() -> None:
 @pytest.mark.asyncio
 async def test_gateway_rejects_unregistered_chat_runtime_source() -> None:
     from backend.protocols.agent_runtime import (
-        AgentChatActor,
         AgentChatContext,
         AgentChatDeliveryEnvelope,
-        AgentChatMessage,
         AgentChatRecipient,
+        AgentRuntimeActor,
+        AgentRuntimeMessage,
     )
 
     gateway = NativeAgentRuntimeGateway(
@@ -126,9 +130,9 @@ async def test_gateway_rejects_unregistered_chat_runtime_source() -> None:
     )
     envelope = AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id="chat-1"),
-        sender=AgentChatActor(user_id="human-1", user_type="human", display_name="Human"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="external-hook"),
-        message=AgentChatMessage(content="hello"),
+        message=AgentRuntimeMessage(content="hello"),
     )
 
     with pytest.raises(ValueError, match="No Agent chat runtime handler registered for runtime_source='external-hook'"):

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from typing import get_type_hints
 
 
 def test_agent_runtime_protocol_types_live_outside_web_service_layer() -> None:
@@ -11,3 +12,20 @@ def test_agent_runtime_protocol_types_live_outside_web_service_layer() -> None:
     assert protocol_module.AgentThreadInputEnvelope.__module__ == "backend.protocols.agent_runtime"
     assert not hasattr(gateway_module, "AgentChatDeliveryEnvelope")
     assert not hasattr(gateway_module, "AgentThreadInputEnvelope")
+
+
+def test_agent_runtime_chat_and_thread_inputs_share_message_protocol_objects() -> None:
+    protocol_module = importlib.import_module("backend.protocols.agent_runtime")
+
+    chat_fields = get_type_hints(protocol_module.AgentChatDeliveryEnvelope)
+    thread_fields = get_type_hints(protocol_module.AgentThreadInputEnvelope)
+
+    assert chat_fields["sender"] is protocol_module.AgentRuntimeActor
+    assert chat_fields["message"] is protocol_module.AgentRuntimeMessage
+    assert chat_fields["transport"] is protocol_module.AgentRuntimeTransport
+    assert thread_fields["sender"] is protocol_module.AgentRuntimeActor
+    assert thread_fields["message"] is protocol_module.AgentRuntimeMessage
+    assert thread_fields["transport"] is protocol_module.AgentRuntimeTransport
+    assert "content" not in thread_fields
+    assert "source" not in thread_fields
+    assert "message_metadata" not in thread_fields

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from backend.protocols.agent_runtime import AgentThreadInputEnvelope
+from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
 from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
 
@@ -41,6 +41,15 @@ def _fake_app() -> SimpleNamespace:
     )
 
 
+def _thread_input(content: str = "hello", *, enable_trajectory: bool = False) -> AgentThreadInputEnvelope:
+    return AgentThreadInputEnvelope(
+        thread_id="thread-1",
+        sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),
+        message=AgentRuntimeMessage(content=content),
+        enable_trajectory=enable_trajectory,
+    )
+
+
 @pytest.mark.asyncio
 async def test_gateway_thread_input_clears_resource_overview_cache_when_starting_run() -> None:
     app = _fake_app()
@@ -52,7 +61,7 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
         patch("backend.web.services.streaming_service.start_agent_run", return_value="run-123"),
         patch("backend.web.services.resource_cache.clear_resource_overview_cache") as clear_cache,
     ):
-        result = await NativeAgentRuntimeGateway(app).dispatch_thread_input(AgentThreadInputEnvelope(thread_id="thread-1", content="hello"))
+        result = await NativeAgentRuntimeGateway(app).dispatch_thread_input(_thread_input())
 
     assert result == {"status": "started", "routing": "direct", "run_id": "run-123", "thread_id": "thread-1"}
     clear_cache.assert_called_once_with()
@@ -69,7 +78,7 @@ async def test_gateway_thread_input_requires_agent_runtime() -> None:
         patch("backend.web.services.resource_cache.clear_resource_overview_cache"),
     ):
         with pytest.raises(AttributeError):
-            await NativeAgentRuntimeGateway(app).dispatch_thread_input(AgentThreadInputEnvelope(thread_id="thread-1", content="hello"))
+            await NativeAgentRuntimeGateway(app).dispatch_thread_input(_thread_input())
 
 
 @pytest.mark.asyncio
@@ -83,8 +92,6 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         patch("backend.web.services.streaming_service.start_agent_run", return_value="run-123") as start_run,
         patch("backend.web.services.resource_cache.clear_resource_overview_cache"),
     ):
-        await NativeAgentRuntimeGateway(app).dispatch_thread_input(
-            AgentThreadInputEnvelope(thread_id="thread-1", content="hello", enable_trajectory=True)
-        )
+        await NativeAgentRuntimeGateway(app).dispatch_thread_input(_thread_input(enable_trajectory=True))
 
     assert start_run.call_args.kwargs["enable_trajectory"] is True


### PR DESCRIPTION
## Summary
- replace Chat-specific actor/message/transport protocol objects with shared Agent runtime protocol objects
- make direct Thread input use sender + message + transport instead of scalar content/source/message_metadata/attachments fields
- keep Chat and Thread callers on the existing Agent Runtime Gateway port; no route/schema/auth/UI/deploy changes

## Non-scope
- no external runtime handler implementation
- no inbox/SSE/ack/idempotency/delivery-state table
- no Monitor/Sandbox behavior change

## Verification
- RED: `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` failed because shared `AgentRuntimeActor` did not exist and Thread input still used scalar fields
- GREEN: `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_router.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py -q` -> 161 passed
- `uv run ruff format --check <changed files>` -> 11 files already formatted
- `uv run ruff check <changed files>` -> all checks passed
- `uv run python -m pyright backend/protocols/agent_runtime.py backend/web/services/agent_runtime_thread_handler.py backend/web/services/chat_delivery_hook.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py` -> 0 errors
- `git diff --check`

Note: touched integration files are covered by behavior pytest. Full pyright over `tests/Integration/test_messaging_social_handle_contract.py` still reports pre-existing typing debt unrelated to this protocol shape change.
