### PR TITLE
refactor: use thread runtime event buffer owners

### DIFF
--- a/backend/thread_runtime/run/buffer_wiring.py
+++ b/backend/thread_runtime/run/buffer_wiring.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Any
 
-from backend.web.services.event_buffer import ThreadEventBuffer
+from backend.thread_runtime.events.buffer import ThreadEventBuffer
 from core.runtime.middleware.monitor import AgentState
 
 logger = logging.getLogger(__name__)

--- a/backend/thread_runtime/run/observer.py
+++ b/backend/thread_runtime/run/observer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncGenerator
 
-from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
+from backend.thread_runtime.events.buffer import RunEventBuffer, ThreadEventBuffer
 
 type SSEEvent = dict[str, str | int]
 

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -109,10 +109,12 @@ def test_streaming_service_uses_thread_runtime_run_cancellation_owner() -> None:
 def test_streaming_service_uses_thread_runtime_buffer_wiring_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.buffer_wiring")
     streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    owner_source = inspect.getsource(owner_module)
 
     assert owner_module.get_or_create_thread_buffer is not None
     assert owner_module.ensure_thread_handlers is not None
     assert "from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring" in streaming_source
+    assert "backend.web.services.event_buffer" not in owner_source
 
 
 def test_streaming_service_uses_thread_runtime_run_lifecycle_owner() -> None:
@@ -145,11 +147,13 @@ def test_streaming_service_uses_thread_runtime_run_followups_owner() -> None:
 def test_streaming_service_uses_thread_runtime_sse_observer_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.observer")
     streaming_source = inspect.getsource(importlib.import_module("backend.web.services.streaming_service"))
+    owner_source = inspect.getsource(owner_module)
 
     assert owner_module.observe_thread_events is not None
     assert owner_module.observe_run_events is not None
     assert owner_module.observe_sse_buffer is not None
     assert "from backend.thread_runtime.run import observer as _run_observer" in streaming_source
+    assert "backend.web.services.event_buffer" not in owner_source
 
 
 def test_streaming_service_uses_thread_runtime_trajectory_owner() -> None:


### PR DESCRIPTION
## Summary
- point `backend.thread_runtime.run.buffer_wiring` and `backend.thread_runtime.run.observer` directly at `backend.thread_runtime.events.buffer`
- keep the web compat shell `backend/web/services/event_buffer.py` intact for external callers
- add source-boundary guards proving these two thread-runtime modules no longer import the web event-buffer shell

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py -q`
- `uv run ruff check backend/thread_runtime/run/buffer_wiring.py backend/thread_runtime/run/observer.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/run/buffer_wiring.py backend/thread_runtime/run/observer.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`
