### PR TITLE
fix: reject chat summaries missing tool members

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -139,7 +139,10 @@ class ChatToolService:
                 return "No chats found."
             lines = []
             for c in chats:
-                others = [member for member in c.get("members", []) if member["id"] != eid]
+                members = c.get("members")
+                if not isinstance(members, list):
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing members")
+                others = [member for member in members if member["id"] != eid]
                 name = c.get("title")
                 if not name:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -315,6 +315,30 @@ def test_chat_tool_list_chats_uses_messaging_service_title() -> None:
     assert result == "- Solo Ops"
 
 
+def test_chat_tool_list_chats_requires_members_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Chat summary chat-1 is missing members"):
+        list_chats.handler()
+
+
 def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
     registry = ToolRegistry()
 


### PR DESCRIPTION
## Summary
- fail loudly when ChatToolService list_chats receives a summary without members
- add focused regression coverage for the old title-only half-truth output

## Scope
- messaging/tools/chat_tool_service.py
- tests/Integration/test_messaging_social_handle_contract.py

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_members_contract -> DID NOT RAISE
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_members_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check