### PR TITLE
fix: reject stray unread counts

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -435,9 +435,12 @@ class MessagingService:
             raise RuntimeError("Unread count collection is invalid")
         normalized_unread_by_chat: dict[str, int] = {}
         for chat_id, unread_count in unread_by_chat.items():
+            normalized_chat_id = str(chat_id)
+            if normalized_chat_id not in last_read_by_chat:
+                raise RuntimeError(f"Unread count row references unrequested chat {normalized_chat_id}")
             if not isinstance(unread_count, int):
-                raise RuntimeError(f"Unread count for chat {chat_id} is invalid")
-            normalized_unread_by_chat[str(chat_id)] = unread_count
+                raise RuntimeError(f"Unread count for chat {normalized_chat_id} is invalid")
+            normalized_unread_by_chat[normalized_chat_id] = unread_count
         return users_by_id, normalized_unread_by_chat
 
     def _project_chat_members(self, members: list[dict[str, Any]], users_by_id: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1584,6 +1584,30 @@ def test_messaging_service_conversation_summaries_fail_on_invalid_unread_value()
         service.list_conversation_summaries_for_user("human-user-1")
 
 
+def test_messaging_service_conversation_summaries_fail_on_unrequested_unread_chat_id() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(
+            list_by_ids=lambda _chat_ids: [SimpleNamespace(id="chat-1", title=None, status="active", created_at=1.0, updated_at=2.0)],
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: ["chat-1"],
+            list_members_for_chats=lambda _chat_ids: [
+                {"chat_id": "chat-1", "user_id": "human-user-1", "last_read_seq": 4},
+                {"chat_id": "chat-1", "user_id": "agent-user-1", "last_read_seq": 0},
+            ],
+        ),
+        messages_repo=SimpleNamespace(count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {"chat-extra": 3}),
+        user_repo=SimpleNamespace(
+            list_by_ids=lambda user_ids: [
+                SimpleNamespace(id=user_id, display_name=user_id, type="human", avatar=None) for user_id in user_ids
+            ]
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Unread count row references unrequested chat chat-extra"):
+        service.list_conversation_summaries_for_user("human-user-1")
+
+
 def test_messaging_service_get_chat_detail_exposes_agent_user_participant_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(),


### PR DESCRIPTION
## Summary
- reject unread-count rows for chats outside the requested visible set
- keep MessagingService unread projection fail-loud at the repo boundary
- prevent stray unread state from silently flowing into summary projection

## Verification
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -q -k "unrequested_unread_chat_id"
- uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run ruff format messaging/service.py tests/Integration/test_messaging_social_handle_contract.py --check
- uv run ruff check messaging/service.py tests/Integration/test_messaging_social_handle_contract.py
- .venv/bin/python -m pyright messaging/service.py
- git diff --check