### PR TITLE
fix: reject invalid relationship state rows

### DIFF
--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -90,4 +90,9 @@ class RelationshipService:
         existing = self._repo.get(user_a, user_b)
         if not existing:
             return "none"
-        return existing.get("state", "none")
+        try:
+            if "state" not in existing:
+                raise ValueError("missing relationship state")
+            return RelationshipRow.model_validate(existing).state
+        except Exception as exc:
+            raise RuntimeError(f"Invalid relationship row {existing.get('id') or '<missing>'}") from exc

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -208,6 +208,24 @@ def test_relationship_list_for_user_fails_on_invalid_row() -> None:
         service.list_for_user("human-user-1")
 
 
+def test_relationship_get_state_fails_on_invalid_existing_row() -> None:
+    service = RelationshipService(
+        SimpleNamespace(
+            get=lambda _user_a, _user_b: {
+                "id": "hire_visit:agent-user-1:human-user-1",
+                "user_low": "agent-user-1",
+                "user_high": "human-user-1",
+                "kind": "hire_visit",
+                "created_at": "2026-04-07T00:00:00Z",
+                "updated_at": "2026-04-07T00:00:01Z",
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid relationship row hire_visit:agent-user-1:human-user-1"):
+        service.get_state("human-user-1", "agent-user-1")
+
+
 def test_chat_tool_registry_exposes_final_contract_only() -> None:
     registry = ToolRegistry()
     ChatToolService(


### PR DESCRIPTION
## Summary
- make RelationshipService.get_state fail loudly when an existing relationship row is malformed or missing an explicit state
- add a focused social-handle contract regression test for the old silent state fallback

## Scope
- messaging/relationships/service.py
- tests/Integration/test_messaging_social_handle_contract.py

## Proof
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "relationship_get_state_fails_on_invalid_existing_row" failed with DID NOT RAISE on the old fallback
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "relationship_get_state_fails_on_invalid_existing_row" -> 1 passed, 59 deselected
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_relationship_router.py tests/Integration/test_messaging_router.py -q -> 86 passed
- uv run ruff format --check messaging/relationships/service.py tests/Integration/test_messaging_social_handle_contract.py -> 2 files already formatted
- uv run ruff check messaging/relationships/service.py tests/Integration/test_messaging_social_handle_contract.py -> All checks passed
- uv run python -m pyright messaging/relationships/service.py -> 0 errors
- git diff --check -> clean