### PR TITLE
Propagate chat runtime delivery failures

### DIFF
--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import logging
 from enum import Enum
 from typing import Any
@@ -56,16 +55,7 @@ def make_chat_delivery_fn(app: Any):
             deliver_to_runtime_gateway(request),
             loop,
         )
-
-        future.add_done_callback(functools.partial(_log_delivery_result, request.recipient_id))
+        future.result()
+        logger.info("[delivery] async delivery completed for %s", request.recipient_id)
 
     return _deliver
-
-
-def _log_delivery_result(recipient_id: str, f: Any) -> None:
-    """Done-callback for async delivery futures."""
-    exc = f.exception()
-    if exc:
-        logger.error("[delivery] async delivery failed for %s: %s", recipient_id, exc, exc_info=exc)
-    else:
-        logger.info("[delivery] async delivery completed for %s", recipient_id)

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
+from types import SimpleNamespace
+
+import pytest
 
 from backend.web.routers import threads as threads_router
 from backend.web.services import chat_delivery_hook
+from messaging.delivery.dispatcher import ChatDeliveryRequest
 
 
 def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> None:
@@ -14,3 +19,26 @@ def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> Non
     assert "NativeAgentRuntimeGateway" not in threads_source
     assert "get_agent_runtime_gateway" in delivery_source
     assert "get_agent_runtime_gateway" in threads_source
+
+
+@pytest.mark.asyncio
+async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
+    class FailingGateway:
+        async def dispatch_chat(self, _envelope):
+            raise RuntimeError("runtime gateway down")
+
+    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=FailingGateway()))
+    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+        content="hello",
+        sender_name="Human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        signal=None,
+    )
+
+    with pytest.raises(RuntimeError, match="runtime gateway down"):
+        await asyncio.to_thread(deliver, request)


### PR DESCRIPTION
## Summary
- make chat_delivery_hook wait for Agent Runtime Gateway dispatch completion
- propagate dispatch_chat exceptions back through the delivery function instead of logging them asynchronously as a side path
- add a unit test proving runtime gateway failures fail loudly

## Proof
- RED: tests/Unit/backend/web/services/test_chat_delivery_hook.py failed because RuntimeError(runtime gateway down) was logged but not raised
- .venv/bin/python -m pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Integration/test_messaging_router.py -q
- .venv/bin/python -m ruff check backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- .venv/bin/python -m ruff format backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py --check
- uv run python -m pyright backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- git diff --check

## Non-scope
- no schema/auth/route/UI/deploy/Monitor/Sandbox change
- no external runtime implementation
- no delivery retry/persistence/dead-letter lifecycle