### PR TITLE
refactor(chat): inject chats route dependencies

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -128,9 +128,8 @@ def _validate_group_chat_relationships(app: Any, participant_ids: list[str], req
 @router.get("")
 def list_chats(
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    messaging_service = get_messaging_service(app)
     return messaging_service.list_chats_for_user(user_id)
 
 
@@ -173,11 +172,10 @@ def get_chat(
 def list_messages(
     chat_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
     limit: int = Query(50, ge=1, le=200),
     before: str | None = Query(None),
 ):
-    messaging_service = get_messaging_service(app)
     if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
     return messaging_service.list_message_responses(chat_id, limit=limit, before=before, viewer_id=user_id)
@@ -188,9 +186,9 @@ def send_message(
     chat_id: str,
     body: SendMessageBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    messaging_service = get_messaging_service(app)
     if not body.content.strip():
         raise HTTPException(400, "Content cannot be empty")
     _verify_user_ownership(messaging_service, body.sender_id, user_id)
@@ -210,9 +208,9 @@ def retract_message(
     chat_id: str,
     message_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    ok = get_messaging_service(app).retract(message_id, user_id)
+    ok = messaging_service.retract(message_id, user_id)
     if not ok:
         raise HTTPException(400, "Cannot retract: not sender, already retracted, or 2-min window expired")
     return {"status": "retracted"}
@@ -223,9 +221,9 @@ def delete_message_for_self(
     chat_id: str,
     message_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    get_messaging_service(app).delete_for(message_id, user_id)
+    messaging_service.delete_for(message_id, user_id)
     return {"status": "deleted"}
 
 
@@ -233,9 +231,9 @@ def delete_message_for_self(
 def mark_read(
     chat_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    get_messaging_service(app).mark_read(chat_id, user_id)
+    messaging_service.mark_read(chat_id, user_id)
     return {"status": "ok"}
 
 
@@ -287,9 +285,8 @@ def mute_chat(
     chat_id: str,
     body: MuteChatBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    messaging_service = get_messaging_service(app)
     _verify_user_ownership(messaging_service, body.user_id, user_id)
     mute_until_iso = datetime.fromtimestamp(body.mute_until, tz=UTC).isoformat() if body.mute_until else None
     messaging_service.update_mute(chat_id, body.user_id, body.muted, mute_until_iso)

--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -162,10 +162,10 @@ def create_chat(
 def get_chat(
     chat_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    messaging_service = get_messaging_service(app)
-    chat = _get_accessible_chat_or_404(get_chat_repo(app), messaging_service, chat_id, user_id)
+    chat = _get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
     return messaging_service.get_chat_detail(chat)
 
 
@@ -243,10 +243,9 @@ def mark_read(
 def delete_chat(
     chat_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
-    messaging_service = get_messaging_service(app)
-    chat_repo = get_chat_repo(app)
     _get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
     chat_repo.delete(chat_id)
     return {"status": "deleted"}
@@ -256,15 +255,15 @@ def delete_chat(
 async def stream_chat_events(
     chat_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)] = None,
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_event_bus: Annotated[Any, Depends(get_chat_event_bus)],
 ):
-    messaging_service = get_messaging_service(app)
-    _get_accessible_chat_or_404(get_chat_repo(app), messaging_service, chat_id, user_id)
+    _get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
 
     from fastapi.responses import StreamingResponse
 
-    event_bus = get_chat_event_bus(app)
-    queue = event_bus.subscribe(chat_id)
+    queue = chat_event_bus.subscribe(chat_id)
 
     async def event_generator():
         try:
@@ -278,7 +277,7 @@ async def stream_chat_events(
                 except TimeoutError:
                     yield ": keepalive\n\n"
         finally:
-            event_bus.unsubscribe(chat_id, queue)
+            chat_event_bus.unsubscribe(chat_id, queue)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 

--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -46,10 +46,10 @@ class MuteChatBody(BaseModel):
     mute_until: float | None = None
 
 
-def _verify_user_ownership(app: Any, sender_id: str, user_id: str) -> None:
+def _verify_user_ownership(messaging_service: Any, sender_id: str, user_id: str) -> None:
     # @@@thread-social-owner-check - sender_id can be a thread-owned social user_id, so
     # ownership must resolve through the thread back to the owning agent user before checking owner.
-    sender = _resolve_display_user(app, sender_id)
+    sender = _resolve_display_user(messaging_service, sender_id)
     if not sender:
         raise HTTPException(403, "User not found")
     if is_owned_by_viewer(user_id, sender):
@@ -57,17 +57,17 @@ def _verify_user_ownership(app: Any, sender_id: str, user_id: str) -> None:
     raise HTTPException(403, "User does not belong to you")
 
 
-def _get_accessible_chat_or_404(app: Any, chat_id: str, user_id: str) -> Any:
-    chat = get_chat_repo(app).get_by_id(chat_id)
+def _get_accessible_chat_or_404(chat_repo: Any, messaging_service: Any, chat_id: str, user_id: str) -> Any:
+    chat = chat_repo.get_by_id(chat_id)
     if not chat:
         raise HTTPException(404, "Chat not found")
-    if not get_messaging_service(app).is_chat_member(chat_id, user_id):
+    if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
     return chat
 
 
-def _resolve_display_user(app: Any, social_user_id: str) -> Any | None:
-    return get_messaging_service(app).resolve_display_user(social_user_id)
+def _resolve_display_user(messaging_service: Any, social_user_id: str) -> Any | None:
+    return messaging_service.resolve_display_user(social_user_id)
 
 
 def _validate_chat_participant_ids(app: Any, participant_ids: list[str], requester_user_id: str) -> list[str]:
@@ -130,7 +130,8 @@ def list_chats(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    return get_messaging_service(app).list_chats_for_user(user_id)
+    messaging_service = get_messaging_service(app)
+    return messaging_service.list_chats_for_user(user_id)
 
 
 @router.post("")
@@ -139,13 +140,14 @@ def create_chat(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
+    messaging_service = get_messaging_service(app)
     try:
         participant_ids = _validate_chat_participant_ids(app, body.user_ids, user_id)
         if len(participant_ids) >= 3:
             _validate_group_chat_relationships(app, participant_ids, user_id)
-            chat = get_messaging_service(app).create_group_chat(participant_ids, body.title)
+            chat = messaging_service.create_group_chat(participant_ids, body.title)
         else:
-            chat = get_messaging_service(app).find_or_create_chat(participant_ids, body.title)
+            chat = messaging_service.find_or_create_chat(participant_ids, body.title)
         return {
             "id": chat["id"],
             "title": chat.get("title"),
@@ -162,8 +164,9 @@ def get_chat(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    chat = _get_accessible_chat_or_404(app, chat_id, user_id)
-    return get_messaging_service(app).get_chat_detail(chat)
+    messaging_service = get_messaging_service(app)
+    chat = _get_accessible_chat_or_404(get_chat_repo(app), messaging_service, chat_id, user_id)
+    return messaging_service.get_chat_detail(chat)
 
 
 @router.get("/{chat_id}/messages")
@@ -174,9 +177,10 @@ def list_messages(
     limit: int = Query(50, ge=1, le=200),
     before: str | None = Query(None),
 ):
-    if not get_messaging_service(app).is_chat_member(chat_id, user_id):
+    messaging_service = get_messaging_service(app)
+    if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
-    return get_messaging_service(app).list_message_responses(chat_id, limit=limit, before=before, viewer_id=user_id)
+    return messaging_service.list_message_responses(chat_id, limit=limit, before=before, viewer_id=user_id)
 
 
 @router.post("/{chat_id}/messages")
@@ -186,10 +190,11 @@ def send_message(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
+    messaging_service = get_messaging_service(app)
     if not body.content.strip():
         raise HTTPException(400, "Content cannot be empty")
-    _verify_user_ownership(app, body.sender_id, user_id)
-    msg = get_messaging_service(app).send(
+    _verify_user_ownership(messaging_service, body.sender_id, user_id)
+    msg = messaging_service.send(
         chat_id,
         body.sender_id,
         body.content,
@@ -197,7 +202,7 @@ def send_message(
         signal=body.signal,
         message_type=body.message_type,
     )
-    return get_messaging_service(app).project_message_response(msg)
+    return messaging_service.project_message_response(msg)
 
 
 @router.post("/{chat_id}/messages/{message_id}/retract")
@@ -240,8 +245,10 @@ def delete_chat(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    _get_accessible_chat_or_404(app, chat_id, user_id)
-    get_chat_repo(app).delete(chat_id)
+    messaging_service = get_messaging_service(app)
+    chat_repo = get_chat_repo(app)
+    _get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    chat_repo.delete(chat_id)
     return {"status": "deleted"}
 
 
@@ -251,7 +258,8 @@ async def stream_chat_events(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ):
-    _get_accessible_chat_or_404(app, chat_id, user_id)
+    messaging_service = get_messaging_service(app)
+    _get_accessible_chat_or_404(get_chat_repo(app), messaging_service, chat_id, user_id)
 
     from fastapi.responses import StreamingResponse
 
@@ -282,7 +290,8 @@ def mute_chat(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)],
 ):
-    _verify_user_ownership(app, body.user_id, user_id)
+    messaging_service = get_messaging_service(app)
+    _verify_user_ownership(messaging_service, body.user_id, user_id)
     mute_until_iso = datetime.fromtimestamp(body.mute_until, tz=UTC).isoformat() if body.mute_until else None
-    get_messaging_service(app).update_mute(chat_id, body.user_id, body.muted, mute_until_iso)
+    messaging_service.update_mute(chat_id, body.user_id, body.muted, mute_until_iso)
     return {"status": "ok", "muted": body.muted}

--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -1,9 +1,9 @@
 """Chat HTTP dependency helpers."""
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 
 from backend.identity.auth.user_resolution import get_current_user_id as resolve_current_user_id
 from backend.threads.owner_reads import list_owner_thread_rows_for_auth_burst
@@ -22,47 +22,47 @@ def _require_state_attr(app: Any, attr_name: str, detail: str) -> Any:
     return value
 
 
-def get_messaging_service(app: Any) -> Any:
+def get_messaging_service(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "messaging_service", "MessagingService not initialized")
 
 
-def get_optional_messaging_service(app: Any) -> Any | None:
+def get_optional_messaging_service(app: Annotated[Any, Depends(get_app)]) -> Any | None:
     return getattr(app.state, "messaging_service", None)
 
 
-def get_relationship_service(app: Any) -> Any:
+def get_relationship_service(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "relationship_service", "Relationship service unavailable")
 
 
-def get_user_repo(app: Any) -> Any:
+def get_user_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "user_repo", "User repo unavailable")
 
 
-def get_thread_repo(app: Any) -> Any:
+def get_thread_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "thread_repo", "Thread repo unavailable")
 
 
-def get_contact_repo(app: Any) -> Any:
+def get_contact_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "contact_repo", "Contact repo unavailable")
 
 
-def get_chat_repo(app: Any) -> Any:
+def get_chat_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "chat_repo", "Chat repo unavailable")
 
 
-def get_chat_event_bus(app: Any) -> Any:
+def get_chat_event_bus(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "chat_event_bus", "Chat event bus unavailable")
 
 
-def get_runtime_thread_activity_reader(app: Any) -> Any:
+def get_runtime_thread_activity_reader(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "agent_runtime_thread_activity_reader", "Thread activity reader unavailable")
 
 
-def get_thread_last_active_map(app: Any) -> Any:
+def get_thread_last_active_map(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "thread_last_active", "Thread last-active map unavailable")
 
 
-def get_owner_thread_rows_loader(app: Any) -> Callable[[str], Awaitable[list[dict[str, Any]]]]:
+def get_owner_thread_rows_loader(app: Annotated[Any, Depends(get_app)]) -> Callable[[str], Awaitable[list[dict[str, Any]]]]:
     async def _load(user_id: str) -> list[dict[str, Any]]:
         return await list_owner_thread_rows_for_auth_burst(app, user_id)
 

--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -96,7 +96,13 @@ async def test_chat_events_requires_chat_membership():
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await chats_router.stream_chat_events("chat-1", user_id="user-1", app=app)
+        await chats_router.stream_chat_events(
+            "chat-1",
+            user_id="user-1",
+            chat_repo=app.state.chat_repo,
+            messaging_service=app.state.messaging_service,
+            chat_event_bus=app.state.chat_event_bus,
+        )
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Not a participant of this chat"
@@ -113,7 +119,13 @@ async def test_chat_events_uses_authenticated_participant():
         )
     )
 
-    response = await chats_router.stream_chat_events("chat-1", user_id="user-1", app=app)
+    response = await chats_router.stream_chat_events(
+        "chat-1",
+        user_id="user-1",
+        chat_repo=app.state.chat_repo,
+        messaging_service=app.state.messaging_service,
+        chat_event_bus=app.state.chat_event_bus,
+    )
 
     assert event_bus.subscribed == ["chat-1"]
     assert response.media_type == "text/event-stream"

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -191,7 +191,12 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
         )
     )
 
-    result = chats_router.get_chat("chat-1", user_id="user-1", app=app)
+    result = chats_router.get_chat(
+        "chat-1",
+        user_id="user-1",
+        chat_repo=app.state.chat_repo,
+        messaging_service=app.state.messaging_service,
+    )
 
     assert result == {
         "id": "chat-1",
@@ -223,7 +228,12 @@ def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
         )
     )
 
-    result = chats_router.delete_chat("chat-1", user_id="user-1", app=app)
+    result = chats_router.delete_chat(
+        "chat-1",
+        user_id="user-1",
+        chat_repo=app.state.chat_repo,
+        messaging_service=app.state.messaging_service,
+    )
 
     assert result == {"status": "deleted"}
     assert seen == [
@@ -275,7 +285,12 @@ def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeypatch: 
         )
     )
 
-    result = chats_router.get_chat("chat-1", user_id="human-user-1", app=app)
+    result = chats_router.get_chat(
+        "chat-1",
+        user_id="human-user-1",
+        chat_repo=app.state.chat_repo,
+        messaging_service=app.state.messaging_service,
+    )
 
     assert result["members"] == [
         {

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -117,43 +117,31 @@ def test_messaging_router_shell_is_deleted() -> None:
 
 def test_get_accessible_chat_or_404_returns_chat():
     chat = _chat("chat-1")
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            chat_repo=SimpleNamespace(get_by_id=lambda chat_id: chat if chat_id == "chat-1" else None),
-            messaging_service=SimpleNamespace(is_chat_member=lambda chat_id, user_id: (chat_id, user_id) == ("chat-1", "user-1")),
-        )
-    )
+    chat_repo = SimpleNamespace(get_by_id=lambda chat_id: chat if chat_id == "chat-1" else None)
+    messaging_service = SimpleNamespace(is_chat_member=lambda chat_id, user_id: (chat_id, user_id) == ("chat-1", "user-1"))
 
-    result = chats_router._get_accessible_chat_or_404(app, "chat-1", "user-1")
+    result = chats_router._get_accessible_chat_or_404(chat_repo, messaging_service, "chat-1", "user-1")
 
     assert result is chat
 
 
 def test_get_accessible_chat_or_404_raises_404_for_missing_chat():
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: None),
-            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: True),
-        )
-    )
+    chat_repo = SimpleNamespace(get_by_id=lambda _chat_id: None)
+    messaging_service = SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: True)
 
     with pytest.raises(HTTPException) as exc_info:
-        chats_router._get_accessible_chat_or_404(app, "missing", "user-1")
+        chats_router._get_accessible_chat_or_404(chat_repo, messaging_service, "missing", "user-1")
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Chat not found"
 
 
 def test_get_accessible_chat_or_404_raises_403_for_non_member():
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: _chat("chat-1")),
-            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False),
-        )
-    )
+    chat_repo = SimpleNamespace(get_by_id=lambda _chat_id: _chat("chat-1"))
+    messaging_service = SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False)
 
     with pytest.raises(HTTPException) as exc_info:
-        chats_router._get_accessible_chat_or_404(app, "chat-1", "user-2")
+        chats_router._get_accessible_chat_or_404(chat_repo, messaging_service, "chat-1", "user-2")
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Not a participant of this chat"
@@ -162,18 +150,11 @@ def test_get_accessible_chat_or_404_raises_403_for_non_member():
 def test_resolve_display_user_delegates_to_messaging_service(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[tuple[str, str]] = []
     expected = SimpleNamespace(id="agent-user-1", display_name="Toad")
-
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            messaging_service=SimpleNamespace(
-                resolve_display_user=lambda social_user_id: seen.append(("resolve_display_user", social_user_id)) or expected
-            ),
-            user_repo=SimpleNamespace(name="user-repo"),
-            thread_repo=SimpleNamespace(name="thread-repo"),
-        )
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda social_user_id: seen.append(("resolve_display_user", social_user_id)) or expected
     )
 
-    result = chats_router._resolve_display_user(app, "thread-user-1")
+    result = chats_router._resolve_display_user(messaging_service, "thread-user-1")
 
     assert result is expected
     assert seen == [("resolve_display_user", "thread-user-1")]
@@ -183,8 +164,8 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
     seen: list[tuple[str, object]] = []
     chat = _chat("chat-1")
 
-    def fake_helper(app_obj, chat_id: str, user_id: str):
-        seen.append(("helper", (app_obj, chat_id, user_id)))
+    def fake_helper(chat_repo, messaging_service, chat_id: str, user_id: str):
+        seen.append(("helper", (chat_repo, messaging_service, chat_id, user_id)))
         return chat
 
     monkeypatch.setattr(chats_router, "_get_accessible_chat_or_404", fake_helper)
@@ -219,15 +200,15 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
         "created_at": "2026-04-07T00:00:00Z",
         "members": [],
     }
-    assert seen == [("helper", (app, "chat-1", "user-1"))]
+    assert seen == [("helper", (app.state.chat_repo, app.state.messaging_service, "chat-1", "user-1"))]
 
 
 def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
     seen: list[tuple[str, object]] = []
     chat = _chat("chat-1")
 
-    def fake_helper(app_obj, chat_id: str, user_id: str):
-        seen.append(("helper", (app_obj, chat_id, user_id)))
+    def fake_helper(chat_repo, messaging_service, chat_id: str, user_id: str):
+        seen.append(("helper", (chat_repo, messaging_service, chat_id, user_id)))
         return chat
 
     monkeypatch.setattr(chats_router, "_get_accessible_chat_or_404", fake_helper)
@@ -238,6 +219,7 @@ def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
                 get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("route should use helper, not chat_repo lookup directly")),
                 delete=lambda chat_id: seen.append(("delete", chat_id)),
             ),
+            messaging_service=SimpleNamespace(name="messaging"),
         )
     )
 
@@ -245,7 +227,7 @@ def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
 
     assert result == {"status": "deleted"}
     assert seen == [
-        ("helper", (app, "chat-1", "user-1")),
+        ("helper", (app.state.chat_repo, app.state.messaging_service, "chat-1", "user-1")),
         ("delete", "chat-1"),
     ]
 
@@ -253,7 +235,11 @@ def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
 def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeypatch: pytest.MonkeyPatch):
     chat = _chat("chat-1")
 
-    monkeypatch.setattr(chats_router, "_get_accessible_chat_or_404", lambda _app, _chat_id, _user_id: chat)
+    monkeypatch.setattr(
+        chats_router,
+        "_get_accessible_chat_or_404",
+        lambda _chat_repo, _messaging_service, _chat_id, _user_id: chat,
+    )
 
     app = SimpleNamespace(
         state=SimpleNamespace(
@@ -273,6 +259,7 @@ def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeypatch: 
                     ],
                 }
             ),
+            chat_repo=SimpleNamespace(name="chat-repo"),
             user_repo=SimpleNamespace(
                 get_by_id=lambda uid: (
                     None

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -344,7 +344,11 @@ def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
         )
     )
 
-    result = chats_router.list_messages("chat-1", user_id="human-user-1", app=app)
+    result = chats_router.list_messages(
+        "chat-1",
+        user_id="human-user-1",
+        messaging_service=app.state.messaging_service,
+    )
 
     assert result == [
         {
@@ -458,6 +462,7 @@ def test_send_message_consumes_service_owned_message_projection() -> None:
         "chat-1",
         chats_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
         user_id="owner-user-1",
+        messaging_service=app.state.messaging_service,
         app=app,
     )
 
@@ -535,6 +540,7 @@ def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
         "chat-1",
         chats_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
         user_id="owner-user-1",
+        messaging_service=app.state.messaging_service,
         app=app,
     )
 


### PR DESCRIPTION
## Summary
- make chat HTTP dependency getters real FastAPI dependencies
- inject explicit dependencies through chats router helpers and selected route signatures
- keep shrinking app-shaped edges inside backend/chat/api/http/chats_router.py

## Proof
- `uv run python -m pytest -q tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py`
- `uv run ruff check backend/chat/api/http/dependencies.py backend/chat/api/http/chats_router.py tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py`
- `uv run ruff format --check backend/chat/api/http/dependencies.py backend/chat/api/http/chats_router.py tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py`
- `git diff --check`