### PR TITLE
refactor(runtime): read gateway and activity through threads runtime state

### DIFF
--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -55,7 +55,8 @@ def get_chat_event_bus(app: Annotated[Any, Depends(get_app)]) -> Any:
 
 
 def get_runtime_thread_activity_reader(app: Annotated[Any, Depends(get_app)]) -> Any:
-    return _require_state_attr(app, "agent_runtime_thread_activity_reader", "Thread activity reader unavailable")
+    runtime_state = _require_state_attr(app, "threads_runtime_state", "Thread activity reader unavailable")
+    return runtime_state.activity_reader
 
 
 def get_thread_last_active_map(app: Annotated[Any, Depends(get_app)]) -> Any:

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -33,11 +33,14 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
     # at bootstrap so downstream gateway setup does not reopen app.state.
     runtime_state = build_agent_runtime_state(app, typing_tracker=typing_tracker)
     app.state.agent_runtime_gateway = runtime_state.gateway
+    app.state.threads_runtime_state = None
     # @@@threads-bootstrap-borrowable-state - bootstrap still attaches thread
     # runtime objects onto app.state for the wider app, but it also returns the
     # freshly built runtime handles so enclosing lifespans do not need to reread them.
-    return ThreadsRuntimeState(
+    state = ThreadsRuntimeState(
         queue_manager=app.state.queue_manager,
         agent_runtime_gateway=app.state.agent_runtime_gateway,
         activity_reader=runtime_state.activity_reader,
     )
+    app.state.threads_runtime_state = state
+    return state

--- a/backend/threads/chat_adapters/port.py
+++ b/backend/threads/chat_adapters/port.py
@@ -19,4 +19,4 @@ class AgentRuntimeGatewayPort(Protocol):
 
 
 def get_agent_runtime_gateway(app: Any) -> AgentRuntimeGatewayPort:
-    return app.state.agent_runtime_gateway
+    return app.state.threads_runtime_state.agent_runtime_gateway

--- a/backend/threads/chat_adapters/port.py
+++ b/backend/threads/chat_adapters/port.py
@@ -19,4 +19,7 @@ class AgentRuntimeGatewayPort(Protocol):
 
 
 def get_agent_runtime_gateway(app: Any) -> AgentRuntimeGatewayPort:
+    # @@@agent-runtime-port-borrowed-state - web routes still read the agent
+    # runtime gateway from app state, but they now borrow it through the
+    # threads_runtime_state bundle instead of a loose top-level attribute.
     return app.state.threads_runtime_state.agent_runtime_gateway

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -36,10 +36,12 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
             terminal_repo=SimpleNamespace(summarize_threads=lambda _thread_ids: {}),
             agent_pool={},
             agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=None,
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
         )
     )
+    app.state.threads_runtime_state = SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
 
     conversations, threads = await asyncio.gather(
         owner_conversations_router.list_conversations(

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -20,6 +20,8 @@ def test_conversations_router_shell_is_deleted() -> None:
 
 
 async def _list_conversations(app: SimpleNamespace, user_id: str = "human-user-1"):
+    if not hasattr(app.state, "threads_runtime_state") and hasattr(app.state, "agent_runtime_thread_activity_reader"):
+        app.state.threads_runtime_state = SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
     return await owner_conversations_router.list_conversations(
         user_id,
         owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -2592,8 +2592,8 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
     )
     gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
     app.state.agent_runtime_gateway = gateway
-    app.state.agent_runtime_gateway_state = SimpleNamespace(
-        gateway=gateway,
+    app.state.threads_runtime_state = SimpleNamespace(
+        agent_runtime_gateway=gateway,
         activity_reader=app.state.agent_runtime_thread_activity_reader,
     )
 
@@ -2667,8 +2667,8 @@ async def _run_chat_delivery(
     )
     gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
     app.state.agent_runtime_gateway = gateway
-    app.state.agent_runtime_gateway_state = SimpleNamespace(
-        gateway=gateway,
+    app.state.threads_runtime_state = SimpleNamespace(
+        agent_runtime_gateway=gateway,
         activity_reader=app.state.agent_runtime_thread_activity_reader,
     )
 

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -2590,7 +2590,12 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
+    gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
+    app.state.agent_runtime_gateway = gateway
+    app.state.agent_runtime_gateway_state = SimpleNamespace(
+        gateway=gateway,
+        activity_reader=app.state.agent_runtime_thread_activity_reader,
+    )
 
     with pytest.raises(AttributeError):
         await asyncio.to_thread(
@@ -2660,7 +2665,12 @@ async def _run_chat_delivery(
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    app.state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
+    gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
+    app.state.agent_runtime_gateway = gateway
+    app.state.agent_runtime_gateway_state = SimpleNamespace(
+        gateway=gateway,
+        activity_reader=app.state.agent_runtime_thread_activity_reader,
+    )
 
     await asyncio.to_thread(
         chat_delivery_hook.make_chat_delivery_fn(

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -532,6 +532,10 @@ def _make_streaming_app(
         gateway=gateway,
         activity_reader=state.agent_runtime_thread_activity_reader,
     )
+    state.threads_runtime_state = SimpleNamespace(
+        agent_runtime_gateway=gateway,
+        activity_reader=state.agent_runtime_thread_activity_reader,
+    )
     return app, queue_manager
 
 

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -526,7 +526,12 @@ def _make_streaming_app(
         state.thread_sandbox = {thread_id: "local"}
         state._event_loop = asyncio.get_running_loop()
     app = SimpleNamespace(state=state)
-    state.agent_runtime_gateway = build_agent_runtime_gateway(app, typing_tracker=state.typing_tracker)
+    gateway = build_agent_runtime_gateway(app, typing_tracker=state.typing_tracker)
+    state.agent_runtime_gateway = gateway
+    state.agent_runtime_gateway_state = SimpleNamespace(
+        gateway=gateway,
+        activity_reader=state.agent_runtime_thread_activity_reader,
+    )
     return app, queue_manager
 
 

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -174,11 +174,17 @@ async def test_send_message_passes_enable_trajectory_to_agent_runtime_gateway() 
             captured.append(envelope)
             return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
 
+    gateway = _Gateway()
     result = await threads_router.send_message(
         "thread-1",
         SendMessageRequest(message="hello", enable_trajectory=True),
         user_id="owner-1",
-        app=SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=_Gateway())),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                agent_runtime_gateway=gateway,
+                threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway),
+            )
+        ),
     )
 
     assert result == {"status": "started", "routing": "direct", "thread_id": "thread-1"}
@@ -1252,13 +1258,19 @@ async def test_resolve_ask_user_question_request_starts_followup_run_with_answer
             captured.append(envelope)
             return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
 
+    gateway = _Gateway()
     result = await threads_router.resolve_thread_permission_request(
         "thread-1",
         "perm-ask",
         payload,
         user_id="owner-1",
         agent=agent,
-        app=SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=_Gateway())),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                agent_runtime_gateway=gateway,
+                threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway),
+            )
+        ),
         thread_lock=_NullLock(),
     )
 

--- a/tests/Unit/backend/test_chat_http_dependencies.py
+++ b/tests/Unit/backend/test_chat_http_dependencies.py
@@ -61,6 +61,14 @@ def test_get_runtime_thread_activity_reader_fails_loud_when_missing():
     assert exc_info.value.detail == "Thread activity reader unavailable"
 
 
+def test_get_runtime_thread_activity_reader_reads_threads_runtime_state():
+    activity_reader = object()
+
+    app = _app_state(threads_runtime_state=SimpleNamespace(activity_reader=activity_reader))
+
+    assert chat_http_dependencies.get_runtime_thread_activity_reader(app) is activity_reader
+
+
 @pytest.mark.parametrize(
     ("getter_name", "detail"),
     [

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -43,6 +43,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert app.state.subagent_buffers == {}
     assert app.state.thread_last_active == {}
     assert app.state.agent_runtime_gateway is gateway
+    assert app.state.threads_runtime_state is state
     assert state.queue_manager is queue_manager
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader

--- a/tests/Unit/backend/web/services/test_agent_runtime_port.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_port.py
@@ -8,5 +8,14 @@ import pytest
 def test_agent_runtime_port_requires_lifespan_registration() -> None:
     from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 
-    with pytest.raises(AttributeError, match="agent_runtime_gateway"):
+    with pytest.raises(AttributeError, match="threads_runtime_state"):
         get_agent_runtime_gateway(SimpleNamespace(state=SimpleNamespace()))
+
+
+def test_agent_runtime_port_reads_gateway_from_threads_runtime_state() -> None:
+    from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+
+    gateway = object()
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+    assert get_agent_runtime_gateway(app) is gateway

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -11,14 +11,19 @@ from messaging.delivery.dispatcher import ChatDeliveryRequest
 
 def _hook_app(gateway: object) -> SimpleNamespace:
     default_thread = {"id": "thread-1", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
+    activity_reader = SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
     return SimpleNamespace(
         state=SimpleNamespace(
             agent_runtime_gateway=gateway,
+            threads_runtime_state=SimpleNamespace(
+                agent_runtime_gateway=gateway,
+                activity_reader=activity_reader,
+            ),
             thread_repo=SimpleNamespace(
                 get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
                 list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
             ),
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            agent_runtime_thread_activity_reader=activity_reader,
         )
     )
 
@@ -158,7 +163,12 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
 
 
 def test_make_chat_delivery_fn_requires_activity_reader():
-    app = SimpleNamespace(state=SimpleNamespace(agent_runtime_gateway=object()))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_runtime_gateway=object(),
+            threads_runtime_state=SimpleNamespace(agent_runtime_gateway=object(), activity_reader=None),
+        )
+    )
 
     with pytest.raises(RuntimeError, match="Agent runtime thread activity reader is not configured"):
         owner_chat_inlet.make_chat_delivery_fn(


### PR DESCRIPTION
## Summary
- store the returned ThreadsRuntimeState on app.state during threads bootstrap
- have the agent runtime port and chat HTTP thread-activity dependency borrow gateway/activity from that bundle instead of loose top-level attrs
- align focused gateway consumer tests and document the borrowed bundle contract

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py -k "threads_runtime_state or agent_runtime_gateway or runtime_thread_activity_reader or send_message_passes_enable_trajectory_to_agent_runtime_gateway or resolve_thread_permission_request"
- uv run ruff check backend/threads/chat_adapters/bootstrap.py backend/threads/chat_adapters/port.py backend/chat/api/http/dependencies.py backend/threads/bootstrap.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py
- uv run ruff format --check backend/threads/chat_adapters/bootstrap.py backend/threads/chat_adapters/port.py backend/chat/api/http/dependencies.py backend/threads/bootstrap.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_port.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Integration/test_threads_router.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py
- git diff --check