### PR TITLE
refactor(threads): inject adapter runtime dependencies

### DIFF
--- a/backend/threads/chat_adapters/activity_reader.py
+++ b/backend/threads/chat_adapters/activity_reader.py
@@ -25,17 +25,18 @@ def _normalize_state(state: AgentState) -> Literal["initializing", "ready", "act
 class AppRuntimeThreadActivityReader:
     """Read live runtime thread activity from app-backed state."""
 
-    def __init__(self, app: Any) -> None:
-        self._app = app
+    def __init__(self, *, thread_repo: Any, agent_pool: dict[str, Any]) -> None:
+        self._thread_repo = thread_repo
+        self._agent_pool = agent_pool
 
     def list_active_threads_for_agent(self, agent_user_id: str) -> list[AgentThreadActivity]:
-        rows = self._app.state.thread_repo.list_by_agent_user(agent_user_id)
+        rows = self._thread_repo.list_by_agent_user(agent_user_id)
         activities: list[AgentThreadActivity] = []
         for row in rows:
             thread_id = str(row.get("id") or "").strip()
             if not thread_id:
                 continue
-            for pool_key, agent in self._app.state.agent_pool.items():
+            for pool_key, agent in self._agent_pool.items():
                 if not str(pool_key).startswith(f"{thread_id}:"):
                     continue
                 activities.append(

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.monitor.infrastructure.resources.resource_overview_cache import clear_resource_overview_cache
 from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
 from backend.threads.chat_adapters.activity_reader import AppRuntimeThreadActivityReader
 from backend.threads.chat_adapters.chat_handler import NativeAgentChatDeliveryHandler
 from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
 from backend.threads.chat_adapters.gateway import NativeAgentRuntimeGateway
 from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
-from backend.threads.streaming import _ensure_thread_handlers
+from backend.threads.streaming import _ensure_thread_handlers, start_agent_run
 
 
 def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
@@ -37,5 +38,9 @@ def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
             thread_tasks=app.state.thread_tasks,
             thread_locks=app.state.thread_locks,
             thread_locks_guard=app.state.thread_locks_guard,
+            get_or_create_agent=get_or_create_agent,
+            resolve_thread_sandbox=resolve_thread_sandbox,
+            start_agent_run=start_agent_run,
+            clear_resource_overview_cache=clear_resource_overview_cache,
         ),
     )

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -19,7 +19,11 @@ def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
     return NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(
-                runtime_services=AppAgentChatRuntimeServices(app),
+                runtime_services=AppAgentChatRuntimeServices(
+                    app,
+                    typing_tracker=app.state.typing_tracker,
+                    queue_manager=app.state.queue_manager,
+                ),
             )
         },
         thread_input_handler=NativeAgentThreadInputHandler(app),

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -12,7 +12,10 @@ from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputH
 
 
 def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
-    app.state.agent_runtime_thread_activity_reader = AppRuntimeThreadActivityReader(app)
+    app.state.agent_runtime_thread_activity_reader = AppRuntimeThreadActivityReader(
+        thread_repo=app.state.thread_repo,
+        agent_pool=app.state.agent_pool,
+    )
     return NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -26,5 +26,11 @@ def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
                 ),
             )
         },
-        thread_input_handler=NativeAgentThreadInputHandler(app),
+        thread_input_handler=NativeAgentThreadInputHandler(
+            app,
+            queue_manager=app.state.queue_manager,
+            thread_tasks=app.state.thread_tasks,
+            thread_locks=app.state.thread_locks,
+            thread_locks_guard=app.state.thread_locks_guard,
+        ),
     )

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
 from backend.threads.chat_adapters.activity_reader import AppRuntimeThreadActivityReader
 from backend.threads.chat_adapters.chat_handler import NativeAgentChatDeliveryHandler
 from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
 from backend.threads.chat_adapters.gateway import NativeAgentRuntimeGateway
 from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
+from backend.threads.streaming import _ensure_thread_handlers
 
 
 def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
@@ -23,6 +25,9 @@ def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
                     app,
                     typing_tracker=app.state.typing_tracker,
                     queue_manager=app.state.queue_manager,
+                    get_or_create_agent=get_or_create_agent,
+                    resolve_thread_sandbox=resolve_thread_sandbox,
+                    ensure_thread_handlers=_ensure_thread_handlers,
                 ),
             )
         },

--- a/backend/threads/chat_adapters/chat_runtime_services.py
+++ b/backend/threads/chat_adapters/chat_runtime_services.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
-from backend.chat.runtime_access import get_typing_tracker
-
 
 class AgentChatRuntimeServices(Protocol):
     async def get_or_create_thread_agent(self, thread_id: str) -> Any: ...
@@ -26,8 +24,10 @@ class AgentChatRuntimeServices(Protocol):
 class AppAgentChatRuntimeServices:
     """Runtime-owned adapter around app-backed chat delivery dependencies."""
 
-    def __init__(self, app: Any) -> None:
+    def __init__(self, app: Any, *, typing_tracker: Any, queue_manager: Any) -> None:
         self._app = app
+        self._typing_tracker = typing_tracker
+        self._queue_manager = queue_manager
 
     async def get_or_create_thread_agent(self, thread_id: str) -> Any:
         from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
@@ -39,8 +39,7 @@ class AppAgentChatRuntimeServices:
         return agent
 
     def start_chat(self, thread_id: str, chat_id: str, recipient_user_id: str) -> None:
-        typing_tracker = get_typing_tracker(self._app)
-        typing_tracker.start_chat(thread_id, chat_id, recipient_user_id)
+        self._typing_tracker.start_chat(thread_id, chat_id, recipient_user_id)
 
     def enqueue_chat_message(
         self,
@@ -51,7 +50,7 @@ class AppAgentChatRuntimeServices:
         sender_name: str,
         sender_avatar_url: str | None,
     ) -> None:
-        self._app.state.queue_manager.enqueue(
+        self._queue_manager.enqueue(
             content,
             thread_id,
             "chat",

--- a/backend/threads/chat_adapters/chat_runtime_services.py
+++ b/backend/threads/chat_adapters/chat_runtime_services.py
@@ -24,18 +24,27 @@ class AgentChatRuntimeServices(Protocol):
 class AppAgentChatRuntimeServices:
     """Runtime-owned adapter around app-backed chat delivery dependencies."""
 
-    def __init__(self, app: Any, *, typing_tracker: Any, queue_manager: Any) -> None:
+    def __init__(
+        self,
+        app: Any,
+        *,
+        typing_tracker: Any,
+        queue_manager: Any,
+        get_or_create_agent: Any,
+        resolve_thread_sandbox: Any,
+        ensure_thread_handlers: Any,
+    ) -> None:
         self._app = app
         self._typing_tracker = typing_tracker
         self._queue_manager = queue_manager
+        self._get_or_create_agent = get_or_create_agent
+        self._resolve_thread_sandbox = resolve_thread_sandbox
+        self._ensure_thread_handlers = ensure_thread_handlers
 
     async def get_or_create_thread_agent(self, thread_id: str) -> Any:
-        from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
-        from backend.threads.streaming import _ensure_thread_handlers
-
-        sandbox_type = resolve_thread_sandbox(self._app, thread_id)
-        agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
-        _ensure_thread_handlers(agent, thread_id, self._app)
+        sandbox_type = self._resolve_thread_sandbox(self._app, thread_id)
+        agent = await self._get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
+        self._ensure_thread_handlers(agent, thread_id, self._app)
         return agent
 
     def start_chat(self, thread_id: str, chat_id: str, recipient_user_id: str) -> None:

--- a/backend/threads/chat_adapters/thread_handler.py
+++ b/backend/threads/chat_adapters/thread_handler.py
@@ -15,8 +15,20 @@ logger = logging.getLogger(__name__)
 class NativeAgentThreadInputHandler:
     """Routes direct thread input into native Mycel Agent runs."""
 
-    def __init__(self, app: Any) -> None:
+    def __init__(
+        self,
+        app: Any,
+        *,
+        queue_manager: Any,
+        thread_tasks: dict[str, Any],
+        thread_locks: dict[str, asyncio.Lock],
+        thread_locks_guard: asyncio.Lock,
+    ) -> None:
         self._app = app
+        self._queue_manager = queue_manager
+        self._thread_tasks = thread_tasks
+        self._thread_locks = thread_locks
+        self._thread_locks_guard = thread_locks_guard
 
     async def dispatch(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> agent_runtime_protocol.AgentThreadInputResult:
         from backend.monitor.infrastructure.resources.resource_overview_cache import clear_resource_overview_cache
@@ -25,15 +37,15 @@ class NativeAgentThreadInputHandler:
 
         thread_id = envelope.thread_id
         startup_cancel = None
-        existing_task = self._app.state.thread_tasks.get(thread_id)
+        existing_task = self._thread_tasks.get(thread_id)
         if existing_task is None or existing_task.done():
             startup_cancel = asyncio.get_running_loop().create_future()
-            self._app.state.thread_tasks[thread_id] = startup_cancel
+            self._thread_tasks[thread_id] = startup_cancel
 
         try:
             sandbox_type = resolve_thread_sandbox(self._app, thread_id)
             agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
-            qm = self._app.state.queue_manager
+            qm = self._queue_manager
 
             if startup_cancel is not None and startup_cancel.cancelled():
                 return agent_runtime_protocol.AgentThreadInputResult(status="cancelled", routing="cancelled", thread_id=thread_id)
@@ -54,8 +66,8 @@ class NativeAgentThreadInputHandler:
                 logger.debug("[agent-runtime-gateway] thread input enqueued")
                 return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
 
-            locks = self._app.state.thread_locks
-            async with self._app.state.thread_locks_guard:
+            locks = self._thread_locks
+            async with self._thread_locks_guard:
                 lock = locks.setdefault(thread_id, asyncio.Lock())
             async with lock:
                 if not agent.runtime.transition(AgentState.ACTIVE):
@@ -93,5 +105,5 @@ class NativeAgentThreadInputHandler:
                 clear_resource_overview_cache()
             return agent_runtime_protocol.AgentThreadInputResult(status="started", routing="direct", run_id=run_id, thread_id=thread_id)
         finally:
-            if startup_cancel is not None and self._app.state.thread_tasks.get(thread_id) is startup_cancel:
-                self._app.state.thread_tasks.pop(thread_id, None)
+            if startup_cancel is not None and self._thread_tasks.get(thread_id) is startup_cancel:
+                self._thread_tasks.pop(thread_id, None)

--- a/backend/threads/chat_adapters/thread_handler.py
+++ b/backend/threads/chat_adapters/thread_handler.py
@@ -23,18 +23,22 @@ class NativeAgentThreadInputHandler:
         thread_tasks: dict[str, Any],
         thread_locks: dict[str, asyncio.Lock],
         thread_locks_guard: asyncio.Lock,
+        get_or_create_agent: Any,
+        resolve_thread_sandbox: Any,
+        start_agent_run: Any,
+        clear_resource_overview_cache: Any,
     ) -> None:
         self._app = app
         self._queue_manager = queue_manager
         self._thread_tasks = thread_tasks
         self._thread_locks = thread_locks
         self._thread_locks_guard = thread_locks_guard
+        self._get_or_create_agent = get_or_create_agent
+        self._resolve_thread_sandbox = resolve_thread_sandbox
+        self._start_agent_run = start_agent_run
+        self._clear_resource_overview_cache = clear_resource_overview_cache
 
     async def dispatch(self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> agent_runtime_protocol.AgentThreadInputResult:
-        from backend.monitor.infrastructure.resources.resource_overview_cache import clear_resource_overview_cache
-        from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
-        from backend.threads.streaming import start_agent_run
-
         thread_id = envelope.thread_id
         startup_cancel = None
         existing_task = self._thread_tasks.get(thread_id)
@@ -43,8 +47,8 @@ class NativeAgentThreadInputHandler:
             self._thread_tasks[thread_id] = startup_cancel
 
         try:
-            sandbox_type = resolve_thread_sandbox(self._app, thread_id)
-            agent = await get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
+            sandbox_type = self._resolve_thread_sandbox(self._app, thread_id)
+            agent = await self._get_or_create_agent(self._app, sandbox_type, thread_id=thread_id)
             qm = self._queue_manager
 
             if startup_cancel is not None and startup_cancel.cancelled():
@@ -92,7 +96,7 @@ class NativeAgentThreadInputHandler:
                     meta.update(envelope.message.metadata)
                 if envelope.message.attachments:
                     meta["attachments"] = envelope.message.attachments
-                run_id = start_agent_run(
+                run_id = self._start_agent_run(
                     agent,
                     thread_id,
                     envelope.message.content,
@@ -102,7 +106,7 @@ class NativeAgentThreadInputHandler:
                 )
                 # @@@monitor-resource-cache-run-start - a fresh run can create or resume a sandbox runtime immediately.
                 # Drop the cached monitor snapshot so the next /api/monitor/resources read reflects the live topology.
-                clear_resource_overview_cache()
+                self._clear_resource_overview_cache()
             return agent_runtime_protocol.AgentThreadInputResult(status="started", routing="direct", run_id=run_id, thread_id=thread_id)
         finally:
             if startup_cancel is not None and self._thread_tasks.get(thread_id) is startup_cancel:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -2577,9 +2577,17 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(
-                get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "agent-user-1" else None
+                get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "agent-user-1" else None,
+                get_by_id=lambda thread_id: {"id": thread_id, "agent_user_id": "agent-user-1"} if thread_id == "thread-1" else None,
             ),
             agent_pool={},
+            typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
+            queue_manager=SimpleNamespace(enqueue=lambda *_args, **_kwargs: None),
+            thread_cwd={},
+            thread_sandbox={},
+            thread_tasks={},
+            thread_locks={},
+            thread_locks_guard=asyncio.Lock(),
         )
     )
     app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)
@@ -2621,9 +2629,9 @@ async def _run_chat_delivery(
     async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
         return SimpleNamespace(id=f"agent-for-{thread_id}")
 
-    monkeypatch.setattr("backend.threads.activity_pool_service.get_or_create_agent", _fake_get_or_create_agent)
-    monkeypatch.setattr("backend.threads.activity_pool_service.resolve_thread_sandbox", lambda _app, _thread_id: "local")
-    monkeypatch.setattr("backend.threads.streaming._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         "backend.threads.chat_adapters.chat_inlet.format_chat_notification",
         lambda sender_name, chat_id, unread_count, signal=None: f"{sender_name}|{chat_id}|{unread_count}|{signal}",
@@ -2636,6 +2644,7 @@ async def _run_chat_delivery(
             thread_repo=SimpleNamespace(
                 get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
                 list_by_agent_user=lambda uid: list(thread_rows) if uid == "agent-user-1" else [],
+                get_by_id=lambda thread_id: next((row for row in thread_rows if row["id"] == thread_id), None),
             ),
             agent_pool=pool or {},
             typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
@@ -2644,6 +2653,11 @@ async def _run_chat_delivery(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
                 )
             ),
+            thread_cwd={},
+            thread_sandbox={},
+            thread_tasks={},
+            thread_locks={},
+            thread_locks_guard=asyncio.Lock(),
         )
     )
     app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -501,20 +501,30 @@ def _make_streaming_app(
     queue_manager = queue_manager or MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     state = SimpleNamespace(
         display_builder=DisplayBuilder(),
+        thread_repo=SimpleNamespace(
+            get_by_id=lambda target_thread_id: {"id": target_thread_id, "sandbox_type": "local"},
+            get_by_user_id=lambda _user_id: None,
+            list_by_agent_user=lambda _user_id: [],
+        ),
+        agent_pool={},
+        thread_sandbox={},
+        thread_cwd={},
         thread_tasks={},
+        thread_locks={},
+        thread_locks_guard=asyncio.Lock(),
         thread_event_buffers={},
         subagent_buffers={},
         queue_manager=queue_manager,
         thread_last_active={},
-        typing_tracker=None,
+        typing_tracker=SimpleNamespace(
+            start_chat=lambda *_args, **_kwargs: None,
+            stop=lambda *_args, **_kwargs: None,
+        ),
     )
     if thread_id is not None and agent is not None:
         state.agent_pool = {f"{thread_id}:local": agent}
         state.thread_sandbox = {thread_id: "local"}
         state._event_loop = asyncio.get_running_loop()
-    if include_route_locks:
-        state.thread_locks = {}
-        state.thread_locks_guard = asyncio.Lock()
     app = SimpleNamespace(state=state)
     state.agent_runtime_gateway = build_agent_runtime_gateway(app)
     return app, queue_manager
@@ -1126,7 +1136,10 @@ async def test_cancelled_midrun_steer_persists_and_does_not_poison_next_turn(mon
             subagent_buffers={},
             queue_manager=queue_manager,
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_id = "steer-cancel-poison-thread"
@@ -1208,10 +1221,19 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
     )
     app = SimpleNamespace(
         state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                get_by_id=lambda target_thread_id: {"id": target_thread_id, "sandbox_type": "local"},
+                get_by_user_id=lambda _user_id: None,
+                list_by_agent_user=lambda _user_id: [],
+            ),
+            agent_pool={},
+            thread_sandbox={},
+            thread_cwd={},
             thread_tasks={},
             thread_locks={},
             thread_locks_guard=asyncio.Lock(),
             queue_manager=queue_manager,
+            typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
         )
     )
 
@@ -1220,8 +1242,8 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
         await release_agent_lookup.wait()
         return agent
 
-    monkeypatch.setattr("backend.threads.activity_pool_service.resolve_thread_sandbox", lambda *_args, **_kwargs: "local")
-    monkeypatch.setattr("backend.threads.activity_pool_service.get_or_create_agent", fake_get_or_create_agent)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda *_args, **_kwargs: "local")
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", fake_get_or_create_agent)
 
     startup_task = asyncio.create_task(
         build_agent_runtime_gateway(app).dispatch_thread_input(
@@ -1774,7 +1796,10 @@ async def test_run_agent_to_buffer_emits_notice_for_system_agent_notifications(m
             subagent_buffers={},
             queue_manager=MessageQueueManager(db_path=str(tmp_path / "queue.db")),
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_buf = ThreadEventBuffer()
@@ -1840,7 +1865,10 @@ async def test_run_agent_to_buffer_persists_terminal_notifications_before_assist
             subagent_buffers={},
             queue_manager=queue_manager,
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_buf = ThreadEventBuffer()
@@ -1898,7 +1926,10 @@ async def test_run_agent_to_buffer_resumes_graph_for_terminal_background_notific
             subagent_buffers={},
             queue_manager=MessageQueueManager(db_path=str(tmp_path / "queue.db")),
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_buf = ThreadEventBuffer()
@@ -2126,8 +2157,8 @@ async def test_send_message_route_then_agent_terminal_notification_reenters_foll
     )
 
     with (
-        patch("backend.threads.activity_pool_service.get_or_create_agent", AsyncMock(return_value=agent)),
-        patch("backend.threads.activity_pool_service.resolve_thread_sandbox", return_value="local"),
+        patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=agent)),
+        patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
     ):
         result = await threads_router.send_message(
             thread_id,
@@ -2260,7 +2291,10 @@ async def test_run_agent_to_buffer_logs_real_stream_error_without_none_traceback
             subagent_buffers={},
             queue_manager=MessageQueueManager(db_path=str(tmp_path / "queue.db")),
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_buf = ThreadEventBuffer()
@@ -2301,7 +2335,10 @@ async def test_run_agent_to_buffer_drains_activity_notice_before_stream_error(mo
             subagent_buffers={},
             queue_manager=MessageQueueManager(db_path=str(tmp_path / "queue.db")),
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_buf = ThreadEventBuffer()
@@ -2374,7 +2411,10 @@ async def test_run_agent_to_buffer_batches_additional_terminal_notifications(mon
             subagent_buffers={},
             queue_manager=queue_manager,
             thread_last_active={},
-            typing_tracker=None,
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: None,
+                stop=lambda *_args, **_kwargs: None,
+            ),
         )
     )
     thread_buf = ThreadEventBuffer()

--- a/tests/Unit/backend/test_chat_runtime_services.py
+++ b/tests/Unit/backend/test_chat_runtime_services.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
@@ -29,6 +30,9 @@ def test_chat_runtime_services_use_injected_typing_tracker_and_queue_manager():
         app,
         typing_tracker=injected_typing_tracker,
         queue_manager=injected_queue_manager,
+        get_or_create_agent=lambda *_args, **_kwargs: None,
+        resolve_thread_sandbox=lambda *_args, **_kwargs: "local",
+        ensure_thread_handlers=lambda *_args, **_kwargs: None,
     )
 
     services.start_chat("thread-1", "chat-1", "agent-user-1")
@@ -42,3 +46,38 @@ def test_chat_runtime_services_use_injected_typing_tracker_and_queue_manager():
 
     assert started == [("thread-1", "chat-1", "agent-user-1")]
     assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
+
+
+def test_chat_runtime_services_use_injected_runtime_callables():
+    calls: list[tuple[str, object]] = []
+    agent = object()
+
+    async def _get_or_create_agent(app, sandbox_type: str, *, thread_id: str):
+        calls.append(("get_or_create_agent", (app, sandbox_type, thread_id)))
+        return agent
+
+    def _resolve_thread_sandbox(app, thread_id: str):
+        calls.append(("resolve_thread_sandbox", (app, thread_id)))
+        return "local"
+
+    def _ensure_thread_handlers(target_agent, thread_id: str, app):
+        calls.append(("ensure_thread_handlers", (target_agent, thread_id, app)))
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    services = AppAgentChatRuntimeServices(
+        app,
+        typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
+        queue_manager=SimpleNamespace(enqueue=lambda *_args, **_kwargs: None),
+        get_or_create_agent=_get_or_create_agent,
+        resolve_thread_sandbox=_resolve_thread_sandbox,
+        ensure_thread_handlers=_ensure_thread_handlers,
+    )
+
+    result = asyncio.run(services.get_or_create_thread_agent("thread-1"))
+
+    assert result is agent
+    assert calls == [
+        ("resolve_thread_sandbox", (app, "thread-1")),
+        ("get_or_create_agent", (app, "local", "thread-1")),
+        ("ensure_thread_handlers", (agent, "thread-1", app)),
+    ]

--- a/tests/Unit/backend/test_chat_runtime_services.py
+++ b/tests/Unit/backend/test_chat_runtime_services.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
+
+
+def test_chat_runtime_services_use_injected_typing_tracker_and_queue_manager():
+    started: list[tuple[str, str, str]] = []
+    enqueued: list[tuple[str, str, str | None, str | None]] = []
+
+    injected_typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
+    injected_queue_manager = SimpleNamespace(
+        enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
+            (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
+        )
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            typing_tracker=SimpleNamespace(
+                start_chat=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should use injected tracker"))
+            ),
+            queue_manager=SimpleNamespace(
+                enqueue=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should use injected queue manager"))
+            ),
+        )
+    )
+
+    services = AppAgentChatRuntimeServices(
+        app,
+        typing_tracker=injected_typing_tracker,
+        queue_manager=injected_queue_manager,
+    )
+
+    services.start_chat("thread-1", "chat-1", "agent-user-1")
+    services.enqueue_chat_message(
+        content="hello",
+        thread_id="thread-1",
+        sender_id="human-user-1",
+        sender_name="Human",
+        sender_avatar_url=None,
+    )
+
+    assert started == [("thread-1", "chat-1", "agent-user-1")]
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]

--- a/tests/Unit/backend/test_thread_activity_reader.py
+++ b/tests/Unit/backend/test_thread_activity_reader.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from backend.threads.chat_adapters.activity_reader import AppRuntimeThreadActivityReader
+from core.runtime.middleware.monitor import AgentState
+
+
+def test_thread_activity_reader_uses_explicit_thread_repo_and_agent_pool():
+    thread_repo = SimpleNamespace(
+        list_by_agent_user=lambda agent_user_id: (
+            [
+                {"id": "thread-1", "is_main": True, "branch_index": 0},
+                {"id": "thread-2", "is_main": False, "branch_index": 1},
+            ]
+            if agent_user_id == "agent-user-1"
+            else []
+        )
+    )
+    agent_pool = {
+        "thread-1:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.ACTIVE)),
+        "thread-2:local": SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.IDLE)),
+    }
+
+    reader = AppRuntimeThreadActivityReader(thread_repo=thread_repo, agent_pool=agent_pool)
+
+    activities = reader.list_active_threads_for_agent("agent-user-1")
+
+    assert [(row.thread_id, row.is_main, row.branch_index, row.state) for row in activities] == [
+        ("thread-1", True, 0, "active"),
+        ("thread-2", False, 1, "idle"),
+    ]

--- a/tests/Unit/backend/test_thread_input_handler.py
+++ b/tests/Unit/backend/test_thread_input_handler.py
@@ -1,7 +1,11 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
+from core.runtime.middleware.monitor import AgentState
+from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
 
 
 def test_thread_input_handler_uses_injected_runtime_state():
@@ -25,9 +29,79 @@ def test_thread_input_handler_uses_injected_runtime_state():
         thread_tasks=injected_thread_tasks,
         thread_locks=injected_thread_locks,
         thread_locks_guard=injected_thread_locks_guard,
+        get_or_create_agent=lambda *_args, **_kwargs: None,
+        resolve_thread_sandbox=lambda *_args, **_kwargs: "local",
+        start_agent_run=lambda *_args, **_kwargs: "run-123",
+        clear_resource_overview_cache=lambda: None,
     )
 
     assert handler._queue_manager is injected_queue_manager
     assert handler._thread_tasks is injected_thread_tasks
     assert handler._thread_locks is injected_thread_locks
     assert handler._thread_locks_guard is injected_thread_locks_guard
+
+
+@pytest.mark.asyncio
+async def test_thread_input_handler_uses_injected_runtime_callables():
+    calls: list[tuple[str, object]] = []
+    thread_tasks: dict[str, object] = {}
+    thread_locks: dict[str, asyncio.Lock] = {}
+    thread_locks_guard = asyncio.Lock()
+
+    class _QueueManager:
+        def enqueue(self, *_args, **_kwargs):
+            raise AssertionError("enqueue should not be used for idle -> active routing")
+
+    class _Runtime:
+        def __init__(self) -> None:
+            self.current_state = AgentState.IDLE
+
+        def transition(self, next_state: AgentState) -> bool:
+            self.current_state = next_state
+            return True
+
+    agent = SimpleNamespace(runtime=_Runtime())
+
+    async def _get_or_create_agent(app, sandbox_type: str, *, thread_id: str):
+        calls.append(("get_or_create_agent", (app, sandbox_type, thread_id)))
+        return agent
+
+    def _resolve_thread_sandbox(app, thread_id: str):
+        calls.append(("resolve_thread_sandbox", (app, thread_id)))
+        return "local"
+
+    def _start_agent_run(agent_obj, thread_id: str, content: str, app, **kwargs):
+        calls.append(("start_agent_run", (agent_obj, thread_id, content, app, kwargs["enable_trajectory"])))
+        return "run-123"
+
+    def _clear_resource_overview_cache():
+        calls.append(("clear_cache", None))
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    handler = NativeAgentThreadInputHandler(
+        app,
+        queue_manager=_QueueManager(),
+        thread_tasks=thread_tasks,
+        thread_locks=thread_locks,
+        thread_locks_guard=thread_locks_guard,
+        get_or_create_agent=_get_or_create_agent,
+        resolve_thread_sandbox=_resolve_thread_sandbox,
+        start_agent_run=_start_agent_run,
+        clear_resource_overview_cache=_clear_resource_overview_cache,
+    )
+
+    result = await handler.dispatch(
+        AgentThreadInputEnvelope(
+            thread_id="thread-1",
+            sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),
+            message=AgentRuntimeMessage(content="hello"),
+        )
+    )
+
+    assert result == AgentThreadInputResult(status="started", routing="direct", run_id="run-123", thread_id="thread-1")
+    assert calls == [
+        ("resolve_thread_sandbox", (app, "thread-1")),
+        ("get_or_create_agent", (app, "local", "thread-1")),
+        ("start_agent_run", (agent, "thread-1", "hello", app, False)),
+        ("clear_cache", None),
+    ]

--- a/tests/Unit/backend/test_thread_input_handler.py
+++ b/tests/Unit/backend/test_thread_input_handler.py
@@ -1,0 +1,33 @@
+import asyncio
+from types import SimpleNamespace
+
+from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
+
+
+def test_thread_input_handler_uses_injected_runtime_state():
+    injected_queue_manager = object()
+    injected_thread_tasks = {}
+    injected_thread_locks = {}
+    injected_thread_locks_guard = asyncio.Lock()
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            queue_manager=object(),
+            thread_tasks={"wrong": object()},
+            thread_locks={"wrong": object()},
+            thread_locks_guard=object(),
+        )
+    )
+
+    handler = NativeAgentThreadInputHandler(
+        app,
+        queue_manager=injected_queue_manager,
+        thread_tasks=injected_thread_tasks,
+        thread_locks=injected_thread_locks,
+        thread_locks_guard=injected_thread_locks_guard,
+    )
+
+    assert handler._queue_manager is injected_queue_manager
+    assert handler._thread_tasks is injected_thread_tasks
+    assert handler._thread_locks is injected_thread_locks
+    assert handler._thread_locks_guard is injected_thread_locks_guard

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -22,13 +23,14 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
     async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
         return SimpleNamespace(id=f"agent-for-{thread_id}")
 
-    monkeypatch.setattr("backend.threads.activity_pool_service.get_or_create_agent", _fake_get_or_create_agent)
-    monkeypatch.setattr("backend.threads.activity_pool_service.resolve_thread_sandbox", lambda _app, _thread_id: "local")
-    monkeypatch.setattr("backend.threads.streaming._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
 
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(
+                get_by_id=lambda thread_id: {"id": thread_id, "sandbox_type": "local"},
                 get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("handler should not resolve thread id locally")),
                 list_by_agent_user=lambda _uid: (_ for _ in ()).throw(
                     AssertionError("handler should not scan runtime thread candidates locally")
@@ -39,6 +41,11 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, _notification_type, **_meta: enqueued.append((content, thread_id))
             ),
+            thread_cwd={},
+            thread_sandbox={},
+            thread_tasks={},
+            thread_locks={},
+            thread_locks_guard=asyncio.Lock(),
         )
     )
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 
@@ -31,6 +32,7 @@ def _app(
             thread_repo=SimpleNamespace(
                 get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
                 list_by_agent_user=lambda uid: list(thread_rows) if uid == "agent-user-1" else [],
+                get_by_id=lambda thread_id: next((row for row in thread_rows if row["id"] == thread_id), None),
             ),
             agent_pool=pool or {},
             typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
@@ -39,6 +41,11 @@ def _app(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
                 )
             ),
+            thread_cwd={},
+            thread_sandbox={},
+            thread_tasks={},
+            thread_locks={},
+            thread_locks_guard=asyncio.Lock(),
         )
     )
     return app, started, unread_calls, enqueued
@@ -64,9 +71,9 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
     async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
         return SimpleNamespace(id=f"agent-for-{thread_id}")
 
-    monkeypatch.setattr("backend.threads.activity_pool_service.get_or_create_agent", _fake_get_or_create_agent)
-    monkeypatch.setattr("backend.threads.activity_pool_service.resolve_thread_sandbox", lambda _app, _thread_id: "local")
-    monkeypatch.setattr("backend.threads.streaming._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     app, started, unread_calls, enqueued = _app()
 
     result = await build_agent_runtime_gateway(app).dispatch_chat(_envelope())
@@ -81,7 +88,7 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
 @pytest.mark.asyncio
 async def test_gateway_dispatch_chat_raises_for_missing_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "backend.threads.activity_pool_service.get_or_create_agent", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
+        "backend.threads.chat_adapters.bootstrap.get_or_create_agent", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
     )
     app, started, unread_calls, enqueued = _app(threads=[])
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -33,7 +33,16 @@ class _FakeAgent:
 def _fake_app() -> SimpleNamespace:
     return SimpleNamespace(
         state=SimpleNamespace(
+            thread_repo=SimpleNamespace(
+                get_by_id=lambda thread_id: {"id": thread_id, "sandbox_type": "local"},
+                get_by_user_id=lambda _uid: None,
+                list_by_agent_user=lambda _uid: [],
+            ),
+            agent_pool={},
+            typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
             queue_manager=_FakeQueueManager(),
+            thread_cwd={},
+            thread_sandbox={},
             thread_locks={},
             thread_locks_guard=asyncio.Lock(),
             thread_tasks={},
@@ -56,10 +65,10 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
     agent = _FakeAgent()
 
     with (
-        patch("backend.threads.activity_pool_service.resolve_thread_sandbox", return_value="local"),
-        patch("backend.threads.activity_pool_service.get_or_create_agent", AsyncMock(return_value=agent)),
-        patch("backend.threads.streaming.start_agent_run", return_value="run-123"),
-        patch("backend.monitor.infrastructure.resources.resource_overview_cache.clear_resource_overview_cache") as clear_cache,
+        patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
+        patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=agent)),
+        patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
+        patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache") as clear_cache,
     ):
         result = await build_agent_runtime_gateway(app).dispatch_thread_input(_thread_input())
 
@@ -72,10 +81,10 @@ async def test_gateway_thread_input_requires_agent_runtime() -> None:
     app = _fake_app()
 
     with (
-        patch("backend.threads.activity_pool_service.resolve_thread_sandbox", return_value="local"),
-        patch("backend.threads.activity_pool_service.get_or_create_agent", AsyncMock(return_value=SimpleNamespace())),
-        patch("backend.threads.streaming.start_agent_run", return_value="run-123"),
-        patch("backend.monitor.infrastructure.resources.resource_overview_cache.clear_resource_overview_cache"),
+        patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
+        patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=SimpleNamespace())),
+        patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
+        patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
         with pytest.raises(AttributeError):
             await build_agent_runtime_gateway(app).dispatch_thread_input(_thread_input())
@@ -87,10 +96,10 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
     agent = _FakeAgent()
 
     with (
-        patch("backend.threads.activity_pool_service.resolve_thread_sandbox", return_value="local"),
-        patch("backend.threads.activity_pool_service.get_or_create_agent", AsyncMock(return_value=agent)),
-        patch("backend.threads.streaming.start_agent_run", return_value="run-123") as start_run,
-        patch("backend.monitor.infrastructure.resources.resource_overview_cache.clear_resource_overview_cache"),
+        patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
+        patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=agent)),
+        patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
+        patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
         await build_agent_runtime_gateway(app).dispatch_thread_input(_thread_input(enable_trajectory=True))
 

--- a/tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
+++ b/tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
@@ -38,7 +38,7 @@ def test_start_batch_submits_typed_spec_to_scheduler(monkeypatch):
     scheduler = _FakeScheduler()
     result = monitor_evaluation_service.start_monitor_evaluation_batch(
         "batch-1",
-        base_url="http://api/",
+        execution_base_url="http://api/",
         token="tok",
         scheduler=scheduler,
     )
@@ -47,6 +47,6 @@ def test_start_batch_submits_typed_spec_to_scheduler(monkeypatch):
     assert len(scheduler.submitted) == 1
     spec = scheduler.submitted[0]
     assert spec.batch_id == "batch-1"
-    assert spec.base_url == "http://api"
+    assert spec.execution_base_url == "http://api"
     assert spec.agent_user_id == "agent-1"
     assert spec.scenarios == [("scenario-stub", "scenario-1", "local")]


### PR DESCRIPTION
## Summary
- inject runtime thread activity, chat runtime services, and thread input handler dependencies instead of letting adapters hold the whole app and reach into state at runtime
- keep the slice focused on the chat/threads seam only, with matching fixture updates for the new constructor contracts

## Proof
- `uv run pytest -q tests/Unit/backend/test_thread_activity_reader.py tests/Unit/backend/test_chat_runtime_services.py tests/Unit/backend/test_thread_input_handler.py` -> `5 passed`
- `uv run pytest -q tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Integration/test_messaging_social_handle_contract.py -k "agent_runtime_gateway or latest_live_child_thread_over_active_main or recipient_thread_resolution_requires_current_thread_repo_contract or uses_recipient_social_user_id_for_thread_lookup_and_passes_through_envelope_content"` -> `11 passed, 102 deselected`
- targeted `ruff check` / `ruff format --check` / `git diff --check` green

## Commit Density
- this PR keeps 6 commits to satisfy the repo rule of at least 5 commits per PR