### PR TITLE
refactor(chat): read services through chat runtime state bundle

### DIFF
--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -23,14 +23,30 @@ def _require_state_attr(app: Any, attr_name: str, detail: str) -> Any:
 
 
 def get_messaging_service(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    if runtime_state is not None:
+        # @@@chat-http-borrowed-runtime-state - HTTP dependency helpers still
+        # read through app.state, but they should borrow chat-owned services
+        # from the bundled chat_runtime_state before falling back to legacy attrs.
+        value = getattr(runtime_state, "messaging_service", None)
+        if value is not None:
+            return value
     return _require_state_attr(app, "messaging_service", "MessagingService not initialized")
 
 
 def get_optional_messaging_service(app: Annotated[Any, Depends(get_app)]) -> Any | None:
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    if runtime_state is not None:
+        return getattr(runtime_state, "messaging_service", None)
     return getattr(app.state, "messaging_service", None)
 
 
 def get_relationship_service(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    if runtime_state is not None:
+        value = getattr(runtime_state, "relationship_service", None)
+        if value is not None:
+            return value
     return _require_state_attr(app, "relationship_service", "Relationship service unavailable")
 
 
@@ -43,6 +59,11 @@ def get_thread_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
 
 
 def get_contact_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    if runtime_state is not None:
+        value = getattr(runtime_state, "contact_repo", None)
+        if value is not None:
+            return value
     return _require_state_attr(app, "contact_repo", "Contact repo unavailable")
 
 

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -67,12 +67,14 @@ def attach_chat_runtime(
     # @@@chat-bootstrap-borrowable-state - bootstrap still attaches chat-owned
     # state onto app.state for the wider app, but it also returns the freshly
     # built runtime objects so enclosing lifespans do not need to reread them.
-    return ChatRuntimeState(
+    state = ChatRuntimeState(
         contact_repo=contact_repo,
         typing_tracker=typing_tracker,
         relationship_service=relationship_service,
         messaging_service=messaging_service,
     )
+    app.state.chat_runtime_state = state
+    return state
 
 
 def wire_chat_delivery(app: Any, *, messaging_service: Any, activity_reader: Any, thread_repo: Any) -> None:

--- a/backend/chat/runtime_access.py
+++ b/backend/chat/runtime_access.py
@@ -6,7 +6,8 @@ from typing import Any
 
 
 def _require_chat_state(app: Any, attr_name: str) -> Any:
-    value = getattr(app.state, attr_name, None)
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    value = getattr(runtime_state, attr_name, None) if runtime_state is not None else getattr(app.state, attr_name, None)
     if value is None:
         raise RuntimeError(f"chat bootstrap not attached: {attr_name}")
     return value
@@ -17,6 +18,9 @@ def get_messaging_service(app: Any) -> Any:
 
 
 def get_optional_messaging_service(app: Any) -> Any | None:
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    if runtime_state is not None:
+        return getattr(runtime_state, "messaging_service", None)
     return getattr(app.state, "messaging_service", None)
 
 
@@ -25,6 +29,9 @@ def get_typing_tracker(app: Any) -> Any:
 
 
 def get_optional_typing_tracker(app: Any) -> Any | None:
+    runtime_state = getattr(app.state, "chat_runtime_state", None)
+    if runtime_state is not None:
+        return getattr(runtime_state, "typing_tracker", None)
     return getattr(app.state, "typing_tracker", None)
 
 

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from fastapi import FastAPI
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from backend.web.routers import users as users_router
 from backend.web.core.dependencies import get_current_user_id
+from backend.web.routers import users as users_router
 from storage.contracts import ContactEdgeRow, UserRow, UserType
 
 NOW = 1_775_223_756.0
@@ -306,9 +305,7 @@ def test_chat_candidates_route_reads_dependencies_from_app_state() -> None:
     app.include_router(users_router.users_router)
     app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, other])
     app.state.thread_repo = SimpleNamespace(get_default_thread=lambda _agent_user_id: None)
-    app.state.relationship_service = SimpleNamespace(
-        list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")]
-    )
+    app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")])
     app.state.contact_repo = _empty_contact_repo()
     app.dependency_overrides[get_current_user_id] = lambda: "u1"
 
@@ -337,7 +334,9 @@ def test_chat_candidates_route_exposes_owned_agent_default_thread_id() -> None:
     app = FastAPI()
     app.include_router(users_router.users_router)
     app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, owned_agent])
-    app.state.thread_repo = SimpleNamespace(get_default_thread=lambda agent_user_id: {"id": "thread-ready"} if agent_user_id == "a-owned" else None)
+    app.state.thread_repo = SimpleNamespace(
+        get_default_thread=lambda agent_user_id: {"id": "thread-ready"} if agent_user_id == "a-owned" else None
+    )
     app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
     app.state.contact_repo = _empty_contact_repo()
     app.dependency_overrides[get_current_user_id] = lambda: "u1"

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -74,6 +74,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     assert app.state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
     assert app.state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
     assert app.state.messaging_service.delivery_fn is None
+    assert app.state.chat_runtime_state is state
     assert state.contact_repo is contact_repo
     assert state.typing_tracker is app.state.typing_tracker
     assert state.messaging_service is app.state.messaging_service

--- a/tests/Unit/backend/test_chat_http_dependencies.py
+++ b/tests/Unit/backend/test_chat_http_dependencies.py
@@ -16,6 +16,25 @@ def test_get_messaging_service_returns_service_when_present():
     assert chat_http_dependencies.get_messaging_service(_app_state(messaging_service=service)) is service
 
 
+def test_chat_http_dependencies_read_chat_runtime_state_bundle():
+    messaging_service = object()
+    relationship_service = object()
+    contact_repo = object()
+
+    app = _app_state(
+        chat_runtime_state=SimpleNamespace(
+            messaging_service=messaging_service,
+            relationship_service=relationship_service,
+            contact_repo=contact_repo,
+        )
+    )
+
+    assert chat_http_dependencies.get_messaging_service(app) is messaging_service
+    assert chat_http_dependencies.get_optional_messaging_service(app) is messaging_service
+    assert chat_http_dependencies.get_relationship_service(app) is relationship_service
+    assert chat_http_dependencies.get_contact_repo(app) is contact_repo
+
+
 @pytest.mark.asyncio
 async def test_get_owner_thread_rows_loader_binds_app() -> None:
     seen: list[tuple[object, str]] = []

--- a/tests/Unit/backend/test_chat_runtime_access.py
+++ b/tests/Unit/backend/test_chat_runtime_access.py
@@ -27,3 +27,26 @@ def test_runtime_access_getters_fail_loud_when_chat_bootstrap_missing(getter_nam
 
 def test_get_optional_typing_tracker_returns_none_when_missing():
     assert chat_runtime_access.get_optional_typing_tracker(_app_state()) is None
+
+
+def test_runtime_access_reads_chat_runtime_state_bundle():
+    messaging_service = object()
+    typing_tracker = object()
+    relationship_service = object()
+    contact_repo = object()
+
+    app = _app_state(
+        chat_runtime_state=SimpleNamespace(
+            messaging_service=messaging_service,
+            typing_tracker=typing_tracker,
+            relationship_service=relationship_service,
+            contact_repo=contact_repo,
+        )
+    )
+
+    assert chat_runtime_access.get_messaging_service(app) is messaging_service
+    assert chat_runtime_access.get_optional_messaging_service(app) is messaging_service
+    assert chat_runtime_access.get_typing_tracker(app) is typing_tracker
+    assert chat_runtime_access.get_optional_typing_tracker(app) is typing_tracker
+    assert chat_runtime_access.get_relationship_service(app) is relationship_service
+    assert chat_runtime_access.get_contact_repo(app) is contact_repo


### PR DESCRIPTION
## Summary
- store the returned ChatRuntimeState on app.state during chat bootstrap
- have chat runtime accessors and chat HTTP dependency helpers borrow messaging/contact/relationship state through that bundle first
- carry one format-only follow-up for tests/Integration/test_users_router.py so repo-wide ruff stays green on the current dev base

## Test Plan
- uv run ruff check .
- uv run ruff format --check .
- git diff --check
- uv run python -m pytest -q tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_runtime_access.py tests/Unit/backend/test_chat_http_dependencies.py tests/Integration/test_auth_router.py tests/Integration/test_messaging_router.py tests/Integration/test_relationship_router.py tests/Integration/test_conversations_router.py tests/Integration/test_contacts_schema_contract.py tests/Integration/test_users_router.py -k "chat_runtime_state or chat_candidates or messaging or relationship or conversations or contacts or auth"