### PR TITLE
refactor: retarget library path owner

### DIFF
--- a/backend/library_paths.py
+++ b/backend/library_paths.py
@@ -1,0 +1,18 @@
+"""Shared library path owner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from config.user_paths import preferred_user_home_dir
+
+
+def leon_home_dir() -> Path:
+    return preferred_user_home_dir()
+
+
+def library_dir() -> Path:
+    return leon_home_dir() / "library"
+
+
+LIBRARY_DIR = library_dir()

--- a/backend/web/services/library_service.py
+++ b/backend/web/services/library_service.py
@@ -8,12 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from backend import sandbox_provider_availability
+from backend.library_paths import LIBRARY_DIR
 from backend.recipe_bootstrap import seed_default_recipes as seed_builtin_recipes
-from backend.web.core.paths import library_dir
 from sandbox.recipes import FEATURE_CATALOG, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 from storage.contracts import RecipeRepo
-
-LIBRARY_DIR = library_dir()
 
 
 def _read_json(path: Path, default: Any = None) -> Any:

--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -12,6 +12,7 @@ import httpx
 import yaml
 from fastapi import HTTPException
 
+import backend.library_paths as _lib_paths
 from backend.web.utils.versioning import BumpType, bump_semver
 from config.loader import load_bundle_from_repo
 from config.types import AgentBundle
@@ -264,8 +265,6 @@ def download(
     installed_version = result["version"]
     item_type = item.get("type", "skill")
 
-    from backend.web.services.library_service import LIBRARY_DIR
-
     now = int(time.time() * 1000)
 
     if item_type == "skill":
@@ -302,8 +301,8 @@ def download(
             return {"resource_id": skill_name, "type": "skill", "version": installed_version, "agent_user_id": agent_user_id}
 
         slug = item.get("slug", item["name"].lower().replace(" ", "-"))
-        skill_dir = (LIBRARY_DIR / "skills" / slug).resolve()
-        if not skill_dir.is_relative_to((LIBRARY_DIR / "skills").resolve()):
+        skill_dir = (_lib_paths.LIBRARY_DIR / "skills" / slug).resolve()
+        if not skill_dir.is_relative_to((_lib_paths.LIBRARY_DIR / "skills").resolve()):
             raise ValueError(f"Invalid slug: {slug}")
         skill_dir.mkdir(parents=True, exist_ok=True)
 
@@ -329,7 +328,7 @@ def download(
 
     if item_type == "agent":
         slug = item.get("slug", item["name"].lower().replace(" ", "-"))
-        agent_dir = (LIBRARY_DIR / "agents").resolve()
+        agent_dir = (_lib_paths.LIBRARY_DIR / "agents").resolve()
         if not (agent_dir / slug).resolve().is_relative_to(agent_dir):
             raise ValueError(f"Invalid slug: {slug}")
         agent_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/Unit/backend/test_auth_runtime_owner.py
+++ b/tests/Unit/backend/test_auth_runtime_owner.py
@@ -60,6 +60,13 @@ def test_web_library_service_keeps_recipe_bootstrap_compat_surface():
     assert library_service.seed_default_recipes is recipe_bootstrap.seed_default_recipes
 
 
+def test_web_library_service_uses_neutral_library_path_owner() -> None:
+    source = inspect.getsource(library_service)
+
+    assert "from backend.web.core.paths import library_dir" not in source
+    assert "from backend.library_paths import LIBRARY_DIR" in source
+
+
 def test_neutral_avatar_helpers_use_neutral_avatar_path_owner():
     avatar_file_source = inspect.getsource(avatar_files)
     avatar_url_source = inspect.getsource(avatar_urls)

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
-import backend.web.services.library_service as _lib_svc
+import backend.library_paths as _lib_paths
 from backend.web.utils.versioning import bump_semver
 
 # ── Version Bump (tested via publish internals) ──
@@ -70,6 +70,15 @@ def test_hub_api_preserves_hub_bad_request_detail(monkeypatch):
     assert exc_info.value.detail == "Unsupported sort: featured"
 
 
+def test_marketplace_client_uses_neutral_library_path_owner() -> None:
+    import backend.web.services.marketplace_client as marketplace_client
+
+    source = importlib.reload(marketplace_client).__loader__.get_source(marketplace_client.__name__) or ""
+
+    assert "from backend.web.services.library_service import LIBRARY_DIR" not in source
+    assert "import backend.library_paths as _lib_paths" in source
+
+
 # ── Helpers ──
 
 
@@ -98,7 +107,7 @@ def _make_hub_response(item_type: str, slug: str, content: str = "# Hello", vers
 class TestDownloadSkill:
     def test_writes_skill_md(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
+        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
         hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
@@ -114,7 +123,7 @@ class TestDownloadSkill:
 
     def test_meta_json_has_source_tracking(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
+        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
         hub_resp = _make_hub_response(
             "skill", "tracked-skill", content="---\nname: Tracked Skill\n---\n# Hello", version="2.1.0", publisher="alice"
         )
@@ -131,7 +140,7 @@ class TestDownloadSkill:
 
     def test_path_traversal_blocked(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
+        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
         hub_resp = _make_hub_response("skill", "../../evil", content="---\nname: Evil\n---\n# Hello")
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
@@ -195,7 +204,7 @@ class TestDownloadSkill:
 class TestDownloadAgent:
     def test_writes_agent_md(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
+        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
         hub_resp = _make_hub_response("agent", "cool-agent", content="# Cool Agent")
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
@@ -211,7 +220,7 @@ class TestDownloadAgent:
 
     def test_meta_json_written(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
+        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
         hub_resp = _make_hub_response("agent", "meta-agent", version="3.0.0", publisher="bob")
 
         with patch("backend.web.services.marketplace_client._hub_api", return_value=hub_resp):
@@ -265,7 +274,7 @@ class TestDownloadUser:
 class TestDownloadIdempotency:
     def test_download_twice_overwrites_cleanly(self, tmp_path, monkeypatch):
         lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_svc, "LIBRARY_DIR", lib)
+        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
 
         v1 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\n---\nV1", version="1.0.0")
         v2 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\n---\nV2", version="1.0.1")


### PR DESCRIPTION
## Summary
- move library path ownership to backend/library_paths.py
- retarget library_service and marketplace_client to the neutral path owner
- update focused tests to patch/assert against the new backend path owner

## Test Plan
- uv run python -m pytest tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/platform/test_marketplace_client.py -q
- uv run ruff check backend/library_paths.py backend/web/services/library_service.py backend/web/services/marketplace_client.py tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/platform/test_marketplace_client.py
- uv run ruff format --check backend/library_paths.py backend/web/services/library_service.py backend/web/services/marketplace_client.py tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/platform/test_marketplace_client.py
- git diff --check