### PR TITLE
refactor(chat): inject web consumer chat dependencies

### DIFF
--- a/backend/web/routers/contacts.py
+++ b/backend/web/routers/contacts.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.chat.runtime_access import get_contact_repo
-from backend.web.core.dependencies import get_app, get_current_user_id
+from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow
 
 router = APIRouter(prefix="/api/contacts", tags=["contacts"])
@@ -24,11 +24,13 @@ class SetContactBody(BaseModel):
 @router.get("")
 async def list_contacts(
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
 ):
     """List contacts (blocked/muted) for the current user."""
     try:
-        rows = get_contact_repo(app).list_for_user(user_id)
+        if contact_repo is None:
+            raise RuntimeError("chat bootstrap not attached: contact_repo")
+        rows = contact_repo.list_for_user(user_id)
     except RuntimeError as exc:
         raise HTTPException(503, str(exc)) from exc
     return [
@@ -50,11 +52,13 @@ async def list_contacts(
 async def set_contact(
     body: SetContactBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
 ):
     """Upsert contact (block/mute/normal)."""
     try:
-        get_contact_repo(app).upsert(
+        if contact_repo is None:
+            raise RuntimeError("chat bootstrap not attached: contact_repo")
+        contact_repo.upsert(
             ContactEdgeRow(
                 source_user_id=user_id,
                 target_user_id=body.target_user_id,
@@ -75,11 +79,13 @@ async def set_contact(
 async def delete_contact(
     target_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
 ):
     """Remove contact entry."""
     try:
-        get_contact_repo(app).delete(user_id, target_id)
+        if contact_repo is None:
+            raise RuntimeError("chat bootstrap not attached: contact_repo")
+        contact_repo.delete(user_id, target_id)
     except RuntimeError as exc:
         raise HTTPException(503, str(exc)) from exc
     return {"status": "deleted"}

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -167,6 +167,10 @@ async def list_chat_candidates(
             continue
         is_owned = user.type is UserType.AGENT and user.owner_user_id == user_id
         if is_owned and thread_repo is None:
+            # @@@owned-agent-thread-truth - owned agent candidates expose
+            # default_thread_id when available, so this consumer must fail loud
+            # when thread_repo is absent instead of silently pretending the
+            # owned agent has no thread truth.
             raise HTTPException(503, "Thread repo unavailable")
         relationship_state = relationship_states.get(user.id, "none")
         owner_user_id = str(user.owner_user_id) if user.type is UserType.AGENT and user.owner_user_id else None

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 
-from backend.chat.api.http.dependencies import get_thread_repo
+from backend.chat.api.http.dependencies import get_thread_repo, get_user_repo
 from backend.chat.runtime_access import get_contact_repo, get_relationship_service
 from backend.identity.avatar.files import process_and_save_avatar
 from backend.identity.avatar.paths import avatars_dir
@@ -127,13 +127,11 @@ async def delete_avatar(
 # ---------------------------------------------------------------------------
 
 
-def _relationship_states_for_user(app: Any, user_id: str) -> dict[str, str]:
-    try:
-        svc = get_relationship_service(app)
-    except RuntimeError as exc:
-        raise HTTPException(503, str(exc)) from exc
+def _relationship_states_for_user(relationship_service: Any, user_id: str) -> dict[str, str]:
+    if relationship_service is None:
+        raise HTTPException(503, "chat bootstrap not attached: relationship_service")
     states: dict[str, str] = {}
-    for row in svc.list_for_user(user_id):
+    for row in relationship_service.list_for_user(user_id):
         other_id = getattr(row, "other_user_id", None)
         if other_id is None:
             user_low = getattr(row, "user_low")
@@ -146,25 +144,30 @@ def _relationship_states_for_user(app: Any, user_id: str) -> dict[str, str]:
 @users_router.get("/chat-candidates")
 async def list_chat_candidates(
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
+    relationship_service: Annotated[Any, Depends(get_relationship_service)],
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
+    thread_repo: Annotated[Any, Depends(get_thread_repo)],
 ):
     """List chattable users for discovery (New Chat picker). Excludes the current user."""
-    user_repo = app.state.user_repo
     users = user_repo.list_all()
     user_map = {user.id: user for user in users}
-    relationship_states = _relationship_states_for_user(app, user_id)
+    relationship_states = _relationship_states_for_user(relationship_service, user_id)
     try:
-        contact_targets = active_contact_target_ids(get_contact_repo(app), user_id)
+        if contact_repo is None:
+            raise RuntimeError("chat bootstrap not attached: contact_repo")
+        contact_targets = active_contact_target_ids(contact_repo, user_id)
     except RuntimeError as exc:
         raise HTTPException(503, str(exc)) from exc
 
     items = []
-    thread_repo = get_thread_repo(app)
 
     for user in users:
         if user.id == user_id:
             continue
         is_owned = user.type is UserType.AGENT and user.owner_user_id == user_id
+        if is_owned and thread_repo is None:
+            raise HTTPException(503, "Thread repo unavailable")
         relationship_state = relationship_states.get(user.id, "none")
         owner_user_id = str(user.owner_user_id) if user.type is UserType.AGENT and user.owner_user_id else None
         can_chat = can_chat_with_owner_scope(

--- a/tests/Integration/test_contacts_schema_contract.py
+++ b/tests/Integration/test_contacts_schema_contract.py
@@ -42,7 +42,7 @@ async def test_list_contacts_exposes_directed_user_edge_shape() -> None:
 
     payload = await contacts_router.list_contacts(
         user_id="user-a",
-        app=SimpleNamespace(state=SimpleNamespace(contact_repo=repo)),
+        contact_repo=repo,
     )
 
     assert payload == [
@@ -66,7 +66,7 @@ async def test_set_contact_persists_directed_edge_contract() -> None:
     result = await contacts_router.set_contact(
         contacts_router.SetContactBody(target_user_id="user-b", kind="blocked", state="active"),
         user_id="user-a",
-        app=SimpleNamespace(state=SimpleNamespace(contact_repo=repo)),
+        contact_repo=repo,
     )
 
     assert result == {"status": "ok", "kind": "blocked", "state": "active"}
@@ -85,7 +85,7 @@ async def test_delete_contact_uses_directed_user_ids() -> None:
     result = await contacts_router.delete_contact(
         "user-b",
         user_id="user-a",
-        app=SimpleNamespace(state=SimpleNamespace(contact_repo=repo)),
+        contact_repo=repo,
     )
 
     assert result == {"status": "deleted"}
@@ -97,7 +97,7 @@ async def test_list_contacts_fails_loud_when_contact_repo_missing() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await contacts_router.list_contacts(
             user_id="user-a",
-            app=SimpleNamespace(state=SimpleNamespace()),
+            contact_repo=None,
         )
 
     assert exc_info.value.status_code == 503
@@ -110,7 +110,7 @@ async def test_set_contact_fails_loud_when_contact_repo_missing() -> None:
         await contacts_router.set_contact(
             contacts_router.SetContactBody(target_user_id="user-b", kind="blocked", state="active"),
             user_id="user-a",
-            app=SimpleNamespace(state=SimpleNamespace()),
+            contact_repo=None,
         )
 
     assert exc_info.value.status_code == 503
@@ -123,7 +123,7 @@ async def test_delete_contact_fails_loud_when_contact_repo_missing() -> None:
         await contacts_router.delete_contact(
             "user-b",
             user_id="user-a",
-            app=SimpleNamespace(state=SimpleNamespace()),
+            contact_repo=None,
         )
 
     assert exc_info.value.status_code == 503

--- a/tests/Integration/test_contacts_schema_contract.py
+++ b/tests/Integration/test_contacts_schema_contract.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 from fastapi import HTTPException
 

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -73,6 +73,16 @@ def _users_app(
     )
 
 
+def _list_chat_candidates(app: SimpleNamespace, *, user_id: str = "u1"):
+    return users_router.list_chat_candidates(
+        user_id=user_id,
+        user_repo=app.state.user_repo,
+        relationship_service=getattr(app.state, "relationship_service", None),
+        contact_repo=getattr(app.state, "contact_repo", None),
+        thread_repo=getattr(app.state, "thread_repo", None),
+    )
+
+
 @pytest.mark.asyncio
 async def test_list_chat_candidates_excludes_current_user_and_returns_all_others():
     current_user = _human("u1", "owner")
@@ -84,7 +94,7 @@ async def test_list_chat_candidates_excludes_current_user_and_returns_all_others
         relationships={"u2": "visit", "a-main": "pending"},
     )
 
-    result = await users_router.list_chat_candidates(user_id="u1", app=app)
+    result = await _list_chat_candidates(app)
 
     # Current user (u1) is excluded; all other users are returned.
     candidates = [(item["type"], item.get("user_id")) for item in result]
@@ -135,7 +145,7 @@ async def test_list_chat_candidates_excludes_current_user_and_returns_all_others
 async def test_list_chat_candidates_marks_owned_agents_as_chat_candidates_without_relationship():
     app = _users_app([_human("u1", "owner"), _agent("a-owned", "Morel", "u1")])
 
-    result = await users_router.list_chat_candidates(user_id="u1", app=app)
+    result = await _list_chat_candidates(app)
 
     assert result[0]["user_id"] == "a-owned"
     assert result[0]["is_owned"] is True
@@ -153,7 +163,7 @@ async def test_list_chat_candidates_exposes_default_thread_id_for_owned_agents_o
         },
     )
 
-    result = await users_router.list_chat_candidates(user_id="u1", app=app)
+    result = await _list_chat_candidates(app)
 
     ready = next(item for item in result if item["user_id"] == "a-owned-ready")
     cold = next(item for item in result if item["user_id"] == "a-owned-cold")
@@ -172,7 +182,7 @@ async def test_list_chat_candidates_fails_loud_when_owned_agent_threads_need_thr
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await users_router.list_chat_candidates(user_id="u1", app=app)
+        await _list_chat_candidates(app)
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Thread repo unavailable"
@@ -185,7 +195,7 @@ async def test_list_chat_candidates_marks_normal_active_contacts_as_chat_candida
         contact_repo=_active_contact_repo("u1", "u2"),
     )
 
-    result = await users_router.list_chat_candidates(user_id="u1", app=app)
+    result = await _list_chat_candidates(app)
 
     assert result == [
         {
@@ -209,7 +219,7 @@ async def test_list_chat_candidates_marks_agents_owned_by_active_contacts_as_cha
         contact_repo=_active_contact_repo("u1", "u2"),
     )
 
-    result = await users_router.list_chat_candidates(user_id="u1", app=app)
+    result = await _list_chat_candidates(app)
 
     human_item = next(item for item in result if item["user_id"] == "u2")
     agent_item = next(item for item in result if item["user_id"] == "a-other")
@@ -230,7 +240,7 @@ async def test_list_chat_candidates_fails_loud_when_relationship_service_missing
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await users_router.list_chat_candidates(user_id="u1", app=app)
+        await _list_chat_candidates(app)
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "chat bootstrap not attached: relationship_service"
@@ -247,7 +257,7 @@ async def test_list_chat_candidates_fails_loud_when_contact_repo_missing():
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await users_router.list_chat_candidates(user_id="u1", app=app)
+        await _list_chat_candidates(app)
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"


### PR DESCRIPTION
## Summary
- inject explicit contact repo into web contacts routes
- inject explicit relationship/contact/thread deps into users chat-candidates route
- keep web consumers honest about owned-agent thread truth

## Proof
- `uv run python -m pytest -q tests/Integration/test_contacts_schema_contract.py tests/Integration/test_users_router.py -k "contacts or chat_candidates"`
- `uv run ruff check backend/web/routers/contacts.py backend/web/routers/users.py tests/Integration/test_contacts_schema_contract.py tests/Integration/test_users_router.py`
- `uv run ruff format --check backend/web/routers/contacts.py backend/web/routers/users.py tests/Integration/test_contacts_schema_contract.py tests/Integration/test_users_router.py`
- `git diff --check`