### PR TITLE
fix: reject chat summaries missing unread counts

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -149,7 +149,9 @@ class ChatToolService:
                 name = c.get("title")
                 if not name:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")
-                unread = c.get("unread_count", 0)
+                if "unread_count" not in c:
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing unread_count")
+                unread = c["unread_count"]
                 last = c.get("last_message")
                 if last and "content" not in last:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} last_message is missing content")

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -389,6 +389,30 @@ def test_chat_tool_list_chats_requires_last_message_content_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_unread_count_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Chat summary chat-1 is missing unread_count"):
+        list_chats.handler()
+
+
 def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
     registry = ToolRegistry()
 


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats fail loudly when a projected chat summary omits unread_count
- add focused messaging social-handle contract coverage for the missing unread_count case

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_unread_count_contract failed with DID NOT RAISE before fix
- GREEN after rebase onto dd3a8baa: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k list_chats_requires_unread_count_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check

## Scope
Only messaging/tools/chat_tool_service.py and tests/Integration/test_messaging_social_handle_contract.py. Non-scope: Monitor read-source seams, routes/UI/schema/auth/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.