### PR TITLE
fix: reject chat messages from missing senders

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -167,6 +167,9 @@ class MessagingService:
         ai_metadata: dict[str, Any] | None = None,
         enforce_caught_up: bool = False,
     ) -> dict[str, Any]:
+        if self._resolve_display_user(sender_id) is None:
+            raise RuntimeError(f"Chat message sender identity not found: {sender_id}")
+
         msg_id = str(uuid.uuid4())
 
         row: dict[str, Any] = {

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -341,6 +341,24 @@ def test_messaging_service_event_bus_message_uses_service_owned_projection() -> 
     }
 
 
+def test_messaging_service_send_fails_before_persisting_unknown_sender() -> None:
+    created_rows: list[dict[str, Any]] = []
+    published: list[dict[str, object]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: []),
+        messages_repo=SimpleNamespace(create=lambda row: created_rows.append(row) or row),
+        user_repo=SimpleNamespace(get_by_id=lambda _uid: None),
+        event_bus=SimpleNamespace(publish=lambda _chat_id, payload: published.append(payload)),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat message sender identity not found: missing-user"):
+        service.send("chat-1", "missing-user", "hello")
+
+    assert created_rows == []
+    assert published == []
+
+
 def test_messaging_service_list_message_responses_projects_sender_name_from_agent_user_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(),


### PR DESCRIPTION
## Summary
- require MessagingService.send to resolve sender identity before persisting a message
- prevent missing sender rows from producing persisted/event-bus messages with synthetic sender_name=unknown
- cover the failure path with a contract test that asserts no message write or event publish happens

## Verification
- RED: test_messaging_service_send_fails_before_persisting_unknown_sender failed because the old path persisted/published before ChatDeliveryDispatcher raised
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Integration/test_threads_router.py -q
- uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- uv run python -m pyright messaging/service.py
- git diff --check

## Note
- Full pyright on tests/Integration/test_messaging_social_handle_contract.py still has pre-existing unrelated typing debt in negative constructor tests and ToolHandlerResult assertions; this PR does not expand that scope.