### PR TITLE
fix: require chat detail member identity

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -98,7 +98,7 @@ class MessagingService:
             social_user_id = member.get("user_id")
             user = self._resolve_display_user(social_user_id) if social_user_id else None
             if user is None:
-                continue
+                raise RuntimeError(f"Chat member {social_user_id or '<missing>'} is not a resolvable user row")
             # @@@thread-social-member-projection - outward chat members must keep the
             # social/thread user id while borrowing display/avatar fields from the resolved user row.
             member_info.append(

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -524,6 +524,31 @@ def test_messaging_service_list_chats_exposes_agent_user_participant_id() -> Non
     assert chats[0]["unread_count"] == 0
 
 
+def test_messaging_service_chat_detail_fails_on_unknown_member_identity() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [
+                {"user_id": "human-user-1"},
+                {"user_id": "missing-user"},
+            ],
+        ),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None) if uid == "human-user-1" else None
+            ),
+        ),
+    )
+
+    chat = SimpleNamespace(id="chat-1", title=None, status="active", created_at="2026-04-07T00:00:00Z")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        service.get_chat_detail(chat)
+
+    assert str(excinfo.value) == "Chat member missing-user is not a resolvable user row"
+
+
 def test_messaging_service_list_chats_ignores_blank_other_names_in_title_default() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- Fail loudly when single-chat detail member projection sees an unresolved member row.
- Align get_chat_detail/_build_chat_members with bulk conversation summaries, which already reject unresolved member identities.
- Prevent malformed chat membership from being laundered into a partial members payload.

## Scope
- messaging/service.py
- tests/Integration/test_messaging_social_handle_contract.py

Non-scope: Sandbox public runtime route cutover, Monitor/Resources, routes/UI/schema/auth/Agent Runtime Gateway/Sandbox/external runtime/retry/persistence model.

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "chat_detail_fails_on_unknown_member_identity" -> failed before implementation because get_chat_detail did not raise
- Rebase/update: PR branch force-with-lease updated from 124c5657 to a0a50ab8 on product dev cb1a8eb9
- GREEN after rebase: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py -q -> 74 passed
- uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py -> 2 files already formatted
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py -> All checks passed
- uv run python -m pyright messaging/service.py -> 0 errors
- git diff --check -> clean

Design ledger updated in mycel-db-design commits c077d60 and 0f72fd2.
