### PR TITLE
fix: reject invalid chat tool collections

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -102,6 +102,8 @@ class ChatToolService:
         self._register_search_messages(registry)
 
     def _format_msgs(self, msgs: list[dict], eid: str) -> str:
+        if not isinstance(msgs, list):
+            raise RuntimeError("Chat message collection is invalid")
         lines = []
         for m in msgs:
             if not isinstance(m, dict):
@@ -139,6 +141,8 @@ class ChatToolService:
 
         def handle(unread_only: bool = False, limit: int = 20) -> str:
             chats = self._messaging.list_chats_for_user(eid)
+            if not isinstance(chats, list):
+                raise RuntimeError("Chat summary collection is invalid")
             for c in chats:
                 if not isinstance(c, dict):
                     raise RuntimeError("Chat summary row is invalid")
@@ -424,6 +428,8 @@ class ChatToolService:
                     name = target.display_name if target else participant_id
                     return f"No messages matching '{query}' with {name}."
             results = self._messaging.search_messages(query, chat_id=chat_id)
+            if not isinstance(results, list):
+                raise RuntimeError("Chat search result collection is invalid")
             if not results:
                 return f"No messages matching '{query}'."
             lines = []

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -358,6 +358,25 @@ def test_chat_tool_list_chats_requires_summary_rows_to_be_objects_contract() -> 
     assert str(excinfo.value) == "Chat summary row is invalid"
 
 
+def test_chat_tool_list_chats_requires_summary_collection_contract() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_chats_for_user=lambda _user_id: {"id": "chat-1"},
+        ),
+    )
+
+    list_chats = registry.get("list_chats")
+    assert list_chats is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        list_chats.handler()
+
+    assert str(excinfo.value) == "Chat summary collection is invalid"
+
+
 def test_chat_tool_list_chats_requires_member_rows_to_be_objects_contract() -> None:
     registry = ToolRegistry()
     ChatToolService(
@@ -1512,6 +1531,50 @@ def test_read_messages_fails_before_mark_read_on_invalid_message_row() -> None:
     assert marked == []
 
 
+def test_read_messages_fails_before_mark_read_on_invalid_history_collection() -> None:
+    registry = ToolRegistry()
+    marked: list[tuple[str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: {"sender_id": "agent-user-1"},
+            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        read_messages.handler(chat_id="chat-1", range="-1h:")
+
+    assert str(excinfo.value) == "Chat message collection is invalid"
+    assert marked == []
+
+
+def test_read_messages_fails_before_mark_read_on_invalid_unread_collection() -> None:
+    registry = ToolRegistry()
+    marked: list[tuple[str, str]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            list_unread=lambda _chat_id, _user_id: {"sender_id": "agent-user-1"},
+            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+        ),
+    )
+
+    read_messages = registry.get("read_messages")
+    assert read_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        read_messages.handler(chat_id="chat-1")
+
+    assert str(excinfo.value) == "Chat message collection is invalid"
+    assert marked == []
+
+
 def test_read_messages_fails_before_mark_read_on_missing_message_content() -> None:
     registry = ToolRegistry()
     marked: list[tuple[str, str]] = []
@@ -1935,6 +1998,25 @@ def test_chat_tool_search_fails_on_invalid_message_row() -> None:
         search_messages.handler(query="hello")
 
     assert str(excinfo.value) == "Chat search message row is invalid"
+
+
+def test_chat_tool_search_fails_on_invalid_result_collection() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="human-user-1",
+        messaging_service=_messaging_display_service(
+            search_messages=lambda _query, *, chat_id=None: {"sender_id": "agent-user-1"},
+        ),
+    )
+
+    search_messages = registry.get("search_messages")
+    assert search_messages is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        search_messages.handler(query="hello")
+
+    assert str(excinfo.value) == "Chat search result collection is invalid"
 
 
 def test_chat_tool_search_fails_on_missing_message_content() -> None:


### PR DESCRIPTION
## Summary
- make list_chats reject non-list summary collections before row validation
- make read_messages reject non-list history/unread collections before rendering or mark_read
- make search_messages reject non-list result collections before rendering

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "summary_collection or invalid_history_collection or invalid_unread_collection or invalid_result_collection"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/tools/chat_tool_service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/tools/chat_tool_service.py
- git diff --check