### PR TITLE
docs: trim leon prompt residue

### DIFF
--- a/.claude/commands/test_leon.md
+++ b/.claude/commands/test_leon.md
@@ -1,6 +1,6 @@
-# 测试 Leon 新功能
+# 测试 Mycel 新功能
 
-在开发 Leon 时，用此命令验证新功能是否正常工作。
+在开发 Mycel 时，用此命令验证新功能是否正常工作。
 
 **重要**：Middleware 级别的更新必须通过此测试才能交付。
 
@@ -28,7 +28,7 @@
 测试前先清理可能卡住的进程：
 
 ```bash
-# 杀掉所有 leonai 相关进程
+# 杀掉 CLI 相关进程
 pkill -9 -f "leonai" 2>/dev/null || true
 pkill -9 -f "context7\|upstash" 2>/dev/null || true
 sleep 1
@@ -41,7 +41,7 @@ sleep 1
 ```bash
 # 1. 清除缓存（必须！否则可能安装旧版本）
 # 如果提示 "Cache is currently in-use"，加 --force
-uv cache clean leonai --force
+uv cache clean mycel --force
 
 # 2. 强制重新安装（必须用 --force）
 uv tool install . --force

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -5,7 +5,7 @@
 修改代码后本地测试：
 
 ```bash
-uv cache clean leonai --force && uv tool install . --force
+uv cache clean mycel --force && uv tool install . --force
 ```
 
 - `--force` 必须加，否则缓存/进程占用会导致安装旧版本

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -1280,7 +1280,7 @@ class AgentService:
             payload,
             ToolPermissionContext(is_read_only=True, is_destructive=False),
             None,
-            "Please answer the following questions so Leon can continue.",
+            "Please answer the following questions so Mycel can continue.",
         )
         request_id = request_result.get("request_id") if isinstance(request_result, dict) else request_result
         if not isinstance(request_id, str) or not request_id:

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1802,7 +1802,7 @@ if __name__ == "__main__":
     try:
         print("=== Example 1: File Operations ===")
         response = leon_agent.get_response(
-            f"Create a Python file at {leon_agent.workspace_root}/hello.py that prints 'Hello, Leon!'",
+            f"Create a Python file at {leon_agent.workspace_root}/hello.py that prints 'Hello, Mycel!'",
             thread_id="demo",
         )
         print(response)

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -370,7 +370,7 @@ class _FakeAskUserQuestionAgent(_FakePermissionAgent):
                         }
                     ]
                 },
-                "message": "Please answer the following questions so Leon can continue.",
+                "message": "Please answer the following questions so Mycel can continue.",
             }
         ]
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1772,7 +1772,7 @@ async def test_ask_user_question_requests_structured_question_payload(tmp_path):
     assert meta["request_id"] == "ask-1"
     assert result.content == "User input required to continue."
     assert captured["name"] == "AskUserQuestion"
-    assert captured["message"] == "Please answer the following questions so Leon can continue."
+    assert captured["message"] == "Please answer the following questions so Mycel can continue."
     assert captured["args"] == {
         "questions": [
             {


### PR DESCRIPTION
## Summary
- retarget remaining ask-user prompt copy from Leon to Mycel and update the matching tests
- update a remaining runtime demo string from Hello, Leon! to Hello, Mycel!
- trim stale Leon descriptive copy from internal Claude command/rule docs while keeping actual command names and CLI invocations unchanged

## Verification
- uv run ruff check core/agents/service.py tests/Unit/core/test_agent_service.py tests/Integration/test_threads_router.py core/runtime/agent.py
- uv run pytest -q tests/Unit/core/test_agent_service.py -k ask_user tests/Integration/test_threads_router.py -k ask_user
- git diff --check