### PR TITLE
fix: reject invalid chat unread counts

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -314,6 +314,8 @@ class ChatToolService:
             # delivery invariant: you must consume unread messages before replying,
             # otherwise siblings can race on stale history and fork the conversation.
             unread = self._messaging.count_unread(resolved_chat_id, eid)
+            if type(unread) is not int:
+                raise RuntimeError(f"Chat unread count is invalid for chat {resolved_chat_id}")
             if unread > 0:
                 return tool_error(
                     f"You have {unread} unread message(s). Call read_messages(chat_id='{resolved_chat_id}') first.",

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1376,6 +1376,29 @@ def test_chat_tool_send_fails_before_unread_check_when_created_chat_id_is_empty(
     assert sent == []
 
 
+def test_chat_tool_send_fails_before_send_when_unread_count_is_invalid() -> None:
+    registry = ToolRegistry()
+    sent: list[tuple[str, str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            find_or_create_chat=lambda _user_ids: {"id": "chat-1"},
+            count_unread=lambda _chat_id, _user_id: None,
+            send=lambda chat_id, sender_id, content, **_kwargs: sent.append((chat_id, sender_id, content)),
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        send_message.handler(content="hello", participant_id="agent-user-1")
+
+    assert str(excinfo.value) == "Chat unread count is invalid for chat chat-1"
+    assert sent == []
+
+
 def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
     registry = ToolRegistry()
     sent: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary
- fail loudly when ChatToolService send_message receives a malformed count_unread result
- preserve the read-before-send gate by stopping before send side effects

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k unread_count_is_invalid
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check