### PR TITLE
fix: reject invalid latest chat previews

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -436,8 +436,12 @@ class MessagingService:
         sender = users_by_id.get(sender_id)
         if sender is None:
             raise RuntimeError(f"Chat message sender {sender_id} is not a resolvable user row")
+        if "content" not in message:
+            raise RuntimeError(f"Latest message {message.get('id') or '<missing>'} is missing content")
+        if not isinstance(message["content"], str):
+            raise RuntimeError(f"Latest message {message.get('id') or '<missing>'} has invalid content")
         return {
-            "content": message.get("content", ""),
+            "content": message["content"],
             "sender_name": sender.display_name,
             "created_at": message.get("created_at"),
         }

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1272,6 +1272,65 @@ def test_messaging_service_list_chats_fail_on_unrequested_latest_message_chat_id
         service.list_chats_for_user("human-user-1")
 
 
+def test_messaging_service_list_chats_fails_on_latest_message_missing_content() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title="Team", status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(
+            count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
+            list_latest_by_chat_ids=lambda _chat_ids: {
+                "chat-1": {
+                    "id": "msg-1",
+                    "chat_id": "chat-1",
+                    "sender_user_id": "human-user-1",
+                    "created_at": 3.0,
+                }
+            },
+        ),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Latest message msg-1 is missing content"):
+        service.list_chats_for_user("human-user-1")
+
+
+def test_messaging_service_list_chats_fails_on_latest_message_invalid_content() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title="Team", status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(
+            count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
+            list_latest_by_chat_ids=lambda _chat_ids: {
+                "chat-1": {
+                    "id": "msg-1",
+                    "chat_id": "chat-1",
+                    "sender_user_id": "human-user-1",
+                    "content": None,
+                    "created_at": 3.0,
+                }
+            },
+        ),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Latest message msg-1 has invalid content"):
+        service.list_chats_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_fail_without_projectable_title() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- make MessagingService.list_chats_for_user reject latest-message rows missing content
- reject latest-message content values that are present but not strings
- preserve existing latest message sender resolution and chat summary projection behavior

## Verification
- RED: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "latest_message_missing_content or latest_message_invalid_content" failed before the implementation: first DID NOT RAISE for missing content, then DID NOT RAISE for invalid content
- GREEN after rebase onto origin/dev=411415c2: uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "latest_message_missing_content or latest_message_invalid_content" => 2 passed, 95 deselected
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q => 112 passed
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check && uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py && .venv/bin/python -m pyright messaging/service.py && git diff --check => clean, pyright 0 errors

## Notes
- Scope is messaging/service.py + tests/Integration/test_messaging_social_handle_contract.py only.
- Design ledger updated locally in mycel-db-design commit 4641dd3.
- Mainline active Monitor operation repo protocol seam is file-disjoint.