### PR TITLE
Fail loudly when chat delivery hook is missing

### DIFF
--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -111,7 +111,7 @@ class ChatDeliveryDispatcher:
         signal: str | None,
     ) -> None:
         if not self._delivery_fn:
-            return
+            raise RuntimeError("Chat delivery function is not configured")
         self._delivery_fn(
             ChatDeliveryRequest(
                 recipient_id=recipient_id,

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -141,3 +141,13 @@ def test_dispatcher_fails_loudly_when_delivery_function_fails() -> None:
         dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
 
     assert delivered == []
+
+
+def test_dispatcher_fails_loudly_when_delivery_function_is_missing() -> None:
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
+        user_repo=_user_repo(),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat delivery function is not configured"):
+        dispatcher.dispatch("chat-1", "human-user-1", "hello", [])


### PR DESCRIPTION
## Summary
- make ChatDeliveryDispatcher raise when an Agent recipient is selected but no delivery function is configured
- add focused regression coverage for the missing-hook path

## Proof
- RED: tests/Unit/messaging/test_chat_delivery_dispatcher.py failed because missing delivery_fn returned success
- .venv/bin/python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_messaging_router.py -q
- .venv/bin/python -m ruff check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py
- .venv/bin/python -m ruff format messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py --check
- uv run python -m pyright messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py
- git diff --check

## Non-scope
- no schema/auth/route/UI/deploy/Monitor/Sandbox change
- no retry/persistence/dead-letter lifecycle