### PR TITLE
refactor: dedupe thread runtime sandbox owner

### DIFF
--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -7,10 +7,10 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from backend.thread_runtime.sandbox import resolve_thread_sandbox
 from backend.web.services.file_channel_service import get_file_channel_binding
 from core.identity.agent_registry import get_or_create_agent_id
 from core.runtime.agent import create_leon_agent
-from sandbox.manager import lookup_sandbox_for_thread
 from sandbox.thread_context import set_current_thread_id
 from storage.runtime import build_storage_container
 
@@ -235,24 +235,6 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
                 manager.set_thread_bind_mounts(thread_id, bind_mounts)
         pool[pool_key] = agent_obj
         return agent_obj
-
-
-def resolve_thread_sandbox(app_obj: FastAPI, thread_id: str) -> str:
-    """Look up sandbox type for a thread: memory cache → SQLite → sandbox DB → default 'local'."""
-    mapping = app_obj.state.thread_sandbox
-    if thread_id in mapping:
-        return mapping[thread_id]
-    thread_data = app_obj.state.thread_repo.get_by_id(thread_id) if hasattr(app_obj.state, "thread_repo") else None
-    if thread_data:
-        mapping[thread_id] = thread_data.get("sandbox_type", "local")
-        if thread_data.get("cwd"):
-            app_obj.state.thread_cwd.setdefault(thread_id, thread_data["cwd"])
-        return thread_data.get("sandbox_type", "local")
-    detected = lookup_sandbox_for_thread(thread_id)
-    if detected:
-        mapping[thread_id] = detected
-        return detected
-    return "local"
 
 
 async def update_agent_config(app_obj: FastAPI, model: str, thread_id: str | None = None) -> dict[str, Any]:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 
 
 def test_thread_runtime_namespace_exports_binding_and_state_helpers() -> None:
@@ -13,3 +14,13 @@ def test_thread_runtime_namespace_exports_binding_and_state_helpers() -> None:
     assert binding_owner.ThreadRuntimeBindingError is binding_shell.ThreadRuntimeBindingError
     assert state_owner.get_sandbox_info is state_shell.get_sandbox_info
     assert state_owner.get_sandbox_status_from_repos is state_shell.get_sandbox_status_from_repos
+
+
+def test_agent_pool_uses_thread_runtime_sandbox_owner() -> None:
+    sandbox_owner = importlib.import_module("backend.thread_runtime.sandbox")
+    agent_pool_module = importlib.import_module("backend.web.services.agent_pool")
+    source = inspect.getsource(agent_pool_module)
+
+    assert agent_pool_module.resolve_thread_sandbox is sandbox_owner.resolve_thread_sandbox
+    assert "from backend.thread_runtime.sandbox import resolve_thread_sandbox" in source
+    assert "def resolve_thread_sandbox(" not in source


### PR DESCRIPTION
## Summary
- make backend.web.services.agent_pool re-export backend.thread_runtime.sandbox.resolve_thread_sandbox instead of keeping a duplicate implementation
- add a focused owner-boundary test proving agent_pool now uses the thread_runtime sandbox owner
- keep agent_pool itself in place; this is not an agent_pool owner move

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/core/test_agent_pool.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py -q
- uv run ruff check backend/web/services/agent_pool.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- uv run ruff format --check backend/web/services/agent_pool.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- git diff --check

## Notes
- local pyright on backend/web/services/agent_pool.py is not authoritative on this host because fastapi import resolution is missing here; CI Python lint/type remains the real type gate for this slice

## Non-scope
- no move of agent_pool into backend/thread_runtime
- no caller import retargeting
- no runtime behavior change