### PR TITLE
refactor: bind convergence delete seam

### DIFF
--- a/backend/thread_runtime/convergence.py
+++ b/backend/thread_runtime/convergence.py
@@ -7,14 +7,18 @@ from typing import Any
 from backend.thread_runtime.binding import ThreadRuntimeBindingError, resolve_thread_runtime_binding
 
 
-def _delete_thread_in_db(thread_id: str) -> None:
-    # @@@compat-delete-seam - existing web/auth tests monkeypatch
-    # backend.web.services.thread_runtime_convergence.delete_thread_in_db.
-    # Keep the shared convergence path routed through that symbol so the old
-    # patch seam still intercepts purges after this helper move.
-    from backend.web.services import thread_runtime_convergence as compatibility_shell
+def _unbound_delete_thread_in_db(thread_id: str) -> None:
+    raise RuntimeError(f"thread_runtime.convergence.delete_thread_in_db not bound for {thread_id}")
 
-    compatibility_shell.delete_thread_in_db(thread_id)
+
+delete_thread_in_db = _unbound_delete_thread_in_db
+
+
+def _delete_thread_in_db(thread_id: str) -> None:
+    # @@@compat-delete-seam - delete_thread_in_db is bound by compat shells so
+    # legacy patch surfaces still intercept purges without introducing a
+    # thread_runtime -> web.services import inversion.
+    delete_thread_in_db(thread_id)
 
 
 def purge_incomplete_owner_thread(app: Any, thread_id: str) -> None:

--- a/backend/thread_runtime_convergence.py
+++ b/backend/thread_runtime_convergence.py
@@ -1,3 +1,23 @@
 """Compatibility shell for thread runtime convergence helpers."""
 
-from backend.thread_runtime.convergence import *  # noqa: F403
+from backend.thread_runtime import convergence as _owner
+from backend.web.utils.helpers import delete_thread_in_db
+
+
+def _delete_thread_proxy(thread_id: str) -> None:
+    delete_thread_in_db(thread_id)
+
+
+_owner.delete_thread_in_db = _delete_thread_proxy
+
+inspect_owner_thread_runtime = _owner.inspect_owner_thread_runtime
+purge_incomplete_owner_thread = _owner.purge_incomplete_owner_thread
+converge_owner_thread_runtime = _owner.converge_owner_thread_runtime
+summarize_owner_thread_runtime = _owner.summarize_owner_thread_runtime
+
+__all__ = [
+    "inspect_owner_thread_runtime",
+    "purge_incomplete_owner_thread",
+    "converge_owner_thread_runtime",
+    "summarize_owner_thread_runtime",
+]

--- a/backend/thread_runtime_convergence.py
+++ b/backend/thread_runtime_convergence.py
@@ -1,11 +1,12 @@
 """Compatibility shell for thread runtime convergence helpers."""
 
 from backend.thread_runtime import convergence as _owner
-from backend.web.utils.helpers import delete_thread_in_db
 
 
 def _delete_thread_proxy(thread_id: str) -> None:
-    delete_thread_in_db(thread_id)
+    from backend.web.services import thread_runtime_convergence as _shell
+
+    _shell.delete_thread_in_db(thread_id)
 
 
 _owner.delete_thread_in_db = _delete_thread_proxy

--- a/backend/web/services/thread_runtime_convergence.py
+++ b/backend/web/services/thread_runtime_convergence.py
@@ -2,50 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from backend.thread_runtime_convergence import inspect_owner_thread_runtime
+from backend.thread_runtime import convergence as _owner
 from backend.web.utils.helpers import delete_thread_in_db
 
 
-def purge_incomplete_owner_thread(app: Any, thread_id: str) -> None:
+def _delete_thread_proxy(thread_id: str) -> None:
     delete_thread_in_db(thread_id)
-    app.state.thread_repo.delete(thread_id)
-
-    for attr in ("thread_sandbox", "thread_cwd", "thread_event_buffers", "thread_tasks", "thread_last_active"):
-        mapping = getattr(app.state, attr, None)
-        if isinstance(mapping, dict):
-            mapping.pop(thread_id, None)
-
-    agent_pool = getattr(app.state, "agent_pool", None)
-    if isinstance(agent_pool, dict):
-        for pool_key in [key for key in agent_pool if key.startswith(f"{thread_id}:")]:
-            agent_pool.pop(pool_key, None)
-
-    queue_manager = getattr(app.state, "queue_manager", None)
-    if queue_manager is not None and hasattr(queue_manager, "clear_all"):
-        queue_manager.clear_all(thread_id)
 
 
-def converge_owner_thread_runtime(app: Any, thread_id: str) -> str:
-    runtime_state = inspect_owner_thread_runtime(app, thread_id)
-    if runtime_state != "incomplete":
-        return runtime_state
+_owner.delete_thread_in_db = _delete_thread_proxy
 
-    purge_incomplete_owner_thread(app, thread_id)
-    return "purged"
-
-
-def summarize_owner_thread_runtime(app: Any, thread_ids: list[str]) -> dict[str, str]:
-    states: dict[str, str] = {}
-    for thread_id in thread_ids:
-        state = inspect_owner_thread_runtime(app, thread_id)
-        if state == "incomplete":
-            purge_incomplete_owner_thread(app, thread_id)
-            state = "purged"
-        states[thread_id] = state
-    return states
-
+inspect_owner_thread_runtime = _owner.inspect_owner_thread_runtime
+purge_incomplete_owner_thread = _owner.purge_incomplete_owner_thread
+converge_owner_thread_runtime = _owner.converge_owner_thread_runtime
+summarize_owner_thread_runtime = _owner.summarize_owner_thread_runtime
 
 __all__ = [
     "converge_owner_thread_runtime",

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -37,6 +37,12 @@ def test_thread_runtime_history_uses_thread_runtime_message_repair_owner() -> No
     assert "backend.web.services.thread_message_interruption_service" not in history_source
 
 
+def test_thread_runtime_convergence_does_not_import_web_compat_shell() -> None:
+    convergence_source = inspect.getsource(importlib.import_module("backend.thread_runtime.convergence"))
+
+    assert "backend.web.services.thread_runtime_convergence" not in convergence_source
+
+
 def test_thread_runtime_namespace_exports_owner_thread_reads() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.owner_reads")
     shell_module = importlib.import_module("backend.web.services.owner_thread_read_service")


### PR DESCRIPTION
## Summary
- replace the direct `backend.web.services.thread_runtime_convergence` import inside `backend.thread_runtime.convergence` with a bound `delete_thread_in_db` seam
- wire that seam from the compat shells at `backend/thread_runtime_convergence.py` and `backend/web/services/thread_runtime_convergence.py`
- preserve the existing legacy monkeypatch surface so convergence tests still patch `backend.web.services.thread_runtime_convergence.delete_thread_in_db`

## Verification
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_thread_runtime_convergence.py -q`
- `uv run ruff check backend/thread_runtime/convergence.py backend/thread_runtime_convergence.py backend/web/services/thread_runtime_convergence.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_thread_runtime_convergence.py`
- `uv run ruff format --check backend/thread_runtime/convergence.py backend/thread_runtime_convergence.py backend/web/services/thread_runtime_convergence.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_thread_runtime_convergence.py`
- `git diff --check`
