### PR TITLE
refactor: move thread runtime run cancellation

### DIFF
--- a/backend/thread_runtime/run/__init__.py
+++ b/backend/thread_runtime/run/__init__.py
@@ -1,0 +1,1 @@
+"""Thread runtime run lifecycle helpers."""

--- a/backend/thread_runtime/run/cancellation.py
+++ b/backend/thread_runtime/run/cancellation.py
@@ -1,0 +1,214 @@
+"""Cancellation and terminal follow-up helpers for thread runtime runs."""
+
+import asyncio
+import json
+from typing import Any
+
+from core.runtime.notifications import is_terminal_background_notification
+
+
+def _is_terminal_background_notification_message(
+    message: str,
+    *,
+    source: str | None,
+    notification_type: str | None,
+) -> bool:
+    return is_terminal_background_notification(
+        message,
+        source=source,
+        notification_type=notification_type,
+    )
+
+
+def partition_terminal_followups(items: list[Any]) -> tuple[list[Any], list[Any]]:
+    terminal = []
+    passthrough = []
+    for item in items:
+        if _is_terminal_background_notification_message(
+            item.content,
+            source=item.source or "system",
+            notification_type=item.notification_type,
+        ):
+            terminal.append(item)
+        else:
+            passthrough.append(item)
+    return terminal, passthrough
+
+
+def _message_metadata_dict(message_metadata: dict[str, Any] | None) -> dict[str, Any]:
+    return dict(message_metadata or {})
+
+
+def _message_already_persisted(message: Any, *, content: str, metadata: dict[str, Any]) -> bool:
+    if message.__class__.__name__ != "HumanMessage":
+        return False
+    if getattr(message, "content", None) != content:
+        return False
+    return (getattr(message, "metadata", None) or {}) == metadata
+
+
+async def persist_cancelled_run_input_if_missing(
+    *,
+    agent: Any,
+    config: dict[str, Any],
+    message: str,
+    message_metadata: dict[str, Any] | None,
+) -> None:
+    graph = getattr(agent, "agent", None)
+    if graph is None or not hasattr(graph, "aget_state") or not hasattr(graph, "aupdate_state"):
+        return
+
+    from langchain_core.messages import HumanMessage
+
+    metadata = _message_metadata_dict(message_metadata)
+    state = await graph.aget_state(config)
+    persisted = list((getattr(state, "values", None) or {}).get("messages", []))
+    if persisted and _message_already_persisted(persisted[-1], content=message, metadata=metadata):
+        return
+
+    # @@@cancelled-run-input-persist - a started run has already accepted this
+    # input at the caller boundary. If cancellation lands before the next loop
+    # checkpoint save, persist the input here so later turns do not pretend it
+    # never happened.
+    candidate = HumanMessage(content=message, metadata=metadata) if metadata else HumanMessage(content=message)
+    await graph.aupdate_state(config, {"messages": [candidate]})
+
+
+def _is_owner_steer_followup_message(
+    *,
+    source: str | None,
+    notification_type: str | None,
+) -> bool:
+    return source == "owner" and notification_type == "steer"
+
+
+async def persist_cancelled_owner_steers(
+    *,
+    agent: Any,
+    config: dict[str, Any],
+    items: list[dict[str, str | None]],
+) -> None:
+    graph = getattr(agent, "agent", None)
+    if graph is None or not hasattr(graph, "aupdate_state") or not items:
+        return
+
+    from langchain_core.messages import HumanMessage
+
+    # @@@cancelled-steer-persist - accepted steer is a real user turn. If the
+    # active run is cancelled before the next model call, we must checkpoint it
+    # now instead of letting it silently relaunch as a ghost instruction.
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [
+                HumanMessage(
+                    content=str(item["content"] or ""),
+                    metadata={
+                        "source": "owner",
+                        "notification_type": "steer",
+                        "is_steer": True,
+                    },
+                )
+                for item in items
+            ]
+        },
+    )
+
+
+async def flush_cancelled_owner_steers(
+    *,
+    agent: Any,
+    config: dict[str, Any],
+    thread_id: str,
+    app: Any,
+) -> None:
+    qm = app.state.queue_manager
+    queued_items = qm.drain_all(thread_id)
+    if not queued_items:
+        return
+
+    owner_steers: list[dict[str, str | None]] = []
+    passthrough: list[Any] = []
+    for item in queued_items:
+        if _is_owner_steer_followup_message(
+            source=item.source,
+            notification_type=item.notification_type,
+        ):
+            owner_steers.append(
+                {
+                    "content": item.content,
+                    "source": item.source or "owner",
+                    "notification_type": item.notification_type,
+                }
+            )
+        else:
+            passthrough.append(item)
+
+    await persist_cancelled_owner_steers(agent=agent, config=config, items=owner_steers)
+
+    for item in passthrough:
+        qm.enqueue(
+            item.content,
+            thread_id,
+            notification_type=item.notification_type,
+            source=item.source,
+            sender_id=item.sender_id,
+            sender_name=item.sender_name,
+            sender_avatar_url=item.sender_avatar_url,
+            is_steer=item.is_steer,
+        )
+
+
+async def emit_queued_terminal_followups(
+    *,
+    app: Any,
+    thread_id: str,
+    emit: Any,
+) -> list[dict[str, str | None]]:
+    emitted_terminal: list[dict[str, str | None]] = []
+
+    async def _drain_once() -> bool:
+        queued_items = app.state.queue_manager.drain_all(thread_id)
+        extra_terminal, passthrough = partition_terminal_followups(queued_items)
+        for item in passthrough:
+            app.state.queue_manager.enqueue(
+                item.content,
+                thread_id,
+                notification_type=item.notification_type,
+                source=item.source,
+                sender_id=item.sender_id,
+                sender_name=item.sender_name,
+                sender_avatar_url=item.sender_avatar_url,
+                is_steer=item.is_steer,
+            )
+        for item in extra_terminal:
+            await emit(
+                {
+                    "event": "notice",
+                    "data": json.dumps(
+                        {
+                            "content": item.content,
+                            "source": item.source or "system",
+                            "notification_type": item.notification_type,
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            )
+            emitted_terminal.append(
+                {
+                    "content": item.content,
+                    "source": item.source or "system",
+                    "notification_type": item.notification_type,
+                }
+            )
+        return bool(extra_terminal)
+
+    # @@@terminal-followup-race-window - multiple background tasks can finish
+    # while the first notice-only followthrough run is being emitted. Drain once
+    # for already-persisted notices, yield one loop tick, then drain again so
+    # same-turn terminal completions are folded into the same stable followthrough.
+    await _drain_once()
+    await asyncio.sleep(0)
+    await _drain_once()
+    return emitted_terminal

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from typing import Any
 
+from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
 from backend.web.utils.serializers import extract_text_content
@@ -443,18 +444,7 @@ def _is_terminal_background_notification_message(
 
 
 def _partition_terminal_followups(items: list[Any]) -> tuple[list[Any], list[Any]]:
-    terminal = []
-    passthrough = []
-    for item in items:
-        if _is_terminal_background_notification_message(
-            item.content,
-            source=item.source or "system",
-            notification_type=item.notification_type,
-        ):
-            terminal.append(item)
-        else:
-            passthrough.append(item)
-    return terminal, passthrough
+    return _run_cancellation.partition_terminal_followups(items)
 
 
 def _message_metadata_dict(message_metadata: dict[str, Any] | None) -> dict[str, Any]:
@@ -476,24 +466,12 @@ async def _persist_cancelled_run_input_if_missing(
     message: str,
     message_metadata: dict[str, Any] | None,
 ) -> None:
-    graph = getattr(agent, "agent", None)
-    if graph is None or not hasattr(graph, "aget_state") or not hasattr(graph, "aupdate_state"):
-        return
-
-    from langchain_core.messages import HumanMessage
-
-    metadata = _message_metadata_dict(message_metadata)
-    state = await graph.aget_state(config)
-    persisted = list((getattr(state, "values", None) or {}).get("messages", []))
-    if persisted and _message_already_persisted(persisted[-1], content=message, metadata=metadata):
-        return
-
-    # @@@cancelled-run-input-persist - a started run has already accepted this
-    # input at the caller boundary. If cancellation lands before the next loop
-    # checkpoint save, persist the input here so later turns do not pretend it
-    # never happened.
-    candidate = HumanMessage(content=message, metadata=metadata) if metadata else HumanMessage(content=message)
-    await graph.aupdate_state(config, {"messages": [candidate]})
+    await _run_cancellation.persist_cancelled_run_input_if_missing(
+        agent=agent,
+        config=config,
+        message=message,
+        message_metadata=message_metadata,
+    )
 
 
 def _is_owner_steer_followup_message(
@@ -510,30 +488,10 @@ async def _persist_cancelled_owner_steers(
     config: dict[str, Any],
     items: list[dict[str, str | None]],
 ) -> None:
-    graph = getattr(agent, "agent", None)
-    if graph is None or not hasattr(graph, "aupdate_state") or not items:
-        return
-
-    from langchain_core.messages import HumanMessage
-
-    # @@@cancelled-steer-persist - accepted steer is a real user turn. If the
-    # active run is cancelled before the next model call, we must checkpoint it
-    # now instead of letting it silently relaunch as a ghost instruction.
-    await graph.aupdate_state(
-        config,
-        {
-            "messages": [
-                HumanMessage(
-                    content=str(item["content"] or ""),
-                    metadata={
-                        "source": "owner",
-                        "notification_type": "steer",
-                        "is_steer": True,
-                    },
-                )
-                for item in items
-            ]
-        },
+    await _run_cancellation.persist_cancelled_owner_steers(
+        agent=agent,
+        config=config,
+        items=items,
     )
 
 
@@ -544,41 +502,12 @@ async def _flush_cancelled_owner_steers(
     thread_id: str,
     app: Any,
 ) -> None:
-    qm = app.state.queue_manager
-    queued_items = qm.drain_all(thread_id)
-    if not queued_items:
-        return
-
-    owner_steers: list[dict[str, str | None]] = []
-    passthrough: list[Any] = []
-    for item in queued_items:
-        if _is_owner_steer_followup_message(
-            source=item.source,
-            notification_type=item.notification_type,
-        ):
-            owner_steers.append(
-                {
-                    "content": item.content,
-                    "source": item.source or "owner",
-                    "notification_type": item.notification_type,
-                }
-            )
-        else:
-            passthrough.append(item)
-
-    await _persist_cancelled_owner_steers(agent=agent, config=config, items=owner_steers)
-
-    for item in passthrough:
-        qm.enqueue(
-            item.content,
-            thread_id,
-            notification_type=item.notification_type,
-            source=item.source,
-            sender_id=item.sender_id,
-            sender_name=item.sender_name,
-            sender_avatar_url=item.sender_avatar_url,
-            is_steer=item.is_steer,
-        )
+    await _run_cancellation.flush_cancelled_owner_steers(
+        agent=agent,
+        config=config,
+        thread_id=thread_id,
+        app=app,
+    )
 
 
 async def _emit_queued_terminal_followups(
@@ -587,53 +516,11 @@ async def _emit_queued_terminal_followups(
     thread_id: str,
     emit: Any,
 ) -> list[dict[str, str | None]]:
-    emitted_terminal: list[dict[str, str | None]] = []
-
-    async def _drain_once() -> bool:
-        queued_items = app.state.queue_manager.drain_all(thread_id)
-        extra_terminal, passthrough = _partition_terminal_followups(queued_items)
-        for item in passthrough:
-            app.state.queue_manager.enqueue(
-                item.content,
-                thread_id,
-                notification_type=item.notification_type,
-                source=item.source,
-                sender_id=item.sender_id,
-                sender_name=item.sender_name,
-                sender_avatar_url=item.sender_avatar_url,
-                is_steer=item.is_steer,
-            )
-        for item in extra_terminal:
-            await emit(
-                {
-                    "event": "notice",
-                    "data": json.dumps(
-                        {
-                            "content": item.content,
-                            "source": item.source or "system",
-                            "notification_type": item.notification_type,
-                        },
-                        ensure_ascii=False,
-                    ),
-                }
-            )
-            emitted_terminal.append(
-                {
-                    "content": item.content,
-                    "source": item.source or "system",
-                    "notification_type": item.notification_type,
-                }
-            )
-        return bool(extra_terminal)
-
-    # @@@terminal-followup-race-window - multiple background tasks can finish
-    # while the first notice-only followthrough run is being emitted. Drain once
-    # for already-persisted notices, yield one loop tick, then drain again so
-    # same-turn terminal completions are folded into the same stable followthrough.
-    await _drain_once()
-    await asyncio.sleep(0)
-    await _drain_once()
-    return emitted_terminal
+    return await _run_cancellation.emit_queued_terminal_followups(
+        app=app,
+        thread_id=thread_id,
+        emit=emit,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -93,3 +93,13 @@ def test_thread_visibility_uses_thread_projection_owner() -> None:
     shell_module = importlib.import_module("backend.web.services.thread_visibility")
 
     assert owner_module.canonical_owner_threads is shell_module.canonical_owner_threads
+
+
+def test_streaming_service_uses_thread_runtime_run_cancellation_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.cancellation")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.persist_cancelled_run_input_if_missing is not None
+    assert owner_module.flush_cancelled_owner_steers is not None
+    assert owner_module.emit_queued_terminal_followups is not None
+    assert "from backend.thread_runtime.run import cancellation as _run_cancellation" in streaming_source


### PR DESCRIPTION
## Summary
- move streaming cancellation/repair persistence helpers under backend/thread_runtime/run/cancellation.py
- keep streaming_service's private helper names as wrappers so existing test patch seams remain intact
- leave the run lifecycle entrypoints and SSE observation in streaming_service for later slices

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q
- uv run ruff check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/cancellation.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- uv run ruff format --check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/cancellation.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- git diff --check

## Notes
- local pyright on this slice is not authoritative on this host because the repo's streaming_service path already trips missing-import resolution for langchain_core/langgraph/httpx in pyright; no new non-import type failures were introduced during the move

## Non-scope
- no start_agent_run or run_child_thread_live move yet
- no SSE observation move yet
- no buffer-wiring move yet