### PR TITLE
fix: reject chat search messages missing content

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -400,8 +400,11 @@ class ChatToolService:
                 return f"No messages matching '{query}'."
             lines = []
             for m in results:
-                name = self._message_sender_name(m.get("sender_id"))
-                lines.append(f"[{name}] {m.get('content', '')[:100]}")
+                sender_id = m.get("sender_id")
+                name = self._message_sender_name(sender_id)
+                if "content" not in m:
+                    raise RuntimeError(f"Chat search message from {sender_id} is missing content")
+                lines.append(f"[{name}] {m['content'][:100]}")
             return "\n".join(lines)
 
         registry.register(

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1559,6 +1559,25 @@ def test_chat_tool_search_fails_on_unknown_message_sender() -> None:
     assert str(excinfo.value) == "Chat message sender identity not found: missing-user"
 
 
+def test_chat_tool_search_fails_on_missing_message_content() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            search_messages=lambda _query, *, chat_id=None: [{"sender_id": "agent-user-1"}],
+        ),
+    )
+
+    search_messages = registry.get("search_messages")
+    assert search_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        search_messages.handler(query="hello")
+
+    assert str(excinfo.value) == "Chat search message from agent-user-1 is missing content"
+
+
 def test_deliver_to_agents_routes_delivery_by_agent_user_id() -> None:
     delivered: list[tuple[str, str]] = []
     dispatcher = ChatDeliveryDispatcher(


### PR DESCRIPTION
## Summary
- make ChatToolService search results fail loudly when a hit omits content
- add integration coverage proving malformed search projection no longer renders an empty result line
- record the checkpoint in mycel-db-design commit 0971de5

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k search_fails_on_missing_message_content -> failed with DID NOT RAISE before implementation
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k search_fails_on_missing_message_content -> 1 passed
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q -> 90 passed
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check