### PR TITLE
fix: reject invalid chat summary unread counts

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -138,6 +138,8 @@ class ChatToolService:
             for c in chats:
                 if "unread_count" not in c:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing unread_count")
+                if type(c["unread_count"]) is not int:
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} has invalid unread_count")
             if unread_only:
                 chats = [c for c in chats if c["unread_count"] > 0]
             chats = chats[:limit]

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -466,6 +466,33 @@ def test_chat_tool_list_chats_requires_unread_count_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_integer_unread_count_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "unread_count": None,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Chat summary chat-1 has invalid unread_count"
+
+
 def test_chat_tool_list_chats_unread_filter_requires_unread_count_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(


### PR DESCRIPTION
## Summary
- fail loudly when ChatToolService list_chats receives a malformed unread_count projection
- stop before unread filtering/rendering can leak raw comparison errors

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k integer_unread_count
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check