### PR TITLE
Require chat delivery recipient id

### DIFF
--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -31,6 +31,9 @@ def make_chat_delivery_fn(app: Any):
         if raw_recipient_type is None:
             raise RuntimeError(f"Chat delivery recipient is missing user type: {request.recipient_id}")
         recipient_type = raw_recipient_type.value if isinstance(raw_recipient_type, Enum) else str(raw_recipient_type)
+        recipient_user_id = getattr(request.recipient_user, "id", None)
+        if recipient_user_id is None:
+            raise RuntimeError(f"Chat delivery recipient is missing user id: {request.recipient_id}")
         envelope = AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=request.chat_id),
             sender=AgentRuntimeActor(
@@ -44,7 +47,7 @@ def make_chat_delivery_fn(app: Any):
             message=AgentRuntimeMessage(content=request.content, signal=request.signal),
             extensions={
                 "mycel": {
-                    "recipient_user_id": getattr(request.recipient_user, "id", request.recipient_id),
+                    "recipient_user_id": recipient_user_id,
                     "recipient_user_type": recipient_type,
                 }
             },
@@ -52,7 +55,7 @@ def make_chat_delivery_fn(app: Any):
         await get_agent_runtime_gateway(app).dispatch_chat(envelope)
 
     def _deliver(request: ChatDeliveryRequest) -> None:
-        logger.info("[delivery] _deliver called: recipient=%s user=%s", request.recipient_id, request.recipient_user.id)
+        logger.info("[delivery] _deliver called: recipient=%s", request.recipient_id)
         future = asyncio.run_coroutine_threadsafe(
             deliver_to_runtime_gateway(request),
             loop,

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -70,3 +70,31 @@ async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
         await asyncio.to_thread(deliver, request)
 
     assert gateway.called is False
+
+
+@pytest.mark.asyncio
+async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_chat(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=gateway))
+    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(type="agent"),
+        content="hello",
+        sender_name="Human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        signal=None,
+    )
+
+    with pytest.raises(RuntimeError, match="Chat delivery recipient is missing user id: agent-user-1"):
+        await asyncio.to_thread(deliver, request)
+
+    assert gateway.called is False


### PR DESCRIPTION
## Summary
- remove the recipient_user.id fallback to request.recipient_id in chat_delivery_hook
- raise a clear RuntimeError before Agent Runtime dispatch when recipient identity is malformed
- make delivery logging use request.recipient_id instead of directly dereferencing recipient_user.id before validation

## Verification
- RED: uv run python -m pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q failed because malformed recipient_user without id did not raise the intended boundary error
- GREEN: uv run python -m pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_threads_router.py tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff format --check backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- uv run ruff check backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- uv run python -m pyright backend/web/services/chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- git diff --check