### PR TITLE
fix: reject chat member rows missing tool ids

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -142,6 +142,9 @@ class ChatToolService:
                 members = c.get("members")
                 if not isinstance(members, list):
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing members")
+                for member in members:
+                    if "id" not in member:
+                        raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} member row is missing id")
                 others = [member for member in members if member["id"] != eid]
                 name = c.get("title")
                 if not name:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -339,6 +339,31 @@ def test_chat_tool_list_chats_requires_members_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_member_ids_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"name": "Human"}],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Chat summary chat-1 member row is missing id"):
+        list_chats.handler()
+
+
 def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
     registry = ToolRegistry()
 


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats fail loudly when a projected member row is missing id
- add focused messaging social-handle contract coverage for the malformed member row

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_member_ids_contract failed with raw KeyError before fix
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_member_ids_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check

## Scope
Only messaging/tools/chat_tool_service.py and tests/Integration/test_messaging_social_handle_contract.py. Non-scope: active Monitor sandbox read-source seam, routes/UI/schema/auth/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.