### PR TITLE
Require chat delivery recipient type

### DIFF
--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -27,7 +27,9 @@ def make_chat_delivery_fn(app: Any):
     logger.info("[delivery] make_chat_delivery_fn: loop=%s", loop)
 
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
-        raw_recipient_type = getattr(request.recipient_user, "type", "agent")
+        raw_recipient_type = getattr(request.recipient_user, "type", None)
+        if raw_recipient_type is None:
+            raise RuntimeError(f"Chat delivery recipient is missing user type: {request.recipient_id}")
         recipient_type = raw_recipient_type.value if isinstance(raw_recipient_type, Enum) else str(raw_recipient_type)
         envelope = AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=request.chat_id),

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -42,3 +42,31 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
 
     with pytest.raises(RuntimeError, match="runtime gateway down"):
         await asyncio.to_thread(deliver, request)
+
+
+@pytest.mark.asyncio
+async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_chat(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=gateway))
+    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(id="agent-user-1"),
+        content="hello",
+        sender_name="Human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        signal=None,
+    )
+
+    with pytest.raises(RuntimeError, match="Chat delivery recipient is missing user type: agent-user-1"):
+        await asyncio.to_thread(deliver, request)
+
+    assert gateway.called is False


### PR DESCRIPTION
## Summary
- remove the implicit agent fallback for chat delivery recipient_user.type
- fail loudly before Agent Runtime dispatch when the recipient user object is missing its type
- add a focused hook regression test that proves no runtime dispatch occurs on malformed recipient identity

## Verification
- RED: uv run python -m pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q failed because missing recipient_user.type did not raise
- GREEN: uv run python -m pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_threads_router.py tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff format --check backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- uv run ruff check backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- uv run python -m pyright backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- git diff --check