### PR TITLE
fix: reject invalid chat summary scalars

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -155,10 +155,14 @@ class ChatToolService:
                 for member in members:
                     if "id" not in member:
                         raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} member row is missing id")
+                    if not isinstance(member["id"], str):
+                        raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} member row has invalid id")
                 others = [member for member in members if member["id"] != eid]
                 name = c.get("title")
                 if not name:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing title")
+                if not isinstance(name, str):
+                    raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} has invalid title")
                 unread = c["unread_count"]
                 last = c.get("last_message")
                 if last is not None and "content" not in last:
@@ -172,6 +176,8 @@ class ChatToolService:
                     chat_id = c.get("id")
                     if not chat_id:
                         raise RuntimeError("Group chat summary is missing id")
+                    if not isinstance(chat_id, str):
+                        raise RuntimeError("Group chat summary has invalid id")
                     id_str = f" [chat_id: {chat_id}]"
                 else:
                     other_id = others[0]["id"] if others else ""

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -364,6 +364,33 @@ def test_chat_tool_list_chats_requires_member_ids_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_string_member_ids_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": [{"id": None, "name": "Human"}],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Chat summary chat-1 member row has invalid id"
+
+
 def test_chat_tool_list_chats_requires_group_chat_id_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(
@@ -392,6 +419,37 @@ def test_chat_tool_list_chats_requires_group_chat_id_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_string_group_chat_id_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": 123,
+                    "title": "Ops Room",
+                    "members": [
+                        {"id": "human-user-1", "name": "Human"},
+                        {"id": "agent-user-1", "name": "Agent"},
+                        {"id": "agent-user-2", "name": "Agent 2"},
+                    ],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Group chat summary has invalid id"
+
+
 def test_chat_tool_list_chats_requires_last_message_content_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(
@@ -415,6 +473,33 @@ def test_chat_tool_list_chats_requires_last_message_content_contract() -> None:
 
     with pytest.raises(RuntimeError, match="Chat summary chat-1 last_message is missing content"):
         list_chats.handler()
+
+
+def test_chat_tool_list_chats_requires_string_title_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": 123,
+                    "members": [{"id": "human-user-1", "name": "Human"}],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Chat summary chat-1 has invalid title"
 
 
 def test_chat_tool_list_chats_requires_empty_last_message_content_contract() -> None:


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats fail loudly when a summary title is present but non-string
- reject malformed member ids and group chat ids before rendering addressable chat summaries
- cover the malformed scalar cases in the social-handle contract tests

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "string_member_ids or string_group_chat_id or string_title"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check