### PR TITLE
fix: reject invalid unread counts

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -429,7 +429,16 @@ class MessagingService:
         with ThreadPoolExecutor(max_workers=2) as executor:
             users_future = executor.submit(self._users_by_id, user_ids)
             unread_future = executor.submit(self._messages.count_unread_by_chat_ids, user_id, last_read_by_chat)
-            return users_future.result(), unread_future.result()
+            users_by_id = users_future.result()
+            unread_by_chat = unread_future.result()
+        if not isinstance(unread_by_chat, Mapping):
+            raise RuntimeError("Unread count collection is invalid")
+        normalized_unread_by_chat: dict[str, int] = {}
+        for chat_id, unread_count in unread_by_chat.items():
+            if not isinstance(unread_count, int):
+                raise RuntimeError(f"Unread count for chat {chat_id} is invalid")
+            normalized_unread_by_chat[str(chat_id)] = unread_count
+        return users_by_id, normalized_unread_by_chat
 
     def _project_chat_members(self, members: list[dict[str, Any]], users_by_id: dict[str, Any]) -> list[dict[str, Any]]:
         return [self._project_known_user_member(str(member.get("user_id") or ""), users_by_id) for member in members]

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1536,6 +1536,54 @@ def test_messaging_service_conversation_summaries_loads_users_and_unread_counts_
     assert summaries[0]["unread_count"] == 2
 
 
+def test_messaging_service_conversation_summaries_fail_on_invalid_unread_collection() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 4},
+                {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: ["chat-1"]),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda user_ids: [
+                SimpleNamespace(id=user_id, display_name=user_id, type="human", avatar=None) for user_id in user_ids
+            ]
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Unread count collection is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
+def test_messaging_service_conversation_summaries_fail_on_invalid_unread_value() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 4},
+                {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {"chat-1": None}),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda user_ids: [
+                SimpleNamespace(id=user_id, display_name=user_id, type="human", avatar=None) for user_id in user_ids
+            ]
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Unread count for chat chat-1 is invalid"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_get_chat_detail_exposes_agent_user_participant_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(),


### PR DESCRIPTION
## Summary
- reject malformed unread-count collections before summary projection reads unread state
- reject non-integer unread-count values before rendering chat summaries
- keep MessagingService bulk unread loading fail-loud at the repo boundary

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "invalid_unread_collection or invalid_unread_value"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check