### PR TITLE
fix: reject invalid chat tool rows

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -104,6 +104,8 @@ class ChatToolService:
     def _format_msgs(self, msgs: list[dict], eid: str) -> str:
         lines = []
         for m in msgs:
+            if not isinstance(m, dict):
+                raise RuntimeError("Chat message row is invalid")
             sender_id = m.get("sender_id")
             name = self._message_sender_name(sender_id)
             tag = "you" if sender_id == eid else name
@@ -138,6 +140,8 @@ class ChatToolService:
         def handle(unread_only: bool = False, limit: int = 20) -> str:
             chats = self._messaging.list_chats_for_user(eid)
             for c in chats:
+                if not isinstance(c, dict):
+                    raise RuntimeError("Chat summary row is invalid")
                 if "unread_count" not in c:
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing unread_count")
                 if type(c["unread_count"]) is not int:
@@ -153,6 +157,8 @@ class ChatToolService:
                 if not isinstance(members, list):
                     raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} is missing members")
                 for member in members:
+                    if not isinstance(member, dict):
+                        raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} member row is invalid")
                     if "id" not in member:
                         raise RuntimeError(f"Chat summary {c.get('id') or '<missing>'} member row is missing id")
                     if not isinstance(member["id"], str):
@@ -418,6 +424,8 @@ class ChatToolService:
                 return f"No messages matching '{query}'."
             lines = []
             for m in results:
+                if not isinstance(m, dict):
+                    raise RuntimeError("Chat search message row is invalid")
                 sender_id = m.get("sender_id")
                 name = self._message_sender_name(sender_id)
                 if "content" not in m:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -339,6 +339,52 @@ def test_chat_tool_list_chats_requires_members_contract() -> None:
         list_chats.handler()
 
 
+def test_chat_tool_list_chats_requires_summary_rows_to_be_objects_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Chat summary row is invalid"
+
+
+def test_chat_tool_list_chats_requires_member_rows_to_be_objects_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "title": "Solo Ops",
+                    "members": ["human-user-1"],
+                    "unread_count": 0,
+                    "last_message": None,
+                }
+            ],
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Chat summary chat-1 member row is invalid"
+
+
 def test_chat_tool_list_chats_requires_member_ids_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(
@@ -1417,6 +1463,28 @@ def test_read_messages_fails_before_mark_read_on_unknown_message_sender() -> Non
     assert marked == []
 
 
+def test_read_messages_fails_before_mark_read_on_invalid_message_row() -> None:
+    registry = ToolRegistry()
+    marked: list[tuple[str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: ["message-1"],
+            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        read_messages.handler(chat_id="chat-1", range="-1h:")
+
+    assert str(excinfo.value) == "Chat message row is invalid"
+    assert marked == []
+
+
 def test_read_messages_fails_before_mark_read_on_missing_message_content() -> None:
     registry = ToolRegistry()
     marked: list[tuple[str, str]] = []
@@ -1796,6 +1864,25 @@ def test_chat_tool_search_fails_on_unknown_message_sender() -> None:
         search_messages.handler(query="hello")
 
     assert str(excinfo.value) == "Chat message sender identity not found: missing-user"
+
+
+def test_chat_tool_search_fails_on_invalid_message_row() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            search_messages=lambda _query, *, chat_id=None: ["message-1"],
+        ),
+    )
+
+    search_messages = registry.get("search_messages")
+    assert search_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        search_messages.handler(query="hello")
+
+    assert str(excinfo.value) == "Chat search message row is invalid"
 
 
 def test_chat_tool_search_fails_on_missing_message_content() -> None:


### PR DESCRIPTION
## Summary
- make ChatToolService list_chats reject non-object summary rows and member rows before field validation
- make read_messages reject non-object message rows before rendering or mark_read
- make search_messages reject non-object result rows before sender/content rendering

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "summary_rows_to_be_objects or member_rows_to_be_objects or invalid_message_row"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check