### PR TITLE
refactor: delete root thread history shell

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -6,8 +6,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.thread_history import build_thread_history_transport, get_thread_history_payload
 from backend.thread_runtime.events.reads import build_run_event_read_transport
+from backend.thread_runtime.history import build_thread_history_transport, get_thread_history_payload
 from backend.thread_runtime.sandbox import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
 

--- a/backend/thread_history.py
+++ b/backend/thread_history.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for thread runtime history helpers."""
-
-from backend.thread_runtime.history import *  # noqa: F403

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -22,9 +22,9 @@ from backend.monitor.infrastructure.read_models.thread_workbench_read_service im
 from backend.monitor.infrastructure.resources.resource_overview_cache import clear_resource_overview_cache
 from backend.sandbox_inventory import init_providers_and_managers
 from backend.sandbox_thread_resources import destroy_thread_resources_sync
-from backend.thread_history import build_thread_history_transport, get_thread_history_payload
 from backend.thread_runtime.events.buffer import ThreadEventBuffer
 from backend.thread_runtime.events.store import get_last_seq, get_latest_run_id, get_run_start_seq, read_events_after
+from backend.thread_runtime.history import build_thread_history_transport, get_thread_history_payload
 from backend.thread_runtime.interruption import repair_interrupted_tool_call_messages
 from backend.thread_runtime.launch_config import resolve_default_config
 from backend.thread_runtime.owner_reads import list_owner_thread_rows_for_auth_burst

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
+
 
 def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     history_owner = importlib.import_module("backend.thread_runtime.history")
-    history_shell = importlib.import_module("backend.thread_history")
     projection_owner = importlib.import_module("backend.thread_runtime.projection")
     projection_shell = importlib.import_module("backend.thread_projection")
     convergence_owner = importlib.import_module("backend.thread_runtime.convergence")
@@ -13,10 +14,15 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     reads_owner = importlib.import_module("backend.thread_runtime.events.reads")
     buffer_owner = importlib.import_module("backend.thread_runtime.events.buffer")
 
-    assert history_owner.build_thread_history_transport is history_shell.build_thread_history_transport
+    assert history_owner.build_thread_history_transport is not None
     assert projection_owner.canonical_owner_threads is projection_shell.canonical_owner_threads
     assert convergence_owner.inspect_owner_thread_runtime is not None
     assert sandbox_owner.resolve_thread_sandbox is not None
     assert reads_owner.build_run_event_read_transport is not None
     assert buffer_owner.ThreadEventBuffer is not None
     assert buffer_owner.RunEventBuffer is not None
+
+
+def test_thread_history_shell_is_deleted() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("backend.thread_history")

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -34,6 +34,13 @@ def test_thread_runtime_history_uses_thread_runtime_message_repair_owner() -> No
     assert "backend.web.services.thread_message_interruption_service" not in history_source
 
 
+def test_trace_read_service_uses_thread_runtime_history_owner() -> None:
+    trace_source = inspect.getsource(importlib.import_module("backend.monitor.infrastructure.read_models.trace_read_service"))
+
+    assert "from backend.thread_history import build_thread_history_transport, get_thread_history_payload" not in trace_source
+    assert "from backend.thread_runtime.history import build_thread_history_transport, get_thread_history_payload" in trace_source
+
+
 def test_thread_runtime_convergence_does_not_import_web_compat_shell() -> None:
     convergence_source = inspect.getsource(importlib.import_module("backend.thread_runtime.convergence"))
 


### PR DESCRIPTION
## Summary
- delete backend/thread_history.py after retargeting the remaining production importers
- switch trace_read_service and threads router directly to backend.thread_runtime.history
- update focused owner tests to assert the root shell is gone

## Test Plan
- uv run python -m pytest tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_conversations_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_threads_router.py -q
- uv run ruff check backend/monitor/infrastructure/read_models/trace_read_service.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_conversations_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_threads_router.py
- uv run ruff format --check backend/monitor/infrastructure/read_models/trace_read_service.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Integration/test_conversations_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_threads_router.py
- git diff --check