### PR TITLE
refactor: fail loud on command event bus setup

### DIFF
--- a/core/tools/command/service.py
+++ b/core/tools/command/service.py
@@ -160,20 +160,17 @@ class CommandService:
         # Build emit_fn for SSE task lifecycle events
         emit_fn: Callable[[dict[str, Any]], Awaitable[None] | None] | None = None
         parent_thread_id = None
-        try:
-            from sandbox.thread_context import get_current_thread_id
+        from sandbox.thread_context import get_current_thread_id
 
-            parent_thread_id = get_current_thread_id()
-            logger.debug("[CommandService] _execute_async: parent_thread_id=%s task_id=%s", parent_thread_id, task_id)
-            if parent_thread_id and self._event_bus_factory is not None:
-                event_bus = self._event_bus_factory()
-                emit_fn = event_bus.make_emitter(
-                    thread_id=parent_thread_id,
-                    agent_id=task_id,
-                    agent_name=f"bash-{task_id[:8]}",
-                )
-        except Exception as e:
-            logger.warning("[CommandService] emit_fn setup failed: %s", e)
+        parent_thread_id = get_current_thread_id()
+        logger.debug("[CommandService] _execute_async: parent_thread_id=%s task_id=%s", parent_thread_id, task_id)
+        if parent_thread_id and self._event_bus_factory is not None:
+            event_bus = self._event_bus_factory()
+            emit_fn = event_bus.make_emitter(
+                thread_id=parent_thread_id,
+                agent_id=task_id,
+                agent_name=f"bash-{task_id[:8]}",
+            )
 
         # Emit task_start so the frontend dot lights up immediately
         if emit_fn is not None:

--- a/tests/Unit/core/test_command_service.py
+++ b/tests/Unit/core/test_command_service.py
@@ -277,3 +277,41 @@ class TestCommandServiceCancellation:
 
         assert "task_id: cmd-1" in result
         assert emitted == ["task_start", "task_done"]
+
+    @pytest.mark.asyncio
+    async def test_execute_async_fails_loud_when_event_bus_factory_breaks(self, tmp_path, monkeypatch):
+        class _Executor(BaseExecutor):
+            runtime_owns_cwd = True
+            shell_name = "bash"
+
+            async def execute(self, command: str, cwd: str | None = None, timeout: float | None = None, env=None):
+                raise AssertionError("blocking path not expected")
+
+            async def execute_async(self, command: str, cwd: str | None = None, env=None):
+                return AsyncCommand(
+                    command_id="cmd-1",
+                    command_line=command,
+                    cwd=str(tmp_path),
+                    done=True,
+                    exit_code=0,
+                )
+
+            async def get_status(self, command_id: str):
+                return None
+
+            async def wait_for(self, command_id: str, timeout: float | None = None):
+                return None
+
+        from sandbox import thread_context
+
+        monkeypatch.setattr(thread_context, "get_current_thread_id", lambda: "thread-1")
+
+        service = CommandService(
+            registry=ToolRegistry(),
+            workspace_root=tmp_path,
+            executor=_Executor(),
+            event_bus_factory=lambda: (_ for _ in ()).throw(RuntimeError("event bus offline")),
+        )
+
+        with pytest.raises(RuntimeError, match="event bus offline"):
+            await service._execute_async("echo hi", str(tmp_path), 5.0, description="bg")


### PR DESCRIPTION
## Summary
- remove the broad emit_fn setup swallow path from CommandService
- let a broken injected event_bus_factory fail loudly instead of warning and continuing
- cover the behavior with a focused unit test

## Verification
- uv run pytest -q tests/Unit/core/test_command_service.py -k "event_bus_factory_breaks or injected_event_bus_factory"
- uv run ruff check core/tools/command/service.py tests/Unit/core/test_command_service.py
- git diff --check