### PR TITLE
Delete empty monitor web local router

### DIFF
--- a/backend/monitor/api/http/web_local_router.py
+++ b/backend/monitor/api/http/web_local_router.py
@@ -1,5 +1,0 @@
-"""Web-runtime-bound monitor routes that still stay on the main web process."""
-
-from fastapi import APIRouter
-
-router = APIRouter()

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -7,7 +7,7 @@ load_env_file_from_env()
 from fastapi import FastAPI  # noqa: E402
 
 from backend.chat.api.http import app_router as chat_app_router  # noqa: E402
-from backend.monitor.api.http import global_router, web_local_router  # noqa: E402
+from backend.monitor.api.http import global_router  # noqa: E402
 from backend.web.core.lifespan import lifespan  # noqa: E402
 from backend.web.routers import (  # noqa: E402
     auth,
@@ -47,9 +47,6 @@ app.include_router(settings.router)
 app.include_router(panel.router)
 app.include_router(global_router.router, prefix="/api/monitor")
 app.include_router(monitor_threads.router, prefix="/api/monitor")
-# @@@monitor-web-local-drain - web_local routes still depend on the main web process.
-# Drain this mount only after those routes are either retired or moved behind the separate monitor process boundary.
-app.include_router(web_local_router.router, prefix="/api/monitor")
 app.include_router(resources.router)
 app.include_router(marketplace.router)
 

--- a/tests/Integration/test_monitor_resources_route.py
+++ b/tests/Integration/test_monitor_resources_route.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.monitor.api.http import global_router, web_local_router
+from backend.monitor.api.http import global_router
 from backend.monitor.application.use_cases import resources as monitor_resources_impl
 from backend.monitor.infrastructure.io import resource_io_service as monitor_resource_io_service
 from backend.monitor.infrastructure.web import gateway as monitor_gateway_impl
@@ -15,7 +15,6 @@ def _app(*, include_product_resources: bool = False) -> FastAPI:
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
     app.include_router(monitor_threads_router.router, prefix="/api/monitor")
-    app.include_router(web_local_router.router, prefix="/api/monitor")
     if include_product_resources:
         app.include_router(resources.router)
         app.dependency_overrides[get_current_user_id] = lambda: "owner-1"

--- a/tests/Integration/test_resource_overview_contract_split.py
+++ b/tests/Integration/test_resource_overview_contract_split.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 import backend.sandboxes.resources.projection as resource_projection_service
 import backend.sandboxes.resources.provider_boundary as resource_provider_boundary_service
-from backend.monitor.api.http import global_router, web_local_router
+from backend.monitor.api.http import global_router
 from backend.monitor.infrastructure.read_models import resource_read_service as monitor_resource_read_service
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 from backend.sandboxes.resources import common as resource_common
@@ -130,7 +130,6 @@ def test_monitor_resources_route_stays_global(monkeypatch) -> None:
 
     test_app = FastAPI()
     test_app.include_router(global_router.router, prefix="/api/monitor")
-    test_app.include_router(web_local_router.router, prefix="/api/monitor")
     test_app.dependency_overrides[get_current_user_id] = lambda: "user-1"
     try:
         with TestClient(test_app) as client:

--- a/tests/Unit/monitor/test_monitor_web_local_owner.py
+++ b/tests/Unit/monitor/test_monitor_web_local_owner.py
@@ -1,0 +1,8 @@
+import importlib
+import inspect
+
+
+def test_web_backend_does_not_mount_empty_monitor_web_local_router() -> None:
+    web_main_source = inspect.getsource(importlib.import_module("backend.web.main"))
+
+    assert "web_local_router" not in web_main_source


### PR DESCRIPTION
## Summary
- delete the empty `backend.monitor.api.http.web_local_router`
- remove the stale web mount from `backend.web.main`
- retarget monitor integration helper apps to the current monitor owners only

## Verification
- `uv run pytest tests/Unit/monitor/test_monitor_web_local_owner.py tests/Integration/test_monitor_resources_route.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_app_entrypoint.py -q`
- `uv run ruff check backend/web/main.py tests/Unit/monitor/test_monitor_web_local_owner.py tests/Integration/test_monitor_resources_route.py tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_app_entrypoint.py`
- `git diff --check origin/dev..HEAD`
