### PR TITLE
fix: reject unrequested chat summary members

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -367,7 +367,7 @@ class MessagingService:
         for member in self._chat_members_repo.list_members_for_chats(active_chat_ids):
             chat_id = str(member.get("chat_id") or "")
             if chat_id not in members_by_chat:
-                continue
+                raise RuntimeError(f"Chat member row references unrequested chat {chat_id or '<missing>'}")
             members_by_chat[chat_id].append(member)
             if member.get("user_id") == user_id:
                 last_read_by_chat[chat_id] = int(member.get("last_read_seq") or 0)

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -647,9 +647,13 @@ def test_messaging_service_conversation_summaries_use_bulk_projection_repos() ->
             list_members_for_chats=lambda chat_ids: (
                 calls.append(f"members:{','.join(chat_ids)}")
                 or [
-                    {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 4},
-                    {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
-                    {"chat_id": "chat-closed", "user_id": "human-user-1", "last_read_seq": 0},
+                    member
+                    for member in [
+                        {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 4},
+                        {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
+                        {"chat_id": "chat-closed", "user_id": "human-user-1", "last_read_seq": 0},
+                    ]
+                    if member["chat_id"] in chat_ids
                 ]
             ),
             list_members=lambda _chat_id: (_ for _ in ()).throw(AssertionError("conversation summaries must not fetch members one by one")),
@@ -735,6 +739,28 @@ def test_messaging_service_conversation_summaries_fail_on_missing_member_user_id
     )
 
     with pytest.raises(RuntimeError, match="Chat member <missing> is not a resolvable user row"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
+def test_messaging_service_conversation_summaries_fail_on_unrequested_member_chat_id() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0},
+                {"chat_id": "chat-extra", "user_id": "agent-user-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat member row references unrequested chat chat-extra"):
         service.list_conversation_summaries_for_user("human-user-1")
 
 


### PR DESCRIPTION
## Summary

- reject chat summary member rows whose chat_id is outside the requested active chat set
- keep the existing bulk projection test honest by making its fake repo respect the requested chat_ids
- record the boundary in the design ledger

## Verification

- RED: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "unrequested_member_chat_id"` failed before the service change with `DID NOT RAISE <class 'RuntimeError'>`
- GREEN: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "unrequested_member_chat_id"` -> 1 passed, 56 deselected
- `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py -q` -> 77 passed
- `uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> 2 files already formatted
- `uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> All checks passed
- `uv run python -m pyright messaging/service.py` -> 0 errors, 0 warnings, 0 informations
- `git diff --check` -> clean
