### PR TITLE
refactor: delete root trace compat shells

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -6,9 +6,9 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.run_event_reads import build_run_event_read_transport
 from backend.thread_history import build_thread_history_transport, get_thread_history_payload
-from backend.thread_sandbox import resolve_thread_sandbox
+from backend.thread_runtime.events.reads import build_run_event_read_transport
+from backend.thread_runtime.sandbox import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
 
 

--- a/backend/run_event_reads.py
+++ b/backend/run_event_reads.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for thread runtime event-read helpers."""
-
-from backend.thread_runtime.events.reads import *  # noqa: F403

--- a/backend/thread_sandbox.py
+++ b/backend/thread_sandbox.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for thread runtime sandbox helpers."""
-
-from backend.thread_runtime.sandbox import *  # noqa: F403

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -10,16 +10,14 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     projection_shell = importlib.import_module("backend.thread_projection")
     convergence_owner = importlib.import_module("backend.thread_runtime.convergence")
     sandbox_owner = importlib.import_module("backend.thread_runtime.sandbox")
-    sandbox_shell = importlib.import_module("backend.thread_sandbox")
     reads_owner = importlib.import_module("backend.thread_runtime.events.reads")
-    reads_shell = importlib.import_module("backend.run_event_reads")
     buffer_owner = importlib.import_module("backend.thread_runtime.events.buffer")
     buffer_shell = importlib.import_module("backend.web.services.event_buffer")
 
     assert history_owner.build_thread_history_transport is history_shell.build_thread_history_transport
     assert projection_owner.canonical_owner_threads is projection_shell.canonical_owner_threads
     assert convergence_owner.inspect_owner_thread_runtime is not None
-    assert sandbox_owner.resolve_thread_sandbox is sandbox_shell.resolve_thread_sandbox
-    assert reads_owner.build_run_event_read_transport is reads_shell.build_run_event_read_transport
+    assert sandbox_owner.resolve_thread_sandbox is not None
+    assert reads_owner.build_run_event_read_transport is not None
     assert buffer_owner.ThreadEventBuffer is buffer_shell.ThreadEventBuffer
     assert buffer_owner.RunEventBuffer is buffer_shell.RunEventBuffer

--- a/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
@@ -82,6 +82,10 @@ def test_monitor_trace_uses_trace_read_source_port():
     assert "get_thread_history_payload" in read_source
     assert "get_thread_history_payload(app=" not in read_source
     assert "build_thread_history_transport" in read_source
+    assert "from backend.thread_runtime.events.reads import build_run_event_read_transport" in read_source
+    assert "from backend.thread_runtime.sandbox import resolve_thread_sandbox" in read_source
+    assert "backend.run_event_reads" not in read_source
+    assert "backend.thread_sandbox" not in read_source
     assert "build_storage_container" not in read_source
     assert "build_run_event_read_transport" in read_source
     assert "backend.web.services.thread_history_service" not in read_source


### PR DESCRIPTION
## Summary
- retarget monitor trace reads to thread runtime owners directly
- delete the root-level `backend/thread_sandbox.py` and `backend/run_event_reads.py` compat shells
- tighten monitor/owner tests so those root shells are no longer treated as required architecture

## Proof
- `uv run python -m pytest tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Unit/backend/web/services/test_event_buffer_owner.py -q`
- `uv run ruff check backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Unit/backend/web/services/test_event_buffer_owner.py`
- `uv run ruff format --check backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Unit/backend/web/services/test_event_buffer_owner.py`
- `git diff --check`