### PR TITLE
Fix Daytona inventory contract drift

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -122,18 +122,9 @@ def _build_providers_and_managers(
                 providers[name] = DaytonaProvider(
                     api_key=key,
                     api_url=config.daytona.api_url,
-                    server_url=config.daytona.server_url,
                     target=config.daytona.target,
-                    default_public=config.daytona.default_public,
-                    default_snapshot=config.daytona.default_snapshot,
-                    default_cpu=config.daytona.default_cpu,
-                    default_memory=config.daytona.default_memory,
-                    default_disk=config.daytona.default_disk,
-                    default_gpu=config.daytona.default_gpu,
-                    default_image=config.daytona.default_image,
-                    default_user=config.daytona.default_user,
-                    workspace_provider=config.daytona.workspace_provider,
-                    workspace_provider_metadata=config.daytona.workspace_provider_metadata,
+                    default_cwd=config.daytona.cwd,
+                    bind_mounts=config.daytona.bind_mounts,
                     provider_name=name,
                 )
             else:

--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -119,6 +119,11 @@ def _build_providers_and_managers(
                 key = _configured_api_key(name, config.daytona.api_key, "DAYTONA_API_KEY")
                 if not key:
                     continue
+                # @@@daytona-inventory-contract - current Daytona config/provider
+                # shape is the narrow api_url/target/cwd/bind_mounts contract.
+                # Do not reintroduce the older wider default_* / server_url /
+                # workspace_provider argument set here unless the provider and
+                # schema grow those fields again together.
                 providers[name] = DaytonaProvider(
                     api_key=key,
                     api_url=config.daytona.api_url,

--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -49,6 +49,9 @@ def _public_runtime_payload(row: dict[str, Any]) -> dict[str, Any]:
 @router.get("/types")
 async def list_sandbox_types() -> dict[str, Any]:
     """List available sandbox types."""
+    # @@@sandbox-type-availability - this route reflects the current process
+    # inventory contract: configured providers are either instantiated and
+    # exposed as available, or reported unavailable with an explicit reason.
     types = await asyncio.to_thread(sandbox_provider_availability.available_sandbox_types)
     return {"types": types}
 

--- a/tests/Integration/test_sandbox_router_user_shell.py
+++ b/tests/Integration/test_sandbox_router_user_shell.py
@@ -52,6 +52,27 @@ def test_sandbox_runtime_routes_do_not_expose_session_paths() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_sandbox_types_reports_current_daytona_provider_when_inventory_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sandbox_router.sandbox_provider_availability,
+        "available_sandbox_types",
+        lambda: [
+            {"name": "local", "provider": "local", "available": True},
+            {"name": "daytona_selfhost", "provider": "daytona", "available": True},
+        ],
+    )
+
+    result = await sandbox_router.list_sandbox_types()
+
+    assert result["types"] == [
+        {"name": "local", "provider": "local", "available": True},
+        {"name": "daytona_selfhost", "provider": "daytona", "available": True},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_list_sandbox_runtimes_strips_lower_runtime_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sandbox_router, "init_providers_and_managers", lambda: ({}, {"local": object()}))
     monkeypatch.setattr(

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -158,3 +158,35 @@ def test_build_providers_and_managers_uses_current_daytona_contract(monkeypatch,
         "bind_mounts": [],
         "provider_name": "daytona_selfhost",
     }
+
+
+def test_available_sandbox_types_marks_daytona_unavailable_when_api_key_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    local_provider = LocalSessionProvider(default_cwd=str(tmp_path))
+    (tmp_path / "daytona_selfhost.json").write_text("{}")
+
+    monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
+    monkeypatch.setattr(
+        sandbox_service,
+        "init_providers_and_managers",
+        lambda: ({"local": local_provider}, {}),
+    )
+    monkeypatch.setattr(
+        sandbox_service.SandboxConfig,
+        "load",
+        classmethod(
+            lambda cls, name: SimpleNamespace(
+                provider="daytona",
+                name=name,
+            )
+        ),
+    )
+
+    types = sandbox_service.available_sandbox_types()
+    daytona = next(item for item in types if item["name"] == "daytona_selfhost")
+
+    assert daytona["provider"] == "daytona"
+    assert daytona["available"] is False
+    assert "unavailable in the current process" in daytona["reason"]

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -103,3 +103,58 @@ def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides
     assert "agentbay" in managers
     assert captured["supports_pause"] is False
     assert captured["supports_resume"] is False
+
+
+def test_build_providers_and_managers_uses_current_daytona_contract(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "daytona_selfhost.json").write_text("{}")
+    monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
+
+    captured: dict[str, object] = {}
+
+    class _FakeDaytonaProvider:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+            self.name = kwargs["provider_name"]
+
+        def get_capability(self):
+            return SimpleNamespace(can_pause=True, can_resume=True, can_destroy=True)
+
+    class _FakeSandboxManager:
+        def __init__(self, provider, db_path=None) -> None:
+            self.provider = provider
+            self.db_path = db_path
+
+    monkeypatch.setattr(sandbox_service, "SandboxManager", _FakeSandboxManager)
+    monkeypatch.setattr(
+        sandbox_service.SandboxConfig,
+        "load",
+        classmethod(
+            lambda cls, name: SimpleNamespace(
+                provider="daytona",
+                daytona=SimpleNamespace(
+                    api_key="test-key",
+                    api_url="https://example.daytona/api",
+                    target="self-host",
+                    cwd="/home/daytona",
+                    bind_mounts=[],
+                ),
+            )
+        ),
+    )
+
+    import sandbox.providers.daytona as daytona_module
+
+    monkeypatch.setattr(daytona_module, "DaytonaProvider", _FakeDaytonaProvider)
+
+    providers, managers = sandbox_service._build_providers_and_managers()
+
+    assert "daytona_selfhost" in providers
+    assert "daytona_selfhost" in managers
+    assert captured == {
+        "api_key": "test-key",
+        "api_url": "https://example.daytona/api",
+        "target": "self-host",
+        "default_cwd": "/home/daytona",
+        "bind_mounts": [],
+        "provider_name": "daytona_selfhost",
+    }


### PR DESCRIPTION
## Summary
- align backend sandbox inventory with the current Daytona config/provider contract
- add provider-availability tests so configured daytona/daytona_selfhost no longer gets dropped by stale inventory args
- lock the owner-facing sandbox availability route contract and preserve missing-key unavailable behavior

## Verification
- uv run pytest -q tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Integration/test_sandbox_router_user_shell.py
- git diff --check origin/dev..HEAD

## Runtime proof
- isolated backend startup on :18010 reached Application startup complete without the old daytona/daytona_selfhost init warnings
- GET /api/sandbox/types returned configured Daytona provider as available when keys were present