### PR TITLE
feat(monitor): redesign evaluation workspace on latest dev

### DIFF
--- a/frontend/monitor/src/pages/EvaluationPage.tsx
+++ b/frontend/monitor/src/pages/EvaluationPage.tsx
@@ -41,6 +41,11 @@ type EvaluationBatchIndexPayload = {
     submitted_by_user_id?: string | null;
     agent_user_id?: string | null;
     created_at?: string | null;
+    config_json?: {
+      sandbox?: string | null;
+      max_concurrent?: number | null;
+      scenario_ids?: string[] | null;
+    } | null;
     summary_json?: {
       total_runs?: number | null;
       running_runs?: number | null;
@@ -69,6 +74,70 @@ type EvaluationBatchCreatePayload = {
   } | null;
 };
 
+const PAGE_SIZE = 8;
+
+const BATCH_STATUS_LABELS: Record<string, string> = {
+  pending: "待启动",
+  running: "进行中",
+  completed: "已完成",
+  failed: "失败",
+  cancelled: "已取消",
+  error: "错误",
+};
+
+const BATCH_STATUS_TONES: Record<string, "pending" | "running" | "completed" | "failed"> = {
+  pending: "pending",
+  running: "running",
+  completed: "completed",
+  failed: "failed",
+  cancelled: "failed",
+  error: "failed",
+};
+
+function asNumber(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function statusLabel(status: string | null | undefined): string {
+  if (!status) return "未知";
+  return BATCH_STATUS_LABELS[status] ?? status;
+}
+
+function statusTone(status: string | null | undefined): "pending" | "running" | "completed" | "failed" {
+  if (!status) return "pending";
+  return BATCH_STATUS_TONES[status] ?? "pending";
+}
+
+function summarizeBatch(batch: NonNullable<EvaluationBatchIndexPayload["items"]>[number]) {
+  const summary = batch.summary_json ?? {};
+  const config = batch.config_json ?? {};
+  const totalRuns = asNumber(summary.total_runs);
+  const runningRuns = asNumber(summary.running_runs);
+  const completedRuns = asNumber(summary.completed_runs);
+  const failedRuns = asNumber(summary.failed_runs);
+  const finishedRuns = completedRuns + failedRuns;
+  const progressPercent = totalRuns > 0 ? Math.min(100, Math.round((finishedRuns / totalRuns) * 100)) : 0;
+  const scenarioCount = Array.isArray(config.scenario_ids) ? config.scenario_ids.length : 0;
+  return {
+    totalRuns,
+    runningRuns,
+    completedRuns,
+    failedRuns,
+    finishedRuns,
+    progressPercent,
+    scenarioCount,
+    sandbox: config.sandbox ?? "-",
+    maxConcurrent: asNumber(config.max_concurrent),
+  };
+}
+
 export default function EvaluationPage() {
   const navigate = useNavigate();
   const { data, error } = useMonitorData<EvaluationPayload>("/evaluation");
@@ -81,19 +150,30 @@ export default function EvaluationPage() {
   const [selectedScenarioIds, setSelectedScenarioIds] = React.useState<string[]>([]);
   const [createError, setCreateError] = React.useState<string | null>(null);
   const [createPending, setCreatePending] = React.useState(false);
+  const [page, setPage] = React.useState(1);
+
+  const overview = data?.overview ?? {};
+  const runs = data?.runs ?? [];
+  const selectedRun = data?.selected_run ?? {};
+  const facts = selectedRun.facts ?? [];
+  const limitations = data?.limitations ?? [];
+  const batches = batchesData?.items ?? [];
+  const scenarios = scenariosData?.items ?? [];
+
+  const totalPages = Math.max(1, Math.ceil(batches.length / PAGE_SIZE));
+  React.useEffect(() => {
+    setPage((current) => Math.min(current, totalPages));
+  }, [totalPages]);
+
+  const visibleBatches = React.useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE;
+    return batches.slice(start, start + PAGE_SIZE);
+  }, [batches, page]);
 
   if (error) return <ErrorState title="Evaluation" error={error} />;
   if (batchesError) return <ErrorState title="Evaluation batches" error={batchesError} />;
   if (scenariosError) return <ErrorState title="Evaluation scenarios" error={scenariosError} />;
   if (!data || !batchesData || !scenariosData) return <div>Loading...</div>;
-
-  const overview = data.overview ?? {};
-  const runs = data.runs ?? [];
-  const selectedRun = data.selected_run ?? {};
-  const facts = selectedRun.facts ?? [];
-  const limitations = data.limitations ?? [];
-  const batches = batchesData.items ?? [];
-  const scenarios = scenariosData.items ?? [];
 
   function toggleScenario(scenarioId: string) {
     setSelectedScenarioIds((current) =>
@@ -122,10 +202,14 @@ export default function EvaluationPage() {
     }
   }
 
+  const batchRangeStart = batches.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const batchRangeEnd = Math.min(page * PAGE_SIZE, batches.length);
+
   return (
     <div className="page">
       <h1>Evaluation</h1>
       <p className="description">{data.headline ?? "Evaluation workbench."}</p>
+
       <section className="surface-section">
         <h2>Workbench Overview</h2>
         <div className="surface-grid">
@@ -147,136 +231,191 @@ export default function EvaluationPage() {
           </article>
         </div>
       </section>
+
       <section className="surface-section">
         <h2>Workbench Summary</h2>
         <p className="surface-card__body">{data.summary ?? "No evaluation summary available."}</p>
       </section>
+
       <section className="surface-section">
-        <h2>Create Batch</h2>
-        <form className="info-grid" onSubmit={(event) => void createBatch(event)}>
-          <label>
-            <strong>Agent user id</strong>
-            <input value={agentUserId} onChange={(event) => setAgentUserId(event.target.value)} />
-          </label>
-          <label>
-            <strong>Sandbox</strong>
-            <input value={sandbox} onChange={(event) => setSandbox(event.target.value)} />
-          </label>
-          <label>
-            <strong>Max concurrent</strong>
-            <input
-              min={1}
-              type="number"
-              value={maxConcurrent}
-              onChange={(event) => setMaxConcurrent(Number(event.target.value))}
-            />
-          </label>
+        <div className="evaluation-batches-header">
           <div>
-            <strong>Selected scenarios</strong>
-            <span>{selectedScenarioIds.length}</span>
+            <h2>Evaluation Batches</h2>
+            <p className="surface-card__body">
+              {batches.length > 0
+                ? `Showing ${batchRangeStart}-${batchRangeEnd} of ${batches.length} batches`
+                : "No evaluation batches yet."}
+            </p>
           </div>
-          <button
-            type="submit"
-            className="monitor-action-button"
-            disabled={createPending || agentUserId.trim() === "" || selectedScenarioIds.length === 0}
-          >
-            Create evaluation batch
-          </button>
-          <p className="surface-card__body">Creates a pending batch. Execution is handled by the batch runner path.</p>
-        </form>
-        {createError ? <p className="description">{createError}</p> : null}
-      </section>
-      <section className="surface-section">
-        <h2>Scenario Catalog</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Select</th>
-              <th>Scenario</th>
-              <th>Name</th>
-              <th>Category</th>
-              <th>Sandbox</th>
-              <th>Messages</th>
-              <th>Timeout</th>
-            </tr>
-          </thead>
-          <tbody>
-            {scenarios.length > 0 ? (
-              scenarios.map((scenario) => (
-                <tr key={scenario.scenario_id ?? scenario.name}>
-                  <td>
-                    {scenario.scenario_id ? (
-                      <input
-                        aria-label={`Select ${scenario.scenario_id}`}
-                        checked={selectedScenarioIds.includes(scenario.scenario_id)}
-                        type="checkbox"
-                        onChange={() => toggleScenario(scenario.scenario_id ?? "")}
+          {totalPages > 1 ? (
+            <div className="evaluation-pagination">
+              <button
+                type="button"
+                className="monitor-action-button"
+                disabled={page <= 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </button>
+              <span className="evaluation-pagination__meta">Page {page} / {totalPages}</span>
+              <button
+                type="button"
+                className="monitor-action-button"
+                disabled={page >= totalPages}
+                onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+              >
+                Next
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        <article className="evaluation-create-panel">
+          <div className="evaluation-create-panel__intro">
+            <p className="evaluation-create-panel__eyebrow">Builder</p>
+            <h3>Create Batch</h3>
+            <p className="surface-card__body">
+              Scenarios are the actual workloads a batch will run. They no longer sit in a standalone catalog section because they only matter while assembling a batch.
+            </p>
+          </div>
+          <form className="evaluation-create-form" onSubmit={(event) => void createBatch(event)}>
+            <div className="evaluation-create-form__grid">
+              <label className="evaluation-create-form__field">
+                <span>Agent user id</span>
+                <input value={agentUserId} onChange={(event) => setAgentUserId(event.target.value)} />
+              </label>
+              <label className="evaluation-create-form__field">
+                <span>Sandbox</span>
+                <input value={sandbox} onChange={(event) => setSandbox(event.target.value)} />
+              </label>
+              <label className="evaluation-create-form__field">
+                <span>Max concurrent</span>
+                <input
+                  min={1}
+                  type="number"
+                  value={maxConcurrent}
+                  onChange={(event) => setMaxConcurrent(Number(event.target.value))}
+                />
+              </label>
+            </div>
+            <div className="evaluation-scenario-picker">
+              <div className="evaluation-scenario-picker__header">
+                <strong>Scenarios</strong>
+                <span>{selectedScenarioIds.length} selected</span>
+              </div>
+              <div className="evaluation-scenario-list">
+                {scenarios.length > 0 ? (
+                  scenarios.map((scenario) => {
+                    const scenarioId = scenario.scenario_id ?? "";
+                    const selected = selectedScenarioIds.includes(scenarioId);
+                    return (
+                      <button
+                        key={scenarioId || scenario.name}
+                        type="button"
+                        className={`evaluation-scenario-chip ${selected ? "evaluation-scenario-chip--selected" : ""}`}
+                        onClick={() => scenarioId && toggleScenario(scenarioId)}
+                      >
+                        <span className="evaluation-scenario-chip__title mono">{scenarioId || scenario.name || "-"}</span>
+                        <span className="evaluation-scenario-chip__meta">
+                          {scenario.category ?? "uncategorized"} · {scenario.message_count ?? 0} msg · {scenario.timeout_seconds ?? "-"}s
+                        </span>
+                      </button>
+                    );
+                  })
+                ) : (
+                  <p className="surface-card__body">No evaluation scenarios found.</p>
+                )}
+              </div>
+            </div>
+            <div className="evaluation-create-panel__footer">
+              {createError ? <span className="evaluation-batch-card__footer-note error">{createError}</span> : <span className="evaluation-batch-card__footer-note">Pending batches start from the batch detail page.</span>}
+              <button
+                type="submit"
+                className="monitor-action-button"
+                disabled={createPending || agentUserId.trim() === "" || selectedScenarioIds.length === 0}
+              >
+                {createPending ? "Creating..." : "Create batch"}
+              </button>
+            </div>
+          </form>
+        </article>
+
+        {visibleBatches.length > 0 ? (
+          <div className="evaluation-batch-grid">
+            {visibleBatches.map((batch) => {
+              const batchId = batch.batch_id ?? "-";
+              const metrics = summarizeBatch(batch);
+              const tone = statusTone(batch.status);
+              return (
+                <article key={batchId} className="evaluation-batch-card">
+                  <div className="evaluation-batch-card__header">
+                    <div className="evaluation-batch-card__heading">
+                      <p className="evaluation-batch-card__eyebrow">{batch.kind ?? "scenario_batch"}</p>
+                      {batch.batch_id ? (
+                        <Link className="evaluation-batch-card__title mono" to={`/evaluation/batches/${batch.batch_id}`}>
+                          {batch.batch_id}
+                        </Link>
+                      ) : (
+                        <span className="evaluation-batch-card__title mono">-</span>
+                      )}
+                    </div>
+                    <span className={`evaluation-batch-card__status evaluation-batch-card__status--${tone}`}>
+                      {statusLabel(batch.status)}
+                    </span>
+                  </div>
+                  <div className="evaluation-batch-card__progress-block">
+                    <div className="evaluation-batch-card__progress-track" aria-hidden="true">
+                      <div
+                        className={`evaluation-batch-card__progress-fill evaluation-batch-card__progress-fill--${tone}`}
+                        style={{ width: `${metrics.progressPercent}%` }}
                       />
+                    </div>
+                    <p className="evaluation-batch-card__progress-copy">
+                      {metrics.completedRuns} completed · {metrics.failedRuns} failed · {metrics.runningRuns} running
+                    </p>
+                  </div>
+                  <div className="evaluation-batch-card__stats">
+                    <div className="evaluation-batch-card__stat">
+                      <span className="evaluation-batch-card__stat-label">Runs</span>
+                      <strong className="evaluation-batch-card__stat-value">{metrics.totalRuns}</strong>
+                    </div>
+                    <div className="evaluation-batch-card__stat">
+                      <span className="evaluation-batch-card__stat-label">Scenarios</span>
+                      <strong className="evaluation-batch-card__stat-value">{metrics.scenarioCount}</strong>
+                    </div>
+                    <div className="evaluation-batch-card__stat">
+                      <span className="evaluation-batch-card__stat-label">Sandbox</span>
+                      <strong className="evaluation-batch-card__stat-value evaluation-batch-card__stat-value--compact">{metrics.sandbox}</strong>
+                    </div>
+                    <div className="evaluation-batch-card__stat">
+                      <span className="evaluation-batch-card__stat-label">Concurrency</span>
+                      <strong className="evaluation-batch-card__stat-value">{metrics.maxConcurrent || "-"}</strong>
+                    </div>
+                  </div>
+                  <div className="evaluation-batch-card__meta">
+                    <span><strong>Agent</strong> {batch.agent_user_id ?? "-"}</span>
+                    <span><strong>Submitted</strong> {batch.submitted_by_user_id ?? "-"}</span>
+                    <span><strong>Created</strong> {formatTimestamp(batch.created_at)}</span>
+                  </div>
+                  <div className="evaluation-batch-card__footer">
+                    <span className="evaluation-batch-card__footer-note">{metrics.finishedRuns}/{metrics.totalRuns || 0} finished</span>
+                    {batch.batch_id ? (
+                      <Link className="evaluation-batch-card__open-link" to={`/evaluation/batches/${batch.batch_id}`}>
+                        Open batch
+                      </Link>
                     ) : null}
-                  </td>
-                  <td className="mono">
-                    {scenario.scenario_id ? (
-                      <Link to={`/evaluation?scenario=${scenario.scenario_id}`}>{scenario.scenario_id}</Link>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
-                  <td>{scenario.name ?? "-"}</td>
-                  <td>{scenario.category ?? "-"}</td>
-                  <td>{scenario.sandbox ?? "-"}</td>
-                  <td>{scenario.message_count ?? 0}</td>
-                  <td>{scenario.timeout_seconds ?? "-"}</td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan={7}>No evaluation scenarios found.</td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <article className="surface-card">
+            <p className="surface-card__body">No evaluation batches yet.</p>
+          </article>
+        )}
       </section>
-      <section className="surface-section">
-        <h2>Batch Queue</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Batch</th>
-              <th>Status</th>
-              <th>Runs</th>
-              <th>Agent</th>
-              <th>Submitted By</th>
-              <th>Created</th>
-            </tr>
-          </thead>
-          <tbody>
-            {batches.length > 0 ? (
-              batches.map((batch) => {
-                const summary = batch.summary_json ?? {};
-                const summaryText = `${summary.total_runs ?? 0} total / ${summary.running_runs ?? 0} running / ${
-                  summary.completed_runs ?? 0
-                } completed / ${summary.failed_runs ?? 0} failed`;
-                return (
-                  <tr key={batch.batch_id ?? `${batch.kind}-${batch.created_at}`}>
-                    <td className="mono">
-                      {batch.batch_id ? <Link to={`/evaluation/batches/${batch.batch_id}`}>{batch.batch_id}</Link> : "-"}
-                    </td>
-                    <td>{batch.status ?? "-"}</td>
-                    <td>{summaryText}</td>
-                    <td>{batch.agent_user_id ?? "-"}</td>
-                    <td>{batch.submitted_by_user_id ?? "-"}</td>
-                    <td>{batch.created_at ?? "-"}</td>
-                  </tr>
-                );
-              })
-            ) : (
-              <tr>
-                <td colSpan={6}>No evaluation batches yet.</td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </section>
+
       <section className="surface-section">
         <h2>Recent Runs</h2>
         <table>
@@ -312,6 +451,7 @@ export default function EvaluationPage() {
           </tbody>
         </table>
       </section>
+
       <section className="surface-section">
         <h2>Current Run</h2>
         <div className="info-grid">
@@ -347,6 +487,7 @@ export default function EvaluationPage() {
           </div>
         </div>
       </section>
+
       <section className="surface-section">
         <h2>Run Facts</h2>
         <div className="info-grid">
@@ -358,6 +499,7 @@ export default function EvaluationPage() {
           ))}
         </div>
       </section>
+
       {limitations.length > 0 ? (
         <section className="surface-section">
           <h2>Notes</h2>

--- a/frontend/monitor/src/pages/EvaluationPage.tsx
+++ b/frontend/monitor/src/pages/EvaluationPage.tsx
@@ -241,33 +241,7 @@ export default function EvaluationPage() {
         <div className="evaluation-batches-header">
           <div>
             <h2>Evaluation Batches</h2>
-            <p className="surface-card__body">
-              {batches.length > 0
-                ? `Showing ${batchRangeStart}-${batchRangeEnd} of ${batches.length} batches`
-                : "No evaluation batches yet."}
-            </p>
           </div>
-          {totalPages > 1 ? (
-            <div className="evaluation-pagination">
-              <button
-                type="button"
-                className="monitor-action-button"
-                disabled={page <= 1}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-              >
-                Previous
-              </button>
-              <span className="evaluation-pagination__meta">Page {page} / {totalPages}</span>
-              <button
-                type="button"
-                className="monitor-action-button"
-                disabled={page >= totalPages}
-                onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
-              >
-                Next
-              </button>
-            </div>
-          ) : null}
         </div>
 
         <article className="evaluation-create-panel">
@@ -339,6 +313,35 @@ export default function EvaluationPage() {
             </div>
           </form>
         </article>
+
+        {batches.length > 0 ? (
+          <div className="evaluation-pagination evaluation-pagination--inline">
+            <span className="evaluation-pagination__meta">
+              Showing {batchRangeStart}-{batchRangeEnd} of {batches.length} batches
+            </span>
+            {totalPages > 1 ? (
+              <>
+                <button
+                  type="button"
+                  className="monitor-action-button"
+                  disabled={page <= 1}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                >
+                  Previous
+                </button>
+                <span className="evaluation-pagination__meta">Page {page} / {totalPages}</span>
+                <button
+                  type="button"
+                  className="monitor-action-button"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+                >
+                  Next
+                </button>
+              </>
+            ) : null}
+          </div>
+        ) : null}
 
         {visibleBatches.length > 0 ? (
           <div className="evaluation-batch-grid">

--- a/frontend/monitor/src/styles.css
+++ b/frontend/monitor/src/styles.css
@@ -1989,3 +1989,14 @@ section li {
     grid-template-columns: 1fr;
   }
 }
+
+.evaluation-pagination--inline {
+  margin: 0.9rem 0 1rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 840px) {
+  .evaluation-pagination--inline {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/monitor/src/styles.css
+++ b/frontend/monitor/src/styles.css
@@ -1629,3 +1629,363 @@ section li {
     border-radius: 0;
   }
 }
+
+.evaluation-batches-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.evaluation-batch-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.evaluation-batch-card {
+  border: 1px solid rgba(81, 59, 29, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 252, 247, 0.98);
+  box-shadow: 0 8px 18px rgba(82, 59, 27, 0.035);
+  padding: 1rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.evaluation-batch-card__header,
+.evaluation-batch-card__footer,
+.evaluation-batch-card__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.evaluation-batch-card__heading {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.evaluation-batch-card__eyebrow {
+  color: #8f5d2f;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.evaluation-batch-card__title {
+  color: #241d14;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.evaluation-batch-card__title:hover,
+.evaluation-batch-card__open-link:hover {
+  text-decoration: underline;
+}
+
+.evaluation-batch-card__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.evaluation-batch-card__status--pending {
+  background: rgba(180, 121, 18, 0.12);
+  color: #9d6508;
+}
+
+.evaluation-batch-card__status--running {
+  background: rgba(36, 110, 196, 0.12);
+  color: #1d4ed8;
+}
+
+.evaluation-batch-card__status--completed {
+  background: rgba(35, 124, 74, 0.12);
+  color: #1e7d4b;
+}
+
+.evaluation-batch-card__status--failed {
+  background: rgba(187, 62, 46, 0.12);
+  color: #bb3e2e;
+}
+
+.evaluation-batch-card__progress-block {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.evaluation-batch-card__progress-track {
+  width: 100%;
+  height: 0.55rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(81, 59, 29, 0.08);
+}
+
+.evaluation-batch-card__progress-fill {
+  height: 100%;
+  border-radius: 999px;
+}
+
+.evaluation-batch-card__progress-fill--pending {
+  background: linear-gradient(90deg, rgba(180, 121, 18, 0.35), rgba(180, 121, 18, 0.6));
+}
+
+.evaluation-batch-card__progress-fill--running {
+  background: linear-gradient(90deg, rgba(29, 78, 216, 0.55), rgba(59, 130, 246, 0.88));
+}
+
+.evaluation-batch-card__progress-fill--completed {
+  background: linear-gradient(90deg, rgba(30, 125, 75, 0.55), rgba(50, 213, 131, 0.92));
+}
+
+.evaluation-batch-card__progress-fill--failed {
+  background: linear-gradient(90deg, rgba(187, 62, 46, 0.45), rgba(249, 112, 102, 0.88));
+}
+
+.evaluation-batch-card__progress-copy,
+.evaluation-batch-card__meta,
+.evaluation-batch-card__footer-note,
+.evaluation-pagination__meta {
+  color: #776a5b;
+  font-size: 0.78rem;
+}
+
+.evaluation-batch-card__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.evaluation-batch-card__stat {
+  padding: 0.75rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(81, 59, 29, 0.08);
+  background: rgba(248, 243, 234, 0.8);
+  display: grid;
+  gap: 0.2rem;
+}
+
+.evaluation-batch-card__stat-label {
+  color: #776a5b;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.evaluation-batch-card__stat-value {
+  color: #241d14;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.evaluation-batch-card__stat-value--compact {
+  font-size: 0.95rem;
+}
+
+.evaluation-batch-card__meta {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.evaluation-batch-card__meta strong {
+  color: #4a3a29;
+  margin-right: 0.35rem;
+}
+
+.evaluation-batch-card__footer {
+  padding-top: 0.75rem;
+  border-top: 1px dashed rgba(81, 59, 29, 0.14);
+}
+
+.evaluation-batch-card__open-link {
+  color: #92582d;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+
+.evaluation-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 840px) {
+  .evaluation-batches-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .evaluation-pagination {
+    justify-content: flex-start;
+  }
+}
+
+.evaluation-batch-card--create {
+  border-style: solid;
+  border-color: rgba(143, 93, 47, 0.24);
+  background: linear-gradient(180deg, rgba(255, 250, 240, 0.98), rgba(255, 252, 247, 0.98));
+  box-shadow: 0 14px 30px rgba(82, 59, 27, 0.05);
+}
+
+.evaluation-create-form {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.evaluation-create-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.evaluation-create-form__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.evaluation-create-form__field span {
+  color: #4a3a29;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.evaluation-create-form__field input {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(81, 59, 29, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 252, 245, 0.92);
+  color: #241d14;
+}
+
+.evaluation-scenario-picker {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.evaluation-scenario-picker__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  color: #4a3a29;
+  font-size: 0.82rem;
+}
+
+.evaluation-scenario-picker__header span {
+  color: #776a5b;
+  font-size: 0.76rem;
+}
+
+.evaluation-scenario-picker__hint {
+  margin-top: 0;
+}
+
+.evaluation-scenario-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.55rem;
+}
+
+.evaluation-scenario-chip {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(81, 59, 29, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 252, 247, 0.88);
+  cursor: pointer;
+  display: grid;
+  gap: 0.22rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.evaluation-scenario-chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(146, 88, 45, 0.24);
+  box-shadow: 0 8px 18px rgba(82, 59, 27, 0.04);
+}
+
+.evaluation-scenario-chip--selected {
+  border-color: rgba(146, 88, 45, 0.45);
+  background: rgba(255, 247, 230, 0.96);
+  box-shadow: 0 0 0 1px rgba(146, 88, 45, 0.12), 0 10px 20px rgba(82, 59, 27, 0.05);
+}
+
+.evaluation-scenario-chip__title {
+  color: #241d14;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.evaluation-scenario-chip__meta {
+  color: #776a5b;
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+
+.evaluation-create-panel {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(0, 2.1fr);
+  gap: 1.25rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(143, 93, 47, 0.2);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 250, 240, 0.98), rgba(255, 252, 247, 0.98));
+  box-shadow: 0 14px 30px rgba(82, 59, 27, 0.05);
+}
+
+.evaluation-create-panel__intro {
+  display: grid;
+  align-content: start;
+  gap: 0.45rem;
+}
+
+.evaluation-create-panel__eyebrow {
+  color: #8f5d2f;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.evaluation-create-panel__intro h3 {
+  color: #241d14;
+  font-size: 1.15rem;
+  line-height: 1.2;
+}
+
+.evaluation-create-panel__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 960px) {
+  .evaluation-create-panel {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign monitor evaluation into a card-based workspace on top of latest dev
- integrate Create Batch into the Evaluation Batches workspace
- paginate evaluation batches and align the batch range with the pagination row

## Testing
- npx tsc --noEmit
- Playwright verification on /evaluation and /resources