### PR TITLE
refactor: promote runtime read protocols

### DIFF
--- a/backend/agent_runtime/thread_activity_reader.py
+++ b/backend/agent_runtime/thread_activity_reader.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from backend.protocols.runtime_read import AgentThreadActivity
 from core.runtime.middleware.monitor import AgentState
+from protocols.runtime_read import AgentThreadActivity
 
 
 def _normalize_state(state: AgentState) -> Literal["initializing", "ready", "active", "idle", "suspended", "stopped", "destroyed"]:

--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -10,9 +10,9 @@ from fastapi import APIRouter, Depends
 
 from backend.avatar_urls import avatar_url
 from backend.chat.api.http.dependencies import get_app, get_current_user_id
-from backend.protocols.runtime_read import RuntimeThreadActivityReader
 from backend.thread_runtime.owner_reads import list_owner_thread_rows_for_auth_burst
 from backend.thread_runtime.projection import canonical_owner_threads
+from protocols.runtime_read import RuntimeThreadActivityReader
 
 router = APIRouter(prefix="/api/conversations", tags=["conversations"])
 

--- a/backend/protocols/runtime_read.py
+++ b/backend/protocols/runtime_read.py
@@ -1,18 +1,5 @@
-"""Runtime read-side protocol contracts."""
+"""Compatibility export surface for top-level runtime-read protocols."""
 
-from __future__ import annotations
+from protocols.runtime_read import AgentThreadActivity, RuntimeThreadActivityReader
 
-from dataclasses import dataclass
-from typing import Literal, Protocol
-
-
-@dataclass(frozen=True)
-class AgentThreadActivity:
-    thread_id: str
-    is_main: bool
-    branch_index: int
-    state: Literal["initializing", "ready", "active", "idle", "suspended", "stopped", "destroyed"]
-
-
-class RuntimeThreadActivityReader(Protocol):
-    def list_active_threads_for_agent(self, agent_user_id: str) -> list[AgentThreadActivity]: ...
+__all__ = ["AgentThreadActivity", "RuntimeThreadActivityReader"]

--- a/messaging/delivery/runtime_thread_selector.py
+++ b/messaging/delivery/runtime_thread_selector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from backend.protocols.runtime_read import RuntimeThreadActivityReader
+from protocols.runtime_read import RuntimeThreadActivityReader
 
 _LIVE_CHILD_STATES = {"initializing", "ready", "active", "idle", "suspended"}
 

--- a/protocols/__init__.py
+++ b/protocols/__init__.py
@@ -1,0 +1,1 @@
+"""Portable protocol contracts shared across non-backend package boundaries."""

--- a/protocols/runtime_read.py
+++ b/protocols/runtime_read.py
@@ -1,0 +1,18 @@
+"""Runtime read-side protocol contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+
+@dataclass(frozen=True)
+class AgentThreadActivity:
+    thread_id: str
+    is_main: bool
+    branch_index: int
+    state: Literal["initializing", "ready", "active", "idle", "suspended", "stopped", "destroyed"]
+
+
+class RuntimeThreadActivityReader(Protocol):
+    def list_active_threads_for_agent(self, agent_user_id: str) -> list[AgentThreadActivity]: ...

--- a/tests/Unit/messaging/test_runtime_read_protocol_owner.py
+++ b/tests/Unit/messaging/test_runtime_read_protocol_owner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib
+from typing import get_type_hints
+
+
+def test_runtime_read_protocols_live_in_top_level_protocols_module() -> None:
+    protocol_module = importlib.import_module("protocols.runtime_read")
+    backend_protocol_module = importlib.import_module("backend.protocols.runtime_read")
+
+    assert protocol_module.AgentThreadActivity.__module__ == "protocols.runtime_read"
+    assert protocol_module.RuntimeThreadActivityReader.__module__ == "protocols.runtime_read"
+    assert backend_protocol_module.AgentThreadActivity is protocol_module.AgentThreadActivity
+    assert backend_protocol_module.RuntimeThreadActivityReader is protocol_module.RuntimeThreadActivityReader
+
+
+def test_runtime_thread_selector_consumes_top_level_runtime_read_protocol() -> None:
+    selector_module = importlib.import_module("messaging.delivery.runtime_thread_selector")
+    protocol_module = importlib.import_module("protocols.runtime_read")
+
+    hints = get_type_hints(selector_module.select_runtime_thread_for_recipient)
+
+    assert hints["activity_reader"] is protocol_module.RuntimeThreadActivityReader


### PR DESCRIPTION
## Summary
- promote `runtime_read` protocol contracts to top-level `protocols/runtime_read.py`
- keep `backend/protocols/runtime_read.py` as a compatibility export surface
- retarget messaging and backend consumers to the top-level protocol owner

## Test Plan
- uv run pytest -q tests/Unit/messaging/test_runtime_read_protocol_owner.py
- uv run pytest -q tests/Unit/messaging/test_runtime_thread_selector.py tests/Integration/test_conversations_router.py
- uv run ruff check protocols/runtime_read.py protocols/__init__.py backend/protocols/runtime_read.py messaging/delivery/runtime_thread_selector.py backend/chat/api/http/conversations_router.py backend/agent_runtime/thread_activity_reader.py tests/Unit/messaging/test_runtime_read_protocol_owner.py tests/Unit/messaging/test_runtime_thread_selector.py tests/Integration/test_conversations_router.py
- git diff --check
