### PR TITLE
refactor(chat): borrow typing tracker explicitly for threads runtime

### DIFF
--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -20,4 +20,7 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
     app.state.thread_event_buffers = {}
     app.state.subagent_buffers = {}
     app.state.thread_last_active = {}
+    # @@@threads-bootstrap-borrowed-typing-tracker - threads runtime needs
+    # chat-owned typing state for agent chat delivery, but the borrow is made
+    # at bootstrap so downstream gateway setup does not reopen app.state.
     app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=typing_tracker)

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -9,7 +9,7 @@ from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
 from core.runtime.middleware.queue import MessageQueueManager
 
 
-def attach_threads_runtime(app: Any, storage_container: Any) -> None:
+def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> None:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.agent_pool = {}
     app.state.thread_sandbox = {}
@@ -20,4 +20,4 @@ def attach_threads_runtime(app: Any, storage_container: Any) -> None:
     app.state.thread_event_buffers = {}
     app.state.subagent_buffers = {}
     app.state.thread_last_active = {}
-    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)
+    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=typing_tracker)

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -14,7 +14,7 @@ from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputH
 from backend.threads.streaming import _ensure_thread_handlers, start_agent_run
 
 
-def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
+def build_agent_runtime_gateway(app: Any, *, typing_tracker: Any) -> NativeAgentRuntimeGateway:
     app.state.agent_runtime_thread_activity_reader = AppRuntimeThreadActivityReader(
         thread_repo=app.state.thread_repo,
         agent_pool=app.state.agent_pool,
@@ -24,7 +24,11 @@ def build_agent_runtime_gateway(app: Any) -> NativeAgentRuntimeGateway:
             "mycel": NativeAgentChatDeliveryHandler(
                 runtime_services=AppAgentChatRuntimeServices(
                     app,
-                    typing_tracker=app.state.typing_tracker,
+                    # @@@chat-runtime-borrowed-typing-tracker - threads runtime
+                    # consumes chat-owned typing state, but the borrow happens at
+                    # bootstrap so this gateway builder does not reach back
+                    # through app.state for chat truth on its own.
+                    typing_tracker=typing_tracker,
                     queue_manager=app.state.queue_manager,
                     get_or_create_agent=get_or_create_agent,
                     resolve_thread_sandbox=resolve_thread_sandbox,

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -76,7 +76,7 @@ async def lifespan(app: FastAPI):
         user_repo=app.state.user_repo,
         thread_repo=app.state.thread_repo,
     )
-    attach_threads_runtime(app, storage_container)
+    attach_threads_runtime(app, storage_container, typing_tracker=app.state.typing_tracker)
     wire_chat_delivery(
         app,
         messaging_service=app.state.messaging_service,

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -2590,7 +2590,7 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)
+    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
 
     with pytest.raises(AttributeError):
         await asyncio.to_thread(
@@ -2660,7 +2660,7 @@ async def _run_chat_delivery(
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app)
+    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
 
     await asyncio.to_thread(
         chat_delivery_hook.make_chat_delivery_fn(

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -526,7 +526,7 @@ def _make_streaming_app(
         state.thread_sandbox = {thread_id: "local"}
         state._event_loop = asyncio.get_running_loop()
     app = SimpleNamespace(state=state)
-    state.agent_runtime_gateway = build_agent_runtime_gateway(app)
+    state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=state.typing_tracker)
     return app, queue_manager
 
 
@@ -1246,7 +1246,7 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", fake_get_or_create_agent)
 
     startup_task = asyncio.create_task(
-        build_agent_runtime_gateway(app).dispatch_thread_input(
+        build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(
             AgentThreadInputEnvelope(
                 thread_id=thread_id,
                 sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from backend.threads import bootstrap as threads_bootstrap
 
 
@@ -7,6 +9,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     queue_repo = object()
     queue_manager = object()
     gateway = object()
+    typing_tracker = object()
     seen: list[tuple[str, object]] = []
 
     storage_container = SimpleNamespace(queue_repo=lambda: queue_repo)
@@ -20,10 +23,12 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     monkeypatch.setattr(
         threads_bootstrap,
         "build_agent_runtime_gateway",
-        lambda target_app: seen.append(("gateway", target_app)) or gateway,
+        lambda target_app, *, typing_tracker: (
+            seen.append(("gateway", target_app)) or seen.append(("typing_tracker", typing_tracker)) or gateway
+        ),
     )
 
-    threads_bootstrap.attach_threads_runtime(app, storage_container)
+    threads_bootstrap.attach_threads_runtime(app, storage_container, typing_tracker=typing_tracker)
 
     assert app.state.queue_manager is queue_manager
     assert app.state.agent_pool == {}
@@ -37,6 +42,15 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert seen == [
         ("queue_manager", queue_repo),
         ("gateway", app),
+        ("typing_tracker", typing_tracker),
     ]
     assert hasattr(app.state, "thread_locks_guard")
     assert hasattr(app.state, "thread_locks")
+
+
+def test_attach_threads_runtime_requires_explicit_typing_tracker():
+    app = SimpleNamespace(state=SimpleNamespace())
+    storage_container = SimpleNamespace(queue_repo=lambda: object())
+
+    with pytest.raises(TypeError, match="typing_tracker"):
+        threads_bootstrap.attach_threads_runtime(app, storage_container)

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -74,9 +74,10 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
         app.state.typing_tracker = object()
         app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
 
-    def _attach_threads_runtime(app, _storage_container):
+    def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
         if not hasattr(app.state, "typing_tracker"):
             raise RuntimeError("threads runtime needs typing_tracker first")
+        assert typing_tracker is app.state.typing_tracker
         app.state.agent_pool = {}
         app.state.agent_runtime_thread_activity_reader = object()
 
@@ -103,8 +104,9 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         app.state.typing_tracker = object()
         app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
 
-    def _attach_threads_runtime(app, _storage_container):
+    def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
         call_log.append("threads")
+        assert typing_tracker is app.state.typing_tracker
         app.state.agent_pool = {}
         app.state.agent_runtime_thread_activity_reader = object()
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
@@ -56,7 +56,7 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
         message=AgentRuntimeMessage(content="hello", signal="ping"),
     )
 
-    result = await build_agent_runtime_gateway(app).dispatch_chat(envelope)
+    result = await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_chat(envelope)
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-preselected"

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -76,7 +76,7 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     app, started, unread_calls, enqueued = _app()
 
-    result = await build_agent_runtime_gateway(app).dispatch_chat(_envelope())
+    result = await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_chat(_envelope())
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-1"
@@ -93,8 +93,30 @@ async def test_gateway_dispatch_chat_raises_for_missing_thread(monkeypatch: pyte
     app, started, unread_calls, enqueued = _app(threads=[])
 
     with pytest.raises(RuntimeError, match="Agent chat recipient has no runtime thread: agent-user-1"):
-        await build_agent_runtime_gateway(app).dispatch_chat(_envelope(thread_id=None))
+        await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_chat(_envelope(thread_id=None))
 
     assert started == []
     assert unread_calls == []
     assert enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_dispatch_chat_uses_explicit_typing_tracker(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
+        return SimpleNamespace(id=f"agent-for-{thread_id}")
+
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    app, _started, _unread_calls, enqueued = _app()
+    started: list[tuple[str, str, str]] = []
+    app.state.typing_tracker = SimpleNamespace(
+        start_chat=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should use explicit typing tracker"))
+    )
+    explicit_typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
+
+    result = await build_agent_runtime_gateway(app, typing_tracker=explicit_typing_tracker).dispatch_chat(_envelope())
+
+    assert result.status == "accepted"
+    assert started == [("thread-1", "chat-1", "agent-user-1")]
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -70,7 +70,7 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache") as clear_cache,
     ):
-        result = await build_agent_runtime_gateway(app).dispatch_thread_input(_thread_input())
+        result = await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(_thread_input())
 
     assert result == AgentThreadInputResult(status="started", routing="direct", run_id="run-123", thread_id="thread-1")
     clear_cache.assert_called_once_with()
@@ -87,7 +87,7 @@ async def test_gateway_thread_input_requires_agent_runtime() -> None:
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
         with pytest.raises(AttributeError):
-            await build_agent_runtime_gateway(app).dispatch_thread_input(_thread_input())
+            await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(_thread_input())
 
 
 @pytest.mark.asyncio
@@ -101,6 +101,8 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
-        await build_agent_runtime_gateway(app).dispatch_thread_input(_thread_input(enable_trajectory=True))
+        await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(
+            _thread_input(enable_trajectory=True)
+        )
 
     assert start_run.call_args.kwargs["enable_trajectory"] is True


### PR DESCRIPTION
## Summary
- require threads bootstrap to borrow chat-owned typing tracker explicitly
- pass the borrowed typing tracker through gateway construction instead of reopening app.state inside the builder
- align focused unit/integration callers and lock the borrowed contract with tests/comments

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/test_chat_runtime_services.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Integration/test_query_loop_backend_contracts.py -k "agent_runtime_gateway or attach_threads_runtime or web_lifespan or recipient_thread_resolution_requires_current_thread_repo_contract or send_message_route_then_agent_terminal_notification_reenters_followthrough" tests/Integration/test_messaging_social_handle_contract.py -k "agent_runtime_gateway or recipient_thread_resolution_requires_current_thread_repo_contract"
- uv run ruff check backend/threads/chat_adapters/bootstrap.py backend/threads/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/test_chat_runtime_services.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff format --check backend/threads/chat_adapters/bootstrap.py backend/threads/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/test_chat_runtime_services.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py
- git diff --check