### PR TITLE
refactor(chat): read repo and event bus through chat runtime bundle

### DIFF
--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -54,11 +54,13 @@ def get_contact_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
 
 
 def get_chat_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
-    return _require_state_attr(app, "chat_repo", "Chat repo unavailable")
+    runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat repo unavailable")
+    return runtime_state.chat_repo
 
 
 def get_chat_event_bus(app: Annotated[Any, Depends(get_app)]) -> Any:
-    return _require_state_attr(app, "chat_event_bus", "Chat event bus unavailable")
+    runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat event bus unavailable")
+    return runtime_state.chat_event_bus
 
 
 def get_runtime_thread_activity_reader(app: Annotated[Any, Depends(get_app)]) -> Any:

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -16,6 +16,8 @@ from messaging.service import MessagingService
 
 @dataclass(frozen=True)
 class ChatRuntimeState:
+    chat_repo: Any
+    chat_event_bus: Any
     contact_repo: Any
     typing_tracker: Any
     relationship_service: Any
@@ -68,6 +70,8 @@ def attach_chat_runtime(
     # state onto app.state for the wider app, but it also returns the freshly
     # built runtime objects so enclosing lifespans do not need to reread them.
     state = ChatRuntimeState(
+        chat_repo=chat_repo,
+        chat_event_bus=chat_event_bus,
         contact_repo=contact_repo,
         typing_tracker=typing_tracker,
         relationship_service=relationship_service,

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -68,7 +68,8 @@ def attach_chat_runtime(
     app.state.messaging_service = messaging_service
     # @@@chat-bootstrap-borrowable-state - bootstrap still attaches chat-owned
     # state onto app.state for the wider app, but it also returns the freshly
-    # built runtime objects so enclosing lifespans do not need to reread them.
+    # built runtime objects so enclosing lifespans and dependency helpers do
+    # not need to reread loose attrs.
     state = ChatRuntimeState(
         chat_repo=chat_repo,
         chat_event_bus=chat_event_bus,

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -75,6 +75,8 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     assert app.state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
     assert app.state.messaging_service.delivery_fn is None
     assert app.state.chat_runtime_state is state
+    assert state.chat_repo is chat_repo
+    assert state.chat_event_bus is event_bus
     assert state.contact_repo is contact_repo
     assert state.typing_tracker is app.state.typing_tracker
     assert state.messaging_service is app.state.messaging_service

--- a/tests/Unit/backend/test_chat_http_dependencies.py
+++ b/tests/Unit/backend/test_chat_http_dependencies.py
@@ -22,12 +22,16 @@ def test_chat_http_dependencies_read_chat_runtime_state_bundle():
     messaging_service = object()
     relationship_service = object()
     contact_repo = object()
+    chat_repo = object()
+    chat_event_bus = object()
 
     app = _app_state(
         chat_runtime_state=SimpleNamespace(
             messaging_service=messaging_service,
             relationship_service=relationship_service,
             contact_repo=contact_repo,
+            chat_repo=chat_repo,
+            chat_event_bus=chat_event_bus,
         )
     )
 
@@ -35,6 +39,8 @@ def test_chat_http_dependencies_read_chat_runtime_state_bundle():
     assert chat_http_dependencies.get_optional_messaging_service(app) is messaging_service
     assert chat_http_dependencies.get_relationship_service(app) is relationship_service
     assert chat_http_dependencies.get_contact_repo(app) is contact_repo
+    assert chat_http_dependencies.get_chat_repo(app) is chat_repo
+    assert chat_http_dependencies.get_chat_event_bus(app) is chat_event_bus
 
 
 def test_chat_http_dependencies_do_not_fall_back_to_legacy_chat_attrs():


### PR DESCRIPTION
## Summary
- add chat_repo and chat_event_bus into ChatRuntimeState
- have chat HTTP dependency helpers borrow repo/event-bus from the chat runtime bundle instead of loose attrs
- lock the bundle contract with focused chat bootstrap + dependency unit tests and a small @@@ note update

## Test Plan
- uv run python -m pytest -q tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py
- uv run ruff check backend/chat/bootstrap.py backend/chat/api/http/dependencies.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py
- uv run ruff format --check backend/chat/bootstrap.py backend/chat/api/http/dependencies.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py
- git diff --check