### PR TITLE
refactor: drain monitor thread route owner

### DIFF
--- a/backend/monitor/api/http/web_local_router.py
+++ b/backend/monitor/api/http/web_local_router.py
@@ -1,10 +1,10 @@
 """Web-runtime-bound monitor routes that stay on the main web process."""
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
-from backend.monitor.api.http.dependencies import get_app, get_current_user_id
+from backend.monitor.api.http.dependencies import get_current_user_id
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 router = APIRouter()
@@ -18,22 +18,6 @@ def _extract_bearer_token(request: Request) -> str:
     if not token:
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     return token
-
-
-@router.get("/threads")
-def threads_snapshot(
-    user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)] = None,
-):
-    return monitor_gateway.list_threads(app, user_id)
-
-
-@router.get("/threads/{thread_id}")
-async def thread_detail_snapshot(request: Request, thread_id: str):
-    try:
-        return await monitor_gateway.get_thread_detail(request.app, thread_id)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/evaluation/batches/{batch_id}/start")

--- a/backend/monitor/infrastructure/web/gateway.py
+++ b/backend/monitor/infrastructure/web/gateway.py
@@ -8,9 +8,7 @@ from backend.monitor.application.use_cases import evaluation as monitor_evaluati
 from backend.monitor.application.use_cases import provider_runtimes as monitor_provider_runtimes
 from backend.monitor.application.use_cases import resources as monitor_resources
 from backend.monitor.application.use_cases import sandbox_configs, sandbox_detail, sandbox_projection
-from backend.monitor.application.use_cases import threads as monitor_threads
 from backend.monitor.infrastructure.evaluation.background_task_scheduler import BackgroundTaskEvaluationScheduler
-from backend.monitor.infrastructure.read_models import thread_read_service, thread_workbench_read_service, trace_read_service
 from backend.monitor.mutations import sandbox_mutations
 
 
@@ -20,13 +18,6 @@ def list_sandboxes() -> dict[str, Any]:
 
 def list_provider_orphan_runtimes() -> dict[str, Any]:
     return monitor_provider_runtimes.list_monitor_provider_orphan_runtimes()
-
-
-def list_threads(app: Any, user_id: str) -> dict[str, Any]:
-    return monitor_threads.list_monitor_threads(
-        user_id,
-        workbench_reader=thread_workbench_read_service.build_owner_thread_workbench_reader(app),
-    )
 
 
 def get_provider_detail(provider_id: str) -> dict[str, Any]:
@@ -62,14 +53,6 @@ def get_runtime_detail(runtime_id: str) -> dict[str, Any]:
 
 def get_sandbox_configs() -> dict[str, Any]:
     return sandbox_configs.get_monitor_sandbox_configs()
-
-
-async def get_thread_detail(app: Any, thread_id: str) -> dict[str, Any]:
-    return await monitor_threads.get_monitor_thread_detail(
-        thread_id,
-        load_thread_base=thread_read_service.build_monitor_thread_base_loader(app),
-        trace_reader=trace_read_service.build_monitor_trace_reader(app),
-    )
 
 
 def get_dashboard() -> dict[str, Any]:

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -14,6 +14,7 @@ from backend.web.routers import (  # noqa: E402
     contacts,
     invite_codes,
     marketplace,
+    monitor_threads,
     panel,
     resources,
     sandbox,
@@ -45,6 +46,7 @@ app.include_router(thread_files._public)
 app.include_router(settings.router)
 app.include_router(panel.router)
 app.include_router(global_router.router, prefix="/api/monitor")
+app.include_router(monitor_threads.router, prefix="/api/monitor")
 # @@@monitor-web-local-drain - web_local routes still depend on the main web process.
 # Drain this mount only after those routes are either retired or moved behind the separate monitor process boundary.
 app.include_router(web_local_router.router, prefix="/api/monitor")

--- a/backend/web/routers/monitor_threads.py
+++ b/backend/web/routers/monitor_threads.py
@@ -5,7 +5,10 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.monitor.api.http.dependencies import get_app, get_current_user_id
-from backend.monitor.infrastructure.web import gateway as monitor_gateway
+from backend.monitor.application.use_cases import threads as monitor_thread_service
+from backend.monitor.infrastructure.read_models import thread_read_service as monitor_thread_read_service
+from backend.monitor.infrastructure.read_models import thread_workbench_read_service as monitor_thread_workbench_read_service
+from backend.monitor.infrastructure.read_models import trace_read_service as monitor_trace_read_service
 
 router = APIRouter()
 
@@ -15,12 +18,19 @@ def threads_snapshot(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ):
-    return monitor_gateway.list_threads(app, user_id)
+    return monitor_thread_service.list_monitor_threads(
+        user_id,
+        workbench_reader=monitor_thread_workbench_read_service.build_owner_thread_workbench_reader(app),
+    )
 
 
 @router.get("/threads/{thread_id}")
 async def thread_detail_snapshot(request: Request, thread_id: str):
     try:
-        return await monitor_gateway.get_thread_detail(request.app, thread_id)
+        return await monitor_thread_service.get_monitor_thread_detail(
+            thread_id,
+            load_thread_base=monitor_thread_read_service.build_monitor_thread_base_loader(request.app),
+            trace_reader=monitor_trace_read_service.build_monitor_trace_reader(request.app),
+        )
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/web/routers/monitor_threads.py
+++ b/backend/web/routers/monitor_threads.py
@@ -1,0 +1,26 @@
+"""Web-owned monitor-local thread routes."""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.monitor.api.http.dependencies import get_app, get_current_user_id
+from backend.monitor.infrastructure.web import gateway as monitor_gateway
+
+router = APIRouter()
+
+
+@router.get("/threads")
+def threads_snapshot(
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    app: Annotated[Any, Depends(get_app)] = None,
+):
+    return monitor_gateway.list_threads(app, user_id)
+
+
+@router.get("/threads/{thread_id}")
+async def thread_detail_snapshot(request: Request, thread_id: str):
+    try:
+        return await monitor_gateway.get_thread_detail(request.app, thread_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -226,11 +226,11 @@ def test_monitor_threads_routes_use_authenticated_owner(monkeypatch):
     expected = {"threads": [{"thread_id": "thread-1", "agent_user_id": "agent-1"}]}
     calls = []
 
-    def _list_threads(app, user_id):
-        calls.append((app, user_id))
+    def _list_threads(user_id, *, workbench_reader):
+        calls.append((user_id, workbench_reader))
         return expected
 
-    monkeypatch.setattr(monitor_gateway_impl, "list_threads", _list_threads)
+    monkeypatch.setattr(monitor_threads_router.monitor_thread_service, "list_monitor_threads", _list_threads)
     app = _app()
     app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
 
@@ -238,14 +238,14 @@ def test_monitor_threads_routes_use_authenticated_owner(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == expected
-    assert calls[0][1] == "owner-1"
+    assert calls[0][0] == "owner-1"
 
 
 def test_monitor_thread_detail_route_awaits_service(monkeypatch):
-    async def _detail(app, thread_id):
+    async def _detail(thread_id, *, load_thread_base, trace_reader):
         return {"thread": {"thread_id": thread_id}, "trajectory": {"events": []}}
 
-    monkeypatch.setattr(monitor_gateway_impl, "get_thread_detail", _detail)
+    monkeypatch.setattr(monitor_threads_router.monitor_thread_service, "get_monitor_thread_detail", _detail)
 
     response = _request("get", "/api/monitor/threads/thread-1")
 

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -7,12 +7,14 @@ from backend.monitor.application.use_cases import resources as monitor_resources
 from backend.monitor.infrastructure.io import resource_io_service as monitor_resource_io_service
 from backend.monitor.infrastructure.web import gateway as monitor_gateway_impl
 from backend.web.core.dependencies import get_current_user_id
+from backend.web.routers import monitor_threads as monitor_threads_router
 from backend.web.routers import resources
 
 
 def _app(*, include_product_resources: bool = False) -> FastAPI:
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
+    app.include_router(monitor_threads_router.router, prefix="/api/monitor")
     app.include_router(web_local_router.router, prefix="/api/monitor")
     if include_product_resources:
         app.include_router(resources.router)


### PR DESCRIPTION
## Summary
- treat this as the first Step 3c owner-drain slice on the monitor independent-backend lane
- move `/api/monitor/threads*` route ownership into a web-owned router while preserving the external path shape
- stop exposing those thread routes from `backend/monitor/api/http/web_local_router.py`
- remove the now-dead thread route entrypoints from `backend.monitor.infrastructure.web.gateway`

## Commit Shape
- this PR intentionally keeps a 5-commit sequence to satisfy the current per-PR density rule

## Non-scope
- no movement of `POST /evaluation/batches/{batch_id}/start`
- no attempt to globalize `/threads` into standalone monitor shell
- no monitor business-logic rewrite
- no chat/runtime changes

## Verification
- uv run pytest -q tests/Integration/test_monitor_resources_route.py -k "monitor_threads_routes_use_authenticated_owner or monitor_thread_detail_route_awaits_service or monitor_evaluation_batch_create_and_start_pass_request_context"
- uv run ruff check backend/web/main.py backend/web/routers/monitor_threads.py backend/monitor/api/http/web_local_router.py backend/monitor/infrastructure/web/gateway.py tests/Integration/test_monitor_resources_route.py
- git diff --check