### PR TITLE
refactor: retarget storage container cache owner

### DIFF
--- a/backend/storage_container_cache.py
+++ b/backend/storage_container_cache.py
@@ -1,0 +1,16 @@
+"""Process-local storage container cache."""
+
+from __future__ import annotations
+
+from storage.container import StorageContainer
+from storage.runtime import build_storage_container
+
+_cached_container: StorageContainer | None = None
+
+
+def get_storage_container() -> StorageContainer:
+    global _cached_container
+    if _cached_container is not None:
+        return _cached_container
+    _cached_container = build_storage_container()
+    return _cached_container

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -6,7 +6,8 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 
 from backend.sandbox_inventory import init_providers_and_managers
-from backend.web.utils.helpers import _get_container, extract_webhook_instance_id
+from backend.storage_container_cache import get_storage_container as _get_container
+from backend.web.utils.helpers import extract_webhook_instance_id
 from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.lease import lease_from_row as lower_runtime_from_row
 from storage.runtime import build_lease_repo as make_lower_runtime_repo

--- a/backend/web/services/file_channel_service.py
+++ b/backend/web/services/file_channel_service.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-from backend.web.utils.helpers import _get_container
+from backend.storage_container_cache import get_storage_container as _get_container
 from config.user_paths import user_home_path
 
 logger = logging.getLogger(__name__)

--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -5,16 +5,13 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from backend.storage_container_cache import get_storage_container as _get_container
 from sandbox.control_plane_repos import make_chat_session_repo, make_terminal_repo, resolve_sandbox_db_path
 from sandbox.sync.state import ProcessLocalSyncFileBacking, SyncState
-from storage.container import StorageContainer
 from storage.runtime import (
-    build_storage_container,
     build_thread_repo,
     uses_supabase_runtime_defaults,
 )
-
-_cached_container: StorageContainer | None = None
 
 
 def is_virtual_thread_id(thread_id: str | None) -> bool:
@@ -38,14 +35,6 @@ def extract_webhook_instance_id(payload: dict[str, Any]) -> str | None:
                 return value
 
     return None
-
-
-def _get_container() -> StorageContainer:
-    global _cached_container
-    if _cached_container is not None:
-        return _cached_container
-    _cached_container = build_storage_container()
-    return _cached_container
 
 
 _cached_thread_repo = None

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -14,6 +14,13 @@ def test_webhooks_router_uses_neutral_provider_inventory_owner() -> None:
     assert "backend.sandbox_inventory import init_providers_and_managers" in source
 
 
+def test_webhooks_router_uses_neutral_storage_container_cache_owner() -> None:
+    source = inspect.getsource(webhooks)
+
+    assert "from backend.web.utils.helpers import _get_container" not in source
+    assert "from backend.storage_container_cache import get_storage_container as _get_container" in source
+
+
 @pytest.mark.asyncio
 async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     class _RuntimeRepo:

--- a/tests/Unit/backend/web/services/test_file_channel_service.py
+++ b/tests/Unit/backend/web/services/test_file_channel_service.py
@@ -67,3 +67,10 @@ def test_save_file_does_not_touch_chat_session_activity(monkeypatch):
     result = file_channel_service.save_file(thread_id="thread-1", relative_path="note.txt", content=b"hello")
 
     assert result == {"path": "note.txt", "size": 5, "thread_id": "thread-1"}
+
+
+def test_file_channel_service_uses_neutral_storage_container_cache_owner() -> None:
+    source = file_channel_service.__loader__.get_source(file_channel_service.__name__) or ""
+
+    assert "from backend.web.utils.helpers import _get_container" not in source
+    assert "from backend.storage_container_cache import get_storage_container as _get_container" in source


### PR DESCRIPTION
## Summary
- move the process-local storage container cache owner to backend/storage_container_cache.py
- retarget webhooks, file_channel_service, and helpers to the neutral backend owner
- keep local _get_container patch seams stable in consuming modules/tests

## Test Plan
- uv run python -m pytest tests/Integration/test_webhooks_router_contract.py tests/Unit/backend/web/services/test_file_channel_service.py -q
- uv run ruff check backend/storage_container_cache.py backend/web/utils/helpers.py backend/web/routers/webhooks.py backend/web/services/file_channel_service.py tests/Integration/test_webhooks_router_contract.py tests/Unit/backend/web/services/test_file_channel_service.py
- uv run ruff format --check backend/storage_container_cache.py backend/web/utils/helpers.py backend/web/routers/webhooks.py backend/web/services/file_channel_service.py tests/Integration/test_webhooks_router_contract.py tests/Unit/backend/web/services/test_file_channel_service.py
- git diff --check