### PR TITLE
refactor: trim sandbox provider factory dead branch

### DIFF
--- a/backend/sandbox_provider_factory.py
+++ b/backend/sandbox_provider_factory.py
@@ -2,21 +2,14 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
-from backend.sandbox_paths import SANDBOXES_DIR
 
-
-def build_provider_from_config_name(name: str, *, sandboxes_dir: Path | None = None) -> Any | None:
+def build_provider_from_config_name(name: str, *, sandboxes_dir=None) -> Any | None:
     """Build one provider instance from sandbox config name."""
     from backend.sandbox_inventory import init_providers_and_managers
 
     providers, _ = init_providers_and_managers()
     if name in providers:
         return providers[name]
-    _sandboxes_dir = sandboxes_dir or SANDBOXES_DIR
-    config_path = _sandboxes_dir / f"{name}.json"
-    if not config_path.exists():
-        return None
     return None

--- a/tests/Unit/backend/web/services/test_resource_common.py
+++ b/tests/Unit/backend/web/services/test_resource_common.py
@@ -270,6 +270,16 @@ def test_resource_modules_use_neutral_sandbox_provider_factory_owner() -> None:
     assert "backend.sandbox_inventory" in sandbox_provider_factory_source
 
 
+def test_sandbox_provider_factory_returns_none_without_filesystem_probe(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "backend.sandbox_inventory.init_providers_and_managers",
+        lambda: ({}, {}),
+    )
+
+    assert not hasattr(neutral_sandbox_provider_factory, "SANDBOXES_DIR")
+    assert neutral_sandbox_provider_factory.build_provider_from_config_name("missing-provider") is None
+
+
 def test_web_sandbox_service_keeps_provider_factory_compat_surface() -> None:
     assert sandbox_service.build_provider_from_config_name is neutral_sandbox_provider_factory.build_provider_from_config_name
 


### PR DESCRIPTION
## Scope
- backend/sandbox_provider_factory.py
- tests/Unit/backend/web/services/test_resource_common.py

## Why
`build_provider_from_config_name()` had a dead filesystem-probe branch: once the provider was absent from `init_providers_and_managers()`, the function always returned `None` whether the config file existed or not.

## Change
- remove the no-op sandbox path / config existence probe
- keep outward behavior unchanged:
  - known provider -> provider instance
  - missing provider -> None
- keep a focused regression proving the factory no longer depends on a filesystem probe for the missing-provider case

## Proof
- `uv run pytest -q tests/Unit/backend/web/services/test_resource_common.py -k 'sandbox_provider_factory_returns_none_without_filesystem_probe or resource_modules_use_neutral_sandbox_provider_factory_owner or web_sandbox_service_keeps_provider_factory_compat_surface'`
- `uv run ruff check backend/sandbox_provider_factory.py tests/Unit/backend/web/services/test_resource_common.py`
- `git diff --check`
