### PR TITLE
refactor: delete dead auth chat service shells

### DIFF
--- a/backend/web/services/auth_service.py
+++ b/backend/web/services/auth_service.py
@@ -1,5 +1,0 @@
-"""Compatibility shell for neutral auth service owner."""
-
-from backend.auth_service import AuthService
-
-__all__ = ["AuthService"]

--- a/backend/web/services/chat_events.py
+++ b/backend/web/services/chat_events.py
@@ -1,5 +1,0 @@
-"""Compatibility shell for messaging realtime events."""
-
-from messaging.realtime.events import ChatEventBus
-
-__all__ = ["ChatEventBus"]

--- a/backend/web/services/contact_bootstrap_service.py
+++ b/backend/web/services/contact_bootstrap_service.py
@@ -1,5 +1,0 @@
-"""Compatibility shell for neutral contact bootstrap owner."""
-
-from backend.contact_bootstrap import ensure_owner_agent_contact
-
-__all__ = ["ensure_owner_agent_contact"]

--- a/backend/web/services/typing_tracker.py
+++ b/backend/web/services/typing_tracker.py
@@ -1,5 +1,0 @@
-"""Compatibility shell for messaging typing tracker."""
-
-from messaging.realtime.typing import TypingTracker
-
-__all__ = ["TypingTracker"]

--- a/tests/Unit/backend/test_auth_runtime_owner.py
+++ b/tests/Unit/backend/test_auth_runtime_owner.py
@@ -2,9 +2,9 @@ import inspect
 
 from backend import auth_runtime_bootstrap, avatar_files, avatar_urls, contact_bootstrap, recipe_bootstrap
 from backend import auth_service as neutral_auth_service
+from backend.auth_service import AuthService
 from backend.web.routers import users as users_router
 from backend.web.services import agent_user_service, library_service
-from backend.web.services.auth_service import AuthService
 
 
 def test_auth_runtime_bootstrap_depends_on_neutral_auth_service():
@@ -43,10 +43,8 @@ def test_agent_user_service_uses_neutral_contact_bootstrap_owner():
     assert "backend.contact_bootstrap" in source
 
 
-def test_web_contact_bootstrap_service_is_compat_shell():
-    from backend.web.services import contact_bootstrap_service
-
-    assert contact_bootstrap_service.ensure_owner_agent_contact is contact_bootstrap.ensure_owner_agent_contact
+def test_contact_bootstrap_owner_exports_contact_bootstrap_entrypoint() -> None:
+    assert contact_bootstrap.ensure_owner_agent_contact is not None
 
 
 def test_neutral_auth_service_uses_neutral_recipe_bootstrap_owner():

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import jwt
 import pytest
 
-from backend.web.services.auth_service import AuthService
+from backend.auth_service import AuthService
 
 
 class _FakeSupabaseAuth:

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -32,14 +32,12 @@ def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> Non
     delivery_source = inspect.getsource(owner_chat_inlet)
     threads_source = inspect.getsource(threads_router)
     from backend.web.core import lifespan as lifespan_module
-    from backend.web.services import chat_events as shell_chat_events
-    from backend.web.services import typing_tracker as shell_typing_tracker
 
     lifespan_source = inspect.getsource(lifespan_module)
 
     assert owner_chat_inlet.make_chat_delivery_fn is chat_delivery_hook.make_chat_delivery_fn
-    assert owner_chat_events.ChatEventBus is shell_chat_events.ChatEventBus
-    assert owner_typing.TypingTracker is shell_typing_tracker.TypingTracker
+    assert owner_chat_events.ChatEventBus is not None
+    assert owner_typing.TypingTracker is not None
     assert "NativeAgentRuntimeGateway" not in delivery_source
     assert "NativeAgentRuntimeGateway" not in threads_source
     assert "get_agent_runtime_gateway" in delivery_source


### PR DESCRIPTION
## Summary
- delete dead web service compat shells for auth service, contact bootstrap, chat events, and typing tracker
- retarget the remaining owner tests to import neutral owners directly
- keep only negative assertions proving production no longer depends on those shells

## Proof
- `uv run python -m pytest tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff format --check tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `git diff --check`