### PR TITLE
Type Agent chat result and handlers

### DIFF
--- a/backend/protocols/agent_runtime.py
+++ b/backend/protocols/agent_runtime.py
@@ -69,7 +69,7 @@ class AgentThreadInputEnvelope:
 
 
 @dataclass(frozen=True)
-class AgentGatewayDeliveryResult:
+class AgentChatDeliveryResult:
     status: Literal["accepted", "skipped"]
     thread_id: str | None
     reason: str | None = None

--- a/backend/web/services/agent_runtime_chat_handler.py
+++ b/backend/web/services/agent_runtime_chat_handler.py
@@ -17,9 +17,7 @@ class NativeAgentChatDeliveryHandler:
     def __init__(self, app: Any) -> None:
         self._app = app
 
-    async def dispatch(
-        self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
-    ) -> agent_runtime_protocol.AgentGatewayDeliveryResult:
+    async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
         from langchain_core.runnables.config import var_child_runnable_config
 
         var_child_runnable_config.set(None)
@@ -37,7 +35,7 @@ class NativeAgentChatDeliveryHandler:
 
         if not thread_id:
             logger.warning("Recipient %s has no thread, skipping delivery", envelope.recipient.agent_user_id)
-            return agent_runtime_protocol.AgentGatewayDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
+            return agent_runtime_protocol.AgentChatDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
 
         from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
         from backend.web.services.streaming_service import _ensure_thread_handlers
@@ -68,7 +66,7 @@ class NativeAgentChatDeliveryHandler:
             sender_name=envelope.sender.display_name,
             sender_avatar_url=envelope.sender.avatar_url,
         )
-        return agent_runtime_protocol.AgentGatewayDeliveryResult(status="accepted", thread_id=thread_id)
+        return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=thread_id)
 
     def _select_runtime_thread_id(self, recipient_id: str) -> str | None:
         thread = self._app.state.thread_repo.get_by_user_id(recipient_id)

--- a/backend/web/services/agent_runtime_gateway.py
+++ b/backend/web/services/agent_runtime_gateway.py
@@ -3,11 +3,23 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Protocol
 
 from backend.protocols import agent_runtime as agent_runtime_protocol
 from backend.web.services.agent_runtime_chat_handler import NativeAgentChatDeliveryHandler
 from backend.web.services.agent_runtime_thread_handler import NativeAgentThreadInputHandler
+
+
+class AgentChatRuntimeHandler(Protocol):
+    async def dispatch(
+        self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
+    ) -> agent_runtime_protocol.AgentChatDeliveryResult: ...
+
+
+class AgentThreadInputRuntimeHandler(Protocol):
+    async def dispatch(
+        self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope
+    ) -> agent_runtime_protocol.AgentThreadInputResult: ...
 
 
 class NativeAgentRuntimeGateway:
@@ -17,15 +29,15 @@ class NativeAgentRuntimeGateway:
         self,
         app: Any,
         *,
-        chat_handlers: Mapping[str, Any] | None = None,
-        thread_input_handler: Any | None = None,
+        chat_handlers: Mapping[str, AgentChatRuntimeHandler] | None = None,
+        thread_input_handler: AgentThreadInputRuntimeHandler | None = None,
     ) -> None:
         self._chat_handlers = dict(chat_handlers or {"mycel": NativeAgentChatDeliveryHandler(app)})
         self._thread_input_handler = thread_input_handler or NativeAgentThreadInputHandler(app)
 
     async def dispatch_chat(
         self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
-    ) -> agent_runtime_protocol.AgentGatewayDeliveryResult:
+    ) -> agent_runtime_protocol.AgentChatDeliveryResult:
         handler = self._chat_handlers.get(envelope.recipient.runtime_source)
         if handler is None:
             raise ValueError(f"No Agent chat runtime handler registered for runtime_source={envelope.recipient.runtime_source!r}")

--- a/backend/web/services/agent_runtime_port.py
+++ b/backend/web/services/agent_runtime_port.py
@@ -6,14 +6,14 @@ from typing import Any, Protocol
 
 from backend.protocols.agent_runtime import (
     AgentChatDeliveryEnvelope,
-    AgentGatewayDeliveryResult,
+    AgentChatDeliveryResult,
     AgentThreadInputEnvelope,
     AgentThreadInputResult,
 )
 
 
 class AgentRuntimeGatewayPort(Protocol):
-    async def dispatch_chat(self, envelope: AgentChatDeliveryEnvelope) -> AgentGatewayDeliveryResult: ...
+    async def dispatch_chat(self, envelope: AgentChatDeliveryEnvelope) -> AgentChatDeliveryResult: ...
 
     async def dispatch_thread_input(self, envelope: AgentThreadInputEnvelope) -> AgentThreadInputResult: ...
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from backend.protocols.agent_runtime import AgentGatewayDeliveryResult, AgentThreadInputResult
+from backend.protocols.agent_runtime import AgentChatDeliveryResult, AgentThreadInputResult
 from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 
 
@@ -15,7 +15,7 @@ class _FakeChatHandler:
 
     async def dispatch(self, envelope):
         self.called_with = envelope
-        return AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
+        return AgentChatDeliveryResult(status="accepted", thread_id="thread-1")
 
 
 @dataclass
@@ -60,7 +60,7 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
     chat_result = await gateway.dispatch_chat(chat_envelope)
     thread_result = await gateway.dispatch_thread_input(thread_envelope)
 
-    assert chat_result == AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
+    assert chat_result == AgentChatDeliveryResult(status="accepted", thread_id="thread-1")
     assert thread_result == AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
     assert chat_handler.called_with is chat_envelope
     assert thread_input_handler.called_with is thread_envelope
@@ -109,7 +109,7 @@ async def test_gateway_routes_chat_delivery_by_runtime_source() -> None:
 
     result = await gateway.dispatch_chat(envelope)
 
-    assert result == AgentGatewayDeliveryResult(status="accepted", thread_id="thread-1")
+    assert result == AgentChatDeliveryResult(status="accepted", thread_id="thread-1")
     assert external_handler.called_with is envelope
 
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -10,8 +10,11 @@ def test_agent_runtime_protocol_types_live_outside_web_service_layer() -> None:
 
     assert protocol_module.AgentChatDeliveryEnvelope.__module__ == "backend.protocols.agent_runtime"
     assert protocol_module.AgentThreadInputEnvelope.__module__ == "backend.protocols.agent_runtime"
+    assert protocol_module.AgentChatDeliveryResult.__module__ == "backend.protocols.agent_runtime"
+    assert not hasattr(protocol_module, "AgentGatewayDeliveryResult")
     assert not hasattr(gateway_module, "AgentChatDeliveryEnvelope")
     assert not hasattr(gateway_module, "AgentThreadInputEnvelope")
+    assert not hasattr(gateway_module, "AgentChatDeliveryResult")
 
 
 def test_agent_runtime_chat_and_thread_inputs_share_message_protocol_objects() -> None:
@@ -42,3 +45,12 @@ def test_agent_runtime_thread_input_result_is_a_protocol_object() -> None:
     assert protocol_module.AgentThreadInputResult.__module__ == "backend.protocols.agent_runtime"
     assert gateway_hints["return"] is protocol_module.AgentThreadInputResult
     assert port_hints["return"] is protocol_module.AgentThreadInputResult
+
+
+def test_agent_runtime_gateway_handler_injection_is_typed() -> None:
+    gateway_module = importlib.import_module("backend.web.services.agent_runtime_gateway")
+
+    constructor_hints = get_type_hints(gateway_module.NativeAgentRuntimeGateway.__init__)
+
+    assert "AgentChatRuntimeHandler" in str(constructor_hints["chat_handlers"])
+    assert constructor_hints["thread_input_handler"] == gateway_module.AgentThreadInputRuntimeHandler | None


### PR DESCRIPTION
## Summary
- rename the Chat delivery result protocol to `AgentChatDeliveryResult`
- keep Thread input result as `AgentThreadInputResult`
- type the gateway handler injection seam with `AgentChatRuntimeHandler` and `AgentThreadInputRuntimeHandler` protocols instead of `Any`

## Scope / Non-scope
- Scope: Agent Runtime Chat result naming and handler injection typing only
- Non-scope: schema, auth, routes, UI, deploy, Monitor, Sandbox, external runtime, inbox/delivery persistence
- No public API response shape changes

## TDD
- RED: protocol boundary test failed because `AgentChatDeliveryResult` did not exist and gateway handler injection used `Any`
- GREEN: renamed the result object and typed the gateway handler protocols

## Verification
- `.venv/bin/python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_router.py -q` -> 114 passed
- `uv run ruff format --check <changed files>` -> clean
- `uv run ruff check <changed files>` -> clean
- `uv run python -m pyright <changed files>` -> 0 errors
- `git diff --check` -> clean
