### PR TITLE
refactor: globalize monitor batch create

### DIFF
--- a/backend/monitor/api/http/global_router.py
+++ b/backend/monitor/api/http/global_router.py
@@ -1,12 +1,22 @@
 """Global monitor routes eligible for future monitor_app mounting."""
 
 import asyncio
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
+from backend.monitor.api.http.dependencies import get_current_user_id
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 router = APIRouter()
+
+
+class EvaluationBatchCreateRequest(BaseModel):
+    agent_user_id: str
+    scenario_ids: list[str] = Field(min_length=1)
+    sandbox: str = "local"
+    max_concurrent: int = Field(default=1, ge=1, le=50)
 
 
 def _or_404(fn, *args):
@@ -92,6 +102,20 @@ def evaluation_snapshot():
 @router.get("/evaluation/batches")
 def evaluation_batches_snapshot(limit: int = Query(default=50, ge=1, le=200)):
     return monitor_gateway.get_evaluation_batches(limit=limit)
+
+
+@router.post("/evaluation/batches")
+def evaluation_batch_create_action(
+    payload: EvaluationBatchCreateRequest,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+):
+    return monitor_gateway.create_evaluation_batch(
+        submitted_by_user_id=user_id,
+        agent_user_id=payload.agent_user_id,
+        scenario_ids=payload.scenario_ids,
+        sandbox=payload.sandbox,
+        max_concurrent=payload.max_concurrent,
+    )
 
 
 @router.get("/evaluation/scenarios")

--- a/backend/monitor/api/http/web_local_router.py
+++ b/backend/monitor/api/http/web_local_router.py
@@ -3,19 +3,11 @@
 from typing import Annotated, Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
 
 from backend.monitor.api.http.dependencies import get_app, get_current_user_id
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 router = APIRouter()
-
-
-class EvaluationBatchCreateRequest(BaseModel):
-    agent_user_id: str
-    scenario_ids: list[str] = Field(min_length=1)
-    sandbox: str = "local"
-    max_concurrent: int = Field(default=1, ge=1, le=50)
 
 
 def _extract_bearer_token(request: Request) -> str:
@@ -42,20 +34,6 @@ async def thread_detail_snapshot(request: Request, thread_id: str):
         return await monitor_gateway.get_thread_detail(request.app, thread_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-
-
-@router.post("/evaluation/batches")
-def evaluation_batch_create_action(
-    payload: EvaluationBatchCreateRequest,
-    user_id: Annotated[str, Depends(get_current_user_id)],
-):
-    return monitor_gateway.create_evaluation_batch(
-        submitted_by_user_id=user_id,
-        agent_user_id=payload.agent_user_id,
-        scenario_ids=payload.scenario_ids,
-        sandbox=payload.sandbox,
-        max_concurrent=payload.max_concurrent,
-    )
 
 
 @router.post("/evaluation/batches/{batch_id}/start")

--- a/backend/monitor/app/lifespan.py
+++ b/backend/monitor/app/lifespan.py
@@ -6,11 +6,13 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from backend.bootstrap.storage import attach_runtime_storage_state
+from backend.identity.auth.runtime_bootstrap import attach_auth_runtime_state
 from backend.monitor.infrastructure.resources.resource_overview_cache import resource_overview_refresh_loop
 
 
 def _require_monitor_runtime_contract(app: FastAPI) -> None:
-    attach_runtime_storage_state(app)
+    runtime_storage = attach_runtime_storage_state(app)
+    attach_auth_runtime_state(app, storage_state=runtime_storage)
 
 
 @asynccontextmanager

--- a/backend/monitor/app/lifespan.py
+++ b/backend/monitor/app/lifespan.py
@@ -12,6 +12,7 @@ from backend.monitor.infrastructure.resources.resource_overview_cache import res
 
 def _require_monitor_runtime_contract(app: FastAPI) -> None:
     runtime_storage = attach_runtime_storage_state(app)
+    app.state.user_repo = runtime_storage.storage_container.user_repo()
     attach_auth_runtime_state(app, storage_state=runtime_storage)
 
 

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -141,6 +141,29 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
     }
 
 
+def test_global_monitor_router_accepts_evaluation_batch_create(monkeypatch):
+    monkeypatch.setattr(
+        monitor_gateway_impl,
+        "create_evaluation_batch",
+        lambda **kwargs: {"batch": kwargs},
+    )
+    app = FastAPI()
+    app.include_router(global_router.router, prefix="/api/monitor")
+    app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/monitor/evaluation/batches",
+                json={"agent_user_id": "agent-1", "scenario_ids": ["scenario-1"], "sandbox": "local", "max_concurrent": 1},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["batch"]["submitted_by_user_id"] == "owner-1"
+    assert response.json()["batch"]["agent_user_id"] == "agent-1"
+
+
 @pytest.mark.parametrize(
     ("method", "path", "service_name", "payload"),
     [

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -1,11 +1,11 @@
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
 
 from backend.bootstrap import app_entrypoint
-from backend.monitor.api.http.dependencies import get_current_user_id
 from backend.monitor.app import lifespan as monitor_app_lifespan
 from backend.monitor.app import main as monitor_app_main
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
@@ -18,7 +18,10 @@ def test_monitor_app_module_path_is_internalized():
 
 
 def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: object())
+    monitor_storage = SimpleNamespace(
+        storage_container=SimpleNamespace(user_repo=lambda: object()),
+    )
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
     monkeypatch.setattr(monitor_app_lifespan, "attach_auth_runtime_state", lambda *_args, **_kwargs: object())
     with TestClient(app) as client:
         response = client.get("/openapi.json")
@@ -35,27 +38,63 @@ def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.Monke
 
 
 def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: object())
-    monkeypatch.setattr(monitor_app_lifespan, "attach_auth_runtime_state", lambda *_args, **_kwargs: object())
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
+    monitor_storage = SimpleNamespace(
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+    )
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
+    monkeypatch.setattr(
+        monitor_app_lifespan,
+        "attach_auth_runtime_state",
+        lambda app, *, storage_state: setattr(
+            app.state,
+            "auth_service",
+            SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+        ) or object(),
+    )
     monkeypatch.setattr(
         monitor_gateway,
         "create_evaluation_batch",
         lambda **kwargs: {"batch": kwargs},
     )
-    app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
-    try:
-        with TestClient(app) as client:
-            response = client.post(
-                "/api/monitor/evaluation/batches",
-                json={"agent_user_id": "agent-1", "scenario_ids": ["scenario-1"], "sandbox": "local", "max_concurrent": 1},
-            )
-    finally:
-        app.dependency_overrides.clear()
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/monitor/evaluation/batches",
+            json={"agent_user_id": "agent-1", "scenario_ids": ["scenario-1"], "sandbox": "local", "max_concurrent": 1},
+            headers={"Authorization": "Bearer token-1"},
+        )
 
     assert response.status_code == 200
     payload = response.json()["batch"]
     assert payload["submitted_by_user_id"] == "owner-1"
     assert payload["agent_user_id"] == "agent-1"
+
+
+def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
+    user_repo = SimpleNamespace(get_by_id=lambda _user_id: None)
+    monitor_storage = SimpleNamespace(
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+    )
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
+    monkeypatch.setattr(
+        monitor_app_lifespan,
+        "attach_auth_runtime_state",
+        lambda app, *, storage_state: setattr(
+            app.state,
+            "auth_service",
+            SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+        ) or object(),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/monitor/evaluation/batches",
+            json={"agent_user_id": "agent-1", "scenario_ids": ["scenario-1"], "sandbox": "local", "max_concurrent": 1},
+            headers={"Authorization": "Bearer token-1"},
+        )
+
+    assert response.status_code == 401
+    assert "User no longer exists" in response.text
 
 
 def test_monitor_app_resolve_port_prefers_monitor_backend_env(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -5,8 +5,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
 
 from backend.bootstrap import app_entrypoint
+from backend.monitor.api.http.dependencies import get_current_user_id
 from backend.monitor.app import lifespan as monitor_app_lifespan
 from backend.monitor.app import main as monitor_app_main
+from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 app = monitor_app_main.app
 
@@ -17,6 +19,7 @@ def test_monitor_app_module_path_is_internalized():
 
 def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: object())
+    monkeypatch.setattr(monitor_app_lifespan, "attach_auth_runtime_state", lambda *_args, **_kwargs: object())
     with TestClient(app) as client:
         response = client.get("/openapi.json")
 
@@ -28,7 +31,31 @@ def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.Monke
     assert "/api/monitor/threads" not in paths
     assert "/api/monitor/threads/{thread_id}" not in paths
     assert "/api/monitor/evaluation/batches/{batch_id}/start" not in paths
-    assert set(paths["/api/monitor/evaluation/batches"]) == {"get"}
+    assert set(paths["/api/monitor/evaluation/batches"]) == {"get", "post"}
+
+
+def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: object())
+    monkeypatch.setattr(monitor_app_lifespan, "attach_auth_runtime_state", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        monitor_gateway,
+        "create_evaluation_batch",
+        lambda **kwargs: {"batch": kwargs},
+    )
+    app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/monitor/evaluation/batches",
+                json={"agent_user_id": "agent-1", "scenario_ids": ["scenario-1"], "sandbox": "local", "max_concurrent": 1},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()["batch"]
+    assert payload["submitted_by_user_id"] == "owner-1"
+    assert payload["agent_user_id"] == "agent-1"
 
 
 def test_monitor_app_resolve_port_prefers_monitor_backend_env(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Unit/monitor/test_monitor_app_lifespan.py
+++ b/tests/Unit/monitor/test_monitor_app_lifespan.py
@@ -12,6 +12,7 @@ from backend.monitor.app import lifespan as monitor_app_lifespan
 async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(monkeypatch: pytest.MonkeyPatch):
     started = asyncio.Event()
     cancelled = asyncio.Event()
+    auth_calls = []
 
     async def _loop():
         started.set()
@@ -21,8 +22,15 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
             cancelled.set()
             raise
 
+    monitor_storage = object()
+
     monkeypatch.setattr(monitor_app_lifespan, "resource_overview_refresh_loop", _loop)
-    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: object())
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
+    monkeypatch.setattr(
+        monitor_app_lifespan,
+        "attach_auth_runtime_state",
+        lambda _app, *, storage_state: auth_calls.append(storage_state) or object(),
+    )
 
     app = SimpleNamespace(state=SimpleNamespace())
 
@@ -32,6 +40,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
         assert not app.state.monitor_resources_task.done()
 
     await asyncio.wait_for(cancelled.wait(), timeout=1)
+    assert auth_calls == [monitor_storage]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/monitor/test_monitor_app_lifespan.py
+++ b/tests/Unit/monitor/test_monitor_app_lifespan.py
@@ -13,6 +13,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
     started = asyncio.Event()
     cancelled = asyncio.Event()
     auth_calls = []
+    user_repo = object()
 
     async def _loop():
         started.set()
@@ -22,7 +23,9 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
             cancelled.set()
             raise
 
-    monitor_storage = object()
+    monitor_storage = SimpleNamespace(
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+    )
 
     monkeypatch.setattr(monitor_app_lifespan, "resource_overview_refresh_loop", _loop)
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
@@ -38,6 +41,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
         await asyncio.wait_for(started.wait(), timeout=1)
         assert app.state.monitor_resources_task is not None
         assert not app.state.monitor_resources_task.done()
+        assert app.state.user_repo is user_repo
 
     await asyncio.wait_for(cancelled.wait(), timeout=1)
     assert auth_calls == [monitor_storage]


### PR DESCRIPTION
## Summary
- treat this as Step 3a of the monitor independent-backend lane, not as end-state closure
- attach auth runtime and user_repo in backend/monitor/app/lifespan.py so monitor process auth semantics match the old web-owned path
- move POST /evaluation/batches from web_local_router to global_router
- add focused tests proving the standalone monitor shell accepts valid users and rejects deleted users with 401

## Commit Shape
- this PR intentionally keeps a 6-commit sequence to satisfy the current per-PR density rule

## Non-scope
- no movement of GET /threads
- no movement of POST /evaluation/batches/{batch_id}/start
- no monitor business-logic rewrite
- no chat/runtime changes

## Verification
- uv run pytest -q tests/Unit/monitor/test_monitor_app_lifespan.py tests/Unit/monitor/test_monitor_app_entrypoint.py tests/Integration/test_monitor_resources_route.py -k "lifespan or evaluation_batch_create or global_monitor_router_accepts_evaluation_batch_create or monitor_app"
- uv run ruff check backend/monitor/app/lifespan.py backend/monitor/api/http/global_router.py backend/monitor/api/http/web_local_router.py tests/Unit/monitor/test_monitor_app_lifespan.py tests/Unit/monitor/test_monitor_app_entrypoint.py tests/Integration/test_monitor_resources_route.py
- git diff --check