### PR TITLE
refactor: move thread runtime followup queue

### DIFF
--- a/backend/thread_runtime/run/followups.py
+++ b/backend/thread_runtime/run/followups.py
@@ -1,0 +1,51 @@
+"""Follow-up queue consumption helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.runtime.middleware.monitor import AgentState
+
+logger = logging.getLogger(__name__)
+
+_start_agent_run = None
+
+
+async def consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
+    """Dequeue a pending followup message and start a new run."""
+    item = None
+    try:
+        qm = app.state.queue_manager
+        if not qm.peek(thread_id) or not app:
+            return
+        if not (hasattr(agent, "runtime") and agent.runtime.transition(AgentState.ACTIVE)):
+            return
+        item = qm.dequeue(thread_id)
+        if item is None:
+            logger.warning("followup dequeue lost race for thread %s; reverting to IDLE", thread_id)
+            if hasattr(agent, "runtime"):
+                agent.runtime.transition(AgentState.IDLE)
+            return
+        if _start_agent_run is None:
+            raise RuntimeError("thread_runtime.run.followups requires _start_agent_run binding")
+        _start_agent_run(
+            agent,
+            thread_id,
+            item.content,
+            app,
+            message_metadata={
+                "source": item.source or "system",
+                "notification_type": item.notification_type,
+                "sender_name": item.sender_name,
+                "sender_avatar_url": item.sender_avatar_url,
+                "is_steer": getattr(item, "is_steer", False),
+            },
+        )
+    except Exception:
+        logger.exception("Failed to consume followup queue for thread %s", thread_id)
+        if item:
+            try:
+                app.state.queue_manager.enqueue(item.content, thread_id, notification_type=item.notification_type)
+            except Exception:
+                logger.error("Failed to re-enqueue followup for thread %s — message lost: %.200s", thread_id, item.content)

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -11,6 +11,7 @@ from typing import Any
 from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
+from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
@@ -966,44 +967,8 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
 
 
 async def _consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
-    """Dequeue a pending followup message and start a new run.
-
-    If starting the new run fails, re-enqueue the message so it is not lost.
-    """
-    item = None
-    try:
-        qm = app.state.queue_manager
-        if not qm.peek(thread_id) or not app:
-            return
-        if not (hasattr(agent, "runtime") and agent.runtime.transition(AgentState.ACTIVE)):
-            return
-        item = qm.dequeue(thread_id)
-        if item is None:
-            logger.warning("followup dequeue lost race for thread %s; reverting to IDLE", thread_id)
-            if hasattr(agent, "runtime"):
-                agent.runtime.transition(AgentState.IDLE)
-            return
-        start_agent_run(
-            agent,
-            thread_id,
-            item.content,
-            app,
-            message_metadata={
-                "source": item.source or "system",
-                "notification_type": item.notification_type,
-                "sender_name": item.sender_name,
-                "sender_avatar_url": item.sender_avatar_url,
-                "is_steer": getattr(item, "is_steer", False),
-            },
-        )
-    except Exception:
-        logger.exception("Failed to consume followup queue for thread %s", thread_id)
-        # Re-enqueue the message if it was already dequeued to prevent data loss
-        if item:
-            try:
-                app.state.queue_manager.enqueue(item.content, thread_id, notification_type=item.notification_type)
-            except Exception:
-                logger.error("Failed to re-enqueue followup for thread %s — message lost: %.200s", thread_id, item.content)
+    _run_followups._start_agent_run = start_agent_run
+    await _run_followups.consume_followup_queue(agent, thread_id, app)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -131,3 +131,11 @@ def test_streaming_service_uses_thread_runtime_run_entrypoints_owner() -> None:
     assert owner_module.start_agent_run is not None
     assert owner_module.run_child_thread_live is not None
     assert "from backend.thread_runtime.run import entrypoints as _run_entrypoints" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_run_followups_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.followups")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.consume_followup_queue is not None
+    assert "from backend.thread_runtime.run import followups as _run_followups" in streaming_source


### PR DESCRIPTION
## Summary
- move _consume_followup_queue ownership under backend/thread_runtime/run/followups.py
- keep streaming_service's private helper name as a wrapper so current patch seams remain intact
- leave SSE observation and the remaining _run_agent_to_buffer body in streaming_service for later slices

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_followup_requeue.py -q
- uv run ruff check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/followups.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_followup_requeue.py
- uv run ruff format --check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/followups.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_followup_requeue.py
- git diff --check

## Notes
- local pyright on this slice remains non-authoritative on this host because streaming_service already trips missing-import resolution for langchain_core/langgraph/httpx; no new non-import type failures were introduced by the move

## Non-scope
- no SSE observation move yet
- no followup caller retargeting
- no further run entrypoint/lifecycle changes in this PR