### PR TITLE
test: prune low-value chat router import-string assertions

### DIFF
--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import inspect
 import threading
 from types import SimpleNamespace
 
@@ -18,31 +17,6 @@ def test_conversations_http_owner_module_lives_under_backend_chat() -> None:
 def test_conversations_router_shell_is_deleted() -> None:
     with pytest.raises(ModuleNotFoundError):
         importlib.import_module("backend.web.routers.conversations")
-
-
-def test_conversations_router_uses_runtime_activity_reader_for_running_state() -> None:
-    source = inspect.getsource(owner_conversations_router)
-
-    assert "AgentState" not in source
-    assert "agent_pool" not in source
-
-
-def test_conversations_router_uses_neutral_chat_dependency_owner() -> None:
-    source = inspect.getsource(owner_conversations_router)
-
-    assert "backend.web.core.dependencies" not in source
-    assert "backend.chat.api.http.dependencies" in source
-
-
-def test_conversations_router_uses_neutral_read_and_avatar_helpers() -> None:
-    source = inspect.getsource(owner_conversations_router)
-
-    assert "backend.web.services.owner_thread_read_service" not in source
-    assert "backend.web.services.thread_visibility" not in source
-    assert "backend.web.utils.serializers" not in source
-    assert "backend.thread_runtime.owner_reads" in source
-    assert "backend.thread_runtime.projection" in source
-    assert "backend.avatar_urls" in source
 
 
 @pytest.mark.asyncio

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -115,36 +115,6 @@ def test_messaging_router_shell_is_deleted() -> None:
         importlib.import_module("backend.web.routers.messaging")
 
 
-def test_chat_router_imports_messaging_social_access_owner() -> None:
-    source = inspect.getsource(chat_router)
-
-    assert "from messaging.social_access import" in source
-
-
-def test_chat_router_uses_neutral_chat_dependency_owner() -> None:
-    source = inspect.getsource(chat_router)
-
-    assert "backend.web.core.dependencies" not in source
-    assert "backend.chat.api.http.dependencies" in source
-    assert "backend.web.services.social_access_service" not in source
-
-
-def test_chat_router_imports_actor_ownership_primitive() -> None:
-    source = inspect.getsource(chat_router)
-
-    assert "from messaging.actor_ownership import" in source
-    assert "owner_user_id ==" not in source
-
-
-def test_chat_router_imports_group_chat_social_access_primitive() -> None:
-    source = inspect.getsource(chat_router)
-
-    assert "can_group_chat_with_participant" in source
-    assert "ACTIVE_CHAT_RELATIONSHIP_STATES" not in source
-    assert "has_active_contact" not in source
-    assert ".get_state(" not in source
-
-
 def test_get_accessible_chat_or_404_returns_chat():
     chat = _chat("chat-1")
     app = SimpleNamespace(


### PR DESCRIPTION
## Summary
- remove low-value inspect.getsource/import-string assertions from the chat and conversations integration packs
- keep the behavior tests and shell-deleted assertions intact
- follow the new governance ruling that these source-string owner tests are transitional guardrails, not strong permanent proof

## Test Plan
- uv run python -m pytest tests/Integration/test_messaging_router.py tests/Integration/test_conversations_router.py -q
- uv run ruff check tests/Integration/test_messaging_router.py tests/Integration/test_conversations_router.py
- uv run ruff format --check tests/Integration/test_messaging_router.py tests/Integration/test_conversations_router.py
- git diff --check