### PR TITLE
refactor: retarget sandbox provider availability path owner

### DIFF
--- a/backend/sandbox_provider_availability.py
+++ b/backend/sandbox_provider_availability.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from backend.sandbox_inventory import init_providers_and_managers
-from backend.web.core.config import SANDBOXES_DIR
+from backend.sandbox_paths import SANDBOXES_DIR
 from sandbox.config import SandboxConfig
 
 

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -22,7 +22,8 @@ def test_sandbox_provider_availability_owner_moves_out_of_sandbox_service() -> N
     source = inspect.getsource(neutral_sandbox_provider_availability)
 
     assert "backend.web.services" not in source
-    assert "backend.web.core.config" in source
+    assert "backend.web.core.config" not in source
+    assert "backend.sandbox_paths" in source
 
 
 def test_sandbox_inventory_owner_moves_out_of_sandbox_service() -> None:


### PR DESCRIPTION
## Scope
- backend/sandbox_provider_availability.py
- tests/Unit/sandbox/test_sandbox_provider_availability.py

## Why
`sandbox_provider_availability` was still reaching back into `backend.web.core.config.SANDBOXES_DIR` even though the neutral owner already exists at `backend.sandbox_paths.SANDBOXES_DIR`.

## Change
- retarget `SANDBOXES_DIR` import from `backend.web.core.config` to `backend.sandbox_paths`
- update the focused source-contract test to assert the new owner path

## Proof
- `uv run pytest -q tests/Unit/sandbox/test_sandbox_provider_availability.py -k 'sandbox_provider_availability_owner_moves_out_of_sandbox_service or library_service_uses_neutral_sandbox_provider_availability_owner or sandbox_service_keeps_sandbox_inventory_compat_surface'`
- `uv run ruff check backend/sandbox_provider_availability.py tests/Unit/sandbox/test_sandbox_provider_availability.py`
- `git diff --check`
