### PR TITLE
refactor: move thread runtime tool call dedup

### DIFF
--- a/backend/thread_runtime/run/tool_call_dedup.py
+++ b/backend/thread_runtime/run/tool_call_dedup.py
@@ -1,0 +1,34 @@
+"""Tool-call dedup helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ToolCallDedup:
+    def __init__(self) -> None:
+        self._checkpoint_ids: set[str] = set()
+        self._emitted_ids: set[str] = set()
+
+    async def prepopulate_from_checkpoint(self, agent: Any, config: dict[str, Any]) -> None:
+        pre_state = await agent.agent.aget_state(config)
+        if not pre_state or not pre_state.values:
+            return
+        for msg in pre_state.values.get("messages", []):
+            if msg.__class__.__name__ != "AIMessage":
+                continue
+            for tc in getattr(msg, "tool_calls", []):
+                tc_id = tc.get("id")
+                if tc_id:
+                    self._checkpoint_ids.add(tc_id)
+                    self._emitted_ids.add(tc_id)
+
+    def is_duplicate(self, tc_id: str | None) -> bool:
+        return bool(tc_id) and tc_id in self._checkpoint_ids
+
+    def already_emitted(self, tc_id: str | None) -> bool:
+        return bool(tc_id) and tc_id in self._emitted_ids
+
+    def register(self, tc_id: str | None) -> None:
+        if tc_id:
+            self._emitted_ids.add(tc_id)

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -18,6 +18,7 @@ from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.thread_runtime.run import observation as _run_observation
 from backend.thread_runtime.run import observer as _run_observer
 from backend.thread_runtime.run import prologue as _run_prologue
+from backend.thread_runtime.run import tool_call_dedup as _run_tool_call_dedup
 from backend.thread_runtime.run import trajectory as _run_trajectory
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
@@ -244,24 +245,17 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         if hasattr(agent, "_sandbox") and message_metadata and message_metadata.get("attachments"):
             await prime_sandbox(agent, thread_id)
 
-        emitted_tool_call_ids: set[str] = set()
-
-        # @@@checkpoint-dedup — pre-populate from checkpoint so replayed tool_calls
-        # and their ToolMessages from astream(None) are skipped.
-        checkpoint_tc_ids: set[str] = set()
+        dedup = _run_tool_call_dedup.ToolCallDedup()
         try:
-            pre_state = await agent.agent.aget_state(config)
-            if pre_state and pre_state.values:
-                for msg in pre_state.values.get("messages", []):
-                    if msg.__class__.__name__ == "AIMessage":
-                        for tc in getattr(msg, "tool_calls", []):
-                            tc_id = tc.get("id")
-                            if tc_id:
-                                checkpoint_tc_ids.add(tc_id)
+            # @@@checkpoint-dedup — pre-populate from checkpoint so replayed tool_calls
+            # and their ToolMessages from astream(None) are skipped.
+            await dedup.prepopulate_from_checkpoint(agent, config)
         except Exception:
             logger.warning("[stream:checkpoint] failed to pre-populate tc_ids for thread=%s", thread_id[:15], exc_info=True)
-        emitted_tool_call_ids.update(checkpoint_tc_ids)
-        logger.debug("[stream:checkpoint] thread=%s pre-populated %d tc_ids", thread_id[:15], len(checkpoint_tc_ids))
+        logger.debug(
+            "[stream:checkpoint] thread=%s pre-populated dedup state",
+            thread_id[:15],
+        )
 
         # Repair broken thread state: if last AIMessage has tool_calls without
         # matching ToolMessages, inject synthetic error ToolMessages so the LLM
@@ -386,8 +380,8 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
                         for tc_chunk in getattr(msg_chunk, "tool_call_chunks", []):
                             tc_id = tc_chunk.get("id")
                             tc_name = tc_chunk.get("name", "")
-                            if tc_id and tc_name and tc_id not in emitted_tool_call_ids:
-                                emitted_tool_call_ids.add(tc_id)
+                            if tc_id and tc_name and not dedup.already_emitted(tc_id):
+                                dedup.register(tc_id)
                                 pending_tool_calls[tc_id] = {"name": tc_name, "args": {}}
                                 tc_data: dict[str, Any] = {
                                     "id": tc_id,
@@ -461,16 +455,16 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
                                         "[stream:update] tc=%s name=%s dup=%s chk=%s thread=%s",
                                         tc_id or "?",
                                         tc_name,
-                                        tc_id in emitted_tool_call_ids,
-                                        tc_id in checkpoint_tc_ids,
+                                        dedup.already_emitted(tc_id),
+                                        dedup.is_duplicate(tc_id),
                                         thread_id,
                                     )
                                     # @@@checkpoint-dedup — skip tool_calls from previous runs
                                     # but allow current run's updates (delivers full args after early emission)
-                                    if tc_id and tc_id in checkpoint_tc_ids:
+                                    if dedup.is_duplicate(tc_id):
                                         continue
-                                    if tc_id and tc_id not in emitted_tool_call_ids:
-                                        emitted_tool_call_ids.add(tc_id)
+                                    if tc_id and not dedup.already_emitted(tc_id):
+                                        dedup.register(tc_id)
                                         pending_tool_calls[tc_id] = {
                                             "name": tc_name,
                                             "args": full_args,
@@ -489,7 +483,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
                                 tc_id = getattr(msg, "tool_call_id", None)
                                 tool_msg_id = getattr(msg, "id", None)
                                 # @@@checkpoint-dedup — skip replayed ToolMessages
-                                if tc_id and tc_id in checkpoint_tc_ids:
+                                if dedup.is_duplicate(tc_id):
                                     continue
                                 if tc_id:
                                     pending_tool_calls.pop(tc_id, None)

--- a/tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py
+++ b/tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class AIMessage:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+
+
+class ToolMessage:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_tool_call_dedup_prepopulates_checkpoint_ids_and_tracks_emission_state() -> None:
+    from backend.thread_runtime.run.tool_call_dedup import ToolCallDedup
+
+    agent = SimpleNamespace(
+        agent=SimpleNamespace(
+            aget_state=lambda _config: _fake_state(
+                [
+                    AIMessage([{"id": "tc-checkpoint-1"}, {"id": "tc-checkpoint-2"}]),
+                    ToolMessage(),
+                ]
+            )
+        )
+    )
+
+    dedup = ToolCallDedup()
+    await dedup.prepopulate_from_checkpoint(agent, {"configurable": {"thread_id": "thread-1"}})
+
+    assert dedup.is_duplicate("tc-checkpoint-1") is True
+    assert dedup.is_duplicate("tc-checkpoint-2") is True
+    assert dedup.already_emitted("tc-checkpoint-1") is True
+    assert dedup.already_emitted("tc-new") is False
+
+    dedup.register("tc-live")
+
+    assert dedup.is_duplicate("tc-live") is False
+    assert dedup.already_emitted("tc-live") is True
+
+
+async def _fake_state(messages):
+    return SimpleNamespace(values={"messages": messages})

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -197,3 +197,11 @@ def test_streaming_service_uses_thread_runtime_input_construction_owner() -> Non
 
     assert owner_module.build_initial_input is not None
     assert "from backend.thread_runtime.run import input_construction as _run_input_construction" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_tool_call_dedup_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.tool_call_dedup")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.ToolCallDedup is not None
+    assert "from backend.thread_runtime.run import tool_call_dedup as _run_tool_call_dedup" in streaming_source


### PR DESCRIPTION
## Summary
- move checkpoint/current-run tool call dedup tracking into `backend/thread_runtime/run/tool_call_dedup.py`
- retarget `_run_agent_to_buffer` to the new dedup owner while preserving the existing checkpoint-skip and current-run update semantics
- add owner smoke plus direct dedup coverage for checkpoint prepopulation and current-run emission state

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run ruff check backend/thread_runtime/run/tool_call_dedup.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py`
- `uv run ruff format --check backend/thread_runtime/run/tool_call_dedup.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py`
- `git diff --check`
