### PR TITLE
fix: reject empty chat last message previews

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -154,7 +154,7 @@ class ChatToolService:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")
                 unread = c["unread_count"]
                 last = c.get("last_message")
-                if last and "content" not in last:
+                if last is not None and "content" not in last:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} last_message is missing content")
                 last_preview = f' — last: "{last["content"][:50]}"' if last else ""
                 unread_str = f" ({unread} unread)" if unread > 0 else ""

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -389,6 +389,31 @@ def test_chat_tool_list_chats_requires_last_message_content_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_empty_last_message_content_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "unread_count": 0,
+                    "last_message": {},
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Chat summary chat-1 last_message is missing content"):
+        list_chats.handler()
+
+
 def test_chat_tool_list_chats_requires_unread_count_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats treat last_message=None as the only absent latest-message value
- reject empty/non-null latest-message objects that omit content instead of silently omitting the preview
- add a focused integration contract for last_message={}

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k empty_last_message_content_contract failed with DID NOT RAISE before the fix
- GREEN after rebase onto 98137731: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k empty_last_message_content_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check

Design ledger: mycel-db-design commit 74d2968