### PR TITLE
fix: reject chat messages missing tool content

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -107,9 +107,12 @@ class ChatToolService:
             sender_id = m.get("sender_id")
             name = self._message_sender_name(sender_id)
             tag = "you" if sender_id == eid else name
-            content = m.get("content", "")
             if m.get("retracted_at"):
                 content = "[已撤回]"
+            elif "content" in m:
+                content = m["content"]
+            else:
+                raise RuntimeError(f"Chat message from {sender_id} is missing content")
             lines.append(f"[{tag}]: {content}")
         return "\n".join(lines)
 

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1278,6 +1278,32 @@ def test_read_messages_fails_before_mark_read_on_unknown_message_sender() -> Non
     assert marked == []
 
 
+def test_read_messages_fails_before_mark_read_on_missing_message_content() -> None:
+    registry = ToolRegistry()
+    marked: list[tuple[str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
+                {
+                    "sender_id": "agent-user-1",
+                }
+            ],
+            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        read_messages.handler(chat_id="chat-1", range="-1h:")
+
+    assert str(excinfo.value) == "Chat message from agent-user-1 is missing content"
+    assert marked == []
+
+
 def test_chat_tool_send_accepts_agent_user_target_id() -> None:
     registry = ToolRegistry()
     sent: list[tuple[str, str, str]] = []


### PR DESCRIPTION
## Summary
- make ChatToolService read rendering fail loudly when a non-retracted message row omits content
- keep retracted messages rendering as [已撤回]
- cover the guard before mark_read so malformed rows do not advance read state

## Proof
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k missing_message_content failed with DID NOT RAISE before implementation
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k missing_message_content -> 1 passed
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q -> 89 passed
- GREEN: uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- GREEN: uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- GREEN: .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- GREEN: git diff --check

Design ledger: mycel-db-design commit 2501948