### PR TITLE
refactor(auth): borrow contact repo explicitly in auth runtime

### DIFF
--- a/backend/identity/auth/runtime_bootstrap.py
+++ b/backend/identity/auth/runtime_bootstrap.py
@@ -19,6 +19,9 @@ def build_auth_runtime_state(storage_state, *, contact_repo) -> AuthRuntimeState
     storage_container = storage_state.storage_container
     supabase_client = storage_state.supabase_client
     supabase_auth_client_factory = create_supabase_auth_client
+    # @@@auth-runtime-borrowed-contact-repo - auth runtime seeds owner-agent
+    # contacts, but chat-owned contact_repo must be borrowed explicitly by the
+    # enclosing app bootstrap instead of being reopened inside this helper.
     auth_service = AuthService(
         users=storage_container.user_repo(),
         agent_configs=storage_container.agent_config_repo(),

--- a/backend/identity/auth/runtime_bootstrap.py
+++ b/backend/identity/auth/runtime_bootstrap.py
@@ -15,7 +15,7 @@ class AuthRuntimeState:
     supabase_auth_client_factory: Callable[[], object]
 
 
-def build_auth_runtime_state(storage_state) -> AuthRuntimeState:
+def build_auth_runtime_state(storage_state, *, contact_repo) -> AuthRuntimeState:
     storage_container = storage_state.storage_container
     supabase_client = storage_state.supabase_client
     supabase_auth_client_factory = create_supabase_auth_client
@@ -25,7 +25,7 @@ def build_auth_runtime_state(storage_state) -> AuthRuntimeState:
         supabase_client=supabase_client,
         supabase_auth_client_factory=supabase_auth_client_factory,
         invite_codes=storage_container.invite_code_repo(),
-        contact_repo=storage_container.contact_repo(),
+        contact_repo=contact_repo,
         recipe_repo=storage_container.recipe_repo(),
     )
     return AuthRuntimeState(
@@ -34,8 +34,8 @@ def build_auth_runtime_state(storage_state) -> AuthRuntimeState:
     )
 
 
-def attach_auth_runtime_state(app, *, storage_state) -> AuthRuntimeState:
-    state = build_auth_runtime_state(storage_state)
+def attach_auth_runtime_state(app, *, storage_state, contact_repo) -> AuthRuntimeState:
+    state = build_auth_runtime_state(storage_state, contact_repo=contact_repo)
     app.state.auth_service = state.auth_service
     app.state._supabase_auth_client_factory = state.supabase_auth_client_factory
     return state

--- a/backend/monitor/app/lifespan.py
+++ b/backend/monitor/app/lifespan.py
@@ -13,7 +13,11 @@ from backend.monitor.infrastructure.resources.resource_overview_cache import res
 def _require_monitor_runtime_contract(app: FastAPI) -> None:
     runtime_storage = attach_runtime_storage_state(app)
     app.state.user_repo = runtime_storage.storage_container.user_repo()
-    attach_auth_runtime_state(app, storage_state=runtime_storage)
+    attach_auth_runtime_state(
+        app,
+        storage_state=runtime_storage,
+        contact_repo=runtime_storage.storage_container.contact_repo(),
+    )
 
 
 @asynccontextmanager

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -62,7 +62,7 @@ async def lifespan(app: FastAPI):
     app.state.invite_code_repo = storage_container.invite_code_repo()
     app.state.user_settings_repo = storage_container.user_settings_repo()
     app.state.agent_config_repo = storage_container.agent_config_repo()
-    attach_auth_runtime_state(app, storage_state=runtime_storage)
+    attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=storage_container.contact_repo())
 
     from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery
     from backend.threads.bootstrap import attach_threads_runtime

--- a/tests/Unit/backend/test_auth_runtime_bootstrap.py
+++ b/tests/Unit/backend/test_auth_runtime_bootstrap.py
@@ -29,7 +29,7 @@ def test_build_auth_runtime_state_uses_runtime_storage_state(monkeypatch):
         storage_container=_fake_storage_container(),
     )
 
-    state = auth_runtime_bootstrap.build_auth_runtime_state(storage_state)
+    state = auth_runtime_bootstrap.build_auth_runtime_state(storage_state, contact_repo="contact-repo")
 
     assert state.supabase_auth_client_factory() is fake_auth_factory
     assert isinstance(state.auth_service, _FakeAuthService)
@@ -44,13 +44,27 @@ def test_build_auth_runtime_state_uses_runtime_storage_state(monkeypatch):
     }
 
 
+def test_build_auth_runtime_state_requires_explicit_contact_repo():
+    storage_state = SimpleNamespace(
+        supabase_client="supabase-client",
+        storage_container=_fake_storage_container(),
+    )
+
+    try:
+        auth_runtime_bootstrap.build_auth_runtime_state(storage_state)
+    except TypeError as exc:
+        assert "contact_repo" in str(exc)
+    else:
+        raise AssertionError("build_auth_runtime_state should require explicit contact_repo")
+
+
 def test_attach_auth_runtime_state_sets_app_state(monkeypatch):
     fake_state = SimpleNamespace(auth_service=object(), supabase_auth_client_factory=object())
     app = type("_App", (), {"state": type("_State", (), {})()})()
 
-    monkeypatch.setattr(auth_runtime_bootstrap, "build_auth_runtime_state", lambda _storage_state: fake_state)
+    monkeypatch.setattr(auth_runtime_bootstrap, "build_auth_runtime_state", lambda _storage_state, *, contact_repo: fake_state)
 
-    result = auth_runtime_bootstrap.attach_auth_runtime_state(app, storage_state=object())
+    result = auth_runtime_bootstrap.attach_auth_runtime_state(app, storage_state=object(), contact_repo=object())
 
     assert result is fake_state
     assert app.state.auth_service is fake_state.auth_service

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -36,6 +36,7 @@ def _patch_lifespan_runtime_contract(monkeypatch, *, attach_chat_runtime, attach
         user_settings_repo=lambda: object(),
         agent_config_repo=lambda: object(),
         queue_repo=lambda: object(),
+        contact_repo=lambda: object(),
     )
 
     runtime_storage = SimpleNamespace(
@@ -98,11 +99,13 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
 @pytest.mark.asyncio
 async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatch):
     call_log: list[str] = []
+    contact_repo = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         call_log.append("chat")
         app.state.typing_tracker = object()
         app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+        app.state.contact_repo = contact_repo
 
     def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
         call_log.append("threads")
@@ -126,6 +129,76 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
 
     async with web_lifespan.lifespan(app):
         assert call_log == ["chat", "threads", "wire"]
+
+
+@pytest.mark.asyncio
+async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monkeypatch):
+    seen: list[object] = []
+    contact_repo = object()
+
+    monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
+    monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
+
+    async def _no_validate():
+        return None
+
+    monkeypatch.setattr(web_lifespan, "_validate_web_checkpointer_contract", _no_validate)
+
+    storage_container = SimpleNamespace(
+        user_repo=lambda: object(),
+        thread_repo=lambda: object(),
+        lease_repo=lambda: object(),
+        recipe_repo=lambda: SimpleNamespace(close=lambda: None),
+        workspace_repo=lambda: object(),
+        sandbox_repo=lambda: object(),
+        invite_code_repo=lambda: object(),
+        user_settings_repo=lambda: object(),
+        agent_config_repo=lambda: object(),
+        queue_repo=lambda: object(),
+        contact_repo=lambda: contact_repo,
+    )
+
+    runtime_storage = SimpleNamespace(
+        supabase_client=object(),
+        storage_container=storage_container,
+    )
+
+    monkeypatch.setattr("backend.bootstrap.storage.attach_runtime_storage_state", lambda _app: runtime_storage)
+    monkeypatch.setattr(
+        "backend.identity.auth.runtime_bootstrap.attach_auth_runtime_state",
+        lambda _app, *, storage_state, contact_repo: seen.append(contact_repo) or object(),
+    )
+    monkeypatch.setattr(
+        "core.runtime.langgraph_checkpoint_store.agent_checkpoint_saver_from_conn_string",
+        lambda _pg_url: _FakeCheckpointCtx(),
+    )
+    monkeypatch.setattr(
+        "core.runtime.langgraph_checkpoint_store.LangGraphCheckpointStore",
+        lambda saver: SimpleNamespace(saver=saver),
+    )
+    monkeypatch.setattr(
+        "backend.chat.bootstrap.attach_chat_runtime",
+        lambda app, _storage_container, *, user_repo, thread_repo: (
+            setattr(app.state, "typing_tracker", object())
+            or setattr(app.state, "messaging_service", SimpleNamespace(set_delivery_fn=lambda _fn: None))
+        ),
+    )
+    monkeypatch.setattr(
+        "backend.threads.bootstrap.attach_threads_runtime",
+        lambda app, *_args, **_kwargs: (
+            setattr(app.state, "agent_runtime_thread_activity_reader", object()) or setattr(app.state, "agent_pool", {})
+        ),
+    )
+    monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
+    monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
+    monkeypatch.setattr("backend.threads.pool.idle_reaper.idle_reaper_loop", lambda _app: _never())
+    monkeypatch.setattr("backend.web.core.config.IDLE_REAPER_INTERVAL_SEC", 1)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with web_lifespan.lifespan(app):
+        assert seen == [contact_repo]
 
 
 async def _never():

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -20,7 +20,7 @@ def test_monitor_app_module_path_is_internalized():
 
 def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.MonkeyPatch):
     monitor_storage = SimpleNamespace(
-        storage_container=SimpleNamespace(user_repo=lambda: object()),
+        storage_container=SimpleNamespace(user_repo=lambda: object(), contact_repo=lambda: object()),
     )
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
     monkeypatch.setattr(monitor_app_lifespan, "attach_auth_runtime_state", lambda *_args, **_kwargs: object())
@@ -41,13 +41,13 @@ def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.Monke
 def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
     user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
     monitor_storage = SimpleNamespace(
-        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
     monkeypatch.setattr(
         monitor_app_lifespan,
         "attach_auth_runtime_state",
-        lambda app, *, storage_state: (
+        lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
                 "auth_service",
@@ -77,13 +77,13 @@ def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyP
 def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
     user_repo = SimpleNamespace(get_by_id=lambda _user_id: None)
     monitor_storage = SimpleNamespace(
-        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
     monkeypatch.setattr(
         monitor_app_lifespan,
         "attach_auth_runtime_state",
-        lambda app, *, storage_state: (
+        lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
                 "auth_service",
@@ -107,13 +107,13 @@ def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatc
 def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPatch):
     user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
     monitor_storage = SimpleNamespace(
-        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
     monkeypatch.setattr(
         monitor_app_lifespan,
         "attach_auth_runtime_state",
-        lambda app, *, storage_state: (
+        lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
                 "auth_service",
@@ -149,13 +149,13 @@ def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPa
 def test_monitor_app_maps_missing_remote_execution_target_to_503(monkeypatch: pytest.MonkeyPatch):
     user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
     monitor_storage = SimpleNamespace(
-        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
     monkeypatch.setattr(monitor_app_lifespan, "attach_runtime_storage_state", lambda _app: monitor_storage)
     monkeypatch.setattr(
         monitor_app_lifespan,
         "attach_auth_runtime_state",
-        lambda app, *, storage_state: (
+        lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
                 "auth_service",

--- a/tests/Unit/monitor/test_monitor_app_lifespan.py
+++ b/tests/Unit/monitor/test_monitor_app_lifespan.py
@@ -14,6 +14,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
     cancelled = asyncio.Event()
     auth_calls = []
     user_repo = object()
+    contact_repo = object()
 
     async def _loop():
         started.set()
@@ -24,7 +25,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
             raise
 
     monitor_storage = SimpleNamespace(
-        storage_container=SimpleNamespace(user_repo=lambda: user_repo),
+        storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: contact_repo),
     )
 
     monkeypatch.setattr(monitor_app_lifespan, "resource_overview_refresh_loop", _loop)
@@ -32,7 +33,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
     monkeypatch.setattr(
         monitor_app_lifespan,
         "attach_auth_runtime_state",
-        lambda _app, *, storage_state: auth_calls.append(storage_state) or object(),
+        lambda _app, *, storage_state, contact_repo: auth_calls.append((storage_state, contact_repo)) or object(),
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
@@ -44,7 +45,7 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
         assert app.state.user_repo is user_repo
 
     await asyncio.wait_for(cancelled.wait(), timeout=1)
-    assert auth_calls == [monitor_storage]
+    assert auth_calls == [(monitor_storage, contact_repo)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- require auth runtime bootstrap to receive chat-owned contact_repo explicitly
- pass the borrowed contact_repo through web and monitor app lifespans instead of reopening it inside auth bootstrap
- lock the borrowed contract with focused bootstrap/lifespan tests and one @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_auth_runtime_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/monitor/test_monitor_app_lifespan.py
- uv run ruff check backend/identity/auth/runtime_bootstrap.py backend/web/core/lifespan.py backend/monitor/app/lifespan.py tests/Unit/backend/test_auth_runtime_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/monitor/test_monitor_app_lifespan.py
- uv run ruff format --check backend/identity/auth/runtime_bootstrap.py backend/web/core/lifespan.py backend/monitor/app/lifespan.py tests/Unit/backend/test_auth_runtime_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/monitor/test_monitor_app_lifespan.py
- git diff --check