### PR TITLE
refactor(chat): borrow messaging service in agent pool

### DIFF
--- a/backend/chat/runtime_access.py
+++ b/backend/chat/runtime_access.py
@@ -16,6 +16,10 @@ def get_messaging_service(app: Any) -> Any:
     return _require_chat_state(app, "messaging_service")
 
 
+def get_optional_messaging_service(app: Any) -> Any | None:
+    return getattr(app.state, "messaging_service", None)
+
+
 def get_typing_tracker(app: Any) -> Any:
     return _require_chat_state(app, "typing_tracker")
 

--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -15,6 +15,10 @@ async def get_or_create_agent(*args, **kwargs):
     _registry.get_file_channel_binding = get_file_channel_binding
     _registry.resolve_thread_sandbox = resolve_thread_sandbox
     if "messaging_service" not in kwargs and app is not None:
+        # @@@agent-pool-chat-borrow - registry owns thread-runtime lifecycle,
+        # but chat-owned messaging_service is still needed when chat_repos are
+        # constructed. Borrow it here so registry does not reach back through
+        # app state for chat truth on its own.
         kwargs["messaging_service"] = get_messaging_service(app)
     return await _registry.get_or_create_agent(*args, **kwargs)
 

--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -1,6 +1,6 @@
 """Agent pool management service."""
 
-from backend.chat.runtime_access import get_messaging_service
+from backend.chat.runtime_access import get_optional_messaging_service
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.pool import registry as _registry
 from backend.threads.pool.factory import create_agent_sync
@@ -19,7 +19,9 @@ async def get_or_create_agent(*args, **kwargs):
         # but chat-owned messaging_service is still needed when chat_repos are
         # constructed. Borrow it here so registry does not reach back through
         # app state for chat truth on its own.
-        kwargs["messaging_service"] = get_messaging_service(app)
+        messaging_service = get_optional_messaging_service(app)
+        if messaging_service is not None:
+            kwargs["messaging_service"] = messaging_service
     return await _registry.get_or_create_agent(*args, **kwargs)
 
 

--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -1,5 +1,6 @@
 """Agent pool management service."""
 
+from backend.chat.runtime_access import get_messaging_service
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.pool import registry as _registry
 from backend.threads.pool.factory import create_agent_sync
@@ -8,10 +9,13 @@ from core.identity.agent_registry import get_or_create_agent_id
 
 
 async def get_or_create_agent(*args, **kwargs):
+    app = args[0] if args else kwargs.get("app_obj")
     _registry.create_agent_sync = create_agent_sync
     _registry.get_or_create_agent_id = get_or_create_agent_id
     _registry.get_file_channel_binding = get_file_channel_binding
     _registry.resolve_thread_sandbox = resolve_thread_sandbox
+    if "messaging_service" not in kwargs and app is not None:
+        kwargs["messaging_service"] = get_messaging_service(app)
     return await _registry.get_or_create_agent(*args, **kwargs)
 
 

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -27,7 +27,14 @@ _config_update_locks: dict[str, asyncio.Lock] = {}
 _agent_create_locks: dict[str, asyncio.Lock] = {}
 
 
-async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: str | None = None, agent: str | None = None) -> Any:
+async def get_or_create_agent(
+    app_obj: FastAPI,
+    sandbox_type: str,
+    thread_id: str | None = None,
+    agent: str | None = None,
+    *,
+    messaging_service: Any | None = None,
+) -> Any:
     """Lazy agent pool — one agent per thread, created on demand."""
     if thread_id:
         set_current_thread_id(thread_id)
@@ -131,7 +138,7 @@ async def get_or_create_agent(app_obj: FastAPI, sandbox_type: str, thread_id: st
                 "chat_identity_id": agent_user_id,
                 "owner_id": owner_id,
                 "user_repo": user_repo,
-                "messaging_service": get_messaging_service(app_obj),
+                "messaging_service": messaging_service if messaging_service is not None else get_messaging_service(app_obj),
                 "agent_config_repo": getattr(app_obj.state, "agent_config_repo", None),
             }
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -20,6 +20,27 @@ class _EmptyAgentConfigRepo:
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+    messaging_service = object()
+
+    async def _fake_registry_get_or_create_agent(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
+    monkeypatch.setattr(agent_pool, "get_messaging_service", lambda app: messaging_service, raising=False)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-borrowed")
+
+    kwargs = cast(dict[str, object], captured["kwargs"])
+    assert kwargs["messaging_service"] is messaging_service
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_creates_once_per_thread(monkeypatch: pytest.MonkeyPatch):
     created: list[object] = []
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -41,6 +41,56 @@ async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkey
 
 
 @pytest.mark.asyncio
+async def test_registry_get_or_create_agent_uses_explicit_messaging_service(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+    messaging_service = object()
+
+    def _fake_create_agent_sync(**kwargs) -> object:
+        captured["chat_repos"] = kwargs.get("chat_repos")
+        return SimpleNamespace()
+
+    class _ThreadRepo:
+        def get_by_id(self, thread_id: str):
+            return {
+                "id": thread_id,
+                "agent_user_id": "agent-user-explicit",
+                "cwd": None,
+                "model": "leon:large",
+            }
+
+    class _UserRepo:
+        def get_by_id(self, user_id: str):
+            return SimpleNamespace(id=user_id, owner_user_id="owner-explicit", agent_config_id="cfg-explicit")
+
+    monkeypatch.setattr(agent_pool._registry, "create_agent_sync", _fake_create_agent_sync)
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-explicit")
+    monkeypatch.setattr(agent_pool._registry, "get_file_channel_binding", lambda _thread_id: (_ for _ in ()).throw(ValueError()), raising=False)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_ThreadRepo(),
+            user_repo=_UserRepo(),
+            agent_config_repo=_EmptyAgentConfigRepo(),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    await agent_pool._registry.get_or_create_agent(
+        cast(Any, app),
+        "local",
+        thread_id="thread-explicit",
+        messaging_service=messaging_service,
+    )
+
+    chat_repos = cast(dict[str, object], captured["chat_repos"])
+    assert chat_repos["messaging_service"] is messaging_service
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_creates_once_per_thread(monkeypatch: pytest.MonkeyPatch):
     created: list[object] = []
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -66,7 +66,9 @@ async def test_registry_get_or_create_agent_uses_explicit_messaging_service(
 
     monkeypatch.setattr(agent_pool._registry, "create_agent_sync", _fake_create_agent_sync)
     monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-explicit")
-    monkeypatch.setattr(agent_pool._registry, "get_file_channel_binding", lambda _thread_id: (_ for _ in ()).throw(ValueError()), raising=False)
+    monkeypatch.setattr(
+        agent_pool._registry, "get_file_channel_binding", lambda _thread_id: (_ for _ in ()).throw(ValueError()), raising=False
+    )
 
     app = SimpleNamespace(
         state=SimpleNamespace(

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -30,7 +30,7 @@ async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkey
         return SimpleNamespace()
 
     monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
-    monkeypatch.setattr(agent_pool, "get_messaging_service", lambda app: messaging_service, raising=False)
+    monkeypatch.setattr(agent_pool, "get_optional_messaging_service", lambda app: messaging_service, raising=False)
 
     app = SimpleNamespace(state=SimpleNamespace())
 
@@ -38,6 +38,25 @@ async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkey
 
     kwargs = cast(dict[str, object], captured["kwargs"])
     assert kwargs["messaging_service"] is messaging_service
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_agent_skips_borrow_when_chat_bootstrap_missing(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_registry_get_or_create_agent(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-no-chat")
+
+    kwargs = cast(dict[str, object], captured["kwargs"])
+    assert "messaging_service" not in kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- borrow chat-owned messaging_service in activity_pool_service instead of letting registry reach through app state
- let registry accept an explicit messaging_service when constructing chat_repos
- lock the borrowed-service contract in focused agent pool tests and a small @@@ note

## Proof
- `uv run python -m pytest -q tests/Unit/core/test_agent_pool.py -k "borrows_messaging_service_for_registry or explicit_messaging_service or chat_repos_need_missing_messaging_service"`
- `uv run ruff check backend/threads/activity_pool_service.py backend/threads/pool/registry.py tests/Unit/core/test_agent_pool.py`
- `uv run ruff format --check backend/threads/activity_pool_service.py backend/threads/pool/registry.py tests/Unit/core/test_agent_pool.py`
- `git diff --check`