### PR TITLE
docs: remove leon naming from second safe slice

### DIFF
--- a/config/defaults/README.md
+++ b/config/defaults/README.md
@@ -1,4 +1,4 @@
-# Leon Default Configurations
+# Mycel Default Configurations
 
 System default configurations for agents and model mappings.
 
@@ -96,7 +96,7 @@ LLM-based summarization when context approaches limit:
 
 Load a preset via CLI:
 ```bash
-leonai --agent coder
+mycel --agent coder
 ```
 
 Or programmatically:

--- a/config/defaults/agents/__init__.py
+++ b/config/defaults/agents/__init__.py
@@ -1,1 +1,1 @@
-"""Built-in agent definitions for Leon AI Task system."""
+"""Built-in agent definitions for Mycel AI task system."""

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,1 +1,1 @@
-"""Leon evaluation system — trajectory tracing, metrics, and test harness."""
+"""Mycel evaluation system — trajectory tracing, metrics, and test harness."""

--- a/eval/harness/client.py
+++ b/eval/harness/client.py
@@ -12,7 +12,7 @@ from eval.models import TrajectoryCapture
 
 
 class EvalClient:
-    """HTTP + SSE client for driving Leon agent evaluation."""
+    """HTTP + SSE client for driving Mycel agent evaluation."""
 
     def __init__(self, base_url: str = "http://localhost:8001", token: str | None = None):
         self.base_url = base_url.rstrip("/")

--- a/eval/harness/runner.py
+++ b/eval/harness/runner.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class EvalRunner:
-    """Run eval scenarios against a Leon backend instance."""
+    """Run eval scenarios against a Mycel backend instance."""
 
     def __init__(
         self,
@@ -205,7 +205,7 @@ async def _main() -> None:
 
     from eval.harness.scenario import load_scenario, load_scenarios_from_dir
 
-    parser = argparse.ArgumentParser(description="Leon Eval Runner")
+    parser = argparse.ArgumentParser(description="Mycel Eval Runner")
     parser.add_argument("--scenario", type=str, help="Path to a single scenario YAML")
     parser.add_argument("--scenario-dir", type=str, help="Path to scenario directory")
     parser.add_argument("--base-url", type=str, default="http://localhost:8001")

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Leon Agent 交互式聊天 - 流式输出 + 工具调用展示
+Mycel Agent 交互式聊天 - 流式输出 + 工具调用展示
 
 特点：
 - 流式输出 agent 响应
@@ -44,7 +44,7 @@ class Colors:
 def print_banner():
     """打印欢迎横幅"""
     print(f"\n{Colors.CYAN}{'=' * 70}")
-    print(f"{Colors.BOLD}  Leon Agent - 交互式聊天{Colors.RESET}")
+    print(f"{Colors.BOLD}  Mycel Agent - 交互式聊天{Colors.RESET}")
     print(f"{Colors.CYAN}  流式输出 + 工具调用展示")
     print(f"{'=' * 70}{Colors.RESET}\n")
 
@@ -82,7 +82,7 @@ def print_tool_result(tool_name: str, result: str):
 
 def stream_response(agent, message: str, thread_id: str = "chat"):
     """流式处理 agent 响应并展示工具调用"""
-    print(f"{Colors.GREEN}🤖 Leon:{Colors.RESET} ", end="", flush=True)
+    print(f"{Colors.GREEN}🤖 Mycel:{Colors.RESET} ", end="", flush=True)
 
     try:
         config = {"configurable": {"thread_id": thread_id}}
@@ -146,7 +146,7 @@ def main():
         return
 
     # 创建 agent
-    print(f"{Colors.BLUE}🚀 初始化 Leon Agent...{Colors.RESET}")
+    print(f"{Colors.BLUE}🚀 初始化 Mycel Agent...{Colors.RESET}")
     agent = create_leon_agent()
     print(f"{Colors.GREEN}✅ Agent 已就绪{Colors.RESET}")
     print(f"{Colors.BLUE}📁 工作目录: {agent.workspace_root}{Colors.RESET}\n")

--- a/examples/sandboxes/README.md
+++ b/examples/sandboxes/README.md
@@ -42,4 +42,4 @@ Config files support `${VAR_NAME}` syntax for environment variable substitution.
 ## See Also
 
 - [Sandbox Documentation](../../docs/en/sandbox.md) — Provider details, lifecycle, monitoring
-- [CLI Reference](../../docs/en/cli.md) — `leonai sandbox` commands
+- [CLI Reference](../../docs/en/cli.md) — `mycel sandbox` commands

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "leon-frontend",
+  "name": "mycel-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "leon-frontend",
+      "name": "mycel-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "leon-frontend",
+  "name": "mycel-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/frontend/monitor/package-lock.json
+++ b/frontend/monitor/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "leon-monitor",
+  "name": "mycel-monitor",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "leon-monitor",
+      "name": "mycel-monitor",
       "version": "0.0.0",
       "dependencies": {
         "lucide-react": "^0.562.0",

--- a/frontend/monitor/package.json
+++ b/frontend/monitor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "leon-monitor",
+  "name": "mycel-monitor",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- remove additional low-risk Leon naming from package manifests, lockfiles, examples, and descriptive backend/config/eval copy
- keep runtime/operator compatibility surfaces out of scope

## Explicit non-scope
- LEON_* env vars
- ~/.leon and .leon paths
- leon:* model aliases
- localStorage keys like leon-auth and leon-monitor-token
- database filenames like leon.db

## Verification
- npm run build (frontend/app)
- npm run build (frontend/monitor)
- uv run pytest -q tests/Unit/backend/test_app_entrypoint.py tests/Unit/monitor/test_monitor_app_entrypoint.py
- scoped rg scan now only leaves deliberate non-scope hits (.leon paths and leon:* aliases)
- git diff --check