### PR TITLE
Refactor chat delivery request boundary

### DIFF
--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -15,7 +15,7 @@ from backend.protocols.agent_runtime import (
     AgentRuntimeMessage,
 )
 from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
-from storage.contracts import UserRow
+from messaging.delivery.dispatcher import ChatDeliveryRequest
 
 logger = logging.getLogger(__name__)
 
@@ -27,64 +27,37 @@ def make_chat_delivery_fn(app: Any):
     loop = asyncio.get_running_loop()
     logger.info("[delivery] make_chat_delivery_fn: loop=%s", loop)
 
-    async def deliver_to_runtime_gateway(
-        recipient_id: str,
-        recipient_user: UserRow,
-        content: str,
-        sender_name: str,
-        chat_id: str,
-        sender_id: str,
-        sender_avatar_url: str | None = None,
-        signal: str | None = None,
-    ) -> None:
-        raw_recipient_type = getattr(recipient_user, "type", "agent")
+    async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
+        raw_recipient_type = getattr(request.recipient_user, "type", "agent")
         recipient_type = raw_recipient_type.value if isinstance(raw_recipient_type, Enum) else str(raw_recipient_type)
         envelope = AgentChatDeliveryEnvelope(
-            chat=AgentChatContext(chat_id=chat_id),
+            chat=AgentChatContext(chat_id=request.chat_id),
             sender=AgentRuntimeActor(
-                user_id=sender_id,
+                user_id=request.sender_id,
                 user_type="unknown",
-                display_name=sender_name,
-                avatar_url=sender_avatar_url,
+                display_name=request.sender_name,
+                avatar_url=request.sender_avatar_url,
                 source="chat",
             ),
-            recipient=AgentChatRecipient(agent_user_id=recipient_id, runtime_source="mycel"),
-            message=AgentRuntimeMessage(content=content, signal=signal),
+            recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source="mycel"),
+            message=AgentRuntimeMessage(content=request.content, signal=request.signal),
             extensions={
                 "mycel": {
-                    "recipient_user_id": getattr(recipient_user, "id", recipient_id),
+                    "recipient_user_id": getattr(request.recipient_user, "id", request.recipient_id),
                     "recipient_user_type": recipient_type,
                 }
             },
         )
         await get_agent_runtime_gateway(app).dispatch_chat(envelope)
 
-    def _deliver(
-        recipient_id: str,
-        recipient_user: UserRow,
-        content: str,
-        sender_name: str,
-        chat_id: str,
-        sender_id: str,
-        sender_avatar_url: str | None = None,
-        signal: str | None = None,
-    ) -> None:
-        logger.info("[delivery] _deliver called: recipient=%s user=%s", recipient_id, recipient_user.id)
+    def _deliver(request: ChatDeliveryRequest) -> None:
+        logger.info("[delivery] _deliver called: recipient=%s user=%s", request.recipient_id, request.recipient_user.id)
         future = asyncio.run_coroutine_threadsafe(
-            deliver_to_runtime_gateway(
-                recipient_id,
-                recipient_user,
-                content,
-                sender_name,
-                chat_id,
-                sender_id,
-                sender_avatar_url,
-                signal=signal,
-            ),
+            deliver_to_runtime_gateway(request),
             loop,
         )
 
-        future.add_done_callback(functools.partial(_log_delivery_result, recipient_id))
+        future.add_done_callback(functools.partial(_log_delivery_result, request.recipient_id))
 
     return _deliver
 

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -3,15 +3,31 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Protocol
 
 from backend.web.utils.serializers import avatar_url
 from messaging.delivery.actions import DeliveryAction
 from messaging.display_user import resolve_messaging_display_user
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ChatDeliveryRequest:
+    recipient_id: str
+    recipient_user: Any
+    content: str
+    sender_name: str
+    chat_id: str
+    sender_id: str
+    sender_avatar_url: str | None
+    signal: str | None
+
+
+class ChatDeliveryFn(Protocol):
+    def __call__(self, request: ChatDeliveryRequest) -> None: ...
 
 
 class ChatDeliveryDispatcher:
@@ -22,14 +38,14 @@ class ChatDeliveryDispatcher:
         chat_member_repo: Any,
         user_repo: Any,
         delivery_resolver: Any | None = None,
-        delivery_fn: Callable | None = None,
+        delivery_fn: ChatDeliveryFn | None = None,
     ) -> None:
         self._chat_members_repo = chat_member_repo
         self._user_repo = user_repo
         self._delivery_resolver = delivery_resolver
         self._delivery_fn = delivery_fn
 
-    def set_delivery_fn(self, fn: Callable) -> None:
+    def set_delivery_fn(self, fn: ChatDeliveryFn) -> None:
         self._delivery_fn = fn
 
     def dispatch(
@@ -96,4 +112,15 @@ class ChatDeliveryDispatcher:
     ) -> None:
         if not self._delivery_fn:
             return
-        self._delivery_fn(recipient_id, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
+        self._delivery_fn(
+            ChatDeliveryRequest(
+                recipient_id=recipient_id,
+                recipient_user=recipient,
+                content=content,
+                sender_name=sender_name,
+                chat_id=chat_id,
+                sender_id=sender_id,
+                sender_avatar_url=sender_avatar_url,
+                signal=signal,
+            )
+        )

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from backend.web.utils.serializers import avatar_url
 from messaging.contracts import ContentType, MessageType
-from messaging.delivery.dispatcher import ChatDeliveryDispatcher
+from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
 from messaging.display_user import resolve_messaging_display_user
 
 logger = logging.getLogger(__name__)
@@ -35,7 +34,7 @@ class MessagingService:
         user_repo: Any,
         thread_repo: Any | None = None,
         delivery_resolver: Any | None = None,
-        delivery_fn: Callable | None = None,
+        delivery_fn: ChatDeliveryFn | None = None,
         delivery_dispatcher: ChatDeliveryDispatcher | None = None,
         event_bus: Any | None = None,
     ) -> None:
@@ -109,7 +108,7 @@ class MessagingService:
             )
         return member_info
 
-    def set_delivery_fn(self, fn: Callable) -> None:
+    def set_delivery_fn(self, fn: ChatDeliveryFn) -> None:
         self._delivery_dispatcher.set_delivery_fn(fn)
 
     # ------------------------------------------------------------------

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -108,7 +108,7 @@ def test_deliver_to_agents_does_not_require_main_thread_id():
                 else SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
             )
         ),
-        delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
 
     dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
@@ -1060,7 +1060,7 @@ def test_deliver_to_agents_routes_delivery_by_agent_user_id() -> None:
                 else SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
             )
         ),
-        delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
 
     dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
@@ -1101,7 +1101,7 @@ def test_same_owner_group_chat_kickoff_delivers_without_relationship() -> None:
             )
         ),
         delivery_resolver=resolver,
-        delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
 
     dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
@@ -1209,7 +1209,7 @@ def test_same_owner_agent_turn_delivers_to_sibling_actor_without_relationship() 
             )
         ),
         delivery_resolver=resolver,
-        delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
 
     dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from messaging.delivery.actions import DeliveryAction
-from messaging.delivery.dispatcher import ChatDeliveryDispatcher
+from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryRequest
 
 
 def _user_repo() -> SimpleNamespace:
@@ -51,16 +51,29 @@ def _member_repo(user_ids: list[str]) -> SimpleNamespace:
 
 
 def test_dispatcher_delivers_to_agent_user_ids() -> None:
-    delivered: list[tuple[str, str]] = []
+    delivered: list[tuple[str, str, str, str, str, str | None]] = []
+
+    def deliver(request: ChatDeliveryRequest) -> None:
+        delivered.append(
+            (
+                request.recipient_id,
+                request.recipient_user.id,
+                request.content,
+                request.sender_name,
+                request.chat_id,
+                request.signal,
+            )
+        )
+
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
         user_repo=_user_repo(),
-        delivery_fn=lambda recipient_id, member, *_args, **_kwargs: delivered.append((recipient_id, member.id)),
+        delivery_fn=deliver,
     )
 
-    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [], signal="urgent")
 
-    assert delivered == [("agent-user-1", "agent-user-1")]
+    assert delivered == [("agent-user-1", "agent-user-1", "hello", "Human", "chat-1", "urgent")]
 
 
 def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:
@@ -71,7 +84,7 @@ def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:
         delivery_resolver=SimpleNamespace(
             resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner path must not call resolver"))
         ),
-        delivery_fn=lambda recipient_id, *_args, **_kwargs: delivered.append(recipient_id),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 
     dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
@@ -87,7 +100,7 @@ def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
         delivery_resolver=SimpleNamespace(
             resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner sibling path must not call resolver"))
         ),
-        delivery_fn=lambda recipient_id, *_args, **_kwargs: delivered.append(recipient_id),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 
     dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])
@@ -102,7 +115,7 @@ def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
         chat_member_repo=_member_repo(["outside-human-user", "agent-user-1"]),
         user_repo=_user_repo(),
         delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: action),
-        delivery_fn=lambda recipient_id, *_args, **_kwargs: delivered.append(recipient_id),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 
     dispatcher.dispatch("chat-1", "outside-human-user", "hello", [])
@@ -113,10 +126,10 @@ def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
 def test_dispatcher_fails_loudly_when_delivery_function_fails() -> None:
     delivered: list[str] = []
 
-    def deliver(recipient_id: str, *_args: Any, **_kwargs: Any) -> None:
-        if recipient_id == "agent-user-1":
+    def deliver(request: ChatDeliveryRequest) -> None:
+        if request.recipient_id == "agent-user-1":
             raise RuntimeError("agent offline")
-        delivered.append(recipient_id)
+        delivered.append(request.recipient_id)
 
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),


### PR DESCRIPTION
## Summary
- add ChatDeliveryRequest and ChatDeliveryFn as the Messaging -> Agent delivery boundary
- change ChatDeliveryDispatcher and MessagingService delivery injection to pass one request object instead of scattered callback arguments
- update chat_delivery_hook to build AgentChatDeliveryEnvelope from the request object

## Proof
- RED: tests/Unit/messaging/test_chat_delivery_dispatcher.py failed because ChatDeliveryRequest did not exist
- .venv/bin/python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Integration/test_messaging_router.py tests/Integration/test_messaging_social_handle_contract.py -q
- .venv/bin/python -m ruff format messaging/delivery/dispatcher.py messaging/service.py backend/web/services/chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py --check
- .venv/bin/python -m ruff check messaging/delivery/dispatcher.py messaging/service.py backend/web/services/chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py
- uv run python -m pyright messaging/delivery/dispatcher.py messaging/service.py backend/web/services/chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py
- git diff --check

## Non-scope
- no schema/auth/route/UI/deploy/Monitor/Sandbox change
- no external runtime implementation
- no delivery retry/persistence/dead-letter lifecycle