### PR TITLE
refactor: move thread runtime observation scope

### DIFF
--- a/backend/thread_runtime/run/observation.py
+++ b/backend/thread_runtime/run/observation.py
@@ -1,0 +1,96 @@
+"""Observation provider setup/flush helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_observation(app: Any, thread_id: str, config: dict[str, Any]) -> tuple[Any, str | None, Callable[[], None]]:
+    """Build an observation handler and its flush callback."""
+    obs_handler = None
+    obs_active = None
+    obs_provider = None
+
+    try:
+        thread_data = app.state.thread_repo.get_by_id(thread_id) if hasattr(app.state, "thread_repo") else None
+        obs_provider = thread_data.get("observation_provider") if thread_data else None
+
+        if obs_provider:
+            from config.observation_loader import ObservationLoader
+
+            obs_config = ObservationLoader().load()
+
+            if obs_provider == "langfuse":
+                from langfuse import Langfuse  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
+                from langfuse.langchain import (
+                    CallbackHandler as LangfuseHandler,  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
+                )
+
+                cfg = obs_config.langfuse
+                if cfg.secret_key and cfg.public_key:
+                    obs_active = "langfuse"
+                    Langfuse(
+                        public_key=cfg.public_key,
+                        secret_key=cfg.secret_key,
+                        host=cfg.host or "https://cloud.langfuse.com",
+                    )
+                    obs_handler = LangfuseHandler(public_key=cfg.public_key)
+                    callbacks = config.setdefault("callbacks", [])
+                    if not isinstance(callbacks, list):
+                        raise RuntimeError("streaming observation callbacks must be a list")
+                    callbacks.append(obs_handler)
+                    metadata = config.setdefault("metadata", {})
+                    if not isinstance(metadata, dict):
+                        raise RuntimeError("streaming observation metadata must be an object")
+                    metadata["langfuse_session_id"] = thread_id
+            elif obs_provider == "langsmith":
+                from langchain_core.tracers.langchain import LangChainTracer  # pyright: ignore[reportMissingImports]
+                from langsmith import Client as LangSmithClient  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
+
+                cfg = obs_config.langsmith
+                if cfg.api_key:
+                    obs_active = "langsmith"
+                    ls_client = LangSmithClient(
+                        api_key=cfg.api_key,
+                        api_url=cfg.endpoint or "https://api.smith.langchain.com",
+                    )
+                    obs_handler = LangChainTracer(
+                        client=ls_client,
+                        project_name=cfg.project or "default",
+                    )
+                    callbacks = config.setdefault("callbacks", [])
+                    if not isinstance(callbacks, list):
+                        raise RuntimeError("streaming observation callbacks must be a list")
+                    callbacks.append(obs_handler)
+                    metadata = config.setdefault("metadata", {})
+                    if not isinstance(metadata, dict):
+                        raise RuntimeError("streaming observation metadata must be an object")
+                    metadata["session_id"] = thread_id
+    except ImportError as imp_err:
+        logger.warning(
+            "Observation provider '%s' missing package: %s. Install: uv pip install 'leonai[%s]'",
+            obs_provider,
+            imp_err,
+            obs_provider,
+        )
+    except Exception as obs_err:
+        logger.warning("Observation handler error: %s", obs_err, exc_info=True)
+
+    def flush() -> None:
+        if obs_handler is None:
+            return
+        try:
+            if obs_active == "langfuse":
+                from langfuse import get_client  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
+
+                get_client().flush()
+            elif obs_active == "langsmith":
+                obs_handler.wait_for_futures()
+        except Exception as flush_err:
+            logger.warning("Observation flush error: %s", flush_err)
+
+    return obs_handler, obs_active, flush

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -12,6 +12,7 @@ from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
 from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
+from backend.thread_runtime.run import observation as _run_observation
 from backend.thread_runtime.run import observer as _run_observer
 from backend.thread_runtime.run import trajectory as _run_trajectory
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
@@ -282,75 +283,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         if trajectory_scope is not None:
             trajectory_scope.inject_callback(config)
 
-        # Observation provider: provider from thread config, credentials from global config
-        obs_handler = None
-        obs_active = None
-        obs_provider = None
-        try:
-            thread_data = app.state.thread_repo.get_by_id(thread_id) if hasattr(app.state, "thread_repo") else None
-            obs_provider = thread_data.get("observation_provider") if thread_data else None
-
-            if obs_provider:
-                from config.observation_loader import ObservationLoader
-
-                obs_config = ObservationLoader().load()
-
-                if obs_provider == "langfuse":
-                    from langfuse import Langfuse  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
-                    from langfuse.langchain import (
-                        CallbackHandler as LangfuseHandler,  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
-                    )
-
-                    cfg = obs_config.langfuse
-                    if cfg.secret_key and cfg.public_key:
-                        obs_active = "langfuse"
-                        # Initialize global Langfuse client (CallbackHandler uses it)
-                        Langfuse(
-                            public_key=cfg.public_key,
-                            secret_key=cfg.secret_key,
-                            host=cfg.host or "https://cloud.langfuse.com",
-                        )
-                        obs_handler = LangfuseHandler(public_key=cfg.public_key)
-                        callbacks = config.setdefault("callbacks", [])
-                        if not isinstance(callbacks, list):
-                            raise RuntimeError("streaming observation callbacks must be a list")
-                        callbacks.append(obs_handler)
-                        metadata = config.setdefault("metadata", {})
-                        if not isinstance(metadata, dict):
-                            raise RuntimeError("streaming observation metadata must be an object")
-                        metadata["langfuse_session_id"] = thread_id
-                elif obs_provider == "langsmith":
-                    from langchain_core.tracers.langchain import LangChainTracer  # pyright: ignore[reportMissingImports]
-                    from langsmith import Client as LangSmithClient  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
-
-                    cfg = obs_config.langsmith
-                    if cfg.api_key:
-                        obs_active = "langsmith"
-                        ls_client = LangSmithClient(
-                            api_key=cfg.api_key,
-                            api_url=cfg.endpoint or "https://api.smith.langchain.com",
-                        )
-                        obs_handler = LangChainTracer(
-                            client=ls_client,
-                            project_name=cfg.project or "default",
-                        )
-                        callbacks = config.setdefault("callbacks", [])
-                        if not isinstance(callbacks, list):
-                            raise RuntimeError("streaming observation callbacks must be a list")
-                        callbacks.append(obs_handler)
-                        metadata = config.setdefault("metadata", {})
-                        if not isinstance(metadata, dict):
-                            raise RuntimeError("streaming observation metadata must be an object")
-                        metadata["session_id"] = thread_id
-        except ImportError as imp_err:
-            logger.warning(
-                "Observation provider '%s' missing package: %s. Install: uv pip install 'leonai[%s]'",
-                obs_provider,
-                imp_err,
-                obs_provider,
-            )
-        except Exception as obs_err:
-            logger.warning("Observation handler error: %s", obs_err, exc_info=True)
+        _obs_handler, _obs_active, flush_observation = _run_observation.build_observation(app, thread_id, config)
 
         # Real-time activity event callback (replaces post-hoc batch drain)
         activity_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=1000)
@@ -892,16 +825,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         if hasattr(agent, "runtime"):
             agent.runtime.set_event_callback(None)
         # Flush observation handler
-        if obs_handler is not None:
-            try:
-                if obs_active == "langfuse":
-                    from langfuse import get_client  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
-
-                    get_client().flush()
-                elif obs_active == "langsmith":
-                    obs_handler.wait_for_futures()
-            except Exception as flush_err:
-                logger.warning("Observation flush error: %s", flush_err)
+        flush_observation()
         # ThreadEventBuffer is persistent — do NOT mark_done or pop
         app.state.thread_tasks.pop(thread_id, None)
         if stream_gen is not None:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -157,3 +157,11 @@ def test_streaming_service_uses_thread_runtime_trajectory_owner() -> None:
 
     assert owner_module.build_trajectory_scope is not None
     assert "from backend.thread_runtime.run import trajectory as _run_trajectory" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_observation_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.observation")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.build_observation is not None
+    assert "from backend.thread_runtime.run import observation as _run_observation" in streaming_source


### PR DESCRIPTION
## Summary
- move streaming observation provider setup and flush into `backend/thread_runtime/run/observation.py`
- retarget `_run_agent_to_buffer` to the new owner while preserving the surrounding run flow
- add owner smoke coverage for the new observation module

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run ruff check backend/thread_runtime/run/observation.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/run/observation.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`
