### PR TITLE
refactor: move thread runtime execution owner

### DIFF
--- a/backend/thread_runtime/run/execution.py
+++ b/backend/thread_runtime/run/execution.py
@@ -1,0 +1,220 @@
+"""Execution orchestration helpers for thread runtime runs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from backend.thread_runtime.run import activity_bridge as _run_activity_bridge
+from backend.thread_runtime.run import emit as _run_emit
+from backend.thread_runtime.run import epilogue as _run_epilogue
+from backend.thread_runtime.run import input_construction as _run_input_construction
+from backend.thread_runtime.run import observation as _run_observation
+from backend.thread_runtime.run import prologue as _run_prologue
+from backend.thread_runtime.run import stream_loop as _run_stream_loop
+from backend.thread_runtime.run import tool_call_dedup as _run_tool_call_dedup
+from backend.thread_runtime.run import trajectory as _run_trajectory
+from core.runtime.middleware.monitor import AgentState
+from sandbox.thread_context import set_current_run_id, set_current_thread_id
+
+logger = logging.getLogger(__name__)
+
+
+async def _unbound_async(*_args, **_kwargs):
+    raise RuntimeError("thread runtime execution helper was not bound")
+
+
+def _unbound_sync(*_args, **_kwargs):
+    raise RuntimeError("thread runtime execution helper was not bound")
+
+
+ensure_thread_handlers = _unbound_sync
+prime_sandbox = _unbound_async
+repair_incomplete_tool_calls = _unbound_async
+write_cancellation_markers = _unbound_async
+persist_cancelled_run_input_if_missing = _unbound_async
+flush_cancelled_owner_steers = _unbound_async
+emit_queued_terminal_followups = _unbound_async
+consume_followup_queue = _unbound_async
+cleanup_old_runs = _unbound_async
+log_captured_exception = _unbound_sync
+
+
+async def run_agent_to_buffer(
+    agent: Any,
+    thread_id: str,
+    message: str,
+    app: Any,
+    enable_trajectory: bool,
+    thread_buf: Any,
+    run_id: str,
+    message_metadata: dict[str, Any] | None = None,
+    input_messages: list[Any] | None = None,
+) -> str:
+    run_event_repo = _run_emit.resolve_run_event_repo(agent)
+    display_builder = app.state.display_builder
+    emit = _run_emit.build_emit(
+        thread_id=thread_id,
+        run_id=run_id,
+        thread_buf=thread_buf,
+        run_event_repo=run_event_repo,
+        display_builder=display_builder,
+    )
+
+    pending_tool_calls: dict[str, dict] = {}
+    output_parts: list[str] = []
+    trajectory_status = "completed"
+
+    def prompt_restore() -> None:
+        return None
+
+    try:
+        config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
+        if hasattr(agent, "_current_model_config"):
+            config["configurable"].update(agent._current_model_config)
+        set_current_thread_id(thread_id)
+        set_current_run_id(run_id)
+
+        trajectory_scope = _run_trajectory.build_trajectory_scope(
+            agent=agent,
+            thread_id=thread_id,
+            run_id=run_id,
+            user_message=message,
+            enable_trajectory=enable_trajectory,
+        )
+        if trajectory_scope is not None:
+            trajectory_scope.inject_callback(config)
+
+        _obs_handler, _obs_active, flush_observation = _run_observation.build_observation(app, thread_id, config)
+
+        drain_activity_events, attach_activity_bridge, detach_activity_bridge = _run_activity_bridge.build_activity_bridge(
+            runtime=getattr(agent, "runtime", None),
+            emit=emit,
+        )
+        attach_activity_bridge()
+
+        ensure_thread_handlers(agent, thread_id, app)
+
+        if hasattr(agent, "_sandbox") and message_metadata and message_metadata.get("attachments"):
+            await prime_sandbox(agent, thread_id)
+
+        dedup = _run_tool_call_dedup.ToolCallDedup()
+        try:
+            await dedup.prepopulate_from_checkpoint(agent, config)
+        except Exception:
+            logger.warning("[stream:checkpoint] failed to pre-populate tc_ids for thread=%s", thread_id[:15], exc_info=True)
+        logger.debug("[stream:checkpoint] thread=%s pre-populated dedup state", thread_id[:15])
+
+        await repair_incomplete_tool_calls(agent, config)
+
+        await _run_prologue.emit_run_prologue(
+            agent=agent,
+            thread_id=thread_id,
+            message=message,
+            message_metadata=message_metadata,
+            run_id=run_id,
+            app=app,
+            emit=emit,
+        )
+
+        _initial_input, prompt_restore = await _run_input_construction.build_initial_input(
+            message=message,
+            message_metadata=message_metadata,
+            input_messages=input_messages,
+            agent=agent,
+            app=app,
+            thread_id=thread_id,
+            emit=emit,
+            emit_queued_terminal_followups=emit_queued_terminal_followups,
+        )
+
+        trajectory_status = await _run_stream_loop.run_stream_loop(
+            agent=agent,
+            config=config,
+            initial_input=_initial_input,
+            emit=emit,
+            dedup=dedup,
+            drain_activity_events=drain_activity_events,
+            pending_tool_calls=pending_tool_calls,
+            output_parts=output_parts,
+            thread_id=thread_id,
+            run_id=run_id,
+            log_captured_exception=log_captured_exception,
+        )
+
+        if hasattr(agent, "runtime"):
+            await _run_epilogue.emit_run_epilogue(
+                emit=emit,
+                thread_id=thread_id,
+                run_id=run_id,
+                outcome="success",
+                payload={"status": agent.runtime.get_status_dict()},
+            )
+
+        if trajectory_scope is not None:
+            try:
+                trajectory_scope.finalize_success(agent=agent, trajectory_status=trajectory_status)
+            except Exception:
+                logger.error("Failed to persist trajectory for thread %s", thread_id, exc_info=True)
+
+        return "".join(output_parts).strip()
+    except asyncio.CancelledError:
+        if trajectory_scope is not None:
+            try:
+                trajectory_scope.finalize_cancelled()
+            except Exception:
+                logger.error("Failed to finalize cancelled trajectory for thread %s", thread_id, exc_info=True)
+        cancelled_tool_call_ids = await write_cancellation_markers(agent, config, pending_tool_calls)
+        await persist_cancelled_run_input_if_missing(
+            agent=agent,
+            config=config,
+            message=message,
+            message_metadata=message_metadata,
+        )
+        await flush_cancelled_owner_steers(
+            agent=agent,
+            config=config,
+            thread_id=thread_id,
+            app=app,
+        )
+        await _run_epilogue.emit_run_epilogue(
+            emit=emit,
+            thread_id=thread_id,
+            run_id=run_id,
+            outcome="cancelled",
+            payload={"cancelled_tool_call_ids": cancelled_tool_call_ids},
+        )
+        return ""
+    except Exception as e:
+        if trajectory_scope is not None:
+            try:
+                trajectory_scope.finalize_error()
+            except Exception:
+                logger.error("Failed to finalize errored trajectory for thread %s", thread_id, exc_info=True)
+        log_captured_exception(f"[streaming] run failed for thread {thread_id}", e)
+        await _run_epilogue.emit_run_epilogue(
+            emit=emit,
+            thread_id=thread_id,
+            run_id=run_id,
+            outcome="error",
+            payload={"error": str(e)},
+        )
+        return ""
+    finally:
+        prompt_restore()
+        typing_tracker = getattr(app.state, "typing_tracker", None)
+        if typing_tracker is not None:
+            typing_tracker.stop(thread_id)
+        detach_activity_bridge()
+        flush_observation()
+        app.state.thread_tasks.pop(thread_id, None)
+        if agent and hasattr(agent, "runtime") and agent.runtime.current_state == AgentState.ACTIVE:
+            agent.runtime.transition(AgentState.IDLE)
+        try:
+            await cleanup_old_runs(thread_id, keep_latest=1, run_event_repo=run_event_repo)
+        except Exception:
+            logger.warning("Failed to cleanup old runs for thread %s", thread_id, exc_info=True)
+        if run_event_repo is not None:
+            run_event_repo.close()
+        await consume_followup_queue(agent, thread_id, app)

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -11,6 +11,7 @@ from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import emit as _run_emit
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
 from backend.thread_runtime.run import epilogue as _run_epilogue
+from backend.thread_runtime.run import execution as _run_execution
 from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import input_construction as _run_input_construction
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
@@ -191,6 +192,28 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     input_messages: list[Any] | None = None,
 ) -> str:
     """Run agent execution and write all SSE events into *thread_buf*."""
+    _run_execution.ensure_thread_handlers = _ensure_thread_handlers
+    _run_execution.prime_sandbox = prime_sandbox
+    _run_execution.repair_incomplete_tool_calls = _repair_incomplete_tool_calls
+    _run_execution.write_cancellation_markers = write_cancellation_markers
+    _run_execution.persist_cancelled_run_input_if_missing = _persist_cancelled_run_input_if_missing
+    _run_execution.flush_cancelled_owner_steers = _flush_cancelled_owner_steers
+    _run_execution.emit_queued_terminal_followups = _emit_queued_terminal_followups
+    _run_execution.consume_followup_queue = _consume_followup_queue
+    _run_execution.cleanup_old_runs = cleanup_old_runs
+    _run_execution.log_captured_exception = _log_captured_exception
+    return await _run_execution.run_agent_to_buffer(
+        agent=agent,
+        thread_id=thread_id,
+        message=message,
+        app=app,
+        enable_trajectory=enable_trajectory,
+        thread_buf=thread_buf,
+        run_id=run_id,
+        message_metadata=message_metadata,
+        input_messages=input_messages,
+    )
+
     run_event_repo = _resolve_run_event_repo(agent)
     display_builder = app.state.display_builder
     emit = _run_emit.build_emit(

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -221,3 +221,11 @@ def test_streaming_service_uses_thread_runtime_epilogue_owner() -> None:
 
     assert owner_module.emit_run_epilogue is not None
     assert "from backend.thread_runtime.run import epilogue as _run_epilogue" in streaming_source
+
+
+def test_streaming_service_uses_thread_runtime_execution_owner() -> None:
+    owner_module = importlib.import_module("backend.thread_runtime.run.execution")
+    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+
+    assert owner_module.run_agent_to_buffer is not None
+    assert "from backend.thread_runtime.run import execution as _run_execution" in streaming_source


### PR DESCRIPTION
## Summary
- move the remaining `_run_agent_to_buffer` orchestration body into `backend/thread_runtime/run/execution.py`
- keep `backend/web/services/streaming_service.py` as the compat wrapper that binds the existing patch seams into the execution owner
- preserve current stream-loop, epilogue, and cancellation behavior while shrinking the web-owned body to a delegation layer

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_cancelled_midrun_steer_persists_and_does_not_poison_next_turn or test_run_agent_to_buffer_tags_display_delta_with_source_seq or test_run_agent_to_buffer_logs_real_stream_error_without_none_traceback_noise or test_run_agent_to_buffer_drains_activity_notice_before_stream_error" -q`
- `uv run ruff check backend/thread_runtime/run/execution.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/run/execution.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`
