### PR TITLE
fix: reject chat summaries missing chat rows

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -357,7 +357,13 @@ class MessagingService:
         if not chat_ids:
             return [], {}, {}, {}
 
-        chat_rows = [chat for chat in self._chats.list_by_ids(chat_ids) if chat.status == "active"]
+        loaded_chat_rows = self._chats.list_by_ids(chat_ids)
+        loaded_chat_ids = {str(chat.id) for chat in loaded_chat_rows}
+        missing_chat_ids = [chat_id for chat_id in chat_ids if str(chat_id) not in loaded_chat_ids]
+        if missing_chat_ids:
+            raise RuntimeError(f"Chat membership references missing chat row {missing_chat_ids[0]}")
+
+        chat_rows = [chat for chat in loaded_chat_rows if chat.status == "active"]
         active_chat_ids = [chat.id for chat in chat_rows]
         if not active_chat_ids:
             return [], {}, {}, {}

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -821,6 +821,21 @@ def test_messaging_service_conversation_summaries_fail_when_viewer_member_row_is
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_when_chat_row_is_missing() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(list_by_ids=lambda _chat_ids: []),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: []),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat membership references missing chat row chat-1"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_fail_without_projectable_title() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- fail loudly when chat membership references a chat id missing from the bulk chat row projection
- keep closed/inactive chat filtering behavior unchanged once the chat row exists
- add focused messaging social-handle contract coverage

## Scope
- `messaging/service.py`
- `tests/Integration/test_messaging_social_handle_contract.py`

## Evidence
- RED before implementation: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "chat_row_is_missing"` failed with `DID NOT RAISE <class 'RuntimeError'>`
- GREEN after rebase onto `09d82403`: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "chat_row_is_missing"` -> 1 passed, 62 deselected
- `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_relationship_router.py tests/Integration/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q` -> 97 passed
- `uv run ruff format --check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> 2 files already formatted
- `uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py` -> All checks passed
- `.venv/bin/python -m pyright messaging/service.py` -> 0 errors
- `git diff --check` -> clean

## Baseline note
- `dev` PR sync run `24612422834` for `09d82403` is green.
- `dev` push run `24612421881` still has a Windows unit job in progress; this branch is file-disjoint from that runtime-helper lane.
