### PR TITLE
refactor: point thread runtime state at binding owner

### DIFF
--- a/backend/thread_runtime/state.py
+++ b/backend/thread_runtime/state.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any
 
-from backend.web.services.thread_runtime_binding_service import resolve_thread_runtime_binding
+from backend.thread_runtime.binding import resolve_thread_runtime_binding
 
 
 def _display_repo_sandbox_status(runtime_row: dict[str, Any], instance: dict[str, Any]) -> str:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -14,6 +14,7 @@ def test_thread_runtime_namespace_exports_binding_and_state_helpers() -> None:
     assert binding_owner.ThreadRuntimeBindingError is binding_shell.ThreadRuntimeBindingError
     assert state_owner.get_sandbox_info is state_shell.get_sandbox_info
     assert state_owner.get_sandbox_status_from_repos is state_shell.get_sandbox_status_from_repos
+    assert "backend.web.services.thread_runtime_binding_service" not in inspect.getsource(state_owner)
 
 
 def test_agent_pool_uses_thread_runtime_sandbox_owner() -> None:


### PR DESCRIPTION
## Summary
- switch `backend.thread_runtime.state` to import `resolve_thread_runtime_binding` from `backend.thread_runtime.binding` instead of the web compat shell
- keep the web compat shell intact for external callers
- add a source-boundary guard so `backend.thread_runtime.state` no longer references `backend.web.services.thread_runtime_binding_service`

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_thread_state_service.py -q`
- `uv run ruff check backend/thread_runtime/state.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_thread_state_service.py`
- `uv run ruff format --check backend/thread_runtime/state.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_thread_state_service.py`
- `git diff --check`
