### PR TITLE
refactor: inject messaging avatar url builder

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -90,6 +90,7 @@ async def lifespan(app: FastAPI):
     # Wire chat delivery after event loop is available
     # ---- Messaging system (Supabase-backed, required) ----
     from backend.agent_runtime.chat_inlet import make_chat_delivery_fn
+    from backend.web.utils.serializers import avatar_url
     from messaging.delivery.resolver import HireVisitDeliveryResolver
     from messaging.relationships.service import RelationshipService
     from messaging.service import MessagingService
@@ -116,6 +117,7 @@ async def lifespan(app: FastAPI):
         thread_repo=app.state.thread_repo,
         event_bus=app.state.chat_event_bus,
         delivery_resolver=_msg_delivery_resolver,
+        avatar_url_builder=avatar_url,
     )
     app.state.messaging_service.set_delivery_fn(make_chat_delivery_fn(app))
 

--- a/messaging/avatars.py
+++ b/messaging/avatars.py
@@ -1,0 +1,9 @@
+"""Avatar URL protocol for messaging-owned projections."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class AvatarUrlBuilder(Protocol):
+    def __call__(self, user_id: str | None, has_avatar: bool) -> str | None: ...

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -6,7 +6,7 @@ import logging
 from enum import Enum
 from typing import Any
 
-from backend.web.utils.serializers import avatar_url
+from messaging.avatars import AvatarUrlBuilder
 from messaging.delivery.actions import DeliveryAction
 from messaging.delivery.contracts import ChatDeliveryFn, ChatDeliveryRequest
 from messaging.display_user import resolve_messaging_display_user
@@ -21,12 +21,15 @@ class ChatDeliveryDispatcher:
         self,
         chat_member_repo: Any,
         user_repo: Any,
+        *,
+        avatar_url_builder: AvatarUrlBuilder | None = None,
         unread_counter: Any | None = None,
         delivery_resolver: Any | None = None,
         delivery_fn: ChatDeliveryFn | None = None,
     ) -> None:
         self._chat_members_repo = chat_member_repo
         self._user_repo = user_repo
+        self._avatar_url_builder = avatar_url_builder
         self._unread_counter = unread_counter
         self._delivery_resolver = delivery_resolver
         self._delivery_fn = delivery_fn
@@ -48,7 +51,7 @@ class ChatDeliveryDispatcher:
         if sender_user is None:
             raise RuntimeError(f"Chat delivery sender identity not found: {sender_id}")
         sender_name = sender_user.display_name
-        sender_avatar_url = avatar_url(sender_user.id, bool(sender_user.avatar))
+        sender_avatar_url = self._build_avatar_url(sender_user.id, bool(sender_user.avatar))
         sender_raw_type = getattr(sender_user, "type", None)
         if sender_raw_type is None:
             raise RuntimeError(f"Chat delivery sender type is missing: {sender_id}")
@@ -119,6 +122,11 @@ class ChatDeliveryDispatcher:
         if type(unread_count) is not int:
             raise RuntimeError(f"Chat delivery unread count is invalid for {recipient_id}: {unread_count!r}")
         return unread_count
+
+    def _build_avatar_url(self, user_id: str | None, has_avatar: bool) -> str | None:
+        if self._avatar_url_builder is None:
+            raise RuntimeError("Chat delivery avatar URL builder is not configured")
+        return self._avatar_url_builder(user_id, has_avatar)
 
     def _deliver(
         self,

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from backend.web.utils.serializers import avatar_url
+from messaging.avatars import AvatarUrlBuilder
 from messaging.contracts import ContentType, MessageType
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
 from messaging.display_user import resolve_messaging_display_user
@@ -38,14 +38,18 @@ class MessagingService:
         delivery_fn: ChatDeliveryFn | None = None,
         delivery_dispatcher: ChatDeliveryDispatcher | None = None,
         event_bus: Any | None = None,
+        *,
+        avatar_url_builder: AvatarUrlBuilder | None = None,
     ) -> None:
         self._chats = chat_repo
         self._chat_members_repo = chat_member_repo
         self._messages = messages_repo
         self._user_repo = user_repo
+        self._avatar_url_builder = avatar_url_builder
         self._delivery_dispatcher = delivery_dispatcher or ChatDeliveryDispatcher(
             chat_member_repo=chat_member_repo,
             user_repo=user_repo,
+            avatar_url_builder=avatar_url_builder,
             unread_counter=getattr(messages_repo, "count_unread", None),
             delivery_resolver=delivery_resolver,
             delivery_fn=delivery_fn,
@@ -108,7 +112,7 @@ class MessagingService:
                     "id": social_user_id,
                     "name": user.display_name,
                     "type": user.type.value if hasattr(user.type, "value") else str(user.type),
-                    "avatar_url": avatar_url(user.id, bool(user.avatar)),
+                    "avatar_url": self._build_avatar_url(user.id, bool(user.avatar)),
                 }
             )
         return member_info
@@ -496,5 +500,10 @@ class MessagingService:
             "id": social_user_id,
             "name": user.display_name,
             "type": user.type.value if hasattr(user.type, "value") else str(user.type),
-            "avatar_url": avatar_url(user.id, bool(user.avatar)),
+            "avatar_url": self._build_avatar_url(user.id, bool(user.avatar)),
         }
+
+    def _build_avatar_url(self, user_id: str | None, has_avatar: bool) -> str | None:
+        if self._avatar_url_builder is None:
+            raise RuntimeError("Messaging avatar URL builder is not configured")
+        return self._avatar_url_builder(user_id, has_avatar)

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -22,6 +22,19 @@ from messaging.relationships.service import RelationshipService
 from messaging.service import MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
 
+_MessagingService = MessagingService
+_ChatDeliveryDispatcher = ChatDeliveryDispatcher
+
+
+def MessagingService(*args, **kwargs):  # noqa: N802
+    kwargs.setdefault("avatar_url_builder", avatar_url)
+    return _MessagingService(*args, **kwargs)
+
+
+def ChatDeliveryDispatcher(*args, **kwargs):  # noqa: N802
+    kwargs.setdefault("avatar_url_builder", avatar_url)
+    return _ChatDeliveryDispatcher(*args, **kwargs)
+
 
 class _FakeRelationshipRepo:
     def __init__(self) -> None:

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -69,6 +69,7 @@ def test_dispatcher_delivers_to_agent_user_ids() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 7,
         delivery_fn=deliver,
     )
@@ -83,6 +84,7 @@ def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(
             resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner path must not call resolver"))
@@ -100,6 +102,7 @@ def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(
             resolve=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("same-owner sibling path must not call resolver"))
@@ -118,6 +121,7 @@ def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["outside-human-user", "agent-user-1"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: action),
         delivery_fn=lambda request: delivered.append(request.recipient_id),
@@ -139,6 +143,7 @@ def test_dispatcher_fails_loudly_when_delivery_function_fails() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=deliver,
     )
@@ -153,6 +158,7 @@ def test_dispatcher_fails_loudly_when_delivery_function_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
     )
 
@@ -165,6 +171,7 @@ def test_dispatcher_fails_loudly_when_sender_identity_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["missing-user", "agent-user-1"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
@@ -180,6 +187,7 @@ def test_dispatcher_fails_loudly_when_member_user_id_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "human-user-1"}, {}]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
@@ -195,6 +203,7 @@ def test_dispatcher_fails_loudly_when_recipient_identity_is_missing() -> None:
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["human-user-1", "missing-recipient"]),
         user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
@@ -203,3 +212,32 @@ def test_dispatcher_fails_loudly_when_recipient_identity_is_missing() -> None:
         dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
 
     assert delivered == []
+
+
+def test_dispatcher_uses_injected_avatar_url_builder_for_sender() -> None:
+    built: list[tuple[str | None, bool]] = []
+    delivered: list[str | None] = []
+
+    def _user_with_avatar_repo() -> SimpleNamespace:
+        return SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar="avatars/human.png", owner_user_id=None)
+                if uid == "human-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None, owner_user_id="human-user-1")
+                if uid == "agent-user-1"
+                else None
+            )
+        )
+
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1"]),
+        user_repo=_user_with_avatar_repo(),
+        unread_counter=lambda _chat_id, _user_id: 0,
+        avatar_url_builder=lambda user_id, has_avatar: built.append((user_id, has_avatar)) or f"custom:{user_id}:{has_avatar}",
+        delivery_fn=lambda request: delivered.append(request.sender_avatar_url),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert built == [("human-user-1", True)]
+    assert delivered == ["custom:human-user-1:True"]

--- a/tests/Unit/messaging/test_module_independence.py
+++ b/tests/Unit/messaging/test_module_independence.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import inspect
+
+from messaging import service as messaging_service_module
+from messaging.delivery import dispatcher as delivery_dispatcher_module
+
+
+def test_messaging_core_modules_do_not_import_backend_web_serializers() -> None:
+    service_source = inspect.getsource(messaging_service_module)
+    dispatcher_source = inspect.getsource(delivery_dispatcher_module)
+
+    assert "backend.web.utils.serializers" not in service_source
+    assert "backend.web.utils.serializers" not in dispatcher_source


### PR DESCRIPTION
## Summary
- introduce messaging/avatars.py as the messaging-owned avatar URL protocol
- stop messaging/service.py and messaging/delivery/dispatcher.py from importing backend.web.utils.serializers directly
- bind the real file-backed avatar URL builder from backend/web/core/lifespan.py, while keeping missing builder usage fail-loud on actual avatar projection paths

## Verification
- `uv run python -m pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/messaging/test_module_independence.py tests/Integration/test_messaging_social_handle_contract.py -q -k "avatar or messaging_service or deliver_to_agents or chat_tool_list_chats or same_owner_agent_turn_delivers_to_sibling_actor_without_relationship"`
- `uv run ruff check messaging/avatars.py messaging/service.py messaging/delivery/dispatcher.py backend/web/core/lifespan.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/messaging/test_module_independence.py tests/Integration/test_messaging_social_handle_contract.py`
- `.venv/bin/python -m pyright messaging/avatars.py messaging/service.py messaging/delivery/dispatcher.py`
- `git diff --check`
