### PR TITLE
refactor(chat): return borrowable state from chat bootstrap

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -64,6 +64,9 @@ def attach_chat_runtime(
     app.state.typing_tracker = typing_tracker
     app.state.relationship_service = relationship_service
     app.state.messaging_service = messaging_service
+    # @@@chat-bootstrap-borrowable-state - bootstrap still attaches chat-owned
+    # state onto app.state for the wider app, but it also returns the freshly
+    # built runtime objects so enclosing lifespans do not need to reread them.
     return ChatRuntimeState(
         contact_repo=contact_repo,
         typing_tracker=typing_tracker,

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
@@ -13,13 +14,21 @@ from messaging.relationships.service import RelationshipService
 from messaging.service import MessagingService
 
 
+@dataclass(frozen=True)
+class ChatRuntimeState:
+    contact_repo: Any
+    typing_tracker: Any
+    relationship_service: Any
+    messaging_service: Any
+
+
 def attach_chat_runtime(
     app: Any,
     storage_container: Any,
     *,
     user_repo: Any,
     thread_repo: Any,
-) -> None:
+) -> ChatRuntimeState:
     chat_repo = storage_container.chat_repo()
     contact_repo = storage_container.contact_repo()
     chat_member_repo = storage_container.chat_member_repo()
@@ -55,6 +64,12 @@ def attach_chat_runtime(
     app.state.typing_tracker = typing_tracker
     app.state.relationship_service = relationship_service
     app.state.messaging_service = messaging_service
+    return ChatRuntimeState(
+        contact_repo=contact_repo,
+        typing_tracker=typing_tracker,
+        relationship_service=relationship_service,
+        messaging_service=messaging_service,
+    )
 
 
 def wire_chat_delivery(app: Any, *, messaging_service: Any, activity_reader: Any, thread_repo: Any) -> None:

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -70,16 +70,16 @@ async def lifespan(app: FastAPI):
     # @@@web-chat-before-threads - threads bootstrap now constructs the agent
     # runtime gateway eagerly, and that path requires chat-owned typing state
     # to exist first. Reordering this back will fail startup on fresh dev.
-    attach_chat_runtime(
+    chat_runtime = attach_chat_runtime(
         app,
         storage_container,
         user_repo=app.state.user_repo,
         thread_repo=app.state.thread_repo,
     )
-    attach_threads_runtime(app, storage_container, typing_tracker=app.state.typing_tracker)
+    attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)
     wire_chat_delivery(
         app,
-        messaging_service=app.state.messaging_service,
+        messaging_service=chat_runtime.messaging_service,
         activity_reader=app.state.agent_runtime_thread_activity_reader,
         thread_repo=app.state.thread_repo,
     )

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -55,7 +55,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         )
     )
 
-    chat_bootstrap.attach_chat_runtime(
+    state = chat_bootstrap.attach_chat_runtime(
         app,
         storage_container,
         user_repo=app.state.user_repo,
@@ -74,6 +74,9 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     assert app.state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
     assert app.state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
     assert app.state.messaging_service.delivery_fn is None
+    assert state.contact_repo is contact_repo
+    assert state.typing_tracker is app.state.typing_tracker
+    assert state.messaging_service is app.state.messaging_service
 
 
 def test_attach_chat_runtime_does_not_read_back_chat_state_during_wiring(monkeypatch):

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -72,8 +72,14 @@ def _patch_lifespan_runtime_contract(monkeypatch, *, attach_chat_runtime, attach
 @pytest.mark.asyncio
 async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeypatch):
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
-        app.state.typing_tracker = object()
-        app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+        typing_tracker = object()
+        messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+        app.state.typing_tracker = typing_tracker
+        app.state.messaging_service = messaging_service
+        return SimpleNamespace(
+            typing_tracker=typing_tracker,
+            messaging_service=messaging_service,
+        )
 
     def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
         if not hasattr(app.state, "typing_tracker"):
@@ -100,22 +106,28 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
 async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatch):
     call_log: list[str] = []
     contact_repo = object()
+    returned_typing_tracker = object()
+    returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         call_log.append("chat")
         app.state.typing_tracker = object()
         app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
         app.state.contact_repo = contact_repo
+        return SimpleNamespace(
+            typing_tracker=returned_typing_tracker,
+            messaging_service=returned_messaging_service,
+        )
 
     def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
         call_log.append("threads")
-        assert typing_tracker is app.state.typing_tracker
+        assert typing_tracker is returned_typing_tracker
         app.state.agent_pool = {}
         app.state.agent_runtime_thread_activity_reader = object()
 
     def _wire_chat_delivery(_app, *, messaging_service, activity_reader, thread_repo):
         call_log.append("wire")
-        assert messaging_service is _app.state.messaging_service
+        assert messaging_service is returned_messaging_service
         assert activity_reader is _app.state.agent_runtime_thread_activity_reader
 
     _patch_lifespan_runtime_contract(
@@ -181,6 +193,10 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
         lambda app, _storage_container, *, user_repo, thread_repo: (
             setattr(app.state, "typing_tracker", object())
             or setattr(app.state, "messaging_service", SimpleNamespace(set_delivery_fn=lambda _fn: None))
+            or SimpleNamespace(
+                typing_tracker=app.state.typing_tracker,
+                messaging_service=app.state.messaging_service,
+            )
         ),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- make attach_chat_runtime return the freshly built chat runtime objects as an explicit state bundle
- update web lifespan to use the returned typing_tracker and messaging_service instead of rereading app.state
- lock the borrowable-state contract with focused chat bootstrap and web lifespan tests plus an @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff check backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff format --check backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- git diff --check