### PR TITLE
Fix prompt caching middleware installation drift

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1055,6 +1055,10 @@ class LeonAgent:
         middleware.append(self._monitor_middleware)
 
         # 2. Prompt Caching — only attach for Anthropic-backed runs
+        # @@@prompt-caching-provider-contract - this middleware is Anthropic-only.
+        # The generic configurable model wrapper used by current runtime models is
+        # not itself a safe signal to install prompt caching, so gate on the
+        # resolved provider name at wiring time instead of warning on every run.
         if self._current_model_config.get("model_provider") == "anthropic":
             middleware.append(PromptCachingMiddleware(ttl="5m", min_messages_to_cache=0))
 

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1054,8 +1054,9 @@ class LeonAgent:
         )
         middleware.append(self._monitor_middleware)
 
-        # 2. Prompt Caching — adds cache_control markers to model requests
-        middleware.append(PromptCachingMiddleware(ttl="5m", min_messages_to_cache=0))
+        # 2. Prompt Caching — only attach for Anthropic-backed runs
+        if self._current_model_config.get("model_provider") == "anthropic":
+            middleware.append(PromptCachingMiddleware(ttl="5m", min_messages_to_cache=0))
 
         # 3. Memory — prunes/compacts context before model call
         memory_enabled = self.config.memory.pruning.enabled or self.config.memory.compaction.enabled

--- a/tests/Unit/core/test_prompt_caching_middleware.py
+++ b/tests/Unit/core/test_prompt_caching_middleware.py
@@ -42,3 +42,37 @@ def test_prompt_caching_raises_for_unsupported_model_when_configured(monkeypatch
 
     with pytest.raises(ValueError, match="only supports Anthropic models"):
         middleware._should_apply_caching(request)
+
+
+def test_prompt_caching_applies_cache_control_to_string_system_message():
+    middleware = PromptCachingMiddleware()
+    request = ModelRequest(
+        model=object(),
+        messages=[],
+        system_message=SimpleNamespace(content="system prompt"),
+    )
+
+    updated = middleware._apply_system_cache(request)
+
+    assert updated.system_message.content == [
+        {"type": "text", "text": "system prompt", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_prompt_caching_applies_cache_control_to_first_system_block():
+    middleware = PromptCachingMiddleware()
+    request = ModelRequest(
+        model=object(),
+        messages=[],
+        system_message=SimpleNamespace(
+            content=[
+                {"type": "text", "text": "system prompt"},
+                {"type": "text", "text": "second block"},
+            ]
+        ),
+    )
+
+    updated = middleware._apply_system_cache(request)
+
+    assert updated.system_message.content[0]["cache_control"] == {"type": "ephemeral"}
+    assert updated.system_message.content[1] == {"type": "text", "text": "second block"}

--- a/tests/Unit/core/test_prompt_caching_middleware.py
+++ b/tests/Unit/core/test_prompt_caching_middleware.py
@@ -76,3 +76,25 @@ def test_prompt_caching_applies_cache_control_to_first_system_block():
 
     assert updated.system_message.content[0]["cache_control"] == {"type": "ephemeral"}
     assert updated.system_message.content[1] == {"type": "text", "text": "second block"}
+
+
+def test_prompt_caching_leaves_request_unchanged_without_system_message():
+    middleware = PromptCachingMiddleware()
+    request = ModelRequest(model=object(), messages=[SimpleNamespace()], system_message=None)
+
+    updated = middleware._apply_system_cache(request)
+
+    assert updated is request
+
+
+def test_prompt_caching_leaves_request_unchanged_for_empty_system_blocks():
+    middleware = PromptCachingMiddleware()
+    request = ModelRequest(
+        model=object(),
+        messages=[],
+        system_message=SimpleNamespace(content=[]),
+    )
+
+    updated = middleware._apply_system_cache(request)
+
+    assert updated is request

--- a/tests/Unit/core/test_prompt_caching_middleware.py
+++ b/tests/Unit/core/test_prompt_caching_middleware.py
@@ -29,3 +29,16 @@ def test_prompt_caching_applies_for_supported_anthropic_model(monkeypatch: pytes
     request = ModelRequest(model=_FakeAnthropicModel(), messages=[SimpleNamespace()], system_message=None)
 
     assert middleware._should_apply_caching(request) is True
+
+
+def test_prompt_caching_raises_for_unsupported_model_when_configured(monkeypatch: pytest.MonkeyPatch):
+    class _FakeAnthropicModel:
+        pass
+
+    monkeypatch.setattr("core.runtime.middleware.prompt_caching.ChatAnthropic", _FakeAnthropicModel)
+
+    middleware = PromptCachingMiddleware(unsupported_model_behavior="raise")
+    request = ModelRequest(model=object(), messages=[SimpleNamespace()], system_message=None)
+
+    with pytest.raises(ValueError, match="only supports Anthropic models"):
+        middleware._should_apply_caching(request)

--- a/tests/Unit/core/test_prompt_caching_middleware.py
+++ b/tests/Unit/core/test_prompt_caching_middleware.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+import pytest
+
+from core.runtime.middleware import ModelRequest
+from core.runtime.middleware.prompt_caching import PromptCachingMiddleware
+
+
+def test_prompt_caching_warns_and_skips_unsupported_model(monkeypatch: pytest.MonkeyPatch):
+    seen: list[str] = []
+
+    monkeypatch.setattr("core.runtime.middleware.prompt_caching.warn", lambda msg, stacklevel=0: seen.append(str(msg)))
+
+    middleware = PromptCachingMiddleware(unsupported_model_behavior="warn")
+    request = ModelRequest(model=object(), messages=[SimpleNamespace()], system_message=None)
+
+    assert middleware._should_apply_caching(request) is False
+    assert len(seen) == 1
+    assert "only supports Anthropic models" in seen[0]
+
+
+def test_prompt_caching_applies_for_supported_anthropic_model(monkeypatch: pytest.MonkeyPatch):
+    class _FakeAnthropicModel:
+        pass
+
+    monkeypatch.setattr("core.runtime.middleware.prompt_caching.ChatAnthropic", _FakeAnthropicModel)
+
+    middleware = PromptCachingMiddleware(min_messages_to_cache=1, unsupported_model_behavior="raise")
+    request = ModelRequest(model=_FakeAnthropicModel(), messages=[SimpleNamespace()], system_message=None)
+
+    assert middleware._should_apply_caching(request) is True

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -156,3 +156,113 @@ def test_memory_config_override_updates_compaction_trigger_without_losing_defaul
     assert updated.memory.compaction.trigger_tokens == 80000
     assert updated.memory.compaction.reserve_tokens == settings.memory.compaction.reserve_tokens
     assert updated.memory.pruning.soft_trim_chars == settings.memory.pruning.soft_trim_chars
+
+
+def test_build_middleware_stack_skips_prompt_caching_for_non_anthropic_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_calls: list[str] = []
+    mcp = object()
+    steering = object()
+    toolrunner = object()
+
+    class _PromptCachingProbe:
+        def __init__(self, **_kwargs) -> None:
+            prompt_calls.append("prompt")
+
+    class _MonitorProbe:
+        def __init__(self, **_kwargs) -> None:
+            self.runtime = SimpleNamespace()
+            self._context_monitor = SimpleNamespace(context_limit=128000)
+
+    monkeypatch.setattr("core.runtime.agent.PromptCachingMiddleware", _PromptCachingProbe)
+    monkeypatch.setattr("core.runtime.agent.MonitorMiddleware", _MonitorProbe)
+    monkeypatch.setattr("core.runtime.agent.McpInstructionsDeltaMiddleware", lambda **_kwargs: mcp)
+    monkeypatch.setattr("core.runtime.agent.SteeringMiddleware", lambda **_kwargs: steering)
+    monkeypatch.setattr("core.runtime.agent.ToolRunner", lambda **_kwargs: toolrunner)
+    monkeypatch.setattr("core.runtime.agent.SpillBufferMiddleware", lambda **_kwargs: "spill")
+
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(fs=lambda: SimpleNamespace(), name="local", close=lambda: None)
+    agent.config = SimpleNamespace(
+        runtime=SimpleNamespace(context_limit=0),
+        memory=SimpleNamespace(
+            pruning=SimpleNamespace(enabled=False),
+            compaction=SimpleNamespace(enabled=False),
+        ),
+        tools=SimpleNamespace(
+            spill_buffer=SimpleNamespace(enabled=False),
+        ),
+    )
+    agent._current_model_config = {"model_provider": "openai"}
+    agent._model_overrides = {}
+    agent.workspace_root = Path("/tmp")
+    agent.queue_manager = SimpleNamespace()
+    agent._tool_registry = SimpleNamespace()
+    agent._get_mcp_instruction_blocks = lambda: []
+    agent.model_name = "gpt-5.4"
+    agent.verbose = False
+    agent._closed = True
+    agent._closing = False
+
+    middleware = LeonAgent._build_middleware_stack(agent)
+
+    assert prompt_calls == []
+    assert middleware == [agent._monitor_middleware, mcp, steering, toolrunner]
+
+
+def test_build_middleware_stack_keeps_prompt_caching_for_anthropic_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_calls: list[str] = []
+    mcp = object()
+    steering = object()
+    toolrunner = object()
+
+    class _PromptCachingProbe:
+        def __init__(self, **_kwargs) -> None:
+            prompt_calls.append("prompt")
+
+    class _MonitorProbe:
+        def __init__(self, **_kwargs) -> None:
+            self.runtime = SimpleNamespace()
+            self._context_monitor = SimpleNamespace(context_limit=128000)
+
+    monkeypatch.setattr("core.runtime.agent.PromptCachingMiddleware", _PromptCachingProbe)
+    monkeypatch.setattr("core.runtime.agent.MonitorMiddleware", _MonitorProbe)
+    monkeypatch.setattr("core.runtime.agent.McpInstructionsDeltaMiddleware", lambda **_kwargs: mcp)
+    monkeypatch.setattr("core.runtime.agent.SteeringMiddleware", lambda **_kwargs: steering)
+    monkeypatch.setattr("core.runtime.agent.ToolRunner", lambda **_kwargs: toolrunner)
+    monkeypatch.setattr("core.runtime.agent.SpillBufferMiddleware", lambda **_kwargs: "spill")
+
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(fs=lambda: SimpleNamespace(), name="local", close=lambda: None)
+    agent.config = SimpleNamespace(
+        runtime=SimpleNamespace(context_limit=0),
+        memory=SimpleNamespace(
+            pruning=SimpleNamespace(enabled=False),
+            compaction=SimpleNamespace(enabled=False),
+        ),
+        tools=SimpleNamespace(
+            spill_buffer=SimpleNamespace(enabled=False),
+        ),
+    )
+    agent._current_model_config = {"model_provider": "anthropic"}
+    agent._model_overrides = {}
+    agent.workspace_root = Path("/tmp")
+    agent.queue_manager = SimpleNamespace()
+    agent._tool_registry = SimpleNamespace()
+    agent._get_mcp_instruction_blocks = lambda: []
+    agent.model_name = "claude-sonnet"
+    agent.verbose = False
+    agent._closed = True
+    agent._closing = False
+
+    middleware = LeonAgent._build_middleware_stack(agent)
+
+    assert prompt_calls == ["prompt"]
+    assert len(middleware) == 5
+    assert middleware[0] is agent._monitor_middleware
+    assert middleware[2] is mcp
+    assert middleware[3] is steering
+    assert middleware[4] is toolrunner

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -266,3 +266,56 @@ def test_build_middleware_stack_keeps_prompt_caching_for_anthropic_provider(
     assert middleware[2] is mcp
     assert middleware[3] is steering
     assert middleware[4] is toolrunner
+
+
+def test_build_middleware_stack_skips_prompt_caching_when_provider_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_calls: list[str] = []
+    mcp = object()
+    steering = object()
+    toolrunner = object()
+
+    class _PromptCachingProbe:
+        def __init__(self, **_kwargs) -> None:
+            prompt_calls.append("prompt")
+
+    class _MonitorProbe:
+        def __init__(self, **_kwargs) -> None:
+            self.runtime = SimpleNamespace()
+            self._context_monitor = SimpleNamespace(context_limit=128000)
+
+    monkeypatch.setattr("core.runtime.agent.PromptCachingMiddleware", _PromptCachingProbe)
+    monkeypatch.setattr("core.runtime.agent.MonitorMiddleware", _MonitorProbe)
+    monkeypatch.setattr("core.runtime.agent.McpInstructionsDeltaMiddleware", lambda **_kwargs: mcp)
+    monkeypatch.setattr("core.runtime.agent.SteeringMiddleware", lambda **_kwargs: steering)
+    monkeypatch.setattr("core.runtime.agent.ToolRunner", lambda **_kwargs: toolrunner)
+    monkeypatch.setattr("core.runtime.agent.SpillBufferMiddleware", lambda **_kwargs: "spill")
+
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(fs=lambda: SimpleNamespace(), name="local", close=lambda: None)
+    agent.config = SimpleNamespace(
+        runtime=SimpleNamespace(context_limit=0),
+        memory=SimpleNamespace(
+            pruning=SimpleNamespace(enabled=False),
+            compaction=SimpleNamespace(enabled=False),
+        ),
+        tools=SimpleNamespace(
+            spill_buffer=SimpleNamespace(enabled=False),
+        ),
+    )
+    agent._current_model_config = {"model_provider": None}
+    agent._model_overrides = {}
+    agent.workspace_root = Path("/tmp")
+    agent.queue_manager = SimpleNamespace()
+    agent._tool_registry = SimpleNamespace()
+    agent._get_mcp_instruction_blocks = lambda: []
+    agent.model_name = "gpt-5.4"
+    agent.verbose = False
+    agent._closed = True
+    agent._closing = False
+
+    middleware = LeonAgent._build_middleware_stack(agent)
+
+    assert prompt_calls == []
+    assert middleware == [agent._monitor_middleware, mcp, steering, toolrunner]


### PR DESCRIPTION
## Summary
- install Anthropic prompt caching only when the resolved provider is anthropic
- preserve prompt-caching middleware contract with focused unit coverage for warn/raise/cache-control/no-op paths
- keep non-Anthropic and provider-unknown runtime paths free of the old _ConfigurableModel warning

## Verification
- uv run pytest -q tests/Unit/core/test_prompt_caching_middleware.py tests/Unit/core/test_runtime_agent.py -k 'prompt_caching'
- git diff --check origin/dev..HEAD

## Runtime proof
- isolated backend on :18020 completed login/panel/thread-create/send without re-emitting the old AnthropicPromptCachingMiddleware/_ConfigurableModel warning in backend logs