### PR TITLE
refactor(runtime): return borrowable state from gateway bootstrap

### DIFF
--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from core.runtime.middleware.queue import MessageQueueManager
 
 
@@ -31,12 +31,13 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
     # @@@threads-bootstrap-borrowed-typing-tracker - threads runtime needs
     # chat-owned typing state for agent chat delivery, but the borrow is made
     # at bootstrap so downstream gateway setup does not reopen app.state.
-    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=typing_tracker)
+    runtime_state = build_agent_runtime_state(app, typing_tracker=typing_tracker)
+    app.state.agent_runtime_gateway = runtime_state.gateway
     # @@@threads-bootstrap-borrowable-state - bootstrap still attaches thread
     # runtime objects onto app.state for the wider app, but it also returns the
     # freshly built runtime handles so enclosing lifespans do not need to reread them.
     return ThreadsRuntimeState(
         queue_manager=app.state.queue_manager,
         agent_runtime_gateway=app.state.agent_runtime_gateway,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=runtime_state.activity_reader,
     )

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from backend.monitor.infrastructure.resources.resource_overview_cache import clear_resource_overview_cache
@@ -14,12 +15,19 @@ from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputH
 from backend.threads.streaming import _ensure_thread_handlers, start_agent_run
 
 
-def build_agent_runtime_gateway(app: Any, *, typing_tracker: Any) -> NativeAgentRuntimeGateway:
-    app.state.agent_runtime_thread_activity_reader = AppRuntimeThreadActivityReader(
+@dataclass(frozen=True)
+class AgentRuntimeGatewayState:
+    gateway: NativeAgentRuntimeGateway
+    activity_reader: Any
+
+
+def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeGatewayState:
+    activity_reader = AppRuntimeThreadActivityReader(
         thread_repo=app.state.thread_repo,
         agent_pool=app.state.agent_pool,
     )
-    return NativeAgentRuntimeGateway(
+    app.state.agent_runtime_thread_activity_reader = activity_reader
+    gateway = NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(
                 runtime_services=AppAgentChatRuntimeServices(
@@ -48,3 +56,8 @@ def build_agent_runtime_gateway(app: Any, *, typing_tracker: Any) -> NativeAgent
             clear_resource_overview_cache=clear_resource_overview_cache,
         ),
     )
+    return AgentRuntimeGatewayState(gateway=gateway, activity_reader=activity_reader)
+
+
+def build_agent_runtime_gateway(app: Any, *, typing_tracker: Any) -> NativeAgentRuntimeGateway:
+    return build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -56,6 +56,9 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
             clear_resource_overview_cache=clear_resource_overview_cache,
         ),
     )
+    # @@@gateway-bootstrap-borrowable-state - bootstrap still attaches the
+    # activity reader onto app.state for wider consumers, but it also returns
+    # the freshly built gateway/activity handles so callers do not need to reread them.
     return AgentRuntimeGatewayState(gateway=gateway, activity_reader=activity_reader)
 
 

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -9,6 +9,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     queue_repo = object()
     queue_manager = object()
     gateway = object()
+    activity_reader = object()
     typing_tracker = object()
     seen: list[tuple[str, object]] = []
 
@@ -22,12 +23,11 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     )
     monkeypatch.setattr(
         threads_bootstrap,
-        "build_agent_runtime_gateway",
+        "build_agent_runtime_state",
         lambda target_app, *, typing_tracker: (
-            seen.append(("gateway", target_app))
+            seen.append(("runtime_state", target_app))
             or seen.append(("typing_tracker", typing_tracker))
-            or setattr(target_app.state, "agent_runtime_thread_activity_reader", "activity-reader")
-            or gateway
+            or SimpleNamespace(gateway=gateway, activity_reader=activity_reader)
         ),
     )
 
@@ -42,13 +42,12 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert app.state.subagent_buffers == {}
     assert app.state.thread_last_active == {}
     assert app.state.agent_runtime_gateway is gateway
-    assert app.state.agent_runtime_thread_activity_reader == "activity-reader"
     assert state.queue_manager is queue_manager
     assert state.agent_runtime_gateway is gateway
-    assert state.activity_reader == "activity-reader"
+    assert state.activity_reader is activity_reader
     assert seen == [
         ("queue_manager", queue_repo),
-        ("gateway", app),
+        ("runtime_state", app),
         ("typing_tracker", typing_tracker),
     ]
     assert hasattr(app.state, "thread_locks_guard")

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from backend.threads import bootstrap as threads_bootstrap
+from backend.threads.chat_adapters import bootstrap as runtime_bootstrap
 
 
 def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
@@ -60,3 +61,17 @@ def test_attach_threads_runtime_requires_explicit_typing_tracker():
 
     with pytest.raises(TypeError, match="typing_tracker"):
         threads_bootstrap.attach_threads_runtime(app, storage_container)
+
+
+def test_build_agent_runtime_gateway_returns_gateway_from_runtime_state(monkeypatch):
+    gateway = object()
+    activity_reader = object()
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    monkeypatch.setattr(
+        runtime_bootstrap,
+        "build_agent_runtime_state",
+        lambda target_app, *, typing_tracker: SimpleNamespace(gateway=gateway, activity_reader=activity_reader),
+    )
+
+    assert runtime_bootstrap.build_agent_runtime_gateway(app, typing_tracker=object()) is gateway


### PR DESCRIPTION
## Summary
- add a borrowable gateway bootstrap state so the freshly built gateway/activity handles can be passed around explicitly
- update threads bootstrap to consume the returned gateway/activity state instead of rereading app.state.agent_runtime_thread_activity_reader
- lock the wrapper/state contract with focused threads bootstrap and web lifespan tests plus an @@@ note

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff check backend/threads/chat_adapters/bootstrap.py backend/threads/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff format --check backend/threads/chat_adapters/bootstrap.py backend/threads/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- git diff --check