### PR TITLE
refactor: bind pool file channel seam

### DIFF
--- a/backend/thread_runtime/pool/registry.py
+++ b/backend/thread_runtime/pool/registry.py
@@ -9,11 +9,17 @@ from fastapi import FastAPI
 
 from backend.thread_runtime.pool.factory import create_agent_sync
 from backend.thread_runtime.sandbox import resolve_thread_sandbox
-from backend.web.services.file_channel_service import get_file_channel_binding
 from core.identity.agent_registry import get_or_create_agent_id
 from sandbox.thread_context import set_current_thread_id
 
 logger = logging.getLogger(__name__)
+
+
+def _unbound_get_file_channel_binding(*_args, **_kwargs):
+    raise RuntimeError("thread_runtime.pool.registry requires get_file_channel_binding binding")
+
+
+get_file_channel_binding = _unbound_get_file_channel_binding
 
 # Thread lock for config updates
 _config_update_locks: dict[str, asyncio.Lock] = {}

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -64,6 +64,7 @@ def test_agent_pool_uses_thread_runtime_pool_registry_owner() -> None:
     owner_module = importlib.import_module("backend.thread_runtime.pool.registry")
     agent_pool_module = importlib.import_module("backend.web.services.agent_pool")
     source = inspect.getsource(agent_pool_module)
+    owner_source = inspect.getsource(owner_module)
 
     assert hasattr(agent_pool_module, "get_or_create_agent")
     assert hasattr(agent_pool_module, "update_agent_config")
@@ -74,6 +75,7 @@ def test_agent_pool_uses_thread_runtime_pool_registry_owner() -> None:
     assert hasattr(agent_pool_module, "get_file_channel_binding")
     assert owner_module.get_or_create_agent.__module__ == "backend.thread_runtime.pool.registry"
     assert owner_module.update_agent_config.__module__ == "backend.thread_runtime.pool.registry"
+    assert "backend.web.services.file_channel_service" not in owner_source
 
 
 def test_thread_launch_config_uses_thread_runtime_launch_config_owner() -> None:


### PR DESCRIPTION
## Summary
- remove the direct `backend.web.services.file_channel_service` import from `backend.thread_runtime.pool.registry`
- require an explicit `get_file_channel_binding` seam binding instead of a web-side reverse dependency
- tighten owner smoke so the pool registry owner stays free of web compat-shell imports

## Proof
- `uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py -q`
- `uv run ruff check backend/thread_runtime/pool/registry.py backend/web/services/agent_pool.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `uv run ruff format --check backend/thread_runtime/pool/registry.py backend/web/services/agent_pool.py tests/Unit/backend/web/services/test_thread_runtime_owner.py`
- `git diff --check`