### PR TITLE
refactor: dedupe thread visibility owner

### DIFF
--- a/backend/web/services/thread_visibility.py
+++ b/backend/web/services/thread_visibility.py
@@ -1,32 +1,5 @@
-"""User-visible thread projection helpers."""
+"""Compatibility shell for shared thread projection helpers."""
 
-from __future__ import annotations
+from backend.thread_projection import canonical_owner_threads
 
-from typing import Any
-
-
-def _branch_index(row: dict[str, Any]) -> int:
-    return int(row.get("branch_index") or 0)
-
-
-def _is_better_canonical_thread(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
-    if bool(candidate.get("is_main")) != bool(current.get("is_main")):
-        return bool(candidate.get("is_main"))
-    return _branch_index(candidate) < _branch_index(current)
-
-
-def canonical_owner_threads(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Return one user-visible thread per agent user, preserving first agent order."""
-    order: list[str] = []
-    by_agent: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        agent_user_id = str(row.get("agent_user_id") or "").strip()
-        if not agent_user_id:
-            raise RuntimeError(f"Owner-visible thread {row.get('id')} is missing agent_user_id")
-        if agent_user_id not in by_agent:
-            order.append(agent_user_id)
-            by_agent[agent_user_id] = row
-            continue
-        if _is_better_canonical_thread(row, by_agent[agent_user_id]):
-            by_agent[agent_user_id] = row
-    return [by_agent[agent_user_id] for agent_user_id in order]
+__all__ = ["canonical_owner_threads"]

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -86,3 +86,10 @@ def test_thread_runtime_pool_exports_idle_reaper_owner() -> None:
     assert hasattr(shell_module, "run_idle_reaper_once")
     assert hasattr(shell_module, "idle_reaper_loop")
     assert owner_module.__name__ == "backend.thread_runtime.pool.idle_reaper"
+
+
+def test_thread_visibility_uses_thread_projection_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_projection")
+    shell_module = importlib.import_module("backend.web.services.thread_visibility")
+
+    assert owner_module.canonical_owner_threads is shell_module.canonical_owner_threads


### PR DESCRIPTION
## Summary
- reduce backend/web/services/thread_visibility.py to a compat shell over backend.thread_projection.canonical_owner_threads
- remove the last duplicate canonical_owner_threads implementation on the web side
- keep callers unchanged

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_conversations_router.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py -q
- uv run ruff check backend/web/services/thread_visibility.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_conversations_router.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
- .venv/bin/python -m pyright backend/web/services/thread_visibility.py
- uv run ruff format --check backend/web/services/thread_visibility.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_conversations_router.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
- git diff --check

## Non-scope
- no caller import retargeting
- no new thread_runtime package moves
- no streaming/agent_pool/idle_reaper work