### PR TITLE
refactor(chat): inject route-level HTTP dependencies

### DIFF
--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -10,8 +10,8 @@ from fastapi import APIRouter, Depends
 
 from backend.chat.api.http.dependencies import (
     get_current_user_id,
-    get_owner_thread_rows_loader,
     get_optional_messaging_service,
+    get_owner_thread_rows_loader,
     get_runtime_thread_activity_reader,
     get_thread_last_active_map,
 )

--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -9,14 +9,13 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 
 from backend.chat.api.http.dependencies import (
-    get_app,
     get_current_user_id,
+    get_owner_thread_rows_loader,
     get_optional_messaging_service,
     get_runtime_thread_activity_reader,
     get_thread_last_active_map,
 )
 from backend.identity.avatar.urls import avatar_url
-from backend.threads.owner_reads import list_owner_thread_rows_for_auth_burst
 from backend.threads.projection import canonical_owner_threads
 from protocols.runtime_read import RuntimeThreadActivityReader
 
@@ -44,13 +43,13 @@ def _conversation_updated_at_key(item: dict[str, Any]) -> float:
 @router.get("")
 async def list_conversations(
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)] = None,
+    owner_thread_rows: Annotated[Any, Depends(get_owner_thread_rows_loader)],
+    activity_reader: Annotated[RuntimeThreadActivityReader, Depends(get_runtime_thread_activity_reader)],
+    thread_last_active: Annotated[dict[str, Any], Depends(get_thread_last_active_map)],
+    messaging_service: Annotated[Any | None, Depends(get_optional_messaging_service)] = None,
 ) -> list[dict[str, Any]]:
-    activity_reader = get_runtime_thread_activity_reader(app)
-    thread_last_active = get_thread_last_active_map(app)
-    messaging_service = get_optional_messaging_service(app)
     raw_threads, visit_items = await asyncio.gather(
-        list_owner_thread_rows_for_auth_burst(app, user_id),
+        owner_thread_rows(user_id),
         asyncio.to_thread(_list_visit_conversations_for_user, messaging_service, user_id),
     )
     hire_items = await asyncio.to_thread(

--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -1,10 +1,12 @@
 """Chat HTTP dependency helpers."""
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request
 
 from backend.identity.auth.user_resolution import get_current_user_id as resolve_current_user_id
+from backend.threads.owner_reads import list_owner_thread_rows_for_auth_burst
 
 get_current_user_id = resolve_current_user_id
 
@@ -58,3 +60,10 @@ def get_runtime_thread_activity_reader(app: Any) -> Any:
 
 def get_thread_last_active_map(app: Any) -> Any:
     return _require_state_attr(app, "thread_last_active", "Thread last-active map unavailable")
+
+
+def get_owner_thread_rows_loader(app: Any) -> Callable[[str], Awaitable[list[dict[str, Any]]]]:
+    async def _load(user_id: str) -> list[dict[str, Any]]:
+        return await list_owner_thread_rows_for_auth_burst(app, user_id)
+
+    return _load

--- a/backend/chat/api/http/relationships_router.py
+++ b/backend/chat/api/http/relationships_router.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 
 from backend.chat.api.http.dependencies import (
-    get_app,
     get_current_user_id,
     get_relationship_service,
     get_user_repo,
@@ -45,10 +44,9 @@ def _get_existing(svc, relationship_id: str, user_id: str) -> dict:
     return existing
 
 
-def _resolve_actor_user_id(app: Any, current_user_id: str, actor_user_id: str | None) -> str:
+def _resolve_actor_user_id(user_repo: Any, current_user_id: str, actor_user_id: str | None) -> str:
     if actor_user_id is None or actor_user_id == current_user_id:
         return current_user_id
-    user_repo = get_user_repo(app)
     actor = user_repo.get_by_id(actor_user_id)
     if actor is None:
         raise HTTPException(404, "Actor user not found")
@@ -80,10 +78,9 @@ def _row_to_dict(row: RelationshipRow, viewer_id: str) -> dict:
 @router.get("")
 async def list_relationships(
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
 ):
-    svc = get_relationship_service(app)
-    rows = svc.list_for_user(user_id)
+    rows = relationship_service.list_for_user(user_id)
     return [_row_to_dict(r, user_id) for r in rows]
 
 
@@ -91,14 +88,14 @@ async def list_relationships(
 async def request_relationship(
     body: RelationshipRequestBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    svc = get_relationship_service(app)
-    actor_user_id = _resolve_actor_user_id(app, user_id, body.actor_user_id)
+    actor_user_id = _resolve_actor_user_id(user_repo, user_id, body.actor_user_id)
     if actor_user_id == body.target_user_id:
         raise HTTPException(400, "Cannot request relationship with yourself")
     try:
-        row = svc.request(actor_user_id, body.target_user_id)
+        row = relationship_service.request(actor_user_id, body.target_user_id)
         return _row_to_dict(row, actor_user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
@@ -109,16 +106,16 @@ async def approve_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    svc = get_relationship_service(app)
-    actor_user_id = _resolve_actor_user_id(app, user_id, body.actor_user_id)
-    existing = _get_existing(svc, relationship_id, actor_user_id)
+    actor_user_id = _resolve_actor_user_id(user_repo, user_id, body.actor_user_id)
+    existing = _get_existing(relationship_service, relationship_id, actor_user_id)
     requester_id, _ = _resolve_parties(existing, actor_user_id)
     if actor_user_id == requester_id:
         raise HTTPException(409, "Cannot approve your own request")
     try:
-        return _row_to_dict(svc.approve(actor_user_id, requester_id), actor_user_id)
+        return _row_to_dict(relationship_service.approve(actor_user_id, requester_id), actor_user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -128,16 +125,16 @@ async def reject_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    svc = get_relationship_service(app)
-    actor_user_id = _resolve_actor_user_id(app, user_id, body.actor_user_id)
-    existing = _get_existing(svc, relationship_id, actor_user_id)
+    actor_user_id = _resolve_actor_user_id(user_repo, user_id, body.actor_user_id)
+    existing = _get_existing(relationship_service, relationship_id, actor_user_id)
     requester_id, _ = _resolve_parties(existing, actor_user_id)
     if actor_user_id == requester_id:
         raise HTTPException(409, "Cannot reject your own request")
     try:
-        return _row_to_dict(svc.reject(actor_user_id, requester_id), actor_user_id)
+        return _row_to_dict(relationship_service.reject(actor_user_id, requester_id), actor_user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -147,14 +144,14 @@ async def upgrade_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    svc = get_relationship_service(app)
-    actor_user_id = _resolve_actor_user_id(app, user_id, body.actor_user_id)
-    existing = _get_existing(svc, relationship_id, actor_user_id)
+    actor_user_id = _resolve_actor_user_id(user_repo, user_id, body.actor_user_id)
+    existing = _get_existing(relationship_service, relationship_id, actor_user_id)
     _, other_id = _resolve_parties(existing, actor_user_id)
     try:
-        return _row_to_dict(svc.upgrade(actor_user_id, other_id), actor_user_id)
+        return _row_to_dict(relationship_service.upgrade(actor_user_id, other_id), actor_user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -164,14 +161,14 @@ async def revoke_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    svc = get_relationship_service(app)
-    actor_user_id = _resolve_actor_user_id(app, user_id, body.actor_user_id)
-    existing = _get_existing(svc, relationship_id, actor_user_id)
+    actor_user_id = _resolve_actor_user_id(user_repo, user_id, body.actor_user_id)
+    existing = _get_existing(relationship_service, relationship_id, actor_user_id)
     _, other_id = _resolve_parties(existing, actor_user_id)
     try:
-        return _row_to_dict(svc.revoke(actor_user_id, other_id), actor_user_id)
+        return _row_to_dict(relationship_service.revoke(actor_user_id, other_id), actor_user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -181,13 +178,13 @@ async def downgrade_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    svc = get_relationship_service(app)
-    actor_user_id = _resolve_actor_user_id(app, user_id, body.actor_user_id)
-    existing = _get_existing(svc, relationship_id, actor_user_id)
+    actor_user_id = _resolve_actor_user_id(user_repo, user_id, body.actor_user_id)
+    existing = _get_existing(relationship_service, relationship_id, actor_user_id)
     _, other_id = _resolve_parties(existing, actor_user_id)
     try:
-        return _row_to_dict(svc.downgrade(actor_user_id, other_id), actor_user_id)
+        return _row_to_dict(relationship_service.downgrade(actor_user_id, other_id), actor_user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -42,7 +42,13 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
     )
 
     conversations, threads = await asyncio.gather(
-        owner_conversations_router.list_conversations("owner-1", app=app),
+        owner_conversations_router.list_conversations(
+            "owner-1",
+            owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),
+            activity_reader=app.state.agent_runtime_thread_activity_reader,
+            thread_last_active=app.state.thread_last_active,
+            messaging_service=app.state.messaging_service,
+        ),
         threads_router.list_threads("owner-1", app=app),
     )
 

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -19,6 +19,22 @@ def test_conversations_router_shell_is_deleted() -> None:
         importlib.import_module("backend.web.routers.conversations")
 
 
+async def _list_conversations(app: SimpleNamespace, user_id: str = "human-user-1"):
+    async def _owner_thread_rows(_user_id: str):
+        return await owner_conversations_router.asyncio.to_thread(
+            app.state.thread_repo.list_by_owner_user_id,
+            _user_id,
+        )
+
+    return await owner_conversations_router.list_conversations(
+        user_id,
+        owner_thread_rows=_owner_thread_rows,
+        activity_reader=owner_conversations_router.get_runtime_thread_activity_reader(app),
+        thread_last_active=owner_conversations_router.get_thread_last_active_map(app),
+        messaging_service=getattr(app.state, "messaging_service", None),
+    )
+
+
 @pytest.mark.asyncio
 async def test_list_conversations_resolves_thread_user_participant_title_and_avatar() -> None:
     app = SimpleNamespace(
@@ -66,7 +82,7 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
         )
     )
 
-    result = await owner_conversations_router.list_conversations("human-user-1", app=app)
+    result = await _list_conversations(app)
 
     assert result == [
         {
@@ -134,7 +150,7 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
         )
     )
 
-    result = await owner_conversations_router.list_conversations("human-user-1", app=app)
+    result = await _list_conversations(app)
 
     assert [item["id"] for item in result] == ["chat-1", "thread-1"]
 
@@ -162,7 +178,7 @@ async def test_list_conversations_hire_entries_do_not_leak_template_member_ids()
         )
     )
 
-    result = await owner_conversations_router.list_conversations("human-user-1", app=app)
+    result = await _list_conversations(app)
 
     assert result == [
         {
@@ -209,7 +225,7 @@ async def test_list_conversations_marks_hire_thread_running_from_runtime_activit
         )
     )
 
-    result = await owner_conversations_router.list_conversations("human-user-1", app=app)
+    result = await _list_conversations(app)
 
     assert result == [
         {
@@ -257,7 +273,7 @@ async def test_list_conversations_collapses_hire_threads_to_one_visible_conversa
         )
     )
 
-    result = await owner_conversations_router.list_conversations("human-user-1", app=app)
+    result = await _list_conversations(app)
 
     assert [(item["id"], item["title"]) for item in result] == [("thread-main", "Morel")]
 
@@ -307,7 +323,7 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
         )
     )
 
-    result = await owner_conversations_router.list_conversations("human-user-1", app=app)
+    result = await _list_conversations(app)
 
     assert result[0]["title"] == "Morel"
     assert result[0]["avatar_url"] == avatar_url("agent-user-1", True)
@@ -316,6 +332,7 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
 @pytest.mark.asyncio
 async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     messaging_service = SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: [])
+    owner_thread_rows_loader = SimpleNamespace()
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
@@ -333,7 +350,13 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
 
     monkeypatch.setattr(owner_conversations_router.asyncio, "to_thread", _fake_to_thread)
 
-    assert await owner_conversations_router.list_conversations("human-user-1", app=app) == []
+    async def _owner_thread_rows(_user_id: str):
+        return []
+
+    assert (
+        await _list_conversations(app)
+        == []
+    )
     assert ("_list_visit_conversations_for_user", (messaging_service, "human-user-1")) in to_thread_calls
     assert (
         "_list_hire_conversations_from_threads",
@@ -368,7 +391,7 @@ async def test_list_conversations_fetches_hire_and_visit_sources_in_parallel() -
         )
     )
 
-    assert await owner_conversations_router.list_conversations("human-user-1", app=app) == []
+    assert await _list_conversations(app) == []
 
 
 @pytest.mark.asyncio
@@ -382,7 +405,7 @@ async def test_list_conversations_fails_loud_when_thread_activity_reader_missing
     )
 
     with pytest.raises(Exception) as exc_info:
-        await owner_conversations_router.list_conversations("human-user-1", app=app)
+        await _list_conversations(app)
 
     assert getattr(exc_info.value, "status_code", None) == 503
     assert getattr(exc_info.value, "detail", None) == "Thread activity reader unavailable"

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -20,15 +20,9 @@ def test_conversations_router_shell_is_deleted() -> None:
 
 
 async def _list_conversations(app: SimpleNamespace, user_id: str = "human-user-1"):
-    async def _owner_thread_rows(_user_id: str):
-        return await owner_conversations_router.asyncio.to_thread(
-            app.state.thread_repo.list_by_owner_user_id,
-            _user_id,
-        )
-
     return await owner_conversations_router.list_conversations(
         user_id,
-        owner_thread_rows=_owner_thread_rows,
+        owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),
         activity_reader=owner_conversations_router.get_runtime_thread_activity_reader(app),
         thread_last_active=owner_conversations_router.get_thread_last_active_map(app),
         messaging_service=getattr(app.state, "messaging_service", None),
@@ -332,7 +326,6 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
 @pytest.mark.asyncio
 async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     messaging_service = SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: [])
-    owner_thread_rows_loader = SimpleNamespace()
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
@@ -353,10 +346,7 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
     async def _owner_thread_rows(_user_id: str):
         return []
 
-    assert (
-        await _list_conversations(app)
-        == []
-    )
+    assert await _list_conversations(app) == []
     assert ("_list_visit_conversations_for_user", (messaging_service, "human-user-1")) in to_thread_calls
     assert (
         "_list_hire_conversations_from_threads",

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -28,21 +28,18 @@ def _row(*, state: str = "pending", initiator_user_id: str = "requester-user-1")
 @pytest.mark.asyncio
 async def test_request_relationship_accepts_owned_agent_actor_user_id() -> None:
     seen: list[tuple[str, str]] = []
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            relationship_service=SimpleNamespace(
-                request=lambda actor_id, target_id: seen.append((actor_id, target_id)) or _row(initiator_user_id=actor_id)
-            ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-            ),
-        )
+    relationship_service = SimpleNamespace(
+        request=lambda actor_id, target_id: seen.append((actor_id, target_id)) or _row(initiator_user_id=actor_id)
+    )
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
     )
 
     result = await owner_relationship_router.request_relationship(
         owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1", actor_user_id="agent-user-1"),
         user_id="owner-user-1",
-        app=app,
+        relationship_service=relationship_service,
+        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -62,25 +59,22 @@ async def test_approve_relationship_accepts_owned_agent_actor_user_id() -> None:
         "state": "pending",
         "initiator_user_id": "requester-user-1",
     }
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            relationship_service=SimpleNamespace(
-                get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
-                approve=lambda actor_id, requester_id: (
-                    seen.append((actor_id, requester_id)) or _row(state="visit", initiator_user_id=requester_id)
-                ),
-            ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-            ),
-        )
+    relationship_service = SimpleNamespace(
+        get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
+        approve=lambda actor_id, requester_id: (
+            seen.append((actor_id, requester_id)) or _row(state="visit", initiator_user_id=requester_id)
+        ),
+    )
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
     )
 
     result = await owner_relationship_router.approve_relationship(
         existing["id"],
         owner_relationship_router.RelationshipActionBody(actor_user_id="agent-user-1"),
         user_id="owner-user-1",
-        app=app,
+        relationship_service=relationship_service,
+        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -100,25 +94,22 @@ async def test_reject_relationship_accepts_owned_agent_actor_user_id() -> None:
         "state": "pending",
         "initiator_user_id": "requester-user-1",
     }
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            relationship_service=SimpleNamespace(
-                get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
-                reject=lambda actor_id, requester_id: (
-                    seen.append((actor_id, requester_id)) or _row(state="none", initiator_user_id=requester_id)
-                ),
-            ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-            ),
-        )
+    relationship_service = SimpleNamespace(
+        get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
+        reject=lambda actor_id, requester_id: (
+            seen.append((actor_id, requester_id)) or _row(state="none", initiator_user_id=requester_id)
+        ),
+    )
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
     )
 
     result = await owner_relationship_router.reject_relationship(
         existing["id"],
         owner_relationship_router.RelationshipActionBody(actor_user_id="agent-user-1"),
         user_id="owner-user-1",
-        app=app,
+        relationship_service=relationship_service,
+        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -136,25 +127,22 @@ async def test_downgrade_relationship_accepts_owned_agent_actor_user_id() -> Non
         "state": "hire",
         "initiator_user_id": "requester-user-1",
     }
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            relationship_service=SimpleNamespace(
-                get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
-                downgrade=lambda actor_id, other_id: (
-                    seen.append((actor_id, other_id)) or _row(state="visit", initiator_user_id="requester-user-1")
-                ),
-            ),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-            ),
-        )
+    relationship_service = SimpleNamespace(
+        get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
+        downgrade=lambda actor_id, other_id: (
+            seen.append((actor_id, other_id)) or _row(state="visit", initiator_user_id="requester-user-1")
+        ),
+    )
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
     )
 
     result = await owner_relationship_router.downgrade_relationship(
         existing["id"],
         owner_relationship_router.RelationshipActionBody(actor_user_id="agent-user-1"),
         user_id="owner-user-1",
-        app=app,
+        relationship_service=relationship_service,
+        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -164,20 +152,17 @@ async def test_downgrade_relationship_accepts_owned_agent_actor_user_id() -> Non
 
 @pytest.mark.asyncio
 async def test_request_relationship_rejects_unowned_actor_user_id() -> None:
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            relationship_service=SimpleNamespace(),
-            user_repo=SimpleNamespace(
-                get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="someone-else") if user_id == "agent-user-1" else None
-            ),
-        )
+    relationship_service = SimpleNamespace()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="someone-else") if user_id == "agent-user-1" else None
     )
 
     with pytest.raises(HTTPException) as exc_info:
         await owner_relationship_router.request_relationship(
             owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1", actor_user_id="agent-user-1"),
             user_id="owner-user-1",
-            app=app,
+            relationship_service=relationship_service,
+            user_repo=user_repo,
         )
 
     assert exc_info.value.status_code == 403

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -61,9 +61,7 @@ async def test_approve_relationship_accepts_owned_agent_actor_user_id() -> None:
     }
     relationship_service = SimpleNamespace(
         get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
-        approve=lambda actor_id, requester_id: (
-            seen.append((actor_id, requester_id)) or _row(state="visit", initiator_user_id=requester_id)
-        ),
+        approve=lambda actor_id, requester_id: seen.append((actor_id, requester_id)) or _row(state="visit", initiator_user_id=requester_id),
     )
     user_repo = SimpleNamespace(
         get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
@@ -96,9 +94,7 @@ async def test_reject_relationship_accepts_owned_agent_actor_user_id() -> None:
     }
     relationship_service = SimpleNamespace(
         get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
-        reject=lambda actor_id, requester_id: (
-            seen.append((actor_id, requester_id)) or _row(state="none", initiator_user_id=requester_id)
-        ),
+        reject=lambda actor_id, requester_id: seen.append((actor_id, requester_id)) or _row(state="none", initiator_user_id=requester_id),
     )
     user_repo = SimpleNamespace(
         get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
@@ -129,9 +125,7 @@ async def test_downgrade_relationship_accepts_owned_agent_actor_user_id() -> Non
     }
     relationship_service = SimpleNamespace(
         get_by_id=lambda relationship_id: existing if relationship_id == existing["id"] else None,
-        downgrade=lambda actor_id, other_id: (
-            seen.append((actor_id, other_id)) or _row(state="visit", initiator_user_id="requester-user-1")
-        ),
+        downgrade=lambda actor_id, other_id: seen.append((actor_id, other_id)) or _row(state="visit", initiator_user_id="requester-user-1"),
     )
     user_repo = SimpleNamespace(
         get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None

--- a/tests/Unit/backend/test_chat_http_dependencies.py
+++ b/tests/Unit/backend/test_chat_http_dependencies.py
@@ -16,6 +16,27 @@ def test_get_messaging_service_returns_service_when_present():
     assert chat_http_dependencies.get_messaging_service(_app_state(messaging_service=service)) is service
 
 
+@pytest.mark.asyncio
+async def test_get_owner_thread_rows_loader_binds_app() -> None:
+    seen: list[tuple[object, str]] = []
+
+    async def _fake_list_owner_thread_rows_for_auth_burst(app, user_id: str):
+        seen.append((app, user_id))
+        return [{"id": "thread-1"}]
+
+    app = _app_state(thread_repo=SimpleNamespace())
+    original = chat_http_dependencies.list_owner_thread_rows_for_auth_burst
+    chat_http_dependencies.list_owner_thread_rows_for_auth_burst = _fake_list_owner_thread_rows_for_auth_burst
+    try:
+        loader = chat_http_dependencies.get_owner_thread_rows_loader(app)
+        result = await loader("owner-1")
+    finally:
+        chat_http_dependencies.list_owner_thread_rows_for_auth_burst = original
+
+    assert result == [{"id": "thread-1"}]
+    assert seen == [(app, "owner-1")]
+
+
 def test_get_messaging_service_fails_loud_when_missing():
     with pytest.raises(HTTPException) as exc_info:
         chat_http_dependencies.get_messaging_service(_app_state())


### PR DESCRIPTION
## Summary
- add a bound owner-thread-rows dependency helper for chat HTTP
- inject explicit dependencies into conversations route instead of reading from app at the endpoint boundary
- inject explicit relationship service and user repo dependencies into relationship routes

## Proof
- `uv run python -m pytest -q tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_conversations_router.py tests/Integration/test_relationship_router.py tests/Integration/test_messaging_router.py`
- `uv run ruff check backend/chat/api/http/dependencies.py backend/chat/api/http/conversations_router.py backend/chat/api/http/relationships_router.py tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_conversations_router.py tests/Integration/test_relationship_router.py`
- `uv run ruff format --check backend/chat/api/http/dependencies.py backend/chat/api/http/conversations_router.py backend/chat/api/http/relationships_router.py tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_conversations_router.py tests/Integration/test_relationship_router.py`
- `git diff --check`