### PR TITLE
refactor: move thread runtime input construction

### DIFF
--- a/backend/thread_runtime/run/input_construction.py
+++ b/backend/thread_runtime/run/input_construction.py
@@ -1,0 +1,111 @@
+"""Input construction helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+_TERMINAL_FOLLOWTHROUGH_SYSTEM_NOTE = (
+    "Terminal background completion notifications require an explicit assistant followthrough. "
+    "Treat these notifications as fresh inputs that need a visible assistant reply. "
+    "You must produce at least one visible assistant message for them; "
+    "do not stay silent and do not end the run after only surfacing a notice. "
+    "Do not call TaskOutput or TaskStop for a terminal notification. "
+    "If no further tool is truly needed, answer directly in natural language "
+    "and briefly acknowledge the completion, failure, or cancellation honestly."
+)
+
+
+def augment_system_prompt_for_terminal_followthrough(system_prompt: Any) -> Any:
+    content = getattr(system_prompt, "content", None)
+    if not isinstance(content, str):
+        return system_prompt
+    if _TERMINAL_FOLLOWTHROUGH_SYSTEM_NOTE in content:
+        return system_prompt
+    # @@@terminal-followthrough-system-note - live models can otherwise treat
+    # terminal background notifications as internal reminders and emit no
+    # assistant text, leaving caller surfaces notice-only.
+    return system_prompt.__class__(content=f"{content}\n\n{_TERMINAL_FOLLOWTHROUGH_SYSTEM_NOTE}")
+
+
+def is_terminal_background_notification_message(
+    message: str,
+    *,
+    source: str | None,
+    notification_type: str | None,
+) -> bool:
+    if source not in {"system", "external"}:
+        return False
+    if notification_type not in {"agent", "command", "chat"}:
+        return False
+    return "<system-reminder>" in message or bool(message.strip())
+
+
+async def build_initial_input(
+    *,
+    message: str,
+    message_metadata: dict[str, Any] | None,
+    input_messages: list[Any] | None,
+    agent: Any,
+    app: Any,
+    thread_id: str,
+    emit_queued_terminal_followups: Callable[..., Awaitable[list[dict[str, str | None]]]] | None,
+) -> tuple[dict[str, Any], Callable[[], None]]:
+    meta = message_metadata or {}
+    src = meta.get("source")
+    ntype = meta.get("notification_type")
+
+    original_system_prompt = None
+
+    def prompt_restore() -> None:
+        nonlocal original_system_prompt
+        if original_system_prompt is not None and hasattr(agent, "agent") and hasattr(agent.agent, "system_prompt"):
+            agent.agent.system_prompt = original_system_prompt
+
+    terminal_followthrough_items: list[dict[str, str | None]] | None = None
+    # @@@terminal-followthrough-reentry - terminal background completions
+    # still surface as durable notices first, but they must then re-enter the
+    # model as a real followthrough turn instead of terminating at notice-only.
+    if is_terminal_background_notification_message(
+        message,
+        source=src,
+        notification_type=ntype,
+    ):
+        terminal_followthrough_items = [
+            {
+                "content": message,
+                "source": src or "system",
+                "notification_type": ntype,
+            }
+        ]
+        if emit_queued_terminal_followups is not None:
+            terminal_followthrough_items.extend(await emit_queued_terminal_followups(app=app, thread_id=thread_id, emit=None))
+        if hasattr(agent, "agent") and hasattr(agent.agent, "system_prompt"):
+            original_system_prompt = agent.agent.system_prompt
+            agent.agent.system_prompt = augment_system_prompt_for_terminal_followthrough(original_system_prompt)
+
+    if terminal_followthrough_items:
+        from langchain_core.messages import HumanMessage
+
+        initial_input: dict[str, Any] = {
+            "messages": [
+                HumanMessage(
+                    content=str(item["content"] or ""),
+                    metadata={
+                        "source": item["source"] or "system",
+                        "notification_type": item["notification_type"],
+                    },
+                )
+                for item in terminal_followthrough_items
+            ]
+        }
+    elif input_messages is not None:
+        initial_input = {"messages": input_messages}
+    elif message_metadata:
+        from langchain_core.messages import HumanMessage
+
+        initial_input = {"messages": [HumanMessage(content=message, metadata=message_metadata)]}
+    else:
+        initial_input = {"messages": [{"role": "user", "content": message}]}
+
+    return initial_input, prompt_restore

--- a/backend/thread_runtime/run/input_construction.py
+++ b/backend/thread_runtime/run/input_construction.py
@@ -49,6 +49,7 @@ async def build_initial_input(
     agent: Any,
     app: Any,
     thread_id: str,
+    emit: Callable[[dict[str, str], str | None], Awaitable[None]] | None,
     emit_queued_terminal_followups: Callable[..., Awaitable[list[dict[str, str | None]]]] | None,
 ) -> tuple[dict[str, Any], Callable[[], None]]:
     meta = message_metadata or {}
@@ -79,7 +80,7 @@ async def build_initial_input(
             }
         ]
         if emit_queued_terminal_followups is not None:
-            terminal_followthrough_items.extend(await emit_queued_terminal_followups(app=app, thread_id=thread_id, emit=None))
+            terminal_followthrough_items.extend(await emit_queued_terminal_followups(app=app, thread_id=thread_id, emit=emit))
         if hasattr(agent, "agent") and hasattr(agent.agent, "system_prompt"):
             original_system_prompt = agent.agent.system_prompt
             agent.agent.system_prompt = augment_system_prompt_for_terminal_followthrough(original_system_prompt)

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -206,6 +206,10 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     pending_tool_calls: dict[str, dict] = {}
     output_parts: list[str] = []
     trajectory_status = "completed"
+
+    def prompt_restore() -> None:
+        return None
+
     try:
         config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
         if hasattr(agent, "_current_model_config"):
@@ -281,6 +285,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
             agent=agent,
             app=app,
             thread_id=thread_id,
+            emit=emit,
             emit_queued_terminal_followups=_emit_queued_terminal_followups,
         )
 

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -13,6 +13,7 @@ from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import emit as _run_emit
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
 from backend.thread_runtime.run import followups as _run_followups
+from backend.thread_runtime.run import input_construction as _run_input_construction
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.thread_runtime.run import observation as _run_observation
 from backend.thread_runtime.run import observer as _run_observer
@@ -30,16 +31,6 @@ logger = logging.getLogger(__name__)
 
 type SSEEvent = dict[str, str | int]
 
-_TERMINAL_FOLLOWTHROUGH_SYSTEM_NOTE = (
-    "Terminal background completion notifications require an explicit assistant followthrough. "
-    "Treat these notifications as fresh inputs that need a visible assistant reply. "
-    "You must produce at least one visible assistant message for them; "
-    "do not stay silent and do not end the run after only surfacing a notice. "
-    "Do not call TaskOutput or TaskStop for a terminal notification. "
-    "If no further tool is truly needed, answer directly in natural language "
-    "and briefly acknowledge the completion, failure, or cancellation honestly."
-)
-
 
 def _log_captured_exception(message: str, err: BaseException) -> None:
     logger.error(
@@ -53,15 +44,7 @@ def _resolve_run_event_repo(agent: Any) -> RunEventRepo:
 
 
 def _augment_system_prompt_for_terminal_followthrough(system_prompt: Any) -> Any:
-    content = getattr(system_prompt, "content", None)
-    if not isinstance(content, str):
-        return system_prompt
-    if _TERMINAL_FOLLOWTHROUGH_SYSTEM_NOTE in content:
-        return system_prompt
-    # @@@terminal-followthrough-system-note - live models can otherwise treat
-    # terminal background notifications as internal reminders and emit no
-    # assistant text, leaving caller surfaces notice-only.
-    return system_prompt.__class__(content=f"{content}\n\n{_TERMINAL_FOLLOWTHROUGH_SYSTEM_NOTE}")
+    return _run_input_construction.augment_system_prompt_for_terminal_followthrough(system_prompt)
 
 
 async def prime_sandbox(agent: Any, thread_id: str) -> None:
@@ -223,7 +206,6 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     pending_tool_calls: dict[str, dict] = {}
     output_parts: list[str] = []
     trajectory_status = "completed"
-    original_system_prompt = None
     try:
         config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
         if hasattr(agent, "_current_model_config"):
@@ -292,50 +274,15 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
             emit=emit,
         )
 
-        terminal_followthrough_items: list[dict[str, str | None]] | None = None
-        # @@@terminal-followthrough-reentry - terminal background completions
-        # still surface as durable notices first, but they must then re-enter the
-        # model as a real followthrough turn instead of terminating at notice-only.
-        if _is_terminal_background_notification_message(
-            message,
-            source=src,
-            notification_type=ntype,
-        ):
-            terminal_followthrough_items = [
-                {
-                    "content": message,
-                    "source": src or "system",
-                    "notification_type": ntype,
-                }
-            ]
-            terminal_followthrough_items.extend(await _emit_queued_terminal_followups(app=app, thread_id=thread_id, emit=emit))
-            if hasattr(agent, "agent") and hasattr(agent.agent, "system_prompt"):
-                original_system_prompt = agent.agent.system_prompt
-                agent.agent.system_prompt = _augment_system_prompt_for_terminal_followthrough(original_system_prompt)
-
-        if terminal_followthrough_items:
-            from langchain_core.messages import HumanMessage
-
-            _initial_input = {
-                "messages": [
-                    HumanMessage(
-                        content=str(item["content"] or ""),
-                        metadata={
-                            "source": item["source"] or "system",
-                            "notification_type": item["notification_type"],
-                        },
-                    )
-                    for item in terminal_followthrough_items
-                ]
-            }
-        elif input_messages is not None:
-            _initial_input = {"messages": input_messages}
-        elif message_metadata:
-            from langchain_core.messages import HumanMessage
-
-            _initial_input: dict | None = {"messages": [HumanMessage(content=message, metadata=message_metadata)]}
-        else:
-            _initial_input = {"messages": [{"role": "user", "content": message}]}
+        _initial_input, prompt_restore = await _run_input_construction.build_initial_input(
+            message=message,
+            message_metadata=message_metadata,
+            input_messages=input_messages,
+            agent=agent,
+            app=app,
+            thread_id=thread_id,
+            emit_queued_terminal_followups=_emit_queued_terminal_followups,
+        )
 
         async def run_agent_stream(input_data: dict | None = _initial_input):
             chunk_count = 0
@@ -683,8 +630,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
         return ""
     finally:
-        if original_system_prompt is not None and hasattr(agent, "agent") and hasattr(agent.agent, "system_prompt"):
-            agent.agent.system_prompt = original_system_prompt
+        prompt_restore()
         # @@@typing-lifecycle-stop — guaranteed cleanup even on crash/cancel
         typing_tracker = getattr(app.state, "typing_tracker", None)
         if typing_tracker is not None:

--- a/tests/Unit/backend/thread_runtime/run/test_input_construction.py
+++ b/tests/Unit/backend/thread_runtime/run/test_input_construction.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_build_initial_input_prefers_explicit_input_messages() -> None:
+    from backend.thread_runtime.run.input_construction import build_initial_input
+
+    input_messages = [object()]
+    initial_input, prompt_restore = asyncio.run(
+        build_initial_input(
+            message="hello",
+            message_metadata={"source": "owner"},
+            input_messages=input_messages,
+            agent=SimpleNamespace(),
+            app=SimpleNamespace(),
+            thread_id="thread-1",
+            emit_queued_terminal_followups=None,
+        )
+    )
+
+    assert initial_input == {"messages": input_messages}
+    prompt_restore()
+
+
+def test_build_initial_input_wraps_message_metadata_when_present() -> None:
+    from backend.thread_runtime.run.input_construction import build_initial_input
+
+    initial_input, _prompt_restore = asyncio.run(
+        build_initial_input(
+            message="hello",
+            message_metadata={"source": "system", "notification_type": "agent"},
+            input_messages=None,
+            agent=SimpleNamespace(),
+            app=SimpleNamespace(),
+            thread_id="thread-1",
+            emit_queued_terminal_followups=None,
+        )
+    )
+
+    messages = initial_input["messages"]
+    assert len(messages) == 1
+    assert messages[0].content == "hello"
+    assert messages[0].metadata == {"source": "system", "notification_type": "agent"}
+
+
+@pytest.mark.asyncio
+async def test_build_initial_input_adds_terminal_followthrough_system_note_and_queued_items() -> None:
+    from backend.thread_runtime.run.input_construction import build_initial_input
+
+    queued = [
+        {
+            "content": "queued notification",
+            "source": "system",
+            "notification_type": "agent",
+        }
+    ]
+
+    async def emit_queued_terminal_followups(*, app, thread_id, emit):
+        assert app is not None
+        assert thread_id == "thread-1"
+        assert emit is None
+        return queued
+
+    agent = SimpleNamespace(agent=SimpleNamespace(system_prompt=SimpleNamespace(content="base prompt")))
+    initial_input, prompt_restore = await build_initial_input(
+        message="terminal done",
+        message_metadata={"source": "system", "notification_type": "command"},
+        input_messages=None,
+        agent=agent,
+        app=SimpleNamespace(),
+        thread_id="thread-1",
+        emit_queued_terminal_followups=emit_queued_terminal_followups,
+    )
+
+    messages = initial_input["messages"]
+    assert [message.content for message in messages] == ["terminal done", "queued notification"]
+    assert agent.agent.system_prompt.content != "base prompt"
+    assert "explicit assistant followthrough" in agent.agent.system_prompt.content
+
+    prompt_restore()
+    assert agent.agent.system_prompt.content == "base prompt"

--- a/tests/Unit/backend/thread_runtime/run/test_input_construction.py
+++ b/tests/Unit/backend/thread_runtime/run/test_input_construction.py
@@ -18,6 +18,7 @@ def test_build_initial_input_prefers_explicit_input_messages() -> None:
             agent=SimpleNamespace(),
             app=SimpleNamespace(),
             thread_id="thread-1",
+            emit=None,
             emit_queued_terminal_followups=None,
         )
     )
@@ -37,6 +38,7 @@ def test_build_initial_input_wraps_message_metadata_when_present() -> None:
             agent=SimpleNamespace(),
             app=SimpleNamespace(),
             thread_id="thread-1",
+            emit=None,
             emit_queued_terminal_followups=None,
         )
     )
@@ -62,7 +64,7 @@ async def test_build_initial_input_adds_terminal_followthrough_system_note_and_q
     async def emit_queued_terminal_followups(*, app, thread_id, emit):
         assert app is not None
         assert thread_id == "thread-1"
-        assert emit is None
+        assert emit is not None
         return queued
 
     agent = SimpleNamespace(agent=SimpleNamespace(system_prompt=SimpleNamespace(content="base prompt")))
@@ -73,6 +75,7 @@ async def test_build_initial_input_adds_terminal_followthrough_system_note_and_q
         agent=agent,
         app=SimpleNamespace(),
         thread_id="thread-1",
+        emit=lambda *_args, **_kwargs: None,
         emit_queued_terminal_followups=emit_queued_terminal_followups,
     )
 

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -189,3 +189,11 @@ def test_streaming_service_uses_thread_runtime_prologue_owner() -> None:
 
     assert owner_module.emit_run_prologue is not None
     assert "from backend.thread_runtime.run import prologue as _run_prologue" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_input_construction_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.input_construction")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.build_initial_input is not None
+    assert "from backend.thread_runtime.run import input_construction as _run_input_construction" in streaming_source


### PR DESCRIPTION
## Summary
- move `_initial_input` building and terminal followthrough prompt mutation into `backend/thread_runtime/run/input_construction.py`
- retarget `_run_agent_to_buffer` to the new input-construction owner without changing stream-loop behavior
- add owner smoke plus direct input-construction coverage for priority order and terminal followthrough queued items

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_input_construction.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_run_agent_to_buffer_adds_terminal_followthrough_system_note_to_prevent_silent_completion or test_run_agent_to_buffer_turns_silent_terminal_reentry_into_visible_followthrough" -q`
- `uv run ruff check backend/thread_runtime/run/input_construction.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_input_construction.py`
- `uv run ruff format --check backend/thread_runtime/run/input_construction.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_input_construction.py`
- `git diff --check`
