### PR TITLE
refactor: extract chat handler runtime services

### DIFF
--- a/backend/agent_runtime/bootstrap.py
+++ b/backend/agent_runtime/bootstrap.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 from typing import Any
 
 from backend.agent_runtime.chat_handler import NativeAgentChatDeliveryHandler
+from backend.agent_runtime.chat_runtime_services import AppAgentChatRuntimeServices
 from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
 from backend.agent_runtime.thread_handler import NativeAgentThreadInputHandler
 
 
 def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
     return NativeAgentRuntimeGateway(
-        chat_handlers={"mycel": NativeAgentChatDeliveryHandler(app)},
+        chat_handlers={
+            "mycel": NativeAgentChatDeliveryHandler(
+                runtime_services=AppAgentChatRuntimeServices(app),
+            )
+        },
         thread_input_handler=NativeAgentThreadInputHandler(app),
     )

--- a/backend/agent_runtime/chat_handler.py
+++ b/backend/agent_runtime/chat_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from backend.agent_runtime.chat_runtime_services import AgentChatRuntimeServices
 from backend.protocols import agent_runtime as agent_runtime_protocol
 from core.runtime.middleware.monitor import AgentState
 
@@ -14,8 +15,12 @@ logger = logging.getLogger(__name__)
 class NativeAgentChatDeliveryHandler:
     """Routes Chat messages into native Mycel Agent threads."""
 
-    def __init__(self, app: Any) -> None:
-        self._app = app
+    def __init__(
+        self,
+        *,
+        runtime_services: AgentChatRuntimeServices,
+    ) -> None:
+        self._runtime_services = runtime_services
 
     async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
         from langchain_core.runnables.config import var_child_runnable_config  # pyright: ignore[reportMissingImports]
@@ -35,40 +40,22 @@ class NativeAgentChatDeliveryHandler:
 
         if not thread_id:
             raise RuntimeError(f"Agent chat recipient has no runtime thread: {envelope.recipient.agent_user_id}")
-
-        from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
-        from backend.web.services.streaming_service import _ensure_thread_handlers
-        from core.runtime.middleware.queue.formatters import format_chat_notification
-
-        sandbox_type = resolve_thread_sandbox(self._app, thread_id)
-        agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
-        _ensure_thread_handlers(agent, thread_id, self._app)
-
-        typing_tracker = getattr(self._app.state, "typing_tracker", None)
-        if typing_tracker is not None:
-            typing_tracker.start_chat(thread_id, envelope.chat.chat_id, envelope.recipient.agent_user_id)
-
-        unread_count = self._app.state.messaging_service.count_unread(envelope.chat.chat_id, envelope.recipient.agent_user_id)
-        formatted = format_chat_notification(
-            envelope.sender.display_name,
-            envelope.chat.chat_id,
-            unread_count,
-            signal=envelope.message.signal,
-        )
-
-        self._app.state.queue_manager.enqueue(
-            formatted,
-            thread_id,
-            "chat",
-            source="external",
-            sender_id=envelope.sender.user_id,
+        await self._runtime_services.get_or_create_thread_agent(thread_id)
+        self._runtime_services.start_chat(thread_id, envelope.chat.chat_id, envelope.recipient.agent_user_id)
+        unread_count = self._runtime_services.count_unread(envelope.chat.chat_id, envelope.recipient.agent_user_id)
+        self._runtime_services.enqueue_chat_notification(
             sender_name=envelope.sender.display_name,
+            chat_id=envelope.chat.chat_id,
+            unread_count=unread_count,
+            signal=envelope.message.signal,
+            thread_id=thread_id,
+            sender_id=envelope.sender.user_id,
             sender_avatar_url=envelope.sender.avatar_url,
         )
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=thread_id)
 
     def _select_runtime_thread_id(self, recipient_id: str) -> str | None:
-        thread = self._app.state.thread_repo.get_by_user_id(recipient_id)
+        thread = self._runtime_services.get_thread_by_user_id(recipient_id)
         active_thread_id = self._resolve_unique_active_thread_id(recipient_id, thread)
         if active_thread_id is not None:
             return active_thread_id
@@ -83,14 +70,14 @@ class NativeAgentChatDeliveryHandler:
 
         active_thread_ids: list[str] = []
         live_child_threads: list[tuple[int, str]] = []
-        for candidate in self._app.state.thread_repo.list_by_agent_user(agent_user_id):
+        for candidate in self._runtime_services.list_threads_by_agent_user(agent_user_id):
             thread_id = str(candidate.get("id") or "").strip()
             if not thread_id:
                 continue
             # @@@active-thread-delivery-precedence - fresh chat delivery should prefer a
             # recipient's latest live child thread over the default-main thread, even when the
             # main thread is still marked ACTIVE from stale work or older child threads still exist.
-            for pool_key, agent in self._app.state.agent_pool.items():
+            for pool_key, agent in self._runtime_services.iter_agent_pool_items():
                 if not str(pool_key).startswith(f"{thread_id}:"):
                     continue
                 state = agent.runtime.current_state

--- a/backend/agent_runtime/chat_runtime_services.py
+++ b/backend/agent_runtime/chat_runtime_services.py
@@ -1,0 +1,94 @@
+"""App-backed services for native Agent Runtime chat delivery."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+
+class AgentChatRuntimeServices(Protocol):
+    def get_thread_by_user_id(self, recipient_user_id: str) -> dict[str, Any] | None: ...
+
+    def list_threads_by_agent_user(self, agent_user_id: str) -> list[dict[str, Any]]: ...
+
+    def iter_agent_pool_items(self) -> Iterable[tuple[str, Any]]: ...
+
+    async def get_or_create_thread_agent(self, thread_id: str) -> Any: ...
+
+    def start_chat(self, thread_id: str, chat_id: str, recipient_user_id: str) -> None: ...
+
+    def count_unread(self, chat_id: str, recipient_user_id: str) -> int: ...
+
+    def enqueue_chat_notification(
+        self,
+        *,
+        sender_name: str,
+        chat_id: str,
+        unread_count: int,
+        signal: str | None,
+        thread_id: str,
+        sender_id: str,
+        sender_avatar_url: str | None,
+    ) -> None: ...
+
+
+class AppAgentChatRuntimeServices:
+    """Runtime-owned adapter around app-backed chat delivery dependencies."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    def get_thread_by_user_id(self, recipient_user_id: str) -> dict[str, Any] | None:
+        return self._app.state.thread_repo.get_by_user_id(recipient_user_id)
+
+    def list_threads_by_agent_user(self, agent_user_id: str) -> list[dict[str, Any]]:
+        return list(self._app.state.thread_repo.list_by_agent_user(agent_user_id))
+
+    def iter_agent_pool_items(self) -> Iterable[tuple[str, Any]]:
+        return self._app.state.agent_pool.items()
+
+    async def get_or_create_thread_agent(self, thread_id: str) -> Any:
+        from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox
+        from backend.web.services.streaming_service import _ensure_thread_handlers
+
+        sandbox_type = resolve_thread_sandbox(self._app, thread_id)
+        agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
+        _ensure_thread_handlers(agent, thread_id, self._app)
+        return agent
+
+    def start_chat(self, thread_id: str, chat_id: str, recipient_user_id: str) -> None:
+        typing_tracker = getattr(self._app.state, "typing_tracker", None)
+        if typing_tracker is not None:
+            typing_tracker.start_chat(thread_id, chat_id, recipient_user_id)
+
+    def count_unread(self, chat_id: str, recipient_user_id: str) -> int:
+        return self._app.state.messaging_service.count_unread(chat_id, recipient_user_id)
+
+    def enqueue_chat_notification(
+        self,
+        *,
+        sender_name: str,
+        chat_id: str,
+        unread_count: int,
+        signal: str | None,
+        thread_id: str,
+        sender_id: str,
+        sender_avatar_url: str | None,
+    ) -> None:
+        from core.runtime.middleware.queue.formatters import format_chat_notification
+
+        formatted = format_chat_notification(
+            sender_name,
+            chat_id,
+            unread_count,
+            signal=signal,
+        )
+        self._app.state.queue_manager.enqueue(
+            formatted,
+            thread_id,
+            "chat",
+            source="external",
+            sender_id=sender_id,
+            sender_name=sender_name,
+            sender_avatar_url=sender_avatar_url,
+        )

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -129,3 +129,33 @@ async def test_gateway_prefers_latest_live_child_thread(monkeypatch: pytest.Monk
     assert result.thread_id == "thread-child-fresh"
     assert started == [("thread-child-fresh", "chat-5", "agent-user-1")]
     assert enqueued == [("Human|chat-5|1|ping", "thread-child-fresh", "human-user-1", "Human")]
+
+
+@pytest.mark.asyncio
+async def test_gateway_chat_delivery_uses_live_thread_repo_after_gateway_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
+        return SimpleNamespace(id=f"agent-for-{thread_id}")
+
+    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "core.runtime.middleware.queue.formatters.format_chat_notification",
+        lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
+    )
+    app, started, unread_calls, enqueued = _app(unread_count=2)
+    gateway = build_agent_runtime_gateway(app)
+
+    replacement_thread = {"id": "thread-replaced", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
+    app.state.thread_repo = SimpleNamespace(
+        get_by_user_id=lambda uid: replacement_thread if uid == "agent-user-1" else None,
+        list_by_agent_user=lambda uid: [replacement_thread] if uid == "agent-user-1" else [],
+    )
+
+    result = await gateway.dispatch_chat(_envelope(chat_id="chat-live"))
+
+    assert result.status == "accepted"
+    assert result.thread_id == "thread-replaced"
+    assert started == [("thread-replaced", "chat-live", "agent-user-1")]
+    assert unread_calls == [("chat-live", "agent-user-1")]
+    assert enqueued == [("Human|chat-live|2|ping", "thread-replaced", "human-user-1", "Human")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from typing import get_type_hints
 
 
@@ -77,3 +78,16 @@ def test_agent_runtime_implementation_lives_under_backend_agent_runtime() -> Non
     assert port_shell.get_agent_runtime_gateway is port_impl.get_agent_runtime_gateway
     assert chat_handler_shell.NativeAgentChatDeliveryHandler is chat_handler_impl.NativeAgentChatDeliveryHandler
     assert thread_handler_shell.NativeAgentThreadInputHandler is thread_handler_impl.NativeAgentThreadInputHandler
+
+
+def test_chat_handler_depends_on_runtime_owned_services_not_web_imports() -> None:
+    chat_handler_impl = importlib.import_module("backend.agent_runtime.chat_handler")
+    bootstrap_impl = importlib.import_module("backend.agent_runtime.bootstrap")
+
+    chat_handler_source = inspect.getsource(chat_handler_impl)
+    bootstrap_source = inspect.getsource(bootstrap_impl)
+
+    assert "backend.web.services.agent_pool" not in chat_handler_source
+    assert "backend.web.services.streaming_service" not in chat_handler_source
+    assert "self._app.state" not in chat_handler_source
+    assert "AppAgentChatRuntimeServices" in bootstrap_source


### PR DESCRIPTION
## Summary
- add `backend/agent_runtime/chat_runtime_services.py` as the runtime-owned app adapter for native chat delivery
- update `backend/agent_runtime/chat_handler.py` to depend on runtime services instead of direct `backend.web.services.*` imports and direct `self._app.state.*` reads
- keep live app-state semantics via the app-backed runtime service adapter and add a regression test for post-bootstrap thread-repo replacement

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py -q`
- `uv run python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Integration/test_query_loop_backend_contracts.py -q -k "dispatch_chat or agent_runtime or chat_handler or agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lookup_and_unread"`
- `uv run ruff format backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/chat_handler.py backend/agent_runtime/bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py --check`
- `uv run ruff check backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/chat_handler.py backend/agent_runtime/bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py`
- `.venv/bin/python -m pyright backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/chat_handler.py backend/agent_runtime/bootstrap.py`
- `rg -n "backend\.web\.services\.(agent_pool|streaming_service)|self\._app\.state" backend/agent_runtime/chat_handler.py`
- `git diff --check`
