### PR TITLE
fix: reject chat summaries missing last message content

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -151,6 +151,8 @@ class ChatToolService:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")
                 unread = c.get("unread_count", 0)
                 last = c.get("last_message")
+                if last and "content" not in last:
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} last_message is missing content")
                 last_preview = f' — last: "{last["content"][:50]}"' if last else ""
                 unread_str = f" ({unread} unread)" if unread > 0 else ""
                 is_group = len(others) >= 2

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -364,6 +364,31 @@ def test_chat_tool_list_chats_requires_member_ids_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_last_message_content_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "unread_count": 0,
+                    "last_message": {"id": "msg-1"},
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Chat summary chat-1 last_message is missing content"):
+        list_chats.handler()
+
+
 def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
     registry = ToolRegistry()
 


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats fail loudly when a projected last_message row is missing content
- add focused messaging social-handle contract coverage for malformed last-message previews

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_last_message_content_contract failed with raw KeyError before fix
- GREEN after rebase onto b88a18a3: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_last_message_content_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check

## Scope
Only messaging/tools/chat_tool_service.py and tests/Integration/test_messaging_social_handle_contract.py. Non-scope: Monitor sandbox detail read-source seam, routes/UI/schema/auth/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.