### PR TITLE
refactor: reduce streaming service to compat shell

### DIFF
--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -1,31 +1,21 @@
 """SSE streaming service for agent execution."""
 
-import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from backend.thread_runtime.run import activity_bridge as _run_activity_bridge
 from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import emit as _run_emit
 from backend.thread_runtime.run import entrypoints as _run_entrypoints
-from backend.thread_runtime.run import epilogue as _run_epilogue
 from backend.thread_runtime.run import execution as _run_execution
 from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import input_construction as _run_input_construction
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
-from backend.thread_runtime.run import observation as _run_observation
 from backend.thread_runtime.run import observer as _run_observer
-from backend.thread_runtime.run import prologue as _run_prologue
-from backend.thread_runtime.run import stream_loop as _run_stream_loop
-from backend.thread_runtime.run import tool_call_dedup as _run_tool_call_dedup
-from backend.thread_runtime.run import trajectory as _run_trajectory
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import cleanup_old_runs
-from core.runtime.middleware.monitor import AgentState
 from core.runtime.notifications import is_terminal_background_notification
-from sandbox.thread_context import set_current_run_id, set_current_thread_id
 from storage.contracts import RunEventRepo
 
 logger = logging.getLogger(__name__)
@@ -213,205 +203,6 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         message_metadata=message_metadata,
         input_messages=input_messages,
     )
-
-    run_event_repo = _resolve_run_event_repo(agent)
-    display_builder = app.state.display_builder
-    emit = _run_emit.build_emit(
-        thread_id=thread_id,
-        run_id=run_id,
-        thread_buf=thread_buf,
-        run_event_repo=run_event_repo,
-        display_builder=display_builder,
-    )
-
-    pending_tool_calls: dict[str, dict] = {}
-    output_parts: list[str] = []
-    trajectory_status = "completed"
-
-    def prompt_restore() -> None:
-        return None
-
-    try:
-        config = {"configurable": {"thread_id": thread_id, "run_id": run_id}}
-        if hasattr(agent, "_current_model_config"):
-            config["configurable"].update(agent._current_model_config)
-        set_current_thread_id(thread_id)
-        # @@@web-run-context - web runs have no TUI checkpoint; use run_id to group file ops per run.
-        set_current_run_id(run_id)
-
-        trajectory_scope = _run_trajectory.build_trajectory_scope(
-            agent=agent,
-            thread_id=thread_id,
-            run_id=run_id,
-            user_message=message,
-            enable_trajectory=enable_trajectory,
-        )
-        if trajectory_scope is not None:
-            trajectory_scope.inject_callback(config)
-
-        _obs_handler, _obs_active, flush_observation = _run_observation.build_observation(app, thread_id, config)
-
-        drain_activity_events, attach_activity_bridge, detach_activity_bridge = _run_activity_bridge.build_activity_bridge(
-            runtime=getattr(agent, "runtime", None),
-            emit=emit,
-        )
-        attach_activity_bridge()
-
-        # Bind per-thread handlers (idempotent — safe across runs)
-        _ensure_thread_handlers(agent, thread_id, app)
-
-        # @@@lazy-sandbox — only prime sandbox eagerly when attachments need syncing.
-        # Without attachments, sandbox starts lazily on first tool call.
-        if hasattr(agent, "_sandbox") and message_metadata and message_metadata.get("attachments"):
-            await prime_sandbox(agent, thread_id)
-
-        dedup = _run_tool_call_dedup.ToolCallDedup()
-        try:
-            # @@@checkpoint-dedup — pre-populate from checkpoint so replayed tool_calls
-            # and their ToolMessages from astream(None) are skipped.
-            await dedup.prepopulate_from_checkpoint(agent, config)
-        except Exception:
-            logger.warning("[stream:checkpoint] failed to pre-populate tc_ids for thread=%s", thread_id[:15], exc_info=True)
-        logger.debug(
-            "[stream:checkpoint] thread=%s pre-populated dedup state",
-            thread_id[:15],
-        )
-
-        # Repair broken thread state: if last AIMessage has tool_calls without
-        # matching ToolMessages, inject synthetic error ToolMessages so the LLM
-        # won't reject the message history.
-        await _repair_incomplete_tool_calls(agent, config)
-
-        src, ntype = await _run_prologue.emit_run_prologue(
-            agent=agent,
-            thread_id=thread_id,
-            message=message,
-            message_metadata=message_metadata,
-            run_id=run_id,
-            app=app,
-            emit=emit,
-        )
-
-        _initial_input, prompt_restore = await _run_input_construction.build_initial_input(
-            message=message,
-            message_metadata=message_metadata,
-            input_messages=input_messages,
-            agent=agent,
-            app=app,
-            thread_id=thread_id,
-            emit=emit,
-            emit_queued_terminal_followups=_emit_queued_terminal_followups,
-        )
-
-        trajectory_status = await _run_stream_loop.run_stream_loop(
-            agent=agent,
-            config=config,
-            initial_input=_initial_input,
-            emit=emit,
-            dedup=dedup,
-            drain_activity_events=drain_activity_events,
-            pending_tool_calls=pending_tool_calls,
-            output_parts=output_parts,
-            thread_id=thread_id,
-            run_id=run_id,
-            log_captured_exception=_log_captured_exception,
-        )
-
-        # Final status
-        if hasattr(agent, "runtime"):
-            await _run_epilogue.emit_run_epilogue(
-                emit=emit,
-                thread_id=thread_id,
-                run_id=run_id,
-                outcome="success",
-                payload={"status": agent.runtime.get_status_dict()},
-            )
-
-        # Persist trajectory
-        if trajectory_scope is not None:
-            try:
-                trajectory_scope.finalize_success(agent=agent, trajectory_status=trajectory_status)
-            except Exception:
-                logger.error("Failed to persist trajectory for thread %s", thread_id, exc_info=True)
-
-        # @@@A6-disabled — aupdate_state after a completed run leaves the graph
-        # at __end__, causing the NEXT astream(new_input) to produce 0 chunks.
-        # This broke multi-run threads (e.g. external message delivery).
-        # run_id is available from run_start SSE event; no need to patch checkpoint.
-        # See: https://github.com/langchain-ai/langgraph/issues/XXX
-
-        return "".join(output_parts).strip()
-    except asyncio.CancelledError:
-        if trajectory_scope is not None:
-            try:
-                trajectory_scope.finalize_cancelled()
-            except Exception:
-                logger.error("Failed to finalize cancelled trajectory for thread %s", thread_id, exc_info=True)
-        cancelled_tool_call_ids = await write_cancellation_markers(agent, config, pending_tool_calls)
-        await _persist_cancelled_run_input_if_missing(
-            agent=agent,
-            config=config,
-            message=message,
-            message_metadata=message_metadata,
-        )
-        await _flush_cancelled_owner_steers(
-            agent=agent,
-            config=config,
-            thread_id=thread_id,
-            app=app,
-        )
-        await _run_epilogue.emit_run_epilogue(
-            emit=emit,
-            thread_id=thread_id,
-            run_id=run_id,
-            outcome="cancelled",
-            payload={"cancelled_tool_call_ids": cancelled_tool_call_ids},
-        )
-        return ""
-    except Exception as e:
-        if trajectory_scope is not None:
-            try:
-                trajectory_scope.finalize_error()
-            except Exception:
-                logger.error("Failed to finalize errored trajectory for thread %s", thread_id, exc_info=True)
-        _log_captured_exception(
-            f"[streaming] run failed for thread {thread_id}",
-            e,
-        )
-        await _run_epilogue.emit_run_epilogue(
-            emit=emit,
-            thread_id=thread_id,
-            run_id=run_id,
-            outcome="error",
-            payload={"error": str(e)},
-        )
-        return ""
-    finally:
-        prompt_restore()
-        # @@@typing-lifecycle-stop — guaranteed cleanup even on crash/cancel
-        typing_tracker = getattr(app.state, "typing_tracker", None)
-        if typing_tracker is not None:
-            typing_tracker.stop(thread_id)
-        # Detach per-run event callback (per-thread handlers survive across runs)
-        detach_activity_bridge()
-        # Flush observation handler
-        flush_observation()
-        # ThreadEventBuffer is persistent — do NOT mark_done or pop
-        app.state.thread_tasks.pop(thread_id, None)
-        if agent and hasattr(agent, "runtime") and agent.runtime.current_state == AgentState.ACTIVE:
-            agent.runtime.transition(AgentState.IDLE)
-
-        # Clean up old run events and close repo BEFORE starting followup run,
-        # so the new run gets a fresh connection and there is no closed-repo race.
-        try:
-            await cleanup_old_runs(thread_id, keep_latest=1, run_event_repo=run_event_repo)
-        except Exception:
-            logger.warning("Failed to cleanup old runs for thread %s", thread_id, exc_info=True)
-        if run_event_repo is not None:
-            run_event_repo.close()
-
-        # Consume followup queue: if messages are pending, start a new run
-        await _consume_followup_queue(agent, thread_id, app)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -153,74 +153,74 @@ def test_streaming_service_uses_thread_runtime_sse_observer_owner() -> None:
 
 def test_streaming_service_uses_thread_runtime_trajectory_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.trajectory")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.build_trajectory_scope is not None
-    assert "from backend.thread_runtime.run import trajectory as _run_trajectory" in streaming_source
+    assert "from backend.thread_runtime.run import trajectory as _run_trajectory" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_observation_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.observation")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.build_observation is not None
-    assert "from backend.thread_runtime.run import observation as _run_observation" in streaming_source
+    assert "from backend.thread_runtime.run import observation as _run_observation" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_activity_bridge_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.activity_bridge")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.build_activity_bridge is not None
-    assert "from backend.thread_runtime.run import activity_bridge as _run_activity_bridge" in streaming_source
+    assert "from backend.thread_runtime.run import activity_bridge as _run_activity_bridge" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_emit_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.emit")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.build_emit is not None
-    assert "from backend.thread_runtime.run import emit as _run_emit" in streaming_source
+    assert "from backend.thread_runtime.run import emit as _run_emit" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_prologue_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.prologue")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.emit_run_prologue is not None
-    assert "from backend.thread_runtime.run import prologue as _run_prologue" in streaming_source
+    assert "from backend.thread_runtime.run import prologue as _run_prologue" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_input_construction_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.input_construction")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.build_initial_input is not None
-    assert "from backend.thread_runtime.run import input_construction as _run_input_construction" in streaming_source
+    assert "from backend.thread_runtime.run import input_construction as _run_input_construction" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_tool_call_dedup_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.tool_call_dedup")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.ToolCallDedup is not None
-    assert "from backend.thread_runtime.run import tool_call_dedup as _run_tool_call_dedup" in streaming_source
+    assert "from backend.thread_runtime.run import tool_call_dedup as _run_tool_call_dedup" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_stream_loop_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.stream_loop")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.run_stream_loop is not None
-    assert "from backend.thread_runtime.run import stream_loop as _run_stream_loop" in streaming_source
+    assert "from backend.thread_runtime.run import stream_loop as _run_stream_loop" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_epilogue_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.epilogue")
-    streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
 
     assert owner_module.emit_run_epilogue is not None
-    assert "from backend.thread_runtime.run import epilogue as _run_epilogue" in streaming_source
+    assert "from backend.thread_runtime.run import epilogue as _run_epilogue" in execution_source
 
 
 def test_streaming_service_uses_thread_runtime_execution_owner() -> None:


### PR DESCRIPTION
## Summary
- reduce `backend/web/services/streaming_service.py` to the real compat shell now that execution orchestration lives in `backend/thread_runtime/run/execution.py`
- remove the dead unreachable `_run_agent_to_buffer` body after the execution-owner delegation
- move the run-owner smoke assertions for trajectory/observation/activity/emit/prologue/input/dedup/stream-loop/epilogue from `streaming_service.py` to `execution.py`

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_cancelled_midrun_steer_persists_and_does_not_poison_next_turn or test_run_agent_to_buffer_tags_display_delta_with_source_seq or test_run_agent_to_buffer_logs_real_stream_error_without_none_traceback_noise or test_run_agent_to_buffer_drains_activity_notice_before_stream_error" -q`
- `uv run ruff check backend/thread_runtime/run/execution.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/run/execution.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`
