### PR TITLE
fix: reject invalid delivery relationship rows

### DIFF
--- a/messaging/delivery/resolver.py
+++ b/messaging/delivery/resolver.py
@@ -17,6 +17,7 @@ import logging
 import time
 from typing import Any
 
+from messaging.contracts import RelationshipRow
 from messaging.delivery.actions import DeliveryAction
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class HireVisitDeliveryResolver:
 
         # Fetch relationship once for checks 2, 6, 7
         rel = self._relationships.get(recipient_id, sender_id) if self._relationships else None
-        rel_state = rel.get("state") if rel else "none"
+        rel_state = self._relationship_state(rel) if rel else "none"
 
         # 2. HIRE → DELIVER
         if rel_state == "hire":
@@ -90,6 +91,14 @@ class HireVisitDeliveryResolver:
 
         # 8. Default → DELIVER
         return DeliveryAction.DELIVER
+
+    def _relationship_state(self, relationship: dict[str, Any]) -> str:
+        try:
+            if "state" not in relationship:
+                raise ValueError("missing relationship state")
+            return RelationshipRow.model_validate(relationship).state
+        except Exception as exc:
+            raise RuntimeError(f"Invalid relationship row {relationship.get('id') or '<missing>'}") from exc
 
     def _get_contact(self, owner_id: str, target_id: str):
         """Fetch contact row from the directional contacts table."""

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1389,6 +1389,26 @@ def test_delivery_resolver_propagates_contact_repo_failures() -> None:
         resolver.resolve("agent-user-1", "chat-1", "human-user-1")
 
 
+def test_delivery_resolver_fails_on_invalid_existing_relationship_row() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: []),
+        relationship_repo=SimpleNamespace(
+            get=lambda _recipient_id, _sender_id: {
+                "id": "hire_visit:agent-user-1:human-user-1",
+                "user_low": "agent-user-1",
+                "user_high": "human-user-1",
+                "kind": "hire_visit",
+                "created_at": "2026-04-07T00:00:00Z",
+                "updated_at": "2026-04-07T00:00:01Z",
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid relationship row hire_visit:agent-user-1:human-user-1"):
+        resolver.resolve("agent-user-1", "chat-1", "human-user-1")
+
+
 def test_delivery_resolver_requires_current_chat_member_contract() -> None:
     resolver = HireVisitDeliveryResolver(
         contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),


### PR DESCRIPTION
## Summary
- Validate existing relationship rows inside `HireVisitDeliveryResolver` before using relationship state for delivery policy.
- Fail loudly on malformed persisted relationship rows, including missing explicit `state`, instead of falling through to default delivery.
- Keep absent relationship rows as the explicit no-relationship path.

## Verification
- RED: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "delivery_resolver_fails_on_invalid_existing_relationship_row"` failed with `Failed: DID NOT RAISE <class 'RuntimeError'>`.
- GREEN: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "delivery_resolver_fails_on_invalid_existing_relationship_row"` -> `1 passed, 60 deselected`.
- Wider: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_relationship_router.py tests/Integration/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q` -> `95 passed`.
- `uv run ruff format --check messaging/delivery/resolver.py tests/Integration/test_messaging_social_handle_contract.py && uv run ruff check messaging/delivery/resolver.py tests/Integration/test_messaging_social_handle_contract.py` -> passed.
- `uv run python -m pyright messaging/delivery/resolver.py` -> `0 errors, 0 warnings, 0 informations`.
- `git diff --check` -> clean.

## Scope
- Product files only: `messaging/delivery/resolver.py`, `tests/Integration/test_messaging_social_handle_contract.py`.
- Non-scope: routes/UI/schema/auth/Chat summary/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.