### PR TITLE
fix: carry chat sender type into runtime envelope

### DIFF
--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -38,7 +38,7 @@ def make_chat_delivery_fn(app: Any):
             chat=AgentChatContext(chat_id=request.chat_id),
             sender=AgentRuntimeActor(
                 user_id=request.sender_id,
-                user_type="unknown",
+                user_type=request.sender_type,
                 display_name=request.sender_name,
                 avatar_url=request.sender_avatar_url,
                 source="chat",

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -20,6 +20,7 @@ class ChatDeliveryRequest:
     recipient_user: Any
     content: str
     sender_name: str
+    sender_type: str
     chat_id: str
     sender_id: str
     sender_avatar_url: str | None
@@ -64,8 +65,10 @@ class ChatDeliveryDispatcher:
         sender_name = sender_user.display_name
         sender_avatar_url = avatar_url(sender_user.id, bool(sender_user.avatar))
         sender_raw_type = getattr(sender_user, "type", None)
-        sender_type = sender_raw_type.value if isinstance(sender_raw_type, Enum) else sender_raw_type
-        sender_owner_id = sender_user.id if sender_user and sender_type == "human" else getattr(sender_user, "owner_user_id", None)
+        if sender_raw_type is None:
+            raise RuntimeError(f"Chat delivery sender type is missing: {sender_id}")
+        sender_type = sender_raw_type.value if isinstance(sender_raw_type, Enum) else str(sender_raw_type)
+        sender_owner_id = sender_user.id if sender_type == "human" else getattr(sender_user, "owner_user_id", None)
 
         for member in members:
             uid = member.get("user_id")
@@ -82,7 +85,7 @@ class ChatDeliveryDispatcher:
             # @@@same-owner-group-delivery - explicit group membership among the same owner
             # must reach sibling actors even when no relationship row exists yet.
             if sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id:
-                self._deliver(uid, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
+                self._deliver(uid, recipient, content, sender_name, sender_type, chat_id, sender_id, sender_avatar_url, signal=signal)
                 continue
 
             if self._delivery_resolver:
@@ -92,7 +95,7 @@ class ChatDeliveryDispatcher:
                     logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])
                     continue
 
-            self._deliver(uid, recipient, content, sender_name, chat_id, sender_id, sender_avatar_url, signal=signal)
+            self._deliver(uid, recipient, content, sender_name, sender_type, chat_id, sender_id, sender_avatar_url, signal=signal)
 
     def _resolve_display_user(self, social_user_id: str) -> Any | None:
         return resolve_messaging_display_user(
@@ -106,6 +109,7 @@ class ChatDeliveryDispatcher:
         recipient: Any,
         content: str,
         sender_name: str,
+        sender_type: str,
         chat_id: str,
         sender_id: str,
         sender_avatar_url: str | None,
@@ -120,6 +124,7 @@ class ChatDeliveryDispatcher:
                 recipient_user=recipient,
                 content=content,
                 sender_name=sender_name,
+                sender_type=sender_type,
                 chat_id=chat_id,
                 sender_id=sender_id,
                 sender_avatar_url=sender_avatar_url,

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -34,6 +34,7 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
         recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
         content="hello",
         sender_name="Human",
+        sender_type="human",
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,
@@ -42,6 +43,35 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
 
     with pytest.raises(RuntimeError, match="runtime gateway down"):
         await asyncio.to_thread(deliver, request)
+
+
+@pytest.mark.asyncio
+async def test_chat_delivery_hook_uses_request_sender_type() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_chat(self, envelope):
+            self.envelope = envelope
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=gateway))
+    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+        content="hello",
+        sender_name="Human",
+        sender_type="human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        signal=None,
+    )
+
+    await asyncio.to_thread(deliver, request)
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.sender.user_type == "human"
 
 
 @pytest.mark.asyncio
@@ -60,6 +90,7 @@ async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
         recipient_user=SimpleNamespace(id="agent-user-1"),
         content="hello",
         sender_name="Human",
+        sender_type="human",
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,
@@ -88,6 +119,7 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
         recipient_user=SimpleNamespace(type="agent"),
         content="hello",
         sender_name="Human",
+        sender_type="human",
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -51,7 +51,7 @@ def _member_repo(user_ids: list[str]) -> SimpleNamespace:
 
 
 def test_dispatcher_delivers_to_agent_user_ids() -> None:
-    delivered: list[tuple[str, str, str, str, str, str | None]] = []
+    delivered: list[tuple[str, str, str, str, str, str, str | None]] = []
 
     def deliver(request: ChatDeliveryRequest) -> None:
         delivered.append(
@@ -60,6 +60,7 @@ def test_dispatcher_delivers_to_agent_user_ids() -> None:
                 request.recipient_user.id,
                 request.content,
                 request.sender_name,
+                request.sender_type,
                 request.chat_id,
                 request.signal,
             )
@@ -73,7 +74,7 @@ def test_dispatcher_delivers_to_agent_user_ids() -> None:
 
     dispatcher.dispatch("chat-1", "human-user-1", "hello", [], signal="urgent")
 
-    assert delivered == [("agent-user-1", "agent-user-1", "hello", "Human", "chat-1", "urgent")]
+    assert delivered == [("agent-user-1", "agent-user-1", "hello", "Human", "human", "chat-1", "urgent")]
 
 
 def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:


### PR DESCRIPTION
## Summary
- add sender_type to ChatDeliveryRequest
- resolve sender user type in ChatDeliveryDispatcher and fail loudly if it is missing
- project sender_type into AgentRuntimeActor.user_type instead of synthetic unknown

## Verification
- RED: focused Chat delivery tests failed on missing request.sender_type and hook sender.user_type still being unknown
- uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_threads_router.py tests/Integration/test_messaging_social_handle_contract.py -q
- uv run ruff format --check messaging/delivery/dispatcher.py backend/web/services/chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- uv run ruff check messaging/delivery/dispatcher.py backend/web/services/chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- uv run python -m pyright messaging/delivery/dispatcher.py backend/web/services/chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py
- git diff --check