### PR TITLE
fix: validate unread counts before chat filtering

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -132,8 +132,11 @@ class ChatToolService:
 
         def handle(unread_only: bool = False, limit: int = 20) -> str:
             chats = self._messaging.list_chats_for_user(eid)
+            for c in chats:
+                if "unread_count" not in c:
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing unread_count")
             if unread_only:
-                chats = [c for c in chats if c.get("unread_count", 0) > 0]
+                chats = [c for c in chats if c["unread_count"] > 0]
             chats = chats[:limit]
             if not chats:
                 return "No chats found."
@@ -149,8 +152,6 @@ class ChatToolService:
                 name = c.get("title")
                 if not name:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")
-                if "unread_count" not in c:
-                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing unread_count")
                 unread = c["unread_count"]
                 last = c.get("last_message")
                 if last and "content" not in last:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -413,6 +413,30 @@ def test_chat_tool_list_chats_requires_unread_count_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_unread_filter_requires_unread_count_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Chat summary chat-1 is missing unread_count"):
+        list_chats.handler(unread_only=True)
+
+
 def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
     registry = ToolRegistry()
 


### PR DESCRIPTION
## Summary
- validate ChatToolService list_chats unread_count before applying unread_only filtering
- add focused contract coverage so malformed summaries are not silently filtered out as zero unread

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k unread_filter_requires_unread_count_contract failed with DID NOT RAISE before fix
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k unread_filter_requires_unread_count_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check

## Scope
Only messaging/tools/chat_tool_service.py and tests/Integration/test_messaging_social_handle_contract.py. Non-scope: Resource provider product-boundary seam, routes/UI/schema/auth/Sandbox/Agent Runtime delivery/external runtime/retry/persistence.