### PR TITLE
Type Agent thread input result protocol

### DIFF
--- a/backend/protocols/agent_runtime.py
+++ b/backend/protocols/agent_runtime.py
@@ -73,3 +73,17 @@ class AgentGatewayDeliveryResult:
     status: Literal["accepted", "skipped"]
     thread_id: str | None
     reason: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentThreadInputResult:
+    status: Literal["cancelled", "injected", "started"]
+    routing: Literal["cancelled", "steer", "direct"]
+    thread_id: str
+    run_id: str | None = None
+
+    def to_response(self) -> dict[str, str]:
+        response = {"status": self.status, "routing": self.routing, "thread_id": self.thread_id}
+        if self.run_id is not None:
+            response["run_id"] = self.run_id
+        return response

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1053,7 +1053,7 @@ async def send_message(
             agent=agent,
         )
 
-    return await get_agent_runtime_gateway(app).dispatch_thread_input(
+    result = await get_agent_runtime_gateway(app).dispatch_thread_input(
         AgentThreadInputEnvelope(
             thread_id=thread_id,
             sender=AgentRuntimeActor(user_id=user_id, user_type="human", display_name="Owner", source="owner"),
@@ -1061,6 +1061,7 @@ async def send_message(
             enable_trajectory=payload.enable_trajectory,
         )
     )
+    return result.to_response()
 
 
 @router.post("/{thread_id}/queue")
@@ -1181,7 +1182,7 @@ async def resolve_thread_permission_request(
             annotations=getattr(payload, "annotations", None),
         )
 
-        followup = await get_agent_runtime_gateway(app).dispatch_thread_input(
+        followup_result = await get_agent_runtime_gateway(app).dispatch_thread_input(
             AgentThreadInputEnvelope(
                 thread_id=thread_id,
                 sender=AgentRuntimeActor(
@@ -1200,6 +1201,7 @@ async def resolve_thread_permission_request(
                 ),
             ),
         )
+        followup = followup_result.to_response()
 
     response = {"ok": True, "thread_id": thread_id, "request_id": request_id}
     if followup is not None:

--- a/backend/web/services/agent_runtime_gateway.py
+++ b/backend/web/services/agent_runtime_gateway.py
@@ -31,6 +31,8 @@ class NativeAgentRuntimeGateway:
             raise ValueError(f"No Agent chat runtime handler registered for runtime_source={envelope.recipient.runtime_source!r}")
         return await handler.dispatch(envelope)
 
-    async def dispatch_thread_input(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
+    async def dispatch_thread_input(
+        self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope
+    ) -> agent_runtime_protocol.AgentThreadInputResult:
         """Route direct thread input through the Agent-side gateway."""
         return await self._thread_input_handler.dispatch(envelope)

--- a/backend/web/services/agent_runtime_port.py
+++ b/backend/web/services/agent_runtime_port.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
-from backend.protocols.agent_runtime import AgentChatDeliveryEnvelope, AgentGatewayDeliveryResult, AgentThreadInputEnvelope
+from backend.protocols.agent_runtime import (
+    AgentChatDeliveryEnvelope,
+    AgentGatewayDeliveryResult,
+    AgentThreadInputEnvelope,
+    AgentThreadInputResult,
+)
 
 
 class AgentRuntimeGatewayPort(Protocol):
     async def dispatch_chat(self, envelope: AgentChatDeliveryEnvelope) -> AgentGatewayDeliveryResult: ...
 
-    async def dispatch_thread_input(self, envelope: AgentThreadInputEnvelope) -> dict[str, Any]: ...
+    async def dispatch_thread_input(self, envelope: AgentThreadInputEnvelope) -> AgentThreadInputResult: ...
 
 
 def get_agent_runtime_gateway(app: Any) -> AgentRuntimeGatewayPort:

--- a/backend/web/services/agent_runtime_thread_handler.py
+++ b/backend/web/services/agent_runtime_thread_handler.py
@@ -18,7 +18,7 @@ class NativeAgentThreadInputHandler:
     def __init__(self, app: Any) -> None:
         self._app = app
 
-    async def dispatch(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
+    async def dispatch(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> agent_runtime_protocol.AgentThreadInputResult:
         from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
         from backend.web.services.resource_cache import clear_resource_overview_cache
         from backend.web.services.streaming_service import start_agent_run
@@ -36,7 +36,7 @@ class NativeAgentThreadInputHandler:
             qm = self._app.state.queue_manager
 
             if startup_cancel is not None and startup_cancel.cancelled():
-                return {"status": "cancelled", "routing": "cancelled", "thread_id": thread_id}
+                return agent_runtime_protocol.AgentThreadInputResult(status="cancelled", routing="cancelled", thread_id=thread_id)
 
             state = agent.runtime.current_state
             logger.debug("[agent-runtime-gateway] thread=%s state=%s source=%s", thread_id[:15], state, envelope.sender.source)
@@ -52,7 +52,7 @@ class NativeAgentThreadInputHandler:
                     is_steer=True,
                 )
                 logger.debug("[agent-runtime-gateway] thread input enqueued")
-                return {"status": "injected", "routing": "steer", "thread_id": thread_id}
+                return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
 
             locks = self._app.state.thread_locks
             async with self._app.state.thread_locks_guard:
@@ -69,7 +69,7 @@ class NativeAgentThreadInputHandler:
                         is_steer=True,
                     )
                     logger.debug("[agent-runtime-gateway] thread input enqueued after transition race")
-                    return {"status": "injected", "routing": "steer", "thread_id": thread_id}
+                    return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
                 logger.debug("[agent-runtime-gateway] thread input starts run")
                 meta = {
                     "source": envelope.sender.source,
@@ -91,7 +91,7 @@ class NativeAgentThreadInputHandler:
                 # @@@monitor-resource-cache-run-start - a fresh run can create or resume a sandbox runtime immediately.
                 # Drop the cached monitor snapshot so the next /api/monitor/resources read reflects the live topology.
                 clear_resource_overview_cache()
-            return {"status": "started", "routing": "direct", "run_id": run_id, "thread_id": thread_id}
+            return agent_runtime_protocol.AgentThreadInputResult(status="started", routing="direct", run_id=run_id, thread_id=thread_id)
         finally:
             if startup_cancel is not None and self._app.state.thread_tasks.get(thread_id) is startup_cancel:
                 self._app.state.thread_tasks.pop(thread_id, None)

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -1240,7 +1240,9 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
     release_agent_lookup.set()
     result = await asyncio.wait_for(startup_task, timeout=2)
 
-    assert result == {"status": "cancelled", "routing": "cancelled", "thread_id": thread_id}
+    from backend.protocols.agent_runtime import AgentThreadInputResult
+
+    assert result == AgentThreadInputResult(status="cancelled", routing="cancelled", thread_id=thread_id)
     assert app.state.thread_tasks.get(thread_id) is None
     assert runtime.current_state == AgentState.IDLE
 

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -167,10 +167,12 @@ class _FakeRecipeRepo:
 async def test_send_message_passes_enable_trajectory_to_agent_runtime_gateway() -> None:
     captured: list[Any] = []
 
+    from backend.protocols.agent_runtime import AgentThreadInputResult
+
     class _Gateway:
-        async def dispatch_thread_input(self, envelope: Any) -> dict[str, str]:
+        async def dispatch_thread_input(self, envelope: Any) -> AgentThreadInputResult:
             captured.append(envelope)
-            return {"status": "started", "thread_id": "thread-1"}
+            return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
 
     result = await threads_router.send_message(
         "thread-1",
@@ -179,7 +181,7 @@ async def test_send_message_passes_enable_trajectory_to_agent_runtime_gateway() 
         app=SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=_Gateway())),
     )
 
-    assert result == {"status": "started", "thread_id": "thread-1"}
+    assert result == {"status": "started", "routing": "direct", "thread_id": "thread-1"}
     assert captured[0].enable_trajectory is True
 
 
@@ -1242,10 +1244,12 @@ async def test_resolve_ask_user_question_request_starts_followup_run_with_answer
 
     captured: list[Any] = []
 
+    from backend.protocols.agent_runtime import AgentThreadInputResult
+
     class _Gateway:
-        async def dispatch_thread_input(self, envelope: Any) -> dict[str, str]:
+        async def dispatch_thread_input(self, envelope: Any) -> AgentThreadInputResult:
             captured.append(envelope)
-            return {"status": "started", "routing": "direct", "thread_id": "thread-1"}
+            return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
 
     result = await threads_router.resolve_thread_permission_request(
         "thread-1",

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from backend.protocols.agent_runtime import AgentGatewayDeliveryResult
+from backend.protocols.agent_runtime import AgentGatewayDeliveryResult, AgentThreadInputResult
 from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 
 
@@ -24,7 +24,7 @@ class _FakeThreadInputHandler:
 
     async def dispatch(self, envelope):
         self.called_with = envelope
-        return {"status": "started", "thread_id": "thread-1"}
+        return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
 
 
 @pytest.mark.asyncio
@@ -61,7 +61,7 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
     thread_result = await gateway.dispatch_thread_input(thread_envelope)
 
     assert chat_result == AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
-    assert thread_result == {"status": "started", "thread_id": "thread-1"}
+    assert thread_result == AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
     assert chat_handler.called_with is chat_envelope
     assert thread_input_handler.called_with is thread_envelope
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -29,3 +29,16 @@ def test_agent_runtime_chat_and_thread_inputs_share_message_protocol_objects() -
     assert "content" not in thread_fields
     assert "source" not in thread_fields
     assert "message_metadata" not in thread_fields
+
+
+def test_agent_runtime_thread_input_result_is_a_protocol_object() -> None:
+    protocol_module = importlib.import_module("backend.protocols.agent_runtime")
+    gateway_module = importlib.import_module("backend.web.services.agent_runtime_gateway")
+    port_module = importlib.import_module("backend.web.services.agent_runtime_port")
+
+    gateway_hints = get_type_hints(gateway_module.NativeAgentRuntimeGateway.dispatch_thread_input)
+    port_hints = get_type_hints(port_module.AgentRuntimeGatewayPort.dispatch_thread_input)
+
+    assert protocol_module.AgentThreadInputResult.__module__ == "backend.protocols.agent_runtime"
+    assert gateway_hints["return"] is protocol_module.AgentThreadInputResult
+    assert port_hints["return"] is protocol_module.AgentThreadInputResult

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
 from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
 
@@ -63,7 +63,7 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
     ):
         result = await NativeAgentRuntimeGateway(app).dispatch_thread_input(_thread_input())
 
-    assert result == {"status": "started", "routing": "direct", "run_id": "run-123", "thread_id": "thread-1"}
+    assert result == AgentThreadInputResult(status="started", routing="direct", run_id="run-123", thread_id="thread-1")
     clear_cache.assert_called_once_with()
 
 


### PR DESCRIPTION
## Summary
- add `AgentThreadInputResult` to `backend.protocols.agent_runtime`
- make `dispatch_thread_input` return the protocol object through the gateway/port/handler boundary
- keep `/api/threads` HTTP responses unchanged by projecting the result object at the route boundary

## Scope / Non-scope
- Scope: Agent Runtime Thread input result shape only
- Non-scope: schema, auth, UI, deploy, Monitor, Sandbox, external runtime, inbox/delivery persistence
- Public thread message response remains the same `status/routing/thread_id/run_id` JSON shape

## TDD
- RED: `test_agent_runtime_thread_input_result_is_a_protocol_object` failed because `AgentThreadInputResult` did not exist and Thread input returned dicts
- GREEN: focused Agent Runtime / Thread router pack passed after converting handler/gateway/port to the result object

## Verification
- `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_router.py -q` -> 113 passed
- `uv run ruff format --check <changed files>` -> clean
- `uv run ruff check <changed files>` -> clean
- `uv run python -m pyright <changed production + touched tests>` -> 0 errors
- `git diff --check` -> clean
