### PR TITLE
refactor: move thread runtime run lifecycle helpers

### DIFF
--- a/backend/thread_runtime/run/lifecycle.py
+++ b/backend/thread_runtime/run/lifecycle.py
@@ -1,0 +1,181 @@
+"""Run lifecycle helpers for thread runtime streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def prime_sandbox(agent: Any, thread_id: str) -> None:
+    """Prime sandbox runtime before tool calls to avoid race conditions."""
+
+    def _prime_sandbox() -> None:
+        mgr = agent._sandbox.manager
+        mgr.enforce_idle_timeouts()
+        capability = mgr.get_sandbox(thread_id)
+        lease = getattr(getattr(capability, "_session", None), "lease", None)
+        if lease:
+            lease_status = lease.refresh_instance_status(mgr.provider)
+            if lease_status == "paused" and mgr.provider_capability.can_resume and not agent._sandbox.resume_thread(thread_id):
+                raise RuntimeError(f"Failed to auto-resume paused sandbox for thread {thread_id}")
+
+    await asyncio.to_thread(_prime_sandbox)
+
+
+async def write_cancellation_markers(
+    agent: Any,
+    config: dict[str, Any],
+    pending_tool_calls: dict[str, dict],
+) -> list[str]:
+    """Write cancellation markers to checkpoint for pending tool calls."""
+    cancelled_tool_call_ids = []
+    if not pending_tool_calls or not agent:
+        return cancelled_tool_call_ids
+
+    try:
+        from langchain_core.messages import ToolMessage
+        from langgraph.checkpoint.base import create_checkpoint
+
+        checkpointer = agent.agent.checkpointer
+        if not checkpointer:
+            return cancelled_tool_call_ids
+
+        checkpoint_tuple = await checkpointer.aget_tuple(config)
+        if not checkpoint_tuple:
+            return cancelled_tool_call_ids
+
+        checkpoint = checkpoint_tuple.checkpoint
+        metadata = checkpoint_tuple.metadata or {}
+
+        cancel_messages = []
+        for tc_id, tc_info in pending_tool_calls.items():
+            cancelled_tool_call_ids.append(tc_id)
+            cancel_messages.append(
+                ToolMessage(
+                    content="任务被用户取消",
+                    tool_call_id=tc_id,
+                    name=tc_info["name"],
+                )
+            )
+
+        updated_channel_values = checkpoint["channel_values"].copy()
+        updated_channel_values["messages"] = list(updated_channel_values.get("messages", []))
+        updated_channel_values["messages"].extend(cancel_messages)
+
+        new_checkpoint = create_checkpoint(checkpoint, None, metadata.get("step", 0))
+        new_checkpoint["channel_values"] = updated_channel_values
+        current_versions = dict(checkpoint.get("channel_versions", {}) or {})
+        get_next_version = getattr(checkpointer, "get_next_version", None)
+        if not callable(get_next_version):
+            raise RuntimeError("Checkpointer missing get_next_version; cannot write cancellation markers honestly")
+        next_message_version = get_next_version(current_versions.get("messages"), None)
+        if not isinstance(next_message_version, str | int | float):
+            raise RuntimeError("Checkpointer returned an invalid messages channel version")
+        new_versions = {"messages": next_message_version}
+        new_checkpoint["channel_versions"] = {**current_versions, **new_versions}
+        new_checkpoint["updated_channels"] = list(new_versions)
+
+        await checkpointer.aput(
+            config,
+            new_checkpoint,
+            {
+                "source": "update",
+                "step": metadata.get("step", 0),
+                "writes": {},
+            },
+            new_versions,
+        )
+    except Exception:
+        logger.exception(
+            "[streaming] failed to write cancellation markers for thread %s",
+            config.get("configurable", {}).get("thread_id"),
+        )
+
+    return cancelled_tool_call_ids
+
+
+async def repair_incomplete_tool_calls(agent: Any, config: dict[str, Any]) -> None:
+    """Detect and repair incomplete tool_call history in checkpoint."""
+    try:
+        from langchain_core.messages import RemoveMessage, ToolMessage
+
+        graph = getattr(agent, "agent", None)
+        if not graph:
+            return
+
+        state = await graph.aget_state(config)
+        if not state or not state.values:
+            return
+
+        messages = state.values.get("messages", [])
+        if not messages:
+            return
+
+        pending_tc_ids: dict[str, str] = {}
+        answered_tc_ids: set[str] = set()
+
+        for msg in messages:
+            msg_class = msg.__class__.__name__
+            if msg_class == "AIMessage":
+                for tc in getattr(msg, "tool_calls", []):
+                    tc_id = tc.get("id")
+                    if tc_id:
+                        pending_tc_ids[tc_id] = tc.get("name", "unknown")
+            elif msg_class == "ToolMessage":
+                tc_id = getattr(msg, "tool_call_id", None)
+                if tc_id:
+                    answered_tc_ids.add(tc_id)
+
+        unmatched = {tc_id: name for tc_id, name in pending_tc_ids.items() if tc_id not in answered_tc_ids}
+        if not unmatched:
+            return
+
+        thread_id = config.get("configurable", {}).get("thread_id")
+        logger.warning(
+            "[streaming] Repairing %d incomplete tool_call(s) in thread %s: %s",
+            len(unmatched),
+            thread_id,
+            list(unmatched.keys()),
+        )
+
+        broken_ai_idx = None
+        for i, msg in enumerate(messages):
+            if msg.__class__.__name__ == "AIMessage":
+                for tc in getattr(msg, "tool_calls", []):
+                    if tc.get("id") in unmatched:
+                        broken_ai_idx = i
+                        break
+            if broken_ai_idx is not None:
+                break
+
+        if broken_ai_idx is None:
+            return
+
+        after_msgs = messages[broken_ai_idx + 1 :]
+
+        updates = []
+        for msg in after_msgs:
+            msg_id = getattr(msg, "id", None)
+            if msg_id:
+                updates.append(RemoveMessage(id=msg_id))
+
+        for tc_id, tool_name in unmatched.items():
+            updates.append(
+                ToolMessage(
+                    content="Error: task was interrupted (server restart or timeout). Results unavailable.",
+                    tool_call_id=tc_id,
+                    name=tool_name,
+                )
+            )
+
+        for msg in after_msgs:
+            if msg.__class__.__name__ != "ToolMessage" or getattr(msg, "tool_call_id", None) not in unmatched:
+                updates.append(msg)
+
+        await graph.aupdate_state(config, {"messages": updates})
+        logger.warning("[streaming] Repaired incomplete tool_calls for thread %s", thread_id)
+    except Exception:
+        logger.exception("[streaming] Failed to repair incomplete tool_calls")

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
+from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
 from backend.web.utils.serializers import extract_text_content
@@ -69,19 +70,7 @@ def _augment_system_prompt_for_terminal_followthrough(system_prompt: Any) -> Any
 
 
 async def prime_sandbox(agent: Any, thread_id: str) -> None:
-    """Prime sandbox runtime before tool calls to avoid race conditions."""
-
-    def _prime_sandbox() -> None:
-        mgr = agent._sandbox.manager
-        mgr.enforce_idle_timeouts()
-        capability = mgr.get_sandbox(thread_id)
-        lease = getattr(getattr(capability, "_session", None), "lease", None)
-        if lease:
-            lease_status = lease.refresh_instance_status(mgr.provider)
-            if lease_status == "paused" and mgr.provider_capability.can_resume and not agent._sandbox.resume_thread(thread_id):
-                raise RuntimeError(f"Failed to auto-resume paused sandbox for thread {thread_id}")
-
-    await asyncio.to_thread(_prime_sandbox)
+    await _run_lifecycle.prime_sandbox(agent, thread_id)
 
 
 async def write_cancellation_markers(
@@ -89,183 +78,11 @@ async def write_cancellation_markers(
     config: dict[str, Any],
     pending_tool_calls: dict[str, dict],
 ) -> list[str]:
-    """Write cancellation markers to checkpoint for pending tool calls.
-
-    Returns:
-        List of cancelled tool call IDs
-    """
-    cancelled_tool_call_ids = []
-    if not pending_tool_calls or not agent:
-        return cancelled_tool_call_ids
-
-    try:
-        from langchain_core.messages import ToolMessage
-        from langgraph.checkpoint.base import create_checkpoint
-
-        checkpointer = agent.agent.checkpointer
-        if not checkpointer:
-            return cancelled_tool_call_ids
-
-        # aget_tuple returns CheckpointTuple with .checkpoint and .metadata
-        checkpoint_tuple = await checkpointer.aget_tuple(config)
-        if not checkpoint_tuple:
-            return cancelled_tool_call_ids
-
-        checkpoint = checkpoint_tuple.checkpoint
-        metadata = checkpoint_tuple.metadata or {}
-
-        # Create ToolMessage for each pending tool call
-        cancel_messages = []
-        for tc_id, tc_info in pending_tool_calls.items():
-            cancelled_tool_call_ids.append(tc_id)
-            cancel_messages.append(
-                ToolMessage(
-                    content="任务被用户取消",
-                    tool_call_id=tc_id,
-                    name=tc_info["name"],
-                )
-            )
-
-        # Update checkpoint with cancellation markers
-        updated_channel_values = checkpoint["channel_values"].copy()
-        updated_channel_values["messages"] = list(updated_channel_values.get("messages", []))
-        updated_channel_values["messages"].extend(cancel_messages)
-
-        # Build complete checkpoint with all required fields
-        new_checkpoint = create_checkpoint(checkpoint, None, metadata.get("step", 0))
-        # Override channel_values with our updated messages
-        new_checkpoint["channel_values"] = updated_channel_values
-        current_versions = dict(checkpoint.get("channel_versions", {}) or {})
-        get_next_version = getattr(checkpointer, "get_next_version", None)
-        # @@@checkpoint-version-contract - LangGraph saver versions are opaque monotonic ids,
-        # not plain ints. Cancellation writes must advance them through the saver contract.
-        if not callable(get_next_version):
-            raise RuntimeError("Checkpointer missing get_next_version; cannot write cancellation markers honestly")
-        next_message_version = get_next_version(current_versions.get("messages"), None)
-        if not isinstance(next_message_version, str | int | float):
-            raise RuntimeError("Checkpointer returned an invalid messages channel version")
-        new_versions = {"messages": next_message_version}
-        new_checkpoint["channel_versions"] = {**current_versions, **new_versions}
-        new_checkpoint["updated_channels"] = list(new_versions)
-
-        # Write updated checkpoint
-        await checkpointer.aput(
-            config,
-            new_checkpoint,
-            {
-                "source": "update",
-                "step": metadata.get("step", 0),
-                "writes": {},
-            },
-            new_versions,
-        )
-    except Exception:
-        logger.exception(
-            "[streaming] failed to write cancellation markers for thread %s",
-            config.get("configurable", {}).get("thread_id"),
-        )
-
-    return cancelled_tool_call_ids
+    return await _run_lifecycle.write_cancellation_markers(agent, config, pending_tool_calls)
 
 
 async def _repair_incomplete_tool_calls(agent: Any, config: dict[str, Any]) -> None:
-    """Detect and repair incomplete tool_call history in checkpoint.
-
-    If an AIMessage has tool_calls without matching ToolMessages,
-    insert synthetic error ToolMessages at the correct position
-    (right after the AIMessage) so the LLM doesn't reject the history.
-    """
-    try:
-        from langchain_core.messages import RemoveMessage, ToolMessage
-
-        graph = getattr(agent, "agent", None)
-        if not graph:
-            return
-
-        state = await graph.aget_state(config)
-        if not state or not state.values:
-            return
-
-        messages = state.values.get("messages", [])
-        if not messages:
-            return
-
-        # Collect all tool_call IDs and their ToolMessage responses
-        pending_tc_ids: dict[str, str] = {}  # tc_id -> tool_name
-        answered_tc_ids: set[str] = set()
-
-        for msg in messages:
-            msg_class = msg.__class__.__name__
-            if msg_class == "AIMessage":
-                for tc in getattr(msg, "tool_calls", []):
-                    tc_id = tc.get("id")
-                    if tc_id:
-                        pending_tc_ids[tc_id] = tc.get("name", "unknown")
-            elif msg_class == "ToolMessage":
-                tc_id = getattr(msg, "tool_call_id", None)
-                if tc_id:
-                    answered_tc_ids.add(tc_id)
-
-        unmatched = {tc_id: name for tc_id, name in pending_tc_ids.items() if tc_id not in answered_tc_ids}
-        if not unmatched:
-            return
-
-        thread_id = config.get("configurable", {}).get("thread_id")
-        logger.warning(
-            "[streaming] Repairing %d incomplete tool_call(s) in thread %s: %s",
-            len(unmatched),
-            thread_id,
-            list(unmatched.keys()),
-        )
-
-        # Strategy: remove messages after the broken AIMessage, then re-add
-        # them with the ToolMessage inserted at the correct position.
-        # Find the first broken AIMessage index
-        broken_ai_idx = None
-        for i, msg in enumerate(messages):
-            if msg.__class__.__name__ == "AIMessage":
-                for tc in getattr(msg, "tool_calls", []):
-                    if tc.get("id") in unmatched:
-                        broken_ai_idx = i
-                        break
-            if broken_ai_idx is not None:
-                break
-
-        if broken_ai_idx is None:
-            return
-
-        # Messages after the broken AIMessage that need to be re-ordered
-        after_msgs = messages[broken_ai_idx + 1 :]
-
-        # Build update: remove all messages after broken AI, then add
-        # ToolMessage(s) + remaining messages in order
-        updates = []
-
-        # Remove messages after the broken AIMessage
-        for msg in after_msgs:
-            msg_id = getattr(msg, "id", None)
-            if msg_id:
-                updates.append(RemoveMessage(id=msg_id))
-
-        # Add synthetic ToolMessages for unmatched tool_calls
-        for tc_id, tool_name in unmatched.items():
-            updates.append(
-                ToolMessage(
-                    content="Error: task was interrupted (server restart or timeout). Results unavailable.",
-                    tool_call_id=tc_id,
-                    name=tool_name,
-                )
-            )
-
-        # Re-add the remaining messages (HumanMessages etc.)
-        for msg in after_msgs:
-            if msg.__class__.__name__ != "ToolMessage" or getattr(msg, "tool_call_id", None) not in unmatched:
-                updates.append(msg)
-
-        await graph.aupdate_state(config, {"messages": updates})
-        logger.warning("[streaming] Repaired incomplete tool_calls for thread %s", thread_id)
-    except Exception:
-        logger.exception("[streaming] Failed to repair incomplete tool_calls")
+    await _run_lifecycle.repair_incomplete_tool_calls(agent, config)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -112,3 +112,13 @@ def test_streaming_service_uses_thread_runtime_buffer_wiring_owner() -> None:
     assert owner_module.get_or_create_thread_buffer is not None
     assert owner_module.ensure_thread_handlers is not None
     assert "from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_run_lifecycle_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.lifecycle")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.prime_sandbox is not None
+    assert owner_module.write_cancellation_markers is not None
+    assert owner_module.repair_incomplete_tool_calls is not None
+    assert "from backend.thread_runtime.run import lifecycle as _run_lifecycle" in streaming_source


### PR DESCRIPTION
## Summary
- move prime_sandbox, write_cancellation_markers, and repair_incomplete_tool_calls under backend/thread_runtime/run/lifecycle.py
- keep streaming_service's existing helper names as wrappers so current patch seams remain intact
- leave start_agent_run / run_child_thread_live and SSE observation in streaming_service for later slices

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q
- uv run ruff check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/lifecycle.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- uv run ruff format --check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/lifecycle.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- git diff --check

## Notes
- local pyright on this slice remains non-authoritative on this host because streaming_service already trips missing-import resolution for langchain_core/langgraph/httpx; no new non-import type failures were introduced by the move

## Non-scope
- no start_agent_run or run_child_thread_live move yet
- no SSE observation move yet
- no buffer wiring or cancellation changes in this PR