### PR TITLE
refactor: inject child thread live runner

### DIFF
--- a/backend/thread_runtime/pool/factory.py
+++ b/backend/thread_runtime/pool/factory.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from backend.event_bus import get_event_bus
+from backend.thread_runtime.run.entrypoints import run_child_thread_live
 from core.runtime.agent import create_leon_agent
 from storage.runtime import build_storage_container
 
@@ -43,6 +44,7 @@ def create_agent_sync(
         chat_repos=chat_repos,
         web_app=web_app,
         event_bus_factory=get_event_bus,
+        child_thread_live_runner=run_child_thread_live,
         models_config_override=models_config_override,
         memory_config_override=memory_config_override,
         verbose=True,

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 
 ChildAgentFactory = Callable[..., "LeonAgent"]
+ChildThreadLiveRunner = Callable[..., Awaitable[str]]
 
 
 def _resolve_default_child_agent_factory() -> ChildAgentFactory:
@@ -470,6 +471,7 @@ class AgentService:
         user_repo: Any = None,
         web_app: Any = None,
         event_bus_factory: EventBusFactory | None = None,
+        child_thread_live_runner: ChildThreadLiveRunner | None = None,
         child_agent_factory: ChildAgentFactory | None = None,
     ):
         self._agent_registry = None
@@ -482,6 +484,7 @@ class AgentService:
         self._user_repo = user_repo
         self._web_app = web_app
         self._event_bus_factory = event_bus_factory
+        self._child_thread_live_runner = child_thread_live_runner
         self._child_agent_factory = child_agent_factory or _resolve_default_child_agent_factory()
         self._parent_bootstrap: BootstrapConfig | None = None
         self._parent_tool_context: Any | None = None
@@ -813,6 +816,7 @@ class AgentService:
                         agent=agent_name_for_role,
                         web_app=self._web_app,
                         event_bus_factory=self._event_bus_factory,
+                        child_thread_live_runner=self._child_thread_live_runner,
                         extra_blocked_tools=extra_blocked,
                         allowed_tools=allowed,
                         verbose=False,
@@ -840,6 +844,7 @@ class AgentService:
                         agent=agent_name_for_role,
                         web_app=self._web_app,
                         event_bus_factory=self._event_bus_factory,
+                        child_thread_live_runner=self._child_thread_live_runner,
                         extra_blocked_tools=extra_blocked,
                         allowed_tools=allowed,
                         verbose=False,
@@ -871,6 +876,7 @@ class AgentService:
                     agent=agent_name_for_role,
                     web_app=self._web_app,
                     event_bus_factory=self._event_bus_factory,
+                    child_thread_live_runner=self._child_thread_live_runner,
                     extra_blocked_tools=extra_blocked,
                     allowed_tools=allowed,
                     verbose=False,
@@ -963,9 +969,10 @@ class AgentService:
                 initial_messages = [{"role": "user", "content": prompt}]
 
             if self._web_app is not None:
-                from backend.web.services.streaming_service import run_child_thread_live
+                if self._child_thread_live_runner is None:
+                    raise RuntimeError("child_thread_live_runner is required when web_app is configured")
 
-                result = await run_child_thread_live(
+                result = await self._child_thread_live_runner(
                     agent,
                     thread_id,
                     prompt,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -163,6 +163,7 @@ class LeonAgent:
         chat_repos: dict | None = None,
         web_app: Any = None,
         event_bus_factory: EventBusFactory | None = None,
+        child_thread_live_runner: Any | None = None,
         extra_allowed_paths: list[str] | None = None,
         extra_blocked_tools: set[str] | None = None,
         allowed_tools: set[str] | None = None,
@@ -204,6 +205,7 @@ class LeonAgent:
         self._user_repo = user_repo
         self._web_app = web_app
         self._event_bus_factory = event_bus_factory
+        self._child_thread_live_runner = child_thread_live_runner
         self._session_started = False
         self._session_ended = False
         self._closing = False
@@ -1249,6 +1251,7 @@ class LeonAgent:
             shared_runs=self._background_runs,
             web_app=self._web_app,
             event_bus_factory=getattr(self, "_event_bus_factory", None),
+            child_thread_live_runner=getattr(self, "_child_thread_live_runner", None),
             child_agent_factory=create_leon_agent,
         )
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -1149,6 +1149,63 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     assert "thread_repo" not in captured
 
 
+def test_leon_agent_init_services_passes_child_thread_live_runner(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from core.runtime.agent import LeonAgent
+    from core.runtime.registry import ToolRegistry
+
+    captured: dict[str, Any] = {}
+
+    class _NoopService:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _CapturingAgentService:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.update(kwargs)
+            self._agent_registry = None
+
+    async def fake_child_thread_live_runner(agent, thread_id, prompt, app, *, input_messages):
+        return "LIVE_CHILD_DONE"
+
+    monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.McpResourceToolService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.AgentService", _CapturingAgentService)
+
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(name="local", fs=lambda: None, shell=lambda: None)
+    agent._tool_registry = ToolRegistry()
+    agent.workspace_root = str(tmp_path)
+    agent.model_name = "test-model"
+    agent._thread_repo = SimpleNamespace()
+    agent._user_repo = SimpleNamespace()
+    agent.queue_manager = SimpleNamespace()
+    agent._web_app = SimpleNamespace()
+    agent._child_thread_live_runner = fake_child_thread_live_runner
+    agent.allowed_file_extensions = []
+    agent.extra_allowed_paths = []
+    agent.enable_audit_log = False
+    agent.block_dangerous_commands = False
+    agent.block_network_commands = False
+    agent.verbose = False
+    agent._get_mcp_server_configs = lambda: {}
+    agent._chat_repos = None
+    cast(Any, agent).config = SimpleNamespace(
+        tools=SimpleNamespace(
+            filesystem=SimpleNamespace(enabled=False),
+            search=SimpleNamespace(enabled=False),
+            web=SimpleNamespace(enabled=False),
+            command=SimpleNamespace(enabled=False),
+        ),
+        skills=SimpleNamespace(enabled=False, paths=[], skills={}),
+    )
+
+    LeonAgent._init_services(agent)
+
+    assert captured["child_thread_live_runner"] is fake_child_thread_live_runner
+    assert captured["web_app"] is agent._web_app
+
+
 def test_build_rules_section_includes_function_result_clearing_guidance_when_spill_buffer_enabled():
     from core.runtime.prompts import build_rules_section
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1124,10 +1124,6 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
         observed["child_lower_runtime_id"] = getattr(child_capability._session.lease, lower_runtime_key)
         return "(Agent completed with no text output)"
 
-    monkeypatch.setattr(
-        "backend.web.services.streaming_service.run_child_thread_live",
-        _fake_run_child_thread_live,
-    )
     set_current_thread_id(parent_thread_id)
 
     thread_repo = _FakeThreadRepo(
@@ -1152,6 +1148,7 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
         tmp_path,
         thread_repo=thread_repo,
         web_app=SimpleNamespace(state=SimpleNamespace(workspace_repo=workspace_repo)),
+        child_thread_live_runner=_fake_run_child_thread_live,
     )
 
     try:
@@ -1175,10 +1172,7 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
 @pytest.mark.asyncio
 async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
-    monkeypatch.setattr(
-        "backend.web.services.streaming_service.run_child_thread_live",
-        AsyncMock(return_value="LIVE_CHILD_DONE"),
-    )
+    live_child_thread_runner = AsyncMock(return_value="LIVE_CHILD_DONE")
 
     thread_repo = _FakeThreadRepo(
         rows={
@@ -1221,6 +1215,7 @@ async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(mon
         thread_repo=thread_repo,
         user_repo=user_repo,
         web_app=web_app,
+        child_thread_live_runner=live_child_thread_runner,
     )
 
     set_current_thread_id("parent-thread")
@@ -1244,10 +1239,7 @@ async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(mon
 @pytest.mark.asyncio
 async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
-    monkeypatch.setattr(
-        "backend.web.services.streaming_service.run_child_thread_live",
-        AsyncMock(return_value="LIVE_CHILD_DONE"),
-    )
+    live_child_thread_runner = AsyncMock(return_value="LIVE_CHILD_DONE")
 
     thread_repo = _FakeThreadRepo(
         rows={
@@ -1271,6 +1263,7 @@ async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkey
         thread_repo=thread_repo,
         user_repo=user_repo,
         web_app=SimpleNamespace(state=SimpleNamespace()),
+        child_thread_live_runner=live_child_thread_runner,
     )
 
     set_current_thread_id("parent-thread")
@@ -1291,10 +1284,7 @@ async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkey
 @pytest.mark.asyncio
 async def test_run_agent_falls_back_to_child_workspace_root_when_parent_workspace_truth_is_absent(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
-    monkeypatch.setattr(
-        "backend.web.services.streaming_service.run_child_thread_live",
-        AsyncMock(return_value="LIVE_CHILD_DONE"),
-    )
+    live_child_thread_runner = AsyncMock(return_value="LIVE_CHILD_DONE")
 
     captured: dict[str, Any] = {}
 
@@ -1306,7 +1296,11 @@ async def test_run_agent_falls_back_to_child_workspace_root_when_parent_workspac
 
     monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_lease", fake_bind)
 
-    service = _make_service(tmp_path)
+    service = _make_service(
+        tmp_path,
+        web_app=SimpleNamespace(),
+        child_thread_live_runner=live_child_thread_runner,
+    )
 
     set_current_thread_id("parent-thread")
     try:
@@ -1318,7 +1312,7 @@ async def test_run_agent_falls_back_to_child_workspace_root_when_parent_workspac
             subagent_type="explore",
             max_turns=None,
         )
-        assert result == "(Agent completed with no text output)"
+        assert result == "LIVE_CHILD_DONE"
         assert captured == {
             "thread_id": "subagent-child",
             "parent_thread_id": "parent-thread",
@@ -1617,10 +1611,8 @@ async def test_run_agent_uses_live_child_thread_path_when_web_app_present(monkey
         return "LIVE_CHILD_DONE"
 
     _patch_create_leon_agent(monkeypatch, captured=captured)
-    monkeypatch.setattr("backend.web.services.streaming_service.run_child_thread_live", fake_run_child_thread_live)
-
     web_app = SimpleNamespace()
-    service = _make_service(tmp_path, web_app=web_app)
+    service = _make_service(tmp_path, web_app=web_app, child_thread_live_runner=fake_run_child_thread_live)
 
     result = await service._run_agent(
         task_id="task-1",
@@ -1645,6 +1637,47 @@ async def test_run_agent_uses_live_child_thread_path_when_web_app_present(monkey
 
 
 @pytest.mark.asyncio
+async def test_run_agent_prefers_injected_live_child_thread_runner(monkeypatch, tmp_path):
+    captured: dict[str, Any] = {}
+
+    async def fake_live_child_thread_runner(agent, thread_id, prompt, app, *, input_messages):
+        captured["agent"] = agent
+        captured["thread_id"] = thread_id
+        captured["prompt"] = prompt
+        captured["app"] = app
+        captured["input_messages"] = input_messages
+        return "INJECTED_LIVE_CHILD_DONE"
+
+    _patch_create_leon_agent(monkeypatch, captured=captured)
+    web_app = SimpleNamespace()
+    service = _make_service(
+        tmp_path,
+        web_app=web_app,
+        child_thread_live_runner=fake_live_child_thread_runner,
+    )
+
+    result = await service._run_agent(
+        task_id="task-1",
+        agent_name="child",
+        thread_id="subagent-1",
+        prompt="do work",
+        subagent_type="general",
+        max_turns=None,
+        fork_context=False,
+    )
+
+    assert result == "INJECTED_LIVE_CHILD_DONE"
+    assert captured["thread_id"] == "subagent-1"
+    assert captured["prompt"] == "do work"
+    assert captured["app"] is web_app
+    assert captured["kwargs"]["web_app"] is web_app
+    assert captured["kwargs"]["child_thread_live_runner"] is fake_live_child_thread_runner
+    assert captured["input_messages"][0]["content"] == "do work"
+    assert captured["agent"].cleanup_calls == 1
+    assert captured["agent"].closed is False
+
+
+@pytest.mark.asyncio
 async def test_run_agent_normalizes_workspace_suffix_in_child_prompt(monkeypatch, tmp_path):
     captured: dict[str, Any] = {}
 
@@ -1654,9 +1687,11 @@ async def test_run_agent_normalizes_workspace_suffix_in_child_prompt(monkeypatch
         return "LIVE_CHILD_DONE"
 
     _patch_create_leon_agent(monkeypatch)
-    monkeypatch.setattr("backend.web.services.streaming_service.run_child_thread_live", fake_run_child_thread_live)
-
-    service = _make_service(tmp_path, web_app=SimpleNamespace())
+    service = _make_service(
+        tmp_path,
+        web_app=SimpleNamespace(),
+        child_thread_live_runner=fake_run_child_thread_live,
+    )
     raw_prompt = f"Inspect the workspace at {tmp_path}/current working directory. Read-only only. Report existing files."
 
     result = await service._run_agent(


### PR DESCRIPTION
## Summary
- inject a child_thread_live_runner into AgentService instead of importing backend.web.services.streaming_service inside core
- thread that callable through LeonAgent and the backend thread runtime pool wiring
- update focused AgentService and LeonAgent tests to use the injected runner explicitly

## Verification
- uv run pytest -q tests/Unit/core/test_agent_service.py -k "parent_workspace or child_thread or normalizes_workspace_suffix or uses_live_child_thread_path_when_web_app_present or prefers_injected_live_child_thread_runner"
- uv run pytest -q tests/Integration/test_leon_agent.py -k "passes_child_thread_live_runner or chat_tool_wiring_does_not_pass_dead_repo_dependencies"
- uv run pytest -q tests/Integration/test_child_thread_live_contract.py tests/Integration/test_query_loop_backend_contracts.py -k "child_thread or subagent"
- uv run ruff check core/agents/service.py core/runtime/agent.py backend/thread_runtime/pool/factory.py tests/Unit/core/test_agent_service.py tests/Integration/test_leon_agent.py
- git diff --check