### PR TITLE
refactor(runtime): borrow typing tracker explicitly in run execution

### DIFF
--- a/backend/threads/run/execution.py
+++ b/backend/threads/run/execution.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 from typing import Any
 
-from backend.chat.runtime_access import get_optional_typing_tracker
 from backend.threads.run import activity_bridge as _run_activity_bridge
 from backend.threads.run import emit as _run_emit
 from backend.threads.run import epilogue as _run_epilogue
@@ -52,6 +51,7 @@ async def run_agent_to_buffer(
     run_id: str,
     message_metadata: dict[str, Any] | None = None,
     input_messages: list[Any] | None = None,
+    typing_tracker: Any | None = None,
 ) -> str:
     run_event_repo = _run_emit.resolve_run_event_repo(agent)
     display_builder = app.state.display_builder
@@ -204,7 +204,6 @@ async def run_agent_to_buffer(
         return ""
     finally:
         prompt_restore()
-        typing_tracker = get_optional_typing_tracker(app)
         if typing_tracker is not None:
             typing_tracker.stop(thread_id)
         detach_activity_bridge()

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from backend.chat.runtime_access import get_optional_typing_tracker
 from backend.threads.events.buffer import RunEventBuffer, ThreadEventBuffer
 from backend.threads.events.store import append_event as _append_event
 from backend.threads.events.store import cleanup_old_runs
@@ -207,6 +208,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         run_id=run_id,
         message_metadata=message_metadata,
         input_messages=input_messages,
+        typing_tracker=get_optional_typing_tracker(app),
     )
 
 

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -198,6 +198,9 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     _run_execution.log_captured_exception = _log_captured_exception
     _run_emit.append_event = _append_event
     _run_buffer_wiring._append_event = _append_event
+    # @@@run-buffer-borrowed-typing-tracker - execution cleanup still needs
+    # chat-owned typing state, but the borrow happens at the streaming wrapper
+    # so the deeper execution helper no longer reopens app.state on its own.
     return await _run_execution.run_agent_to_buffer(
         agent=agent,
         thread_id=thread_id,

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -317,6 +317,41 @@ async def test_streaming_run_agent_to_buffer_borrows_optional_typing_tracker(mon
 
 
 @pytest.mark.asyncio
+async def test_streaming_run_agent_to_buffer_passes_none_when_optional_typing_tracker_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent_to_buffer(**kwargs):
+        captured.update(kwargs)
+        return "done"
+
+    monkeypatch.setattr("backend.threads.streaming._run_execution.run_agent_to_buffer", _fake_run_agent_to_buffer)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            display_builder=_FakeDisplayBuilder(),
+            thread_tasks={},
+            thread_last_active={},
+            queue_manager=SimpleNamespace(peek=lambda _thread_id: False),
+        )
+    )
+
+    result = await _run_agent_to_buffer(
+        SimpleNamespace(),
+        "thread-no-typing",
+        "hello",
+        app,
+        False,
+        ThreadEventBuffer(),
+        "run-no-typing",
+    )
+
+    assert result == "done"
+    assert captured["typing_tracker"] is None
+
+
+@pytest.mark.asyncio
 async def test_write_cancellation_markers_advances_string_channel_versions() -> None:
     saver = _VersionedCheckpointSaver()
     agent = SimpleNamespace(agent=SimpleNamespace(checkpointer=saver))

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -289,6 +289,34 @@ async def test_run_agent_to_buffer_finalizes_same_eval_row_on_cancel(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_streaming_run_agent_to_buffer_borrows_optional_typing_tracker(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    typing_tracker = object()
+
+    async def _fake_run_agent_to_buffer(**kwargs):
+        captured.update(kwargs)
+        return "done"
+
+    monkeypatch.setattr("backend.threads.streaming._run_execution.run_agent_to_buffer", _fake_run_agent_to_buffer)
+
+    app = _make_app()
+    app.state.typing_tracker = typing_tracker
+
+    result = await _run_agent_to_buffer(
+        SimpleNamespace(),
+        "thread-typing",
+        "hello",
+        app,
+        False,
+        ThreadEventBuffer(),
+        "run-typing",
+    )
+
+    assert result == "done"
+    assert captured["typing_tracker"] is typing_tracker
+
+
+@pytest.mark.asyncio
 async def test_write_cancellation_markers_advances_string_channel_versions() -> None:
     saver = _VersionedCheckpointSaver()
     agent = SimpleNamespace(agent=SimpleNamespace(checkpointer=saver))

--- a/tests/Unit/core/test_prompt_caching_middleware.py
+++ b/tests/Unit/core/test_prompt_caching_middleware.py
@@ -54,9 +54,7 @@ def test_prompt_caching_applies_cache_control_to_string_system_message():
 
     updated = middleware._apply_system_cache(request)
 
-    assert updated.system_message.content == [
-        {"type": "text", "text": "system prompt", "cache_control": {"type": "ephemeral"}}
-    ]
+    assert updated.system_message.content == [{"type": "text", "text": "system prompt", "cache_control": {"type": "ephemeral"}}]
 
 
 def test_prompt_caching_applies_cache_control_to_first_system_block():


### PR DESCRIPTION
## Summary
- let thread run execution accept optional typing_tracker explicitly instead of reopening app.state itself
- have the streaming wrapper borrow chat-owned typing_tracker and pass it down into execution cleanup
- lock the borrowed contract with focused streaming/query-loop tests and an @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py -k "typing_tracker or persists_running_then_completed_eval_row or finalizes_same_eval_row or run_agent_to_buffer"
- uv run ruff check backend/threads/run/execution.py backend/threads/streaming.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- uv run ruff format --check backend/threads/run/execution.py backend/threads/streaming.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- git diff --check