### PR TITLE
refactor: delete root thread projection shell

### DIFF
--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -11,8 +11,8 @@ from fastapi import APIRouter, Depends
 from backend.avatar_urls import avatar_url
 from backend.chat.api.http.dependencies import get_app, get_current_user_id
 from backend.protocols.runtime_read import RuntimeThreadActivityReader
-from backend.thread_projection import canonical_owner_threads
 from backend.thread_runtime.owner_reads import list_owner_thread_rows_for_auth_burst
+from backend.thread_runtime.projection import canonical_owner_threads
 
 router = APIRouter(prefix="/api/conversations", tags=["conversations"])
 

--- a/backend/monitor/infrastructure/read_models/thread_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_read_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from backend.thread_projection import canonical_owner_threads, thread_owners
+from backend.thread_runtime.projection import canonical_owner_threads, thread_owners
 from storage.runtime import build_thread_repo
 
 

--- a/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
@@ -8,8 +8,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from backend.avatar_urls import avatar_url
-from backend.thread_projection import canonical_owner_threads
 from backend.thread_runtime.convergence import converge_owner_thread_runtime, summarize_owner_thread_runtime
+from backend.thread_runtime.projection import canonical_owner_threads
 from core.runtime.middleware.monitor import AgentState
 
 

--- a/backend/thread_projection.py
+++ b/backend/thread_projection.py
@@ -1,3 +1,0 @@
-"""Compatibility shell for thread runtime projection helpers."""
-
-from backend.thread_runtime.projection import *  # noqa: F403

--- a/backend/user_sandbox_reads.py
+++ b/backend/user_sandbox_reads.py
@@ -7,7 +7,7 @@ from collections import Counter
 from typing import Any
 
 from backend.avatar_urls import avatar_url
-from backend.thread_projection import canonical_owner_threads
+from backend.thread_runtime.projection import canonical_owner_threads
 from backend.virtual_threads import is_virtual_thread_id
 from sandbox.recipes import default_recipe_id, normalize_recipe_snapshot, provider_type_from_name
 from storage.models import map_sandbox_state_to_display_status

--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -9,7 +9,7 @@ from backend import sandbox_provider_availability, sandbox_runtime_metrics, sand
 from backend.avatar_urls import avatar_url
 from backend.sandbox_inventory import init_providers_and_managers
 from backend.sandbox_runtime_reads import find_runtime_and_manager, load_all_sandbox_runtimes
-from backend.thread_projection import canonical_owner_threads
+from backend.thread_runtime.projection import canonical_owner_threads
 from backend.virtual_threads import is_virtual_thread_id
 from backend.web.core.dependencies import get_current_user_id
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo

--- a/backend/web/services/sandbox_service.py
+++ b/backend/web/services/sandbox_service.py
@@ -13,7 +13,7 @@ from backend import sandbox_runtime_mutations as _sandbox_runtime_mutations
 from backend import sandbox_runtime_reads as _sandbox_runtime_reads
 from backend import sandbox_thread_resources as _sandbox_thread_resources
 from backend.avatar_urls import avatar_url
-from backend.thread_projection import canonical_owner_threads
+from backend.thread_runtime.projection import canonical_owner_threads
 from backend.virtual_threads import is_virtual_thread_id
 from backend.web.core.config import LOCAL_WORKSPACE_ROOT, SANDBOXES_DIR
 from sandbox.config import SandboxConfig

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -41,7 +41,7 @@ def test_conversations_router_uses_neutral_read_and_avatar_helpers() -> None:
     assert "backend.web.services.thread_visibility" not in source
     assert "backend.web.utils.serializers" not in source
     assert "backend.thread_runtime.owner_reads" in source
-    assert "backend.thread_projection" in source
+    assert "backend.thread_runtime.projection" in source
     assert "backend.avatar_urls" in source
 
 

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -8,14 +8,13 @@ import pytest
 def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     history_owner = importlib.import_module("backend.thread_runtime.history")
     projection_owner = importlib.import_module("backend.thread_runtime.projection")
-    projection_shell = importlib.import_module("backend.thread_projection")
     convergence_owner = importlib.import_module("backend.thread_runtime.convergence")
     sandbox_owner = importlib.import_module("backend.thread_runtime.sandbox")
     reads_owner = importlib.import_module("backend.thread_runtime.events.reads")
     buffer_owner = importlib.import_module("backend.thread_runtime.events.buffer")
 
     assert history_owner.build_thread_history_transport is not None
-    assert projection_owner.canonical_owner_threads is projection_shell.canonical_owner_threads
+    assert projection_owner.canonical_owner_threads is not None
     assert convergence_owner.inspect_owner_thread_runtime is not None
     assert sandbox_owner.resolve_thread_sandbox is not None
     assert reads_owner.build_run_event_read_transport is not None
@@ -26,3 +25,8 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
 def test_thread_history_shell_is_deleted() -> None:
     with pytest.raises(ModuleNotFoundError):
         importlib.import_module("backend.thread_history")
+
+
+def test_thread_projection_shell_is_deleted() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("backend.thread_projection")

--- a/tests/Unit/backend/web/services/test_resource_common.py
+++ b/tests/Unit/backend/web/services/test_resource_common.py
@@ -225,7 +225,7 @@ def test_user_sandbox_reads_uses_neutral_avatar_and_virtual_thread_helpers() -> 
     assert "backend.web.services.thread_visibility" not in source
     assert "backend.avatar_urls" in source
     assert "backend.virtual_threads" in source
-    assert "backend.thread_projection" in source
+    assert "backend.thread_runtime.projection" in source
     assert "def count_user_visible_sandboxes_by_provider(" in source
 
 
@@ -235,7 +235,7 @@ def test_sandbox_service_uses_neutral_helper_owners_for_read_wrappers() -> None:
     assert "backend.web.services.thread_visibility" not in source
     assert "backend.web.utils.serializers" not in source
     assert "backend.web.utils.helpers" not in source
-    assert "backend.thread_projection" in source
+    assert "backend.thread_runtime.projection" in source
     assert "backend.avatar_urls" in source
     assert "backend.virtual_threads" in source
 

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -106,7 +106,7 @@ def test_thread_runtime_pool_exports_idle_reaper_owner() -> None:
 
 
 def test_thread_visibility_uses_thread_projection_owner() -> None:
-    owner_module = importlib.import_module("backend.thread_projection")
+    owner_module = importlib.import_module("backend.thread_runtime.projection")
 
     assert owner_module.canonical_owner_threads is not None
 


### PR DESCRIPTION
## Summary
- delete backend/thread_projection.py after retargeting its remaining production importers
- switch the remaining read-side consumers directly to backend.thread_runtime.projection
- update focused tests to assert the root shell is gone

## Test Plan
- uv run python -m pytest tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_resource_common.py tests/Integration/test_conversations_router.py tests/Integration/test_threads_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_sandbox_router_user_shell.py -q
- uv run ruff check backend/user_sandbox_reads.py backend/chat/api/http/conversations_router.py backend/monitor/infrastructure/read_models/thread_read_service.py backend/web/services/sandbox_service.py backend/monitor/infrastructure/read_models/thread_workbench_read_service.py backend/web/routers/sandbox.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_resource_common.py tests/Integration/test_conversations_router.py tests/Integration/test_threads_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_sandbox_router_user_shell.py
- uv run ruff format --check backend/user_sandbox_reads.py backend/chat/api/http/conversations_router.py backend/monitor/infrastructure/read_models/thread_read_service.py backend/web/services/sandbox_service.py backend/monitor/infrastructure/read_models/thread_workbench_read_service.py backend/web/routers/sandbox.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_resource_common.py tests/Integration/test_conversations_router.py tests/Integration/test_threads_router.py tests/Integration/test_resource_overview_contract_split.py tests/Integration/test_sandbox_router_user_shell.py
- git diff --check