### PR TITLE
refactor: move chat delivery inlet to agent runtime

### DIFF
--- a/backend/agent_runtime/chat_inlet.py
+++ b/backend/agent_runtime/chat_inlet.py
@@ -1,4 +1,4 @@
-"""Chat delivery bridge from messaging into Agent Runtime."""
+"""Chat delivery inlet from messaging into Agent Runtime."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from backend.protocols.agent_runtime import (
     AgentRuntimeActor,
     AgentRuntimeMessage,
 )
-from messaging.delivery.dispatcher import ChatDeliveryRequest
+from messaging.delivery.contracts import ChatDeliveryRequest
 
 logger = logging.getLogger(__name__)
 

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -89,8 +89,8 @@ async def lifespan(app: FastAPI):
 
     # Wire chat delivery after event loop is available
     # ---- Messaging system (Supabase-backed, required) ----
+    from backend.agent_runtime.chat_inlet import make_chat_delivery_fn
     from messaging.delivery.resolver import HireVisitDeliveryResolver
-    from messaging.delivery.runtime_bridge import make_chat_delivery_fn
     from messaging.relationships.service import RelationshipService
     from messaging.service import MessagingService
 

--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -1,5 +1,5 @@
-"""Compatibility shell for messaging runtime delivery bridge."""
+"""Compatibility shell for Agent Runtime chat inlet."""
 
-from messaging.delivery.runtime_bridge import make_chat_delivery_fn
+from backend.agent_runtime.chat_inlet import make_chat_delivery_fn
 
 __all__ = ["make_chat_delivery_fn"]

--- a/messaging/delivery/contracts.py
+++ b/messaging/delivery/contracts.py
@@ -1,0 +1,23 @@
+"""Pure contracts for Chat delivery wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class ChatDeliveryRequest:
+    recipient_id: str
+    recipient_user: Any
+    content: str
+    sender_name: str
+    sender_type: str
+    chat_id: str
+    sender_id: str
+    sender_avatar_url: str | None
+    signal: str | None
+
+
+class ChatDeliveryFn(Protocol):
+    def __call__(self, request: ChatDeliveryRequest) -> None: ...

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -3,32 +3,15 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Protocol
+from typing import Any
 
 from backend.web.utils.serializers import avatar_url
 from messaging.delivery.actions import DeliveryAction
+from messaging.delivery.contracts import ChatDeliveryFn, ChatDeliveryRequest
 from messaging.display_user import resolve_messaging_display_user
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class ChatDeliveryRequest:
-    recipient_id: str
-    recipient_user: Any
-    content: str
-    sender_name: str
-    sender_type: str
-    chat_id: str
-    sender_id: str
-    sender_avatar_url: str | None
-    signal: str | None
-
-
-class ChatDeliveryFn(Protocol):
-    def __call__(self, request: ChatDeliveryRequest) -> None: ...
 
 
 class ChatDeliveryDispatcher:

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -6,16 +6,16 @@ from types import SimpleNamespace
 
 import pytest
 
+from backend.agent_runtime import chat_inlet as owner_chat_inlet
 from backend.web.routers import threads as threads_router
 from backend.web.services import chat_delivery_hook
-from messaging.delivery import runtime_bridge as owner_runtime_bridge
 from messaging.delivery.dispatcher import ChatDeliveryRequest
 from messaging.realtime import events as owner_chat_events
 from messaging.realtime import typing as owner_typing
 
 
 def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> None:
-    delivery_source = inspect.getsource(owner_runtime_bridge)
+    delivery_source = inspect.getsource(owner_chat_inlet)
     threads_source = inspect.getsource(threads_router)
     from backend.web.core import lifespan as lifespan_module
     from backend.web.services import chat_events as shell_chat_events
@@ -23,7 +23,7 @@ def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> Non
 
     lifespan_source = inspect.getsource(lifespan_module)
 
-    assert owner_runtime_bridge.make_chat_delivery_fn is chat_delivery_hook.make_chat_delivery_fn
+    assert owner_chat_inlet.make_chat_delivery_fn is chat_delivery_hook.make_chat_delivery_fn
     assert owner_chat_events.ChatEventBus is shell_chat_events.ChatEventBus
     assert owner_typing.TypingTracker is shell_typing_tracker.TypingTracker
     assert "NativeAgentRuntimeGateway" not in delivery_source
@@ -32,13 +32,16 @@ def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> Non
     assert "get_agent_runtime_gateway" in threads_source
     assert "backend.agent_runtime.port" in delivery_source
     assert "backend.agent_runtime.port" in threads_source
+    assert "messaging.delivery.dispatcher" not in delivery_source
+    assert "messaging.delivery.contracts" in delivery_source
     assert "backend.web.services.agent_runtime_port" not in delivery_source
     assert "backend.web.services.agent_runtime_port" not in threads_source
     assert "backend.agent_runtime.bootstrap" in lifespan_source
+    assert "backend.agent_runtime.chat_inlet" in lifespan_source
     assert "build_agent_runtime_gateway" in lifespan_source
     assert "messaging.realtime.events" in lifespan_source
     assert "messaging.realtime.typing" in lifespan_source
-    assert "messaging.delivery.runtime_bridge" in lifespan_source
+    assert "messaging.delivery.runtime_bridge" not in lifespan_source
     assert "backend.web.services.agent_runtime_gateway" not in lifespan_source
     assert "backend.web.services.chat_events" not in lifespan_source
     assert "backend.web.services.typing_tracker" not in lifespan_source


### PR DESCRIPTION
## Summary
- move the native chat delivery inlet from  to 
- extract  and  into  so the runtime owner no longer imports the dispatcher implementation module
- rewire web startup and compatibility shell imports to the new runtime-owned inlet

## Verification
- ................                                                         [100%]
16 passed, 112 deselected in 0.52s
- 6 files already formatted
- All checks passed!
- 0 errors, 0 warnings, 0 informations
- 
- 
