### PR TITLE
fix: reject invalid chat projection inputs

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -367,6 +367,8 @@ class MessagingService:
         user_id: str,
     ) -> tuple[list[Any], dict[str, list[dict[str, Any]]], dict[str, Any], dict[str, int]]:
         chat_ids = self._chat_members_repo.list_chats_for_user(user_id)
+        if not isinstance(chat_ids, list):
+            raise RuntimeError("Chat id collection is invalid")
         if not chat_ids:
             return [], {}, {}, {}
 
@@ -384,12 +386,15 @@ class MessagingService:
         members_by_chat: dict[str, list[dict[str, Any]]] = {chat_id: [] for chat_id in active_chat_ids}
         last_read_by_chat: dict[str, int] = {}
         for member in self._chat_members_repo.list_members_for_chats(active_chat_ids):
-            chat_id = str(member.get("chat_id") or "")
+            if not isinstance(member, Mapping):
+                raise RuntimeError("Chat member row is invalid")
+            member_row = dict(member)
+            chat_id = str(member_row.get("chat_id") or "")
             if chat_id not in members_by_chat:
                 raise RuntimeError(f"Chat member row references unrequested chat {chat_id or '<missing>'}")
-            members_by_chat[chat_id].append(member)
-            if member.get("user_id") == user_id:
-                last_read_by_chat[chat_id] = int(member.get("last_read_seq") or 0)
+            members_by_chat[chat_id].append(member_row)
+            if member_row.get("user_id") == user_id:
+                last_read_by_chat[chat_id] = int(member_row.get("last_read_seq") or 0)
 
         for chat_id in active_chat_ids:
             if chat_id not in last_read_by_chat:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1242,6 +1242,42 @@ def test_messaging_service_conversation_summaries_fail_when_chat_row_is_missing(
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_on_invalid_chat_id_collection() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda chat_ids: [
+                SimpleNamespace(id=chat_id, title=None, status="active", created_at=1.0, updated_at=2.0) for chat_id in chat_ids
+            ],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: {"chat-1": True},
+            list_members_for_chats=lambda _chat_ids: [],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: []),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat id collection is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
+def test_messaging_service_conversation_summaries_fail_on_invalid_member_row() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: ["chat-1"],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: []),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat member row is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_list_chats_fail_on_unrequested_latest_message_chat_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- reject malformed chat-id collections before bulk chat projection starts
- reject non-object chat-member rows before membership projection
- keep MessagingService chat projection inputs fail-loud at the repo boundary

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "invalid_chat_id_collection or invalid_member_row"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check