### PR TITLE
Require chat delivery sender identity

### DIFF
--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -59,9 +59,11 @@ class ChatDeliveryDispatcher:
         mention_set = set(mentions)
         members = self._chat_members_repo.list_members(chat_id)
         sender_user = self._resolve_display_user(sender_id)
-        sender_name = sender_user.display_name if sender_user else "unknown"
-        sender_avatar_url = avatar_url(sender_user.id if sender_user else sender_id, bool(sender_user.avatar if sender_user else None))
-        sender_raw_type = getattr(sender_user, "type", None) if sender_user else None
+        if sender_user is None:
+            raise RuntimeError(f"Chat delivery sender identity not found: {sender_id}")
+        sender_name = sender_user.display_name
+        sender_avatar_url = avatar_url(sender_user.id, bool(sender_user.avatar))
+        sender_raw_type = getattr(sender_user, "type", None)
         sender_type = sender_raw_type.value if isinstance(sender_raw_type, Enum) else sender_raw_type
         sender_owner_id = sender_user.id if sender_user and sender_type == "human" else getattr(sender_user, "owner_user_id", None)
 

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -151,3 +151,17 @@ def test_dispatcher_fails_loudly_when_delivery_function_is_missing() -> None:
 
     with pytest.raises(RuntimeError, match="Chat delivery function is not configured"):
         dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+
+def test_dispatcher_fails_loudly_when_sender_identity_is_missing() -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["missing-user", "agent-user-1"]),
+        user_repo=_user_repo(),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat delivery sender identity not found: missing-user"):
+        dispatcher.dispatch("chat-1", "missing-user", "hello", [])
+
+    assert delivered == []


### PR DESCRIPTION
## Summary
- remove the unknown-sender fallback from ChatDeliveryDispatcher
- fail loudly when sender identity cannot be resolved before delivery
- keep Agent Runtime delivery envelopes from receiving synthetic sender names

## Verification
- RED: uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py -q failed because missing sender identity did not raise
- GREEN: uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_threads_router.py tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff format --check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py
- uv run ruff check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py
- uv run python -m pyright messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py
- git diff --check