### PR TITLE
refactor: move thread runtime epilogue

### DIFF
--- a/backend/thread_runtime/run/epilogue.py
+++ b/backend/thread_runtime/run/epilogue.py
@@ -1,0 +1,41 @@
+"""Run epilogue helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+
+
+async def emit_run_epilogue(
+    *,
+    emit: Callable[[dict[str, str]], Awaitable[None]],
+    thread_id: str,
+    run_id: str,
+    outcome: str,
+    payload: dict[str, object],
+) -> None:
+    if outcome == "success":
+        await emit(
+            {
+                "event": "status",
+                "data": json.dumps(payload["status"], ensure_ascii=False),
+            }
+        )
+    elif outcome == "cancelled":
+        await emit(
+            {
+                "event": "cancelled",
+                "data": json.dumps(
+                    {
+                        "message": "Run cancelled by user",
+                        "cancelled_tool_call_ids": payload["cancelled_tool_call_ids"],
+                    }
+                ),
+            }
+        )
+    elif outcome == "error":
+        await emit({"event": "error", "data": json.dumps({"error": payload["error"]}, ensure_ascii=False)})
+    else:
+        raise RuntimeError(f"unsupported run epilogue outcome: {outcome}")
+
+    await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -1,7 +1,6 @@
 """SSE streaming service for agent execution."""
 
 import asyncio
-import json
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -11,6 +10,7 @@ from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import emit as _run_emit
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
+from backend.thread_runtime.run import epilogue as _run_epilogue
 from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import input_construction as _run_input_construction
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
@@ -296,11 +296,12 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
 
         # Final status
         if hasattr(agent, "runtime"):
-            await emit(
-                {
-                    "event": "status",
-                    "data": json.dumps(agent.runtime.get_status_dict(), ensure_ascii=False),
-                }
+            await _run_epilogue.emit_run_epilogue(
+                emit=emit,
+                thread_id=thread_id,
+                run_id=run_id,
+                outcome="success",
+                payload={"status": agent.runtime.get_status_dict()},
             )
 
         # Persist trajectory
@@ -316,8 +317,6 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         # run_id is available from run_start SSE event; no need to patch checkpoint.
         # See: https://github.com/langchain-ai/langgraph/issues/XXX
 
-        # A5: emit run_done instead of done (persistent buffer — no mark_done)
-        await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
         return "".join(output_parts).strip()
     except asyncio.CancelledError:
         if trajectory_scope is not None:
@@ -338,19 +337,13 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
             thread_id=thread_id,
             app=app,
         )
-        await emit(
-            {
-                "event": "cancelled",
-                "data": json.dumps(
-                    {
-                        "message": "Run cancelled by user",
-                        "cancelled_tool_call_ids": cancelled_tool_call_ids,
-                    }
-                ),
-            }
+        await _run_epilogue.emit_run_epilogue(
+            emit=emit,
+            thread_id=thread_id,
+            run_id=run_id,
+            outcome="cancelled",
+            payload={"cancelled_tool_call_ids": cancelled_tool_call_ids},
         )
-        # Also emit run_done so frontend knows the run ended
-        await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
         return ""
     except Exception as e:
         if trajectory_scope is not None:
@@ -362,8 +355,13 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
             f"[streaming] run failed for thread {thread_id}",
             e,
         )
-        await emit({"event": "error", "data": json.dumps({"error": str(e)}, ensure_ascii=False)})
-        await emit({"event": "run_done", "data": json.dumps({"thread_id": thread_id, "run_id": run_id})})
+        await _run_epilogue.emit_run_epilogue(
+            emit=emit,
+            thread_id=thread_id,
+            run_id=run_id,
+            outcome="error",
+            payload={"error": str(e)},
+        )
         return ""
     finally:
         prompt_restore()

--- a/tests/Unit/backend/thread_runtime/run/test_epilogue.py
+++ b/tests/Unit/backend/thread_runtime/run/test_epilogue.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _decode(events: list[dict[str, str]]) -> list[tuple[str, dict[str, object]]]:
+    return [(event["event"], json.loads(event["data"])) for event in events]
+
+
+@pytest.mark.asyncio
+async def test_emit_run_epilogue_success_emits_status_then_run_done() -> None:
+    from backend.thread_runtime.run.epilogue import emit_run_epilogue
+
+    events: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        events.append(event)
+
+    await emit_run_epilogue(
+        emit=emit,
+        thread_id="thread-1",
+        run_id="run-1",
+        outcome="success",
+        payload={"status": {"state": {"state": "idle", "flags": {}}, "calls": 0}},
+    )
+
+    assert _decode(events) == [
+        ("status", {"state": {"state": "idle", "flags": {}}, "calls": 0}),
+        ("run_done", {"thread_id": "thread-1", "run_id": "run-1"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emit_run_epilogue_cancelled_emits_cancelled_then_run_done() -> None:
+    from backend.thread_runtime.run.epilogue import emit_run_epilogue
+
+    events: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        events.append(event)
+
+    await emit_run_epilogue(
+        emit=emit,
+        thread_id="thread-1",
+        run_id="run-1",
+        outcome="cancelled",
+        payload={"cancelled_tool_call_ids": ["tc-1"]},
+    )
+
+    assert _decode(events) == [
+        ("cancelled", {"message": "Run cancelled by user", "cancelled_tool_call_ids": ["tc-1"]}),
+        ("run_done", {"thread_id": "thread-1", "run_id": "run-1"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emit_run_epilogue_error_emits_error_then_run_done() -> None:
+    from backend.thread_runtime.run.epilogue import emit_run_epilogue
+
+    events: list[dict[str, str]] = []
+
+    async def emit(event: dict[str, str]) -> None:
+        events.append(event)
+
+    await emit_run_epilogue(
+        emit=emit,
+        thread_id="thread-1",
+        run_id="run-1",
+        outcome="error",
+        payload={"error": "boom"},
+    )
+
+    assert _decode(events) == [
+        ("error", {"error": "boom"}),
+        ("run_done", {"thread_id": "thread-1", "run_id": "run-1"}),
+    ]

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -213,3 +213,11 @@ def test_streaming_service_uses_thread_runtime_stream_loop_owner() -> None:
 
     assert owner_module.run_stream_loop is not None
     assert "from backend.thread_runtime.run import stream_loop as _run_stream_loop" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_epilogue_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.epilogue")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.emit_run_epilogue is not None
+    assert "from backend.thread_runtime.run import epilogue as _run_epilogue" in streaming_source


### PR DESCRIPTION
## Summary
- move success/cancel/error final event emission into `backend/thread_runtime/run/epilogue.py`
- retarget `_run_agent_to_buffer` to the new epilogue owner while leaving trajectory finalization and outer cleanup in place
- add owner smoke plus direct epilogue coverage for success/cancel/error event shapes

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_epilogue.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_run_agent_to_buffer_logs_real_stream_error_without_none_traceback_noise or test_cancelled_midrun_steer_persists_and_does_not_poison_next_turn" -q`
- `uv run ruff check backend/thread_runtime/run/epilogue.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_epilogue.py`
- `uv run ruff format --check backend/thread_runtime/run/epilogue.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/thread_runtime/run/test_epilogue.py`
- `git diff --check`
