### PR TITLE
refactor: move thread runtime pool factory

### DIFF
--- a/backend/thread_runtime/pool/__init__.py
+++ b/backend/thread_runtime/pool/__init__.py
@@ -1,0 +1,1 @@
+"""Thread runtime pool helpers."""

--- a/backend/thread_runtime/pool/factory.py
+++ b/backend/thread_runtime/pool/factory.py
@@ -1,0 +1,52 @@
+"""Thread runtime instance factory."""
+
+from pathlib import Path
+from typing import Any
+
+from core.runtime.agent import create_leon_agent
+from storage.runtime import build_storage_container
+
+
+def create_agent_sync(
+    sandbox_name: str,
+    workspace_root: Path | None = None,
+    model_name: str | None = None,
+    agent: str | None = None,
+    bundle_dir: Path | None = None,
+    agent_config_id: str | None = None,
+    agent_config_repo: Any = None,
+    thread_repo: Any = None,
+    user_repo: Any = None,
+    queue_manager: Any = None,
+    chat_repos: dict | None = None,
+    extra_allowed_paths: list[str] | None = None,
+    web_app: Any = None,
+    models_config_override: dict[str, Any] | None = None,
+    memory_config_override: dict[str, Any] | None = None,
+) -> Any:
+    """Create a LeonAgent with the given sandbox. Runs in a thread."""
+    storage_container = build_storage_container()
+    # @@@web-file-ops-repo - inject storage-backed repo so file_operations route to correct provider.
+    from core.operations import FileOperationRecorder, set_recorder
+
+    set_recorder(FileOperationRecorder(repo=storage_container.file_operation_repo()))
+    return create_leon_agent(
+        model_name=model_name,
+        workspace_root=workspace_root or Path.cwd(),
+        sandbox=sandbox_name if sandbox_name != "local" else None,
+        storage_container=storage_container,
+        permission_resolver_scope="thread",
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+        queue_manager=queue_manager,
+        chat_repos=chat_repos,
+        web_app=web_app,
+        models_config_override=models_config_override,
+        memory_config_override=memory_config_override,
+        verbose=True,
+        agent=agent,
+        bundle_dir=bundle_dir,
+        agent_config_id=agent_config_id,
+        agent_config_repo=agent_config_repo,
+        extra_allowed_paths=extra_allowed_paths,
+    )

--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -7,63 +7,17 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from backend.thread_runtime.pool.factory import create_agent_sync
 from backend.thread_runtime.sandbox import resolve_thread_sandbox
 from backend.web.services.file_channel_service import get_file_channel_binding
 from core.identity.agent_registry import get_or_create_agent_id
-from core.runtime.agent import create_leon_agent
 from sandbox.thread_context import set_current_thread_id
-from storage.runtime import build_storage_container
 
 logger = logging.getLogger(__name__)
 
 # Thread lock for config updates
 _config_update_locks: dict[str, asyncio.Lock] = {}
 _agent_create_locks: dict[str, asyncio.Lock] = {}
-
-
-def create_agent_sync(
-    sandbox_name: str,
-    workspace_root: Path | None = None,
-    model_name: str | None = None,
-    agent: str | None = None,
-    bundle_dir: Path | None = None,
-    agent_config_id: str | None = None,
-    agent_config_repo: Any = None,
-    thread_repo: Any = None,
-    user_repo: Any = None,
-    queue_manager: Any = None,
-    chat_repos: dict | None = None,
-    extra_allowed_paths: list[str] | None = None,
-    web_app: Any = None,
-    models_config_override: dict[str, Any] | None = None,
-    memory_config_override: dict[str, Any] | None = None,
-) -> Any:
-    """Create a LeonAgent with the given sandbox. Runs in a thread."""
-    storage_container = build_storage_container()
-    # @@@web-file-ops-repo - inject storage-backed repo so file_operations route to correct provider.
-    from core.operations import FileOperationRecorder, set_recorder
-
-    set_recorder(FileOperationRecorder(repo=storage_container.file_operation_repo()))
-    return create_leon_agent(
-        model_name=model_name,
-        workspace_root=workspace_root or Path.cwd(),
-        sandbox=sandbox_name if sandbox_name != "local" else None,
-        storage_container=storage_container,
-        permission_resolver_scope="thread",
-        thread_repo=thread_repo,
-        user_repo=user_repo,
-        queue_manager=queue_manager,
-        chat_repos=chat_repos,
-        web_app=web_app,
-        models_config_override=models_config_override,
-        memory_config_override=memory_config_override,
-        verbose=True,
-        agent=agent,
-        bundle_dir=bundle_dir,
-        agent_config_id=agent_config_id,
-        agent_config_repo=agent_config_repo,
-        extra_allowed_paths=extra_allowed_paths,
-    )
 
 
 async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: str | None = None, agent: str | None = None) -> Any:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -41,3 +41,13 @@ def test_thread_runtime_namespace_exports_owner_thread_reads() -> None:
     shell_module = importlib.import_module("backend.web.services.owner_thread_read_service")
 
     assert owner_module.list_owner_thread_rows_for_auth_burst is shell_module.list_owner_thread_rows_for_auth_burst
+
+
+def test_agent_pool_uses_thread_runtime_pool_factory_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.pool.factory")
+    agent_pool_module = importlib.import_module("backend.web.services.agent_pool")
+    source = inspect.getsource(agent_pool_module)
+
+    assert owner_module.create_agent_sync is agent_pool_module.create_agent_sync
+    assert "from backend.thread_runtime.pool.factory import create_agent_sync" in source
+    assert "def create_agent_sync(" not in source


### PR DESCRIPTION
## Summary
- extract create_agent_sync into backend/thread_runtime/pool/factory.py
- keep backend/web/services/agent_pool.py as the caller/import surface for now
- add a focused owner-boundary test proving create_agent_sync now comes from the thread_runtime pool package

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/core/test_agent_pool.py -q
- uv run ruff check backend/thread_runtime/pool/__init__.py backend/thread_runtime/pool/factory.py backend/web/services/agent_pool.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/core/test_agent_pool.py
- uv run ruff format --check backend/thread_runtime/pool/__init__.py backend/thread_runtime/pool/factory.py backend/web/services/agent_pool.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/core/test_agent_pool.py
- git diff --check

## Notes
- local pyright on backend/web/services/agent_pool.py remains non-authoritative on this host because fastapi import resolution is missing here; this slice does not add new pyright errors beyond that host issue

## Non-scope
- no move of get_or_create_agent or update_agent_config
- no agent_pool caller retargeting
- no behavior change