### PR TITLE
Fix and globalize monitor batch start route

### DIFF
--- a/backend/monitor/api/http/global_router.py
+++ b/backend/monitor/api/http/global_router.py
@@ -147,6 +147,8 @@ def evaluation_batch_start_action(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @router.get("/evaluation/scenarios")

--- a/backend/monitor/api/http/global_router.py
+++ b/backend/monitor/api/http/global_router.py
@@ -3,10 +3,11 @@
 import asyncio
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from backend.monitor.api.http.dependencies import get_current_user_id
+from backend.monitor.api.http.execution_target import resolve_monitor_evaluation_base_url
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 router = APIRouter()
@@ -33,6 +34,16 @@ def _or_404_or_503(fn, *args):
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def _extract_bearer_token(request: Request) -> str:
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    token = auth_header.removeprefix("Bearer ").strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    return token
 
 
 async def _resource_io(fn, *args):
@@ -116,6 +127,26 @@ def evaluation_batch_create_action(
         sandbox=payload.sandbox,
         max_concurrent=payload.max_concurrent,
     )
+
+
+@router.post("/evaluation/batches/{batch_id}/start")
+def evaluation_batch_start_action(
+    batch_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    _user_id: Annotated[str, Depends(get_current_user_id)],
+):
+    try:
+        return monitor_gateway.start_evaluation_batch(
+            batch_id=batch_id,
+            execution_base_url=resolve_monitor_evaluation_base_url(request),
+            token=_extract_bearer_token(request),
+            schedule_task=background_tasks.add_task,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/evaluation/scenarios")

--- a/backend/monitor/api/http/web_local_router.py
+++ b/backend/monitor/api/http/web_local_router.py
@@ -1,41 +1,5 @@
-"""Web-runtime-bound monitor routes that stay on the main web process."""
+"""Web-runtime-bound monitor routes that still stay on the main web process."""
 
-from typing import Annotated
-
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-
-from backend.monitor.api.http.dependencies import get_current_user_id
-from backend.monitor.api.http.execution_target import resolve_monitor_evaluation_base_url
-from backend.monitor.infrastructure.web import gateway as monitor_gateway
+from fastapi import APIRouter
 
 router = APIRouter()
-
-
-def _extract_bearer_token(request: Request) -> str:
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
-    token = auth_header.removeprefix("Bearer ").strip()
-    if not token:
-        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
-    return token
-
-
-@router.post("/evaluation/batches/{batch_id}/start")
-def evaluation_batch_start_action(
-    batch_id: str,
-    request: Request,
-    background_tasks: BackgroundTasks,
-    _user_id: Annotated[str, Depends(get_current_user_id)],
-):
-    try:
-        return monitor_gateway.start_evaluation_batch(
-            batch_id=batch_id,
-            execution_base_url=resolve_monitor_evaluation_base_url(request),
-            token=_extract_bearer_token(request),
-            schedule_task=background_tasks.add_task,
-        )
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/monitor/infrastructure/web/gateway.py
+++ b/backend/monitor/infrastructure/web/gateway.py
@@ -118,13 +118,13 @@ def get_evaluation_scenarios() -> dict[str, Any]:
 def start_evaluation_batch(
     *,
     batch_id: str,
-    base_url: str,
+    execution_base_url: str,
     token: str,
     schedule_task,
 ) -> dict[str, Any]:
     return monitor_evaluation.start_monitor_evaluation_batch(
         batch_id=batch_id,
-        base_url=base_url,
+        execution_base_url=execution_base_url,
         token=token,
         scheduler=BackgroundTaskEvaluationScheduler(schedule_task),
     )

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -295,7 +295,17 @@ def test_monitor_evaluation_batch_create_and_start_pass_request_context(monkeypa
     monkeypatch.setattr(
         monitor_gateway_impl,
         "start_evaluation_batch",
-        lambda **kwargs: start_calls.append(kwargs) or {"accepted": True},
+        lambda *, batch_id, execution_base_url, token, schedule_task: (
+            start_calls.append(
+                {
+                    "batch_id": batch_id,
+                    "execution_base_url": execution_base_url,
+                    "token": token,
+                    "schedule_task": schedule_task,
+                }
+            )
+            or {"accepted": True}
+        ),
     )
     app = _app()
     app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
@@ -319,7 +329,7 @@ def test_monitor_evaluation_batch_create_and_start_pass_request_context(monkeypa
         }
     ]
     assert start_calls[0]["batch_id"] == "batch-1"
-    assert start_calls[0]["base_url"] == "http://testserver"
+    assert start_calls[0]["execution_base_url"] == "http://testserver"
     assert start_calls[0]["token"] == "token-1"
 
 

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from backend.bootstrap import app_entrypoint
 from backend.monitor.app import lifespan as monitor_app_lifespan
 from backend.monitor.app import main as monitor_app_main
+from backend.monitor.api.http import execution_target as monitor_execution_target
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 app = monitor_app_main.app
@@ -33,7 +34,7 @@ def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.Monke
     assert "/api/monitor/sandboxes" in paths
     assert "/api/monitor/threads" not in paths
     assert "/api/monitor/threads/{thread_id}" not in paths
-    assert "/api/monitor/evaluation/batches/{batch_id}/start" not in paths
+    assert "/api/monitor/evaluation/batches/{batch_id}/start" in paths
     assert set(paths["/api/monitor/evaluation/batches"]) == {"get", "post"}
 
 
@@ -101,6 +102,48 @@ def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatc
 
     assert response.status_code == 401
     assert "User no longer exists" in response.text
+
+
+def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPatch):
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
+    monitor_storage = SimpleNamespace(
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+    )
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
+    monkeypatch.setattr(
+        monitor_app_lifespan,
+        "attach_auth_runtime_state",
+        lambda app, *, storage_state: (
+            setattr(
+                app.state,
+                "auth_service",
+                SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+            )
+            or object()
+        ),
+    )
+    monkeypatch.setattr(
+        monitor_gateway,
+        "start_evaluation_batch",
+        lambda **kwargs: {"batch": kwargs},
+    )
+    monkeypatch.setattr(
+        monitor_execution_target,
+        "resolve_app_port",
+        lambda *_args, **_kwargs: 55417,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/monitor/evaluation/batches/batch-1/start",
+            headers={"Authorization": "Bearer token-1"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()["batch"]
+    assert payload["batch_id"] == "batch-1"
+    assert payload["execution_base_url"] == "http://127.0.0.1:55417"
+    assert payload["token"] == "token-1"
 
 
 def test_monitor_app_resolve_port_prefers_monitor_backend_env(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -6,9 +6,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
 
 from backend.bootstrap import app_entrypoint
+from backend.monitor.api.http import execution_target as monitor_execution_target
 from backend.monitor.app import lifespan as monitor_app_lifespan
 from backend.monitor.app import main as monitor_app_main
-from backend.monitor.api.http import execution_target as monitor_execution_target
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 
 app = monitor_app_main.app

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -146,6 +146,36 @@ def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPa
     assert payload["token"] == "token-1"
 
 
+def test_monitor_app_maps_missing_remote_execution_target_to_503(monkeypatch: pytest.MonkeyPatch):
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
+    monitor_storage = SimpleNamespace(
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+    )
+    monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
+    monkeypatch.setattr(
+        monitor_app_lifespan,
+        "attach_auth_runtime_state",
+        lambda app, *, storage_state: (
+            setattr(
+                app.state,
+                "auth_service",
+                SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+            )
+            or object()
+        ),
+    )
+    monkeypatch.delenv("LEON_MONITOR_EVALUATION_BASE_URL", raising=False)
+
+    with TestClient(app, base_url="https://monitor.example.com", raise_server_exceptions=False) as client:
+        response = client.post(
+            "/api/monitor/evaluation/batches/batch-1/start",
+            headers={"Authorization": "Bearer token-1"},
+        )
+
+    assert response.status_code == 503
+    assert "LEON_MONITOR_EVALUATION_BASE_URL is required" in response.text
+
+
 def test_monitor_app_resolve_port_prefers_monitor_backend_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("LEON_MONITOR_BACKEND_PORT", "55417")
     monkeypatch.setenv("PORT", "9000")

--- a/tests/Unit/monitor/test_monitor_gateway_execution_target.py
+++ b/tests/Unit/monitor/test_monitor_gateway_execution_target.py
@@ -1,0 +1,32 @@
+from backend.monitor.infrastructure.web import gateway as monitor_gateway
+
+
+def test_monitor_gateway_starts_batches_with_explicit_execution_target(monkeypatch):
+    captured = {}
+
+    def _start_monitor_evaluation_batch(*, batch_id, execution_base_url, token, scheduler):
+        captured.update(
+            batch_id=batch_id,
+            execution_base_url=execution_base_url,
+            token=token,
+            scheduler=scheduler,
+        )
+        return {"accepted": True}
+
+    monkeypatch.setattr(
+        monitor_gateway.monitor_evaluation,
+        "start_monitor_evaluation_batch",
+        _start_monitor_evaluation_batch,
+    )
+
+    payload = monitor_gateway.start_evaluation_batch(
+        batch_id="batch-1",
+        execution_base_url="http://backend-main",
+        token="token-1",
+        schedule_task=lambda *args, **kwargs: None,
+    )
+
+    assert payload == {"accepted": True}
+    assert captured["batch_id"] == "batch-1"
+    assert captured["execution_base_url"] == "http://backend-main"
+    assert captured["token"] == "token-1"


### PR DESCRIPTION
## Summary
- fix the merged execution-target regression in monitor gateway
- move  to the global monitor router
- update monitor app and monitor route tests to match the new owner

## Verification
- .........................................                                [100%]
41 passed in 1.00s
- All checks passed!
- 