### PR TITLE
fix(monitor): expose evaluation scenario selection state

### DIFF
--- a/frontend/monitor/src/pages/EvaluationPage.contract.test.js
+++ b/frontend/monitor/src/pages/EvaluationPage.contract.test.js
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("evaluation page scenario selector", () => {
+  it("exposes pressed state for selectable scenario chips", () => {
+    const source = readFileSync(resolve(import.meta.dirname, "EvaluationPage.tsx"), "utf8");
+
+    expect(source).toContain("aria-pressed={selected}");
+  });
+});

--- a/frontend/monitor/src/pages/EvaluationPage.tsx
+++ b/frontend/monitor/src/pages/EvaluationPage.tsx
@@ -286,6 +286,7 @@ export default function EvaluationPage() {
                       <button
                         key={scenarioId || scenario.name}
                         type="button"
+                        aria-pressed={selected}
                         className={`evaluation-scenario-chip ${selected ? "evaluation-scenario-chip--selected" : ""}`}
                         onClick={() => scenarioId && toggleScenario(scenarioId)}
                       >


### PR DESCRIPTION
## Summary
- add pressed-state semantics back to EvaluationPage scenario chips
- cover the accessibility contract with a small frontend source test
- keep the fix isolated from the larger #937 redesign

## Verification
- npm test -- --run src/pages/EvaluationPage.contract.test.js src/app/routes.contract.test.js src/pages/DashboardPage.test.ts
- npm run build
- git diff --check