### PR TITLE
Fix monitor owner thread workbench timeout

### DIFF
--- a/backend/monitor/application/use_cases/thread_workbench.py
+++ b/backend/monitor/application/use_cases/thread_workbench.py
@@ -24,20 +24,44 @@ def build_owner_thread_workbench(user_id: str, *, reader: OwnerThreadWorkbenchRe
     return build_owner_thread_workbench_from_rows(raw, reader=reader)
 
 
-def build_owner_thread_workbench_from_rows(raw: list[dict[str, object]], *, reader: OwnerThreadWorkbenchReader) -> dict[str, object]:
-    runtime_states = reader.summarize_runtime_states(raw)
-    visible_threads = []
+def _group_visible_threads_by_agent(raw: list[dict[str, object]]) -> list[list[dict[str, object]]]:
+    groups: dict[str, list[dict[str, object]]] = {}
+    order: list[str] = []
     for thread in raw:
-        thread_id = thread["id"]
-        runtime_state = runtime_states.get(thread_id) or reader.converge_runtime_state(thread_id)
-        if runtime_state in {"missing", "purged"}:
-            continue
+        thread_id = str(thread.get("id") or "")
         if is_internal_child_thread(thread_id):
             continue
-        visible_threads.append(thread)
+        agent_user_id = str(thread.get("agent_user_id") or "").strip()
+        if not agent_user_id:
+            raise RuntimeError(f"Owner-visible thread {thread_id or '<missing>'} is missing agent_user_id")
+        if agent_user_id not in groups:
+            groups[agent_user_id] = []
+            order.append(agent_user_id)
+        groups[agent_user_id].append(thread)
+    return [groups[agent_user_id] for agent_user_id in order]
 
+
+def _select_visible_thread(group: list[dict[str, object]], *, reader: OwnerThreadWorkbenchReader) -> dict[str, object] | None:
+    remaining = list(group)
+    while remaining:
+        candidate = reader.canonical_owner_threads(remaining)[0]
+        thread_id = candidate["id"]
+        runtime_state = reader.converge_runtime_state(thread_id)
+        if runtime_state not in {"missing", "purged"}:
+            return candidate
+        remaining = [thread for thread in remaining if thread["id"] != thread_id]
+    return None
+
+
+def build_owner_thread_workbench_from_rows(raw: list[dict[str, object]], *, reader: OwnerThreadWorkbenchReader) -> dict[str, object]:
     threads = []
-    for thread in reader.canonical_owner_threads(visible_threads):
+    # @@@lazy-owner-thread-selection - monitor only needs one visible thread per agent.
+    # Choosing the best candidate lazily avoids N full runtime-binding inspections
+    # across every historical branch before we even know which thread would surface.
+    for group in _group_visible_threads_by_agent(raw):
+        thread = _select_visible_thread(group, reader=reader)
+        if thread is None:
+            continue
         thread_id = thread["id"]
         sandbox_type = thread.get("sandbox_type", "local")
         running = reader.is_runtime_active(thread_id, sandbox_type)

--- a/backend/monitor/application/use_cases/thread_workbench.py
+++ b/backend/monitor/application/use_cases/thread_workbench.py
@@ -24,9 +24,8 @@ def build_owner_thread_workbench(user_id: str, *, reader: OwnerThreadWorkbenchRe
     return build_owner_thread_workbench_from_rows(raw, reader=reader)
 
 
-def _group_visible_threads_by_agent(raw: list[dict[str, object]]) -> list[list[dict[str, object]]]:
+def _group_visible_threads_by_agent(raw: list[dict[str, object]]) -> dict[str, list[dict[str, object]]]:
     groups: dict[str, list[dict[str, object]]] = {}
-    order: list[str] = []
     for thread in raw:
         thread_id = str(thread.get("id") or "")
         if is_internal_child_thread(thread_id):
@@ -36,9 +35,8 @@ def _group_visible_threads_by_agent(raw: list[dict[str, object]]) -> list[list[d
             raise RuntimeError(f"Owner-visible thread {thread_id or '<missing>'} is missing agent_user_id")
         if agent_user_id not in groups:
             groups[agent_user_id] = []
-            order.append(agent_user_id)
         groups[agent_user_id].append(thread)
-    return [groups[agent_user_id] for agent_user_id in order]
+    return groups
 
 
 def _select_visible_thread(group: list[dict[str, object]], *, reader: OwnerThreadWorkbenchReader) -> dict[str, object] | None:
@@ -58,14 +56,21 @@ def _select_visible_thread(group: list[dict[str, object]], *, reader: OwnerThrea
 
 
 def build_owner_thread_workbench_from_rows(raw: list[dict[str, object]], *, reader: OwnerThreadWorkbenchReader) -> dict[str, object]:
+    raw_index = {str(thread.get("id") or ""): index for index, thread in enumerate(raw)}
     threads = []
     # @@@lazy-owner-thread-selection - monitor only needs one visible thread per agent.
     # Choosing the best candidate lazily avoids N full runtime-binding inspections
     # across every historical branch before we even know which thread would surface.
-    for group in _group_visible_threads_by_agent(raw):
+    selected_threads = []
+    for group in _group_visible_threads_by_agent(raw).values():
         thread = _select_visible_thread(group, reader=reader)
         if thread is None:
             continue
+        selected_threads.append(thread)
+
+    selected_threads.sort(key=lambda thread: raw_index.get(str(thread.get("id") or ""), 0))
+
+    for thread in selected_threads:
         thread_id = thread["id"]
         sandbox_type = thread.get("sandbox_type", "local")
         running = reader.is_runtime_active(thread_id, sandbox_type)

--- a/backend/monitor/application/use_cases/thread_workbench.py
+++ b/backend/monitor/application/use_cases/thread_workbench.py
@@ -44,6 +44,10 @@ def _group_visible_threads_by_agent(raw: list[dict[str, object]]) -> list[list[d
 def _select_visible_thread(group: list[dict[str, object]], *, reader: OwnerThreadWorkbenchReader) -> dict[str, object] | None:
     remaining = list(group)
     while remaining:
+        # @@@owner-thread-candidate-fallback - pick the current best candidate for one agent,
+        # inspect just that candidate, and only fall through when it is purged/missing.
+        # This keeps user-surface selection correct without paying a full binding scan
+        # across every historical branch before we know which thread could even surface.
         candidate = reader.canonical_owner_threads(remaining)[0]
         thread_id = candidate["id"]
         runtime_state = reader.converge_runtime_state(thread_id)

--- a/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
@@ -123,3 +123,9 @@ def test_owner_thread_workbench_uses_app_state_read_source():
     assert "backend.web.services.thread_visibility" not in read_source
     assert "backend.web.utils.serializers" not in read_source
     assert "backend.web.services.thread_runtime_convergence" not in read_source
+
+
+def test_owner_thread_workbench_does_not_eagerly_summarize_all_runtime_states():
+    workbench_source = inspect.getsource(owner_thread_workbench_service)
+
+    assert "summarize_runtime_states(raw)" not in workbench_source

--- a/tests/Unit/monitor/test_thread_workbench_projection.py
+++ b/tests/Unit/monitor/test_thread_workbench_projection.py
@@ -129,3 +129,24 @@ def test_build_owner_thread_workbench_preserves_agent_order_across_fallback_sele
     payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
 
     assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-1-branch", "agent-2-main"]
+
+
+def test_build_owner_thread_workbench_omits_agent_groups_with_no_visible_runtime_candidate():
+    rows = [
+        {"id": "agent-1-main", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+        {"id": "agent-1-branch", "agent_user_id": "agent-1", "is_main": False, "branch_index": 1, "sandbox_type": "local"},
+        {"id": "agent-2-main", "agent_user_id": "agent-2", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+    ]
+    reader = _reader(
+        rows=rows,
+        runtime_states={
+            "agent-1-main": "purged",
+            "agent-1-branch": "missing",
+            "agent-2-main": "ready",
+        },
+        converge_calls=[],
+    )
+
+    payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-2-main"]

--- a/tests/Unit/monitor/test_thread_workbench_projection.py
+++ b/tests/Unit/monitor/test_thread_workbench_projection.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+from backend.monitor.application.use_cases import thread_workbench
+
+
+def _reader(
+    *,
+    rows,
+    runtime_states,
+    converge_calls,
+):
+    return SimpleNamespace(
+        list_owner_thread_rows=lambda _user_id: rows,
+        summarize_runtime_states=lambda _raw: (_ for _ in ()).throw(AssertionError("should not eagerly summarize all runtime states")),
+        converge_runtime_state=lambda thread_id: converge_calls.append(thread_id) or runtime_states[thread_id],
+        is_runtime_active=lambda _thread_id, _sandbox_type: False,
+        last_active_at=lambda _thread_id: None,
+        canonical_owner_threads=lambda group: sorted(
+            group,
+            key=lambda row: (
+                not bool(row.get("is_main", False)),
+                int(row.get("branch_index", 0)),
+            ),
+        )[:1],
+        avatar_url=lambda _agent_user_id, _has_avatar: None,
+    )
+
+
+def test_build_owner_thread_workbench_avoids_eager_runtime_summary_scan():
+    rows = [
+        {"id": "thread-main", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+        {"id": "thread-branch", "agent_user_id": "agent-1", "is_main": False, "branch_index": 1, "sandbox_type": "local"},
+        {"id": "thread-other", "agent_user_id": "agent-2", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+    ]
+    converge_calls: list[str] = []
+    reader = _reader(
+        rows=rows,
+        runtime_states={
+            "thread-main": "ready",
+            "thread-branch": "ready",
+            "thread-other": "ready",
+        },
+        converge_calls=converge_calls,
+    )
+
+    payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["thread-main", "thread-other"]
+    assert converge_calls == ["thread-main", "thread-other"]
+
+
+def test_build_owner_thread_workbench_falls_through_to_next_candidate_when_preferred_thread_is_purged():
+    rows = [
+        {"id": "thread-main", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+        {"id": "thread-branch", "agent_user_id": "agent-1", "is_main": False, "branch_index": 1, "sandbox_type": "local"},
+    ]
+    converge_calls: list[str] = []
+    reader = _reader(
+        rows=rows,
+        runtime_states={
+            "thread-main": "purged",
+            "thread-branch": "ready",
+        },
+        converge_calls=converge_calls,
+    )
+
+    payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["thread-branch"]
+    assert converge_calls == ["thread-main", "thread-branch"]
+
+
+def test_build_owner_thread_workbench_skips_internal_child_threads_before_runtime_checks():
+    rows = [
+        {"id": "subagent-hidden", "agent_user_id": "agent-1", "is_main": False, "branch_index": 1, "sandbox_type": "local"},
+        {"id": "thread-main", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+    ]
+    converge_calls: list[str] = []
+    reader = _reader(
+        rows=rows,
+        runtime_states={
+            "thread-main": "ready",
+        },
+        converge_calls=converge_calls,
+    )
+
+    payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["thread-main"]
+    assert converge_calls == ["thread-main"]
+
+
+def test_build_owner_thread_workbench_requires_agent_user_id_for_visible_threads():
+    rows = [
+        {"id": "thread-main", "agent_user_id": "", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+    ]
+    converge_calls: list[str] = []
+    reader = _reader(
+        rows=rows,
+        runtime_states={},
+        converge_calls=converge_calls,
+    )
+
+    try:
+        thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+    except RuntimeError as exc:
+        assert "missing agent_user_id" in str(exc)
+    else:
+        raise AssertionError("expected owner-visible thread rows without agent_user_id to fail loudly")

--- a/tests/Unit/monitor/test_thread_workbench_projection.py
+++ b/tests/Unit/monitor/test_thread_workbench_projection.py
@@ -107,3 +107,25 @@ def test_build_owner_thread_workbench_requires_agent_user_id_for_visible_threads
         assert "missing agent_user_id" in str(exc)
     else:
         raise AssertionError("expected owner-visible thread rows without agent_user_id to fail loudly")
+
+
+def test_build_owner_thread_workbench_preserves_agent_order_across_fallback_selection():
+    rows = [
+        {"id": "agent-1-main", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+        {"id": "agent-2-main", "agent_user_id": "agent-2", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+        {"id": "agent-1-branch", "agent_user_id": "agent-1", "is_main": False, "branch_index": 1, "sandbox_type": "local"},
+    ]
+    converge_calls: list[str] = []
+    reader = _reader(
+        rows=rows,
+        runtime_states={
+            "agent-1-main": "purged",
+            "agent-1-branch": "ready",
+            "agent-2-main": "ready",
+        },
+        converge_calls=converge_calls,
+    )
+
+    payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-1-branch", "agent-2-main"]

--- a/tests/Unit/monitor/test_thread_workbench_projection.py
+++ b/tests/Unit/monitor/test_thread_workbench_projection.py
@@ -128,7 +128,7 @@ def test_build_owner_thread_workbench_preserves_agent_order_across_fallback_sele
 
     payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
 
-    assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-1-branch", "agent-2-main"]
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-2-main", "agent-1-branch"]
 
 
 def test_build_owner_thread_workbench_omits_agent_groups_with_no_visible_runtime_candidate():

--- a/tests/Unit/monitor/test_thread_workbench_projection.py
+++ b/tests/Unit/monitor/test_thread_workbench_projection.py
@@ -150,3 +150,26 @@ def test_build_owner_thread_workbench_omits_agent_groups_with_no_visible_runtime
     payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
 
     assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-2-main"]
+
+
+def test_build_owner_thread_workbench_stops_after_first_ready_candidate_per_agent():
+    rows = [
+        {"id": "agent-1-main", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0, "sandbox_type": "local"},
+        {"id": "agent-1-branch-1", "agent_user_id": "agent-1", "is_main": False, "branch_index": 1, "sandbox_type": "local"},
+        {"id": "agent-1-branch-2", "agent_user_id": "agent-1", "is_main": False, "branch_index": 2, "sandbox_type": "local"},
+    ]
+    converge_calls: list[str] = []
+    reader = _reader(
+        rows=rows,
+        runtime_states={
+            "agent-1-main": "ready",
+            "agent-1-branch-1": "ready",
+            "agent-1-branch-2": "ready",
+        },
+        converge_calls=converge_calls,
+    )
+
+    payload = thread_workbench.build_owner_thread_workbench_from_rows(rows, reader=reader)
+
+    assert [thread["thread_id"] for thread in payload["threads"]] == ["agent-1-main"]
+    assert converge_calls == ["agent-1-main"]


### PR DESCRIPTION
## Summary
- stop eagerly scanning runtime state across every owner thread row
- lazily choose the first visible thread candidate per agent with fallback for purged/missing preferred threads
- preserve final cross-agent order by the selected thread's original raw-row position

## Verification
- `uv run pytest tests/Unit/monitor/test_thread_workbench_projection.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py -q`
- `uv run ruff check backend/monitor/application/use_cases/thread_workbench.py tests/Unit/monitor/test_thread_workbench_projection.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py`
- `git diff --check origin/dev..HEAD`
- branch-local route probe: `GET /api/monitor/threads` -> `200`
