### PR TITLE
refactor(chat): remove residual hidden state dependencies

### DIFF
--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -12,7 +12,7 @@ from backend.chat.api.http.dependencies import (
     get_app,
     get_current_user_id,
     get_optional_messaging_service,
-    get_optional_runtime_thread_activity_reader,
+    get_runtime_thread_activity_reader,
     get_thread_last_active_map,
 )
 from backend.identity.avatar.urls import avatar_url
@@ -46,7 +46,7 @@ async def list_conversations(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> list[dict[str, Any]]:
-    activity_reader = get_optional_runtime_thread_activity_reader(app)
+    activity_reader = get_runtime_thread_activity_reader(app)
     thread_last_active = get_thread_last_active_map(app)
     raw_threads, visit_items = await asyncio.gather(
         list_owner_thread_rows_for_auth_burst(app, user_id),
@@ -63,7 +63,7 @@ async def list_conversations(
 
 def _list_hire_conversations_from_threads(
     raw_thread_rows: list[dict[str, Any]],
-    activity_reader: RuntimeThreadActivityReader | None,
+    activity_reader: RuntimeThreadActivityReader,
     thread_last_active: dict[str, Any],
 ) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
@@ -89,9 +89,7 @@ def _list_hire_conversations_from_threads(
     return items
 
 
-def _thread_running(activity_reader: RuntimeThreadActivityReader | None, agent_user_id: Any, thread_id: str) -> bool:
-    if activity_reader is None:
-        return False
+def _thread_running(activity_reader: RuntimeThreadActivityReader, agent_user_id: Any, thread_id: str) -> bool:
     normalized_agent_user_id = str(agent_user_id or "").strip()
     if not normalized_agent_user_id:
         return False

--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -52,8 +52,8 @@ def get_chat_event_bus(app: Any) -> Any:
     return _require_state_attr(app, "chat_event_bus", "Chat event bus unavailable")
 
 
-def get_optional_runtime_thread_activity_reader(app: Any) -> Any | None:
-    return getattr(app.state, "agent_runtime_thread_activity_reader", None)
+def get_runtime_thread_activity_reader(app: Any) -> Any:
+    return _require_state_attr(app, "agent_runtime_thread_activity_reader", "Thread activity reader unavailable")
 
 
 def get_thread_last_active_map(app: Any) -> Any:

--- a/backend/web/routers/contacts.py
+++ b/backend/web/routers/contacts.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import time
 from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from backend.chat.runtime_access import get_contact_repo
 from backend.web.core.dependencies import get_app, get_current_user_id
 from storage.contracts import ContactEdgeRow
 
@@ -26,7 +27,10 @@ async def list_contacts(
     app: Annotated[Any, Depends(get_app)],
 ):
     """List contacts (blocked/muted) for the current user."""
-    rows = app.state.contact_repo.list_for_user(user_id)
+    try:
+        rows = get_contact_repo(app).list_for_user(user_id)
+    except RuntimeError as exc:
+        raise HTTPException(503, str(exc)) from exc
     return [
         {
             "source_user_id": row.source_user_id,
@@ -49,18 +53,21 @@ async def set_contact(
     app: Annotated[Any, Depends(get_app)],
 ):
     """Upsert contact (block/mute/normal)."""
-    app.state.contact_repo.upsert(
-        ContactEdgeRow(
-            source_user_id=user_id,
-            target_user_id=body.target_user_id,
-            kind=body.kind,
-            state=body.state,
-            muted=body.kind == "muted",
-            blocked=body.kind == "blocked",
-            created_at=time.time(),
-            updated_at=time.time(),
+    try:
+        get_contact_repo(app).upsert(
+            ContactEdgeRow(
+                source_user_id=user_id,
+                target_user_id=body.target_user_id,
+                kind=body.kind,
+                state=body.state,
+                muted=body.kind == "muted",
+                blocked=body.kind == "blocked",
+                created_at=time.time(),
+                updated_at=time.time(),
+            )
         )
-    )
+    except RuntimeError as exc:
+        raise HTTPException(503, str(exc)) from exc
     return {"status": "ok", "kind": body.kind, "state": body.state}
 
 
@@ -71,5 +78,8 @@ async def delete_contact(
     app: Annotated[Any, Depends(get_app)],
 ):
     """Remove contact entry."""
-    app.state.contact_repo.delete(user_id, target_id)
+    try:
+        get_contact_repo(app).delete(user_id, target_id)
+    except RuntimeError as exc:
+        raise HTTPException(503, str(exc)) from exc
     return {"status": "deleted"}

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from backend.chat.api.http.dependencies import get_thread_repo
 from backend.chat.runtime_access import get_contact_repo
 from backend.identity import profile as profile_owner
 from backend.library import service as library_service
@@ -186,9 +187,11 @@ async def delete_agent(
         raise HTTPException(403, "Cannot delete builtin agent")
     user_repo = request.app.state.user_repo
     await asyncio.to_thread(_require_owned_agent_user, agent_id, user_id, user_repo)
-    thread_repo = getattr(request.app.state, "thread_repo", None)
-    if thread_repo is not None:
-        await asyncio.to_thread(_ensure_agent_has_no_threads_or_409, agent_id, thread_repo)
+    try:
+        thread_repo = get_thread_repo(request.app)
+    except HTTPException:
+        raise
+    await asyncio.to_thread(_ensure_agent_has_no_threads_or_409, agent_id, thread_repo)
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     try:
         contact_repo = get_contact_repo(request.app)

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 
+from backend.chat.api.http.dependencies import get_thread_repo
 from backend.chat.runtime_access import get_contact_repo, get_relationship_service
 from backend.identity.avatar.files import process_and_save_avatar
 from backend.identity.avatar.paths import avatars_dir
@@ -158,7 +159,7 @@ async def list_chat_candidates(
         raise HTTPException(503, str(exc)) from exc
 
     items = []
-    thread_repo = getattr(app.state, "thread_repo", None)
+    thread_repo = get_thread_repo(app)
 
     for user in users:
         if user.id == user_id:

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -35,6 +35,7 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
             thread_repo=thread_repo,
             terminal_repo=SimpleNamespace(summarize_threads=lambda _thread_ids: {}),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
         )

--- a/tests/Integration/test_contacts_schema_contract.py
+++ b/tests/Integration/test_contacts_schema_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from backend.web.routers import contacts as contacts_router
 from storage.contracts import ContactEdgeRow
@@ -89,3 +90,41 @@ async def test_delete_contact_uses_directed_user_ids() -> None:
 
     assert result == {"status": "deleted"}
     assert repo.deleted == [("user-a", "user-b")]
+
+
+@pytest.mark.asyncio
+async def test_list_contacts_fails_loud_when_contact_repo_missing() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await contacts_router.list_contacts(
+            user_id="user-a",
+            app=SimpleNamespace(state=SimpleNamespace()),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"
+
+
+@pytest.mark.asyncio
+async def test_set_contact_fails_loud_when_contact_repo_missing() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await contacts_router.set_contact(
+            contacts_router.SetContactBody(target_user_id="user-b", kind="blocked", state="active"),
+            user_id="user-a",
+            app=SimpleNamespace(state=SimpleNamespace()),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"
+
+
+@pytest.mark.asyncio
+async def test_delete_contact_fails_loud_when_contact_repo_missing() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await contacts_router.delete_contact(
+            "user-b",
+            user_id="user-a",
+            app=SimpleNamespace(state=SimpleNamespace()),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -30,6 +30,7 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
                 ),
             ),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -97,6 +98,7 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
                 get_by_user_id=lambda _uid: None,
             ),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={"thread-1": 1775540000.0},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -154,6 +156,7 @@ async def test_list_conversations_hire_entries_do_not_leak_template_member_ids()
                 get_by_user_id=lambda _uid: None,
             ),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={},
             messaging_service=None,
         )
@@ -248,6 +251,7 @@ async def test_list_conversations_collapses_hire_threads_to_one_visible_conversa
                 ],
             ),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={"thread-main": 1775540000.0, "thread-extra": 1775541000.0},
             messaging_service=None,
         )
@@ -267,6 +271,7 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
                 get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not read visit rows itself")),
             ),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -314,6 +319,7 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
         )
@@ -328,7 +334,10 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
 
     assert await owner_conversations_router.list_conversations("human-user-1", app=app) == []
     assert ("_list_visit_conversations_for_user", (app, "human-user-1")) in to_thread_calls
-    assert ("_list_hire_conversations_from_threads", ([], None, {})) in to_thread_calls
+    assert (
+        "_list_hire_conversations_from_threads",
+        ([], app.state.agent_runtime_thread_activity_reader, {}),
+    ) in to_thread_calls
 
 
 @pytest.mark.asyncio
@@ -352,9 +361,27 @@ async def test_list_conversations_fetches_hire_and_visit_sources_in_parallel() -
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=_list_threads),
             agent_pool={},
+            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=_list_visit_summaries),
         )
     )
 
     assert await owner_conversations_router.list_conversations("human-user-1", app=app) == []
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_fails_loud_when_thread_activity_reader_missing() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
+            thread_last_active={},
+            messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
+        )
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await owner_conversations_router.list_conversations("human-user-1", app=app)
+
+    assert getattr(exc_info.value, "status_code", None) == 503
+    assert getattr(exc_info.value, "detail", None) == "Thread activity reader unavailable"

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -435,7 +435,7 @@ async def test_delete_agent_route_fails_loud_when_contact_repo_missing(monkeypat
             state=SimpleNamespace(
                 user_repo=SimpleNamespace(),
                 agent_config_repo=SimpleNamespace(),
-                thread_repo=None,
+                thread_repo=SimpleNamespace(list_by_agent_user=lambda _agent_id: []),
             )
         )
     )
@@ -450,6 +450,30 @@ async def test_delete_agent_route_fails_loud_when_contact_repo_missing(monkeypat
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_route_fails_loud_when_thread_repo_missing(monkeypatch: pytest.MonkeyPatch):
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                user_repo=SimpleNamespace(),
+                agent_config_repo=SimpleNamespace(),
+                contact_repo=SimpleNamespace(),
+            )
+        )
+    )
+    monkeypatch.setattr(panel_router, "_require_owned_agent_user", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await panel_router.delete_agent(
+            "agent-1",
+            request=request,
+            user_id="user-1",
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Thread repo unavailable"
 
 
 def test_get_agent_user_preserves_explicit_empty_repo_skill_desc(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -162,6 +162,23 @@ async def test_list_chat_candidates_exposes_default_thread_id_for_owned_agents_o
 
 
 @pytest.mark.asyncio
+async def test_list_chat_candidates_fails_loud_when_owned_agent_threads_need_thread_repo():
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            user_repo=SimpleNamespace(list_all=lambda: [_human("u1", "owner"), _agent("a-owned", "Morel", "u1")]),
+            relationship_service=SimpleNamespace(list_for_user=lambda _user_id: []),
+            contact_repo=_empty_contact_repo(),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_router.list_chat_candidates(user_id="u1", app=app)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Thread repo unavailable"
+
+
+@pytest.mark.asyncio
 async def test_list_chat_candidates_marks_normal_active_contacts_as_chat_candidates():
     app = _users_app(
         [_human("u1", "owner"), _human("u2", "other")],

--- a/tests/Unit/backend/test_chat_http_dependencies.py
+++ b/tests/Unit/backend/test_chat_http_dependencies.py
@@ -26,8 +26,12 @@ def test_get_relationship_service_fails_loud_when_missing():
     assert exc_info.value.detail == "Relationship service unavailable"
 
 
-def test_get_optional_runtime_thread_activity_reader_returns_none_when_missing():
-    assert chat_http_dependencies.get_optional_runtime_thread_activity_reader(_app_state()) is None
+def test_get_runtime_thread_activity_reader_fails_loud_when_missing():
+    with pytest.raises(HTTPException) as exc_info:
+        chat_http_dependencies.get_runtime_thread_activity_reader(_app_state())
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Thread activity reader unavailable"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- fail loud on remaining hidden chat-owned state dependencies in conversations, contacts, users, and panel routes
- require messaging_service when thread runtime constructs chat_repos for repo-backed identities
- continue narrowing the gap between chat backend truth and silent degraded behavior

## Proof
- `uv run pytest -q tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_conversations_router.py tests/Integration/test_contacts_schema_contract.py tests/Integration/test_users_router.py tests/Integration/test_panel_auth_shell_coherence.py -k "thread_activity_reader or contact_repo or owned_agent_threads_need_thread_repo or delete_agent_route_fails_loud_when_thread_repo_missing or delete_agent_route_fails_loud_when_contact_repo_missing or list_chat_candidates or contacts"` -> `20 passed, 39 deselected`
- `uv run pytest -q tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_runtime_access.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/core/test_agent_pool.py tests/Integration/test_messaging_router.py tests/Integration/test_relationship_router.py tests/Integration/test_auth_router.py tests/Integration/test_chat_app_router.py tests/Integration/test_users_avatar_auth_shell.py tests/Integration/test_messaging_social_handle_contract.py -k "chat or conversation or relationship or attach_chat_runtime_requires or avatar_url_uses_local_file_truth or get_agent_user or send_otp or login or latest_live_child_thread_over_active_main or recipient_thread_resolution_requires_current_thread_repo_contract or agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lookup_and_passes_through_envelope_content or missing_messaging_service or repo_backed_runtime_startup or repo_backed_default_model_contract or passes_repo_backed_models_config_to_runtime or passes_repo_backed_compact_config_to_runtime or binding_local_staging_root or keys_registry_by_agent_user_id or does_not_use_local_preferences_when_repo_missing"` -> `140 passed, 35 deselected`
- targeted `ruff check` / `ruff format --check` / `git diff --check` green

## Commit Density
- this PR keeps 5 commits to satisfy the repo rule of at least 5 commits per PR