### PR TITLE
refactor: move thread runtime sse observer

### DIFF
--- a/backend/thread_runtime/run/observer.py
+++ b/backend/thread_runtime/run/observer.py
@@ -1,0 +1,64 @@
+"""SSE observer helpers for thread runtime event buffers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+
+from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
+
+type SSEEvent = dict[str, str | int]
+
+
+async def observe_thread_events(
+    thread_buf: ThreadEventBuffer,
+    after: int = 0,
+) -> AsyncGenerator[SSEEvent, None]:
+    """Consume events from a persistent ThreadEventBuffer."""
+    async for event in observe_sse_buffer(thread_buf, after=after, stop_on_finish=False):
+        yield event
+
+
+async def observe_run_events(
+    buf: RunEventBuffer,
+    after: int = 0,
+) -> AsyncGenerator[SSEEvent, None]:
+    """Consume events from a RunEventBuffer (subagent streams only)."""
+    async for event in observe_sse_buffer(buf, after=after, stop_on_finish=True):
+        yield event
+
+
+async def observe_sse_buffer(
+    buf: ThreadEventBuffer | RunEventBuffer,
+    *,
+    after: int,
+    stop_on_finish: bool,
+) -> AsyncGenerator[SSEEvent, None]:
+    """Shared SSE observer loop for thread and run buffers."""
+    yield {"retry": 5000}
+
+    cursor = 0
+    while True:
+        events, cursor = await buf.read_with_timeout(cursor, timeout=30)
+        if events is None and not buf.finished.is_set():
+            yield {"comment": "keepalive"}
+            continue
+        if stop_on_finish and not events and buf.finished.is_set():
+            break
+        if not events:
+            continue
+        for event in events:
+            parsed_data = None
+            try:
+                parsed_data = json.loads(event.get("data", "{}"))
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+            if after > 0 and isinstance(parsed_data, dict) and "_seq" in parsed_data and parsed_data["_seq"] <= after:
+                continue
+
+            seq_id = str(parsed_data["_seq"]) if isinstance(parsed_data, dict) and "_seq" in parsed_data else None
+            if seq_id:
+                yield {**event, "id": seq_id}
+            else:
+                yield event

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -13,6 +13,7 @@ from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
 from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
+from backend.thread_runtime.run import observer as _run_observer
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
 from backend.web.utils.serializers import extract_text_content
@@ -1032,17 +1033,7 @@ async def observe_thread_events(
     thread_buf: ThreadEventBuffer,
     after: int = 0,
 ) -> AsyncGenerator[SSEEvent, None]:
-    """Consume events from a persistent ThreadEventBuffer. Yields SSE event dicts.
-
-    Unlike observe_run_events, this never terminates on its own — the client
-    disconnect (or server shutdown) closes the connection.
-    run_done is a flow event, not a terminal signal.
-    """
-    # Always start from the beginning of the ring buffer.
-    # For after=0 (new connection): replay all buffered events so we never miss
-    # events emitted between postRun and SSE connect (race condition fix).
-    # For after>0 (reconnect): start from ring start, filter by _seq below.
-    async for event in _observe_sse_buffer(thread_buf, after=after, stop_on_finish=False):
+    async for event in _run_observer.observe_thread_events(thread_buf, after=after):
         yield event
 
 
@@ -1050,8 +1041,7 @@ async def observe_run_events(
     buf: RunEventBuffer,
     after: int = 0,
 ) -> AsyncGenerator[SSEEvent, None]:
-    """Consume events from a RunEventBuffer (subagent streams only). Yields SSE event dicts."""
-    async for event in _observe_sse_buffer(buf, after=after, stop_on_finish=True):
+    async for event in _run_observer.observe_run_events(buf, after=after):
         yield event
 
 
@@ -1061,34 +1051,5 @@ async def _observe_sse_buffer(
     after: int,
     stop_on_finish: bool,
 ) -> AsyncGenerator[SSEEvent, None]:
-    """Shared SSE observer loop for thread and run buffers."""
-    yield {"retry": 5000}
-
-    cursor = 0
-    while True:
-        events, cursor = await buf.read_with_timeout(cursor, timeout=30)
-        if events is None and not buf.finished.is_set():
-            yield {"comment": "keepalive"}
-            continue
-        if stop_on_finish and not events and buf.finished.is_set():
-            break
-        if not events:
-            continue
-        for event in events:
-            parsed_data = None
-            try:
-                parsed_data = json.loads(event.get("data", "{}"))
-            except (json.JSONDecodeError, TypeError):
-                pass
-
-            # @@@after-filter — skip events already seen on reconnect.
-            # display_delta now carries the source raw-event seq too, so stale
-            # derived deltas are filtered together with their persisted source.
-            if after > 0 and isinstance(parsed_data, dict) and "_seq" in parsed_data and parsed_data["_seq"] <= after:
-                continue
-
-            seq_id = str(parsed_data["_seq"]) if isinstance(parsed_data, dict) and "_seq" in parsed_data else None
-            if seq_id:
-                yield {**event, "id": seq_id}
-            else:
-                yield event
+    async for event in _run_observer.observe_sse_buffer(buf, after=after, stop_on_finish=stop_on_finish):
+        yield event

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -139,3 +139,13 @@ def test_streaming_service_uses_thread_runtime_run_followups_owner() -> None:
 
     assert owner_module.consume_followup_queue is not None
     assert "from backend.thread_runtime.run import followups as _run_followups" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_sse_observer_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.observer")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.observe_thread_events is not None
+    assert owner_module.observe_run_events is not None
+    assert owner_module.observe_sse_buffer is not None
+    assert "from backend.thread_runtime.run import observer as _run_observer" in streaming_source


### PR DESCRIPTION
## Summary
- move observe_thread_events, observe_run_events, and _observe_sse_buffer under backend/thread_runtime/run/observer.py
- keep streaming_service helper names as wrappers so current patch seams remain intact
- leave the rest of streaming_service in place for later slices

## Local proof
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py -q
- uv run python -m pytest tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py -q -k "observe_thread_events or observe_run_events or _observe_sse_buffer or display_delta or keepalive"
- uv run ruff check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/observer.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py
- uv run ruff format --check backend/thread_runtime/run/__init__.py backend/thread_runtime/run/observer.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py
- git diff --check

## Notes
- local pyright on this slice remains non-authoritative on this host because streaming_service already trips missing-import resolution for langchain_core/langgraph/httpx; no new non-import type failures were introduced by the move

## Non-scope
- no followup queue move in this PR
- no run entrypoint changes in this PR
- no _run_agent_to_buffer body extraction yet