### PR TITLE
refactor: retarget file channel owner

### DIFF
--- a/backend/file_channel.py
+++ b/backend/file_channel.py
@@ -63,11 +63,6 @@ def get_file_channel_binding(thread_id: str) -> FileChannelBinding:
     )
 
 
-# ---------------------------------------------------------------------------
-# File CRUD -- delegates to the local file-channel source
-# ---------------------------------------------------------------------------
-
-
 def save_file(*, thread_id: str, relative_path: str, content: bytes) -> dict:
     """Save file to the thread's file channel."""
     source = get_file_channel_source(thread_id)

--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -7,8 +7,8 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 
+from backend import file_channel as file_channel_service
 from backend.web.core.dependencies import get_app, verify_thread_owner
-from backend.web.services import file_channel_service
 from backend.web.services.agent_pool import resolve_thread_sandbox
 from backend.web.utils.helpers import resolve_local_workspace_path
 from sandbox.thread_context import set_current_thread_id

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 from sse_starlette.sse import EventSourceResponse
 
 from backend import sandbox_provider_factory
+from backend.file_channel import get_file_channel_binding
 from backend.monitor.application.use_cases.thread_workbench import (
     build_owner_thread_workbench_from_rows,
     sidebar_label,
@@ -49,7 +50,6 @@ from backend.web.models.requests import (
 )
 from backend.web.services import account_resource_service
 from backend.web.services.agent_pool import get_or_create_agent
-from backend.web.services.file_channel_service import get_file_channel_binding
 from backend.web.utils.helpers import delete_thread_in_db
 from backend.web.utils.serializers import avatar_url, serialize_message
 from core.agents.service import _background_run_cancelled, _background_run_result, request_background_run_stop

--- a/backend/web/services/agent_pool.py
+++ b/backend/web/services/agent_pool.py
@@ -1,9 +1,9 @@
 """Agent pool management service."""
 
+from backend.file_channel import get_file_channel_binding
 from backend.thread_runtime.pool import registry as _registry
 from backend.thread_runtime.pool.factory import create_agent_sync
 from backend.thread_runtime.sandbox import resolve_thread_sandbox
-from backend.web.services.file_channel_service import get_file_channel_binding
 from core.identity.agent_registry import get_or_create_agent_id
 
 

--- a/tests/Unit/backend/web/routers/test_threads_attachment_paths.py
+++ b/tests/Unit/backend/web/routers/test_threads_attachment_paths.py
@@ -80,6 +80,13 @@ def test_threads_router_uses_neutral_thread_sandbox_owner() -> None:
     assert "from backend.thread_runtime.sandbox import resolve_thread_sandbox" in source
 
 
+def test_threads_router_uses_neutral_file_channel_owner() -> None:
+    source = inspect.getsource(threads_router)
+
+    assert "from backend.web.services.file_channel_service import get_file_channel_binding" not in source
+    assert "from backend.file_channel import get_file_channel_binding" in source
+
+
 def test_threads_router_uses_neutral_resource_cache_owner() -> None:
     source = inspect.getsource(threads_router)
 

--- a/tests/Unit/backend/web/services/test_file_channel_service.py
+++ b/tests/Unit/backend/web/services/test_file_channel_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from backend.web.services import file_channel_service
+from backend import file_channel as file_channel_service
 
 
 class _ThreadRepo:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -72,6 +72,8 @@ def test_agent_pool_uses_thread_runtime_pool_registry_owner() -> None:
     assert owner_module.get_or_create_agent.__module__ == "backend.thread_runtime.pool.registry"
     assert owner_module.update_agent_config.__module__ == "backend.thread_runtime.pool.registry"
     assert "backend.web.services.file_channel_service" not in owner_source
+    assert "from backend.file_channel import get_file_channel_binding" in source
+    assert "backend.web.services.file_channel_service" not in source
 
 
 def test_thread_launch_config_uses_thread_runtime_launch_config_owner() -> None:


### PR DESCRIPTION
## Summary
- move the file-channel owner from backend/web/services/file_channel_service.py to backend/file_channel.py
- retarget agent_pool, threads router, and thread_files router to the neutral backend owner
- update focused tests and delete the old web-service path

## Test Plan
- uv run python -m pytest tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/routers/test_threads_attachment_paths.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Integration/test_webhooks_router_contract.py -q
- uv run ruff check backend/file_channel.py backend/web/services/agent_pool.py backend/web/routers/threads.py backend/web/routers/thread_files.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/routers/test_threads_attachment_paths.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Integration/test_webhooks_router_contract.py
- uv run ruff format --check backend/file_channel.py backend/web/services/agent_pool.py backend/web/routers/threads.py backend/web/routers/thread_files.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/routers/test_threads_attachment_paths.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Integration/test_webhooks_router_contract.py
- git diff --check