### PR TITLE
refactor(copy): replace visible Leon product naming

### DIFF
--- a/backend/monitor_app/main.py
+++ b/backend/monitor_app/main.py
@@ -8,7 +8,7 @@ from backend.monitor_app.lifespan import lifespan
 
 load_env_file_from_env()
 
-app = FastAPI(title="Leon Monitor Backend", lifespan=lifespan)
+app = FastAPI(title="Mycel Monitor Backend", lifespan=lifespan)
 add_permissive_cors(app)
 
 # @@@monitor-app-global-only - the first separate-process shell mounts only the route bucket already ruled process-safe.

--- a/backend/web/core/__init__.py
+++ b/backend/web/core/__init__.py
@@ -1,1 +1,1 @@
-"""Core module for Leon web backend."""
+"""Core module for Mycel web backend."""

--- a/backend/web/core/config.py
+++ b/backend/web/core/config.py
@@ -1,4 +1,4 @@
-"""Configuration constants for Leon web backend."""
+"""Configuration constants for Mycel web backend."""
 
 from backend.sandboxes import paths as sandbox_paths
 from backend.sandboxes.local_workspace import local_workspace_root

--- a/backend/web/core/paths.py
+++ b/backend/web/core/paths.py
@@ -9,7 +9,7 @@ from config.user_paths import preferred_user_home_dir
 
 
 def leon_home_dir() -> Path:
-    """Return the filesystem root for Leon web runtime assets."""
+    """Return the filesystem root for Mycel web runtime assets."""
     return preferred_user_home_dir()
 
 

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -1,4 +1,4 @@
-"""Leon Web Backend - FastAPI Application."""
+"""Mycel Web Backend - FastAPI Application."""
 
 from backend.bootstrap.app_entrypoint import add_permissive_cors, load_env_file_from_env, resolve_app_port, run_reloadable_app
 
@@ -29,7 +29,7 @@ from backend.web.routers import (  # noqa: E402
 )
 
 # Create FastAPI app
-app = FastAPI(title="Leon Web Backend", lifespan=lifespan)
+app = FastAPI(title="Mycel Web Backend", lifespan=lifespan)
 
 add_permissive_cors(app)
 

--- a/backend/web/models/__init__.py
+++ b/backend/web/models/__init__.py
@@ -1,1 +1,1 @@
-"""Models module for Leon web backend."""
+"""Models module for Mycel web backend."""

--- a/backend/web/models/requests.py
+++ b/backend/web/models/requests.py
@@ -1,4 +1,4 @@
-"""Pydantic request models for Leon web API."""
+"""Pydantic request models for Mycel web API."""
 
 from typing import Any, Literal
 

--- a/frontend/app/src/components/chat-area/AskUserQuestionCard.tsx
+++ b/frontend/app/src/components/chat-area/AskUserQuestionCard.tsx
@@ -83,7 +83,7 @@ export function AskUserQuestionCard(props: AskUserQuestionCardProps) {
             <span className="text-xs font-medium text-foreground">等待回答</span>
           </div>
           <p className="text-xs text-muted-foreground">
-            {pending.promptMessage || "Leon 需要你的回答后才能继续当前任务。"}
+            {pending.promptMessage || "Mycel 需要你的回答后才能继续当前任务。"}
           </p>
         </div>
 

--- a/frontend/app/src/pages/ChatPage.tsx
+++ b/frontend/app/src/pages/ChatPage.tsx
@@ -221,7 +221,7 @@ function ChatPageInner({ threadId }: { threadId: string }) {
         asRecord(currentPermissionRequest.args.annotations) ?? undefined,
       );
       await refreshThread();
-      toast.success("已提交回答，Leon 会继续当前任务");
+      toast.success("已提交回答，Mycel 会继续当前任务");
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(`提交回答失败: ${message}`);
@@ -313,7 +313,7 @@ function ChatPageInner({ threadId }: { threadId: string }) {
                     <>
                       <p>{currentPermissionRequest.message || "该工具需要你明确批准后才能继续。"}</p>
                       <p className="text-xs text-muted-foreground">
-                        处理后不会自动重跑；Leon 需要在下一次相同操作时继续执行。
+                        处理后不会自动重跑；Mycel 需要在下一次相同操作时继续执行。
                       </p>
                       <code className="block w-full overflow-x-auto rounded-md bg-background/80 px-2 py-1 text-xs text-foreground border border-border/60">
                         {JSON.stringify(currentPermissionRequest.args)}
@@ -409,7 +409,7 @@ function ChatPageInner({ threadId }: { threadId: string }) {
                 isAskUserQuestionRequest(currentPermissionRequest)
                   ? {
                       requestId: currentPermissionRequest.request_id,
-                      promptMessage: currentPermissionRequest.message || "Leon 需要你的回答后才能继续当前任务。",
+                      promptMessage: currentPermissionRequest.message || "Mycel 需要你的回答后才能继续当前任务。",
                       prompts: questionPrompts,
                       selections: questionSelections,
                       resolving: resolvingId === currentPermissionRequest.request_id,
@@ -433,7 +433,7 @@ function ChatPageInner({ threadId }: { threadId: string }) {
           <InputBox
             disabled={isStreaming}
             isStreaming={isStreaming}
-            placeholder="告诉 Leon 你需要什么帮助..."
+            placeholder="告诉 Mycel 你需要什么帮助..."
             onSendMessage={(msg) => void handleSendWithAttachments(msg)}
             onSendQueueMessage={handleSendQueueMessage}
             onStop={handleStopStreaming}

--- a/frontend/monitor/README.md
+++ b/frontend/monitor/README.md
@@ -1,6 +1,6 @@
-# Leon Sandbox Monitor
+# Mycel Sandbox Monitor
 
-This is a standalone frontend for Leon's sandbox monitoring APIs.
+This is a standalone frontend for Mycel's sandbox monitoring APIs.
 
 Dev:
 

--- a/frontend/monitor/index.html
+++ b/frontend/monitor/index.html
@@ -7,7 +7,7 @@
       rel="icon"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%2312161d'/%3E%3Cpath d='M18 45V19h8v19h20v7H18Z' fill='%2374b0ff'/%3E%3Cpath d='M32 19h14v7H32z' fill='%23eaf0ff'/%3E%3C/svg%3E"
     />
-    <title>Leon Sandbox Monitor</title>
+    <title>Mycel Sandbox Monitor</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/monitor/src/app/MonitorNav.tsx
+++ b/frontend/monitor/src/app/MonitorNav.tsx
@@ -21,8 +21,8 @@ export function MonitorNav({
       <div className="monitor-sidebar__brand">
         <div className="monitor-sidebar__brand-row">
           <div>
-            <span className="monitor-sidebar__eyebrow">Leon Ops</span>
-            <h1>{collapsed ? "LM" : "Leon Sandbox Monitor"}</h1>
+            <span className="monitor-sidebar__eyebrow">Mycel Ops</span>
+            <h1>{collapsed ? "MM" : "Mycel Sandbox Monitor"}</h1>
           </div>
           <button
             type="button"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "leonai"
+name = "mycel"
 version = "0.3.0"
-description = "Leon - Proactive AI coding assistant with persistent memory"
+description = "Mycel - proactive human-agent collaboration platform with persistent memory"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}
@@ -67,9 +67,9 @@ otel = ["opentelemetry-api>=1.20.0", "opentelemetry-sdk>=1.20.0", "opentelemetry
 all = ["pymupdf>=1.24.0", "python-pptx>=1.0.0", "httpx-sse>=0.4.0", "langfuse>=3.0.0", "langsmith>=0.1.0"]
 
 [project.urls]
-Homepage = "https://github.com/Ju-Yi-AI-Lab/leonai"
-Repository = "https://github.com/Ju-Yi-AI-Lab/leonai"
-Issues = "https://github.com/Ju-Yi-AI-Lab/leonai/issues"
+Homepage = "https://github.com/OpenDCAI/Mycel"
+Repository = "https://github.com/OpenDCAI/Mycel"
+Issues = "https://github.com/OpenDCAI/Mycel/issues"
 
 [tool.setuptools]
 packages = [

--- a/uv.lock
+++ b/uv.lock
@@ -1460,138 +1460,6 @@ wheels = [
 ]
 
 [[package]]
-name = "leonai"
-version = "0.3.0"
-source = { editable = "." }
-dependencies = [
-    { name = "bcrypt" },
-    { name = "croniter" },
-    { name = "daytona-sdk" },
-    { name = "duckduckgo-search" },
-    { name = "e2b" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "langchain" },
-    { name = "langchain-anthropic" },
-    { name = "langchain-mcp-adapters" },
-    { name = "langchain-openai" },
-    { name = "langgraph" },
-    { name = "langgraph-checkpoint-postgres" },
-    { name = "langgraph-checkpoint-sqlite" },
-    { name = "multilspy" },
-    { name = "pillow" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "pyright" },
-    { name = "python-socks" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "sse-starlette" },
-    { name = "supabase" },
-    { name = "uvicorn" },
-    { name = "wuying-agentbay-sdk" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "httpx-sse" },
-    { name = "langfuse" },
-    { name = "langsmith" },
-    { name = "pymupdf" },
-    { name = "python-pptx" },
-]
-docs = [
-    { name = "pymupdf" },
-    { name = "python-pptx" },
-]
-eval = [
-    { name = "httpx-sse" },
-]
-langfuse = [
-    { name = "langfuse" },
-]
-langsmith = [
-    { name = "langsmith" },
-]
-otel = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-]
-pdf = [
-    { name = "pymupdf" },
-]
-pptx = [
-    { name = "python-pptx" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-timeout" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "bcrypt", specifier = ">=4.0.0" },
-    { name = "croniter", specifier = ">=6.0.0" },
-    { name = "daytona-sdk", specifier = ">=0.139.0,<0.140.0" },
-    { name = "duckduckgo-search", specifier = ">=8.1.1" },
-    { name = "e2b", specifier = ">=2.13.0" },
-    { name = "fastapi", specifier = ">=0.118.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx-sse", marker = "extra == 'all'", specifier = ">=0.4.0" },
-    { name = "httpx-sse", marker = "extra == 'eval'", specifier = ">=0.4.0" },
-    { name = "langchain", specifier = ">=1.2.6" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.1.0" },
-    { name = "langchain-openai", specifier = ">=1.1.7" },
-    { name = "langfuse", marker = "extra == 'all'", specifier = ">=3.0.0" },
-    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=3.0.0" },
-    { name = "langgraph", specifier = ">=1.0.7" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.5" },
-    { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.0" },
-    { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.1.0" },
-    { name = "langsmith", marker = "extra == 'langsmith'", specifier = ">=0.1.0" },
-    { name = "multilspy", specifier = ">=0.0.15" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
-    { name = "pillow", specifier = ">=10.0.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
-    { name = "pydantic", specifier = ">=2.0" },
-    { name = "pyjwt", specifier = ">=2.0.0" },
-    { name = "pymupdf", marker = "extra == 'all'", specifier = ">=1.24.0" },
-    { name = "pymupdf", marker = "extra == 'docs'", specifier = ">=1.24.0" },
-    { name = "pymupdf", marker = "extra == 'pdf'", specifier = ">=1.24.0" },
-    { name = "pyright", specifier = ">=1.1.0" },
-    { name = "python-pptx", marker = "extra == 'all'", specifier = ">=1.0.0" },
-    { name = "python-pptx", marker = "extra == 'docs'", specifier = ">=1.0.0" },
-    { name = "python-pptx", marker = "extra == 'pptx'", specifier = ">=1.0.0" },
-    { name = "python-socks", specifier = ">=2.7.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "sse-starlette", specifier = ">=1.6.0" },
-    { name = "supabase", specifier = ">=2.28.3" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
-    { name = "wuying-agentbay-sdk", specifier = ">=0.10.0" },
-]
-provides-extras = ["pdf", "pptx", "docs", "eval", "langfuse", "langsmith", "otel", "all"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pyright", specifier = ">=1.1.0" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.2.0" },
-    { name = "pytest-timeout", specifier = ">=2.0.0" },
-    { name = "ruff", specifier = ">=0.9.0" },
-]
-
-[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1955,6 +1823,138 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/c9/c6f5ab81bae667d4fe42a58df29f4c2db6ad8377cfd0e9baa729e4fa3ebb/multipart-1.3.0.tar.gz", hash = "sha256:a46bd6b0eb4c1ba865beb88ddd886012a3da709b6e7b86084fc37e99087e5cf1", size = 38816, upload-time = "2025-07-26T15:09:38.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/d6/d547a7004b81fa0b2aafa143b09196f6635e4105cd9d2c641fa8a4051c05/multipart-1.3.0-py3-none-any.whl", hash = "sha256:439bf4b00fd7cb2dbff08ae13f49f4f49798931ecd8d496372c63537fa19f304", size = 14938, upload-time = "2025-07-26T15:09:36.884Z" },
+]
+
+[[package]]
+name = "mycel"
+version = "0.3.0"
+source = { editable = "." }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "croniter" },
+    { name = "daytona-sdk" },
+    { name = "duckduckgo-search" },
+    { name = "e2b" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "langgraph-checkpoint-sqlite" },
+    { name = "multilspy" },
+    { name = "pillow" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pyright" },
+    { name = "python-socks" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "sse-starlette" },
+    { name = "supabase" },
+    { name = "uvicorn" },
+    { name = "wuying-agentbay-sdk" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "httpx-sse" },
+    { name = "langfuse" },
+    { name = "langsmith" },
+    { name = "pymupdf" },
+    { name = "python-pptx" },
+]
+docs = [
+    { name = "pymupdf" },
+    { name = "python-pptx" },
+]
+eval = [
+    { name = "httpx-sse" },
+]
+langfuse = [
+    { name = "langfuse" },
+]
+langsmith = [
+    { name = "langsmith" },
+]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+]
+pdf = [
+    { name = "pymupdf" },
+]
+pptx = [
+    { name = "python-pptx" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bcrypt", specifier = ">=4.0.0" },
+    { name = "croniter", specifier = ">=6.0.0" },
+    { name = "daytona-sdk", specifier = ">=0.139.0,<0.140.0" },
+    { name = "duckduckgo-search", specifier = ">=8.1.1" },
+    { name = "e2b", specifier = ">=2.13.0" },
+    { name = "fastapi", specifier = ">=0.118.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx-sse", marker = "extra == 'all'", specifier = ">=0.4.0" },
+    { name = "httpx-sse", marker = "extra == 'eval'", specifier = ">=0.4.0" },
+    { name = "langchain", specifier = ">=1.2.6" },
+    { name = "langchain-anthropic", specifier = ">=1.3.1" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.1.0" },
+    { name = "langchain-openai", specifier = ">=1.1.7" },
+    { name = "langfuse", marker = "extra == 'all'", specifier = ">=3.0.0" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=3.0.0" },
+    { name = "langgraph", specifier = ">=1.0.7" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.5" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.0" },
+    { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.1.0" },
+    { name = "langsmith", marker = "extra == 'langsmith'", specifier = ">=0.1.0" },
+    { name = "multilspy", specifier = ">=0.0.15" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyjwt", specifier = ">=2.0.0" },
+    { name = "pymupdf", marker = "extra == 'all'", specifier = ">=1.24.0" },
+    { name = "pymupdf", marker = "extra == 'docs'", specifier = ">=1.24.0" },
+    { name = "pymupdf", marker = "extra == 'pdf'", specifier = ">=1.24.0" },
+    { name = "pyright", specifier = ">=1.1.0" },
+    { name = "python-pptx", marker = "extra == 'all'", specifier = ">=1.0.0" },
+    { name = "python-pptx", marker = "extra == 'docs'", specifier = ">=1.0.0" },
+    { name = "python-pptx", marker = "extra == 'pptx'", specifier = ">=1.0.0" },
+    { name = "python-socks", specifier = ">=2.7.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "sse-starlette", specifier = ">=1.6.0" },
+    { name = "supabase", specifier = ">=2.28.3" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
+    { name = "wuying-agentbay-sdk", specifier = ">=0.10.0" },
+]
+provides-extras = ["pdf", "pptx", "docs", "eval", "langfuse", "langsmith", "otel", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-timeout", specifier = ">=2.0.0" },
+    { name = "ruff", specifier = ">=0.9.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Scope
Visible old product-name cleanup only.

## Included
- README / README.zh / frontend/monitor/README visible copy
- visible frontend prompts/titles
- visible backend web/monitor titles and docstrings
- pyproject metadata + URLs
- lockfile refresh for package rename

## Explicit non-scope
- LEON_* env vars
- ~/.leon / .leon
- leon:* model aliases
- localStorage keys
- leon.db / runtime contracts

## Local proof
- targeted rg over first-slice files finds no remaining Leon tokens
- targeted backend ruff check/format + git diff --check green
- frontend app/monitor build not claimed on this host because package contexts currently lack tsc (tsc: command not found)
