### PR TITLE
refactor: move thread runtime activity bridge

### DIFF
--- a/backend/thread_runtime/run/activity_bridge.py
+++ b/backend/thread_runtime/run/activity_bridge.py
@@ -1,0 +1,47 @@
+"""Runtime activity-event bridge helpers for thread runs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_activity_bridge(
+    *,
+    runtime: Any | None,
+    emit: Callable[[dict[str, Any]], Awaitable[None]],
+    maxsize: int = 1000,
+) -> tuple[Callable[[], Awaitable[None]], Callable[[], None], Callable[[], None]]:
+    """Build queue-backed runtime event attach/drain/detach helpers."""
+    activity_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
+
+    def on_activity_event(event: dict[str, Any]) -> None:
+        try:
+            activity_queue.put_nowait(event)
+        except asyncio.QueueFull:
+            return
+
+    async def drain() -> None:
+        while not activity_queue.empty():
+            try:
+                act_event = activity_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            logger.info("[stream:drain] emitting activity event: %s", act_event.get("event", "?"))
+            await emit(act_event)
+
+    def attach() -> None:
+        if runtime is None:
+            return
+        runtime.set_event_callback(on_activity_event)
+
+    def detach() -> None:
+        if runtime is None:
+            return
+        runtime.set_event_callback(None)
+
+    return drain, attach, detach

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -7,6 +7,7 @@ import random
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from backend.thread_runtime.run import activity_bridge as _run_activity_bridge
 from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
@@ -285,26 +286,11 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
 
         _obs_handler, _obs_active, flush_observation = _run_observation.build_observation(app, thread_id, config)
 
-        # Real-time activity event callback (replaces post-hoc batch drain)
-        activity_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=1000)
-
-        def on_activity_event(event: dict) -> None:
-            try:
-                activity_queue.put_nowait(event)
-            except asyncio.QueueFull:
-                pass  # Backpressure: drop under overload
-
-        async def drain_activity_events() -> None:
-            while not activity_queue.empty():
-                try:
-                    act_event = activity_queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    break
-                logger.info("[stream:drain] emitting activity event: %s", act_event.get("event", "?"))
-                await emit(act_event)
-
-        if hasattr(agent, "runtime"):
-            agent.runtime.set_event_callback(on_activity_event)
+        drain_activity_events, attach_activity_bridge, detach_activity_bridge = _run_activity_bridge.build_activity_bridge(
+            runtime=getattr(agent, "runtime", None),
+            emit=emit,
+        )
+        attach_activity_bridge()
 
         # Bind per-thread handlers (idempotent — safe across runs)
         _ensure_thread_handlers(agent, thread_id, app)
@@ -822,8 +808,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         if typing_tracker is not None:
             typing_tracker.stop(thread_id)
         # Detach per-run event callback (per-thread handlers survive across runs)
-        if hasattr(agent, "runtime"):
-            agent.runtime.set_event_callback(None)
+        detach_activity_bridge()
         # Flush observation handler
         flush_observation()
         # ThreadEventBuffer is persistent — do NOT mark_done or pop

--- a/tests/Unit/backend/thread_runtime/run/test_activity_bridge.py
+++ b/tests/Unit/backend/thread_runtime/run/test_activity_bridge.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_activity_bridge_attaches_drains_and_detaches_runtime_events() -> None:
+    from backend.thread_runtime.run.activity_bridge import build_activity_bridge
+
+    emitted: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        emitted.append(event)
+
+    runtime = SimpleNamespace(callback=None)
+
+    def set_event_callback(callback) -> None:
+        runtime.callback = callback
+
+    runtime.set_event_callback = set_event_callback
+
+    drain, attach, detach = build_activity_bridge(runtime=runtime, emit=emit)
+
+    attach()
+    assert runtime.callback is not None
+
+    runtime.callback({"event": "notice", "data": "one"})
+    runtime.callback({"event": "notice", "data": "two"})
+    await drain()
+
+    assert emitted == [
+        {"event": "notice", "data": "one"},
+        {"event": "notice", "data": "two"},
+    ]
+
+    detach()
+    assert runtime.callback is None
+
+
+@pytest.mark.asyncio
+async def test_activity_bridge_drops_events_after_queue_is_full() -> None:
+    from backend.thread_runtime.run.activity_bridge import build_activity_bridge
+
+    emitted: list[dict[str, int]] = []
+
+    async def emit(event: dict[str, int]) -> None:
+        emitted.append(event)
+
+    runtime = SimpleNamespace(callback=None)
+    runtime.set_event_callback = lambda callback: setattr(runtime, "callback", callback)
+
+    drain, attach, _detach = build_activity_bridge(runtime=runtime, emit=emit, maxsize=2)
+
+    attach()
+    runtime.callback({"event": 1})
+    runtime.callback({"event": 2})
+    runtime.callback({"event": 3})
+
+    await drain()
+
+    assert emitted == [{"event": 1}, {"event": 2}]

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -165,3 +165,11 @@ def test_streaming_service_uses_thread_runtime_observation_owner() -> None:
 
     assert owner_module.build_observation is not None
     assert "from backend.thread_runtime.run import observation as _run_observation" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_activity_bridge_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.activity_bridge")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.build_activity_bridge is not None
+    assert "from backend.thread_runtime.run import activity_bridge as _run_activity_bridge" in streaming_source


### PR DESCRIPTION
## Summary
- move the runtime activity callback queue/drain logic into `backend/thread_runtime/run/activity_bridge.py`
- retarget `_run_agent_to_buffer` to the new activity bridge owner while preserving the existing drain sites
- add owner smoke and direct activity-bridge behavior coverage

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_activity_bridge.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_run_agent_to_buffer_drains_activity_notice_before_stream_error" -q`
- `uv run ruff check backend/thread_runtime/run/activity_bridge.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_activity_bridge.py`
- `uv run ruff format --check backend/thread_runtime/run/activity_bridge.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_activity_bridge.py`
- `git diff --check`
