### PR TITLE
Remove loose runtime state mirrors

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -57,19 +57,9 @@ def attach_chat_runtime(
         avatar_url_builder=avatar_url,
     )
 
-    app.state.chat_repo = chat_repo
-    app.state.contact_repo = contact_repo
-    app.state.chat_member_repo = chat_member_repo
-    app.state.messages_repo = messages_repo
-    app.state.relationship_repo = relationship_repo
-    app.state.chat_event_bus = chat_event_bus
-    app.state.typing_tracker = typing_tracker
-    app.state.relationship_service = relationship_service
-    app.state.messaging_service = messaging_service
-    # @@@chat-bootstrap-borrowable-state - bootstrap still attaches chat-owned
-    # state onto app.state for the wider app, but it also returns the freshly
-    # built runtime objects so enclosing lifespans and dependency helpers do
-    # not need to reread loose attrs.
+    # @@@chat-bootstrap-borrowable-state - chat bootstrap now keeps its owned
+    # runtime objects inside the returned/chat_runtime_state bundle so the app
+    # has one canonical read surface instead of loose top-level mirrors.
     state = ChatRuntimeState(
         chat_repo=chat_repo,
         chat_event_bus=chat_event_bus,

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -32,14 +32,13 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
     # chat-owned typing state for agent chat delivery, but the borrow is made
     # at bootstrap so downstream gateway setup does not reopen app.state.
     runtime_state = build_agent_runtime_state(app, typing_tracker=typing_tracker)
-    app.state.agent_runtime_gateway = runtime_state.gateway
     app.state.threads_runtime_state = None
-    # @@@threads-bootstrap-borrowable-state - bootstrap still attaches thread
-    # runtime objects onto app.state for the wider app, but it also returns the
-    # freshly built runtime handles so enclosing lifespans do not need to reread them.
+    # @@@threads-bootstrap-borrowable-state - threads runtime now exposes its
+    # shared handles only through the returned/state bundle so downstream code
+    # has one canonical read surface instead of loose app.state mirrors.
     state = ThreadsRuntimeState(
         queue_manager=app.state.queue_manager,
-        agent_runtime_gateway=app.state.agent_runtime_gateway,
+        agent_runtime_gateway=runtime_state.gateway,
         activity_reader=runtime_state.activity_reader,
     )
     app.state.threads_runtime_state = state

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -26,7 +26,6 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
         thread_repo=app.state.thread_repo,
         agent_pool=app.state.agent_pool,
     )
-    app.state.agent_runtime_thread_activity_reader = activity_reader
     gateway = NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(
@@ -56,9 +55,9 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
             clear_resource_overview_cache=clear_resource_overview_cache,
         ),
     )
-    # @@@gateway-bootstrap-borrowable-state - bootstrap still attaches the
-    # activity reader onto app.state for wider consumers, but it also returns
-    # the freshly built gateway/activity handles so callers do not need to reread them.
+    # @@@gateway-bootstrap-borrowable-state - gateway bootstrap now returns the
+    # runtime handles without mirroring them onto loose app.state attrs, so
+    # callers must keep borrowing through the bundle they just built.
     return AgentRuntimeGatewayState(gateway=gateway, activity_reader=activity_reader)
 
 

--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -92,9 +92,7 @@ async def test_chat_events_requires_chat_membership():
         messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False),
         chat_event_bus=_ChatEventBus(),
     )
-    app = SimpleNamespace(
-        state=SimpleNamespace(chat_runtime_state=runtime_state)
-    )
+    app = SimpleNamespace(state=SimpleNamespace(chat_runtime_state=runtime_state))
 
     with pytest.raises(HTTPException) as exc_info:
         await chats_router.stream_chat_events(
@@ -117,9 +115,7 @@ async def test_chat_events_uses_authenticated_participant():
         messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, user_id: user_id == "user-1"),
         chat_event_bus=event_bus,
     )
-    app = SimpleNamespace(
-        state=SimpleNamespace(chat_runtime_state=runtime_state)
-    )
+    app = SimpleNamespace(state=SimpleNamespace(chat_runtime_state=runtime_state))
 
     response = await chats_router.stream_chat_events(
         "chat-1",

--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -87,21 +87,22 @@ class _ChatEventBus:
 
 @pytest.mark.asyncio
 async def test_chat_events_requires_chat_membership():
+    runtime_state = SimpleNamespace(
+        chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: {"id": "chat-1"}),
+        messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False),
+        chat_event_bus=_ChatEventBus(),
+    )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: {"id": "chat-1"}),
-            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, _user_id: False),
-            chat_event_bus=_ChatEventBus(),
-        )
+        state=SimpleNamespace(chat_runtime_state=runtime_state)
     )
 
     with pytest.raises(HTTPException) as exc_info:
         await chats_router.stream_chat_events(
             "chat-1",
             user_id="user-1",
-            chat_repo=app.state.chat_repo,
-            messaging_service=app.state.messaging_service,
-            chat_event_bus=app.state.chat_event_bus,
+            chat_repo=app.state.chat_runtime_state.chat_repo,
+            messaging_service=app.state.chat_runtime_state.messaging_service,
+            chat_event_bus=app.state.chat_runtime_state.chat_event_bus,
         )
 
     assert exc_info.value.status_code == 403
@@ -111,20 +112,21 @@ async def test_chat_events_requires_chat_membership():
 @pytest.mark.asyncio
 async def test_chat_events_uses_authenticated_participant():
     event_bus = _ChatEventBus()
+    runtime_state = SimpleNamespace(
+        chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: {"id": "chat-1"}),
+        messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, user_id: user_id == "user-1"),
+        chat_event_bus=event_bus,
+    )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            chat_repo=SimpleNamespace(get_by_id=lambda _chat_id: {"id": "chat-1"}),
-            messaging_service=SimpleNamespace(is_chat_member=lambda _chat_id, user_id: user_id == "user-1"),
-            chat_event_bus=event_bus,
-        )
+        state=SimpleNamespace(chat_runtime_state=runtime_state)
     )
 
     response = await chats_router.stream_chat_events(
         "chat-1",
         user_id="user-1",
-        chat_repo=app.state.chat_repo,
-        messaging_service=app.state.messaging_service,
-        chat_event_bus=app.state.chat_event_bus,
+        chat_repo=app.state.chat_runtime_state.chat_repo,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
+        chat_event_bus=app.state.chat_runtime_state.chat_event_bus,
     )
 
     assert event_bus.subscribed == ["chat-1"]

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -30,6 +30,7 @@ class _CountingOwnerThreadRepo:
 @pytest.mark.asyncio
 async def test_first_screen_reuses_inflight_owner_thread_read_across_conversations_and_threads() -> None:
     thread_repo = _CountingOwnerThreadRepo()
+    messaging_service = SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: [])
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=thread_repo,
@@ -39,7 +40,7 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
                 activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
             ),
             thread_last_active={},
-            messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
+            chat_runtime_state=SimpleNamespace(messaging_service=messaging_service),
         )
     )
 
@@ -49,7 +50,7 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
             owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),
             activity_reader=app.state.threads_runtime_state.activity_reader,
             thread_last_active=app.state.thread_last_active,
-            messaging_service=app.state.messaging_service,
+            messaging_service=app.state.chat_runtime_state.messaging_service,
         ),
         threads_router.list_threads("owner-1", app=app),
     )

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -36,9 +36,7 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
             thread_repo=thread_repo,
             terminal_repo=SimpleNamespace(summarize_threads=lambda _thread_ids: {}),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
             chat_runtime_state=SimpleNamespace(messaging_service=messaging_service),
         )

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -35,19 +35,19 @@ async def test_first_screen_reuses_inflight_owner_thread_read_across_conversatio
             thread_repo=thread_repo,
             terminal_repo=SimpleNamespace(summarize_threads=lambda _thread_ids: {}),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-            threads_runtime_state=None,
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
         )
     )
-    app.state.threads_runtime_state = SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
 
     conversations, threads = await asyncio.gather(
         owner_conversations_router.list_conversations(
             "owner-1",
             owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),
-            activity_reader=app.state.agent_runtime_thread_activity_reader,
+            activity_reader=app.state.threads_runtime_state.activity_reader,
             thread_last_active=app.state.thread_last_active,
             messaging_service=app.state.messaging_service,
         ),

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -20,8 +20,6 @@ def test_conversations_router_shell_is_deleted() -> None:
 
 
 async def _list_conversations(app: SimpleNamespace, user_id: str = "human-user-1"):
-    if not hasattr(app.state, "threads_runtime_state") and hasattr(app.state, "agent_runtime_thread_activity_reader"):
-        app.state.threads_runtime_state = SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
     return await owner_conversations_router.list_conversations(
         user_id,
         owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),
@@ -42,7 +40,9 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
                 ),
             ),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -110,7 +110,9 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
                 get_by_user_id=lambda _uid: None,
             ),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={"thread-1": 1775540000.0},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -168,7 +170,9 @@ async def test_list_conversations_hire_entries_do_not_leak_template_member_ids()
                 get_by_user_id=lambda _uid: None,
             ),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={},
             messaging_service=None,
         )
@@ -211,10 +215,12 @@ async def test_list_conversations_marks_hire_thread_running_from_runtime_activit
                     AssertionError("conversations router should not read agent_pool directly for running state")
                 )
             ),
-            agent_runtime_thread_activity_reader=SimpleNamespace(
-                list_active_threads_for_agent=lambda _agent_user_id: [
-                    SimpleNamespace(thread_id="thread-1", is_main=True, branch_index=0, state="active")
-                ]
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(
+                    list_active_threads_for_agent=lambda _agent_user_id: [
+                        SimpleNamespace(thread_id="thread-1", is_main=True, branch_index=0, state="active")
+                    ]
+                )
             ),
             thread_last_active={},
             messaging_service=None,
@@ -263,7 +269,9 @@ async def test_list_conversations_collapses_hire_threads_to_one_visible_conversa
                 ],
             ),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={"thread-main": 1775540000.0, "thread-extra": 1775541000.0},
             messaging_service=None,
         )
@@ -283,7 +291,9 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
                 get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not read visit rows itself")),
             ),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -332,7 +342,9 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={},
             messaging_service=messaging_service,
         )
@@ -352,7 +364,7 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
     assert ("_list_visit_conversations_for_user", (messaging_service, "human-user-1")) in to_thread_calls
     assert (
         "_list_hire_conversations_from_threads",
-        ([], app.state.agent_runtime_thread_activity_reader, {}),
+        ([], app.state.threads_runtime_state.activity_reader, {}),
     ) in to_thread_calls
 
 
@@ -377,7 +389,9 @@ async def test_list_conversations_fetches_hire_and_visit_sources_in_parallel() -
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=_list_threads),
             agent_pool={},
-            agent_runtime_thread_activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+            threads_runtime_state=SimpleNamespace(
+                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+            ),
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=_list_visit_summaries),
         )

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -40,9 +40,7 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
                 ),
             ),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -110,9 +108,7 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
                 get_by_user_id=lambda _uid: None,
             ),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={"thread-1": 1775540000.0},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -170,9 +166,7 @@ async def test_list_conversations_hire_entries_do_not_leak_template_member_ids()
                 get_by_user_id=lambda _uid: None,
             ),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
             messaging_service=None,
         )
@@ -269,9 +263,7 @@ async def test_list_conversations_collapses_hire_threads_to_one_visible_conversa
                 ],
             ),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={"thread-main": 1775540000.0, "thread-extra": 1775541000.0},
             messaging_service=None,
         )
@@ -291,9 +283,7 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
                 get_by_user_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not read visit rows itself")),
             ),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
             messaging_service=SimpleNamespace(
                 list_conversation_summaries_for_user=lambda _user_id: [
@@ -342,9 +332,7 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
             messaging_service=messaging_service,
         )
@@ -389,9 +377,7 @@ async def test_list_conversations_fetches_hire_and_visit_sources_in_parallel() -
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=_list_threads),
             agent_pool={},
-            threads_runtime_state=SimpleNamespace(
-                activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
-            ),
+            threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
             messaging_service=SimpleNamespace(list_conversation_summaries_for_user=_list_visit_summaries),
         )

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -26,16 +26,6 @@ def _chat(chat_id: str) -> SimpleNamespace:
 def _route_test_app(state: SimpleNamespace) -> FastAPI:
     app = FastAPI()
     app.state = state
-    if not hasattr(app.state, "chat_runtime_state"):
-        messaging_service = getattr(app.state, "messaging_service", None)
-        relationship_service = getattr(app.state, "relationship_service", None)
-        contact_repo = getattr(app.state, "contact_repo", None)
-        if any(value is not None for value in (messaging_service, relationship_service, contact_repo)):
-            app.state.chat_runtime_state = SimpleNamespace(
-                messaging_service=messaging_service,
-                relationship_service=relationship_service,
-                contact_repo=contact_repo,
-            )
     app.include_router(chats_router.router)
     app.dependency_overrides[get_current_user_id] = lambda: "human-user-1"
     return app
@@ -85,14 +75,19 @@ def _create_chat_route_state(
         return relationship_state.get(participant, "none") if isinstance(relationship_state, dict) else relationship_state
 
     messaging_entrypoint = {"create_group_chat" if group_route else "find_or_create_chat": chat_factory}
+    relationship_service = SimpleNamespace(get_state=get_state)
+    contact_repo = _contact_repo(active_contact_pairs)
+    messaging_service = SimpleNamespace(**messaging_entrypoint)
     state = SimpleNamespace(
         user_repo=SimpleNamespace(get_by_id=lambda uid: users.get(uid)),
         thread_repo=SimpleNamespace(
             get_by_user_id=lambda uid: {"id": f"thread-{uid}"} if uid in thread_user_ids else None,
         ),
-        relationship_service=SimpleNamespace(get_state=get_state),
-        contact_repo=_contact_repo(active_contact_pairs),
-        messaging_service=SimpleNamespace(**messaging_entrypoint),
+        chat_runtime_state=SimpleNamespace(
+            relationship_service=relationship_service,
+            contact_repo=contact_repo,
+            messaging_service=messaging_service,
+        ),
     )
     return state, called
 
@@ -101,11 +96,11 @@ def _create_chat(app: SimpleNamespace, body: chats_router.CreateChatBody, *, use
     return chats_router.create_chat(
         body,
         user_id=user_id,
-        messaging_service=app.state.messaging_service,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
         user_repo=app.state.user_repo,
         thread_repo=app.state.thread_repo,
-        contact_repo=app.state.contact_repo,
-        relationship_service=app.state.relationship_service,
+        contact_repo=app.state.chat_runtime_state.contact_repo,
+        relationship_service=app.state.chat_runtime_state.relationship_service,
     )
 
 
@@ -193,19 +188,23 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
 
     app = SimpleNamespace(
         state=SimpleNamespace(
-            chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("route should use helper, not chat_repo lookup directly"))
-            ),
-            messaging_service=SimpleNamespace(
-                get_chat_detail=lambda chat_obj: {
-                    "id": chat_obj.id,
-                    "title": chat_obj.title,
-                    "status": chat_obj.status,
-                    "created_at": chat_obj.created_at,
-                    "members": [],
-                },
-                list_chat_members=lambda _chat_id: (_ for _ in ()).throw(
-                    AssertionError("route should consume service-owned chat detail, not rebuild members locally")
+            chat_runtime_state=SimpleNamespace(
+                chat_repo=SimpleNamespace(
+                    get_by_id=lambda _chat_id: (_ for _ in ()).throw(
+                        AssertionError("route should use helper, not chat_repo lookup directly")
+                    )
+                ),
+                messaging_service=SimpleNamespace(
+                    get_chat_detail=lambda chat_obj: {
+                        "id": chat_obj.id,
+                        "title": chat_obj.title,
+                        "status": chat_obj.status,
+                        "created_at": chat_obj.created_at,
+                        "members": [],
+                    },
+                    list_chat_members=lambda _chat_id: (_ for _ in ()).throw(
+                        AssertionError("route should consume service-owned chat detail, not rebuild members locally")
+                    ),
                 ),
             ),
             user_repo=SimpleNamespace(get_by_id=lambda _user_id: None),
@@ -215,8 +214,8 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
     result = chats_router.get_chat(
         "chat-1",
         user_id="user-1",
-        chat_repo=app.state.chat_repo,
-        messaging_service=app.state.messaging_service,
+        chat_repo=app.state.chat_runtime_state.chat_repo,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
     )
 
     assert result == {
@@ -226,7 +225,9 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
         "created_at": "2026-04-07T00:00:00Z",
         "members": [],
     }
-    assert seen == [("helper", (app.state.chat_repo, app.state.messaging_service, "chat-1", "user-1"))]
+    assert seen == [
+        ("helper", (app.state.chat_runtime_state.chat_repo, app.state.chat_runtime_state.messaging_service, "chat-1", "user-1"))
+    ]
 
 
 def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
@@ -241,24 +242,28 @@ def test_delete_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
 
     app = SimpleNamespace(
         state=SimpleNamespace(
-            chat_repo=SimpleNamespace(
-                get_by_id=lambda _chat_id: (_ for _ in ()).throw(AssertionError("route should use helper, not chat_repo lookup directly")),
-                delete=lambda chat_id: seen.append(("delete", chat_id)),
+            chat_runtime_state=SimpleNamespace(
+                chat_repo=SimpleNamespace(
+                    get_by_id=lambda _chat_id: (_ for _ in ()).throw(
+                        AssertionError("route should use helper, not chat_repo lookup directly")
+                    ),
+                    delete=lambda chat_id: seen.append(("delete", chat_id)),
+                ),
+                messaging_service=SimpleNamespace(name="messaging"),
             ),
-            messaging_service=SimpleNamespace(name="messaging"),
         )
     )
 
     result = chats_router.delete_chat(
         "chat-1",
         user_id="user-1",
-        chat_repo=app.state.chat_repo,
-        messaging_service=app.state.messaging_service,
+        chat_repo=app.state.chat_runtime_state.chat_repo,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
     )
 
     assert result == {"status": "deleted"}
     assert seen == [
-        ("helper", (app.state.chat_repo, app.state.messaging_service, "chat-1", "user-1")),
+        ("helper", (app.state.chat_runtime_state.chat_repo, app.state.chat_runtime_state.messaging_service, "chat-1", "user-1")),
         ("delete", "chat-1"),
     ]
 
@@ -274,23 +279,25 @@ def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeypatch: 
 
     app = SimpleNamespace(
         state=SimpleNamespace(
-            messaging_service=SimpleNamespace(
-                get_chat_detail=lambda _chat: {
-                    "id": "chat-1",
-                    "title": "Chat title",
-                    "status": "active",
-                    "created_at": "2026-04-07T00:00:00Z",
-                    "members": [
-                        {
-                            "id": "thread-user-1",
-                            "name": "Toad",
-                            "type": "agent",
-                            "avatar_url": avatar_url("agent-user-1", False),
-                        }
-                    ],
-                }
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    get_chat_detail=lambda _chat: {
+                        "id": "chat-1",
+                        "title": "Chat title",
+                        "status": "active",
+                        "created_at": "2026-04-07T00:00:00Z",
+                        "members": [
+                            {
+                                "id": "thread-user-1",
+                                "name": "Toad",
+                                "type": "agent",
+                                "avatar_url": avatar_url("agent-user-1", False),
+                            }
+                        ],
+                    }
+                ),
+                chat_repo=SimpleNamespace(name="chat-repo"),
             ),
-            chat_repo=SimpleNamespace(name="chat-repo"),
             user_repo=SimpleNamespace(
                 get_by_id=lambda uid: (
                     None
@@ -309,8 +316,8 @@ def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeypatch: 
     result = chats_router.get_chat(
         "chat-1",
         user_id="human-user-1",
-        chat_repo=app.state.chat_repo,
-        messaging_service=app.state.messaging_service,
+        chat_repo=app.state.chat_runtime_state.chat_repo,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
     )
 
     assert result["members"] == [
@@ -326,28 +333,30 @@ def test_get_chat_resolves_thread_user_participant_via_thread_repo(monkeypatch: 
 def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
     app = SimpleNamespace(
         state=SimpleNamespace(
-            messaging_service=SimpleNamespace(
-                is_chat_member=lambda _chat_id, _user_id: True,
-                list_message_responses=lambda _chat_id, **_kwargs: [
-                    {
-                        "id": "msg-1",
-                        "chat_id": "chat-1",
-                        "sender_id": "thread-user-1",
-                        "sender_name": "Toad",
-                        "content": "hello",
-                        "message_type": "human",
-                        "mentioned_ids": [],
-                        "signal": None,
-                        "retracted_at": None,
-                        "created_at": "2026-04-07T00:00:00Z",
-                    }
-                ],
-                resolve_display_user=lambda uid: (
-                    SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None)
-                    if uid == "thread-user-1"
-                    else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
-                    if uid == "agent-user-1"
-                    else None
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    is_chat_member=lambda _chat_id, _user_id: True,
+                    list_message_responses=lambda _chat_id, **_kwargs: [
+                        {
+                            "id": "msg-1",
+                            "chat_id": "chat-1",
+                            "sender_id": "thread-user-1",
+                            "sender_name": "Toad",
+                            "content": "hello",
+                            "message_type": "human",
+                            "mentioned_ids": [],
+                            "signal": None,
+                            "retracted_at": None,
+                            "created_at": "2026-04-07T00:00:00Z",
+                        }
+                    ],
+                    resolve_display_user=lambda uid: (
+                        SimpleNamespace(id="agent-user-1", display_name="Toad", type="agent", avatar=None)
+                        if uid == "thread-user-1"
+                        else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
+                        if uid == "agent-user-1"
+                        else None
+                    ),
                 ),
             ),
             user_repo=SimpleNamespace(
@@ -368,7 +377,7 @@ def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
     result = chats_router.list_messages(
         "chat-1",
         user_id="human-user-1",
-        messaging_service=app.state.messaging_service,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
     )
 
     assert result == [
@@ -390,26 +399,28 @@ def test_list_messages_resolves_thread_user_sender_name_via_thread_repo():
 def test_list_messages_route_resolves_sender_name_via_messaging_service() -> None:
     test_app = _route_test_app(
         SimpleNamespace(
-            messaging_service=SimpleNamespace(
-                is_chat_member=lambda _chat_id, _user_id: True,
-                list_message_responses=lambda _chat_id, **_kwargs: [
-                    {
-                        "id": "msg-1",
-                        "chat_id": "chat-1",
-                        "sender_id": "thread-user-1",
-                        "sender_name": "Projected Toad",
-                        "content": "hello",
-                        "message_type": "human",
-                        "mentioned_ids": [],
-                        "signal": None,
-                        "retracted_at": None,
-                        "created_at": "2026-04-07T00:00:00Z",
-                    }
-                ],
-                list_messages=lambda _chat_id, **_kwargs: (_ for _ in ()).throw(
-                    AssertionError("route should consume service-owned message projection")
-                ),
-            )
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    is_chat_member=lambda _chat_id, _user_id: True,
+                    list_message_responses=lambda _chat_id, **_kwargs: [
+                        {
+                            "id": "msg-1",
+                            "chat_id": "chat-1",
+                            "sender_id": "thread-user-1",
+                            "sender_name": "Projected Toad",
+                            "content": "hello",
+                            "message_type": "human",
+                            "mentioned_ids": [],
+                            "signal": None,
+                            "retracted_at": None,
+                            "created_at": "2026-04-07T00:00:00Z",
+                        }
+                    ],
+                    list_messages=lambda _chat_id, **_kwargs: (_ for _ in ()).throw(
+                        AssertionError("route should consume service-owned message projection")
+                    ),
+                )
+            ),
         )
     )
 
@@ -440,41 +451,43 @@ def test_send_message_consumes_service_owned_message_projection() -> None:
     seen: list[tuple[str, str, str]] = []
     app = SimpleNamespace(
         state=SimpleNamespace(
-            messaging_service=SimpleNamespace(
-                resolve_display_user=lambda uid: (
-                    SimpleNamespace(
-                        id="agent-user-1",
-                        display_name="Ownership Toad",
-                        type="agent",
-                        avatar=None,
-                        owner_user_id="owner-user-1",
-                    )
-                    if uid == "thread-user-1"
-                    else None
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    resolve_display_user=lambda uid: (
+                        SimpleNamespace(
+                            id="agent-user-1",
+                            display_name="Ownership Toad",
+                            type="agent",
+                            avatar=None,
+                            owner_user_id="owner-user-1",
+                        )
+                        if uid == "thread-user-1"
+                        else None
+                    ),
+                    send=lambda chat_id, sender_id, content, **_kwargs: (
+                        seen.append((chat_id, sender_id, content))
+                        or {
+                            "id": "msg-1",
+                            "chat_id": chat_id,
+                            "sender_id": sender_id,
+                            "content": content,
+                            "message_type": "human",
+                            "created_at": "2026-04-07T00:00:00Z",
+                        }
+                    ),
+                    project_message_response=lambda msg: {
+                        "id": msg["id"],
+                        "chat_id": msg["chat_id"],
+                        "sender_id": msg["sender_id"],
+                        "sender_name": "Projected Toad",
+                        "content": msg["content"],
+                        "message_type": msg["message_type"],
+                        "mentioned_ids": [],
+                        "signal": None,
+                        "retracted_at": None,
+                        "created_at": msg["created_at"],
+                    },
                 ),
-                send=lambda chat_id, sender_id, content, **_kwargs: (
-                    seen.append((chat_id, sender_id, content))
-                    or {
-                        "id": "msg-1",
-                        "chat_id": chat_id,
-                        "sender_id": sender_id,
-                        "content": content,
-                        "message_type": "human",
-                        "created_at": "2026-04-07T00:00:00Z",
-                    }
-                ),
-                project_message_response=lambda msg: {
-                    "id": msg["id"],
-                    "chat_id": msg["chat_id"],
-                    "sender_id": msg["sender_id"],
-                    "sender_name": "Projected Toad",
-                    "content": msg["content"],
-                    "message_type": msg["message_type"],
-                    "mentioned_ids": [],
-                    "signal": None,
-                    "retracted_at": None,
-                    "created_at": msg["created_at"],
-                },
             ),
         )
     )
@@ -483,7 +496,7 @@ def test_send_message_consumes_service_owned_message_projection() -> None:
         "chat-1",
         chats_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
         user_id="owner-user-1",
-        messaging_service=app.state.messaging_service,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
     )
 
     assert seen == [("chat-1", "thread-user-1", "hello")]
@@ -517,41 +530,43 @@ def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
             thread_repo=SimpleNamespace(
                 get_by_user_id=lambda uid: {"id": "thread-1", "agent_user_id": "agent-user-1"} if uid == "thread-user-1" else None
             ),
-            messaging_service=SimpleNamespace(
-                resolve_display_user=lambda uid: (
-                    SimpleNamespace(
-                        id="agent-user-1",
-                        display_name="Toad",
-                        type="agent",
-                        avatar=None,
-                        owner_user_id="owner-user-1",
-                    )
-                    if uid == "thread-user-1"
-                    else None
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    resolve_display_user=lambda uid: (
+                        SimpleNamespace(
+                            id="agent-user-1",
+                            display_name="Toad",
+                            type="agent",
+                            avatar=None,
+                            owner_user_id="owner-user-1",
+                        )
+                        if uid == "thread-user-1"
+                        else None
+                    ),
+                    send=lambda chat_id, sender_id, content, **_kwargs: (
+                        seen.append((chat_id, sender_id, content))
+                        or {
+                            "id": "msg-1",
+                            "chat_id": chat_id,
+                            "sender_id": sender_id,
+                            "content": content,
+                            "message_type": "human",
+                            "created_at": "2026-04-07T00:00:00Z",
+                        }
+                    ),
+                    project_message_response=lambda msg: {
+                        "id": msg["id"],
+                        "chat_id": msg["chat_id"],
+                        "sender_id": msg["sender_id"],
+                        "sender_name": "Toad",
+                        "content": msg["content"],
+                        "message_type": msg["message_type"],
+                        "mentioned_ids": [],
+                        "signal": None,
+                        "retracted_at": None,
+                        "created_at": msg["created_at"],
+                    },
                 ),
-                send=lambda chat_id, sender_id, content, **_kwargs: (
-                    seen.append((chat_id, sender_id, content))
-                    or {
-                        "id": "msg-1",
-                        "chat_id": chat_id,
-                        "sender_id": sender_id,
-                        "content": content,
-                        "message_type": "human",
-                        "created_at": "2026-04-07T00:00:00Z",
-                    }
-                ),
-                project_message_response=lambda msg: {
-                    "id": msg["id"],
-                    "chat_id": msg["chat_id"],
-                    "sender_id": msg["sender_id"],
-                    "sender_name": "Toad",
-                    "content": msg["content"],
-                    "message_type": msg["message_type"],
-                    "mentioned_ids": [],
-                    "signal": None,
-                    "retracted_at": None,
-                    "created_at": msg["created_at"],
-                },
             ),
         )
     )
@@ -560,7 +575,7 @@ def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
         "chat-1",
         chats_router.SendMessageBody(content="hello", sender_id="thread-user-1"),
         user_id="owner-user-1",
-        messaging_service=app.state.messaging_service,
+        messaging_service=app.state.chat_runtime_state.messaging_service,
     )
 
     assert seen == [("chat-1", "thread-user-1", "hello")]

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -2581,7 +2581,6 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
                 get_by_id=lambda thread_id: {"id": thread_id, "agent_user_id": "agent-user-1"} if thread_id == "thread-1" else None,
             ),
             agent_pool={},
-            typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
             queue_manager=SimpleNamespace(enqueue=lambda *_args, **_kwargs: None),
             thread_cwd={},
             thread_sandbox={},
@@ -2590,7 +2589,7 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    runtime_state = build_agent_runtime_state(app, typing_tracker=app.state.typing_tracker)
+    runtime_state = build_agent_runtime_state(app, typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None))
     gateway = runtime_state.gateway
     app.state.threads_runtime_state = SimpleNamespace(
         agent_runtime_gateway=gateway,
@@ -2652,7 +2651,6 @@ async def _run_chat_delivery(
                 get_by_id=lambda thread_id: next((row for row in thread_rows if row["id"] == thread_id), None),
             ),
             agent_pool=pool or {},
-            typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
@@ -2665,7 +2663,10 @@ async def _run_chat_delivery(
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    runtime_state = build_agent_runtime_state(app, typing_tracker=app.state.typing_tracker)
+    runtime_state = build_agent_runtime_state(
+        app,
+        typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
+    )
     gateway = runtime_state.gateway
     app.state.threads_runtime_state = SimpleNamespace(
         agent_runtime_gateway=gateway,

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -9,7 +9,7 @@ import pytest
 
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters import chat_inlet as chat_delivery_hook
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.registry import ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope
@@ -2590,18 +2590,18 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
-    app.state.agent_runtime_gateway = gateway
+    runtime_state = build_agent_runtime_state(app, typing_tracker=app.state.typing_tracker)
+    gateway = runtime_state.gateway
     app.state.threads_runtime_state = SimpleNamespace(
         agent_runtime_gateway=gateway,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=runtime_state.activity_reader,
     )
 
     with pytest.raises(AttributeError):
         await asyncio.to_thread(
             chat_delivery_hook.make_chat_delivery_fn(
                 app,
-                activity_reader=app.state.agent_runtime_thread_activity_reader,
+                activity_reader=runtime_state.activity_reader,
                 thread_repo=app.state.thread_repo,
             ),
             ChatDeliveryRequest(
@@ -2665,17 +2665,17 @@ async def _run_chat_delivery(
             thread_locks_guard=asyncio.Lock(),
         )
     )
-    gateway = build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker)
-    app.state.agent_runtime_gateway = gateway
+    runtime_state = build_agent_runtime_state(app, typing_tracker=app.state.typing_tracker)
+    gateway = runtime_state.gateway
     app.state.threads_runtime_state = SimpleNamespace(
         agent_runtime_gateway=gateway,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=runtime_state.activity_reader,
     )
 
     await asyncio.to_thread(
         chat_delivery_hook.make_chat_delivery_fn(
             app,
-            activity_reader=app.state.agent_runtime_thread_activity_reader,
+            activity_reader=runtime_state.activity_reader,
             thread_repo=app.state.thread_repo,
         ),
         ChatDeliveryRequest(

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -466,7 +466,7 @@ async def test_delete_agent_route_fails_loud_when_thread_repo_missing(monkeypatc
             state=SimpleNamespace(
                 user_repo=SimpleNamespace(),
                 agent_config_repo=SimpleNamespace(),
-                contact_repo=SimpleNamespace(),
+                chat_runtime_state=SimpleNamespace(contact_repo=SimpleNamespace()),
             )
         )
     )
@@ -478,7 +478,7 @@ async def test_delete_agent_route_fails_loud_when_thread_repo_missing(monkeypatc
             request=request,
             user_id="user-1",
             thread_repo=None,
-            contact_repo=request.app.state.contact_repo,
+            contact_repo=request.app.state.chat_runtime_state.contact_repo,
         )
 
     assert exc_info.value.status_code == 503

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -499,6 +499,10 @@ def _make_streaming_app(
     include_route_locks: bool = False,
 ) -> tuple[SimpleNamespace, MessageQueueManager]:
     queue_manager = queue_manager or MessageQueueManager(db_path=str(tmp_path / "queue.db"))
+    typing_tracker = SimpleNamespace(
+        start_chat=lambda *_args, **_kwargs: None,
+        stop=lambda *_args, **_kwargs: None,
+    )
     state = SimpleNamespace(
         display_builder=DisplayBuilder(),
         thread_repo=SimpleNamespace(
@@ -516,17 +520,13 @@ def _make_streaming_app(
         subagent_buffers={},
         queue_manager=queue_manager,
         thread_last_active={},
-        typing_tracker=SimpleNamespace(
-            start_chat=lambda *_args, **_kwargs: None,
-            stop=lambda *_args, **_kwargs: None,
-        ),
     )
     if thread_id is not None and agent is not None:
         state.agent_pool = {f"{thread_id}:local": agent}
         state.thread_sandbox = {thread_id: "local"}
         state._event_loop = asyncio.get_running_loop()
     app = SimpleNamespace(state=state)
-    runtime_state = build_agent_runtime_state(app, typing_tracker=state.typing_tracker)
+    runtime_state = build_agent_runtime_state(app, typing_tracker=typing_tracker)
     gateway = runtime_state.gateway
     state.agent_runtime_gateway_state = runtime_state
     state.threads_runtime_state = SimpleNamespace(
@@ -1250,9 +1250,10 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
 
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda *_args, **_kwargs: "local")
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", fake_get_or_create_agent)
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
 
     startup_task = asyncio.create_task(
-        build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(
+        build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(
             AgentThreadInputEnvelope(
                 thread_id=thread_id,
                 sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway, build_agent_runtime_state
 from backend.threads.display.builder import DisplayBuilder
 from backend.threads.events.buffer import ThreadEventBuffer
 from backend.threads.streaming import (
@@ -526,15 +526,12 @@ def _make_streaming_app(
         state.thread_sandbox = {thread_id: "local"}
         state._event_loop = asyncio.get_running_loop()
     app = SimpleNamespace(state=state)
-    gateway = build_agent_runtime_gateway(app, typing_tracker=state.typing_tracker)
-    state.agent_runtime_gateway = gateway
-    state.agent_runtime_gateway_state = SimpleNamespace(
-        gateway=gateway,
-        activity_reader=state.agent_runtime_thread_activity_reader,
-    )
+    runtime_state = build_agent_runtime_state(app, typing_tracker=state.typing_tracker)
+    gateway = runtime_state.gateway
+    state.agent_runtime_gateway_state = runtime_state
     state.threads_runtime_state = SimpleNamespace(
         agent_runtime_gateway=gateway,
-        activity_reader=state.agent_runtime_thread_activity_reader,
+        activity_reader=runtime_state.activity_reader,
     )
     return app, queue_manager
 

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -313,9 +313,7 @@ def test_chat_candidates_route_reads_dependencies_from_app_state() -> None:
     app.include_router(users_router.users_router)
     app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, other])
     app.state.thread_repo = SimpleNamespace(get_default_thread=lambda _agent_user_id: None)
-    relationship_service = SimpleNamespace(
-        list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")]
-    )
+    relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")])
     contact_repo = _empty_contact_repo()
     app.state.chat_runtime_state = SimpleNamespace(
         relationship_service=relationship_service,

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -61,16 +61,20 @@ def _users_app(
 ) -> SimpleNamespace:
     relationships = relationships or {}
     default_threads = default_threads or {}
+    relationship_service = SimpleNamespace(
+        list_for_user=lambda _user_id: [
+            SimpleNamespace(other_user_id=other_user_id, state=state) for other_user_id, state in relationships.items()
+        ]
+    )
+    chat_runtime_state = SimpleNamespace(
+        relationship_service=relationship_service,
+        contact_repo=contact_repo or _empty_contact_repo(),
+    )
     return SimpleNamespace(
         state=SimpleNamespace(
             user_repo=SimpleNamespace(list_all=lambda: users),
             thread_repo=SimpleNamespace(get_default_thread=lambda agent_user_id: default_threads.get(agent_user_id)),
-            relationship_service=SimpleNamespace(
-                list_for_user=lambda _user_id: [
-                    SimpleNamespace(other_user_id=other_user_id, state=state) for other_user_id, state in relationships.items()
-                ]
-            ),
-            contact_repo=contact_repo or _empty_contact_repo(),
+            chat_runtime_state=chat_runtime_state,
         )
     )
 
@@ -79,8 +83,8 @@ def _list_chat_candidates(app: SimpleNamespace, *, user_id: str = "u1"):
     return users_router.list_chat_candidates(
         user_id=user_id,
         user_repo=app.state.user_repo,
-        relationship_service=getattr(app.state, "relationship_service", None),
-        contact_repo=getattr(app.state, "contact_repo", None),
+        relationship_service=getattr(app.state.chat_runtime_state, "relationship_service", None),
+        contact_repo=getattr(app.state.chat_runtime_state, "contact_repo", None),
         thread_repo=getattr(app.state, "thread_repo", None),
     )
 
@@ -178,8 +182,10 @@ async def test_list_chat_candidates_fails_loud_when_owned_agent_threads_need_thr
     app = SimpleNamespace(
         state=SimpleNamespace(
             user_repo=SimpleNamespace(list_all=lambda: [_human("u1", "owner"), _agent("a-owned", "Morel", "u1")]),
-            relationship_service=SimpleNamespace(list_for_user=lambda _user_id: []),
-            contact_repo=_empty_contact_repo(),
+            chat_runtime_state=SimpleNamespace(
+                relationship_service=SimpleNamespace(list_for_user=lambda _user_id: []),
+                contact_repo=_empty_contact_repo(),
+            ),
         )
     )
 
@@ -237,7 +243,7 @@ async def test_list_chat_candidates_fails_loud_when_relationship_service_missing
         state=SimpleNamespace(
             user_repo=SimpleNamespace(list_all=lambda: [_human("u1", "owner"), _human("u2", "other")]),
             thread_repo=SimpleNamespace(get_default_thread=lambda _agent_user_id: None),
-            contact_repo=_empty_contact_repo(),
+            chat_runtime_state=SimpleNamespace(contact_repo=_empty_contact_repo()),
         )
     )
 
@@ -254,7 +260,9 @@ async def test_list_chat_candidates_fails_loud_when_contact_repo_missing():
         state=SimpleNamespace(
             user_repo=SimpleNamespace(list_all=lambda: [_human("u1", "owner"), _human("u2", "other")]),
             thread_repo=SimpleNamespace(get_default_thread=lambda _agent_user_id: None),
-            relationship_service=SimpleNamespace(list_for_user=lambda _user_id: []),
+            chat_runtime_state=SimpleNamespace(
+                relationship_service=SimpleNamespace(list_for_user=lambda _user_id: []),
+            ),
         )
     )
 
@@ -305,11 +313,13 @@ def test_chat_candidates_route_reads_dependencies_from_app_state() -> None:
     app.include_router(users_router.users_router)
     app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, other])
     app.state.thread_repo = SimpleNamespace(get_default_thread=lambda _agent_user_id: None)
-    app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")])
-    app.state.contact_repo = _empty_contact_repo()
+    relationship_service = SimpleNamespace(
+        list_for_user=lambda _user_id: [SimpleNamespace(other_user_id="u2", state="visit")]
+    )
+    contact_repo = _empty_contact_repo()
     app.state.chat_runtime_state = SimpleNamespace(
-        relationship_service=app.state.relationship_service,
-        contact_repo=app.state.contact_repo,
+        relationship_service=relationship_service,
+        contact_repo=contact_repo,
     )
     app.dependency_overrides[get_current_user_id] = lambda: "u1"
 
@@ -341,11 +351,11 @@ def test_chat_candidates_route_exposes_owned_agent_default_thread_id() -> None:
     app.state.thread_repo = SimpleNamespace(
         get_default_thread=lambda agent_user_id: {"id": "thread-ready"} if agent_user_id == "a-owned" else None
     )
-    app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
-    app.state.contact_repo = _empty_contact_repo()
+    relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
+    contact_repo = _empty_contact_repo()
     app.state.chat_runtime_state = SimpleNamespace(
-        relationship_service=app.state.relationship_service,
-        contact_repo=app.state.contact_repo,
+        relationship_service=relationship_service,
+        contact_repo=contact_repo,
     )
     app.dependency_overrides[get_current_user_id] = lambda: "u1"
 
@@ -376,9 +386,9 @@ def test_chat_candidates_route_fails_loud_when_contact_repo_missing() -> None:
     app.include_router(users_router.users_router)
     app.state.user_repo = SimpleNamespace(list_all=lambda: [owner, other])
     app.state.thread_repo = SimpleNamespace(get_default_thread=lambda _agent_user_id: None)
-    app.state.relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
+    relationship_service = SimpleNamespace(list_for_user=lambda _user_id: [])
     app.state.chat_runtime_state = SimpleNamespace(
-        relationship_service=app.state.relationship_service,
+        relationship_service=relationship_service,
         contact_repo=None,
     )
     app.dependency_overrides[get_current_user_id] = lambda: "u1"

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -177,7 +177,7 @@ def test_wire_chat_delivery_binds_delivery_fn(monkeypatch):
 
     messaging_service.set_delivery_fn = _set_delivery_fn
 
-    app = SimpleNamespace(state=SimpleNamespace(messaging_service=messaging_service))
+    app = SimpleNamespace(state=SimpleNamespace())
 
     monkeypatch.setattr(
         chat_bootstrap,
@@ -192,7 +192,7 @@ def test_wire_chat_delivery_binds_delivery_fn(monkeypatch):
         thread_repo=thread_repo,
     )
 
-    assert app.state.messaging_service.delivery_fn is delivery_fn
+    assert messaging_service.delivery_fn is delivery_fn
 
 
 def test_wire_chat_delivery_does_not_read_back_messaging_service(monkeypatch):

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -62,24 +62,25 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         thread_repo=app.state.thread_repo,
     )
 
-    assert app.state.chat_repo is chat_repo
-    assert app.state.contact_repo is contact_repo
-    assert app.state.chat_member_repo is chat_member_repo
-    assert app.state.messages_repo is messages_repo
-    assert app.state.relationship_repo is relationship_repo
-    assert app.state.chat_event_bus is event_bus
-    assert app.state.typing_tracker.event_bus is event_bus
-    assert app.state.relationship_service.repo is relationship_repo
-    assert app.state.messaging_service.kwargs["chat_repo"] is chat_repo
-    assert app.state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
-    assert app.state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
-    assert app.state.messaging_service.delivery_fn is None
     assert app.state.chat_runtime_state is state
     assert state.chat_repo is chat_repo
     assert state.chat_event_bus is event_bus
     assert state.contact_repo is contact_repo
-    assert state.typing_tracker is app.state.typing_tracker
-    assert state.messaging_service is app.state.messaging_service
+    assert state.typing_tracker.event_bus is event_bus
+    assert state.relationship_service.repo is relationship_repo
+    assert state.messaging_service.kwargs["chat_repo"] is chat_repo
+    assert state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
+    assert state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
+    assert state.messaging_service.delivery_fn is None
+    assert not hasattr(app.state, "chat_repo")
+    assert not hasattr(app.state, "contact_repo")
+    assert not hasattr(app.state, "chat_member_repo")
+    assert not hasattr(app.state, "messages_repo")
+    assert not hasattr(app.state, "relationship_repo")
+    assert not hasattr(app.state, "chat_event_bus")
+    assert not hasattr(app.state, "typing_tracker")
+    assert not hasattr(app.state, "relationship_service")
+    assert not hasattr(app.state, "messaging_service")
 
 
 def test_attach_chat_runtime_does_not_read_back_chat_state_during_wiring(monkeypatch):

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -42,11 +42,11 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert app.state.thread_event_buffers == {}
     assert app.state.subagent_buffers == {}
     assert app.state.thread_last_active == {}
-    assert app.state.agent_runtime_gateway is gateway
     assert app.state.threads_runtime_state is state
     assert state.queue_manager is queue_manager
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
+    assert not hasattr(app.state, "agent_runtime_gateway")
     assert seen == [
         ("queue_manager", queue_repo),
         ("runtime_state", app),
@@ -76,3 +76,30 @@ def test_build_agent_runtime_gateway_returns_gateway_from_runtime_state(monkeypa
     )
 
     assert runtime_bootstrap.build_agent_runtime_gateway(app, typing_tracker=object()) is gateway
+
+
+def test_build_agent_runtime_state_does_not_write_top_level_activity_reader(monkeypatch):
+    gateway = object()
+    activity_reader = object()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=object(),
+            agent_pool={},
+            queue_manager=object(),
+            thread_tasks={},
+            thread_locks={},
+            thread_locks_guard=object(),
+        )
+    )
+
+    monkeypatch.setattr(runtime_bootstrap, "AppRuntimeThreadActivityReader", lambda **_kwargs: activity_reader)
+    monkeypatch.setattr(runtime_bootstrap, "NativeAgentRuntimeGateway", lambda **_kwargs: gateway)
+    monkeypatch.setattr(runtime_bootstrap, "NativeAgentChatDeliveryHandler", lambda **_kwargs: object())
+    monkeypatch.setattr(runtime_bootstrap, "AppAgentChatRuntimeServices", lambda *args, **kwargs: object())
+    monkeypatch.setattr(runtime_bootstrap, "NativeAgentThreadInputHandler", lambda *args, **kwargs: object())
+
+    state = runtime_bootstrap.build_agent_runtime_state(app, typing_tracker=object())
+
+    assert state.gateway is gateway
+    assert state.activity_reader is activity_reader
+    assert not hasattr(app.state, "agent_runtime_thread_activity_reader")

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -96,8 +96,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
             raise RuntimeError("threads runtime needs typing_tracker first")
         assert typing_tracker is app.state.typing_tracker
         app.state.agent_pool = {}
-        app.state.agent_runtime_thread_activity_reader = object()
-        return SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
+        return SimpleNamespace(activity_reader=object())
 
     _patch_lifespan_runtime_contract(
         monkeypatch,
@@ -143,7 +142,6 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         call_log.append("threads")
         assert typing_tracker is returned_typing_tracker
         app.state.agent_pool = {}
-        app.state.agent_runtime_thread_activity_reader = object()
         return SimpleNamespace(activity_reader=returned_activity_reader)
 
     def _wire_chat_delivery(_app, *, messaging_service, activity_reader, thread_repo):
@@ -225,9 +223,8 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     monkeypatch.setattr(
         "backend.threads.bootstrap.attach_threads_runtime",
         lambda app, *_args, **_kwargs: (
-            setattr(app.state, "agent_runtime_thread_activity_reader", object())
-            or setattr(app.state, "agent_pool", {})
-            or SimpleNamespace(activity_reader=app.state.agent_runtime_thread_activity_reader)
+            setattr(app.state, "agent_pool", {})
+            or SimpleNamespace(activity_reader=object())
         ),
     )
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -209,10 +209,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     )
     monkeypatch.setattr(
         "backend.threads.bootstrap.attach_threads_runtime",
-        lambda app, *_args, **_kwargs: (
-            setattr(app.state, "agent_pool", {})
-            or SimpleNamespace(activity_reader=object())
-        ),
+        lambda app, *_args, **_kwargs: setattr(app.state, "agent_pool", {}) or SimpleNamespace(activity_reader=object()),
     )
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -78,23 +78,19 @@ def _patch_lifespan_runtime_contract(
 
 @pytest.mark.asyncio
 async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeypatch):
+    returned_typing_tracker = object()
+
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         contact_repo = object()
-        typing_tracker = object()
         messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
-        app.state.contact_repo = contact_repo
-        app.state.typing_tracker = typing_tracker
-        app.state.messaging_service = messaging_service
         return SimpleNamespace(
             contact_repo=contact_repo,
-            typing_tracker=typing_tracker,
+            typing_tracker=returned_typing_tracker,
             messaging_service=messaging_service,
         )
 
     def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
-        if not hasattr(app.state, "typing_tracker"):
-            raise RuntimeError("threads runtime needs typing_tracker first")
-        assert typing_tracker is app.state.typing_tracker
+        assert typing_tracker is returned_typing_tracker
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=object())
 
@@ -109,14 +105,12 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
     app = SimpleNamespace(state=SimpleNamespace())
 
     async with web_lifespan.lifespan(app):
-        assert hasattr(app.state, "typing_tracker")
         assert hasattr(app.state, "agent_pool")
 
 
 @pytest.mark.asyncio
 async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatch):
     call_log: list[str] = []
-    contact_repo = object()
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_contact_repo = object()
@@ -124,9 +118,6 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         call_log.append("chat")
-        app.state.typing_tracker = object()
-        app.state.messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
-        app.state.contact_repo = contact_repo
         return SimpleNamespace(
             contact_repo=returned_contact_repo,
             typing_tracker=returned_typing_tracker,
@@ -210,14 +201,10 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     )
     monkeypatch.setattr(
         "backend.chat.bootstrap.attach_chat_runtime",
-        lambda app, _storage_container, *, user_repo, thread_repo: (
-            setattr(app.state, "typing_tracker", object())
-            or setattr(app.state, "messaging_service", SimpleNamespace(set_delivery_fn=lambda _fn: None))
-            or SimpleNamespace(
-                contact_repo=contact_repo,
-                typing_tracker=app.state.typing_tracker,
-                messaging_service=app.state.messaging_service,
-            )
+        lambda app, _storage_container, *, user_repo, thread_repo: SimpleNamespace(
+            contact_repo=contact_repo,
+            typing_tracker=object(),
+            messaging_service=SimpleNamespace(set_delivery_fn=lambda _fn: None),
         ),
     )
     monkeypatch.setattr(

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
@@ -37,7 +37,6 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
                 ),
             ),
             agent_pool={},
-            typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, _notification_type, **_meta: enqueued.append((content, thread_id))
             ),
@@ -48,6 +47,7 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
             thread_locks_guard=asyncio.Lock(),
         )
     )
+    typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
     envelope = AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id="chat-1"),
@@ -56,7 +56,7 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
         message=AgentRuntimeMessage(content="hello", signal="ping"),
     )
 
-    result = await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_chat(envelope)
+    result = await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_chat(envelope)
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-preselected"

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -35,7 +35,6 @@ def _app(
                 get_by_id=lambda thread_id: next((row for row in thread_rows if row["id"] == thread_id), None),
             ),
             agent_pool=pool or {},
-            typing_tracker=SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id))),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
@@ -75,8 +74,9 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda _app, _thread_id: "local")
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     app, started, unread_calls, enqueued = _app()
+    typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
-    result = await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_chat(_envelope())
+    result = await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_chat(_envelope())
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-1"
@@ -91,9 +91,10 @@ async def test_gateway_dispatch_chat_raises_for_missing_thread(monkeypatch: pyte
         "backend.threads.chat_adapters.bootstrap.get_or_create_agent", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
     )
     app, started, unread_calls, enqueued = _app(threads=[])
+    typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
     with pytest.raises(RuntimeError, match="Agent chat recipient has no runtime thread: agent-user-1"):
-        await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_chat(_envelope(thread_id=None))
+        await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_chat(_envelope(thread_id=None))
 
     assert started == []
     assert unread_calls == []
@@ -110,9 +111,6 @@ async def test_gateway_dispatch_chat_uses_explicit_typing_tracker(monkeypatch: p
     monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
     app, _started, _unread_calls, enqueued = _app()
     started: list[tuple[str, str, str]] = []
-    app.state.typing_tracker = SimpleNamespace(
-        start_chat=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should use explicit typing tracker"))
-    )
     explicit_typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
     result = await build_agent_runtime_gateway(app, typing_tracker=explicit_typing_tracker).dispatch_chat(_envelope())

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -39,7 +39,6 @@ def _fake_app() -> SimpleNamespace:
                 list_by_agent_user=lambda _uid: [],
             ),
             agent_pool={},
-            typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
             queue_manager=_FakeQueueManager(),
             thread_cwd={},
             thread_sandbox={},
@@ -63,6 +62,7 @@ def _thread_input(content: str = "hello", *, enable_trajectory: bool = False) ->
 async def test_gateway_thread_input_clears_resource_overview_cache_when_starting_run() -> None:
     app = _fake_app()
     agent = _FakeAgent()
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
 
     with (
         patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
@@ -70,7 +70,7 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache") as clear_cache,
     ):
-        result = await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(_thread_input())
+        result = await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(_thread_input())
 
     assert result == AgentThreadInputResult(status="started", routing="direct", run_id="run-123", thread_id="thread-1")
     clear_cache.assert_called_once_with()
@@ -79,6 +79,7 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
 @pytest.mark.asyncio
 async def test_gateway_thread_input_requires_agent_runtime() -> None:
     app = _fake_app()
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
 
     with (
         patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
@@ -87,13 +88,14 @@ async def test_gateway_thread_input_requires_agent_runtime() -> None:
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
         with pytest.raises(AttributeError):
-            await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(_thread_input())
+            await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(_thread_input())
 
 
 @pytest.mark.asyncio
 async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run() -> None:
     app = _fake_app()
     agent = _FakeAgent()
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
 
     with (
         patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
@@ -101,7 +103,7 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
-        await build_agent_runtime_gateway(app, typing_tracker=app.state.typing_tracker).dispatch_thread_input(
+        await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(
             _thread_input(enable_trajectory=True)
         )
 

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -103,8 +103,6 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
-        await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(
-            _thread_input(enable_trajectory=True)
-        )
+        await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(_thread_input(enable_trajectory=True))
 
     assert start_run.call_args.kwargs["enable_trajectory"] is True

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -14,7 +14,6 @@ def _hook_app(gateway: object) -> SimpleNamespace:
     activity_reader = SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
     return SimpleNamespace(
         state=SimpleNamespace(
-            agent_runtime_gateway=gateway,
             threads_runtime_state=SimpleNamespace(
                 agent_runtime_gateway=gateway,
                 activity_reader=activity_reader,
@@ -23,7 +22,6 @@ def _hook_app(gateway: object) -> SimpleNamespace:
                 get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
                 list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
             ),
-            agent_runtime_thread_activity_reader=activity_reader,
         )
     )
 
@@ -37,7 +35,7 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
     app = _hook_app(FailingGateway())
     deliver = owner_chat_inlet.make_chat_delivery_fn(
         app,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
         thread_repo=app.state.thread_repo,
     )
     request = ChatDeliveryRequest(
@@ -69,7 +67,7 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
     app = _hook_app(gateway)
     deliver = owner_chat_inlet.make_chat_delivery_fn(
         app,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
         thread_repo=app.state.thread_repo,
     )
     request = ChatDeliveryRequest(
@@ -106,7 +104,7 @@ async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
     app = _hook_app(gateway)
     deliver = owner_chat_inlet.make_chat_delivery_fn(
         app,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
         thread_repo=app.state.thread_repo,
     )
     request = ChatDeliveryRequest(
@@ -140,7 +138,7 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
     app = _hook_app(gateway)
     deliver = owner_chat_inlet.make_chat_delivery_fn(
         app,
-        activity_reader=app.state.agent_runtime_thread_activity_reader,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
         thread_repo=app.state.thread_repo,
     )
     request = ChatDeliveryRequest(
@@ -165,7 +163,6 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
 def test_make_chat_delivery_fn_requires_activity_reader():
     app = SimpleNamespace(
         state=SimpleNamespace(
-            agent_runtime_gateway=object(),
             threads_runtime_state=SimpleNamespace(agent_runtime_gateway=object(), activity_reader=None),
         )
     )


### PR DESCRIPTION
## Summary
- remove loose threads/chat runtime state mirrors from production bootstrap so canonical read surfaces stay in `threads_runtime_state`, `agent_runtime_gateway_state`, and `chat_runtime_state`
- realign auth/users/messaging/conversations/runtime-gateway tests to consume those bundles instead of hand-populating top-level `app.state` mirrors
- align remaining gateway tests to pass `typing_tracker` as an explicit borrow instead of via top-level `app.state`

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/backend/test_chat_runtime_access.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_conversations_router.py tests/Integration/test_chat_first_screen_owner_threads.py tests/Integration/test_auth_router.py tests/Integration/test_users_router.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_messaging_router.py`
- `.venv/bin/python -m ruff check backend/threads/bootstrap.py backend/threads/chat_adapters/bootstrap.py backend/chat/bootstrap.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_conversations_router.py tests/Integration/test_chat_first_screen_owner_threads.py tests/Integration/test_auth_router.py tests/Integration/test_users_router.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_messaging_router.py`
- `git diff --check`
