### PR TITLE
refactor(chat): require explicit registry messaging service

### DIFF
--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from fastapi import FastAPI
 
-from backend.chat.runtime_access import get_messaging_service
 from backend.threads.pool.factory import create_agent_sync
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from core.identity.agent_registry import get_or_create_agent_id
@@ -130,6 +129,8 @@ async def get_or_create_agent(
         if user_repo is not None and thread_data:
             if not agent_user_id:
                 raise RuntimeError(f"thread.agent_user_id is required for agent chat identity: {thread_id}")
+            if messaging_service is None:
+                raise RuntimeError(f"messaging_service is required for agent chat runtime: {thread_id}")
             agent_user = agent_user or user_repo.get_by_id(agent_user_id)
             # @@@thread-chat-identity-source - agent users are now the stable social
             # identity root. Runtime threads no longer carry a second dedicated user_id.
@@ -138,7 +139,7 @@ async def get_or_create_agent(
                 "chat_identity_id": agent_user_id,
                 "owner_id": owner_id,
                 "user_repo": user_repo,
-                "messaging_service": messaging_service if messaging_service is not None else get_messaging_service(app_obj),
+                "messaging_service": messaging_service,
                 "agent_config_repo": getattr(app_obj.state, "agent_config_repo", None),
             }
 

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -129,6 +129,10 @@ async def get_or_create_agent(
         if user_repo is not None and thread_data:
             if not agent_user_id:
                 raise RuntimeError(f"thread.agent_user_id is required for agent chat identity: {thread_id}")
+            # @@@agent-chat-runtime-explicit-messaging - registry constructs
+            # chat_repos for runtime startup, but chat-owned messaging_service
+            # must be borrowed explicitly by the caller instead of falling back
+            # to app.state here.
             if messaging_service is None:
                 raise RuntimeError(f"messaging_service is required for agent chat runtime: {thread_id}")
             agent_user = agent_user or user_repo.get_by_id(agent_user_id)

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -112,6 +112,45 @@ async def test_registry_get_or_create_agent_uses_explicit_messaging_service(
 
 
 @pytest.mark.asyncio
+async def test_registry_get_or_create_agent_requires_explicit_messaging_service_for_chat_repos(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _fake_create_agent_sync(**_kwargs) -> object:
+        return SimpleNamespace()
+
+    class _ThreadRepo:
+        def get_by_id(self, thread_id: str):
+            return {
+                "id": thread_id,
+                "agent_user_id": "agent-user-direct-missing",
+                "cwd": None,
+                "model": "leon:large",
+            }
+
+    class _UserRepo:
+        def get_by_id(self, user_id: str):
+            return SimpleNamespace(id=user_id, owner_user_id="owner-direct-missing", agent_config_id="cfg-direct-missing")
+
+    monkeypatch.setattr(agent_pool._registry, "create_agent_sync", _fake_create_agent_sync)
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-direct-missing")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_ThreadRepo(),
+            user_repo=_UserRepo(),
+            messaging_service=SimpleNamespace(),
+            agent_config_repo=_EmptyAgentConfigRepo(),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="messaging_service is required for agent chat runtime"):
+        await agent_pool._registry.get_or_create_agent(cast(Any, app), "local", thread_id="thread-direct-missing")
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_creates_once_per_thread(monkeypatch: pytest.MonkeyPatch):
     created: list[object] = []
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -191,7 +191,7 @@ async def test_registry_get_or_create_agent_does_not_read_app_state_messaging_se
         raising=False,
     )
 
-    with pytest.raises(AssertionError, match="registry should not read app.state messaging_service"):
+    with pytest.raises(RuntimeError, match="messaging_service is required for agent chat runtime"):
         await agent_pool._registry.get_or_create_agent(cast(Any, app), "local", thread_id="thread-no-fallback")
 
 
@@ -502,7 +502,7 @@ async def test_get_or_create_agent_fails_loud_when_chat_repos_need_missing_messa
         )
     )
 
-    with pytest.raises(RuntimeError, match="chat bootstrap not attached: messaging_service"):
+    with pytest.raises(RuntimeError, match="messaging_service is required for agent chat runtime"):
         await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-5")
 
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -151,6 +151,51 @@ async def test_registry_get_or_create_agent_requires_explicit_messaging_service_
 
 
 @pytest.mark.asyncio
+async def test_registry_get_or_create_agent_does_not_read_app_state_messaging_service_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _fake_create_agent_sync(**_kwargs) -> object:
+        return SimpleNamespace()
+
+    class _ThreadRepo:
+        def get_by_id(self, thread_id: str):
+            return {
+                "id": thread_id,
+                "agent_user_id": "agent-user-no-fallback",
+                "cwd": None,
+                "model": "leon:large",
+            }
+
+    class _UserRepo:
+        def get_by_id(self, user_id: str):
+            return SimpleNamespace(id=user_id, owner_user_id="owner-no-fallback", agent_config_id="cfg-no-fallback")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_ThreadRepo(),
+            user_repo=_UserRepo(),
+            messaging_service=SimpleNamespace(),
+            agent_config_repo=_EmptyAgentConfigRepo(),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    monkeypatch.setattr(agent_pool._registry, "create_agent_sync", _fake_create_agent_sync)
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-no-fallback")
+    monkeypatch.setattr(
+        agent_pool._registry,
+        "get_messaging_service",
+        lambda _app: (_ for _ in ()).throw(AssertionError("registry should not read app.state messaging_service")),
+        raising=False,
+    )
+
+    with pytest.raises(AssertionError, match="registry should not read app.state messaging_service"):
+        await agent_pool._registry.get_or_create_agent(cast(Any, app), "local", thread_id="thread-no-fallback")
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_creates_once_per_thread(monkeypatch: pytest.MonkeyPatch):
     created: list[object] = []
 


### PR DESCRIPTION
## Summary
- require backend/threads/pool/registry.py to receive chat-owned messaging_service explicitly when chat_repos are needed
- remove the last registry fallback that re-read app.state messaging_service directly
- lock the explicit contract with focused agent_pool regression tests and a small @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_borrows_messaging_service_for_registry tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_skips_borrow_when_chat_bootstrap_missing tests/Unit/core/test_agent_pool.py::test_registry_get_or_create_agent_uses_explicit_messaging_service tests/Unit/core/test_agent_pool.py::test_registry_get_or_create_agent_requires_explicit_messaging_service_for_chat_repos tests/Unit/core/test_agent_pool.py::test_registry_get_or_create_agent_does_not_read_app_state_messaging_service_fallback tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_creates_once_per_thread tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_ignores_unavailable_local_cwd tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_honors_fresh_local_thread_cwd_even_when_missing tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_fails_loud_when_chat_repos_need_missing_messaging_service tests/Integration/test_child_thread_live_contract.py::test_run_child_thread_live_rebinds_from_parent_sink_and_surfaces_runtime_and_detail_before_completion tests/Integration/test_query_loop_backend_contracts.py::test_send_message_route_then_agent_terminal_notification_reenters_followthrough
- uv run ruff check backend/threads/pool/registry.py tests/Unit/core/test_agent_pool.py
- uv run ruff format --check backend/threads/pool/registry.py tests/Unit/core/test_agent_pool.py
- git diff --check