### PR TITLE
fix: reject chat summaries missing viewer rows

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -372,6 +372,10 @@ class MessagingService:
             if member.get("user_id") == user_id:
                 last_read_by_chat[chat_id] = int(member.get("last_read_seq") or 0)
 
+        for chat_id in active_chat_ids:
+            if chat_id not in last_read_by_chat:
+                raise RuntimeError(f"Chat {chat_id} is missing viewer member row {user_id}")
+
         visible_chats = [chat for chat in chat_rows if chat.id in last_read_by_chat]
         if not visible_chats:
             return [], {}, {}, {}

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -802,6 +802,25 @@ def test_messaging_service_conversation_summaries_fail_on_unrequested_member_cha
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_when_viewer_member_row_is_missing() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat chat-1 is missing viewer member row human-user-1"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_fail_without_projectable_title() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- Fail loudly when `list_chats_for_user` returns an active chat but the bulk member projection omits the requesting user's member row.
- Prevent Chat list/conversation summaries from silently dropping a visible chat because `last_read_seq` could not be derived from the viewer member row.

## Verification
- RED: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "viewer_member_row_is_missing"` failed with `Failed: DID NOT RAISE <class 'RuntimeError'>`.
- GREEN after implementation and rebase onto `3c0c1cde`: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "viewer_member_row_is_missing"` -> `1 passed, 61 deselected`.
- Wider after rebase: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_relationship_router.py tests/Integration/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q` -> `96 passed`.
- `uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py && uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> passed.
- `uv run python -m pyright messaging/service.py` -> `0 errors, 0 warnings, 0 informations`.
- `git diff --check` -> clean.

## Scope
- Product files only: `messaging/service.py`, `tests/Integration/test_messaging_social_handle_contract.py`.
- Non-scope: routes/UI/schema/auth/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.