### PR TITLE
refactor: bind buffer wiring start-run seam

### DIFF
--- a/backend/thread_runtime/run/buffer_wiring.py
+++ b/backend/thread_runtime/run/buffer_wiring.py
@@ -11,6 +11,8 @@ from core.runtime.middleware.monitor import AgentState
 
 logger = logging.getLogger(__name__)
 
+_start_agent_run = None
+
 
 def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
     """Get existing or create new ThreadEventBuffer for a thread."""
@@ -102,9 +104,9 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
 
         async def _start_run():
             try:
-                from backend.web.services.streaming_service import start_agent_run
-
-                start_agent_run(
+                if _start_agent_run is None:
+                    raise RuntimeError("thread_runtime.run.buffer_wiring requires _start_agent_run binding")
+                _start_agent_run(
                     agent,
                     thread_id,
                     item.content,

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -69,6 +69,7 @@ def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
 
 
 def _ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
+    _run_buffer_wiring._start_agent_run = start_agent_run
     _run_buffer_wiring.ensure_thread_handlers(agent, thread_id, app)
 
 

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -115,6 +115,7 @@ def test_streaming_service_uses_thread_runtime_buffer_wiring_owner() -> None:
     assert owner_module.ensure_thread_handlers is not None
     assert "from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring" in streaming_source
     assert "backend.web.services.event_buffer" not in owner_source
+    assert "backend.web.services.streaming_service" not in owner_source
 
 
 def test_streaming_service_uses_thread_runtime_run_lifecycle_owner() -> None:


### PR DESCRIPTION
## Summary
- replace the direct `backend.web.services.streaming_service.start_agent_run` import inside `backend.thread_runtime.run.buffer_wiring` with an explicit `_start_agent_run` binding seam
- keep `streaming_service._ensure_thread_handlers` responsible for binding the compat surface into the owner module
- add source-boundary smoke showing `buffer_wiring` no longer imports the web streaming service directly

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_queue_wake_handler_starts_terminal_followthrough_run" -q`
- `uv run ruff check backend/thread_runtime/run/buffer_wiring.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/run/buffer_wiring.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`
