### PR TITLE
refactor: read conversation running state via runtime activity

### DIFF
--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -8,11 +8,11 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 
+from backend.protocols.runtime_read import RuntimeThreadActivityReader
 from backend.web.core.dependencies import get_app, get_current_user_id
 from backend.web.services.owner_thread_read_service import list_owner_thread_rows_for_auth_burst
 from backend.web.services.thread_visibility import canonical_owner_threads
 from backend.web.utils.serializers import avatar_url
-from core.runtime.middleware.monitor import AgentState
 
 router = APIRouter(prefix="/api/conversations", tags=["conversations"])
 
@@ -51,16 +51,12 @@ async def list_conversations(
 def _list_hire_conversations_from_threads(app: Any, raw_thread_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     raw_threads = canonical_owner_threads(raw_thread_rows)
-    pool = app.state.agent_pool
+    activity_reader = getattr(app.state, "agent_runtime_thread_activity_reader", None)
     for t in raw_threads:
         tid = t["id"]
         if _is_internal_child_thread(tid):
             continue
-        sandbox_type = t.get("sandbox_type", "local")
-        running = False
-        agent = pool.get(f"{tid}:{sandbox_type}")
-        if agent and hasattr(agent, "runtime"):
-            running = agent.runtime.current_state == AgentState.ACTIVE
+        running = _thread_running(activity_reader, t.get("agent_user_id"), tid)
         last_active = app.state.thread_last_active.get(tid)
         updated_at = datetime.fromtimestamp(last_active, tz=UTC).isoformat() if last_active else None
         items.append(
@@ -75,6 +71,18 @@ def _list_hire_conversations_from_threads(app: Any, raw_thread_rows: list[dict[s
             }
         )
     return items
+
+
+def _thread_running(activity_reader: RuntimeThreadActivityReader | None, agent_user_id: Any, thread_id: str) -> bool:
+    if activity_reader is None:
+        return False
+    normalized_agent_user_id = str(agent_user_id or "").strip()
+    if not normalized_agent_user_id:
+        return False
+    return any(
+        activity.thread_id == thread_id and activity.state == "active"
+        for activity in activity_reader.list_active_threads_for_agent(normalized_agent_user_id)
+    )
 
 
 def _list_visit_conversations_for_user(app: Any, user_id: str) -> list[dict[str, Any]]:

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import threading
 from types import SimpleNamespace
 
@@ -14,6 +15,13 @@ def test_conversations_http_owner_module_lives_under_backend_chat() -> None:
     assert owner_conversations_router.__name__ == "backend.chat.api.http.conversations_router"
     assert owner_conversations_router.router is conversations_router.router
     assert owner_conversations_router.list_conversations is conversations_router.list_conversations
+
+
+def test_conversations_router_uses_runtime_activity_reader_for_running_state() -> None:
+    source = inspect.getsource(owner_conversations_router)
+
+    assert "AgentState" not in source
+    assert "agent_pool" not in source
 
 
 @pytest.mark.asyncio
@@ -170,6 +178,52 @@ async def test_list_conversations_hire_entries_do_not_leak_template_member_ids()
         }
     ]
     assert "member_id" not in result[0]
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_marks_hire_thread_running_from_runtime_activity_reader() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                list_by_owner_user_id=lambda _user_id: [
+                    {
+                        "id": "thread-1",
+                        "agent_user_id": "agent-user-1",
+                        "agent_name": "Morel",
+                        "agent_avatar": "avatars/morel.png",
+                        "sandbox_type": "local",
+                    }
+                ],
+                get_by_user_id=lambda _uid: None,
+            ),
+            agent_pool=SimpleNamespace(
+                get=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("conversations router should not read agent_pool directly for running state")
+                )
+            ),
+            agent_runtime_thread_activity_reader=SimpleNamespace(
+                list_active_threads_for_agent=lambda _agent_user_id: [
+                    SimpleNamespace(thread_id="thread-1", is_main=True, branch_index=0, state="active")
+                ]
+            ),
+            thread_last_active={},
+            messaging_service=None,
+        )
+    )
+
+    result = await conversations_router.list_conversations("human-user-1", app=app)
+
+    assert result == [
+        {
+            "id": "thread-1",
+            "type": "hire",
+            "title": "Morel",
+            "avatar_url": avatar_url("agent-user-1", True),
+            "updated_at": None,
+            "unread_count": 0,
+            "running": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make backend/chat/api/http/conversations_router.py read hire-conversation running state from the runtime thread activity reader instead of reading app.state.agent_pool directly
- remove the direct AgentState dependency from conversations_router
- add focused conversation-router tests that lock the new running-state source boundary

## Verification
- `uv run python -m pytest tests/Integration/test_conversations_router.py -q`
- `uv run ruff check backend/chat/api/http/conversations_router.py tests/Integration/test_conversations_router.py`
- `git diff --check`

## Note
- `.venv/bin/python -m pyright backend/chat/api/http/conversations_router.py` is not usable on this host right now because the local type environment cannot resolve `fastapi`; no new type error specific to this slice was surfaced beyond that environment issue.
