### PR TITLE
fix: reject empty created direct chat ids

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -304,6 +304,8 @@ class ChatToolService:
                 chat = self._messaging.find_or_create_chat([eid, participant_id])
                 if "id" not in chat:
                     raise RuntimeError("Created direct chat is missing id")
+                if not isinstance(chat["id"], str) or not chat["id"]:
+                    raise RuntimeError("Created direct chat has invalid id")
                 resolved_chat_id = chat["id"]
             else:
                 raise RuntimeError("Provide participant_id (for 1:1) or chat_id (for group)")

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1351,6 +1351,31 @@ def test_chat_tool_send_fails_before_unread_check_when_created_chat_is_missing_i
     assert sent == []
 
 
+def test_chat_tool_send_fails_before_unread_check_when_created_chat_id_is_empty() -> None:
+    registry = ToolRegistry()
+    unread_checks: list[tuple[str, str]] = []
+    sent: list[tuple[str, str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            find_or_create_chat=lambda _user_ids: {"id": ""},
+            count_unread=lambda chat_id, user_id: unread_checks.append((chat_id, user_id)) or 0,
+            send=lambda chat_id, sender_id, content, **_kwargs: sent.append((chat_id, sender_id, content)),
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        send_message.handler(content="hello", participant_id="agent-user-1")
+
+    assert str(excinfo.value) == "Created direct chat has invalid id"
+    assert unread_checks == []
+    assert sent == []
+
+
 def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
     registry = ToolRegistry()
     sent: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary
- make ChatToolService direct send reject created chat ids that are empty or non-string
- assert unread checks and send side effects do not run when direct-chat creation returns an invalid id
- record the checkpoint in mycel-db-design commit a33db52

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k created_chat_id_is_empty -> failed with DID NOT RAISE before implementation
- GREEN: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k created_chat_id_is_empty -> 1 passed
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q -> 92 passed
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check