### PR TITLE
refactor: delete dead messaging service shells

### DIFF
--- a/backend/web/services/chat_delivery_hook.py
+++ b/backend/web/services/chat_delivery_hook.py
@@ -1,5 +1,0 @@
-"""Compatibility shell for Agent Runtime chat inlet."""
-
-from backend.agent_runtime.chat_inlet import make_chat_delivery_fn
-
-__all__ = ["make_chat_delivery_fn"]

--- a/backend/web/services/social_access_service.py
+++ b/backend/web/services/social_access_service.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for messaging social access rules."""
-
-from messaging.social_access import *  # noqa: F403

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -7,8 +7,8 @@ from typing import Any, cast
 
 import pytest
 
+from backend.agent_runtime import chat_inlet as chat_delivery_hook
 from backend.agent_runtime.bootstrap import build_agent_runtime_gateway
-from backend.web.services import chat_delivery_hook
 from backend.web.utils.serializers import avatar_url
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -8,7 +8,6 @@ import pytest
 
 from backend.agent_runtime import chat_inlet as owner_chat_inlet
 from backend.web.routers import threads as threads_router
-from backend.web.services import chat_delivery_hook
 from messaging.delivery.dispatcher import ChatDeliveryRequest
 from messaging.realtime import events as owner_chat_events
 from messaging.realtime import typing as owner_typing
@@ -35,7 +34,7 @@ def test_delivery_paths_depend_on_agent_runtime_port_not_native_gateway() -> Non
 
     lifespan_source = inspect.getsource(lifespan_module)
 
-    assert owner_chat_inlet.make_chat_delivery_fn is chat_delivery_hook.make_chat_delivery_fn
+    assert owner_chat_inlet.make_chat_delivery_fn is not None
     assert owner_chat_events.ChatEventBus is not None
     assert owner_typing.TypingTracker is not None
     assert "NativeAgentRuntimeGateway" not in delivery_source
@@ -78,7 +77,7 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
             raise RuntimeError("runtime gateway down")
 
     app = _hook_app(FailingGateway())
-    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    deliver = owner_chat_inlet.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
         recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
@@ -106,7 +105,7 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
 
     gateway = RecordingGateway()
     app = _hook_app(gateway)
-    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    deliver = owner_chat_inlet.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
         recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
@@ -139,7 +138,7 @@ async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
 
     gateway = RecordingGateway()
     app = _hook_app(gateway)
-    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    deliver = owner_chat_inlet.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
         recipient_user=SimpleNamespace(id="agent-user-1"),
@@ -169,7 +168,7 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
 
     gateway = RecordingGateway()
     app = _hook_app(gateway)
-    deliver = chat_delivery_hook.make_chat_delivery_fn(app)
+    deliver = owner_chat_inlet.make_chat_delivery_fn(app)
     request = ChatDeliveryRequest(
         recipient_id="agent-user-1",
         recipient_user=SimpleNamespace(type="agent"),


### PR DESCRIPTION
## Summary
- delete dead web service compat shells for chat delivery hook and social access
- retarget tests to import messaging/agent-runtime owners directly
- keep only negative assertions proving production no longer depends on those shells

## Proof
- `uv run python -m pytest tests/Integration/test_messaging_social_handle_contract.py -k "chat_delivery_hook" tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff format --check tests/Integration/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `git diff --check`