### PR TITLE
refactor: bind event store append seams

### DIFF
--- a/backend/thread_runtime/run/buffer_wiring.py
+++ b/backend/thread_runtime/run/buffer_wiring.py
@@ -12,6 +12,7 @@ from core.runtime.middleware.monitor import AgentState
 logger = logging.getLogger(__name__)
 
 _start_agent_run = None
+_append_event = None
 
 
 def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
@@ -39,9 +40,9 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
     display_builder_ref = app.state.display_builder
 
     async def activity_sink(event: dict) -> None:
-        from backend.web.services.event_store import append_event as _append
-
-        seq = await _append(thread_id, f"activity_{thread_id}", event)
+        if _append_event is None:
+            raise RuntimeError("thread_runtime.run.buffer_wiring requires _append_event binding")
+        seq = await _append_event(thread_id, f"activity_{thread_id}", event)
         try:
             data = json.loads(event.get("data", "{}")) if isinstance(event.get("data"), str) else event.get("data", {})
         except (json.JSONDecodeError, TypeError):

--- a/backend/thread_runtime/run/emit.py
+++ b/backend/thread_runtime/run/emit.py
@@ -6,8 +6,9 @@ import json
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from backend.web.services.event_store import append_event
 from storage.contracts import RunEventRepo
+
+append_event = None
 
 
 def resolve_run_event_repo(agent: Any) -> RunEventRepo:
@@ -34,6 +35,8 @@ def build_emit(
     display_builder: Any,
 ) -> Callable[[dict[str, Any], str | None], Awaitable[None]]:
     async def emit(event: dict[str, Any], message_id: str | None = None) -> None:
+        if append_event is None:
+            raise RuntimeError("thread_runtime.run.emit requires append_event binding")
         seq = await append_event(
             thread_id,
             run_id,

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -14,6 +14,7 @@ from backend.thread_runtime.run import input_construction as _run_input_construc
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.thread_runtime.run import observer as _run_observer
 from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
+from backend.web.services.event_store import append_event as _append_event
 from backend.web.services.event_store import cleanup_old_runs
 from core.runtime.notifications import is_terminal_background_notification
 from storage.contracts import RunEventRepo
@@ -69,6 +70,7 @@ def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
 
 
 def _ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
+    _run_buffer_wiring._append_event = _append_event
     _run_buffer_wiring._start_agent_run = start_agent_run
     _run_buffer_wiring.ensure_thread_handlers(agent, thread_id, app)
 
@@ -193,6 +195,8 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     _run_execution.consume_followup_queue = _consume_followup_queue
     _run_execution.cleanup_old_runs = cleanup_old_runs
     _run_execution.log_captured_exception = _log_captured_exception
+    _run_emit.append_event = _append_event
+    _run_buffer_wiring._append_event = _append_event
     return await _run_execution.run_agent_to_buffer(
         agent=agent,
         thread_id=thread_id,

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -116,6 +116,7 @@ def test_streaming_service_uses_thread_runtime_buffer_wiring_owner() -> None:
     assert "from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring" in streaming_source
     assert "backend.web.services.event_buffer" not in owner_source
     assert "backend.web.services.streaming_service" not in owner_source
+    assert "backend.web.services.event_store" not in owner_source
 
 
 def test_streaming_service_uses_thread_runtime_run_lifecycle_owner() -> None:
@@ -184,9 +185,11 @@ def test_streaming_service_uses_thread_runtime_activity_bridge_owner() -> None:
 def test_streaming_service_uses_thread_runtime_emit_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.run.emit")
     execution_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.execution"))
+    owner_source = inspect.getsource(owner_module)
 
     assert owner_module.build_emit is not None
     assert "from backend.thread_runtime.run import emit as _run_emit" in execution_source
+    assert "backend.web.services.event_store" not in owner_source
 
 
 def test_streaming_service_uses_thread_runtime_prologue_owner() -> None:


### PR DESCRIPTION
## Summary
- replace the direct `backend.web.services.event_store.append_event` imports in `backend.thread_runtime.run.emit` and `backend.thread_runtime.run.buffer_wiring` with explicit append-event binding seams
- bind those seams from `backend/web/services/streaming_service.py` so existing web-side patch points still work
- add source-boundary smoke proving the two owner modules no longer import the web event-store shell directly

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -q`
- `uv run python -m pytest tests/Integration/test_query_loop_backend_contracts.py -k "test_run_agent_to_buffer_tags_display_delta_with_source_seq" -q`
- `uv run ruff check backend/thread_runtime/run/emit.py backend/thread_runtime/run/buffer_wiring.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/run/emit.py backend/thread_runtime/run/buffer_wiring.py backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`
