### PR TITLE
refactor: move thread runtime event store owner

### DIFF
--- a/backend/thread_runtime/events/store.py
+++ b/backend/thread_runtime/events/store.py
@@ -1,0 +1,118 @@
+"""Persistent run-event write service via storage repository boundary."""
+
+import asyncio
+import json
+from typing import Any
+
+from storage.contracts import RunEventRepo
+from storage.runtime import build_storage_container
+
+_default_run_event_repo: RunEventRepo | None = None
+
+
+def _resolve_run_event_repo(run_event_repo: RunEventRepo | None) -> RunEventRepo:
+    if run_event_repo is not None:
+        return run_event_repo
+
+    global _default_run_event_repo
+    if _default_run_event_repo is not None:
+        return _default_run_event_repo
+
+    # @@@event-store-single-path - keep one persistence boundary; when caller omits repo, resolve default repo from storage container.
+    container = build_storage_container()
+    _default_run_event_repo = container.run_event_repo()
+    return _default_run_event_repo
+
+
+async def append_event(
+    thread_id: str,
+    run_id: str,
+    event: dict[str, Any],
+    message_id: str | None = None,
+    run_event_repo: RunEventRepo | None = None,
+) -> int:
+    repo = _resolve_run_event_repo(run_event_repo)
+    payload = _event_payload_to_dict(event)
+    return int(
+        await asyncio.to_thread(
+            repo.append_event,
+            thread_id,
+            run_id,
+            event.get("event", ""),
+            payload,
+            message_id,
+        )
+    )
+
+
+async def read_events_after(
+    thread_id: str,
+    run_id: str,
+    after_seq: int = 0,
+    run_event_repo: RunEventRepo | None = None,
+) -> list[dict[str, Any]]:
+    repo = _resolve_run_event_repo(run_event_repo)
+    rows = await asyncio.to_thread(
+        repo.list_events,
+        thread_id,
+        run_id,
+        after=after_seq,
+        limit=10000,
+    )
+    return [
+        {
+            "seq": row.get("seq"),
+            "event": row.get("event_type", ""),
+            "data": json.dumps(row.get("data", {}), ensure_ascii=False),
+            "message_id": row.get("message_id"),
+        }
+        for row in rows
+    ]
+
+
+async def get_last_seq(thread_id: str, run_event_repo: RunEventRepo | None = None) -> int:
+    repo = _resolve_run_event_repo(run_event_repo)
+    return int(await asyncio.to_thread(repo.latest_seq, thread_id))
+
+
+async def get_run_start_seq(thread_id: str, run_id: str, run_event_repo: RunEventRepo | None = None) -> int:
+    repo = _resolve_run_event_repo(run_event_repo)
+    return int(await asyncio.to_thread(repo.run_start_seq, thread_id, run_id))
+
+
+async def get_latest_run_id(thread_id: str, run_event_repo: RunEventRepo | None = None) -> str | None:
+    repo = _resolve_run_event_repo(run_event_repo)
+    return await asyncio.to_thread(repo.latest_run_id, thread_id)
+
+
+async def cleanup_old_runs(
+    thread_id: str,
+    keep_latest: int = 1,
+    run_event_repo: RunEventRepo | None = None,
+) -> int:
+    repo = _resolve_run_event_repo(run_event_repo)
+    run_ids = await asyncio.to_thread(repo.list_run_ids, thread_id)
+    if len(run_ids) <= keep_latest:
+        return 0
+    old_ids = run_ids[keep_latest:]
+    old_ids = [rid for rid in old_ids if not rid.startswith("activity_")]
+    if not old_ids:
+        return 0
+    return int(await asyncio.to_thread(repo.delete_runs, thread_id, old_ids))
+
+
+def _event_payload_to_dict(event: dict[str, Any]) -> dict[str, Any]:
+    raw_data = event.get("data", {})
+    if isinstance(raw_data, dict):
+        return raw_data
+    if raw_data in (None, ""):
+        return {}
+    if not isinstance(raw_data, str):
+        raise RuntimeError("Run event data must be a dict or JSON string when using storage_container run_event_repo.")
+    try:
+        payload = json.loads(raw_data)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Run event data must be valid JSON when using storage_container run_event_repo.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Run event data JSON must decode to an object when using storage_container run_event_repo.")
+    return payload

--- a/backend/web/services/event_store.py
+++ b/backend/web/services/event_store.py
@@ -1,144 +1,53 @@
-"""Persistent run-event service via storage repository boundary."""
+"""Compatibility shell for thread runtime event store helpers."""
 
-import asyncio
-import json
-from dataclasses import dataclass
 from typing import Any
 
+from backend.thread_runtime.events import reads as _reads
+from backend.thread_runtime.events import store as _store
 from storage.contracts import RunEventRepo
 from storage.runtime import build_storage_container
 
 _default_run_event_repo: RunEventRepo | None = None
+RunEventReadTransport = _reads.RunEventReadTransport
 
 
-@dataclass(frozen=True)
-class RunEventReadTransport:
-    latest_run_id: Any
-    list_events: Any
-
-
-def _resolve_run_event_repo(run_event_repo: RunEventRepo | None) -> RunEventRepo:
-    if run_event_repo is not None:
-        return run_event_repo
-
-    global _default_run_event_repo
-    if _default_run_event_repo is not None:
-        return _default_run_event_repo
-
-    container = build_storage_container()
-    _default_run_event_repo = container.run_event_repo()
-    return _default_run_event_repo
+def _sync_owner_modules() -> None:
+    _reads._default_run_event_repo = _default_run_event_repo
+    _reads.build_storage_container = build_storage_container
+    _store._default_run_event_repo = _default_run_event_repo
+    _store.build_storage_container = build_storage_container
 
 
 def build_run_event_read_transport(run_event_repo: RunEventRepo | None = None) -> RunEventReadTransport:
-    repo = _resolve_run_event_repo(run_event_repo)
-    return RunEventReadTransport(
-        latest_run_id=lambda thread_id: repo.latest_run_id(thread_id),
-        list_events=lambda thread_id, run_id, *, after=0, limit=1000: repo.list_events(
-            thread_id,
-            run_id,
-            after=after,
-            limit=limit,
-        ),
-    )
+    _sync_owner_modules()
+    return _reads.build_run_event_read_transport(run_event_repo)
 
 
-async def append_event(
-    thread_id: str,
-    run_id: str,
-    event: dict[str, Any],
-    message_id: str | None = None,
-    run_event_repo: RunEventRepo | None = None,
-) -> int:
-    """Persist one SSE event and return its sequence number."""
-    repo = _resolve_run_event_repo(run_event_repo)
-    payload = _event_payload_to_dict(event)
-    return int(
-        await asyncio.to_thread(
-            repo.append_event,
-            thread_id,
-            run_id,
-            event.get("event", ""),
-            payload,
-            message_id,
-        )
-    )
+async def append_event(*args: Any, **kwargs: Any) -> int:
+    _sync_owner_modules()
+    return await _store.append_event(*args, **kwargs)
 
 
-async def read_events_after(
-    thread_id: str,
-    run_id: str,
-    after_seq: int = 0,
-    run_event_repo: RunEventRepo | None = None,
-) -> list[dict[str, Any]]:
-    """Return events with seq > after_seq for the given run."""
-    repo = _resolve_run_event_repo(run_event_repo)
-    rows = await asyncio.to_thread(
-        repo.list_events,
-        thread_id,
-        run_id,
-        after=after_seq,
-        limit=10000,
-    )
-    return [
-        {
-            "seq": row.get("seq"),
-            "event": row.get("event_type", ""),
-            "data": json.dumps(row.get("data", {}), ensure_ascii=False),
-            "message_id": row.get("message_id"),
-        }
-        for row in rows
-    ]
+async def read_events_after(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+    _sync_owner_modules()
+    return await _store.read_events_after(*args, **kwargs)
 
 
-async def get_last_seq(thread_id: str, run_event_repo: RunEventRepo | None = None) -> int:
-    """Return the highest seq for a thread, or 0."""
-    repo = _resolve_run_event_repo(run_event_repo)
-    return int(await asyncio.to_thread(repo.latest_seq, thread_id))
+async def get_last_seq(*args: Any, **kwargs: Any) -> int:
+    _sync_owner_modules()
+    return await _store.get_last_seq(*args, **kwargs)
 
 
-async def get_run_start_seq(thread_id: str, run_id: str, run_event_repo: RunEventRepo | None = None) -> int:
-    """Return the first seq for a specific run, or 0."""
-    repo = _resolve_run_event_repo(run_event_repo)
-    return int(await asyncio.to_thread(repo.run_start_seq, thread_id, run_id))
+async def get_run_start_seq(*args: Any, **kwargs: Any) -> int:
+    _sync_owner_modules()
+    return await _store.get_run_start_seq(*args, **kwargs)
 
 
-async def get_latest_run_id(thread_id: str, run_event_repo: RunEventRepo | None = None) -> str | None:
-    """Return the run_id of the most recent run for a thread, or None."""
-    repo = _resolve_run_event_repo(run_event_repo)
-    return await asyncio.to_thread(repo.latest_run_id, thread_id)
+async def get_latest_run_id(*args: Any, **kwargs: Any) -> str | None:
+    _sync_owner_modules()
+    return await _store.get_latest_run_id(*args, **kwargs)
 
 
-async def cleanup_old_runs(
-    thread_id: str,
-    keep_latest: int = 1,
-    run_event_repo: RunEventRepo | None = None,
-) -> int:
-    """Delete all but the N most recent runs for a thread. Returns deleted count."""
-    repo = _resolve_run_event_repo(run_event_repo)
-    run_ids = await asyncio.to_thread(repo.list_run_ids, thread_id)
-    if len(run_ids) <= keep_latest:
-        return 0
-    old_ids = run_ids[keep_latest:]
-    # Preserve activity run_ids — they have per-thread lifetime, not per-run.
-    old_ids = [rid for rid in old_ids if not rid.startswith("activity_")]
-    if not old_ids:
-        return 0
-    return int(await asyncio.to_thread(repo.delete_runs, thread_id, old_ids))
-
-
-def _event_payload_to_dict(event: dict[str, Any]) -> dict[str, Any]:
-    raw_data = event.get("data", {})
-    if isinstance(raw_data, dict):
-        return raw_data
-    if raw_data in (None, ""):
-        return {}
-    if not isinstance(raw_data, str):
-        raise RuntimeError("Run event data must be a dict or JSON string when using storage_container run_event_repo.")
-    try:
-        payload = json.loads(raw_data)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("Run event data must be valid JSON when using storage_container run_event_repo.") from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError("Run event data JSON must decode to an object when using storage_container run_event_repo.")
-    return payload
+async def cleanup_old_runs(*args: Any, **kwargs: Any) -> int:
+    _sync_owner_modules()
+    return await _store.cleanup_old_runs(*args, **kwargs)

--- a/tests/Unit/backend/web/services/test_event_store.py
+++ b/tests/Unit/backend/web/services/test_event_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from backend.web.services import event_store
@@ -59,3 +61,16 @@ def test_build_run_event_read_transport_uses_repo_boundary() -> None:
         ("latest_run_id", ("thread-1",), {}),
         ("list_events", ("thread-1", "run-1"), {"after": 3, "limit": 50}),
     ]
+
+
+def test_run_event_store_write_owner_lives_under_backend_thread_runtime_events() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.events.store")
+    shell_module = importlib.import_module("backend.web.services.event_store")
+
+    assert owner_module.__name__ == "backend.thread_runtime.events.store"
+    assert hasattr(shell_module, "append_event")
+    assert hasattr(shell_module, "read_events_after")
+    assert hasattr(shell_module, "get_last_seq")
+    assert hasattr(shell_module, "get_run_start_seq")
+    assert hasattr(shell_module, "get_latest_run_id")
+    assert hasattr(shell_module, "cleanup_old_runs")


### PR DESCRIPTION
## Summary
- move the remaining event-store write/seq/cleanup owner under backend/thread_runtime/events/store.py
- keep backend.thread_runtime.events.reads as the read-transport owner
- reduce backend/web/services/event_store.py to a compatibility shell that preserves existing patch seams for append/read/build_storage_container paths

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_event_store.py -q
- uv run python -m pytest tests/Unit/backend/web/services/test_event_store.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py -q
- uv run ruff check backend/thread_runtime/events/store.py backend/web/services/event_store.py tests/Unit/backend/web/services/test_event_store.py
- uv run ruff format --check backend/thread_runtime/events/store.py backend/web/services/event_store.py tests/Unit/backend/web/services/test_event_store.py
- .venv/bin/python -m pyright backend/thread_runtime/events/store.py backend/web/services/event_store.py
- git diff --check

## Non-scope
- no caller import retargeting
- no changes to backend.thread_runtime.events.reads ownership
- no event_buffer changes
- no threads router or streaming_service import changes