### PR TITLE
fix: reject invalid chat mute membership

### DIFF
--- a/messaging/delivery/resolver.py
+++ b/messaging/delivery/resolver.py
@@ -123,7 +123,10 @@ class HireVisitDeliveryResolver:
         members = self._chat_members.list_members(chat_id)
 
         for member in members:
-            if member.get("user_id") != user_id:
+            member_user_id = member.get("user_id")
+            if not member_user_id:
+                raise RuntimeError(f"Chat mute member row is missing user_id in chat {chat_id}")
+            if member_user_id != user_id:
                 continue
             if not member.get("muted", False):
                 return False
@@ -133,4 +136,4 @@ class HireVisitDeliveryResolver:
                 if isinstance(mute_until, (int, float)) and mute_until < time.time():
                     return False
             return True
-        return False
+        raise RuntimeError(f"Chat {chat_id} is missing delivery recipient member row {user_id}")

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1454,6 +1454,28 @@ def test_delivery_resolver_requires_current_chat_member_contract() -> None:
         resolver.resolve("agent-user-1", "chat-1", "human-user-1")
 
 
+def test_delivery_resolver_fails_on_chat_member_row_missing_user_id() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{}]),
+        relationship_repo=None,
+    )
+
+    with pytest.raises(RuntimeError, match="Chat mute member row is missing user_id in chat chat-1"):
+        resolver.resolve("agent-user-1", "chat-1", "human-user-1")
+
+
+def test_delivery_resolver_fails_when_recipient_membership_is_missing() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "human-user-1"}]),
+        relationship_repo=None,
+    )
+
+    with pytest.raises(RuntimeError, match="Chat chat-1 is missing delivery recipient member row agent-user-1"):
+        resolver.resolve("agent-user-1", "chat-1", "human-user-1")
+
+
 def test_delivery_resolver_notifies_when_new_contact_edge_is_muted() -> None:
     resolver = HireVisitDeliveryResolver(
         contact_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- fail loudly when chat-level mute lookup sees a chat member row without `user_id`
- fail loudly when the delivery recipient has no member row in the chat member projection
- preserve existing contact mute/block, hire, mention, visit, and stranger policy ordering

## Scope
- `messaging/delivery/resolver.py`
- `tests/Integration/test_messaging_social_handle_contract.py`

## Evidence
- RED: `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "chat_member_row_missing_user_id or recipient_membership_is_missing"` failed with two `DID NOT RAISE` failures
- GREEN: same focused command -> 2 passed, 63 deselected
- `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_messaging_router.py tests/Integration/test_relationship_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q` -> 101 passed
- `uv run ruff format --check messaging/delivery/resolver.py tests/Integration/test_messaging_social_handle_contract.py` -> 2 files already formatted
- `uv run ruff check messaging/delivery/resolver.py tests/Integration/test_messaging_social_handle_contract.py` -> All checks passed
- `.venv/bin/python -m pyright messaging/delivery/resolver.py` -> 0 errors
- `git diff --check` -> clean
