### PR TITLE
Fail loudly on Chat delivery errors

### DIFF
--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -96,7 +96,4 @@ class ChatDeliveryDispatcher:
     ) -> None:
         if not self._delivery_fn:
             return
-        try:
-            self._delivery_fn(recipient_id, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
-        except Exception:
-            logger.exception("[messaging] delivery failed for member %s", recipient_id)
+        self._delivery_fn(recipient_id, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -110,7 +110,7 @@ def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
     assert delivered == []
 
 
-def test_dispatcher_continues_after_delivery_function_failure() -> None:
+def test_dispatcher_fails_loudly_when_delivery_function_fails() -> None:
     delivered: list[str] = []
 
     def deliver(recipient_id: str, *_args: Any, **_kwargs: Any) -> None:
@@ -124,6 +124,7 @@ def test_dispatcher_continues_after_delivery_function_failure() -> None:
         delivery_fn=deliver,
     )
 
-    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+    with pytest.raises(RuntimeError, match="agent offline"):
+        dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
 
-    assert delivered == ["agent-user-2"]
+    assert delivered == []


### PR DESCRIPTION
## Summary
- remove log-and-continue swallowing from `ChatDeliveryDispatcher._deliver`
- delivery handler failures now raise through dispatch instead of pretending Chat delivery succeeded
- update dispatcher test from silent continuation to fail-loud behavior

## Scope / Non-scope
- Scope: Chat delivery dispatcher error semantics only
- Non-scope: schema, auth, routes, UI, deploy, Monitor, Sandbox, external runtime implementation, delivery persistence/retry
- No public API payload shape change

## TDD
- RED: `test_dispatcher_fails_loudly_when_delivery_function_fails` failed because dispatcher caught `RuntimeError("agent offline")` and continued to the next recipient
- GREEN: removed the catch/log-only branch so the delivery error propagates and no later recipient is silently delivered after the failure

## Verification
- `.venv/bin/python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py -q` -> 84 passed
- `uv run ruff format --check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py` -> clean
- `uv run ruff check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py` -> clean
- `uv run python -m pyright messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py` -> 0 errors
- `git diff --check` -> clean
