### PR TITLE
refactor: retarget neutral message content helpers

### DIFF
--- a/backend/display_builder.py
+++ b/backend/display_builder.py
@@ -16,8 +16,8 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from backend.web.utils.serializers import extract_text_content as _extract_text_content
-from backend.web.utils.serializers import strip_system_tags as _strip_system_tags
+from backend.message_content import extract_text_content as _extract_text_content
+from backend.message_content import strip_system_tags as _strip_system_tags
 
 logger = logging.getLogger(__name__)
 

--- a/backend/message_content.py
+++ b/backend/message_content.py
@@ -1,0 +1,29 @@
+"""Neutral message-content helpers shared across backend owners."""
+
+import re
+from typing import Any
+
+_SYSTEM_HINT_RE = re.compile(r"\s*<system-hint>.*?</system-hint>\s*", re.DOTALL)
+_SYSTEM_REMINDER_RE = re.compile(r"\s*<system-reminder>.*?</system-reminder>\s*", re.DOTALL)
+
+
+def strip_system_tags(content: str) -> str:
+    """Remove user-hidden system tags from owner-visible content."""
+    content = _SYSTEM_HINT_RE.sub("", content)
+    content = _SYSTEM_REMINDER_RE.sub("", content)
+    return content.strip()
+
+
+def extract_text_content(raw_content: Any) -> str:
+    """Extract text content from common message payload shapes."""
+    if isinstance(raw_content, str):
+        return raw_content
+    if isinstance(raw_content, list):
+        parts: list[str] = []
+        for block in raw_content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "".join(parts)
+    return str(raw_content)

--- a/backend/thread_runtime/history.py
+++ b/backend/thread_runtime/history.py
@@ -6,8 +6,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from backend.message_content import extract_text_content
 from backend.thread_runtime.interruption import repair_interrupted_tool_call_messages
-from backend.web.utils.serializers import extract_text_content
 
 
 @dataclass(frozen=True)

--- a/backend/thread_runtime/run/entrypoints.py
+++ b/backend/thread_runtime/run/entrypoints.py
@@ -7,9 +7,9 @@ import json
 import uuid as _uuid
 from typing import Any
 
+from backend.message_content import extract_text_content
 from backend.thread_runtime.run.buffer_wiring import ensure_thread_handlers, get_or_create_thread_buffer
 from backend.thread_runtime.sandbox import resolve_thread_sandbox
-from backend.web.utils.serializers import extract_text_content
 from core.runtime.middleware.monitor import AgentState
 
 _ensure_thread_handlers = ensure_thread_handlers

--- a/backend/thread_runtime/run/prologue.py
+++ b/backend/thread_runtime/run/prologue.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from backend.web.utils.serializers import strip_system_tags
+from backend.message_content import strip_system_tags
 
 
 async def emit_run_prologue(

--- a/backend/thread_runtime/run/stream_loop.py
+++ b/backend/thread_runtime/run/stream_loop.py
@@ -8,7 +8,7 @@ import logging
 import random
 from typing import Any
 
-from backend.web.utils.serializers import extract_text_content
+from backend.message_content import extract_text_content
 
 logger = logging.getLogger(__name__)
 

--- a/backend/web/utils/serializers.py
+++ b/backend/web/utils/serializers.py
@@ -1,13 +1,11 @@
 """Message serialization utilities."""
 
-import re
 from typing import Any
 
 from backend.avatar_paths import avatars_dir
+from backend.message_content import extract_text_content, strip_system_tags
 
-# @@@strip-system-tags — remove injected system tags from user-visible content
-_SYSTEM_HINT_RE = re.compile(r"\s*<system-hint>.*?</system-hint>\s*", re.DOTALL)
-_SYSTEM_REMINDER_RE = re.compile(r"\s*<system-reminder>.*?</system-reminder>\s*", re.DOTALL)
+__all__ = ["avatar_url", "strip_system_tags", "extract_text_content", "serialize_message"]
 
 
 def avatar_url(user_id: str | None, has_avatar: bool) -> str | None:
@@ -16,28 +14,6 @@ def avatar_url(user_id: str | None, has_avatar: bool) -> str | None:
     if has_avatar or (avatars_dir() / f"{user_id}.png").exists():
         return f"/api/users/{user_id}/avatar"
     return None
-
-
-def strip_system_tags(content: str) -> str:
-    """Remove <system-hint> and <system-reminder> tags from user-visible content."""
-    content = _SYSTEM_HINT_RE.sub("", content)
-    content = _SYSTEM_REMINDER_RE.sub("", content)
-    return content.strip()
-
-
-def extract_text_content(raw_content: Any) -> str:
-    """Extract text content from various message content formats."""
-    if isinstance(raw_content, str):
-        return raw_content
-    if isinstance(raw_content, list):
-        parts: list[str] = []
-        for block in raw_content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
-            elif isinstance(block, str):
-                parts.append(block)
-        return "".join(parts)
-    return str(raw_content)
 
 
 def serialize_message(msg: Any) -> dict[str, Any]:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -262,3 +262,33 @@ def test_lifespan_uses_neutral_display_builder_owner() -> None:
     assert owner_module.DisplayBuilder is not None
     assert "from backend.web.services.display_builder import DisplayBuilder" not in lifespan_source
     assert "from backend.display_builder import DisplayBuilder" in lifespan_source
+
+
+def test_display_builder_uses_neutral_message_content_owner() -> None:
+    owner_module = importlib.import_module("backend.message_content")
+    source = inspect.getsource(importlib.import_module("backend.display_builder"))
+
+    assert owner_module.extract_text_content is not None
+    assert owner_module.strip_system_tags is not None
+    assert "from backend.message_content import extract_text_content as _extract_text_content" in source
+    assert "from backend.message_content import strip_system_tags as _strip_system_tags" in source
+    assert "backend.web.utils.serializers" not in source
+
+
+def test_thread_runtime_modules_use_neutral_message_content_owner() -> None:
+    owner_module = importlib.import_module("backend.message_content")
+    history_source = inspect.getsource(importlib.import_module("backend.thread_runtime.history"))
+    entrypoints_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.entrypoints"))
+    prologue_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.prologue"))
+    stream_loop_source = inspect.getsource(importlib.import_module("backend.thread_runtime.run.stream_loop"))
+
+    assert owner_module.extract_text_content is not None
+    assert owner_module.strip_system_tags is not None
+    assert "from backend.message_content import extract_text_content" in history_source
+    assert "from backend.message_content import extract_text_content" in entrypoints_source
+    assert "from backend.message_content import strip_system_tags" in prologue_source
+    assert "from backend.message_content import extract_text_content" in stream_loop_source
+    assert "backend.web.utils.serializers" not in history_source
+    assert "backend.web.utils.serializers" not in entrypoints_source
+    assert "backend.web.utils.serializers" not in prologue_source
+    assert "backend.web.utils.serializers" not in stream_loop_source


### PR DESCRIPTION
## Summary
- add a neutral `backend.message_content` owner for generic text-content helpers
- retarget non-web runtime/display modules away from `backend.web.utils.serializers`
- keep `backend.web.utils.serializers` as the web-facing export surface and add owner tests for the new boundary

## Test Plan
- uv run pytest -q tests/Unit/backend/web/services/test_thread_runtime_owner.py
- uv run pytest -q tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py
- uv run pytest -q tests/Integration/test_settings_local_path_shell.py
- uv run pytest -q tests/Unit/backend/web/routers/test_threads_attachment_paths.py
- uv run ruff check backend/message_content.py backend/display_builder.py backend/thread_runtime/history.py backend/thread_runtime/run/entrypoints.py backend/thread_runtime/run/prologue.py backend/thread_runtime/run/stream_loop.py backend/web/utils/serializers.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- git diff --check
