### PR TITLE
fix: reject invalid latest message shapes

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -305,13 +306,20 @@ class MessagingService:
         chat_rows, members_by_chat, users_by_id, unread_by_chat = self._chat_projection_inputs(user_id)
         chat_ids = [chat.id for chat in chat_rows]
         latest_messages = self._messages.list_latest_by_chat_ids(chat_ids)
+        if not isinstance(latest_messages, Mapping):
+            raise RuntimeError("Latest message collection is invalid")
         chat_id_set = set(chat_ids)
         for latest_chat_id in latest_messages:
             if latest_chat_id not in chat_id_set:
                 raise RuntimeError(f"Latest message row references unrequested chat {latest_chat_id}")
+        latest_by_chat: dict[str, dict[str, Any]] = {}
         latest_sender_ids: set[str] = set()
-        for row in latest_messages.values():
-            sender_id = str(self._normalize_message_row(row).get("sender_id") or "")
+        for latest_chat_id, row in latest_messages.items():
+            if not isinstance(row, Mapping):
+                raise RuntimeError("Latest message row is invalid")
+            message_row = dict(row)
+            latest_by_chat[str(latest_chat_id)] = message_row
+            sender_id = str(self._normalize_message_row(message_row).get("sender_id") or "")
             if sender_id:
                 latest_sender_ids.add(sender_id)
         missing_sender_ids = sorted(latest_sender_ids - set(users_by_id))
@@ -330,7 +338,7 @@ class MessagingService:
                     "updated_at": getattr(chat, "updated_at", None) or getattr(chat, "created_at", None),
                     "avatar_url": chat_avatar_url,
                     "members": member_info,
-                    "last_message": self._project_latest_message(latest_messages.get(chat.id), users_by_id),
+                    "last_message": self._project_latest_message(latest_by_chat.get(chat.id), users_by_id),
                     "unread_count": int(unread_by_chat.get(chat.id, 0)),
                 }
             )

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1331,6 +1331,50 @@ def test_messaging_service_list_chats_fails_on_latest_message_invalid_content() 
         service.list_chats_for_user("human-user-1")
 
 
+def test_messaging_service_list_chats_fails_on_invalid_latest_message_collection() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title="Team", status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(
+            count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
+            list_latest_by_chat_ids=lambda _chat_ids: ["chat-1"],
+        ),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Latest message collection is invalid"):
+        service.list_chats_for_user("human-user-1")
+
+
+def test_messaging_service_list_chats_fails_on_invalid_latest_message_row() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title="Team", status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [{"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0}],
+        ),
+        messages_repo=SimpleNamespace(
+            count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
+            list_latest_by_chat_ids=lambda _chat_ids: {"chat-1": "msg-1"},
+        ),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Latest message row is invalid"):
+        service.list_chats_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_fail_without_projectable_title() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- reject non-mapping latest-message collections before chat summary projection
- reject non-object latest-message rows before sender/content projection
- keep MessagingService latest-message preview fail-loud at the repo boundary

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "invalid_latest_message_collection or invalid_latest_message_row"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check