### PR TITLE
refactor: move thread runtime idle reaper

### DIFF
--- a/backend/thread_runtime/pool/idle_reaper.py
+++ b/backend/thread_runtime/pool/idle_reaper.py
@@ -1,0 +1,49 @@
+"""Idle session reaper service."""
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+IDLE_REAPER_INTERVAL_SEC = 0
+init_providers_and_managers: Callable[[], tuple[Any, dict[str, Any]]] | None = None
+
+
+def run_idle_reaper_once(app_obj: Any) -> int:
+    """External idle manager: enforce idle timeout across providers."""
+    total = 0
+    managed_providers: set[str] = set()
+
+    # First use live managers from resident agents (can close live runtimes safely).
+    # @@@idle-reaper-pool-snapshot - reaping a live manager can evict sibling agents from the pool.
+    # Iterate a stable snapshot so cleanup never mutates the dict view we're walking.
+    for agent in list(app_obj.state.agent_pool.values()):
+        sandbox = getattr(agent, "_sandbox", None)
+        manager = getattr(sandbox, "manager", None)
+        if manager is None:
+            continue
+        provider_name = str(getattr(manager.provider, "name", ""))
+        managed_providers.add(provider_name)
+        total += manager.enforce_idle_timeouts()
+
+    # Then cover providers without resident agent (DB-only cleanup).
+    if init_providers_and_managers is None:
+        raise RuntimeError("thread_runtime.pool.idle_reaper requires init_providers_and_managers binding")
+    _, managers = init_providers_and_managers()
+    for provider_name, manager in managers.items():
+        if provider_name in managed_providers:
+            continue
+        total += manager.enforce_idle_timeouts()
+
+    return total
+
+
+async def idle_reaper_loop(app_obj: Any) -> None:
+    """Background task that periodically enforces idle timeouts."""
+    while True:
+        try:
+            count = await asyncio.to_thread(run_idle_reaper_once, app_obj)
+            if count > 0:
+                print(f"[idle-reaper] reclaimed+closed {count} expired chat session(s)")
+        except Exception as e:
+            print(f"[idle-reaper] error: {e}")
+        await asyncio.sleep(IDLE_REAPER_INTERVAL_SEC)

--- a/backend/web/services/idle_reaper.py
+++ b/backend/web/services/idle_reaper.py
@@ -1,48 +1,19 @@
-"""Idle session reaper service."""
+"""Compatibility shell for thread runtime idle reaper helpers."""
 
-import asyncio
+from typing import Any
 
-from fastapi import FastAPI
-
+from backend.thread_runtime.pool import idle_reaper as _owner
 from backend.web.core.config import IDLE_REAPER_INTERVAL_SEC
 
 from .sandbox_service import init_providers_and_managers
 
 
-def run_idle_reaper_once(app_obj: FastAPI) -> int:
-    """External idle manager: enforce idle timeout across providers."""
-    total = 0
-    managed_providers: set[str] = set()
-
-    # First use live managers from resident agents (can close live runtimes safely).
-    # @@@idle-reaper-pool-snapshot - reaping a live manager can evict sibling agents from the pool.
-    # Iterate a stable snapshot so cleanup never mutates the dict view we're walking.
-    for agent in list(app_obj.state.agent_pool.values()):
-        sandbox = getattr(agent, "_sandbox", None)
-        manager = getattr(sandbox, "manager", None)
-        if manager is None:
-            continue
-        provider_name = str(getattr(manager.provider, "name", ""))
-        managed_providers.add(provider_name)
-        total += manager.enforce_idle_timeouts()
-
-    # Then cover providers without resident agent (DB-only cleanup).
-    _, managers = init_providers_and_managers()
-    for provider_name, manager in managers.items():
-        if provider_name in managed_providers:
-            continue
-        total += manager.enforce_idle_timeouts()
-
-    return total
+def run_idle_reaper_once(app_obj: Any) -> int:
+    _owner.init_providers_and_managers = init_providers_and_managers
+    return _owner.run_idle_reaper_once(app_obj)
 
 
-async def idle_reaper_loop(app_obj: FastAPI) -> None:
-    """Background task that periodically enforces idle timeouts."""
-    while True:
-        try:
-            count = await asyncio.to_thread(run_idle_reaper_once, app_obj)
-            if count > 0:
-                print(f"[idle-reaper] reclaimed+closed {count} expired chat session(s)")
-        except Exception as e:
-            print(f"[idle-reaper] error: {e}")
-        await asyncio.sleep(IDLE_REAPER_INTERVAL_SEC)
+async def idle_reaper_loop(app_obj: Any) -> None:
+    _owner.init_providers_and_managers = init_providers_and_managers
+    _owner.IDLE_REAPER_INTERVAL_SEC = IDLE_REAPER_INTERVAL_SEC
+    await _owner.idle_reaper_loop(app_obj)

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -77,3 +77,12 @@ def test_thread_launch_config_uses_thread_runtime_launch_config_owner() -> None:
     assert hasattr(shell_module, "normalize_launch_config_payload")
     assert hasattr(shell_module, "build_new_launch_config")
     assert hasattr(shell_module, "resolve_default_config")
+
+
+def test_thread_runtime_pool_exports_idle_reaper_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.pool.idle_reaper")
+    shell_module = importlib.import_module("backend.web.services.idle_reaper")
+
+    assert hasattr(shell_module, "run_idle_reaper_once")
+    assert hasattr(shell_module, "idle_reaper_loop")
+    assert owner_module.__name__ == "backend.thread_runtime.pool.idle_reaper"


### PR DESCRIPTION
## Summary
- move idle reaper ownership under backend/thread_runtime/pool/idle_reaper.py
- keep backend/web/services/idle_reaper.py as a compatibility shell that preserves the init_providers_and_managers and config patch seams
- keep web/lifespan callers unchanged

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_idle_reaper.py -q
- uv run ruff check backend/thread_runtime/pool/idle_reaper.py backend/web/services/idle_reaper.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_idle_reaper.py
- .venv/bin/python -m pyright backend/thread_runtime/pool/idle_reaper.py backend/web/services/idle_reaper.py
- uv run ruff format --check backend/thread_runtime/pool/idle_reaper.py backend/web/services/idle_reaper.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_idle_reaper.py
- git diff --check

## Non-scope
- no lifespan caller retargeting
- no streaming_service decomposition
- no agent_pool or launch_config changes