### PR TITLE
refactor: move runtime thread selection upstream

### DIFF
--- a/backend/agent_runtime/bootstrap.py
+++ b/backend/agent_runtime/bootstrap.py
@@ -7,10 +7,12 @@ from typing import Any
 from backend.agent_runtime.chat_handler import NativeAgentChatDeliveryHandler
 from backend.agent_runtime.chat_runtime_services import AppAgentChatRuntimeServices
 from backend.agent_runtime.gateway import NativeAgentRuntimeGateway
+from backend.agent_runtime.thread_activity_reader import AppRuntimeThreadActivityReader
 from backend.agent_runtime.thread_handler import NativeAgentThreadInputHandler
 
 
 def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
+    app.state.agent_runtime_thread_activity_reader = AppRuntimeThreadActivityReader(app)
     return NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(

--- a/backend/agent_runtime/chat_handler.py
+++ b/backend/agent_runtime/chat_handler.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from backend.agent_runtime.chat_runtime_services import AgentChatRuntimeServices
 from backend.protocols import agent_runtime as agent_runtime_protocol
-from core.runtime.middleware.monitor import AgentState
 
 logger = logging.getLogger(__name__)
 
@@ -27,17 +25,15 @@ class NativeAgentChatDeliveryHandler:
 
         var_child_runnable_config.set(None)
 
-        # @@@thread-delivery-route - delivery target must come from the recipient social handle,
-        # never from the template default-thread shortcut.
-        thread_id = self._select_runtime_thread_id(envelope.recipient.agent_user_id)
         logger.info(
             "[agent-runtime-gateway] dispatch_chat: recipient=%s user=%s thread=%s from=%s",
             envelope.recipient.agent_user_id,
             envelope.recipient.agent_user_id,
-            thread_id,
+            envelope.recipient.thread_id,
             envelope.sender.display_name,
         )
 
+        thread_id = envelope.recipient.thread_id
         if not thread_id:
             raise RuntimeError(f"Agent chat recipient has no runtime thread: {envelope.recipient.agent_user_id}")
         await self._runtime_services.get_or_create_thread_agent(thread_id)
@@ -50,49 +46,3 @@ class NativeAgentChatDeliveryHandler:
             sender_avatar_url=envelope.sender.avatar_url,
         )
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=thread_id)
-
-    def _select_runtime_thread_id(self, recipient_id: str) -> str | None:
-        thread = self._runtime_services.get_thread_by_user_id(recipient_id)
-        active_thread_id = self._resolve_unique_active_thread_id(recipient_id, thread)
-        if active_thread_id is not None:
-            return active_thread_id
-        if thread is None:
-            return None
-        return thread["id"]
-
-    def _resolve_unique_active_thread_id(self, recipient_id: str, thread: dict[str, Any] | None) -> str | None:
-        agent_user_id = str((thread or {}).get("agent_user_id") or recipient_id).strip()
-        if not agent_user_id:
-            return None
-
-        active_thread_ids: list[str] = []
-        live_child_threads: list[tuple[int, str]] = []
-        for candidate in self._runtime_services.list_threads_by_agent_user(agent_user_id):
-            thread_id = str(candidate.get("id") or "").strip()
-            if not thread_id:
-                continue
-            # @@@active-thread-delivery-precedence - fresh chat delivery should prefer a
-            # recipient's latest live child thread over the default-main thread, even when the
-            # main thread is still marked ACTIVE from stale work or older child threads still exist.
-            for pool_key, agent in self._runtime_services.iter_agent_pool_items():
-                if not str(pool_key).startswith(f"{thread_id}:"):
-                    continue
-                state = agent.runtime.current_state
-                if state in {
-                    AgentState.READY,
-                    AgentState.ACTIVE,
-                    AgentState.IDLE,
-                    AgentState.SUSPENDED,
-                    AgentState.INITIALIZING,
-                } and not bool(candidate.get("is_main")):
-                    live_child_threads.append((int(candidate.get("branch_index") or -1), thread_id))
-                if state == AgentState.ACTIVE:
-                    active_thread_ids.append(thread_id)
-                    break
-
-        if live_child_threads:
-            return max(live_child_threads)[1]
-        unique_active_thread_ids = list(dict.fromkeys(active_thread_ids))
-        if len(unique_active_thread_ids) == 1:
-            return unique_active_thread_ids[0]
-        return None

--- a/backend/agent_runtime/chat_inlet.py
+++ b/backend/agent_runtime/chat_inlet.py
@@ -16,6 +16,7 @@ from backend.protocols.agent_runtime import (
     AgentRuntimeMessage,
 )
 from messaging.delivery.contracts import ChatDeliveryRequest
+from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,9 @@ def make_chat_delivery_fn(app: Any):
 
     loop = asyncio.get_running_loop()
     logger.info("[delivery] make_chat_delivery_fn: loop=%s", loop)
+    activity_reader = getattr(app.state, "agent_runtime_thread_activity_reader", None)
+    if activity_reader is None:
+        raise RuntimeError("Agent runtime thread activity reader is not configured")
 
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
         raw_recipient_type = getattr(request.recipient_user, "type", None)
@@ -43,6 +47,13 @@ def make_chat_delivery_fn(app: Any):
             request.unread_count,
             signal=request.signal,
         )
+        thread_id = select_runtime_thread_for_recipient(
+            request.recipient_id,
+            thread_repo=app.state.thread_repo,
+            activity_reader=activity_reader,
+        )
+        if thread_id is None:
+            raise RuntimeError(f"Agent chat recipient has no runtime thread: {request.recipient_id}")
         envelope = AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=request.chat_id),
             sender=AgentRuntimeActor(
@@ -52,7 +63,7 @@ def make_chat_delivery_fn(app: Any):
                 avatar_url=request.sender_avatar_url,
                 source="chat",
             ),
-            recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source="mycel"),
+            recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source="mycel", thread_id=thread_id),
             message=AgentRuntimeMessage(content=rendered_content, signal=request.signal),
             extensions={
                 "mycel": {

--- a/backend/agent_runtime/chat_runtime_services.py
+++ b/backend/agent_runtime/chat_runtime_services.py
@@ -2,17 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import Any, Protocol
 
 
 class AgentChatRuntimeServices(Protocol):
-    def get_thread_by_user_id(self, recipient_user_id: str) -> dict[str, Any] | None: ...
-
-    def list_threads_by_agent_user(self, agent_user_id: str) -> list[dict[str, Any]]: ...
-
-    def iter_agent_pool_items(self) -> Iterable[tuple[str, Any]]: ...
-
     async def get_or_create_thread_agent(self, thread_id: str) -> Any: ...
 
     def start_chat(self, thread_id: str, chat_id: str, recipient_user_id: str) -> None: ...
@@ -33,15 +26,6 @@ class AppAgentChatRuntimeServices:
 
     def __init__(self, app: Any) -> None:
         self._app = app
-
-    def get_thread_by_user_id(self, recipient_user_id: str) -> dict[str, Any] | None:
-        return self._app.state.thread_repo.get_by_user_id(recipient_user_id)
-
-    def list_threads_by_agent_user(self, agent_user_id: str) -> list[dict[str, Any]]:
-        return list(self._app.state.thread_repo.list_by_agent_user(agent_user_id))
-
-    def iter_agent_pool_items(self) -> Iterable[tuple[str, Any]]:
-        return self._app.state.agent_pool.items()
 
     async def get_or_create_thread_agent(self, thread_id: str) -> Any:
         from backend.web.services.agent_pool import get_or_create_agent, resolve_thread_sandbox

--- a/backend/agent_runtime/thread_activity_reader.py
+++ b/backend/agent_runtime/thread_activity_reader.py
@@ -1,0 +1,50 @@
+"""App-backed runtime thread activity reader."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from backend.protocols.runtime_read import AgentThreadActivity
+from core.runtime.middleware.monitor import AgentState
+
+
+def _normalize_state(state: AgentState) -> Literal["initializing", "ready", "active", "idle", "suspended", "stopped", "destroyed"]:
+    if state == AgentState.INITIALIZING:
+        return "initializing"
+    if state == AgentState.READY:
+        return "ready"
+    if state == AgentState.ACTIVE:
+        return "active"
+    if state == AgentState.IDLE:
+        return "idle"
+    if state == AgentState.SUSPENDED:
+        return "suspended"
+    return "stopped"
+
+
+class AppRuntimeThreadActivityReader:
+    """Read live runtime thread activity from app-backed state."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    def list_active_threads_for_agent(self, agent_user_id: str) -> list[AgentThreadActivity]:
+        rows = self._app.state.thread_repo.list_by_agent_user(agent_user_id)
+        activities: list[AgentThreadActivity] = []
+        for row in rows:
+            thread_id = str(row.get("id") or "").strip()
+            if not thread_id:
+                continue
+            for pool_key, agent in self._app.state.agent_pool.items():
+                if not str(pool_key).startswith(f"{thread_id}:"):
+                    continue
+                activities.append(
+                    AgentThreadActivity(
+                        thread_id=thread_id,
+                        is_main=bool(row.get("is_main")),
+                        branch_index=int(row.get("branch_index") or 0),
+                        state=_normalize_state(agent.runtime.current_state),
+                    )
+                )
+                break
+        return activities

--- a/backend/protocols/agent_runtime.py
+++ b/backend/protocols/agent_runtime.py
@@ -25,6 +25,7 @@ class AgentRuntimeActor:
 class AgentChatRecipient:
     agent_user_id: str
     runtime_source: str
+    thread_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/protocols/runtime_read.py
+++ b/backend/protocols/runtime_read.py
@@ -1,0 +1,18 @@
+"""Runtime read-side protocol contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+
+@dataclass(frozen=True)
+class AgentThreadActivity:
+    thread_id: str
+    is_main: bool
+    branch_index: int
+    state: Literal["initializing", "ready", "active", "idle", "suspended", "stopped", "destroyed"]
+
+
+class RuntimeThreadActivityReader(Protocol):
+    def list_active_threads_for_agent(self, agent_user_id: str) -> list[AgentThreadActivity]: ...

--- a/messaging/delivery/runtime_thread_selector.py
+++ b/messaging/delivery/runtime_thread_selector.py
@@ -1,0 +1,66 @@
+"""Thread selection policy for chat delivery into runtime-backed agents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.protocols.runtime_read import RuntimeThreadActivityReader
+
+_LIVE_CHILD_STATES = {"initializing", "ready", "active", "idle", "suspended"}
+
+
+def select_runtime_thread_for_recipient(
+    recipient_user_id: str,
+    *,
+    thread_repo: Any,
+    activity_reader: RuntimeThreadActivityReader,
+) -> str | None:
+    thread = thread_repo.get_by_user_id(recipient_user_id)
+    active_thread_id = _resolve_unique_active_thread_id(
+        recipient_user_id,
+        thread,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    if active_thread_id is not None:
+        return active_thread_id
+    if thread is None:
+        return None
+    return str(thread["id"])
+
+
+def _resolve_unique_active_thread_id(
+    recipient_user_id: str,
+    thread: dict[str, Any] | None,
+    *,
+    thread_repo: Any,
+    activity_reader: RuntimeThreadActivityReader,
+) -> str | None:
+    agent_user_id = str((thread or {}).get("agent_user_id") or recipient_user_id).strip()
+    if not agent_user_id:
+        return None
+
+    active_thread_ids: list[str] = []
+    live_child_threads: list[tuple[int, str]] = []
+    by_thread_id = {activity.thread_id: activity for activity in activity_reader.list_active_threads_for_agent(agent_user_id)}
+    for candidate in thread_repo.list_by_agent_user(agent_user_id):
+        thread_id = str(candidate.get("id") or "").strip()
+        if not thread_id:
+            continue
+        activity = by_thread_id.get(thread_id)
+        if activity is None:
+            continue
+        # @@@active-thread-delivery-precedence - fresh chat delivery should prefer a
+        # recipient's latest live child thread over the default-main thread, even when the
+        # main thread is still marked ACTIVE from stale work or older child threads still exist.
+        if activity.state in _LIVE_CHILD_STATES and not activity.is_main:
+            live_child_threads.append((activity.branch_index, thread_id))
+        if activity.state == "active":
+            active_thread_ids.append(thread_id)
+
+    if live_child_threads:
+        return max(live_child_threads)[1]
+    unique_active_thread_ids = list(dict.fromkeys(active_thread_ids))
+    if len(unique_active_thread_ids) == 1:
+        return unique_active_thread_ids[0]
+    return None

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import threading
 from types import SimpleNamespace
 from typing import Any, cast
@@ -7,18 +8,13 @@ from typing import Any, cast
 import pytest
 
 from backend.agent_runtime.bootstrap import build_agent_runtime_gateway
-from backend.protocols.agent_runtime import (
-    AgentChatContext,
-    AgentChatDeliveryEnvelope,
-    AgentChatRecipient,
-    AgentRuntimeActor,
-    AgentRuntimeMessage,
-)
+from backend.web.services import chat_delivery_hook
 from backend.web.utils.serializers import avatar_url
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope
 from messaging.delivery.actions import DeliveryAction
+from messaging.delivery.contracts import ChatDeliveryRequest
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.display_user import resolve_messaging_display_user
@@ -2560,7 +2556,7 @@ async def test_agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lo
 
     assert started == [("thread-1", "chat-1", "agent-user-1")]
     assert unread_calls == []
-    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
+    assert enqueued == [("Human|chat-1|7|ping", "thread-1", "human-user-1", "Human")]
 
 
 @pytest.mark.asyncio
@@ -2573,18 +2569,24 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
             agent_pool={},
         )
     )
+    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)
 
     with pytest.raises(AttributeError):
-        await build_agent_runtime_gateway(app).dispatch_chat(_chat_delivery_envelope())
-
-
-def _chat_delivery_envelope(*, chat_id: str = "chat-1", signal: str | None = "ping") -> AgentChatDeliveryEnvelope:
-    return AgentChatDeliveryEnvelope(
-        chat=AgentChatContext(chat_id=chat_id),
-        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
-        recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel"),
-        message=AgentRuntimeMessage(content="hello", signal=signal),
-    )
+        await asyncio.to_thread(
+            chat_delivery_hook.make_chat_delivery_fn(app),
+            ChatDeliveryRequest(
+                recipient_id="agent-user-1",
+                recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+                content="hello",
+                sender_name="Human",
+                sender_type="human",
+                chat_id="chat-1",
+                sender_id="human-user-1",
+                sender_avatar_url=None,
+                unread_count=1,
+                signal="ping",
+            ),
+        )
 
 
 async def _run_chat_delivery(
@@ -2606,7 +2608,7 @@ async def _run_chat_delivery(
     monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
     monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        "backend.agent_runtime.chat_notification_format.format_chat_notification",
+        "backend.agent_runtime.chat_inlet.format_chat_notification",
         lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
     )
 
@@ -2627,8 +2629,23 @@ async def _run_chat_delivery(
             ),
         )
     )
+    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)
 
-    await build_agent_runtime_gateway(app).dispatch_chat(_chat_delivery_envelope(chat_id=chat_id))
+    await asyncio.to_thread(
+        chat_delivery_hook.make_chat_delivery_fn(app),
+        ChatDeliveryRequest(
+            recipient_id="agent-user-1",
+            recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+            content="hello",
+            sender_name="Human",
+            sender_type="human",
+            chat_id=chat_id,
+            sender_id="human-user-1",
+            sender_avatar_url=None,
+            unread_count=unread_count,
+            signal="ping",
+        ),
+    )
 
     return started, unread_calls, enqueued
 
@@ -2711,4 +2728,4 @@ async def test_agent_runtime_gateway_prefers_latest_live_child_thread_over_activ
     )
 
     assert started == [(expected_thread_id, chat_id, "agent-user-1")]
-    assert enqueued == [("hello", expected_thread_id, "human-user-1", "Human")]
+    assert enqueued == [(f"Human|{chat_id}|{unread_count}|ping", expected_thread_id, "human-user-1", "Human")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.agent_runtime.bootstrap import build_agent_runtime_gateway
+from backend.protocols.agent_runtime import (
+    AgentChatContext,
+    AgentChatDeliveryEnvelope,
+    AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+)
+
+
+@pytest.mark.asyncio
+async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    started: list[tuple[str, str, str]] = []
+    enqueued: list[tuple[str, str]] = []
+
+    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
+        return SimpleNamespace(id=f"agent-for-{thread_id}")
+
+    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("handler should not resolve thread id locally")),
+                list_by_agent_user=lambda _uid: (_ for _ in ()).throw(
+                    AssertionError("handler should not scan runtime thread candidates locally")
+                ),
+            ),
+            agent_pool={},
+            typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
+            queue_manager=SimpleNamespace(
+                enqueue=lambda content, thread_id, _notification_type, **_meta: enqueued.append((content, thread_id))
+            ),
+        )
+    )
+
+    envelope = AgentChatDeliveryEnvelope(
+        chat=AgentChatContext(chat_id="chat-1"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
+        recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel", thread_id="thread-preselected"),
+        message=AgentRuntimeMessage(content="hello", signal="ping"),
+    )
+
+    result = await build_agent_runtime_gateway(app).dispatch_chat(envelope)
+
+    assert result.status == "accepted"
+    assert result.thread_id == "thread-preselected"
+    assert started == [("thread-preselected", "chat-1", "agent-user-1")]
+    assert enqueued == [("hello", "thread-preselected")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -13,7 +13,6 @@ from backend.protocols.agent_runtime import (
     AgentRuntimeActor,
     AgentRuntimeMessage,
 )
-from core.runtime.middleware.monitor import AgentState
 
 
 def _app(
@@ -45,11 +44,17 @@ def _app(
     return app, started, unread_calls, enqueued
 
 
-def _envelope(*, chat_id: str = "chat-1", signal: str | None = "ping", content: str = "hello") -> AgentChatDeliveryEnvelope:
+def _envelope(
+    *,
+    chat_id: str = "chat-1",
+    signal: str | None = "ping",
+    content: str = "hello",
+    thread_id: str | None = "thread-1",
+) -> AgentChatDeliveryEnvelope:
     return AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id=chat_id),
         sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
-        recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel"),
+        recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel", thread_id=thread_id),
         message=AgentRuntimeMessage(content=content, signal=signal),
     )
 
@@ -79,66 +84,10 @@ async def test_gateway_dispatch_chat_raises_for_missing_thread(monkeypatch: pyte
         "backend.web.services.agent_pool.get_or_create_agent", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
     )
     app, started, unread_calls, enqueued = _app(threads=[])
-    app.state.thread_repo = SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: [])
 
     with pytest.raises(RuntimeError, match="Agent chat recipient has no runtime thread: agent-user-1"):
-        await build_agent_runtime_gateway(app).dispatch_chat(_envelope())
+        await build_agent_runtime_gateway(app).dispatch_chat(_envelope(thread_id=None))
 
     assert started == []
     assert unread_calls == []
     assert enqueued == []
-
-
-@pytest.mark.asyncio
-async def test_gateway_prefers_latest_live_child_thread(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
-        return SimpleNamespace(id=f"agent-for-{thread_id}")
-
-    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
-    monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
-    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
-    app, started, _, enqueued = _app(
-        threads=[
-            {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0},
-            {"id": "thread-child-old", "agent_user_id": "agent-user-1", "is_main": False, "branch_index": 1},
-            {"id": "thread-child-fresh", "agent_user_id": "agent-user-1", "is_main": False, "branch_index": 2},
-        ],
-        pool={
-            "thread-main:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.ACTIVE)),
-            "thread-child-old:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.IDLE)),
-            "thread-child-fresh:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.READY)),
-        },
-    )
-
-    result = await build_agent_runtime_gateway(app).dispatch_chat(_envelope(chat_id="chat-5"))
-
-    assert result.status == "accepted"
-    assert result.thread_id == "thread-child-fresh"
-    assert started == [("thread-child-fresh", "chat-5", "agent-user-1")]
-    assert enqueued == [("hello", "thread-child-fresh", "human-user-1", "Human")]
-
-
-@pytest.mark.asyncio
-async def test_gateway_chat_delivery_uses_live_thread_repo_after_gateway_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
-        return SimpleNamespace(id=f"agent-for-{thread_id}")
-
-    monkeypatch.setattr("backend.web.services.agent_pool.get_or_create_agent", _fake_get_or_create_agent)
-    monkeypatch.setattr("backend.web.services.agent_pool.resolve_thread_sandbox", lambda _app, _thread_id: "local")
-    monkeypatch.setattr("backend.web.services.streaming_service._ensure_thread_handlers", lambda *_args, **_kwargs: None)
-    app, started, unread_calls, enqueued = _app()
-    gateway = build_agent_runtime_gateway(app)
-
-    replacement_thread = {"id": "thread-replaced", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
-    app.state.thread_repo = SimpleNamespace(
-        get_by_user_id=lambda uid: replacement_thread if uid == "agent-user-1" else None,
-        list_by_agent_user=lambda uid: [replacement_thread] if uid == "agent-user-1" else [],
-    )
-
-    result = await gateway.dispatch_chat(_envelope(chat_id="chat-live"))
-
-    assert result.status == "accepted"
-    assert result.thread_id == "thread-replaced"
-    assert started == [("thread-replaced", "chat-live", "agent-user-1")]
-    assert unread_calls == []
-    assert enqueued == [("hello", "thread-replaced", "human-user-1", "Human")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -35,6 +35,14 @@ def test_agent_runtime_chat_and_thread_inputs_share_message_protocol_objects() -
     assert "message_metadata" not in thread_fields
 
 
+def test_agent_chat_recipient_supports_optional_preselected_thread_id() -> None:
+    protocol_module = importlib.import_module("backend.protocols.agent_runtime")
+
+    recipient_fields = get_type_hints(protocol_module.AgentChatRecipient)
+
+    assert recipient_fields["thread_id"] == str | None
+
+
 def test_agent_runtime_thread_input_result_is_a_protocol_object() -> None:
     protocol_module = importlib.import_module("backend.protocols.agent_runtime")
     gateway_module = importlib.import_module("backend.agent_runtime.gateway")
@@ -93,4 +101,7 @@ def test_chat_handler_depends_on_runtime_owned_services_not_web_imports() -> Non
     assert "count_unread" not in chat_handler_source
     assert "enqueue_chat_notification" not in chat_handler_source
     assert "format_chat_notification" not in chat_handler_source
+    assert "list_by_agent_user" not in chat_handler_source
+    assert "iter_agent_pool_items" not in chat_handler_source
+    assert "AgentState" not in chat_handler_source
     assert "AppAgentChatRuntimeServices" in bootstrap_source

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -14,6 +14,20 @@ from messaging.realtime import events as owner_chat_events
 from messaging.realtime import typing as owner_typing
 
 
+def _hook_app(gateway: object) -> SimpleNamespace:
+    default_thread = {"id": "thread-1", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            agent_runtime_gateway=gateway,
+            thread_repo=SimpleNamespace(
+                get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
+                list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
+            ),
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        )
+    )
+
+
 def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> None:
     delivery_source = inspect.getsource(owner_chat_inlet)
     threads_source = inspect.getsource(threads_router)
@@ -55,7 +69,7 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
         async def dispatch_chat(self, _envelope):
             raise RuntimeError("runtime gateway down")
 
-    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=FailingGateway()))
+    app = _hook_app(FailingGateway())
     deliver = chat_delivery_hook.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
@@ -83,7 +97,7 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
             self.envelope = envelope
 
     gateway = RecordingGateway()
-    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=gateway))
+    app = _hook_app(gateway)
     deliver = chat_delivery_hook.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
@@ -116,7 +130,7 @@ async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
             self.called = True
 
     gateway = RecordingGateway()
-    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=gateway))
+    app = _hook_app(gateway)
     deliver = chat_delivery_hook.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
@@ -146,7 +160,7 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
             self.called = True
 
     gateway = RecordingGateway()
-    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=gateway))
+    app = _hook_app(gateway)
     deliver = chat_delivery_hook.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",

--- a/tests/Unit/messaging/test_runtime_thread_selector.py
+++ b/tests/Unit/messaging/test_runtime_thread_selector.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
+
+
+def test_selector_prefers_latest_live_child_thread_over_active_main() -> None:
+    thread_repo = SimpleNamespace(
+        get_by_user_id=lambda uid: {"id": "thread-main", "agent_user_id": "agent-user-1"} if uid == "agent-user-1" else None,
+        list_by_agent_user=lambda uid: (
+            [
+                {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0},
+                {"id": "thread-child-old", "agent_user_id": "agent-user-1", "is_main": False, "branch_index": 1},
+                {"id": "thread-child-fresh", "agent_user_id": "agent-user-1", "is_main": False, "branch_index": 2},
+            ]
+            if uid == "agent-user-1"
+            else []
+        ),
+    )
+    activity_reader = SimpleNamespace(
+        list_active_threads_for_agent=lambda _agent_user_id: [
+            SimpleNamespace(thread_id="thread-main", is_main=True, branch_index=0, state="active"),
+            SimpleNamespace(thread_id="thread-child-old", is_main=False, branch_index=1, state="idle"),
+            SimpleNamespace(thread_id="thread-child-fresh", is_main=False, branch_index=2, state="ready"),
+        ]
+    )
+
+    selected = select_runtime_thread_for_recipient(
+        "agent-user-1",
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+
+    assert selected == "thread-child-fresh"
+
+
+def test_selector_falls_back_to_default_thread_when_no_live_runtime_candidate_exists() -> None:
+    default_thread = {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
+    thread_repo = SimpleNamespace(
+        get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
+        list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
+    )
+    activity_reader = SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+
+    selected = select_runtime_thread_for_recipient(
+        "agent-user-1",
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+
+    assert selected == "thread-main"


### PR DESCRIPTION
## Summary
- add a runtime-read protocol and app-backed thread activity reader for live agent thread activity snapshots
- move chat recipient thread selection out of backend/agent_runtime/chat_handler.py and into messaging/delivery/runtime_thread_selector.py
- have chat_inlet preselect recipient.thread_id before dispatch so chat_handler only consumes the chosen thread id

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_runtime_thread_selector.py tests/Integration/test_messaging_social_handle_contract.py -q -k "thread_selector or dispatch_chat or chat_handler or chat_delivery_hook or recipient_social_user_id or latest_live_child_thread"`
- `uv run ruff check backend/protocols/runtime_read.py backend/protocols/agent_runtime.py backend/agent_runtime/thread_activity_reader.py messaging/delivery/runtime_thread_selector.py backend/agent_runtime/chat_inlet.py backend/agent_runtime/chat_handler.py backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_runtime_thread_selector.py tests/Integration/test_messaging_social_handle_contract.py`
- `.venv/bin/python -m pyright backend/protocols/runtime_read.py backend/protocols/agent_runtime.py backend/agent_runtime/thread_activity_reader.py messaging/delivery/runtime_thread_selector.py backend/agent_runtime/chat_inlet.py backend/agent_runtime/chat_handler.py backend/agent_runtime/chat_runtime_services.py backend/agent_runtime/bootstrap.py`
- `git diff --check`
