### PR TITLE
refactor: move thread runtime buffer wiring

### DIFF
--- a/backend/thread_runtime/run/buffer_wiring.py
+++ b/backend/thread_runtime/run/buffer_wiring.py
@@ -1,0 +1,145 @@
+"""Thread buffer lifecycle and runtime handler wiring helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from backend.web.services.event_buffer import ThreadEventBuffer
+from core.runtime.middleware.monitor import AgentState
+
+logger = logging.getLogger(__name__)
+
+
+def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
+    """Get existing or create new ThreadEventBuffer for a thread."""
+    buf = app.state.thread_event_buffers.get(thread_id)
+    if isinstance(buf, ThreadEventBuffer):
+        return buf
+    buf = ThreadEventBuffer()
+    app.state.thread_event_buffers[thread_id] = buf
+    return buf
+
+
+def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
+    """Bind per-thread handlers (activity_sink, wake_handler) if not already set."""
+    runtime = getattr(agent, "runtime", None)
+    if not runtime:
+        return
+    if getattr(runtime, "_bound_thread_id", None) == thread_id and getattr(runtime, "_bound_thread_app", None) is app:
+        return
+    if not hasattr(runtime, "bind_thread"):
+        return
+
+    thread_buf = get_or_create_thread_buffer(app, thread_id)
+
+    display_builder_ref = app.state.display_builder
+
+    async def activity_sink(event: dict) -> None:
+        from backend.web.services.event_store import append_event as _append
+
+        seq = await _append(thread_id, f"activity_{thread_id}", event)
+        try:
+            data = json.loads(event.get("data", "{}")) if isinstance(event.get("data"), str) else event.get("data", {})
+        except (json.JSONDecodeError, TypeError):
+            data = event.get("data", {})
+        if isinstance(data, dict):
+            data["_seq"] = seq
+            event = {**event, "data": json.dumps(data, ensure_ascii=False)}
+        _sse_fields = frozenset({"event", "data", "id", "retry", "comment"})
+        sse_event = {k: v for k, v in event.items() if k in _sse_fields}
+        await thread_buf.put(sse_event)
+
+        event_type = sse_event.get("event", "")
+        if event_type and isinstance(data, dict):
+            delta = display_builder_ref.apply_event(thread_id, event_type, data)
+            if delta:
+                delta["_seq"] = seq
+                await thread_buf.put(
+                    {
+                        "event": "display_delta",
+                        "data": json.dumps(delta, ensure_ascii=False),
+                    }
+                )
+
+    qm = app.state.queue_manager
+    loop = getattr(app.state, "_event_loop", None)
+
+    def wake_handler(item: Any) -> None:
+        """Called by enqueue() with the newly-enqueued QueueItem — may run in any thread."""
+        if not (hasattr(agent, "runtime") and agent.runtime.transition(AgentState.ACTIVE)):
+            source = getattr(item, "source", None)
+            if loop and not loop.is_closed():
+
+                async def _emit_active_event() -> None:
+                    if source == "owner":
+                        await activity_sink(
+                            {
+                                "event": "user_message",
+                                "data": json.dumps(
+                                    {
+                                        "content": item.content,
+                                        "showing": True,
+                                    },
+                                    ensure_ascii=False,
+                                ),
+                            }
+                        )
+
+                loop.call_soon_threadsafe(loop.create_task, _emit_active_event())
+            return
+
+        item = qm.dequeue(thread_id)
+        if not item:
+            logger.warning(
+                "wake_handler: dequeue returned None for thread %s (race with drain_all), reverting to IDLE",
+                thread_id,
+            )
+            if hasattr(agent, "runtime"):
+                agent.runtime.transition(AgentState.IDLE)
+            return
+
+        async def _start_run():
+            try:
+                from backend.web.services.streaming_service import start_agent_run
+
+                start_agent_run(
+                    agent,
+                    thread_id,
+                    item.content,
+                    app,
+                    message_metadata={
+                        "source": getattr(item, "source", None) or "system",
+                        "notification_type": item.notification_type,
+                        "sender_name": getattr(item, "sender_name", None),
+                        "sender_avatar_url": getattr(item, "sender_avatar_url", None),
+                        "is_steer": getattr(item, "is_steer", False),
+                    },
+                )
+            except Exception:
+                logger.error("wake_handler failed for thread %s", thread_id, exc_info=True)
+                if hasattr(agent, "runtime"):
+                    agent.runtime.transition(AgentState.IDLE)
+
+        if loop and not loop.is_closed():
+            loop.call_soon_threadsafe(loop.create_task, _start_run())
+        else:
+            logger.warning("wake_handler: no event loop for thread %s", thread_id)
+            if hasattr(agent, "runtime"):
+                agent.runtime.transition(AgentState.IDLE)
+
+    runtime.bind_thread(activity_sink=activity_sink)
+    runtime._bound_thread_id = thread_id
+    runtime._bound_thread_app = app
+    qm.register_wake(thread_id, wake_handler)
+
+    try:
+        from backend.web.event_bus import get_event_bus
+
+        unsubscribe = getattr(runtime, "_thread_event_unsubscribe", None)
+        if callable(unsubscribe):
+            unsubscribe()
+        runtime._thread_event_unsubscribe = get_event_bus().subscribe(thread_id, activity_sink)
+    except ImportError:
+        pass

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from typing import Any
 
+from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
@@ -273,13 +274,7 @@ async def _repair_incomplete_tool_calls(agent: Any, config: dict[str, Any]) -> N
 
 
 def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
-    """Get existing or create new ThreadEventBuffer for a thread."""
-    buf = app.state.thread_event_buffers.get(thread_id)
-    if isinstance(buf, ThreadEventBuffer):
-        return buf
-    buf = ThreadEventBuffer()
-    app.state.thread_event_buffers[thread_id] = buf
-    return buf
+    return _run_buffer_wiring.get_or_create_thread_buffer(app, thread_id)
 
 
 # ---------------------------------------------------------------------------
@@ -288,146 +283,7 @@ def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
 
 
 def _ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
-    """Bind per-thread handlers (activity_sink, wake_handler) if not already set.
-
-    These handlers have per-thread lifetime and must NOT be cleared between runs.
-    Idempotent — safe to call at the start of every run.
-    """
-    runtime = getattr(agent, "runtime", None)
-    if not runtime:
-        return
-    if getattr(runtime, "_bound_thread_id", None) == thread_id and getattr(runtime, "_bound_thread_app", None) is app:
-        return
-    # Runtime must support bind_thread (AgentRuntime does, test fakes may not)
-    if not hasattr(runtime, "bind_thread"):
-        return
-
-    thread_buf = get_or_create_thread_buffer(app, thread_id)
-
-    display_builder_ref = app.state.display_builder
-
-    async def activity_sink(event: dict) -> None:
-        from backend.web.services.event_store import append_event as _append
-
-        seq = await _append(thread_id, f"activity_{thread_id}", event)
-        try:
-            data = json.loads(event.get("data", "{}")) if isinstance(event.get("data"), str) else event.get("data", {})
-        except (json.JSONDecodeError, TypeError):
-            data = event.get("data", {})
-        if isinstance(data, dict):
-            data["_seq"] = seq
-            event = {**event, "data": json.dumps(data, ensure_ascii=False)}
-        # Only SSE-valid fields: extra metadata (agent_id, agent_name) stays in event_store
-        _sse_fields = frozenset({"event", "data", "id", "retry", "comment"})
-        sse_event = {k: v for k, v in event.items() if k in _sse_fields}
-        await thread_buf.put(sse_event)
-
-        # @@@display-builder — compute display delta for activity events (notices, etc.)
-        event_type = sse_event.get("event", "")
-        if event_type and isinstance(data, dict):
-            delta = display_builder_ref.apply_event(thread_id, event_type, data)
-            if delta:
-                delta["_seq"] = seq
-                await thread_buf.put(
-                    {
-                        "event": "display_delta",
-                        "data": json.dumps(delta, ensure_ascii=False),
-                    }
-                )
-
-    qm = app.state.queue_manager
-    loop = getattr(app.state, "_event_loop", None)
-
-    def wake_handler(item: Any) -> None:
-        """Called by enqueue() with the newly-enqueued QueueItem — may run in any thread."""
-        if not (hasattr(agent, "runtime") and agent.runtime.transition(AgentState.ACTIVE)):
-            # Agent already ACTIVE — before_model will drain_all on the next LLM call.
-            source = getattr(item, "source", None)
-            if loop and not loop.is_closed():
-
-                async def _emit_active_event() -> None:
-                    if source == "owner":
-                        # @@@steer-instant-feedback — emit user_message immediately
-                        # so display_builder creates user entry without waiting for
-                        # before_model or _consume_followup_queue.
-                        await activity_sink(
-                            {
-                                "event": "user_message",
-                                "data": json.dumps(
-                                    {
-                                        "content": item.content,
-                                        "showing": True,
-                                    },
-                                    ensure_ascii=False,
-                                ),
-                            }
-                        )
-                    # @@@no-steer-notice — external notifications (chat, etc.) should NOT
-                    # emit notice here. Two cases:
-                    #   1. before_model drains it → agent processes inline, no divider needed
-                    #   2. Not drained → _consume_followup_queue starts new run →
-                    #      _run_agent_to_buffer emits notice at run-start (the correct path)
-                    # Emitting here causes duplicate: this transient notice + the persistent
-                    # run-notice from case 2 (which has checkpoint backing).
-
-                loop.call_soon_threadsafe(loop.create_task, _emit_active_event())
-            return
-
-        item = qm.dequeue(thread_id)
-        if not item:
-            # Lost race to finally block — undo transition
-            logger.warning("wake_handler: dequeue returned None for thread %s (race with drain_all), reverting to IDLE", thread_id)
-            if hasattr(agent, "runtime"):
-                agent.runtime.transition(AgentState.IDLE)
-            return
-
-        async def _start_run():
-            # @@@idle-notice — notice is emitted inside _run_agent_to_buffer
-            # after run_start (@@@run-notice) so frontend folds it into the
-            # reopened turn.
-            try:
-                start_agent_run(
-                    agent,
-                    thread_id,
-                    item.content,
-                    app,
-                    message_metadata={
-                        "source": getattr(item, "source", None) or "system",
-                        "notification_type": item.notification_type,
-                        "sender_name": getattr(item, "sender_name", None),
-                        "sender_avatar_url": getattr(item, "sender_avatar_url", None),
-                        "is_steer": getattr(item, "is_steer", False),
-                    },
-                )
-            except Exception:
-                logger.error("wake_handler failed for thread %s", thread_id, exc_info=True)
-                if hasattr(agent, "runtime"):
-                    agent.runtime.transition(AgentState.IDLE)
-                # Do NOT re-enqueue — avoid enqueue→wake→enqueue infinite recursion
-
-        if loop and not loop.is_closed():
-            loop.call_soon_threadsafe(loop.create_task, _start_run())
-        else:
-            logger.warning("wake_handler: no event loop for thread %s", thread_id)
-            if hasattr(agent, "runtime"):
-                agent.runtime.transition(AgentState.IDLE)
-
-    runtime.bind_thread(activity_sink=activity_sink)
-    runtime._bound_thread_id = thread_id
-    runtime._bound_thread_app = app
-    qm.register_wake(thread_id, wake_handler)
-
-    # Subscribe to EventBus so sub-agent events (spawned via AgentService)
-    # flow into this thread's SSE stream.
-    try:
-        from backend.web.event_bus import get_event_bus
-
-        unsubscribe = getattr(runtime, "_thread_event_unsubscribe", None)
-        if callable(unsubscribe):
-            unsubscribe()
-        runtime._thread_event_unsubscribe = get_event_bus().subscribe(thread_id, activity_sink)
-    except ImportError:
-        pass
+    _run_buffer_wiring.ensure_thread_handlers(agent, thread_id, app)
 
 
 def _is_terminal_background_notification_message(

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -103,3 +103,12 @@ def test_streaming_service_uses_thread_runtime_run_cancellation_owner() -> None:
     assert owner_module.flush_cancelled_owner_steers is not None
     assert owner_module.emit_queued_terminal_followups is not None
     assert "from backend.thread_runtime.run import cancellation as _run_cancellation" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_buffer_wiring_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.buffer_wiring")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.get_or_create_thread_buffer is not None
+    assert owner_module.ensure_thread_handlers is not None
+    assert "from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring" in streaming_source


### PR DESCRIPTION
## Summary
- move get_or_create_thread_buffer and ensure_thread_handlers ownership under backend/thread_runtime/run/buffer_wiring.py
- keep streaming_service's existing helper names as wrappers so current patch seams remain intact
- leave run lifecycle entrypoints and SSE observation in streaming_service for later slices

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q
- uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q
- uv run ruff check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/buffer_wiring.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py
- uv run ruff format --check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/buffer_wiring.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py
- git diff --check

## Notes
- local pyright on streaming_service remains non-authoritative on this host because the repo already trips missing-import resolution for langchain_core/langgraph/httpx there; no new non-import type failures were introduced by this slice

## Non-scope
- no start_agent_run or run_child_thread_live move yet
- no SSE observation move yet
- no idle_reaper or agent_pool changes in this PR