### PR TITLE
test: point agent runtime imports at owner module

### DIFF
--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import pytest
 
+from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
 from backend.protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -13,7 +14,6 @@ from backend.protocols.agent_runtime import (
     AgentRuntimeActor,
     AgentRuntimeMessage,
 )
-from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from backend.web.utils.serializers import avatar_url
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -12,11 +12,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
+from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
 from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
 from backend.web.models.requests import SendMessageRequest
 from backend.web.routers import threads as threads_router
 from backend.web.routers.threads import get_thread_history, get_thread_messages
-from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from backend.web.services.display_builder import DisplayBuilder
 from backend.web.services.event_buffer import ThreadEventBuffer
 from backend.web.services.streaming_service import (

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
 from backend.protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -12,7 +13,6 @@ from backend.protocols.agent_runtime import (
     AgentRuntimeActor,
     AgentRuntimeMessage,
 )
-from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
 
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import pytest
 
+from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
 from backend.protocols.agent_runtime import AgentChatDeliveryResult, AgentThreadInputResult
-from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 
 
 @dataclass
@@ -67,8 +67,8 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
 
 
 def test_split_handler_modules_are_the_behavior_owners() -> None:
-    from backend.web.services.agent_runtime_chat_handler import NativeAgentChatDeliveryHandler
-    from backend.web.services.agent_runtime_thread_handler import NativeAgentThreadInputHandler
+    from backend.agent_runtime.chat_handler import NativeAgentChatDeliveryHandler
+    from backend.agent_runtime.thread_handler import NativeAgentThreadInputHandler
 
     assert NativeAgentChatDeliveryHandler.__name__ == "NativeAgentChatDeliveryHandler"
     assert NativeAgentThreadInputHandler.__name__ == "NativeAgentThreadInputHandler"

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -6,7 +6,7 @@ from typing import get_type_hints
 
 def test_agent_runtime_protocol_types_live_outside_web_service_layer() -> None:
     protocol_module = importlib.import_module("backend.protocols.agent_runtime")
-    gateway_module = importlib.import_module("backend.web.services.agent_runtime_gateway")
+    gateway_module = importlib.import_module("backend.agent_runtime.gateway")
 
     assert protocol_module.AgentChatDeliveryEnvelope.__module__ == "backend.protocols.agent_runtime"
     assert protocol_module.AgentThreadInputEnvelope.__module__ == "backend.protocols.agent_runtime"
@@ -36,8 +36,8 @@ def test_agent_runtime_chat_and_thread_inputs_share_message_protocol_objects() -
 
 def test_agent_runtime_thread_input_result_is_a_protocol_object() -> None:
     protocol_module = importlib.import_module("backend.protocols.agent_runtime")
-    gateway_module = importlib.import_module("backend.web.services.agent_runtime_gateway")
-    port_module = importlib.import_module("backend.web.services.agent_runtime_port")
+    gateway_module = importlib.import_module("backend.agent_runtime.gateway")
+    port_module = importlib.import_module("backend.agent_runtime.port")
 
     gateway_hints = get_type_hints(gateway_module.NativeAgentRuntimeGateway.dispatch_thread_input)
     port_hints = get_type_hints(port_module.AgentRuntimeGatewayPort.dispatch_thread_input)
@@ -48,7 +48,7 @@ def test_agent_runtime_thread_input_result_is_a_protocol_object() -> None:
 
 
 def test_agent_runtime_gateway_handler_injection_is_typed() -> None:
-    gateway_module = importlib.import_module("backend.web.services.agent_runtime_gateway")
+    gateway_module = importlib.import_module("backend.agent_runtime.gateway")
 
     constructor_hints = get_type_hints(gateway_module.NativeAgentRuntimeGateway.__init__)
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
 from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
-from backend.web.services.agent_runtime_gateway import NativeAgentRuntimeGateway
 from core.runtime.middleware.monitor import AgentState
 
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_port.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_port.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def test_agent_runtime_port_requires_lifespan_registration() -> None:
-    from backend.web.services.agent_runtime_port import get_agent_runtime_gateway
+    from backend.agent_runtime.port import get_agent_runtime_gateway
 
     with pytest.raises(AttributeError, match="agent_runtime_gateway"):
         get_agent_runtime_gateway(SimpleNamespace(state=SimpleNamespace()))


### PR DESCRIPTION
## Summary
- switch remaining internal/test imports from backend.web.services agent-runtime shells to backend.agent_runtime owners
- keep compatibility-shell coverage in protocol-boundary tests
- reduce backsliding toward the old web-service path after the module-root migration

## Verification
- uv run python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py -q -k "agent_runtime or delivery_paths_depend_on_agent_runtime_port_not_native_gateway or agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lookup_and_unread or send_message_passes_enable_trajectory_to_agent_runtime_gateway"
- uv run ruff format tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_port.py --check
- uv run ruff check tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_port.py
- git diff --check