### PR TITLE
refactor: move thread runtime emit adapter

### DIFF
--- a/backend/thread_runtime/run/emit.py
+++ b/backend/thread_runtime/run/emit.py
@@ -1,0 +1,73 @@
+"""Event emission helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from backend.web.services.event_store import append_event
+from storage.contracts import RunEventRepo
+
+
+def resolve_run_event_repo(agent: Any) -> RunEventRepo:
+    storage_container = getattr(agent, "storage_container", None)
+    if storage_container is None:
+        raise RuntimeError("streaming_service requires agent.storage_container.run_event_repo()")
+
+    # @@@runtime-storage-consumer - runtime run lifecycle must consume injected storage container, not assignment-only wiring.
+    run_event_repo = getattr(storage_container, "run_event_repo", None)
+    if not callable(run_event_repo):
+        raise RuntimeError("streaming_service requires agent.storage_container.run_event_repo()")
+    repo = run_event_repo()
+    if not isinstance(repo, RunEventRepo):
+        raise RuntimeError("agent.storage_container.run_event_repo() returned an invalid repo")
+    return repo
+
+
+def build_emit(
+    *,
+    thread_id: str,
+    run_id: str,
+    thread_buf: Any,
+    run_event_repo: RunEventRepo,
+    display_builder: Any,
+) -> Callable[[dict[str, Any], str | None], Awaitable[None]]:
+    async def emit(event: dict[str, Any], message_id: str | None = None) -> None:
+        seq = await append_event(
+            thread_id,
+            run_id,
+            event,
+            message_id,
+            run_event_repo=run_event_repo,
+        )
+        try:
+            data = json.loads(event.get("data", "{}")) if isinstance(event.get("data"), str) else event.get("data", {})
+        except (json.JSONDecodeError, TypeError):
+            data = event.get("data", {})
+        if isinstance(data, dict):
+            data["_seq"] = seq
+            data["_run_id"] = run_id
+            if message_id:
+                data["message_id"] = message_id
+            event = {**event, "data": json.dumps(data, ensure_ascii=False)}
+        await thread_buf.put(event)
+
+        # @@@display-builder — compute display deltas alongside raw events
+        event_type = event.get("event", "")
+        if event_type and isinstance(data, dict):
+            delta = display_builder.apply_event(thread_id, event_type, data)
+            if delta:
+                # @@@display-delta-source-seq - replay after-filter only knows raw
+                # event seqs. Carry the source seq onto the derived delta so a
+                # reconnect after GET /thread can skip stale display_delta
+                # replays instead of rebuilding the same thread a second time.
+                delta["_seq"] = seq
+                await thread_buf.put(
+                    {
+                        "event": "display_delta",
+                        "data": json.dumps(delta, ensure_ascii=False),
+                    }
+                )
+
+    return emit

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -10,6 +10,7 @@ from typing import Any
 from backend.thread_runtime.run import activity_bridge as _run_activity_bridge
 from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
+from backend.thread_runtime.run import emit as _run_emit
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
 from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
@@ -47,18 +48,7 @@ def _log_captured_exception(message: str, err: BaseException) -> None:
 
 
 def _resolve_run_event_repo(agent: Any) -> RunEventRepo:
-    storage_container = getattr(agent, "storage_container", None)
-    if storage_container is None:
-        raise RuntimeError("streaming_service requires agent.storage_container.run_event_repo()")
-
-    # @@@runtime-storage-consumer - runtime run lifecycle must consume injected storage container, not assignment-only wiring.
-    run_event_repo = getattr(storage_container, "run_event_repo", None)
-    if not callable(run_event_repo):
-        raise RuntimeError("streaming_service requires agent.storage_container.run_event_repo()")
-    repo = run_event_repo()
-    if not isinstance(repo, RunEventRepo):
-        raise RuntimeError("agent.storage_container.run_event_repo() returned an invalid repo")
-    return repo
+    return _run_emit.resolve_run_event_repo(agent)
 
 
 def _augment_system_prompt_for_terminal_followthrough(system_prompt: Any) -> Any:
@@ -217,55 +207,22 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     input_messages: list[Any] | None = None,
 ) -> str:
     """Run agent execution and write all SSE events into *thread_buf*."""
-    from backend.web.services.event_store import append_event
-
     run_event_repo = _resolve_run_event_repo(agent)
-
-    # @@@display-builder — compute display deltas alongside raw events
     display_builder = app.state.display_builder
-
-    async def emit(event: dict, message_id: str | None = None) -> None:
-        seq = await append_event(
-            thread_id,
-            run_id,
-            event,
-            message_id,
-            run_event_repo=run_event_repo,
-        )
-        try:
-            data = json.loads(event.get("data", "{}")) if isinstance(event.get("data"), str) else event.get("data", {})
-        except (json.JSONDecodeError, TypeError):
-            data = event.get("data", {})
-        if isinstance(data, dict):
-            data["_seq"] = seq
-            data["_run_id"] = run_id
-            if message_id:
-                data["message_id"] = message_id
-            event = {**event, "data": json.dumps(data, ensure_ascii=False)}
-        await thread_buf.put(event)
-
-        # Compute display delta and emit it alongside the raw event.
-        event_type = event.get("event", "")
-        if event_type and isinstance(data, dict):
-            delta = display_builder.apply_event(thread_id, event_type, data)
-            if delta:
-                # @@@display-delta-source-seq - replay after-filter only knows raw
-                # event seqs. Carry the source seq onto the derived delta so a
-                # reconnect after GET /thread can skip stale display_delta
-                # replays instead of rebuilding the same thread a second time.
-                delta["_seq"] = seq
-                await thread_buf.put(
-                    {
-                        "event": "display_delta",
-                        "data": json.dumps(delta, ensure_ascii=False),
-                    }
-                )
+    emit = _run_emit.build_emit(
+        thread_id=thread_id,
+        run_id=run_id,
+        thread_buf=thread_buf,
+        run_event_repo=run_event_repo,
+        display_builder=display_builder,
+    )
 
     task = None
     stream_gen = None
     pending_tool_calls: dict[str, dict] = {}
     output_parts: list[str] = []
     trajectory_status = "completed"
+    original_system_prompt = None
     try:
         config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
         if hasattr(agent, "_current_model_config"):
@@ -410,7 +367,6 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
             )
 
         terminal_followthrough_items: list[dict[str, str | None]] | None = None
-        original_system_prompt = None
         # @@@terminal-followthrough-reentry - terminal background completions
         # still surface as durable notices first, but they must then re-enter the
         # model as a real followthrough turn instead of terminating at notice-only.

--- a/tests/Unit/backend/thread_runtime/run/test_emit.py
+++ b/tests/Unit/backend/thread_runtime/run/test_emit.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from backend.thread_runtime.events.buffer import ThreadEventBuffer
+
+
+class _FakeDisplayBuilder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, object]]] = []
+
+    def apply_event(self, thread_id: str, event_type: str, data: dict[str, object]) -> dict[str, object] | None:
+        self.calls.append((thread_id, event_type, dict(data)))
+        if event_type != "text":
+            return None
+        return {
+            "type": "text",
+            "content": data["content"],
+        }
+
+
+@pytest.mark.asyncio
+async def test_build_emit_carries_seq_run_id_message_id_and_display_delta(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.thread_runtime.run.emit import build_emit
+
+    seq = 40
+
+    async def fake_append_event(thread_id, run_id, event, message_id=None, run_event_repo=None):
+        nonlocal seq
+        seq += 1
+        return seq
+
+    monkeypatch.setattr("backend.thread_runtime.run.emit.append_event", fake_append_event)
+
+    thread_buf = ThreadEventBuffer()
+    display_builder = _FakeDisplayBuilder()
+    emit = build_emit(
+        thread_id="thread-1",
+        run_id="run-1",
+        thread_buf=thread_buf,
+        run_event_repo=SimpleNamespace(),
+        display_builder=display_builder,
+    )
+
+    await emit(
+        {
+            "event": "text",
+            "data": json.dumps({"content": "hello", "showing": True}, ensure_ascii=False),
+        },
+        message_id="msg-1",
+    )
+
+    events, cursor = await thread_buf.read_with_timeout(0, timeout=0.01)
+    assert cursor == 2
+    assert events is not None
+    assert [event["event"] for event in events] == ["text", "display_delta"]
+
+    raw_payload = json.loads(events[0]["data"])
+    assert raw_payload["_seq"] == 41
+    assert raw_payload["_run_id"] == "run-1"
+    assert raw_payload["message_id"] == "msg-1"
+
+    delta_payload = json.loads(events[1]["data"])
+    assert delta_payload == {
+        "type": "text",
+        "content": "hello",
+        "_seq": 41,
+    }
+
+    assert display_builder.calls == [
+        (
+            "thread-1",
+            "text",
+            {
+                "content": "hello",
+                "showing": True,
+                "_seq": 41,
+                "_run_id": "run-1",
+                "message_id": "msg-1",
+            },
+        )
+    ]
+
+
+def test_resolve_run_event_repo_requires_callable_repo_factory() -> None:
+    from backend.thread_runtime.run.emit import resolve_run_event_repo
+
+    agent = SimpleNamespace(storage_container=SimpleNamespace(run_event_repo=None))
+
+    with pytest.raises(RuntimeError, match="run_event_repo"):
+        resolve_run_event_repo(agent)

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -173,3 +173,11 @@ def test_streaming_service_uses_thread_runtime_activity_bridge_owner() -> None:
 
     assert owner_module.build_activity_bridge is not None
     assert "from backend.thread_runtime.run import activity_bridge as _run_activity_bridge" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_emit_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.emit")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.build_emit is not None
+    assert "from backend.thread_runtime.run import emit as _run_emit" in streaming_source


### PR DESCRIPTION
## Summary
- move the run-event repo resolution and emit/display-delta adapter into `backend/thread_runtime/run/emit.py`
- retarget `_run_agent_to_buffer` to the new emit owner while preserving existing event and display-delta behavior
- add owner smoke plus direct emit-adapter coverage for `_seq`, `_run_id`, `message_id`, and `display_delta`

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_emit.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_run_agent_to_buffer_tags_display_delta_with_source_seq" -q`
- `uv run ruff check backend/thread_runtime/run/emit.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_emit.py`
- `uv run ruff format --check backend/thread_runtime/run/emit.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_emit.py`
- `git diff --check`
