### PR TITLE
refactor: extract group chat social access

### DIFF
--- a/backend/chat/api/http/router.py
+++ b/backend/chat/api/http/router.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from backend.web.core.dependencies import get_app, get_current_user_id
 from messaging.actor_ownership import access_scope_targets, is_owned_by_viewer
-from messaging.social_access import ACTIVE_CHAT_RELATIONSHIP_STATES, has_active_contact
+from messaging.social_access import can_group_chat_with_participant
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
@@ -108,18 +108,23 @@ def _validate_group_chat_relationships(app: Any, participant_ids: list[str], req
     if svc is None:
         raise ValueError("Relationship service is required for group chat creation")
     contact_repo = getattr(app.state, "contact_repo", None)
+    user_repo = getattr(app.state, "user_repo", None)
     for participant_id in dict.fromkeys(participant_ids):
         if participant_id == requester_user_id or _is_owned_participant(app, participant_id, requester_user_id):
             continue
         try:
-            access_targets = _participant_access_targets(app, participant_id)
-            if any(has_active_contact(contact_repo, requester_user_id, target_id) for target_id in access_targets):
+            participant_user = user_repo.get_by_id(participant_id) if user_repo is not None else None
+            if can_group_chat_with_participant(
+                viewer_user_id=requester_user_id,
+                participant_user_id=participant_id,
+                participant_user=participant_user,
+                contact_repo=contact_repo,
+                relationship_service=svc,
+            ):
                 continue
         except RuntimeError as exc:
             raise ValueError(str(exc)) from exc
-        states = [svc.get_state(requester_user_id, target_id) for target_id in access_targets]
-        if not any(state in ACTIVE_CHAT_RELATIONSHIP_STATES for state in states):
-            raise ValueError(f"Active relationship required for group chat participant: {participant_id}")
+        raise ValueError(f"Active relationship required for group chat participant: {participant_id}")
 
 
 @router.get("")

--- a/messaging/social_access.py
+++ b/messaging/social_access.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from messaging.actor_ownership import access_scope_targets
+
 ACTIVE_CHAT_RELATIONSHIP_STATES = {"visit", "hire"}
 
 
@@ -43,3 +45,17 @@ def can_chat_with_owner_scope(
     return can_chat_with(is_owned=is_owned, relationship_state=relationship_state, has_contact=has_contact) or (
         not is_owned and (owner_has_contact or owner_relationship_state in ACTIVE_CHAT_RELATIONSHIP_STATES)
     )
+
+
+def can_group_chat_with_participant(
+    *,
+    viewer_user_id: str,
+    participant_user_id: str,
+    participant_user: Any | None,
+    contact_repo: Any,
+    relationship_service: Any,
+) -> bool:
+    targets = access_scope_targets(participant_user, fallback_actor_id=participant_user_id)
+    if any(has_active_contact(contact_repo, viewer_user_id, target_id) for target_id in targets):
+        return True
+    return any(relationship_service.get_state(viewer_user_id, target_id) in ACTIVE_CHAT_RELATIONSHIP_STATES for target_id in targets)

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -128,6 +128,15 @@ def test_chat_router_imports_actor_ownership_primitive() -> None:
     assert "owner_user_id ==" not in source
 
 
+def test_chat_router_imports_group_chat_social_access_primitive() -> None:
+    source = inspect.getsource(chat_router)
+
+    assert "can_group_chat_with_participant" in source
+    assert "ACTIVE_CHAT_RELATIONSHIP_STATES" not in source
+    assert "has_active_contact" not in source
+    assert ".get_state(" not in source
+
+
 def test_get_accessible_chat_or_404_returns_chat():
     chat = _chat("chat-1")
     app = SimpleNamespace(

--- a/tests/Unit/messaging/test_social_access_group_chat.py
+++ b/tests/Unit/messaging/test_social_access_group_chat.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from messaging.social_access import can_group_chat_with_participant
+
+
+def test_group_chat_participant_allowed_by_active_contact() -> None:
+    contact_repo = SimpleNamespace(
+        get=lambda viewer_id, target_id: (
+            SimpleNamespace(state="active", kind="normal", blocked=False) if (viewer_id, target_id) == ("viewer-1", "human-2") else None
+        )
+    )
+    relationship_service = SimpleNamespace(get_state=lambda _viewer_id, _target_id: "none")
+
+    allowed = can_group_chat_with_participant(
+        viewer_user_id="viewer-1",
+        participant_user_id="human-2",
+        participant_user=SimpleNamespace(id="human-2", owner_user_id=None),
+        contact_repo=contact_repo,
+        relationship_service=relationship_service,
+    )
+
+    assert allowed is True
+
+
+def test_group_chat_participant_allowed_by_owner_relationship_scope() -> None:
+    contact_repo = SimpleNamespace(get=lambda _viewer_id, _target_id: None)
+    relationship_service = SimpleNamespace(
+        get_state=lambda viewer_id, target_id: "visit" if (viewer_id, target_id) == ("viewer-1", "owner-2") else "none"
+    )
+
+    allowed = can_group_chat_with_participant(
+        viewer_user_id="viewer-1",
+        participant_user_id="agent-2",
+        participant_user=SimpleNamespace(id="agent-2", owner_user_id="owner-2"),
+        contact_repo=contact_repo,
+        relationship_service=relationship_service,
+    )
+
+    assert allowed is True
+
+
+def test_group_chat_participant_denied_without_contact_or_relationship() -> None:
+    contact_repo = SimpleNamespace(get=lambda _viewer_id, _target_id: None)
+    relationship_service = SimpleNamespace(get_state=lambda _viewer_id, _target_id: "none")
+
+    allowed = can_group_chat_with_participant(
+        viewer_user_id="viewer-1",
+        participant_user_id="human-2",
+        participant_user=SimpleNamespace(id="human-2", owner_user_id=None),
+        contact_repo=contact_repo,
+        relationship_service=relationship_service,
+    )
+
+    assert allowed is False


### PR DESCRIPTION
## Summary
- extract group chat participant access policy into messaging/social_access.py
- keep backend/chat/api/http/router.py as transport-only iteration + HTTP error translation
- preserve existing group chat eligibility behavior for active contact / visit-hire relationship / owned agent cases

## Verification
- `uv run python -m pytest tests/Unit/messaging/test_social_access_group_chat.py tests/Integration/test_messaging_router.py -q -k "group_chat"`
- `uv run ruff check messaging/social_access.py backend/chat/api/http/router.py tests/Unit/messaging/test_social_access_group_chat.py tests/Integration/test_messaging_router.py`
- `.venv/bin/python -m pyright messaging/social_access.py`
- `git diff --check`
