### PR TITLE
fix: reject invalid relationship list rows

### DIFF
--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -79,8 +79,8 @@ class RelationshipService:
         for r in rows:
             try:
                 result.append(RelationshipRow.model_validate(r))
-            except Exception:
-                logger.warning("[relationship] invalid row: %s", r)
+            except Exception as exc:
+                raise RuntimeError(f"Invalid relationship row {r.get('id') or '<missing>'}") from exc
         return result
 
     def get_by_id(self, relationship_id: str) -> dict | None:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -188,6 +188,26 @@ def test_relationship_upgrade_does_not_write_removed_hire_timestamp_columns() ->
     assert "hire_snapshot" not in captured
 
 
+def test_relationship_list_for_user_fails_on_invalid_row() -> None:
+    service = RelationshipService(
+        SimpleNamespace(
+            list_for_user=lambda _user_id: [
+                {
+                    "id": "hire_visit:agent-user-1:human-user-1",
+                    "user_low": "agent-user-1",
+                    "user_high": "human-user-1",
+                    "kind": "hire_visit",
+                    "state": "visit",
+                    "created_at": "2026-04-07T00:00:00Z",
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid relationship row hire_visit:agent-user-1:human-user-1"):
+        service.list_for_user("human-user-1")
+
+
 def test_chat_tool_registry_exposes_final_contract_only() -> None:
     registry = ToolRegistry()
     ChatToolService(


### PR DESCRIPTION
## Summary

- make RelationshipService.list_for_user fail loudly on invalid persisted relationship rows
- stop warning-and-dropping malformed social graph rows from relationship list projection
- record the boundary in the design ledger

## Verification

- RED: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "relationship_list_for_user_fails_on_invalid_row"` failed before the service change with `DID NOT RAISE <class 'RuntimeError'>` and logged the invalid row warning
- GREEN: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "relationship_list_for_user_fails_on_invalid_row"` -> 1 passed, 58 deselected
- `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_relationship_router.py tests/Integration/test_messaging_router.py -q` -> 85 passed
- `uv run ruff format --check messaging/relationships/service.py tests/Integration/test_messaging_social_handle_contract.py` -> 2 files already formatted
- `uv run ruff check messaging/relationships/service.py tests/Integration/test_messaging_social_handle_contract.py` -> All checks passed
- `uv run python -m pyright messaging/relationships/service.py` -> 0 errors, 0 warnings, 0 informations
- `git diff --check` -> clean
