### PR TITLE
fix: reject invalid user rows

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -467,7 +467,13 @@ class MessagingService:
     def _users_by_id(self, user_ids: list[str]) -> dict[str, Any]:
         if not user_ids:
             return {}
-        return {user.id: user for user in self._user_repo.list_by_ids(user_ids)}
+        rows = self._user_repo.list_by_ids(user_ids)
+        if not isinstance(rows, list):
+            raise RuntimeError("User row collection is invalid")
+        for user in rows:
+            if not hasattr(user, "id"):
+                raise RuntimeError("User row is invalid")
+        return {user.id: user for user in rows}
 
     def _project_known_user_member(self, social_user_id: str, users_by_id: dict[str, Any]) -> dict[str, Any]:
         user = users_by_id.get(social_user_id)

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1164,6 +1164,46 @@ def test_messaging_service_conversation_summaries_fail_on_unknown_member_identit
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_on_invalid_user_row_collection() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0},
+                {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: {"human-user-1": True}),
+    )
+
+    with pytest.raises(RuntimeError, match="User row collection is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
+def test_messaging_service_conversation_summaries_fail_on_invalid_user_row() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 0},
+                {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {}),
+        user_repo=SimpleNamespace(list_by_ids=lambda _user_ids: ["human-user-1"]),
+    )
+
+    with pytest.raises(RuntimeError, match="User row is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_conversation_summaries_fail_on_missing_member_user_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(


### PR DESCRIPTION
## Summary
- reject malformed user-row collections before bulk user mapping
- reject non-object user rows before reading ids for member/sender projection
- keep MessagingService bulk user loading fail-loud at the repo boundary

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "invalid_user_row_collection or invalid_user_row"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check