### PR TITLE
refactor(chat): borrow auth contact from chat runtime state

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -73,6 +73,9 @@ async def lifespan(app: FastAPI):
         user_repo=app.state.user_repo,
         thread_repo=app.state.thread_repo,
     )
+    # @@@web-auth-borrowed-chat-contact - auth startup still needs the
+    # owner-agent contact repo, but web bootstrap should borrow the chat-owned
+    # contact_repo returned by chat bootstrap instead of reopening storage.
     app.state.agent_config_repo = storage_container.agent_config_repo()
     attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=chat_runtime.contact_repo)
     attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -61,9 +61,6 @@ async def lifespan(app: FastAPI):
     app.state.sandbox_repo = storage_container.sandbox_repo()
     app.state.invite_code_repo = storage_container.invite_code_repo()
     app.state.user_settings_repo = storage_container.user_settings_repo()
-    app.state.agent_config_repo = storage_container.agent_config_repo()
-    attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=storage_container.contact_repo())
-
     from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery
     from backend.threads.bootstrap import attach_threads_runtime
 
@@ -76,6 +73,8 @@ async def lifespan(app: FastAPI):
         user_repo=app.state.user_repo,
         thread_repo=app.state.thread_repo,
     )
+    app.state.agent_config_repo = storage_container.agent_config_repo()
+    attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=chat_runtime.contact_repo)
     attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)
     wire_chat_delivery(
         app,

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -213,6 +213,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
             setattr(app.state, "typing_tracker", object())
             or setattr(app.state, "messaging_service", SimpleNamespace(set_delivery_fn=lambda _fn: None))
             or SimpleNamespace(
+                contact_repo=contact_repo,
                 typing_tracker=app.state.typing_tracker,
                 messaging_service=app.state.messaging_service,
             )

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -119,6 +119,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     contact_repo = object()
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+    returned_contact_repo = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         call_log.append("chat")
@@ -126,9 +127,15 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
         app.state.contact_repo = contact_repo
         return SimpleNamespace(
+            contact_repo=returned_contact_repo,
             typing_tracker=returned_typing_tracker,
             messaging_service=returned_messaging_service,
         )
+
+    def _attach_auth_runtime(_app, *, storage_state, contact_repo):
+        call_log.append("auth")
+        assert contact_repo is returned_contact_repo
+        return object()
 
     def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
         call_log.append("threads")
@@ -144,7 +151,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     _patch_lifespan_runtime_contract(
         monkeypatch,
         attach_chat_runtime=_attach_chat_runtime,
-        attach_auth_runtime=lambda *_args, **_kwargs: object(),
+        attach_auth_runtime=_attach_auth_runtime,
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=_wire_chat_delivery,
     )
@@ -152,7 +159,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     app = SimpleNamespace(state=SimpleNamespace())
 
     async with web_lifespan.lifespan(app):
-        assert call_log == ["chat", "threads", "wire"]
+        assert call_log == ["chat", "auth", "threads", "wire"]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -16,7 +16,14 @@ class _FakeCheckpointCtx:
         return None
 
 
-def _patch_lifespan_runtime_contract(monkeypatch, *, attach_chat_runtime, attach_threads_runtime, wire_chat_delivery):
+def _patch_lifespan_runtime_contract(
+    monkeypatch,
+    *,
+    attach_chat_runtime,
+    attach_auth_runtime,
+    attach_threads_runtime,
+    wire_chat_delivery,
+):
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
     monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
 
@@ -50,7 +57,7 @@ def _patch_lifespan_runtime_contract(monkeypatch, *, attach_chat_runtime, attach
     )
     monkeypatch.setattr(
         "backend.identity.auth.runtime_bootstrap.attach_auth_runtime_state",
-        lambda *_args, **_kwargs: object(),
+        attach_auth_runtime,
     )
     monkeypatch.setattr(
         "core.runtime.langgraph_checkpoint_store.agent_checkpoint_saver_from_conn_string",
@@ -72,11 +79,14 @@ def _patch_lifespan_runtime_contract(monkeypatch, *, attach_chat_runtime, attach
 @pytest.mark.asyncio
 async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeypatch):
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
+        contact_repo = object()
         typing_tracker = object()
         messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+        app.state.contact_repo = contact_repo
         app.state.typing_tracker = typing_tracker
         app.state.messaging_service = messaging_service
         return SimpleNamespace(
+            contact_repo=contact_repo,
             typing_tracker=typing_tracker,
             messaging_service=messaging_service,
         )
@@ -91,6 +101,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
     _patch_lifespan_runtime_contract(
         monkeypatch,
         attach_chat_runtime=_attach_chat_runtime,
+        attach_auth_runtime=lambda *_args, **_kwargs: object(),
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=lambda *_args, **_kwargs: None,
     )
@@ -133,6 +144,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     _patch_lifespan_runtime_contract(
         monkeypatch,
         attach_chat_runtime=_attach_chat_runtime,
+        attach_auth_runtime=lambda *_args, **_kwargs: object(),
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=_wire_chat_delivery,
     )


### PR DESCRIPTION
## Summary
- make web startup borrow auth contact_repo from the returned ChatRuntimeState instead of reopening storage directly
- lock the chat -> auth -> threads -> wire startup order in focused web lifespan tests
- document the borrowed auth contact boundary with one @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff check backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff format --check backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- git diff --check