### PR TITLE
Fail loudly when chat recipient has no runtime thread

### DIFF
--- a/backend/protocols/agent_runtime.py
+++ b/backend/protocols/agent_runtime.py
@@ -70,9 +70,8 @@ class AgentThreadInputEnvelope:
 
 @dataclass(frozen=True)
 class AgentChatDeliveryResult:
-    status: Literal["accepted", "skipped"]
-    thread_id: str | None
-    reason: str | None = None
+    status: Literal["accepted"]
+    thread_id: str
 
 
 @dataclass(frozen=True)

--- a/backend/web/services/agent_runtime_chat_handler.py
+++ b/backend/web/services/agent_runtime_chat_handler.py
@@ -34,8 +34,7 @@ class NativeAgentChatDeliveryHandler:
         )
 
         if not thread_id:
-            logger.warning("Recipient %s has no thread, skipping delivery", envelope.recipient.agent_user_id)
-            return agent_runtime_protocol.AgentChatDeliveryResult(status="skipped", thread_id=None, reason="missing_thread")
+            raise RuntimeError(f"Agent chat recipient has no runtime thread: {envelope.recipient.agent_user_id}")
 
         from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
         from backend.web.services.streaming_service import _ensure_thread_handlers

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -76,25 +76,22 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-1"
-    assert result.reason is None
     assert started == [("thread-1", "chat-1", "agent-user-1")]
     assert unread_calls == [("chat-1", "agent-user-1")]
     assert enqueued == [("Human|chat-1|7|ping", "thread-1", "human-user-1", "Human")]
 
 
 @pytest.mark.asyncio
-async def test_gateway_dispatch_chat_skips_missing_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_gateway_dispatch_chat_raises_for_missing_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "backend.web.services.agent_pool.get_or_create_agent", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
     )
     app, started, unread_calls, enqueued = _app(threads=[])
     app.state.thread_repo = SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: [])
 
-    result = await NativeAgentRuntimeGateway(app).dispatch_chat(_envelope())
+    with pytest.raises(RuntimeError, match="Agent chat recipient has no runtime thread: agent-user-1"):
+        await NativeAgentRuntimeGateway(app).dispatch_chat(_envelope())
 
-    assert result.status == "skipped"
-    assert result.thread_id is None
-    assert result.reason == "missing_thread"
     assert started == []
     assert unread_calls == []
     assert enqueued == []


### PR DESCRIPTION
## Summary
- make native Agent chat delivery raise when the selected Agent recipient has no runtime thread
- remove the skipped/missing_thread success-shaped Chat delivery result
- narrow AgentChatDeliveryResult to accepted deliveries only

## Verification
- RED: uv run python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py -q failed because RuntimeError was not raised and current code returned skipped
- GREEN: uv run python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_threads_router.py -q
- uv run ruff format --check backend/protocols/agent_runtime.py backend/web/services/agent_runtime_chat_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
- uv run ruff check backend/protocols/agent_runtime.py backend/web/services/agent_runtime_chat_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
- uv run python -m pyright backend/protocols/agent_runtime.py backend/web/services/agent_runtime_chat_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
- git diff --check