### PR TITLE
fix: reject invalid chat delivery members

### DIFF
--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -72,11 +72,13 @@ class ChatDeliveryDispatcher:
 
         for member in members:
             uid = member.get("user_id")
-            if not uid or uid == sender_id:
+            if not uid:
+                raise RuntimeError(f"Chat delivery member row is missing user_id in chat {chat_id}")
+            if uid == sender_id:
                 continue
             recipient = self._resolve_display_user(uid)
             if not recipient:
-                continue
+                raise RuntimeError(f"Chat delivery recipient identity not found: {uid}")
             member_raw_type = getattr(recipient, "type", None)
             member_type = member_raw_type.value if isinstance(member_raw_type, Enum) else member_raw_type
             if member_type == "human":

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -166,3 +166,31 @@ def test_dispatcher_fails_loudly_when_sender_identity_is_missing() -> None:
         dispatcher.dispatch("chat-1", "missing-user", "hello", [])
 
     assert delivered == []
+
+
+def test_dispatcher_fails_loudly_when_member_user_id_is_missing() -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "human-user-1"}, {}]),
+        user_repo=_user_repo(),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat delivery member row is missing user_id in chat chat-1"):
+        dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert delivered == []
+
+
+def test_dispatcher_fails_loudly_when_recipient_identity_is_missing() -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "missing-recipient"]),
+        user_repo=_user_repo(),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat delivery recipient identity not found: missing-recipient"):
+        dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert delivered == []


### PR DESCRIPTION
## Summary
- fail loudly when Chat delivery sees a chat member row without `user_id`
- fail loudly when a non-sender chat member cannot resolve to a recipient user
- preserve legitimate skip behavior for the sender and human recipients

## Scope
- `messaging/delivery/dispatcher.py`
- `tests/Unit/messaging/test_chat_delivery_dispatcher.py`

## Evidence
- RED: `uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py -q -k "member_user_id_is_missing"` failed with `DID NOT RAISE`
- RED: `uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py -q -k "recipient_identity_is_missing"` failed with `DID NOT RAISE`
- GREEN: `uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py -q -k "member_user_id_is_missing or recipient_identity_is_missing"` -> 2 passed, 8 deselected
- `uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py tests/Integration/test_relationship_router.py -q` -> 99 passed
- `uv run ruff format --check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py` -> 2 files already formatted
- `uv run ruff check messaging/delivery/dispatcher.py tests/Unit/messaging/test_chat_delivery_dispatcher.py` -> All checks passed
- `.venv/bin/python -m pyright messaging/delivery/dispatcher.py` -> 0 errors
- `git diff --check` -> clean
