### PR TITLE
Fix dunder-del shutdown cleanup noise

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1030,7 +1030,11 @@ class LeonAgent:
         self._mcp_client = None
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except RuntimeError as exc:
+            if "interpreter shutdown" not in str(exc):
+                raise
 
     def _build_middleware_stack(self) -> list:
         """Build middleware stack.

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1033,6 +1033,10 @@ class LeonAgent:
         try:
             self.close()
         except RuntimeError as exc:
+            # @@@dunder-del-shutdown-noise - interpreter teardown can still
+            # trip a late RuntimeError while Python is dismantling the default
+            # executor; suppress only that shutdown-specific noise here and
+            # leave all other runtime errors loud.
             if "interpreter shutdown" not in str(exc):
                 raise
 

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -154,6 +154,17 @@ def test_dunder_del_swallows_interpreter_shutdown_runtimeerror(monkeypatch: pyte
     LeonAgent.__del__(agent)
 
 
+def test_dunder_del_swallows_executor_shutdown_runtimeerror(monkeypatch: pytest.MonkeyPatch):
+    agent = object.__new__(LeonAgent)
+
+    def _boom() -> None:
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+    monkeypatch.setattr(agent, "close", _boom)
+
+    LeonAgent.__del__(agent)
+
+
 def test_dunder_del_reraises_unrelated_runtimeerror(monkeypatch: pytest.MonkeyPatch):
     agent = object.__new__(LeonAgent)
 

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -143,6 +143,29 @@ def test_close_remains_idempotent_after_shutdown_fallback(monkeypatch: pytest.Mo
     assert events == ["async", "sync"]
 
 
+def test_dunder_del_swallows_interpreter_shutdown_runtimeerror(monkeypatch: pytest.MonkeyPatch):
+    agent = object.__new__(LeonAgent)
+
+    def _boom() -> None:
+        raise RuntimeError("can't create new thread at interpreter shutdown")
+
+    monkeypatch.setattr(agent, "close", _boom)
+
+    LeonAgent.__del__(agent)
+
+
+def test_dunder_del_reraises_unrelated_runtimeerror(monkeypatch: pytest.MonkeyPatch):
+    agent = object.__new__(LeonAgent)
+
+    def _boom() -> None:
+        raise RuntimeError("some other runtime problem")
+
+    monkeypatch.setattr(agent, "close", _boom)
+
+    with pytest.raises(RuntimeError, match="some other runtime problem"):
+        LeonAgent.__del__(agent)
+
+
 def test_memory_config_override_updates_compaction_trigger_without_losing_defaults():
     from config.schema import LeonSettings
 

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -177,6 +177,20 @@ def test_dunder_del_reraises_unrelated_runtimeerror(monkeypatch: pytest.MonkeyPa
         LeonAgent.__del__(agent)
 
 
+def test_dunder_del_calls_close_without_noise_when_close_succeeds(monkeypatch: pytest.MonkeyPatch):
+    calls: list[str] = []
+    agent = object.__new__(LeonAgent)
+
+    def _ok() -> None:
+        calls.append("close")
+
+    monkeypatch.setattr(agent, "close", _ok)
+
+    LeonAgent.__del__(agent)
+
+    assert calls == ["close"]
+
+
 def test_memory_config_override_updates_compaction_trigger_without_losing_defaults():
     from config.schema import LeonSettings
 

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -191,6 +191,18 @@ def test_dunder_del_calls_close_without_noise_when_close_succeeds(monkeypatch: p
     assert calls == ["close"]
 
 
+def test_dunder_del_reraises_non_runtime_errors(monkeypatch: pytest.MonkeyPatch):
+    agent = object.__new__(LeonAgent)
+
+    def _boom() -> None:
+        raise ValueError("not a runtime error")
+
+    monkeypatch.setattr(agent, "close", _boom)
+
+    with pytest.raises(ValueError, match="not a runtime error"):
+        LeonAgent.__del__(agent)
+
+
 def test_memory_config_override_updates_compaction_trigger_without_losing_defaults():
     from config.schema import LeonSettings
 


### PR DESCRIPTION
## Summary
- suppress interpreter-shutdown RuntimeError noise from LeonAgent.__del__ while keeping other errors loud
- add focused dunder-del coverage for shutdown signatures, quiet success path, and non-runtime error propagation
- preserve the earlier cleanup-model-client shutdown fix and verify the combined cleanup contract on current dev

## Verification
- uv run pytest -q tests/Unit/core/test_agent_model_clients.py tests/Unit/core/test_runtime_agent.py -k 'cleanup or dunder_del'
- git diff --check origin/dev..HEAD

## Runtime proof
- on current shared dev, a real backend run followed by Ctrl-C no longer reproduces the previous Exception ignored in LeonAgent.__del__ noise