### PR TITLE
refactor(runtime): return borrowable state from threads bootstrap

### DIFF
--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -32,6 +32,9 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
     # chat-owned typing state for agent chat delivery, but the borrow is made
     # at bootstrap so downstream gateway setup does not reopen app.state.
     app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=typing_tracker)
+    # @@@threads-bootstrap-borrowable-state - bootstrap still attaches thread
+    # runtime objects onto app.state for the wider app, but it also returns the
+    # freshly built runtime handles so enclosing lifespans do not need to reread them.
     return ThreadsRuntimeState(
         queue_manager=app.state.queue_manager,
         agent_runtime_gateway=app.state.agent_runtime_gateway,

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
 from core.runtime.middleware.queue import MessageQueueManager
 
 
-def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> None:
+@dataclass(frozen=True)
+class ThreadsRuntimeState:
+    queue_manager: Any
+    agent_runtime_gateway: Any
+    activity_reader: Any
+
+
+def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> ThreadsRuntimeState:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.agent_pool = {}
     app.state.thread_sandbox = {}
@@ -24,3 +32,8 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
     # chat-owned typing state for agent chat delivery, but the borrow is made
     # at bootstrap so downstream gateway setup does not reopen app.state.
     app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=typing_tracker)
+    return ThreadsRuntimeState(
+        queue_manager=app.state.queue_manager,
+        agent_runtime_gateway=app.state.agent_runtime_gateway,
+        activity_reader=app.state.agent_runtime_thread_activity_reader,
+    )

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -78,11 +78,11 @@ async def lifespan(app: FastAPI):
     # contact_repo returned by chat bootstrap instead of reopening storage.
     app.state.agent_config_repo = storage_container.agent_config_repo()
     attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=chat_runtime.contact_repo)
-    attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)
+    threads_runtime = attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)
     wire_chat_delivery(
         app,
         messaging_service=chat_runtime.messaging_service,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=threads_runtime.activity_reader,
         thread_repo=app.state.thread_repo,
     )
 

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -24,11 +24,14 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
         threads_bootstrap,
         "build_agent_runtime_gateway",
         lambda target_app, *, typing_tracker: (
-            seen.append(("gateway", target_app)) or seen.append(("typing_tracker", typing_tracker)) or gateway
+            seen.append(("gateway", target_app))
+            or seen.append(("typing_tracker", typing_tracker))
+            or setattr(target_app.state, "agent_runtime_thread_activity_reader", "activity-reader")
+            or gateway
         ),
     )
 
-    threads_bootstrap.attach_threads_runtime(app, storage_container, typing_tracker=typing_tracker)
+    state = threads_bootstrap.attach_threads_runtime(app, storage_container, typing_tracker=typing_tracker)
 
     assert app.state.queue_manager is queue_manager
     assert app.state.agent_pool == {}
@@ -39,6 +42,10 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert app.state.subagent_buffers == {}
     assert app.state.thread_last_active == {}
     assert app.state.agent_runtime_gateway is gateway
+    assert app.state.agent_runtime_thread_activity_reader == "activity-reader"
+    assert state.queue_manager is queue_manager
+    assert state.agent_runtime_gateway is gateway
+    assert state.activity_reader == "activity-reader"
     assert seen == [
         ("queue_manager", queue_repo),
         ("gateway", app),

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -97,6 +97,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
         assert typing_tracker is app.state.typing_tracker
         app.state.agent_pool = {}
         app.state.agent_runtime_thread_activity_reader = object()
+        return SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
 
     _patch_lifespan_runtime_contract(
         monkeypatch,
@@ -120,6 +121,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_contact_repo = object()
+    returned_activity_reader = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         call_log.append("chat")
@@ -142,11 +144,12 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert typing_tracker is returned_typing_tracker
         app.state.agent_pool = {}
         app.state.agent_runtime_thread_activity_reader = object()
+        return SimpleNamespace(activity_reader=returned_activity_reader)
 
     def _wire_chat_delivery(_app, *, messaging_service, activity_reader, thread_repo):
         call_log.append("wire")
         assert messaging_service is returned_messaging_service
-        assert activity_reader is _app.state.agent_runtime_thread_activity_reader
+        assert activity_reader is returned_activity_reader
 
     _patch_lifespan_runtime_contract(
         monkeypatch,
@@ -222,7 +225,9 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     monkeypatch.setattr(
         "backend.threads.bootstrap.attach_threads_runtime",
         lambda app, *_args, **_kwargs: (
-            setattr(app.state, "agent_runtime_thread_activity_reader", object()) or setattr(app.state, "agent_pool", {})
+            setattr(app.state, "agent_runtime_thread_activity_reader", object())
+            or setattr(app.state, "agent_pool", {})
+            or SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
         ),
     )
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)


### PR DESCRIPTION
## Summary
- make attach_threads_runtime return the freshly built threads runtime handles as an explicit state bundle
- update web lifespan to use the returned activity reader instead of rereading app.state
- lock the borrowable-state contract with focused threads bootstrap and web lifespan tests plus an @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff check backend/threads/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff format --check backend/threads/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- git diff --check