### PR TITLE
refactor: move thread runtime prologue

### DIFF
--- a/backend/thread_runtime/run/prologue.py
+++ b/backend/thread_runtime/run/prologue.py
@@ -1,0 +1,103 @@
+"""Run prologue helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from backend.web.utils.serializers import strip_system_tags
+
+
+async def emit_run_prologue(
+    *,
+    agent: Any,
+    thread_id: str,
+    message: str,
+    message_metadata: dict[str, Any] | None,
+    run_id: str,
+    app: Any,
+    emit: Callable[[dict[str, str]], Awaitable[None]],
+) -> tuple[str | None, str | None]:
+    meta = message_metadata or {}
+    src = meta.get("source")
+
+    # @@@run-source-tracking — set on runtime for source tracking
+    if hasattr(agent, "runtime"):
+        agent.runtime.current_run_source = src or "owner"
+
+    app.state.thread_last_active[thread_id] = time.time()
+
+    # @@@user-entry — emit user_message so display_builder can add a UserMessage
+    # entry. Skip for steers — wake_handler already emitted user_message at
+    # enqueue time (@@@steer-instant-feedback). Note: is_steer is not persisted
+    # in queue, so check notification_type too.
+    is_steer = meta.get("is_steer") or meta.get("notification_type") == "steer"
+    if meta.get("ask_user_question_answered"):
+        await emit(
+            {
+                "event": "user_message",
+                "data": json.dumps(
+                    {
+                        "content": "",
+                        "showing": False,
+                        "ask_user_question_answered": meta["ask_user_question_answered"],
+                    },
+                    ensure_ascii=False,
+                ),
+            }
+        )
+    elif (not src or src == "owner") and not is_steer:
+        # @@@strip-for-display — agent sees full content (with system-reminder),
+        # frontend sees clean text (tags stripped)
+        display_content = strip_system_tags(message) if "<system-reminder>" in message else message
+        await emit(
+            {
+                "event": "user_message",
+                "data": json.dumps(
+                    {
+                        "content": display_content,
+                        "showing": True,
+                        **({"attachments": meta["attachments"]} if meta.get("attachments") else {}),
+                    },
+                    ensure_ascii=False,
+                ),
+            }
+        )
+
+    await emit(
+        {
+            "event": "run_start",
+            "data": json.dumps(
+                {
+                    "thread_id": thread_id,
+                    "run_id": run_id,
+                    "source": src,
+                    "sender_name": meta.get("sender_name"),
+                    "showing": True,
+                }
+            ),
+        }
+    )
+
+    # @@@run-notice — emit notice right after run_start so frontend folds it
+    # into the (re)opened turn. Mirror the cold-path DisplayBuilder rule:
+    # any source=system message is a notice; external notices stay chat-only.
+    ntype = meta.get("notification_type")
+    if src == "system" or (src == "external" and ntype == "chat"):
+        await emit(
+            {
+                "event": "notice",
+                "data": json.dumps(
+                    {
+                        "content": message,
+                        "source": src,
+                        "notification_type": ntype,
+                    },
+                    ensure_ascii=False,
+                ),
+            }
+        )
+
+    return src, ntype

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -16,6 +16,7 @@ from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.thread_runtime.run import observation as _run_observation
 from backend.thread_runtime.run import observer as _run_observer
+from backend.thread_runtime.run import prologue as _run_prologue
 from backend.thread_runtime.run import trajectory as _run_trajectory
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
@@ -281,90 +282,15 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         # won't reject the message history.
         await _repair_incomplete_tool_calls(agent, config)
 
-        meta = message_metadata or {}
-        src = meta.get("source")
-
-        # @@@run-source-tracking — set on runtime for source tracking
-        if hasattr(agent, "runtime"):
-            agent.runtime.current_run_source = src or "owner"
-
-        # Track last-active for sidebar sorting
-        import time as _time
-
-        app.state.thread_last_active[thread_id] = _time.time()
-
-        # @@@user-entry — emit user_message so display_builder can add a UserMessage
-        # entry.  Skip for steers — wake_handler already emitted user_message at
-        # enqueue time (@@@steer-instant-feedback).
-        # Note: is_steer is NOT persisted in queue, so check notification_type too.
-        is_steer = meta.get("is_steer") or meta.get("notification_type") == "steer"
-        if meta.get("ask_user_question_answered"):
-            await emit(
-                {
-                    "event": "user_message",
-                    "data": json.dumps(
-                        {
-                            "content": "",
-                            "showing": False,
-                            "ask_user_question_answered": meta["ask_user_question_answered"],
-                        },
-                        ensure_ascii=False,
-                    ),
-                }
-            )
-        elif (not src or src == "owner") and not is_steer:
-            # @@@strip-for-display — agent sees full content (with system-reminder),
-            # frontend sees clean text (tags stripped)
-            from backend.web.utils.serializers import strip_system_tags
-
-            display_content = strip_system_tags(message) if "<system-reminder>" in message else message
-            await emit(
-                {
-                    "event": "user_message",
-                    "data": json.dumps(
-                        {
-                            "content": display_content,
-                            "showing": True,
-                            **({"attachments": meta["attachments"]} if meta.get("attachments") else {}),
-                        },
-                        ensure_ascii=False,
-                    ),
-                }
-            )
-
-        await emit(
-            {
-                "event": "run_start",
-                "data": json.dumps(
-                    {
-                        "thread_id": thread_id,
-                        "run_id": run_id,
-                        "source": src,
-                        "sender_name": meta.get("sender_name"),
-                        "showing": True,
-                    }
-                ),
-            }
+        src, ntype = await _run_prologue.emit_run_prologue(
+            agent=agent,
+            thread_id=thread_id,
+            message=message,
+            message_metadata=message_metadata,
+            run_id=run_id,
+            app=app,
+            emit=emit,
         )
-
-        # @@@run-notice — emit notice right after run_start so frontend folds it
-        # into the (re)opened turn. Mirror the cold-path DisplayBuilder rule:
-        # any source=system message is a notice; external notices stay chat-only.
-        ntype = meta.get("notification_type")
-        if src == "system" or (src == "external" and ntype == "chat"):
-            await emit(
-                {
-                    "event": "notice",
-                    "data": json.dumps(
-                        {
-                            "content": message,
-                            "source": src,
-                            "notification_type": ntype,
-                        },
-                        ensure_ascii=False,
-                    ),
-                }
-            )
 
         terminal_followthrough_items: list[dict[str, str | None]] | None = None
         # @@@terminal-followthrough-reentry - terminal background completions

--- a/tests/Unit/backend/thread_runtime/run/test_prologue.py
+++ b/tests/Unit/backend/thread_runtime/run/test_prologue.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+def _decode(events: list[dict[str, str]]) -> list[tuple[str, dict[str, object]]]:
+    return [(event["event"], json.loads(event["data"])) for event in events]
+
+
+@pytest.mark.asyncio
+async def test_emit_run_prologue_owner_message_emits_user_message_then_run_start() -> None:
+    from backend.thread_runtime.run.prologue import emit_run_prologue
+
+    events: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        events.append(event)
+
+    app = SimpleNamespace(state=SimpleNamespace(thread_last_active={}))
+    runtime = SimpleNamespace(current_run_source=None)
+    agent = SimpleNamespace(runtime=runtime)
+
+    await emit_run_prologue(
+        agent=agent,
+        thread_id="thread-1",
+        message="<system-reminder>ignore</system-reminder>hello",
+        message_metadata=None,
+        run_id="run-1",
+        app=app,
+        emit=emit,
+    )
+
+    decoded = _decode(events)
+    assert [item[0] for item in decoded] == ["user_message", "run_start"]
+    assert decoded[0][1] == {"content": "hello", "showing": True}
+    assert decoded[1][1]["run_id"] == "run-1"
+    assert decoded[1][1]["thread_id"] == "thread-1"
+    assert runtime.current_run_source == "owner"
+    assert "thread-1" in app.state.thread_last_active
+
+
+@pytest.mark.asyncio
+async def test_emit_run_prologue_skips_duplicate_user_message_for_steer() -> None:
+    from backend.thread_runtime.run.prologue import emit_run_prologue
+
+    events: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        events.append(event)
+
+    app = SimpleNamespace(state=SimpleNamespace(thread_last_active={}))
+    runtime = SimpleNamespace(current_run_source=None)
+    agent = SimpleNamespace(runtime=runtime)
+
+    await emit_run_prologue(
+        agent=agent,
+        thread_id="thread-steer",
+        message="steer please",
+        message_metadata={"notification_type": "steer"},
+        run_id="run-steer",
+        app=app,
+        emit=emit,
+    )
+
+    decoded = _decode(events)
+    assert [item[0] for item in decoded] == ["run_start"]
+    assert decoded[0][1]["source"] is None
+
+
+@pytest.mark.asyncio
+async def test_emit_run_prologue_emits_notice_after_run_start_for_system_message() -> None:
+    from backend.thread_runtime.run.prologue import emit_run_prologue
+
+    events: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        events.append(event)
+
+    app = SimpleNamespace(state=SimpleNamespace(thread_last_active={}))
+    runtime = SimpleNamespace(current_run_source=None)
+    agent = SimpleNamespace(runtime=runtime)
+
+    await emit_run_prologue(
+        agent=agent,
+        thread_id="thread-system",
+        message="system notice",
+        message_metadata={"source": "system", "notification_type": "agent"},
+        run_id="run-system",
+        app=app,
+        emit=emit,
+    )
+
+    decoded = _decode(events)
+    assert [item[0] for item in decoded] == ["run_start", "notice"]
+    assert decoded[1][1] == {
+        "content": "system notice",
+        "source": "system",
+        "notification_type": "agent",
+    }

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -181,3 +181,11 @@ def test_streaming_service_uses_thread_runtime_emit_owner() -> None:
 
     assert owner_module.build_emit is not None
     assert "from backend.thread_runtime.run import emit as _run_emit" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_prologue_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.prologue")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.emit_run_prologue is not None
+    assert "from backend.thread_runtime.run import prologue as _run_prologue" in streaming_source


### PR DESCRIPTION
## Summary
- move run-source tracking and the user_message/run_start/notice prologue block into `backend/thread_runtime/run/prologue.py`
- retarget `_run_agent_to_buffer` to the new prologue owner without changing terminal followthrough/input behavior
- add owner smoke plus direct prologue coverage for owner, steer, and system-notice paths

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_prologue.py tests/Integration/test_query_loop_backend_contracts.py -k "test_run_agent_to_buffer_emits_notice_for_system_agent_notifications or test_run_agent_to_buffer_surfaces_notice_then_assistant_followthrough or test_run_agent_to_buffer_turns_silent_terminal_reentry_into_visible_followthrough" -q`
- `uv run ruff check backend/thread_runtime/run/prologue.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_prologue.py`
- `uv run ruff format --check backend/thread_runtime/run/prologue.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_prologue.py`
- `git diff --check`
