### PR TITLE
test: prune low-value runtime storage import-string assertions

### DIFF
--- a/tests/Unit/backend/test_runtime_storage_bootstrap.py
+++ b/tests/Unit/backend/test_runtime_storage_bootstrap.py
@@ -1,14 +1,6 @@
-import inspect
 from types import SimpleNamespace
 
 from backend import runtime_storage_bootstrap
-
-
-def test_runtime_storage_bootstrap_depends_on_neutral_supabase_runtime():
-    source = inspect.getsource(runtime_storage_bootstrap)
-
-    assert "backend.web.core.supabase_factory" not in source
-    assert "backend.supabase_runtime" in source
 
 
 def test_build_runtime_storage_state_uses_shared_supabase_client(monkeypatch):


### PR DESCRIPTION
## Summary
- remove the low-value inspect.getsource/source-string assertion from tests/Unit/backend/test_runtime_storage_bootstrap.py
- keep the concrete runtime storage bootstrap behavior tests intact
- follow the import-string governance ruling by pruning transitional source-string checks where behavior coverage already exists

## Test Plan
- uv run python -m pytest tests/Unit/backend/test_runtime_storage_bootstrap.py -q
- uv run ruff check tests/Unit/backend/test_runtime_storage_bootstrap.py
- uv run ruff format --check tests/Unit/backend/test_runtime_storage_bootstrap.py
- git diff --check