### PR TITLE
fix: restore users chat candidates route

### DIFF
--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -8,8 +8,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 
-from backend.chat.api.http.dependencies import get_thread_repo, get_user_repo
-from backend.chat.runtime_access import get_contact_repo, get_relationship_service
+from backend.chat.api.http.dependencies import get_contact_repo, get_relationship_service, get_thread_repo, get_user_repo
 from backend.identity.avatar.files import process_and_save_avatar
 from backend.identity.avatar.paths import avatars_dir
 from backend.identity.avatar.urls import avatar_url

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -143,6 +143,9 @@ def _relationship_states_for_user(relationship_service: Any, user_id: str) -> di
 @users_router.get("/chat-candidates")
 async def list_chat_candidates(
     user_id: Annotated[str, Depends(get_current_user_id)],
+    # @@@chat-candidate-http-di - keep these as HTTP dependency helpers; the
+    # raw runtime_access functions take a plain app param and FastAPI will
+    # otherwise misread that as a query arg on real route calls.
     user_repo: Annotated[Any, Depends(get_user_repo)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
     contact_repo: Annotated[Any, Depends(get_contact_repo)],

--- a/frontend/app/src/pages/contacts/ContactDetailPage.test.tsx
+++ b/frontend/app/src/pages/contacts/ContactDetailPage.test.tsx
@@ -139,6 +139,41 @@ describe("ContactDetailPage", () => {
     expect(screen.queryByText("分支")).toBeNull();
   });
 
+  it("opens a human contact through the chat surface", async () => {
+    authFetch
+      .mockResolvedValueOnce(okJson([
+        {
+          user_id: "human-2",
+          name: "Ada",
+          type: "human",
+          avatar_url: null,
+          owner_name: null,
+          is_owned: false,
+          relationship_state: "visit",
+          can_chat: true,
+        },
+      ]))
+      .mockResolvedValueOnce(okJson({ id: "chat-human-2" }));
+
+    render(
+      <MemoryRouter initialEntries={["/contacts/users/human-2"]}>
+        <Routes>
+          <Route path="/contacts/users/:userId" element={<ContactDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "发起对话" }));
+
+    await waitFor(() => {
+      expect(authFetch).toHaveBeenCalledWith("/api/chats", {
+        method: "POST",
+        body: JSON.stringify({ user_ids: ["human-1", "human-2"] }),
+      });
+    });
+    expect(navigate).toHaveBeenCalledWith("/chat/visit/chat-human-2");
+  });
+
   it("shows chat-capable contacts as contacts instead of exposing raw none state", async () => {
     authFetch.mockResolvedValueOnce(okJson([
       {

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from fastapi import FastAPI
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 from backend.web.routers import users as users_router
+from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow, UserRow, UserType
 
 NOW = 1_775_223_756.0
@@ -294,3 +297,35 @@ def test_user_router_exposes_chat_candidates_route():
     paths = {route.path for route in users_router.users_router.routes}
 
     assert "/api/users/chat-candidates" in paths
+
+
+def test_chat_candidates_route_reads_dependencies_from_app_state() -> None:
+    owner = _human("u1", "owner")
+    other = _human("u2", "other")
+    app = FastAPI()
+    app.include_router(users_router.users_router)
+    app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, other])
+    app.state.thread_repo = SimpleNamespace(get_default_thread=lambda _agent_user_id: None)
+    app.state.relationship_service = SimpleNamespace(
+        list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")]
+    )
+    app.state.contact_repo = _empty_contact_repo()
+    app.dependency_overrides[get_current_user_id] = lambda: "u1"
+
+    with TestClient(app) as client:
+        response = client.get("/api/users/chat-candidates", headers={"Authorization": "Bearer token"})
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "user_id": "u2",
+            "name": "other",
+            "type": "human",
+            "avatar_url": None,
+            "owner_name": None,
+            "agent_name": "other",
+            "is_owned": False,
+            "relationship_state": "visit",
+            "can_chat": True,
+        }
+    ]

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -329,3 +329,51 @@ def test_chat_candidates_route_reads_dependencies_from_app_state() -> None:
             "can_chat": True,
         }
     ]
+
+
+def test_chat_candidates_route_exposes_owned_agent_default_thread_id() -> None:
+    owner = _human("u1", "owner")
+    owned_agent = _agent("a-owned", "Ready Agent", "u1")
+    app = FastAPI()
+    app.include_router(users_router.users_router)
+    app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, owned_agent])
+    app.state.thread_repo = SimpleNamespace(get_default_thread=lambda agent_user_id: {"id": "thread-ready"} if agent_user_id == "a-owned" else None)
+    app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
+    app.state.contact_repo = _empty_contact_repo()
+    app.dependency_overrides[get_current_user_id] = lambda: "u1"
+
+    with TestClient(app) as client:
+        response = client.get("/api/users/chat-candidates", headers={"Authorization": "Bearer token"})
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "user_id": "a-owned",
+            "name": "Ready Agent",
+            "type": "agent",
+            "avatar_url": None,
+            "owner_name": "owner",
+            "agent_name": "Ready Agent",
+            "is_owned": True,
+            "relationship_state": "none",
+            "can_chat": True,
+            "default_thread_id": "thread-ready",
+        }
+    ]
+
+
+def test_chat_candidates_route_fails_loud_when_contact_repo_missing() -> None:
+    owner = _human("u1", "owner")
+    other = _human("u2", "other")
+    app = FastAPI()
+    app.include_router(users_router.users_router)
+    app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, other])
+    app.state.thread_repo = SimpleNamespace(get_default_thread=lambda _agent_user_id: None)
+    app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
+    app.dependency_overrides[get_current_user_id] = lambda: "u1"
+
+    with TestClient(app) as client:
+        response = client.get("/api/users/chat-candidates", headers={"Authorization": "Bearer token"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Contact repo unavailable"}


### PR DESCRIPTION
## Summary
- fix  to use HTTP dependency helpers for contact and relationship state
- add route-level regression coverage for chat candidates DI and owned-agent/default-thread payloads
- add frontend regression coverage for opening a human contact through the chat surface

## Verification
- ............                                                             [100%]
12 passed, 2 deselected in 0.41s
- 
> mycel-frontend@0.0.0 test
> vitest run src/api/users.test.ts src/pages/contacts/ContactList.test.tsx src/pages/contacts/ContactDetailPage.test.tsx


 RUN  v4.1.2 /Users/lexicalmathical/worktrees/leonai--dev-runnable-closure/frontend/app


 Test Files  3 passed (3)
      Tests  10 passed (10)
   Start at  05:04:27
   Duration  693ms (transform 204ms, setup 0ms, import 517ms, tests 179ms, environment 863ms)
- 
- Playwright CLI YATU:  renders again, human contact detail opens,  navigates to , and sending  succeeds with backend readback
