### PR TITLE
refactor: inject event bus seam for core services

### DIFF
--- a/backend/thread_runtime/pool/factory.py
+++ b/backend/thread_runtime/pool/factory.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 
+from backend.event_bus import get_event_bus
 from core.runtime.agent import create_leon_agent
 from storage.runtime import build_storage_container
 
@@ -41,6 +42,7 @@ def create_agent_sync(
         queue_manager=queue_manager,
         chat_repos=chat_repos,
         web_app=web_app,
+        event_bus_factory=get_event_bus,
         models_config_override=models_config_override,
         memory_config_override=memory_config_override,
         verbose=True,

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -28,6 +28,7 @@ from core.runtime.permissions import ToolPermissionContext
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
 from core.runtime.state import BootstrapConfig, ToolUseContext
 from core.runtime.tool_result import tool_error, tool_permission_request, tool_success
+from protocols.event_bus import EventBusFactory, EventEmitter
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     from core.runtime.agent import LeonAgent
 
 
-EventEmitter = Callable[[dict[str, Any]], Awaitable[None] | None]
 ChildAgentFactory = Callable[..., "LeonAgent"]
 
 
@@ -469,6 +469,7 @@ class AgentService:
         thread_repo: Any = None,
         user_repo: Any = None,
         web_app: Any = None,
+        event_bus_factory: EventBusFactory | None = None,
         child_agent_factory: ChildAgentFactory | None = None,
     ):
         self._agent_registry = None
@@ -480,6 +481,7 @@ class AgentService:
         self._thread_repo = thread_repo
         self._user_repo = user_repo
         self._web_app = web_app
+        self._event_bus_factory = event_bus_factory
         self._child_agent_factory = child_agent_factory or _resolve_default_child_agent_factory()
         self._parent_bootstrap: BootstrapConfig | None = None
         self._parent_tool_context: Any | None = None
@@ -756,18 +758,13 @@ class AgentService:
 
         # emit_fn is set if EventBus is available; used for task lifecycle SSE events
         emit_fn: EventEmitter | None = None
-        try:
-            from backend.web.event_bus import get_event_bus
-
-            if parent_thread_id:
-                event_bus = get_event_bus()
-                emit_fn = event_bus.make_emitter(
-                    thread_id=parent_thread_id,
-                    agent_id=task_id,
-                    agent_name=agent_name,
-                )
-        except ImportError:
-            pass  # backend not available in standalone core usage
+        if self._event_bus_factory is not None and parent_thread_id:
+            event_bus = self._event_bus_factory()
+            emit_fn = event_bus.make_emitter(
+                thread_id=parent_thread_id,
+                agent_id=task_id,
+                agent_name=agent_name,
+            )
 
         agent: LeonAgent | None = None
         progress_task: asyncio.Task | None = None
@@ -815,6 +812,7 @@ class AgentService:
                         sandbox=self._normalize_child_sandbox(getattr(child_bootstrap, "sandbox_type", None)),
                         agent=agent_name_for_role,
                         web_app=self._web_app,
+                        event_bus_factory=self._event_bus_factory,
                         extra_blocked_tools=extra_blocked,
                         allowed_tools=allowed,
                         verbose=False,
@@ -841,6 +839,7 @@ class AgentService:
                         sandbox=self._normalize_child_sandbox(getattr(child_bootstrap, "sandbox_type", None)),
                         agent=agent_name_for_role,
                         web_app=self._web_app,
+                        event_bus_factory=self._event_bus_factory,
                         extra_blocked_tools=extra_blocked,
                         allowed_tools=allowed,
                         verbose=False,
@@ -871,6 +870,7 @@ class AgentService:
                     ),
                     agent=agent_name_for_role,
                     web_app=self._web_app,
+                    event_bus_factory=self._event_bus_factory,
                     extra_blocked_tools=extra_blocked,
                     allowed_tools=allowed,
                     verbose=False,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1185,6 +1185,7 @@ class LeonAgent:
         # Command tools
         if self.config.tools.command.enabled:
             command_hooks = []
+            event_bus_factory = getattr(self, "_event_bus_factory", None)
             if self._sandbox.name == "local":
                 if self.block_dangerous_commands:
                     command_hooks.append(
@@ -1201,7 +1202,7 @@ class LeonAgent:
                 executor=cmd_executor,
                 queue_manager=self.queue_manager,
                 background_runs=self._background_runs,
-                event_bus_factory=self._event_bus_factory,
+                event_bus_factory=event_bus_factory,
             )
 
         # Skills tools
@@ -1247,7 +1248,7 @@ class LeonAgent:
             queue_manager=self.queue_manager,
             shared_runs=self._background_runs,
             web_app=self._web_app,
-            event_bus_factory=self._event_bus_factory,
+            event_bus_factory=getattr(self, "_event_bus_factory", None),
             child_agent_factory=create_leon_agent,
         )
 

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -80,6 +80,7 @@ from core.tools.skills.service import SkillsService  # noqa: E402
 from core.tools.task.service import TaskService  # noqa: E402
 from core.tools.tool_search.service import ToolSearchService  # noqa: E402
 from core.tools.web.service import WebService  # noqa: E402
+from protocols.event_bus import EventBusFactory  # noqa: E402
 from storage.container import StorageContainer  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -161,6 +162,7 @@ class LeonAgent:
         queue_manager: MessageQueueManager | None = None,
         chat_repos: dict | None = None,
         web_app: Any = None,
+        event_bus_factory: EventBusFactory | None = None,
         extra_allowed_paths: list[str] | None = None,
         extra_blocked_tools: set[str] | None = None,
         allowed_tools: set[str] | None = None,
@@ -201,6 +203,7 @@ class LeonAgent:
         self._thread_repo = thread_repo
         self._user_repo = user_repo
         self._web_app = web_app
+        self._event_bus_factory = event_bus_factory
         self._session_started = False
         self._session_ended = False
         self._closing = False
@@ -1198,6 +1201,7 @@ class LeonAgent:
                 executor=cmd_executor,
                 queue_manager=self.queue_manager,
                 background_runs=self._background_runs,
+                event_bus_factory=self._event_bus_factory,
             )
 
         # Skills tools
@@ -1243,6 +1247,7 @@ class LeonAgent:
             queue_manager=self.queue_manager,
             shared_runs=self._background_runs,
             web_app=self._web_app,
+            event_bus_factory=self._event_bus_factory,
             child_agent_factory=create_leon_agent,
         )
 

--- a/core/tools/command/service.py
+++ b/core/tools/command/service.py
@@ -13,6 +13,7 @@ from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_s
 from core.runtime.tool_result import ToolResultEnvelope, tool_permission_denied
 from core.tools.command.base import describe_execution_exception
 from core.tools.command.dispatcher import get_executor
+from protocols.event_bus import EventBusFactory
 from sandbox.interfaces.executor import BaseExecutor
 
 logger = logging.getLogger(__name__)
@@ -33,12 +34,14 @@ class CommandService:
         executor: BaseExecutor | None = None,
         queue_manager: Any = None,
         background_runs: dict | None = None,
+        event_bus_factory: EventBusFactory | None = None,
     ):
         self.workspace_root = Path(workspace_root).resolve()
         self.hooks = hooks or []
         self.env = env
         self._queue_manager = queue_manager
         self._background_runs = background_runs  # shared with AgentService
+        self._event_bus_factory = event_bus_factory
 
         if executor is not None:
             self._executor = executor
@@ -158,20 +161,17 @@ class CommandService:
         emit_fn: Callable[[dict[str, Any]], Awaitable[None] | None] | None = None
         parent_thread_id = None
         try:
-            from backend.web.event_bus import get_event_bus
             from sandbox.thread_context import get_current_thread_id
 
             parent_thread_id = get_current_thread_id()
             logger.debug("[CommandService] _execute_async: parent_thread_id=%s task_id=%s", parent_thread_id, task_id)
-            if parent_thread_id:
-                event_bus = get_event_bus()
+            if parent_thread_id and self._event_bus_factory is not None:
+                event_bus = self._event_bus_factory()
                 emit_fn = event_bus.make_emitter(
                     thread_id=parent_thread_id,
                     agent_id=task_id,
                     agent_name=f"bash-{task_id[:8]}",
                 )
-        except ImportError:
-            logger.debug("[CommandService] backend.web.event_bus not available")
         except Exception as e:
             logger.warning("[CommandService] emit_fn setup failed: %s", e)
 

--- a/protocols/event_bus.py
+++ b/protocols/event_bus.py
@@ -1,0 +1,18 @@
+"""Portable event-bus seam for top-level runtime consumers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol
+
+EventEmitter = Callable[[dict[str, Any]], Awaitable[None] | None]
+EventBusFactory = Callable[[], "EventBusPort"]
+
+
+class EventBusPort(Protocol):
+    def make_emitter(
+        self,
+        thread_id: str,
+        agent_id: str = "",
+        agent_name: str = "",
+    ) -> EventEmitter: ...

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -479,6 +479,43 @@ async def test_run_agent_uses_injected_child_agent_factory(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_run_agent_uses_injected_event_bus_factory(monkeypatch, tmp_path):
+    created: list[_FakeChildAgent] = []
+    emitted: list[str] = []
+    _patch_create_leon_agent(monkeypatch, created=created)
+
+    class _Bus:
+        def make_emitter(self, *, thread_id: str, agent_id: str = "", agent_name: str = ""):
+            assert thread_id == "parent-thread"
+            assert agent_id == "task-1"
+
+            async def _emit(event: dict) -> None:
+                emitted.append(event["event"])
+
+            return _emit
+
+    service = _make_service(tmp_path, event_bus_factory=lambda: _Bus())
+
+    set_current_thread_id("parent-thread")
+    try:
+        result = await service._run_agent(
+            task_id="task-1",
+            agent_name="child",
+            thread_id="subagent-1",
+            prompt="do work",
+            subagent_type="general",
+            max_turns=None,
+            fork_context=False,
+        )
+    finally:
+        set_current_thread_id(None)
+
+    assert result == "(Agent completed with no text output)"
+    assert emitted == ["task_start", "task_done"]
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
 async def test_agent_tool_fork_context_uses_parent_tool_context_messages(monkeypatch, tmp_path):
     captured: dict[str, Any] = {}
 

--- a/tests/Unit/core/test_command_service.py
+++ b/tests/Unit/core/test_command_service.py
@@ -224,3 +224,56 @@ class TestCommandServiceCancellation:
 
         assert emitted == []
         queue_manager.enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_async_uses_injected_event_bus_factory(self, tmp_path, monkeypatch):
+        class _Executor(BaseExecutor):
+            runtime_owns_cwd = True
+            shell_name = "bash"
+
+            async def execute(self, command: str, cwd: str | None = None, timeout: float | None = None, env=None):
+                raise AssertionError("blocking path not expected")
+
+            async def execute_async(self, command: str, cwd: str | None = None, env=None):
+                return AsyncCommand(
+                    command_id="cmd-1",
+                    command_line=command,
+                    cwd=str(tmp_path),
+                    done=True,
+                    exit_code=0,
+                )
+
+            async def get_status(self, command_id: str):
+                return None
+
+            async def wait_for(self, command_id: str, timeout: float | None = None):
+                return None
+
+        emitted: list[str] = []
+
+        class _Bus:
+            def make_emitter(self, *, thread_id: str, agent_id: str = "", agent_name: str = ""):
+                assert thread_id == "thread-1"
+                assert agent_id == "cmd-1"
+
+                async def _emit(event: dict) -> None:
+                    emitted.append(event["event"])
+
+                return _emit
+
+        from sandbox import thread_context
+
+        monkeypatch.setattr(thread_context, "get_current_thread_id", lambda: "thread-1")
+
+        service = CommandService(
+            registry=ToolRegistry(),
+            workspace_root=tmp_path,
+            executor=_Executor(),
+            event_bus_factory=lambda: _Bus(),
+        )
+
+        result = await service._execute_async("echo hi", str(tmp_path), 5.0, description="bg")
+        await asyncio.sleep(0)
+
+        assert "task_id: cmd-1" in result
+        assert emitted == ["task_start", "task_done"]


### PR DESCRIPTION
## Summary
- add top-level `protocols/event_bus.py` for core-side event bus consumption
- inject an optional `event_bus_factory` seam into `CommandService` and `AgentService`
- thread that seam through `LeonAgent` and backend thread pool factory instead of letting top-level core code import backend event bus directly

## Test Plan
- uv run pytest -q tests/Unit/core/test_command_service.py -k injected_event_bus_factory tests/Unit/core/test_agent_service.py -k injected_event_bus_factory tests/Integration/test_background_task_cleanup.py -k 'taskstop_terminates_real_background_bash_run or background_agent_progress_notification_reaches_parent_next_turn or background_agent_completion_notification_waits_for_followthrough_run'
- uv run ruff check protocols/event_bus.py core/agents/service.py core/tools/command/service.py core/runtime/agent.py backend/thread_runtime/pool/factory.py tests/Unit/core/test_command_service.py tests/Unit/core/test_agent_service.py tests/Integration/test_background_task_cleanup.py
- git diff --check
