### PR TITLE
refactor: move chat notification upstream

### DIFF
--- a/backend/agent_runtime/chat_handler.py
+++ b/backend/agent_runtime/chat_handler.py
@@ -42,14 +42,11 @@ class NativeAgentChatDeliveryHandler:
             raise RuntimeError(f"Agent chat recipient has no runtime thread: {envelope.recipient.agent_user_id}")
         await self._runtime_services.get_or_create_thread_agent(thread_id)
         self._runtime_services.start_chat(thread_id, envelope.chat.chat_id, envelope.recipient.agent_user_id)
-        unread_count = self._runtime_services.count_unread(envelope.chat.chat_id, envelope.recipient.agent_user_id)
-        self._runtime_services.enqueue_chat_notification(
-            sender_name=envelope.sender.display_name,
-            chat_id=envelope.chat.chat_id,
-            unread_count=unread_count,
-            signal=envelope.message.signal,
+        self._runtime_services.enqueue_chat_message(
+            content=envelope.message.content,
             thread_id=thread_id,
             sender_id=envelope.sender.user_id,
+            sender_name=envelope.sender.display_name,
             sender_avatar_url=envelope.sender.avatar_url,
         )
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=thread_id)

--- a/backend/agent_runtime/chat_inlet.py
+++ b/backend/agent_runtime/chat_inlet.py
@@ -6,6 +6,7 @@ import logging
 from enum import Enum
 from typing import Any
 
+from backend.agent_runtime.chat_notification_format import format_chat_notification
 from backend.agent_runtime.port import get_agent_runtime_gateway
 from backend.protocols.agent_runtime import (
     AgentChatContext,
@@ -34,6 +35,14 @@ def make_chat_delivery_fn(app: Any):
         recipient_user_id = getattr(request.recipient_user, "id", None)
         if recipient_user_id is None:
             raise RuntimeError(f"Chat delivery recipient is missing user id: {request.recipient_id}")
+        # @@@chat-rendered-content - runtime handlers should enqueue the already rendered
+        # chat reminder content; chat-specific unread/rendering belongs on the upstream delivery path.
+        rendered_content = format_chat_notification(
+            request.sender_name,
+            request.chat_id,
+            request.unread_count,
+            signal=request.signal,
+        )
         envelope = AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=request.chat_id),
             sender=AgentRuntimeActor(
@@ -44,11 +53,12 @@ def make_chat_delivery_fn(app: Any):
                 source="chat",
             ),
             recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source="mycel"),
-            message=AgentRuntimeMessage(content=request.content, signal=request.signal),
+            message=AgentRuntimeMessage(content=rendered_content, signal=request.signal),
             extensions={
                 "mycel": {
                     "recipient_user_id": recipient_user_id,
                     "recipient_user_type": recipient_type,
+                    "raw_content": request.content,
                 }
             },
         )

--- a/backend/agent_runtime/chat_notification_format.py
+++ b/backend/agent_runtime/chat_notification_format.py
@@ -1,0 +1,22 @@
+"""Native runtime formatting for Chat delivery notifications."""
+
+from __future__ import annotations
+
+
+def format_chat_notification(sender_name: str, chat_id: str, unread_count: int, signal: str | None = None) -> str:
+    """Lightweight notification — agent must read_messages to see content.
+
+    @@@v3-notification-only - no message content injected. Agent calls
+    read_messages(chat_id=...) to read, then send_message() to reply.
+    """
+    signal_hint = f" [signal: {signal}]" if signal and signal != "open" else ""
+    return (
+        "<system-reminder>\n"
+        f"New message from {sender_name} in chat {chat_id} ({unread_count} unread).{signal_hint}\n"
+        f'Read it with read_messages(chat_id="{chat_id}").\n'
+        f'Do not call send_message(chat_id="{chat_id}", ...) before read_messages(chat_id="{chat_id}") succeeds.\n'
+        f'Reply with send_message(chat_id="{chat_id}", content="...").\n'
+        "Prefer using this exact chat_id directly.\n"
+        "Do not treat your normal assistant text as a chat reply.\n"
+        "</system-reminder>"
+    )

--- a/backend/agent_runtime/chat_runtime_services.py
+++ b/backend/agent_runtime/chat_runtime_services.py
@@ -17,17 +17,13 @@ class AgentChatRuntimeServices(Protocol):
 
     def start_chat(self, thread_id: str, chat_id: str, recipient_user_id: str) -> None: ...
 
-    def count_unread(self, chat_id: str, recipient_user_id: str) -> int: ...
-
-    def enqueue_chat_notification(
+    def enqueue_chat_message(
         self,
         *,
-        sender_name: str,
-        chat_id: str,
-        unread_count: int,
-        signal: str | None,
+        content: str,
         thread_id: str,
         sender_id: str,
+        sender_name: str,
         sender_avatar_url: str | None,
     ) -> None: ...
 
@@ -61,30 +57,17 @@ class AppAgentChatRuntimeServices:
         if typing_tracker is not None:
             typing_tracker.start_chat(thread_id, chat_id, recipient_user_id)
 
-    def count_unread(self, chat_id: str, recipient_user_id: str) -> int:
-        return self._app.state.messaging_service.count_unread(chat_id, recipient_user_id)
-
-    def enqueue_chat_notification(
+    def enqueue_chat_message(
         self,
         *,
-        sender_name: str,
-        chat_id: str,
-        unread_count: int,
-        signal: str | None,
+        content: str,
         thread_id: str,
         sender_id: str,
+        sender_name: str,
         sender_avatar_url: str | None,
     ) -> None:
-        from core.runtime.middleware.queue.formatters import format_chat_notification
-
-        formatted = format_chat_notification(
-            sender_name,
-            chat_id,
-            unread_count,
-            signal=signal,
-        )
         self._app.state.queue_manager.enqueue(
-            formatted,
+            content,
             thread_id,
             "chat",
             source="external",

--- a/core/runtime/middleware/queue/__init__.py
+++ b/core/runtime/middleware/queue/__init__.py
@@ -5,7 +5,6 @@ from storage.contracts import QueueItem
 from .formatters import (
     format_agent_message,
     format_background_notification,
-    format_chat_notification,
     format_progress_notification,
 )
 from .manager import MessageQueueManager
@@ -17,6 +16,5 @@ __all__ = [
     "SteeringMiddleware",
     "format_agent_message",
     "format_background_notification",
-    "format_chat_notification",
     "format_progress_notification",
 ]

--- a/core/runtime/middleware/queue/formatters.py
+++ b/core/runtime/middleware/queue/formatters.py
@@ -10,25 +10,6 @@ from html import escape
 from typing import Literal
 
 
-def format_chat_notification(sender_name: str, chat_id: str, unread_count: int, signal: str | None = None) -> str:
-    """Lightweight notification — agent must read_messages to see content.
-
-    @@@v3-notification-only — no message content injected. Agent calls
-    read_messages(chat_id=...) to read, then send_message() to reply.
-    """
-    signal_hint = f" [signal: {signal}]" if signal and signal != "open" else ""
-    return (
-        "<system-reminder>\n"
-        f"New message from {sender_name} in chat {chat_id} ({unread_count} unread).{signal_hint}\n"
-        f'Read it with read_messages(chat_id="{chat_id}").\n'
-        f'Do not call send_message(chat_id="{chat_id}", ...) before read_messages(chat_id="{chat_id}") succeeds.\n'
-        f'Reply with send_message(chat_id="{chat_id}", content="...").\n'
-        "Prefer using this exact chat_id directly.\n"
-        "Do not treat your normal assistant text as a chat reply.\n"
-        "</system-reminder>"
-    )
-
-
 def format_agent_message(sender_name: str, message: str) -> str:
     """Format inter-agent delivery for steering injection on the next turn."""
     return (

--- a/messaging/delivery/contracts.py
+++ b/messaging/delivery/contracts.py
@@ -16,6 +16,7 @@ class ChatDeliveryRequest:
     chat_id: str
     sender_id: str
     sender_avatar_url: str | None
+    unread_count: int
     signal: str | None
 
 

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -21,11 +21,13 @@ class ChatDeliveryDispatcher:
         self,
         chat_member_repo: Any,
         user_repo: Any,
+        unread_counter: Any | None = None,
         delivery_resolver: Any | None = None,
         delivery_fn: ChatDeliveryFn | None = None,
     ) -> None:
         self._chat_members_repo = chat_member_repo
         self._user_repo = user_repo
+        self._unread_counter = unread_counter
         self._delivery_resolver = delivery_resolver
         self._delivery_fn = delivery_fn
 
@@ -70,7 +72,18 @@ class ChatDeliveryDispatcher:
             # @@@same-owner-group-delivery - explicit group membership among the same owner
             # must reach sibling actors even when no relationship row exists yet.
             if sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id:
-                self._deliver(uid, recipient, content, sender_name, sender_type, chat_id, sender_id, sender_avatar_url, signal=signal)
+                self._deliver(
+                    uid,
+                    recipient,
+                    content,
+                    sender_name,
+                    sender_type,
+                    chat_id,
+                    sender_id,
+                    sender_avatar_url,
+                    unread_count=self._count_unread(chat_id, uid),
+                    signal=signal,
+                )
                 continue
 
             if self._delivery_resolver:
@@ -80,13 +93,32 @@ class ChatDeliveryDispatcher:
                     logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])
                     continue
 
-            self._deliver(uid, recipient, content, sender_name, sender_type, chat_id, sender_id, sender_avatar_url, signal=signal)
+            self._deliver(
+                uid,
+                recipient,
+                content,
+                sender_name,
+                sender_type,
+                chat_id,
+                sender_id,
+                sender_avatar_url,
+                unread_count=self._count_unread(chat_id, uid),
+                signal=signal,
+            )
 
     def _resolve_display_user(self, social_user_id: str) -> Any | None:
         return resolve_messaging_display_user(
             user_repo=self._user_repo,
             social_user_id=social_user_id,
         )
+
+    def _count_unread(self, chat_id: str, recipient_id: str) -> int:
+        if self._unread_counter is None:
+            raise RuntimeError("Chat delivery unread counter is not configured")
+        unread_count = self._unread_counter(chat_id, recipient_id)
+        if type(unread_count) is not int:
+            raise RuntimeError(f"Chat delivery unread count is invalid for {recipient_id}: {unread_count!r}")
+        return unread_count
 
     def _deliver(
         self,
@@ -98,6 +130,7 @@ class ChatDeliveryDispatcher:
         chat_id: str,
         sender_id: str,
         sender_avatar_url: str | None,
+        unread_count: int,
         *,
         signal: str | None,
     ) -> None:
@@ -113,6 +146,7 @@ class ChatDeliveryDispatcher:
                 chat_id=chat_id,
                 sender_id=sender_id,
                 sender_avatar_url=sender_avatar_url,
+                unread_count=unread_count,
                 signal=signal,
             )
         )

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -46,6 +46,7 @@ class MessagingService:
         self._delivery_dispatcher = delivery_dispatcher or ChatDeliveryDispatcher(
             chat_member_repo=chat_member_repo,
             user_repo=user_repo,
+            unread_counter=getattr(messages_repo, "count_unread", None),
             delivery_resolver=delivery_resolver,
             delivery_fn=delivery_fn,
         )

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -108,6 +108,7 @@ def test_deliver_to_agents_does_not_require_main_thread_id():
                 else SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
             )
         ),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
 
@@ -2349,6 +2350,7 @@ def test_deliver_to_agents_routes_delivery_by_agent_user_id() -> None:
                 else SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None)
             )
         ),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
 
@@ -2389,6 +2391,7 @@ def test_same_owner_group_chat_kickoff_delivers_without_relationship() -> None:
                 else None
             )
         ),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=resolver,
         delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
@@ -2539,6 +2542,7 @@ def test_same_owner_agent_turn_delivers_to_sibling_actor_without_relationship() 
                 else None
             )
         ),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=resolver,
         delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
     )
@@ -2549,14 +2553,14 @@ def test_same_owner_agent_turn_delivers_to_sibling_actor_without_relationship() 
 
 
 @pytest.mark.asyncio
-async def test_agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lookup_and_unread(
+async def test_agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lookup_and_passes_through_envelope_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     started, unread_calls, enqueued = await _run_chat_delivery(monkeypatch, chat_id="chat-1", unread_count=7)
 
     assert started == [("thread-1", "chat-1", "agent-user-1")]
-    assert unread_calls == [("chat-1", "agent-user-1")]
-    assert enqueued == [("Human|chat-1|7|ping", "thread-1", "human-user-1", "Human")]
+    assert unread_calls == []
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
 
 
 @pytest.mark.asyncio
@@ -2602,7 +2606,7 @@ async def _run_chat_delivery(
     monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
     monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        "core.runtime.middleware.queue.formatters.format_chat_notification",
+        "backend.agent_runtime.chat_notification_format.format_chat_notification",
         lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
     )
 
@@ -2616,9 +2620,6 @@ async def _run_chat_delivery(
             ),
             agent_pool=pool or {},
             typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
-            messaging_service=SimpleNamespace(
-                count_unread=lambda chat_id, user_id: unread_calls.append((chat_id, user_id)) or unread_count
-            ),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
@@ -2710,4 +2711,4 @@ async def test_agent_runtime_gateway_prefers_latest_live_child_thread_over_activ
     )
 
     assert started == [(expected_thread_id, chat_id, "agent-user-1")]
-    assert enqueued == [(f"Human|{chat_id}|{unread_count}|ping", expected_thread_id, "human-user-1", "Human")]
+    assert enqueued == [("hello", expected_thread_id, "human-user-1", "Human")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_notification_format.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_notification_format.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from backend.agent_runtime.chat_notification_format import format_chat_notification
+
+
+def test_chat_notification_format_includes_explicit_read_and_reply_instructions() -> None:
+    result = format_chat_notification(
+        sender_name="alice",
+        chat_id="chat-123",
+        unread_count=2,
+    )
+
+    assert 'read_messages(chat_id="chat-123")' in result
+    assert 'Do not call send_message(chat_id="chat-123", ...) before read_messages(chat_id="chat-123") succeeds.' in result
+    assert 'send_message(chat_id="chat-123", content="...")' in result
+    assert "Prefer using this exact chat_id directly" in result
+    assert "Do not treat your normal assistant text as a chat reply." in result

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -20,7 +20,6 @@ def _app(
     *,
     threads: list[dict[str, Any]] | None = None,
     pool: dict[str, Any] | None = None,
-    unread_count: int = 7,
 ) -> tuple[SimpleNamespace, list[tuple[str, str, str]], list[tuple[str, str]], list[tuple[str, str, str | None, str | None]]]:
     started: list[tuple[str, str, str]] = []
     unread_calls: list[tuple[str, str]] = []
@@ -36,9 +35,6 @@ def _app(
             ),
             agent_pool=pool or {},
             typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
-            messaging_service=SimpleNamespace(
-                count_unread=lambda chat_id, user_id: unread_calls.append((chat_id, user_id)) or unread_count
-            ),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
@@ -49,12 +45,12 @@ def _app(
     return app, started, unread_calls, enqueued
 
 
-def _envelope(*, chat_id: str = "chat-1", signal: str | None = "ping") -> AgentChatDeliveryEnvelope:
+def _envelope(*, chat_id: str = "chat-1", signal: str | None = "ping", content: str = "hello") -> AgentChatDeliveryEnvelope:
     return AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id=chat_id),
         sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel"),
-        message=AgentRuntimeMessage(content="hello", signal=signal),
+        message=AgentRuntimeMessage(content=content, signal=signal),
     )
 
 
@@ -66,19 +62,15 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
     monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
     monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
     monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        "core.runtime.middleware.queue.formatters.format_chat_notification",
-        lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
-    )
-    app, started, unread_calls, enqueued = _app(unread_count=7)
+    app, started, unread_calls, enqueued = _app()
 
     result = await build_agent_runtime_gateway(app).dispatch_chat(_envelope())
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-1"
     assert started == [("thread-1", "chat-1", "agent-user-1")]
-    assert unread_calls == [("chat-1", "agent-user-1")]
-    assert enqueued == [("Human|chat-1|7|ping", "thread-1", "human-user-1", "Human")]
+    assert unread_calls == []
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
 
 
 @pytest.mark.asyncio
@@ -105,10 +97,6 @@ async def test_gateway_prefers_latest_live_child_thread(monkeypatch: pytest.Monk
     monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
     monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
     monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        "core.runtime.middleware.queue.formatters.format_chat_notification",
-        lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
-    )
     app, started, _, enqueued = _app(
         threads=[
             {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0},
@@ -120,7 +108,6 @@ async def test_gateway_prefers_latest_live_child_thread(monkeypatch: pytest.Monk
             "thread-child-old:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.IDLE)),
             "thread-child-fresh:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.READY)),
         },
-        unread_count=1,
     )
 
     result = await build_agent_runtime_gateway(app).dispatch_chat(_envelope(chat_id="chat-5"))
@@ -128,7 +115,7 @@ async def test_gateway_prefers_latest_live_child_thread(monkeypatch: pytest.Monk
     assert result.status == "accepted"
     assert result.thread_id == "thread-child-fresh"
     assert started == [("thread-child-fresh", "chat-5", "agent-user-1")]
-    assert enqueued == [("Human|chat-5|1|ping", "thread-child-fresh", "human-user-1", "Human")]
+    assert enqueued == [("hello", "thread-child-fresh", "human-user-1", "Human")]
 
 
 @pytest.mark.asyncio
@@ -139,11 +126,7 @@ async def test_gateway_chat_delivery_uses_live_thread_repo_after_gateway_bootstr
     monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
     monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
     monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        "core.runtime.middleware.queue.formatters.format_chat_notification",
-        lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
-    )
-    app, started, unread_calls, enqueued = _app(unread_count=2)
+    app, started, unread_calls, enqueued = _app()
     gateway = build_agent_runtime_gateway(app)
 
     replacement_thread = {"id": "thread-replaced", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
@@ -157,5 +140,5 @@ async def test_gateway_chat_delivery_uses_live_thread_repo_after_gateway_bootstr
     assert result.status == "accepted"
     assert result.thread_id == "thread-replaced"
     assert started == [("thread-replaced", "chat-live", "agent-user-1")]
-    assert unread_calls == [("chat-live", "agent-user-1")]
-    assert enqueued == [("Human|chat-live|2|ping", "thread-replaced", "human-user-1", "Human")]
+    assert unread_calls == []
+    assert enqueued == [("hello", "thread-replaced", "human-user-1", "Human")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -90,4 +90,7 @@ def test_chat_handler_depends_on_runtime_owned_services_not_web_imports() -> Non
     assert "backend.web.services.agent_pool" not in chat_handler_source
     assert "backend.web.services.streaming_service" not in chat_handler_source
     assert "self._app.state" not in chat_handler_source
+    assert "count_unread" not in chat_handler_source
+    assert "enqueue_chat_notification" not in chat_handler_source
+    assert "format_chat_notification" not in chat_handler_source
     assert "AppAgentChatRuntimeServices" in bootstrap_source

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -34,6 +34,7 @@ def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> Non
     assert "backend.agent_runtime.port" in threads_source
     assert "messaging.delivery.dispatcher" not in delivery_source
     assert "messaging.delivery.contracts" in delivery_source
+    assert "backend.agent_runtime.chat_notification_format" in delivery_source
     assert "backend.web.services.agent_runtime_port" not in delivery_source
     assert "backend.web.services.agent_runtime_port" not in threads_source
     assert "backend.agent_runtime.bootstrap" in lifespan_source
@@ -65,6 +66,7 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,
+        unread_count=0,
         signal=None,
     )
 
@@ -92,6 +94,7 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,
+        unread_count=3,
         signal=None,
     )
 
@@ -99,6 +102,9 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
 
     assert gateway.envelope is not None
     assert gateway.envelope.sender.user_type == "human"
+    assert "New message from Human in chat chat-1 (3 unread)." in gateway.envelope.message.content
+    assert 'read_messages(chat_id="chat-1")' in gateway.envelope.message.content
+    assert gateway.envelope.extensions["mycel"]["raw_content"] == "hello"
 
 
 @pytest.mark.asyncio
@@ -121,6 +127,7 @@ async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,
+        unread_count=0,
         signal=None,
     )
 
@@ -150,6 +157,7 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
         chat_id="chat-1",
         sender_id="human-user-1",
         sender_avatar_url=None,
+        unread_count=0,
         signal=None,
     )
 

--- a/tests/Unit/core/test_queue_formatters.py
+++ b/tests/Unit/core/test_queue_formatters.py
@@ -2,7 +2,7 @@
 
 import xml.etree.ElementTree as ET
 
-from core.runtime.middleware.queue.formatters import format_chat_notification, format_command_notification
+from core.runtime.middleware.queue.formatters import format_command_notification
 
 
 def _require_child(parent: ET.Element, tag: str) -> ET.Element:
@@ -14,21 +14,6 @@ def _require_child(parent: ET.Element, tag: str) -> ET.Element:
 def _require_text(element: ET.Element) -> str:
     assert element.text is not None
     return element.text
-
-
-class TestFormatChatNotification:
-    def test_includes_explicit_read_messages_and_send_message_instructions(self):
-        result = format_chat_notification(
-            sender_name="alice",
-            chat_id="chat-123",
-            unread_count=2,
-        )
-
-        assert 'read_messages(chat_id="chat-123")' in result
-        assert 'Do not call send_message(chat_id="chat-123", ...) before read_messages(chat_id="chat-123") succeeds.' in result
-        assert 'send_message(chat_id="chat-123", content="...")' in result
-        assert "Prefer using this exact chat_id directly" in result
-        assert "Do not treat your normal assistant text as a chat reply." in result
 
 
 class TestFormatCommandNotification:

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -69,6 +69,7 @@ def test_dispatcher_delivers_to_agent_user_ids() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 7,
         delivery_fn=deliver,
     )
 
@@ -82,6 +83,7 @@ def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(
             resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner path must not call resolver"))
         ),
@@ -98,6 +100,7 @@ def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(
             resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner sibling path must not call resolver"))
         ),
@@ -115,6 +118,7 @@ def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["outside-human-user", "agent-user-1"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: action),
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
@@ -135,6 +139,7 @@ def test_dispatcher_fails_loudly_when_delivery_function_fails() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=deliver,
     )
 
@@ -148,6 +153,7 @@ def test_dispatcher_fails_loudly_when_delivery_function_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
     )
 
     with pytest.raises(RuntimeError, match="Chat delivery function is not configured"):
@@ -159,6 +165,7 @@ def test_dispatcher_fails_loudly_when_sender_identity_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["missing-user", "agent-user-1"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 
@@ -173,6 +180,7 @@ def test_dispatcher_fails_loudly_when_member_user_id_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "human-user-1"}, {}]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 
@@ -187,6 +195,7 @@ def test_dispatcher_fails_loudly_when_recipient_identity_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "missing-recipient"]),
         user_repo=_user_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 


### PR DESCRIPTION
## Summary
- move unread-count lookup out of backend/agent_runtime/chat_handler.py and into the upstream chat delivery path
- keep the native runtime prompt formatter beside the native runtime inlet in backend/agent_runtime/chat_notification_format.py
- make chat_handler/runtime services only enqueue pre-rendered envelope content, preserving live thread-repo state while removing chat-specific unread/formatting responsibilities from the handler

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_chat_notification_format.py tests/Unit/core/test_queue_formatters.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py -q -k "chat_delivery_hook or dispatch_chat or chat_handler or chat_notification_format or test_dispatcher or recipient_social_user_id or queue_formatters"`
- `uv run ruff check backend/agent_runtime/chat_notification_format.py backend/agent_runtime/chat_inlet.py backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/chat_handler.py messaging/delivery/contracts.py messaging/delivery/dispatcher.py messaging/service.py core/runtime/middleware/queue/formatters.py core/runtime/middleware/queue/__init__.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_chat_notification_format.py tests/Unit/core/test_queue_formatters.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py`
- `uv run ruff format backend/agent_runtime/chat_notification_format.py backend/agent_runtime/chat_inlet.py backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/chat_handler.py messaging/delivery/contracts.py messaging/delivery/dispatcher.py messaging/service.py core/runtime/middleware/queue/formatters.py core/runtime/middleware/queue/__init__.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_chat_notification_format.py tests/Unit/core/test_queue_formatters.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Integration/test_messaging_social_handle_contract.py --check`
- `.venv/bin/python -m pyright backend/agent_runtime/chat_notification_format.py backend/agent_runtime/chat_inlet.py backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/chat_handler.py messaging/delivery/contracts.py messaging/delivery/dispatcher.py messaging/service.py`
- `git diff --check`
