### PR TITLE
test: prune monitor app lifespan source guard assertion

### DIFF
--- a/tests/Unit/monitor/test_monitor_app_lifespan.py
+++ b/tests/Unit/monitor/test_monitor_app_lifespan.py
@@ -1,23 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 from types import SimpleNamespace
 
 import pytest
 
 from backend.monitor_app import lifespan as monitor_app_lifespan
-from backend.web.core import lifespan as web_lifespan
-
-
-def test_resource_refresh_loop_moves_from_web_lifespan_to_monitor_app_lifespan():
-    monitor_source = inspect.getsource(monitor_app_lifespan)
-    web_source = inspect.getsource(web_lifespan)
-
-    assert "resource_overview_refresh_loop" in monitor_source
-    assert "monitor_resources_task" in monitor_source
-    assert "resource_overview_refresh_loop" not in web_source
-    assert "monitor_resources_task" not in web_source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the low-value inspect.getsource/source-string assertion from monitor app lifespan tests
- preserve the concrete async lifespan behavior tests in the same file

## Test Plan
- uv run pytest -q tests/Unit/monitor/test_monitor_app_lifespan.py
- uv run ruff check tests/Unit/monitor/test_monitor_app_lifespan.py
- uv run ruff format --check tests/Unit/monitor/test_monitor_app_lifespan.py
- git diff --check
