### PR TITLE
refactor: delete messaging router shell

### DIFF
--- a/backend/web/routers/messaging.py
+++ b/backend/web/routers/messaging.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for chat HTTP routes."""
-
-from backend.chat.api.http.router import *  # noqa: F403

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import inspect
 from types import SimpleNamespace
 
@@ -106,12 +107,12 @@ def test_messaging_crud_routes_are_sync_threadpool_boundaries() -> None:
 
 
 def test_chat_http_owner_module_lives_under_backend_chat() -> None:
-    from backend.web.routers import messaging as messaging_shell
-
-    assert chat_router.router is messaging_shell.router
-    assert chat_router.list_chats is messaging_shell.list_chats
-    assert chat_router.send_message is messaging_shell.send_message
     assert chat_router.__name__ == "backend.chat.api.http.router"
+
+
+def test_messaging_router_shell_is_deleted() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("backend.web.routers.messaging")
 
 
 def test_chat_router_imports_messaging_social_access_owner() -> None:


### PR DESCRIPTION
## Summary
- delete backend/web/routers/messaging.py, which had no production importer surface
- retarget the integration test from shell-identity assertions to a negative shell-deleted check
- keep backend/web/main.py on the existing owner router import path

## Test Plan
- uv run python -m pytest tests/Integration/test_messaging_router.py -q
- uv run ruff check tests/Integration/test_messaging_router.py backend/web/main.py
- uv run ruff format --check tests/Integration/test_messaging_router.py backend/web/main.py
- git diff --check