### PR TITLE
fix: reject invalid chat rows

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -373,6 +373,11 @@ class MessagingService:
             return [], {}, {}, {}
 
         loaded_chat_rows = self._chats.list_by_ids(chat_ids)
+        if not isinstance(loaded_chat_rows, list):
+            raise RuntimeError("Chat row collection is invalid")
+        for chat in loaded_chat_rows:
+            if not hasattr(chat, "id") or not hasattr(chat, "status"):
+                raise RuntimeError("Chat row is invalid")
         loaded_chat_ids = {str(chat.id) for chat in loaded_chat_rows}
         missing_chat_ids = [chat_id for chat_id in chat_ids if str(chat_id) not in loaded_chat_ids]
         if missing_chat_ids:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1278,6 +1278,36 @@ def test_messaging_service_conversation_summaries_fail_on_invalid_member_row() -
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_on_invalid_chat_row_collection() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(list_by_ids=lambda _chat_ids: {"chat-1": True}),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: []),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat row collection is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
+def test_messaging_service_conversation_summaries_fail_on_invalid_chat_row() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(list_by_ids=lambda _chat_ids: ["chat-1"]),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: []),
+    )
+
+    with pytest.raises(RuntimeError, match="Chat row is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_list_chats_fail_on_unrequested_latest_message_chat_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- reject malformed chat-row collections before chat projection derives missing rows
- reject non-object chat rows before reading id/status
- keep MessagingService bulk chat loading fail-loud at the repo boundary

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "invalid_chat_row_collection or invalid_chat_row"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check