### PR TITLE
Fix runtime shutdown cleanup noise

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -949,7 +949,15 @@ class LeonAgent:
         if async_client is not None:
             await async_client.aclose()
         if sync_client is not None:
-            await asyncio.to_thread(sync_client.close)
+            try:
+                await asyncio.to_thread(sync_client.close)
+            except RuntimeError as exc:
+                # @@@shutdown-sync-close - interpreter shutdown can make to_thread
+                # unavailable after product work already completed; fall back to a
+                # direct close instead of turning cleanup noise into a fake blocker.
+                if "interpreter shutdown" not in str(exc):
+                    raise
+                sync_client.close()
 
     def _build_session_hook_payload(self, event: str) -> dict[str, Any]:
         return {

--- a/tests/Unit/core/test_agent_model_clients.py
+++ b/tests/Unit/core/test_agent_model_clients.py
@@ -98,3 +98,24 @@ async def test_runtime_model_client_cleanup_falls_back_when_to_thread_unavailabl
     assert events == ["async", "sync"]
     assert agent._model_http_client is None
     assert agent._model_http_async_client is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_model_client_cleanup_reraises_unexpected_runtimeerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _SyncClient:
+        def close(self) -> None:
+            raise AssertionError("sync close should stay inside to_thread")
+
+    async def _boom(_fn: Any, *_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("some other runtime problem")
+
+    monkeypatch.setattr("core.runtime.agent.asyncio.to_thread", _boom)
+
+    agent = cast(Any, object.__new__(LeonAgent))
+    agent._model_http_client = _SyncClient()
+    agent._model_http_async_client = None
+
+    with pytest.raises(RuntimeError, match="some other runtime problem"):
+        await LeonAgent._cleanup_model_clients(agent)

--- a/tests/Unit/core/test_agent_model_clients.py
+++ b/tests/Unit/core/test_agent_model_clients.py
@@ -68,3 +68,33 @@ async def test_runtime_model_client_cleanup_closes_both_clients() -> None:
     assert events == ["async", "sync"]
     assert agent._model_http_client is None
     assert agent._model_http_async_client is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_model_client_cleanup_falls_back_when_to_thread_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class _SyncClient:
+        def close(self) -> None:
+            events.append("sync")
+
+    class _AsyncClient:
+        async def aclose(self) -> None:
+            events.append("async")
+
+    async def _boom(_fn: Any, *_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+    monkeypatch.setattr("core.runtime.agent.asyncio.to_thread", _boom)
+
+    agent = cast(Any, object.__new__(LeonAgent))
+    agent._model_http_client = _SyncClient()
+    agent._model_http_async_client = _AsyncClient()
+
+    await LeonAgent._cleanup_model_clients(agent)
+
+    assert events == ["async", "sync"]
+    assert agent._model_http_client is None
+    assert agent._model_http_async_client is None

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -75,6 +75,40 @@ def test_close_uses_shutdown_fallback_for_model_client_cleanup(monkeypatch: pyte
 
     assert events == ["async", "sync"]
     assert agent._closed is True
+    assert agent._model_http_client is None
+    assert agent._model_http_async_client is None
+
+
+def test_close_logs_unexpected_runtimeerror_from_model_client_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    events: list[str] = []
+
+    class _SyncClient:
+        def close(self) -> None:
+            events.append("sync")
+
+    async def _boom(_fn, *_args, **_kwargs):
+        raise RuntimeError("some other runtime problem")
+
+    monkeypatch.setattr("core.runtime.agent.asyncio.to_thread", _boom)
+
+    agent = object.__new__(LeonAgent)
+    agent._session_started = False
+    agent._session_ended = False
+    agent._closing = False
+    agent._closed = False
+    agent._model_http_client = _SyncClient()
+    agent._model_http_async_client = None
+    agent._cleanup_registry = CleanupRegistry()
+    agent._cleanup_registry.register(agent._cleanup_model_clients, priority=1)
+
+    LeonAgent.close(agent)
+
+    assert "some other runtime problem" in caplog.text
+    assert events == []
+    assert agent._closed is True
 
 
 def test_memory_config_override_updates_compaction_trigger_without_losing_defaults():

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -2,8 +2,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from core.runtime.abort import AbortController
 from core.runtime.agent import LeonAgent
+from core.runtime.cleanup import CleanupRegistry
 from core.runtime.state import BootstrapConfig
 
 
@@ -40,6 +43,38 @@ def test_close_skips_sandbox_cleanup_and_stays_idempotent():
     agent._cleanup_sandbox.assert_not_called()
     agent._mark_terminated.assert_called_once()
     agent._cleanup_mcp_client.assert_called_once()
+
+
+def test_close_uses_shutdown_fallback_for_model_client_cleanup(monkeypatch: pytest.MonkeyPatch):
+    events: list[str] = []
+
+    class _SyncClient:
+        def close(self) -> None:
+            events.append("sync")
+
+    class _AsyncClient:
+        async def aclose(self) -> None:
+            events.append("async")
+
+    async def _boom(_fn, *_args, **_kwargs):
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+    monkeypatch.setattr("core.runtime.agent.asyncio.to_thread", _boom)
+
+    agent = object.__new__(LeonAgent)
+    agent._session_started = False
+    agent._session_ended = False
+    agent._closing = False
+    agent._closed = False
+    agent._model_http_client = _SyncClient()
+    agent._model_http_async_client = _AsyncClient()
+    agent._cleanup_registry = CleanupRegistry()
+    agent._cleanup_registry.register(agent._cleanup_model_clients, priority=1)
+
+    LeonAgent.close(agent)
+
+    assert events == ["async", "sync"]
+    assert agent._closed is True
 
 
 def test_memory_config_override_updates_compaction_trigger_without_losing_defaults():

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -111,6 +111,38 @@ def test_close_logs_unexpected_runtimeerror_from_model_client_cleanup(
     assert agent._closed is True
 
 
+def test_close_remains_idempotent_after_shutdown_fallback(monkeypatch: pytest.MonkeyPatch):
+    events: list[str] = []
+
+    class _SyncClient:
+        def close(self) -> None:
+            events.append("sync")
+
+    class _AsyncClient:
+        async def aclose(self) -> None:
+            events.append("async")
+
+    async def _boom(_fn, *_args, **_kwargs):
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+    monkeypatch.setattr("core.runtime.agent.asyncio.to_thread", _boom)
+
+    agent = object.__new__(LeonAgent)
+    agent._session_started = False
+    agent._session_ended = False
+    agent._closing = False
+    agent._closed = False
+    agent._model_http_client = _SyncClient()
+    agent._model_http_async_client = _AsyncClient()
+    agent._cleanup_registry = CleanupRegistry()
+    agent._cleanup_registry.register(agent._cleanup_model_clients, priority=1)
+
+    LeonAgent.close(agent)
+    LeonAgent.close(agent)
+
+    assert events == ["async", "sync"]
+
+
 def test_memory_config_override_updates_compaction_trigger_without_losing_defaults():
     from config.schema import LeonSettings
 

--- a/tests/Unit/core/test_runtime_support.py
+++ b/tests/Unit/core/test_runtime_support.py
@@ -194,6 +194,21 @@ async def test_cleanup_registry_runs_in_priority_order_and_survives_failures():
 
 
 @pytest.mark.asyncio
+async def test_cleanup_registry_logs_fail_loud_exception(caplog):
+    reg = CleanupRegistry()
+
+    def failing():
+        raise RuntimeError("boom")
+
+    reg.register(failing, priority=1)
+
+    await reg.run_cleanup()
+
+    assert "CleanupRegistry: error in cleanup fn" in caplog.text
+    assert "boom" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_cleanup_registry_reuses_first_inflight_run():
     order = []
     release = asyncio.Event()


### PR DESCRIPTION
## Summary
- fall back to direct sync model-client close when interpreter shutdown makes asyncio.to_thread unavailable
- harden model-client cleanup tests around shutdown fallback, unexpected runtime errors, and idempotent close behavior
- lock CleanupRegistry fail-loud logging coverage for cleanup failures

## Verification
- uv run pytest -q tests/Unit/core/test_agent_model_clients.py tests/Unit/core/test_runtime_agent.py -k 'cleanup'
- uv run pytest -q tests/Unit/core/test_runtime_support.py -k 'cleanup_registry'
- git diff --check origin/dev..HEAD

## Product proof
- on current shared dev, auth + panel + thread create/send/history stayed green
- monitor/eval batch create/start/completion also stayed green
- backend shutdown no longer reproduced the earlier CleanupRegistry/interpreter-shutdown noise after a real thread run