### PR TITLE
refactor: retarget agent user snapshot install owner

### DIFF
--- a/backend/agent_user_snapshot_install.py
+++ b/backend/agent_user_snapshot_install.py
@@ -1,0 +1,196 @@
+"""Neutral owner for marketplace agent-user snapshot installs."""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+import yaml
+
+
+def _parse_agent_md_content(content: str) -> dict[str, Any] | None:
+    if not content.startswith("---"):
+        return None
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        fm = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    if not fm or "name" not in fm:
+        return None
+    return {
+        "name": fm["name"],
+        "description": fm.get("description", ""),
+        "model": fm.get("model"),
+        "tools": fm.get("tools", ["*"]),
+        "system_prompt": parts[2].strip(),
+    }
+
+
+def _sanitize_name(name: str) -> str:
+    sanitized = re.sub(r'[/\\<>:"|?*\x00-\x1f]', "_", name)
+    sanitized = sanitized.strip(". ")
+    if not sanitized:
+        sanitized = "unnamed"
+    return sanitized
+
+
+def _save_config_to_repo(
+    agent_config_repo: Any,
+    agent_config_id: str,
+    *,
+    agent_user_id: str,
+    owner_user_id: str,
+    name: str,
+    description: str = "",
+    model: str | None = None,
+    tools: list[str] | None = None,
+    system_prompt: str = "",
+    status: str = "draft",
+    version: str = "0.1.0",
+    created_at: int = 0,
+    updated_at: int = 0,
+    runtime: dict | None = None,
+    mcp: dict | None = None,
+    meta: dict | None = None,
+) -> None:
+    agent_config_repo.save_config(
+        agent_config_id,
+        {
+            "agent_user_id": agent_user_id,
+            "owner_user_id": owner_user_id,
+            "name": name,
+            "description": description,
+            "model": model,
+            "tools": tools or ["*"],
+            "system_prompt": system_prompt,
+            "status": status,
+            "version": version,
+            "created_at": created_at,
+            "updated_at": updated_at,
+            "runtime": runtime or {},
+            "mcp": mcp or {},
+            "meta": meta or {},
+        },
+    )
+
+
+def install_from_snapshot(
+    snapshot: dict,
+    name: str,
+    description: str,
+    marketplace_item_id: str,
+    installed_version: str,
+    owner_user_id: str,
+    existing_user_id: str | None = None,
+    user_repo: Any = None,
+    agent_config_repo: Any = None,
+) -> str:
+    """Create or update a marketplace-backed agent user via repos only."""
+    from storage.contracts import UserRow, UserType
+    from storage.utils import generate_agent_config_id, generate_agent_user_id
+
+    if user_repo is None or agent_config_repo is None:
+        raise RuntimeError("user_repo and agent_config_repo are required to install marketplace user snapshot")
+
+    now = time.time()
+    now_ms = int(now * 1000)
+    agent_md = _parse_agent_md_content(str(snapshot.get("agent_md") or "")) or {}
+    agent_name = str(agent_md.get("name") or name)
+    agent_description = str(agent_md.get("description") or description)
+    agent_model = agent_md.get("model")
+    agent_tools = list(agent_md.get("tools") or ["*"])
+    agent_prompt = str(agent_md.get("system_prompt") or "")
+    runtime_data = snapshot.get("runtime") if isinstance(snapshot.get("runtime"), dict) else {}
+    mcp_data = snapshot.get("mcp") if isinstance(snapshot.get("mcp"), dict) else {}
+
+    if existing_user_id:
+        user_id = existing_user_id
+        user = user_repo.get_by_id(user_id)
+        if user is None or user.agent_config_id is None:
+            raise RuntimeError(f"Agent user {user_id} is missing agent_config_id")
+        agent_config_id = user.agent_config_id
+        current_config = agent_config_repo.get_config(agent_config_id)
+        if current_config is None:
+            raise RuntimeError(f"Agent config {agent_config_id} is missing for {user_id}")
+        created_at = int(current_config.get("created_at", now_ms))
+        user_repo.update(user_id, display_name=agent_name)
+    else:
+        user_id = generate_agent_user_id()
+        agent_config_id = generate_agent_config_id()
+        created_at = now_ms
+        row = UserRow(
+            id=user_id,
+            type=UserType.AGENT,
+            display_name=agent_name,
+            owner_user_id=owner_user_id,
+            agent_config_id=agent_config_id,
+            created_at=now,
+        )
+        user_repo.create(row)
+
+    _save_config_to_repo(
+        agent_config_repo,
+        agent_config_id,
+        agent_user_id=user_id,
+        owner_user_id=owner_user_id,
+        name=agent_name,
+        description=agent_description,
+        model=agent_model,
+        tools=agent_tools,
+        system_prompt=agent_prompt,
+        status="active",
+        version=installed_version,
+        created_at=created_at,
+        updated_at=now_ms,
+        runtime=runtime_data,
+        mcp=mcp_data,
+        meta={
+            "source": {
+                "marketplace_item_id": marketplace_item_id,
+                "installed_version": installed_version,
+                "installed_at": now_ms,
+                "modified": False,
+            }
+        },
+    )
+
+    for row in agent_config_repo.list_rules(agent_config_id):
+        agent_config_repo.delete_rule(row["id"])
+    for rule in snapshot.get("rules", []):
+        if not isinstance(rule, dict):
+            continue
+        rule_name = _sanitize_name(str(rule.get("name") or "default"))
+        agent_config_repo.save_rule(agent_config_id, f"{rule_name}.md", str(rule.get("content") or ""))
+
+    for row in agent_config_repo.list_skills(agent_config_id):
+        agent_config_repo.delete_skill(row["id"])
+    for skill in snapshot.get("skills", []):
+        if not isinstance(skill, dict):
+            continue
+        skill_name = _sanitize_name(str(skill.get("name") or "default"))
+        skill_meta = dict(skill.get("meta")) if isinstance(skill.get("meta"), dict) else {}
+        if skill.get("desc") is not None:
+            skill_meta["desc"] = str(skill.get("desc") or "")
+        agent_config_repo.save_skill(agent_config_id, skill_name, str(skill.get("content") or ""), meta=skill_meta)
+
+    for row in agent_config_repo.list_sub_agents(agent_config_id):
+        agent_config_repo.delete_sub_agent(row["id"])
+    for item in snapshot.get("agents", []):
+        if not isinstance(item, dict):
+            continue
+        parsed_sub_agent = _parse_agent_md_content(str(item.get("content") or "")) or {}
+        sub_agent_name = str(parsed_sub_agent.get("name") or item.get("name") or "default")
+        agent_config_repo.save_sub_agent(
+            agent_config_id,
+            _sanitize_name(sub_agent_name),
+            description=str(parsed_sub_agent.get("description") or ""),
+            model=parsed_sub_agent.get("model"),
+            tools=list(parsed_sub_agent.get("tools") or ["*"]),
+            system_prompt=str(parsed_sub_agent.get("system_prompt") or ""),
+        )
+
+    return user_id

--- a/backend/web/services/agent_user_service.py
+++ b/backend/web/services/agent_user_service.py
@@ -1,18 +1,19 @@
 """Agent-user CRUD over repo-backed users/configs."""
 
-import re
 import time
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+import backend.agent_user_snapshot_install as _snapshot_install_owner
 from backend.versioning import BumpType, bump_semver
 from backend.web.utils.serializers import avatar_url
 from config.defaults.tool_catalog import TOOLS_BY_NAME, ToolDef
 from config.loader import AgentLoader
 
 _SYSTEM_AGENTS_DIR = (Path(__file__).resolve().parents[3] / "config" / "defaults" / "agents").resolve()
+install_from_snapshot = _snapshot_install_owner.install_from_snapshot
 
 
 def _parse_agent_md_content(content: str) -> dict[str, Any] | None:
@@ -655,133 +656,3 @@ def delete_agent_user(
     user_repo.delete(agent_user_id)
 
     return True
-
-
-def _sanitize_name(name: str) -> str:
-    """Strip path-unsafe characters from snapshot-derived names."""
-    sanitized = re.sub(r'[/\\<>:"|?*\x00-\x1f]', "_", name)
-    sanitized = sanitized.strip(". ")
-    if not sanitized:
-        sanitized = "unnamed"
-    return sanitized
-
-
-def install_from_snapshot(
-    snapshot: dict,
-    name: str,
-    description: str,
-    marketplace_item_id: str,
-    installed_version: str,
-    owner_user_id: str,
-    existing_user_id: str | None = None,
-    user_repo: Any = None,
-    agent_config_repo: Any = None,
-) -> str:
-    """Create or update a marketplace-backed agent user via repos only."""
-    from storage.contracts import UserRow, UserType
-    from storage.utils import generate_agent_config_id, generate_agent_user_id
-
-    if user_repo is None or agent_config_repo is None:
-        raise RuntimeError("user_repo and agent_config_repo are required to install marketplace user snapshot")
-
-    now = time.time()
-    now_ms = int(now * 1000)
-    agent_md = _parse_agent_md_content(str(snapshot.get("agent_md") or "")) or {}
-    agent_name = str(agent_md.get("name") or name)
-    agent_description = str(agent_md.get("description") or description)
-    agent_model = agent_md.get("model")
-    agent_tools = list(agent_md.get("tools") or ["*"])
-    agent_prompt = str(agent_md.get("system_prompt") or "")
-    runtime_data = snapshot.get("runtime") if isinstance(snapshot.get("runtime"), dict) else {}
-    mcp_data = snapshot.get("mcp") if isinstance(snapshot.get("mcp"), dict) else {}
-
-    if existing_user_id:
-        user_id = existing_user_id
-        user = user_repo.get_by_id(user_id)
-        if user is None or user.agent_config_id is None:
-            raise RuntimeError(f"Agent user {user_id} is missing agent_config_id")
-        agent_config_id = user.agent_config_id
-        current_config = agent_config_repo.get_config(agent_config_id)
-        if current_config is None:
-            raise RuntimeError(f"Agent config {agent_config_id} is missing for {user_id}")
-        created_at = int(current_config.get("created_at", now_ms))
-        user_repo.update(user_id, display_name=agent_name)
-    else:
-        user_id = generate_agent_user_id()
-        agent_config_id = generate_agent_config_id()
-        created_at = now_ms
-        row = UserRow(
-            id=user_id,
-            type=UserType.AGENT,
-            display_name=agent_name,
-            owner_user_id=owner_user_id,
-            agent_config_id=agent_config_id,
-            created_at=now,
-        )
-        user_repo.create(row)
-
-    # @@@snapshot-install-repo-only - marketplace agent installs no longer materialize
-    # a local agent directory. The DB is now the live shell; marketplace lineage still needs
-    # a separate repo-rooted home because publish records source lineage.
-    _save_config_to_repo(
-        agent_config_repo,
-        agent_config_id,
-        agent_user_id=user_id,
-        owner_user_id=owner_user_id,
-        name=agent_name,
-        description=agent_description,
-        model=agent_model,
-        tools=agent_tools,
-        system_prompt=agent_prompt,
-        status="active",
-        version=installed_version,
-        created_at=created_at,
-        updated_at=now_ms,
-        runtime=runtime_data,
-        mcp=mcp_data,
-        meta={
-            "source": {
-                "marketplace_item_id": marketplace_item_id,
-                "installed_version": installed_version,
-                "installed_at": now_ms,
-                "modified": False,
-            }
-        },
-    )
-
-    for row in agent_config_repo.list_rules(agent_config_id):
-        agent_config_repo.delete_rule(row["id"])
-    for rule in snapshot.get("rules", []):
-        if not isinstance(rule, dict):
-            continue
-        rule_name = _sanitize_name(str(rule.get("name") or "default"))
-        agent_config_repo.save_rule(agent_config_id, f"{rule_name}.md", str(rule.get("content") or ""))
-
-    for row in agent_config_repo.list_skills(agent_config_id):
-        agent_config_repo.delete_skill(row["id"])
-    for skill in snapshot.get("skills", []):
-        if not isinstance(skill, dict):
-            continue
-        skill_name = _sanitize_name(str(skill.get("name") or "default"))
-        skill_meta = dict(skill.get("meta")) if isinstance(skill.get("meta"), dict) else {}
-        if skill.get("desc") is not None:
-            skill_meta["desc"] = str(skill.get("desc") or "")
-        agent_config_repo.save_skill(agent_config_id, skill_name, str(skill.get("content") or ""), meta=skill_meta)
-
-    for row in agent_config_repo.list_sub_agents(agent_config_id):
-        agent_config_repo.delete_sub_agent(row["id"])
-    for item in snapshot.get("agents", []):
-        if not isinstance(item, dict):
-            continue
-        parsed_sub_agent = _parse_agent_md_content(str(item.get("content") or "")) or {}
-        sub_agent_name = str(parsed_sub_agent.get("name") or item.get("name") or "default")
-        agent_config_repo.save_sub_agent(
-            agent_config_id,
-            _sanitize_name(sub_agent_name),
-            description=str(parsed_sub_agent.get("description") or ""),
-            model=parsed_sub_agent.get("model"),
-            tools=list(parsed_sub_agent.get("tools") or ["*"]),
-            system_prompt=str(parsed_sub_agent.get("system_prompt") or ""),
-        )
-
-    return user_id

--- a/backend/web/services/marketplace_client.py
+++ b/backend/web/services/marketplace_client.py
@@ -12,6 +12,7 @@ import httpx
 import yaml
 from fastapi import HTTPException
 
+import backend.agent_user_snapshot_install as _snapshot_install_owner
 import backend.library_paths as _lib_paths
 from backend.versioning import BumpType, bump_semver
 from config.loader import load_bundle_from_repo
@@ -356,9 +357,7 @@ def download(
         if user_repo is None or agent_config_repo is None:
             raise RuntimeError("user_repo and agent_config_repo are required to install marketplace user snapshot")
 
-        from backend.web.services.agent_user_service import install_from_snapshot
-
-        user_id = install_from_snapshot(
+        user_id = _snapshot_install_owner.install_from_snapshot(
             snapshot=snapshot,
             name=item["name"],
             description=item.get("description", ""),
@@ -382,9 +381,7 @@ def upgrade(user_id: str, item_id: str, owner_user_id: str, user_repo: Any = Non
     snapshot = result["snapshot"]
     installed_version = result["version"]
 
-    from backend.web.services.agent_user_service import install_from_snapshot
-
-    install_from_snapshot(
+    _snapshot_install_owner.install_from_snapshot(
         snapshot=snapshot,
         name=result["item"]["name"],
         description=result["item"].get("description", ""),

--- a/tests/Unit/backend/test_auth_runtime_owner.py
+++ b/tests/Unit/backend/test_auth_runtime_owner.py
@@ -75,6 +75,14 @@ def test_agent_user_service_uses_neutral_versioning_owner() -> None:
     assert "from backend.versioning import BumpType, bump_semver" in source
 
 
+def test_agent_user_service_uses_neutral_snapshot_install_owner() -> None:
+    source = inspect.getsource(agent_user_service)
+
+    assert "def install_from_snapshot(" not in source
+    assert "import backend.agent_user_snapshot_install as _snapshot_install_owner" in source
+    assert "install_from_snapshot = _snapshot_install_owner.install_from_snapshot" in source
+
+
 def test_panel_models_uses_neutral_versioning_owner() -> None:
     source = inspect.getsource(panel_models)
 

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -88,6 +88,15 @@ def test_marketplace_client_uses_neutral_versioning_owner() -> None:
     assert "from backend.versioning import BumpType, bump_semver" in source
 
 
+def test_marketplace_client_uses_neutral_agent_user_snapshot_install_owner() -> None:
+    import backend.web.services.marketplace_client as marketplace_client
+
+    source = importlib.reload(marketplace_client).__loader__.get_source(marketplace_client.__name__) or ""
+
+    assert "from backend.web.services.agent_user_service import install_from_snapshot" not in source
+    assert "import backend.agent_user_snapshot_install as _snapshot_install_owner" in source
+
+
 # ── Helpers ──
 
 
@@ -249,7 +258,7 @@ class TestDownloadUser:
         seen: dict[str, object] = {}
 
         monkeypatch.setattr(
-            "backend.web.services.agent_user_service.install_from_snapshot",
+            "backend.web.services.marketplace_client._snapshot_install_owner.install_from_snapshot",
             lambda **kwargs: seen.update(kwargs) or "agent-user-1",
         )
 
@@ -307,7 +316,7 @@ def test_upgrade_returns_user_id_contract(monkeypatch):
     seen: dict[str, object] = {}
 
     monkeypatch.setattr(
-        "backend.web.services.agent_user_service.install_from_snapshot",
+        "backend.web.services.marketplace_client._snapshot_install_owner.install_from_snapshot",
         lambda **kwargs: seen.update(kwargs) or "agent-user-1",
     )
 
@@ -337,7 +346,7 @@ def test_upgrade_passes_existing_user_id_to_snapshot_install(monkeypatch):
         return "agent-user-1"
 
     monkeypatch.setattr(
-        "backend.web.services.agent_user_service.install_from_snapshot",
+        "backend.web.services.marketplace_client._snapshot_install_owner.install_from_snapshot",
         fake_install_from_snapshot,
     )
 


### PR DESCRIPTION
## Summary
- move install_from_snapshot into backend/agent_user_snapshot_install.py
- keep backend/web/services/agent_user_service.py as a compat exporter for that owner
- retarget marketplace_client and focused tests to the neutral owner module

## Test Plan
- uv run python -m pytest tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/platform/test_marketplace_client.py tests/Integration/test_panel_auth_shell_coherence.py -q
- uv run ruff check backend/agent_user_snapshot_install.py backend/web/services/agent_user_service.py backend/web/services/marketplace_client.py tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/platform/test_marketplace_client.py tests/Integration/test_panel_auth_shell_coherence.py
- uv run ruff format --check backend/agent_user_snapshot_install.py backend/web/services/agent_user_service.py backend/web/services/marketplace_client.py tests/Unit/backend/test_auth_runtime_owner.py tests/Unit/platform/test_marketplace_client.py tests/Integration/test_panel_auth_shell_coherence.py
- git diff --check