### PR TITLE
fix: reject unrequested latest chat messages

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -303,7 +303,12 @@ class MessagingService:
     def list_chats_for_user(self, user_id: str) -> list[dict[str, Any]]:
         """List all active chats for user with summary info."""
         chat_rows, members_by_chat, users_by_id, unread_by_chat = self._chat_projection_inputs(user_id)
-        latest_messages = self._messages.list_latest_by_chat_ids([chat.id for chat in chat_rows])
+        chat_ids = [chat.id for chat in chat_rows]
+        latest_messages = self._messages.list_latest_by_chat_ids(chat_ids)
+        chat_id_set = set(chat_ids)
+        for latest_chat_id in latest_messages:
+            if latest_chat_id not in chat_id_set:
+                raise RuntimeError(f"Latest message row references unrequested chat {latest_chat_id}")
         latest_sender_ids: set[str] = set()
         for row in latest_messages.values():
             sender_id = str(self._normalize_message_row(row).get("sender_id") or "")

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -836,6 +836,36 @@ def test_messaging_service_conversation_summaries_fail_when_chat_row_is_missing(
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_list_chats_fail_on_unrequested_latest_message_chat_id() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title="Team", status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(
+            count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
+            list_latest_by_chat_ids=lambda _chat_ids: {
+                "chat-extra": {
+                    "id": "msg-1",
+                    "chat_id": "chat-extra",
+                    "sender_user_id": "human-user-1",
+                    "content": "wrong chat",
+                    "created_at": 3.0,
+                }
+            },
+        ),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Latest message row references unrequested chat chat-extra"):
+        service.list_chats_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_fail_without_projectable_title() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- fail loudly when chat summary latest-message projection returns a chat id outside the requested visible chat set
- add focused regression coverage for the old silent ignore behavior

## Scope
- messaging/service.py
- tests/Integration/test_messaging_social_handle_contract.py

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k unrequested_latest_message_chat_id -> DID NOT RAISE
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k unrequested_latest_message_chat_id
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_router.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check