### PR TITLE
refactor(chat): inject panel consumer dependencies

### DIFF
--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -89,11 +89,13 @@ async def create_agent(
     req: CreateAgentRequest,
     user_id: CurrentUserId,
     request: Request,
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     try:
-        contact_repo = get_contact_repo(request.app)
+        if contact_repo is None:
+            raise RuntimeError("chat bootstrap not attached: contact_repo")
     except RuntimeError as exc:
         raise HTTPException(503, str(exc)) from exc
     return await asyncio.to_thread(

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -94,6 +94,9 @@ async def create_agent(
     user_repo = request.app.state.user_repo
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     try:
+        # @@@panel-chat-consumer - panel owns the agent CRUD route, but contact
+        # edge cleanup is chat-owned truth. Borrow the repo explicitly so panel
+        # does not reach through request.app for chat runtime state.
         if contact_repo is None:
             raise RuntimeError("chat bootstrap not attached: contact_repo")
     except RuntimeError as exc:

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -184,19 +184,20 @@ async def delete_agent(
     agent_id: str,
     request: Request,
     user_id: CurrentUserId,
+    thread_repo: Annotated[Any, Depends(get_thread_repo)],
+    contact_repo: Annotated[Any, Depends(get_contact_repo)],
 ) -> dict[str, Any]:
     if agent_id == "__leon__":
         raise HTTPException(403, "Cannot delete builtin agent")
     user_repo = request.app.state.user_repo
     await asyncio.to_thread(_require_owned_agent_user, agent_id, user_id, user_repo)
-    try:
-        thread_repo = get_thread_repo(request.app)
-    except HTTPException:
-        raise
+    if thread_repo is None:
+        raise HTTPException(503, "Thread repo unavailable")
     await asyncio.to_thread(_ensure_agent_has_no_threads_or_409, agent_id, thread_repo)
     agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
     try:
-        contact_repo = get_contact_repo(request.app)
+        if contact_repo is None:
+            raise RuntimeError("chat bootstrap not attached: contact_repo")
     except RuntimeError as exc:
         raise HTTPException(503, str(exc)) from exc
     ok = await asyncio.to_thread(

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -422,6 +422,7 @@ async def test_create_agent_route_fails_loud_when_contact_repo_missing():
             panel_router.CreateAgentRequest(name="Toad", description="probe"),
             request=request,
             user_id="user-1",
+            contact_repo=None,
         )
 
     assert exc_info.value.status_code == 503

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -130,6 +130,8 @@ async def test_delete_agent_route_keeps_builtin_guard_before_owner_lookup(monkey
             "__leon__",
             request=SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(user_repo=SimpleNamespace()))),
             user_id="user-1",
+            thread_repo=SimpleNamespace(),
+            contact_repo=SimpleNamespace(),
         )
 
     assert excinfo.value.status_code == 403
@@ -155,6 +157,8 @@ async def test_delete_agent_route_rejects_agent_with_existing_threads(monkeypatc
                 )
             ),
             user_id="user-1",
+            thread_repo=SimpleNamespace(list_by_agent_user=lambda agent_user_id: [{"id": f"{agent_user_id}-1"}]),
+            contact_repo=SimpleNamespace(),
         )
 
     assert excinfo.value.status_code == 409

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -447,6 +447,8 @@ async def test_delete_agent_route_fails_loud_when_contact_repo_missing(monkeypat
             "agent-1",
             request=request,
             user_id="user-1",
+            thread_repo=request.app.state.thread_repo,
+            contact_repo=None,
         )
 
     assert exc_info.value.status_code == 503
@@ -471,6 +473,8 @@ async def test_delete_agent_route_fails_loud_when_thread_repo_missing(monkeypatc
             "agent-1",
             request=request,
             user_id="user-1",
+            thread_repo=None,
+            contact_repo=request.app.state.contact_repo,
         )
 
     assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary
- inject explicit contact repo into panel create_agent route
- inject explicit thread/contact deps into panel delete_agent route
- keep the panel/chat borrowed-consumer contract explicit in code comments

## Proof
- `uv run python -m pytest -q tests/Integration/test_panel_auth_shell_coherence.py -k "create_agent_route_fails_loud or delete_agent_route_fails_loud"`
- `uv run ruff check backend/web/routers/panel.py tests/Integration/test_panel_auth_shell_coherence.py`
- `uv run ruff format --check backend/web/routers/panel.py tests/Integration/test_panel_auth_shell_coherence.py`
- `git diff --check`