### PR TITLE
fix: reject chat summary members without user id

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -399,9 +399,7 @@ class MessagingService:
             return users_future.result(), unread_future.result()
 
     def _project_chat_members(self, members: list[dict[str, Any]], users_by_id: dict[str, Any]) -> list[dict[str, Any]]:
-        return [
-            self._project_known_user_member(str(member.get("user_id") or ""), users_by_id) for member in members if member.get("user_id")
-        ]
+        return [self._project_known_user_member(str(member.get("user_id") or ""), users_by_id) for member in members]
 
     def _chat_title_and_avatar(self, title: str | None, members: list[dict[str, Any]], viewer_id: str) -> tuple[str, str | None]:
         other_members = [member for member in members if member["id"] != viewer_id]
@@ -430,7 +428,7 @@ class MessagingService:
     def _project_known_user_member(self, social_user_id: str, users_by_id: dict[str, Any]) -> dict[str, Any]:
         user = users_by_id.get(social_user_id)
         if user is None:
-            raise RuntimeError(f"Chat member {social_user_id} is not a resolvable user row")
+            raise RuntimeError(f"Chat member {social_user_id or '<missing>'} is not a resolvable user row")
         return {
             "id": social_user_id,
             "name": user.display_name,

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -716,6 +716,28 @@ def test_messaging_service_conversation_summaries_fail_on_unknown_member_identit
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_on_missing_member_user_id() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0},
+                {"chat_id": "chat-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat member <missing> is not a resolvable user row"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_loads_users_and_unread_counts_in_parallel() -> None:
     users_started = threading.Event()
     unread_started = threading.Event()


### PR DESCRIPTION
## Summary
- Reject malformed chat summary member rows that omit user_id.
- Route every summary member row through the same known-user projection path instead of silently filtering missing ids.
- Keep the existing unresolved-member error shape, using <missing> for absent user ids.

## Scope
- messaging/service.py
- tests/Integration/test_messaging_social_handle_contract.py

Non-scope: ChatToolService title contract, routes/UI/schema/auth/Monitor/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "missing_member_user_id" -> failed because no RuntimeError was raised
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py -q -> 76 passed
- uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py -> 2 files already formatted
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py -> All checks passed
- uv run python -m pyright messaging/service.py -> 0 errors
- git diff --check -> clean

Design ledger updated in mycel-db-design commit fdf1e9b.
