### PR TITLE
refactor(chat): make delivery wiring borrow messaging service

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -58,6 +58,10 @@ def attach_chat_runtime(
 
 
 def wire_chat_delivery(app: Any, *, messaging_service: Any, activity_reader: Any, thread_repo: Any) -> None:
+    # @@@chat-delivery-borrowed-service - delivery wiring runs after chat bootstrap,
+    # but it should still consume the already-constructed messaging service
+    # explicitly rather than re-reading app.state and silently depending on
+    # bootstrap ordering through a hidden state lookup.
     messaging_service.set_delivery_fn(
         make_chat_delivery_fn(
             app,

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -57,8 +57,8 @@ def attach_chat_runtime(
     app.state.messaging_service = messaging_service
 
 
-def wire_chat_delivery(app: Any, *, activity_reader: Any, thread_repo: Any) -> None:
-    app.state.messaging_service.set_delivery_fn(
+def wire_chat_delivery(app: Any, *, messaging_service: Any, activity_reader: Any, thread_repo: Any) -> None:
+    messaging_service.set_delivery_fn(
         make_chat_delivery_fn(
             app,
             activity_reader=activity_reader,

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -79,6 +79,7 @@ async def lifespan(app: FastAPI):
     attach_threads_runtime(app, storage_container)
     wire_chat_delivery(
         app,
+        messaging_service=app.state.messaging_service,
         activity_reader=app.state.agent_runtime_thread_activity_reader,
         thread_repo=app.state.thread_repo,
     )

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -180,8 +180,56 @@ def test_wire_chat_delivery_binds_delivery_fn(monkeypatch):
 
     chat_bootstrap.wire_chat_delivery(
         app,
+        messaging_service=messaging_service,
         activity_reader=activity_reader,
         thread_repo=thread_repo,
     )
 
     assert app.state.messaging_service.delivery_fn is delivery_fn
+
+
+def test_wire_chat_delivery_does_not_read_back_messaging_service(monkeypatch):
+    class _TrackingState:
+        def __init__(self):
+            object.__setattr__(self, "_values", {})
+            object.__setattr__(self, "reads", [])
+
+        def __getattribute__(self, name):
+            if name in {"_values", "reads", "__dict__", "__class__"}:
+                return object.__getattribute__(self, name)
+            reads = object.__getattribute__(self, "reads")
+            reads.append(name)
+            values = object.__getattribute__(self, "_values")
+            if name in values:
+                return values[name]
+            raise AttributeError(name)
+
+        def __setattr__(self, name, value):
+            self._values[name] = value
+
+    delivery_fn = object()
+    messaging_service = SimpleNamespace(delivery_fn=None)
+
+    def _set_delivery_fn(value):
+        messaging_service.delivery_fn = value
+
+    messaging_service.set_delivery_fn = _set_delivery_fn
+
+    tracking_state = _TrackingState()
+    app = SimpleNamespace(state=tracking_state)
+
+    monkeypatch.setattr(
+        chat_bootstrap,
+        "make_chat_delivery_fn",
+        lambda target_app, *, activity_reader, thread_repo: delivery_fn,
+    )
+
+    chat_bootstrap.wire_chat_delivery(
+        app,
+        messaging_service=messaging_service,
+        activity_reader=object(),
+        thread_repo=object(),
+    )
+
+    assert "messaging_service" not in tracking_state.reads
+    assert messaging_service.delivery_fn is delivery_fn

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -108,8 +108,9 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         app.state.agent_pool = {}
         app.state.agent_runtime_thread_activity_reader = object()
 
-    def _wire_chat_delivery(_app, *, activity_reader, thread_repo):
+    def _wire_chat_delivery(_app, *, messaging_service, activity_reader, thread_repo):
         call_log.append("wire")
+        assert messaging_service is _app.state.messaging_service
         assert activity_reader is _app.state.agent_runtime_thread_activity_reader
 
     _patch_lifespan_runtime_contract(


### PR DESCRIPTION
## Summary
- require wire_chat_delivery to accept the already-constructed messaging service explicitly
- pass that service explicitly from web lifespan after chat bootstrap
- keep the ordering and borrowing contract explicit in unit tests and code comments

## Proof
- `uv run python -m pytest -q tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py`
- `uv run ruff check backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py`
- `uv run ruff format --check backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py`
- `git diff --check`