### PR TITLE
test: prune low-value sandbox provider import-string assertions

### DIFF
--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -1,65 +1,10 @@
 from __future__ import annotations
 
-import importlib
-import inspect
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
-from backend import sandbox_inventory as neutral_sandbox_inventory
-from backend import sandbox_recipe_catalog as neutral_sandbox_recipe_catalog
 from backend.web.services import sandbox_service
 from sandbox.providers.local import LocalSessionProvider
-
-
-def test_sandbox_provider_availability_owner_moves_out_of_sandbox_service() -> None:
-    try:
-        neutral_sandbox_provider_availability = importlib.import_module("backend.sandbox_provider_availability")
-    except ModuleNotFoundError:
-        pytest.fail("backend.sandbox_provider_availability module missing")
-
-    source = inspect.getsource(neutral_sandbox_provider_availability)
-
-    assert "backend.web.services" not in source
-    assert "backend.web.core.config" not in source
-    assert "backend.sandbox_paths" in source
-
-
-def test_sandbox_inventory_owner_moves_out_of_sandbox_service() -> None:
-    source = inspect.getsource(neutral_sandbox_inventory)
-
-    assert "backend.web.services import sandbox_service" not in source
-    assert "SandboxConfig" in source
-
-
-def test_sandbox_service_keeps_sandbox_inventory_compat_surface() -> None:
-    source = inspect.getsource(sandbox_service)
-
-    assert "_sandbox_provider_availability.available_sandbox_types(" in source
-    assert "sandbox_inventory.init_providers_and_managers()" in source
-
-
-def test_sandbox_service_keeps_recipe_catalog_compat_surface() -> None:
-    source = inspect.getsource(sandbox_service)
-
-    assert "_sandbox_recipe_catalog.list_default_recipes()" in source
-
-
-def test_sandbox_recipe_catalog_owner_moves_out_of_sandbox_service() -> None:
-    source = inspect.getsource(neutral_sandbox_recipe_catalog)
-
-    assert "backend.web.services" not in source
-    assert "backend.sandbox_inventory" in source
-
-
-def test_library_service_uses_neutral_sandbox_provider_availability_owner() -> None:
-    from backend.web.services import library_service
-
-    source = inspect.getsource(library_service)
-
-    assert "sandbox_service.available_sandbox_types" not in source
-    assert "sandbox_provider_availability.available_sandbox_types" in source
 
 
 def test_available_sandbox_types_marks_configured_but_unavailable_provider(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove low-value inspect.getsource/import-string assertions from tests/Unit/sandbox/test_sandbox_provider_availability.py
- keep the concrete provider-availability behavior tests intact
- follow the governance ruling that these source-string owner tests are transitional guardrails rather than strong permanent proof

## Test Plan
- uv run python -m pytest tests/Unit/sandbox/test_sandbox_provider_availability.py -q
- uv run ruff check tests/Unit/sandbox/test_sandbox_provider_availability.py
- uv run ruff format --check tests/Unit/sandbox/test_sandbox_provider_availability.py
- git diff --check