### PR TITLE
fix: require chat read sender identity

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -63,12 +63,15 @@ class MessagingService:
         # @@@message-response-projection - public chat message payload must keep
         # sender projection ownership in MessagingService so route send/list stay thin.
         message = self._normalize_message_row(row)
-        sender = self._resolve_display_user(message.get("sender_id", ""))
+        sender_id = str(message.get("sender_id") or "")
+        sender = self._resolve_display_user(sender_id)
+        if sender is None:
+            raise RuntimeError(f"Chat message sender identity not found: {sender_id or '<missing>'}")
         return {
             "id": message["id"],
             "chat_id": message["chat_id"],
-            "sender_id": message.get("sender_id"),
-            "sender_name": sender.display_name if sender else "unknown",
+            "sender_id": sender_id,
+            "sender_name": sender.display_name,
             "content": message["content"],
             "message_type": message.get("message_type", "human"),
             "mentioned_ids": message.get("mentioned_ids") or [],

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -87,6 +87,14 @@ class ChatToolService:
             return None
         return self._messaging.resolve_display_user(social_user_id)
 
+    def _message_sender_name(self, sender_id: str | None) -> str:
+        if not sender_id:
+            raise RuntimeError("Chat message sender identity not found: <missing>")
+        sender = self._resolve_display_user(sender_id)
+        if not sender:
+            raise RuntimeError(f"Chat message sender identity not found: {sender_id}")
+        return sender.display_name
+
     def _register(self, registry: ToolRegistry) -> None:
         self._register_list_chats(registry)
         self._register_chat_read(registry)
@@ -96,9 +104,9 @@ class ChatToolService:
     def _format_msgs(self, msgs: list[dict], eid: str) -> str:
         lines = []
         for m in msgs:
-            sender = self._resolve_display_user(m.get("sender_id", ""))
-            name = sender.display_name if sender else "unknown"
-            tag = "you" if m.get("sender_id") == eid else name
+            sender_id = m.get("sender_id")
+            name = self._message_sender_name(sender_id)
+            tag = "you" if sender_id == eid else name
             content = m.get("content", "")
             if m.get("retracted_at"):
                 content = "[已撤回]"
@@ -193,13 +201,15 @@ class ChatToolService:
                 msgs = self._fetch_by_range(chat_id, parsed)
                 if not msgs:
                     return "No messages in that range."
+                rendered = self._format_msgs(msgs, eid)
                 self._messaging.mark_read(chat_id, eid)
-                return self._format_msgs(msgs, eid)
+                return rendered
 
             msgs = self._messaging.list_unread(chat_id, eid)
             if msgs:
+                rendered = self._format_msgs(msgs, eid)
                 self._messaging.mark_read(chat_id, eid)
-                return self._format_msgs(msgs, eid)
+                return rendered
 
             return (
                 "No unread messages. To read history, call again with range:\n"
@@ -371,8 +381,7 @@ class ChatToolService:
                 return f"No messages matching '{query}'."
             lines = []
             for m in results:
-                sender = self._resolve_display_user(m.get("sender_id", ""))
-                name = sender.display_name if sender else "unknown"
+                name = self._message_sender_name(m.get("sender_id"))
                 lines.append(f"[{name}] {m.get('content', '')[:100]}")
             return "\n".join(lines)
 

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -398,6 +398,31 @@ def test_messaging_service_list_message_responses_projects_sender_name_from_agen
     ]
 
 
+def test_messaging_service_list_message_responses_fails_on_unknown_sender() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(),
+        messages_repo=SimpleNamespace(
+            list_by_chat=lambda _chat_id, **_kwargs: [
+                {
+                    "id": "msg-1",
+                    "chat_id": "chat-1",
+                    "sender_user_id": "missing-user",
+                    "content": "hello",
+                    "message_type": "human",
+                    "created_at": "2026-04-07T00:00:00Z",
+                }
+            ]
+        ),
+        user_repo=SimpleNamespace(get_by_id=lambda _uid: None),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        service.list_message_responses("chat-1", viewer_id="human-user-1")
+
+    assert str(excinfo.value) == "Chat message sender identity not found: missing-user"
+
+
 def test_messaging_service_agent_send_passes_expected_read_seq_to_messages_repo() -> None:
     created_rows: list[tuple[dict[str, Any], int | None]] = []
 
@@ -831,6 +856,33 @@ def test_chat_tool_formats_agent_user_id_sender_as_agent_name() -> None:
     assert "[Toad]: hello" in rendered
 
 
+def test_read_messages_fails_before_mark_read_on_unknown_message_sender() -> None:
+    registry = ToolRegistry()
+    marked: list[tuple[str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
+                {
+                    "sender_id": "missing-user",
+                    "content": f"after={after};before={before}",
+                }
+            ],
+            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        read_messages.handler(chat_id="chat-1", range="-1h:")
+
+    assert str(excinfo.value) == "Chat message sender identity not found: missing-user"
+    assert marked == []
+
+
 def test_chat_tool_send_accepts_agent_user_target_id() -> None:
     registry = ToolRegistry()
     sent: list[tuple[str, str, str]] = []
@@ -1065,6 +1117,25 @@ def test_chat_tool_search_uses_messaging_service_direct_chat_lookup_without_memb
 
     assert result == "No messages matching 'hello'."
     assert search_calls == [("hello", "chat-1")]
+
+
+def test_chat_tool_search_fails_on_unknown_message_sender() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            search_messages=lambda _query, *, chat_id=None: [{"sender_id": "missing-user", "content": f"chat_id={chat_id}"}],
+        ),
+    )
+
+    search_messages = registry.get("search_messages")
+    assert search_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        search_messages.handler(query="hello")
+
+    assert str(excinfo.value) == "Chat message sender identity not found: missing-user"
 
 
 def test_deliver_to_agents_routes_delivery_by_agent_user_id() -> None:


### PR DESCRIPTION
## Summary
- Fail loudly when MessagingService message response projection sees an unresolved sender instead of emitting sender_name=unknown.
- Fail loudly when ChatToolService read/search formatting sees an unresolved sender instead of rendering [unknown].
- Format read messages before mark_read so malformed history does not advance the read watermark.

## Scope
- messaging/service.py
- messaging/tools/chat_tool_service.py
- tests/Integration/test_messaging_social_handle_contract.py

Non-scope: Monitor Resources overview payload rename, routes/UI/schema/auth/Agent Runtime Gateway/Sandbox/external runtime/retry/persistence model.

## Rebase Note
- Initial PR base f2d68cb2 inherited a mainline Monitor Resources baseline-contract CI failure.
- Rebasing onto green dev 1964e39e removes that unrelated failure; current head is 1aa9d0fc.

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "unknown_message_sender" -> 2 failed before implementation
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "list_message_responses_fails_on_unknown_sender" -> 1 failed before implementation
- GREEN after rebase: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py -q -> 89 passed
- uv run ruff format --check messaging/service.py messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py -> 3 files already formatted
- uv run ruff check messaging/service.py messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py -> All checks passed
- uv run python -m pyright messaging/service.py messaging/tools/chat_tool_service.py -> 0 errors
- git diff --check -> clean

Design ledger updated in mycel-db-design commits 1747318, cf869fc, 7aea952.