### PR TITLE
refactor(chat): inject create and send route dependencies

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -70,9 +70,12 @@ def _resolve_display_user(messaging_service: Any, social_user_id: str) -> Any | 
     return messaging_service.resolve_display_user(social_user_id)
 
 
-def _validate_chat_participant_ids(app: Any, participant_ids: list[str], requester_user_id: str) -> list[str]:
-    user_repo = get_user_repo(app)
-    thread_repo = get_thread_repo(app)
+def _validate_chat_participant_ids(
+    user_repo: Any,
+    thread_repo: Any,
+    participant_ids: list[str],
+    requester_user_id: str,
+) -> list[str]:
     validated: list[str] = []
     for participant_id in participant_ids:
         if participant_id == requester_user_id:
@@ -91,24 +94,25 @@ def _validate_chat_participant_ids(app: Any, participant_ids: list[str], request
     return validated
 
 
-def _is_owned_participant(app: Any, participant_id: str, requester_user_id: str) -> bool:
-    user_repo = get_user_repo(app)
+def _is_owned_participant(user_repo: Any, participant_id: str, requester_user_id: str) -> bool:
     participant = user_repo.get_by_id(participant_id)
     return is_owned_by_viewer(requester_user_id, participant)
 
 
-def _participant_access_targets(app: Any, participant_id: str) -> list[str]:
-    user_repo = get_user_repo(app)
+def _participant_access_targets(user_repo: Any, participant_id: str) -> list[str]:
     participant = user_repo.get_by_id(participant_id)
     return access_scope_targets(participant, fallback_actor_id=participant_id)
 
 
-def _validate_group_chat_relationships(app: Any, participant_ids: list[str], requester_user_id: str) -> None:
-    svc = get_relationship_service(app)
-    contact_repo = get_contact_repo(app)
-    user_repo = get_user_repo(app)
+def _validate_group_chat_relationships(
+    relationship_service: Any,
+    contact_repo: Any,
+    user_repo: Any,
+    participant_ids: list[str],
+    requester_user_id: str,
+) -> None:
     for participant_id in dict.fromkeys(participant_ids):
-        if participant_id == requester_user_id or _is_owned_participant(app, participant_id, requester_user_id):
+        if participant_id == requester_user_id or _is_owned_participant(user_repo, participant_id, requester_user_id):
             continue
         try:
             participant_user = user_repo.get_by_id(participant_id)
@@ -117,7 +121,7 @@ def _validate_group_chat_relationships(app: Any, participant_ids: list[str], req
                 participant_user_id=participant_id,
                 participant_user=participant_user,
                 contact_repo=contact_repo,
-                relationship_service=svc,
+                relationship_service=relationship_service,
             ):
                 continue
         except RuntimeError as exc:
@@ -137,13 +141,22 @@ def list_chats(
 def create_chat(
     body: CreateChatBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
+    thread_repo: Annotated[Any, Depends(get_thread_repo)],
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
 ):
-    messaging_service = get_messaging_service(app)
     try:
-        participant_ids = _validate_chat_participant_ids(app, body.user_ids, user_id)
+        participant_ids = _validate_chat_participant_ids(user_repo, thread_repo, body.user_ids, user_id)
         if len(participant_ids) >= 3:
-            _validate_group_chat_relationships(app, participant_ids, user_id)
+            _validate_group_chat_relationships(
+                relationship_service,
+                contact_repo,
+                user_repo,
+                participant_ids,
+                user_id,
+            )
             chat = messaging_service.create_group_chat(participant_ids, body.title)
         else:
             chat = messaging_service.find_or_create_chat(participant_ids, body.title)

--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -20,7 +20,7 @@ from backend.chat.api.http.dependencies import (
     get_thread_repo,
     get_user_repo,
 )
-from messaging.actor_ownership import access_scope_targets, is_owned_by_viewer
+from messaging.actor_ownership import is_owned_by_viewer
 from messaging.social_access import can_group_chat_with_participant
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -96,11 +96,6 @@ def _validate_chat_participant_ids(
 def _is_owned_participant(user_repo: Any, participant_id: str, requester_user_id: str) -> bool:
     participant = user_repo.get_by_id(participant_id)
     return is_owned_by_viewer(requester_user_id, participant)
-
-
-def _participant_access_targets(user_repo: Any, participant_id: str) -> list[str]:
-    participant = user_repo.get_by_id(participant_id)
-    return access_scope_targets(participant, fallback_actor_id=participant_id)
 
 
 def _validate_group_chat_relationships(

--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from backend.chat.api.http.dependencies import (
-    get_app,
     get_chat_event_bus,
     get_chat_repo,
     get_contact_repo,
@@ -200,7 +199,6 @@ def send_message(
     body: SendMessageBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     messaging_service: Annotated[Any, Depends(get_messaging_service)],
-    app: Annotated[Any, Depends(get_app)],
 ):
     if not body.content.strip():
         raise HTTPException(400, "Content cannot be empty")

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -88,6 +88,18 @@ def _create_chat_route_state(
     return state, called
 
 
+def _create_chat(app: SimpleNamespace, body: chats_router.CreateChatBody, *, user_id: str = "human-user-1"):
+    return chats_router.create_chat(
+        body,
+        user_id=user_id,
+        messaging_service=app.state.messaging_service,
+        user_repo=app.state.user_repo,
+        thread_repo=app.state.thread_repo,
+        contact_repo=app.state.contact_repo,
+        relationship_service=app.state.relationship_service,
+    )
+
+
 def test_messaging_crud_routes_are_sync_threadpool_boundaries() -> None:
     sync_routes = [
         chats_router.list_chats,
@@ -570,13 +582,12 @@ def test_create_chat_rejects_template_member_ids_for_group_participants() -> Non
     app = SimpleNamespace(state=state)
 
     with pytest.raises(HTTPException) as exc_info:
-        chats_router.create_chat(
+        _create_chat(
+            app,
             chats_router.CreateChatBody(
                 user_ids=["human-user-1", "agent-user-1", "agent-user-2"],
                 title="bad-group",
             ),
-            user_id="human-user-1",
-            app=app,
         )
 
     assert exc_info.value.status_code == 400
@@ -593,13 +604,12 @@ def test_create_chat_rejects_template_member_id_for_direct_participant() -> None
     app = SimpleNamespace(state=state)
 
     with pytest.raises(HTTPException) as exc_info:
-        chats_router.create_chat(
+        _create_chat(
+            app,
             chats_router.CreateChatBody(
                 user_ids=["human-user-1", "agent-user-1"],
                 title=None,
             ),
-            user_id="human-user-1",
-            app=app,
         )
 
     assert exc_info.value.status_code == 400
@@ -611,13 +621,12 @@ def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_particip
     state, called = _create_chat_route_state(thread_user_ids={"thread-user-1", "thread-user-2"})
     app = SimpleNamespace(state=state)
 
-    result = chats_router.create_chat(
+    result = _create_chat(
+        app,
         chats_router.CreateChatBody(
             user_ids=["human-user-1", "thread-user-1", "thread-user-2"],
             title="good-group",
         ),
-        user_id="human-user-1",
-        app=app,
     )
 
     assert called == [(["human-user-1", "thread-user-1", "thread-user-2"], "good-group")]
@@ -641,13 +650,12 @@ def test_create_group_chat_rejects_external_participant_without_active_relations
     app = SimpleNamespace(state=state)
 
     with pytest.raises(HTTPException) as exc_info:
-        chats_router.create_chat(
+        _create_chat(
+            app,
             chats_router.CreateChatBody(
                 user_ids=["human-user-1", "owned-agent-1", "human-user-2"],
                 title="bad-group",
             ),
-            user_id="human-user-1",
-            app=app,
         )
 
     assert exc_info.value.status_code == 400
@@ -667,13 +675,12 @@ def test_create_group_chat_accepts_external_active_contact_without_relationship(
     )
     app = SimpleNamespace(state=state)
 
-    result = chats_router.create_chat(
+    result = _create_chat(
+        app,
         chats_router.CreateChatBody(
             user_ids=["human-user-1", "owned-agent-1", "human-user-2"],
             title="contact-group",
         ),
-        user_id="human-user-1",
-        app=app,
     )
 
     assert called == [(["human-user-1", "owned-agent-1", "human-user-2"], "contact-group")]
@@ -693,13 +700,12 @@ def test_create_group_chat_accepts_agent_owned_by_external_active_contact() -> N
     )
     app = SimpleNamespace(state=state)
 
-    result = chats_router.create_chat(
+    result = _create_chat(
+        app,
         chats_router.CreateChatBody(
             user_ids=["human-user-1", "owned-agent-1", "external-agent-1"],
             title="owner-contact-agent-group",
         ),
-        user_id="human-user-1",
-        app=app,
     )
 
     assert called == [(["human-user-1", "owned-agent-1", "external-agent-1"], "owner-contact-agent-group")]
@@ -717,13 +723,12 @@ def test_create_group_chat_accepts_owned_agent_without_relationship() -> None:
     )
     app = SimpleNamespace(state=state)
 
-    result = chats_router.create_chat(
+    result = _create_chat(
+        app,
         chats_router.CreateChatBody(
             user_ids=["human-user-1", "owned-agent-1", "human-user-2"],
             title="good-group",
         ),
-        user_id="human-user-1",
-        app=app,
     )
 
     assert called == [(["human-user-1", "owned-agent-1", "human-user-2"], "good-group")]
@@ -735,13 +740,12 @@ def test_create_chat_rejects_unknown_participant_ids_instead_of_falling_to_stora
     app = SimpleNamespace(state=state)
 
     with pytest.raises(HTTPException) as exc_info:
-        chats_router.create_chat(
+        _create_chat(
+            app,
             chats_router.CreateChatBody(
                 user_ids=["human-user-1", "thread-id-not-a-user", "thread-user-2"],
                 title="bad-group",
             ),
-            user_id="human-user-1",
-            app=app,
         )
 
     assert exc_info.value.status_code == 400

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 from backend.chat.api.http import chats_router
 from backend.identity.avatar.urls import avatar_url
-from backend.web.core.dependencies import get_app, get_current_user_id
+from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow
 
 
@@ -28,7 +28,6 @@ def _route_test_app(state: SimpleNamespace) -> FastAPI:
     app.state = state
     app.include_router(chats_router.router)
     app.dependency_overrides[get_current_user_id] = lambda: "human-user-1"
-    app.dependency_overrides[get_app] = lambda: app
     return app
 
 
@@ -475,7 +474,6 @@ def test_send_message_consumes_service_owned_message_projection() -> None:
         chats_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
         user_id="owner-user-1",
         messaging_service=app.state.messaging_service,
-        app=app,
     )
 
     assert seen == [("chat-1", "thread-user-1", "hello")]
@@ -553,7 +551,6 @@ def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
         chats_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
         user_id="owner-user-1",
         messaging_service=app.state.messaging_service,
-        app=app,
     )
 
     assert seen == [("chat-1", "thread-user-1", "hello")]


### PR DESCRIPTION
## Summary
- inject explicit dependencies into create_chat instead of routing through app
- drop the stale app dependency from send_message
- remove a dead helper from chats_router

## Proof
- `uv run python -m pytest -q tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py`
- `uv run ruff check backend/chat/api/http/chats_router.py tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py`
- `uv run ruff format --check backend/chat/api/http/chats_router.py tests/Integration/test_messaging_router.py tests/Integration/test_auth_router.py`
- `git diff --check`