### PR TITLE
refactor: decouple monitor evaluation execution target

### DIFF
--- a/backend/monitor/api/http/execution_target.py
+++ b/backend/monitor/api/http/execution_target.py
@@ -1,0 +1,26 @@
+"""Execution target resolution for monitor-triggered evaluation runs."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Request
+
+from backend.bootstrap.app_entrypoint import resolve_app_port
+
+
+def resolve_monitor_evaluation_base_url(request: Request) -> str:
+    explicit = os.getenv("LEON_MONITOR_EVALUATION_BASE_URL")
+    if explicit:
+        return explicit.rstrip("/")
+
+    if getattr(request.app, "title", "") != "Mycel Monitor Backend":
+        return str(request.base_url).rstrip("/")
+
+    backend_port = resolve_app_port("LEON_BACKEND_PORT", "worktree.ports.backend", 8001)
+    hostname = getattr(request.url, "hostname", None) or "127.0.0.1"
+    scheme = getattr(request.url, "scheme", "http")
+    if hostname in {"127.0.0.1", "localhost", "testserver"}:
+        return f"{scheme}://127.0.0.1:{backend_port}"
+
+    raise RuntimeError("LEON_MONITOR_EVALUATION_BASE_URL is required for standalone monitor execution targeting")

--- a/backend/monitor/api/http/web_local_router.py
+++ b/backend/monitor/api/http/web_local_router.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
 from backend.monitor.api.http.dependencies import get_current_user_id
+from backend.monitor.api.http.execution_target import resolve_monitor_evaluation_base_url
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 router = APIRouter()
@@ -30,7 +31,7 @@ def evaluation_batch_start_action(
     try:
         return monitor_gateway.start_evaluation_batch(
             batch_id=batch_id,
-            base_url=str(request.base_url).rstrip("/"),
+            execution_base_url=resolve_monitor_evaluation_base_url(request),
             token=_extract_bearer_token(request),
             schedule_task=background_tasks.add_task,
         )

--- a/backend/monitor/application/use_cases/evaluation.py
+++ b/backend/monitor/application/use_cases/evaluation.py
@@ -142,7 +142,7 @@ def create_monitor_evaluation_batch(
 def start_monitor_evaluation_batch(
     batch_id: str,
     *,
-    base_url: str,
+    execution_base_url: str,
     token: str,
     scheduler: EvaluationJobScheduler,
 ) -> dict[str, Any]:
@@ -168,7 +168,7 @@ def start_monitor_evaluation_batch(
         EvaluationJobSpec(
             batch_id=batch_id,
             scenarios=scenarios,
-            base_url=base_url.rstrip("/"),
+            execution_base_url=execution_base_url.rstrip("/"),
             token=token,
             agent_user_id=str(agent_user_id),
         )

--- a/backend/monitor/infrastructure/evaluation/background_task_scheduler.py
+++ b/backend/monitor/infrastructure/evaluation/background_task_scheduler.py
@@ -16,7 +16,7 @@ class BackgroundTaskEvaluationScheduler(EvaluationJobScheduler):
             run_monitor_evaluation_batch,
             batch_id=spec.batch_id,
             scenarios=spec.scenarios,
-            base_url=spec.base_url,
+            execution_base_url=spec.execution_base_url,
             token=spec.token,
             agent_user_id=spec.agent_user_id,
             batch_service=make_eval_batch_service(),

--- a/backend/monitor/infrastructure/evaluation/evaluation_execution_service.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_execution_service.py
@@ -31,12 +31,12 @@ async def run_monitor_evaluation_batch(
     *,
     batch_id: str,
     scenarios: list[EvalScenario],
-    base_url: str,
+    execution_base_url: str,
     token: str,
     agent_user_id: str,
     batch_service: EvaluationBatchService,
 ) -> None:
-    client = EvalClient(base_url=base_url, token=token)
+    client = EvalClient(base_url=execution_base_url, token=token)
     try:
         runner = EvalRunner(
             client=client,

--- a/backend/monitor/infrastructure/evaluation/evaluation_scheduler.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_scheduler.py
@@ -12,7 +12,7 @@ from eval.models import EvalScenario
 class EvaluationJobSpec:
     batch_id: str
     scenarios: list[EvalScenario]
-    base_url: str
+    execution_base_url: str
     token: str
     agent_user_id: str
 

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -391,7 +391,7 @@ def test_create_monitor_evaluation_batch_uses_batch_service(monkeypatch):
     ]
 
 
-def test_start_monitor_evaluation_batch_schedules_runner(tmp_path, monkeypatch):
+def test_start_monitor_evaluation_batch_schedules_runner_with_explicit_execution_target(tmp_path, monkeypatch):
     scenario_dir = tmp_path / "scenarios"
     scenario_dir.mkdir()
     (scenario_dir / "scenario-1.yaml").write_text(
@@ -433,14 +433,14 @@ def test_start_monitor_evaluation_batch_schedules_runner(tmp_path, monkeypatch):
 
     payload = monitor_evaluation_service.start_monitor_evaluation_batch(
         "batch-1",
-        base_url="http://testserver",
+        execution_base_url="http://backend-main",
         token="token-1",
         scheduler=_Scheduler(),
     )
 
     assert payload == {"accepted": True, "batch": {"batch_id": "batch-1", "status": "running"}}
     assert len(scheduled) == 1
-    assert scheduled[0].base_url == "http://testserver"
+    assert scheduled[0].execution_base_url == "http://backend-main"
     assert scheduled[0].token == "token-1"
     assert scheduled[0].agent_user_id == "agent-1"
     assert scheduled[0].scenarios[0].id == "scenario-1"

--- a/tests/Unit/monitor/test_monitor_execution_target.py
+++ b/tests/Unit/monitor/test_monitor_execution_target.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import pytest
+
+from backend.monitor.api.http.execution_target import resolve_monitor_evaluation_base_url
+
+
+def _request(*, title: str, hostname: str = "testserver", scheme: str = "http"):
+    return SimpleNamespace(
+        app=SimpleNamespace(title=title),
+        url=SimpleNamespace(hostname=hostname, scheme=scheme),
+        base_url=f"{scheme}://{hostname}",
+    )
+
+
+def test_monitor_evaluation_target_uses_request_base_url_on_web_app(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEON_MONITOR_EVALUATION_BASE_URL", raising=False)
+    request = _request(title="Mycel Web Backend")
+
+    assert resolve_monitor_evaluation_base_url(request) == "http://testserver"
+
+
+def test_monitor_evaluation_target_uses_backend_port_for_monitor_app(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEON_MONITOR_EVALUATION_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        "backend.monitor.api.http.execution_target.resolve_app_port",
+        lambda *_args, **_kwargs: 8010,
+    )
+    request = _request(title="Mycel Monitor Backend")
+
+    assert resolve_monitor_evaluation_base_url(request) == "http://127.0.0.1:8010"
+
+
+def test_monitor_evaluation_target_requires_explicit_env_for_nonlocal_monitor_host(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEON_MONITOR_EVALUATION_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        "backend.monitor.api.http.execution_target.resolve_app_port",
+        lambda *_args, **_kwargs: 8010,
+    )
+    request = _request(title="Mycel Monitor Backend", hostname="monitor.example.com", scheme="https")
+
+    with pytest.raises(RuntimeError, match="LEON_MONITOR_EVALUATION_BASE_URL"):
+        resolve_monitor_evaluation_base_url(request)


### PR DESCRIPTION
## Summary
- treat this as the first execution-target decoupling slice for blocked monitor batch-start globalization
- stop monitor evaluation scheduling from carrying a generic request-derived `base_url` and rename it to explicit `execution_base_url`
- add a monitor execution-target resolver helper so the web-local batch-start route no longer directly hardcodes `request.base_url` semantics
- keep batch-start on `web_local_router` for now; this PR does not globalize that route

## Commit Shape
- this PR intentionally keeps a 5-commit sequence to satisfy the current per-PR density rule

## Non-scope
- no move of `POST /evaluation/batches/{batch_id}/start` into the standalone monitor shell yet
- no move of `/threads`
- no monitor business-logic rewrite
- no chat/runtime changes

## Verification
- uv run pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py -k explicit_execution_target
- uv run pytest -q tests/Unit/monitor/test_monitor_execution_target.py
- uv run pytest -q tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
- uv run ruff check backend/monitor/api/http/execution_target.py backend/monitor/api/http/web_local_router.py backend/monitor/infrastructure/web/gateway.py backend/monitor/application/use_cases/evaluation.py backend/monitor/infrastructure/evaluation/evaluation_scheduler.py backend/monitor/infrastructure/evaluation/background_task_scheduler.py backend/monitor/infrastructure/evaluation/evaluation_execution_service.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_execution_target.py tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
- git diff --check