### PR TITLE
test: prune webhooks source guard assertions

### DIFF
--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -1,24 +1,8 @@
 from __future__ import annotations
 
-import inspect
-
 import pytest
 
 from backend.web.routers import webhooks
-
-
-def test_webhooks_router_uses_neutral_provider_inventory_owner() -> None:
-    source = inspect.getsource(webhooks)
-
-    assert "backend.web.services.sandbox_service" not in source
-    assert "backend.sandbox_inventory import init_providers_and_managers" in source
-
-
-def test_webhooks_router_uses_neutral_storage_container_cache_owner() -> None:
-    source = inspect.getsource(webhooks)
-
-    assert "from backend.web.utils.helpers import _get_container" not in source
-    assert "from backend.storage_container_cache import get_storage_container as _get_container" in source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove low-value inspect.getsource/source-string assertions from webhook router contract tests
- preserve the concrete webhook behavior tests in the same file

## Test Plan
- uv run pytest -q tests/Integration/test_webhooks_router_contract.py
- uv run ruff check tests/Integration/test_webhooks_router_contract.py
- uv run ruff format --check tests/Integration/test_webhooks_router_contract.py
- git diff --check
