### PR TITLE
fix: use chat summary title in chat tool list

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -140,7 +140,9 @@ class ChatToolService:
             lines = []
             for c in chats:
                 others = [member for member in c.get("members", []) if member["id"] != eid]
-                name = ", ".join(e["name"] for e in others) or "Unknown"
+                name = c.get("title")
+                if not name:
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")
                 unread = c.get("unread_count", 0)
                 last = c.get("last_message")
                 last_preview = f' — last: "{last["content"][:50]}"' if last else ""

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -251,6 +251,32 @@ def test_chat_tool_service_accepts_chat_identity_id_contract() -> None:
     assert registry.get("list_chats") is not None
 
 
+def test_chat_tool_list_chats_uses_messaging_service_title() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    result = list_chats.handler()
+
+    assert result == "- Solo Ops"
+
+
 def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
     registry = ToolRegistry()
 


### PR DESCRIPTION
## Summary
- Make ChatToolService list_chats render the MessagingService-provided chat title.
- Remove duplicate title derivation in the tool layer and the Unknown fallback for malformed summaries.
- Fail loudly if a chat summary reaches the tool without a title.

## Scope
- messaging/tools/chat_tool_service.py
- tests/Integration/test_messaging_social_handle_contract.py

Non-scope: schema/auth/routes/UI/Monitor/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "list_chats_uses_messaging_service_title" -> failed with old output "- Unknown"
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py -q -> 75 passed
- uv run ruff format --check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py -> 2 files already formatted
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py -> All checks passed
- uv run python -m pyright messaging/tools/chat_tool_service.py -> 0 errors
- git diff --check -> clean

Design ledger updated in mycel-db-design commits 0375d42 and 551b4de.
