### PR TITLE
fix: reject chat summaries without title

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -315,7 +315,7 @@ class MessagingService:
         result: list[dict[str, Any]] = []
         for chat in chat_rows:
             member_info = self._project_chat_members(members_by_chat[chat.id], users_by_id)
-            title, chat_avatar_url = self._chat_title_and_avatar(chat.title, member_info, user_id)
+            title, chat_avatar_url = self._chat_title_and_avatar(chat.id, chat.title, member_info, user_id)
             result.append(
                 {
                     "id": chat.id,
@@ -337,7 +337,7 @@ class MessagingService:
         result: list[dict[str, Any]] = []
         for chat in chat_rows:
             member_info = self._project_chat_members(members_by_chat[chat.id], users_by_id)
-            title, chat_avatar_url = self._chat_title_and_avatar(chat.title, member_info, user_id)
+            title, chat_avatar_url = self._chat_title_and_avatar(chat.id, chat.title, member_info, user_id)
             result.append(
                 {
                     "id": chat.id,
@@ -401,10 +401,17 @@ class MessagingService:
     def _project_chat_members(self, members: list[dict[str, Any]], users_by_id: dict[str, Any]) -> list[dict[str, Any]]:
         return [self._project_known_user_member(str(member.get("user_id") or ""), users_by_id) for member in members]
 
-    def _chat_title_and_avatar(self, title: str | None, members: list[dict[str, Any]], viewer_id: str) -> tuple[str, str | None]:
+    def _chat_title_and_avatar(
+        self, chat_id: str, title: str | None, members: list[dict[str, Any]], viewer_id: str
+    ) -> tuple[str, str | None]:
         other_members = [member for member in members if member["id"] != viewer_id]
+        if title:
+            return title, other_members[0]["avatar_url"] if other_members else None
         other_names = [member["name"] for member in other_members if member.get("name")]
-        return title or ", ".join(other_names) or "Chat", other_members[0]["avatar_url"] if other_members else None
+        projected_title = ", ".join(other_names)
+        if not projected_title:
+            raise RuntimeError(f"Chat {chat_id} has no projectable title")
+        return projected_title, other_members[0]["avatar_url"] if other_members else None
 
     def _project_latest_message(self, row: dict[str, Any] | None, users_by_id: dict[str, Any]) -> dict[str, Any] | None:
         if row is None:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -764,6 +764,25 @@ def test_messaging_service_conversation_summaries_fail_on_unrequested_member_cha
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_without_projectable_title() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat chat-1 has no projectable title"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_loads_users_and_unread_counts_in_parallel() -> None:
     users_started = threading.Event()
     unread_started = threading.Event()


### PR DESCRIPTION
## Summary

- reject chat summaries that have no explicit title and no displayable peer member name
- remove the generic `Chat` synthesized title fallback from MessagingService summary projection
- record the boundary in the design ledger

## Verification

- RED: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "without_projectable_title"` failed before the service change with `DID NOT RAISE <class 'RuntimeError'>`
- GREEN: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "without_projectable_title"` -> 1 passed, 57 deselected
- `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py -q` -> 78 passed
- `uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> 2 files already formatted
- `uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> All checks passed
- `uv run python -m pyright messaging/service.py` -> 0 errors, 0 warnings, 0 informations
- `git diff --check` -> clean
