### PR TITLE
fix: reject group chat summaries missing ids

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -160,7 +160,10 @@ class ChatToolService:
                 unread_str = f" ({unread} unread)" if unread > 0 else ""
                 is_group = len(others) >= 2
                 if is_group:
-                    id_str = f" [chat_id: {c['id']}]"
+                    chat_id = c.get("id")
+                    if not chat_id:
+                        raise RuntimeError("Group chat summary is missing id")
+                    id_str = f" [chat_id: {chat_id}]"
                 else:
                     other_id = others[0]["id"] if others else ""
                     id_str = f" [id: {other_id}]" if other_id else ""

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -364,6 +364,34 @@ def test_chat_tool_list_chats_requires_member_ids_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_group_chat_id_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "title": "Ops Room",
+                    "members": [
+                        {"id": "human-user-1", "name": "Human"},
+                        {"id": "agent-user-1", "name": "Agent"},
+                        {"id": "agent-user-2", "name": "Agent 2"},
+                    ],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError, match="Group chat summary is missing id"):
+        list_chats.handler()
+
+
 def test_chat_tool_list_chats_requires_last_message_content_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats fail loudly when group chat output needs a chat id but the summary omits id
- avoid raw KeyError while rendering [chat_id]
- add a focused integration contract for missing group chat summary id

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k group_chat_id_contract failed with raw KeyError before fix
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k group_chat_id_contract
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check

Design ledger: mycel-db-design commit 063a745