### PR TITLE
refactor: extract actor ownership primitive

### DIFF
--- a/backend/chat/api/http/router.py
+++ b/backend/chat/api/http/router.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
+from messaging.actor_ownership import access_scope_targets, is_owned_by_viewer
 from messaging.social_access import ACTIVE_CHAT_RELATIONSHIP_STATES, has_active_contact
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -48,9 +49,7 @@ def _verify_user_ownership(app: Any, sender_id: str, user_id: str) -> None:
     sender = _resolve_display_user(app, sender_id)
     if not sender:
         raise HTTPException(403, "User not found")
-    if sender.id == user_id:
-        return
-    if sender.owner_user_id == user_id:
+    if is_owned_by_viewer(user_id, sender):
         return
     raise HTTPException(403, "User does not belong to you")
 
@@ -95,14 +94,13 @@ def _is_owned_participant(app: Any, participant_id: str, requester_user_id: str)
     if user_repo is None:
         return False
     participant = user_repo.get_by_id(participant_id)
-    return getattr(participant, "owner_user_id", None) == requester_user_id
+    return is_owned_by_viewer(requester_user_id, participant)
 
 
 def _participant_access_targets(app: Any, participant_id: str) -> list[str]:
     user_repo = getattr(app.state, "user_repo", None)
     participant = user_repo.get_by_id(participant_id) if user_repo is not None else None
-    owner_user_id = getattr(participant, "owner_user_id", None)
-    return [participant_id, str(owner_user_id)] if owner_user_id else [participant_id]
+    return access_scope_targets(participant, fallback_actor_id=participant_id)
 
 
 def _validate_group_chat_relationships(app: Any, participant_ids: list[str], requester_user_id: str) -> None:

--- a/messaging/actor_ownership.py
+++ b/messaging/actor_ownership.py
@@ -1,0 +1,16 @@
+"""Pure actor-ownership predicates for chat-related identity checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_owned_by_viewer(viewer_user_id: str, candidate_user: Any | None) -> bool:
+    return candidate_user is not None and (
+        getattr(candidate_user, "id", None) == viewer_user_id or getattr(candidate_user, "owner_user_id", None) == viewer_user_id
+    )
+
+
+def access_scope_targets(actor_user: Any | None, fallback_actor_id: str) -> list[str]:
+    owner_user_id = getattr(actor_user, "owner_user_id", None) if actor_user is not None else None
+    return [fallback_actor_id, str(owner_user_id)] if owner_user_id else [fallback_actor_id]

--- a/messaging/relationships/router.py
+++ b/messaging/relationships/router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 
 from backend.web.core.dependencies import get_app, get_current_user_id
+from messaging.actor_ownership import is_owned_by_viewer
 from messaging.contracts import RelationshipRow
 from messaging.relationships.state_machine import TransitionError
 
@@ -55,7 +56,7 @@ def _resolve_actor_user_id(app: Any, current_user_id: str, actor_user_id: str | 
     actor = user_repo.get_by_id(actor_user_id)
     if actor is None:
         raise HTTPException(404, "Actor user not found")
-    if getattr(actor, "owner_user_id", None) != current_user_id:
+    if not is_owned_by_viewer(current_user_id, actor):
         raise HTTPException(403, "Actor user does not belong to you")
     return actor_user_id
 

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -121,6 +121,13 @@ def test_chat_router_imports_messaging_social_access_owner() -> None:
     assert "backend.web.services.social_access_service" not in source
 
 
+def test_chat_router_imports_actor_ownership_primitive() -> None:
+    source = inspect.getsource(chat_router)
+
+    assert "from messaging.actor_ownership import" in source
+    assert "owner_user_id ==" not in source
+
+
 def test_get_accessible_chat_or_404_returns_chat():
     chat = _chat("chat-1")
     app = SimpleNamespace(

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -23,6 +24,13 @@ def _row(*, state: str = "pending", initiator_user_id: str = "requester-user-1")
         created_at=now,
         updated_at=now,
     )
+
+
+def test_relationship_router_imports_actor_ownership_primitive() -> None:
+    source = inspect.getsource(relationship_router)
+
+    assert "from messaging.actor_ownership import" in source
+    assert "owner_user_id" not in source
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/messaging/test_actor_ownership.py
+++ b/tests/Unit/messaging/test_actor_ownership.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from messaging.actor_ownership import access_scope_targets, is_owned_by_viewer
+
+
+def test_is_owned_by_viewer_accepts_self() -> None:
+    user = SimpleNamespace(id="viewer-1", owner_user_id=None)
+
+    assert is_owned_by_viewer("viewer-1", user) is True
+
+
+def test_is_owned_by_viewer_accepts_owned_actor() -> None:
+    user = SimpleNamespace(id="agent-user-1", owner_user_id="viewer-1")
+
+    assert is_owned_by_viewer("viewer-1", user) is True
+
+
+def test_is_owned_by_viewer_rejects_stranger() -> None:
+    user = SimpleNamespace(id="agent-user-1", owner_user_id="someone-else")
+
+    assert is_owned_by_viewer("viewer-1", user) is False
+
+
+def test_is_owned_by_viewer_rejects_missing_candidate() -> None:
+    assert is_owned_by_viewer("viewer-1", None) is False
+
+
+def test_access_scope_targets_expands_owned_actor_scope() -> None:
+    user = SimpleNamespace(id="agent-user-1", owner_user_id="viewer-1")
+
+    assert access_scope_targets(user, fallback_actor_id="agent-user-1") == ["agent-user-1", "viewer-1"]
+
+
+def test_access_scope_targets_falls_back_to_raw_actor_id() -> None:
+    user = SimpleNamespace(id="human-user-2", owner_user_id=None)
+
+    assert access_scope_targets(user, fallback_actor_id="human-user-2") == ["human-user-2"]


### PR DESCRIPTION
## Summary
- add messaging/actor_ownership.py as a messaging-owned primitive for actor ownership and access-scope targeting
- rewrite messaging/relationships/router.py and backend/chat/api/http/router.py to use the new primitive instead of duplicating owner_user_id checks inline
- lock the new ownership source boundary with focused unit/integration tests

## Verification
- `uv run python -m pytest tests/Unit/messaging/test_actor_ownership.py tests/Integration/test_messaging_router.py tests/Integration/test_relationship_router.py -q`
- `uv run ruff check messaging/actor_ownership.py messaging/relationships/router.py backend/chat/api/http/router.py tests/Unit/messaging/test_actor_ownership.py tests/Integration/test_messaging_router.py tests/Integration/test_relationship_router.py`
- `.venv/bin/python -m pyright messaging/actor_ownership.py`
- `git diff --check`
