### PR TITLE
refactor: delete event buffer service shell

### DIFF
--- a/backend/web/services/event_buffer.py
+++ b/backend/web/services/event_buffer.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for thread runtime event buffers."""
-
-from backend.thread_runtime.events.buffer import *  # noqa: F403

--- a/backend/web/services/streaming_service.py
+++ b/backend/web/services/streaming_service.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from backend.thread_runtime.events.buffer import RunEventBuffer, ThreadEventBuffer
 from backend.thread_runtime.run import buffer_wiring as _run_buffer_wiring
 from backend.thread_runtime.run import cancellation as _run_cancellation
 from backend.thread_runtime.run import emit as _run_emit
@@ -13,7 +14,6 @@ from backend.thread_runtime.run import followups as _run_followups
 from backend.thread_runtime.run import input_construction as _run_input_construction
 from backend.thread_runtime.run import lifecycle as _run_lifecycle
 from backend.thread_runtime.run import observer as _run_observer
-from backend.web.services.event_buffer import RunEventBuffer, ThreadEventBuffer
 from backend.web.services.event_store import append_event as _append_event
 from backend.web.services.event_store import cleanup_old_runs
 from core.runtime.notifications import is_terminal_background_notification

--- a/tests/Integration/test_child_thread_live_contract.py
+++ b/tests/Integration/test_child_thread_live_contract.py
@@ -11,9 +11,9 @@ import pytest
 from fastapi import Request
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
+from backend.thread_runtime.events.buffer import ThreadEventBuffer
 from backend.web.routers import threads as threads_router
 from backend.web.services.display_builder import DisplayBuilder
-from backend.web.services.event_buffer import ThreadEventBuffer
 from backend.web.services.streaming_service import run_child_thread_live
 from backend.web.utils.serializers import serialize_message
 from core.runtime.middleware.monitor import AgentState

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -14,11 +14,11 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 
 from backend.agent_runtime.bootstrap import build_agent_runtime_gateway
 from backend.protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+from backend.thread_runtime.events.buffer import ThreadEventBuffer
 from backend.web.models.requests import SendMessageRequest
 from backend.web.routers import threads as threads_router
 from backend.web.routers.threads import get_thread_history, get_thread_messages
 from backend.web.services.display_builder import DisplayBuilder
-from backend.web.services.event_buffer import ThreadEventBuffer
 from backend.web.services.streaming_service import (
     _ensure_thread_handlers,
     _repair_incomplete_tool_calls,

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -12,12 +12,11 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     sandbox_owner = importlib.import_module("backend.thread_runtime.sandbox")
     reads_owner = importlib.import_module("backend.thread_runtime.events.reads")
     buffer_owner = importlib.import_module("backend.thread_runtime.events.buffer")
-    buffer_shell = importlib.import_module("backend.web.services.event_buffer")
 
     assert history_owner.build_thread_history_transport is history_shell.build_thread_history_transport
     assert projection_owner.canonical_owner_threads is projection_shell.canonical_owner_threads
     assert convergence_owner.inspect_owner_thread_runtime is not None
     assert sandbox_owner.resolve_thread_sandbox is not None
     assert reads_owner.build_run_event_read_transport is not None
-    assert buffer_owner.ThreadEventBuffer is buffer_shell.ThreadEventBuffer
-    assert buffer_owner.RunEventBuffer is buffer_shell.RunEventBuffer
+    assert buffer_owner.ThreadEventBuffer is not None
+    assert buffer_owner.RunEventBuffer is not None

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from backend.web.services.event_buffer import ThreadEventBuffer
+from backend.thread_runtime.events.buffer import ThreadEventBuffer
 from backend.web.services.streaming_service import _run_agent_to_buffer, write_cancellation_markers
 from core.runtime.middleware.monitor import AgentState
 from eval.models import RunTrajectory


### PR DESCRIPTION
## Summary
- delete the web-service event buffer compat shell
- retarget streaming and focused tests to import thread runtime event buffer owners directly
- keep only negative assertions proving old web-service import paths are gone

## Proof
- `uv run python -m pytest tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py -k "ThreadEventBuffer or event_buffer or child_thread_live or idle_rebuild_replays_latest_run_error_from_event_log" -q`
- `uv run ruff check backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py`
- `uv run ruff format --check backend/web/services/streaming_service.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py`
- `git diff --check`