### PR TITLE
Continue runtime state decoupling

### DIFF
--- a/backend/bootstrap/storage.py
+++ b/backend/bootstrap/storage.py
@@ -25,6 +25,5 @@ def build_runtime_storage_state() -> RuntimeStorageState:
 
 def attach_runtime_storage_state(app) -> RuntimeStorageState:
     state = build_runtime_storage_state()
-    app.state._supabase_client = state.supabase_client
-    app.state._storage_container = state.storage_container
+    app.state.runtime_storage_state = state
     return state

--- a/backend/identity/auth/dependencies.py
+++ b/backend/identity/auth/dependencies.py
@@ -4,7 +4,8 @@ from fastapi import FastAPI, HTTPException
 
 
 def _get_auth_service(app: FastAPI):
-    auth_service = getattr(app.state, "auth_service", None)
+    runtime_state = getattr(app.state, "auth_runtime_state", None)
+    auth_service = getattr(runtime_state, "auth_service", None)
     if auth_service is None:
         raise HTTPException(500, "Auth service not initialized")
     return auth_service

--- a/backend/identity/auth/runtime_bootstrap.py
+++ b/backend/identity/auth/runtime_bootstrap.py
@@ -39,6 +39,5 @@ def build_auth_runtime_state(storage_state, *, contact_repo) -> AuthRuntimeState
 
 def attach_auth_runtime_state(app, *, storage_state, contact_repo) -> AuthRuntimeState:
     state = build_auth_runtime_state(storage_state, contact_repo=contact_repo)
-    app.state.auth_service = state.auth_service
-    app.state._supabase_auth_client_factory = state.supabase_auth_client_factory
+    app.state.auth_runtime_state = state
     return state

--- a/backend/sandboxes/account.py
+++ b/backend/sandboxes/account.py
@@ -73,7 +73,8 @@ def list_account_resource_limits(app: Any, user_id: str) -> dict[str, list[dict[
         raise RuntimeError("thread_repo is required for account resource limits")
 
     count_kwargs = {"thread_repo": thread_repo}
-    supabase_client = getattr(app.state, "_supabase_client", None)
+    runtime_storage = getattr(app.state, "runtime_storage_state", None)
+    supabase_client = getattr(runtime_storage, "supabase_client", None)
     if supabase_client is not None:
         count_kwargs["supabase_client"] = supabase_client
     used_by_provider = sandbox_service.count_user_visible_sandboxes_by_provider(user_id, **count_kwargs)

--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -18,7 +18,8 @@ def _invite_code_payload(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _invite_code_repo(request: Request) -> InviteCodeRepo:
-    sb_client = getattr(request.app.state, "_supabase_client", None)
+    runtime_storage = getattr(request.app.state, "runtime_storage_state", None)
+    sb_client = getattr(runtime_storage, "supabase_client", None)
     if sb_client is None:
         raise HTTPException(503, "邀请码服务不可用（当前为 SQLite 模式）")
     repo = getattr(request.app.state, "invite_code_repo", None)

--- a/tests/Integration/test_auth_router.py
+++ b/tests/Integration/test_auth_router.py
@@ -32,7 +32,7 @@ class _FakeAuthService:
 @pytest.mark.asyncio
 async def test_send_otp_calls_auth_service_directly():
     service = _FakeAuthService()
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
+    app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
 
     result = await auth_router.send_otp(
         auth_router.SendOtpRequest(email="fresh@example.com", password="pass1234", invite_code="invite-1"),
@@ -47,7 +47,7 @@ async def test_send_otp_calls_auth_service_directly():
 async def test_send_otp_maps_value_error_to_bad_request():
     service = _FakeAuthService()
     service.send_otp_error = ValueError("邀请码无效或已过期")
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
+    app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
 
     with pytest.raises(HTTPException) as exc_info:
         await auth_router.send_otp(
@@ -63,7 +63,7 @@ async def test_send_otp_maps_value_error_to_bad_request():
 async def test_login_maps_value_error_to_unauthorized():
     service = _FakeAuthService()
     service.login_error = ValueError("Invalid username or password")
-    app = SimpleNamespace(state=SimpleNamespace(auth_service=service))
+    app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
 
     with pytest.raises(HTTPException) as exc_info:
         await auth_router.login(auth_router.LoginRequest(identifier="fresh@example.com", password="pass1234"), app)

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -400,9 +400,7 @@ async def test_list_conversations_fails_loud_when_thread_activity_reader_missing
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
             thread_last_active={},
-            chat_runtime_state=SimpleNamespace(
-                messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: [])
-            ),
+            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: [])),
         )
     )
 

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -25,7 +25,7 @@ async def _list_conversations(app: SimpleNamespace, user_id: str = "human-user-1
         owner_thread_rows=owner_conversations_router.get_owner_thread_rows_loader(app),
         activity_reader=owner_conversations_router.get_runtime_thread_activity_reader(app),
         thread_last_active=owner_conversations_router.get_thread_last_active_map(app),
-        messaging_service=getattr(app.state, "messaging_service", None),
+        messaging_service=getattr(getattr(app.state, "chat_runtime_state", None), "messaging_service", None),
     )
 
 
@@ -42,27 +42,29 @@ async def test_list_conversations_resolves_thread_user_participant_title_and_ava
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
-            messaging_service=SimpleNamespace(
-                list_conversation_summaries_for_user=lambda _user_id: [
-                    {
-                        "id": "chat-1",
-                        "title": "Toad",
-                        "avatar_url": avatar_url("agent-user-1", False),
-                        "updated_at": "2026-04-07T00:00:00Z",
-                        "unread_count": 3,
-                        "members": [
-                            {
-                                "id": "thread-user-1",
-                                "name": "Toad",
-                                "type": "agent",
-                                "avatar_url": avatar_url("agent-user-1", False),
-                            }
-                        ],
-                    }
-                ],
-                list_chats_for_user=lambda _user_id: (_ for _ in ()).throw(
-                    AssertionError("conversation sidebar must use lightweight chat summaries")
-                ),
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    list_conversation_summaries_for_user=lambda _user_id: [
+                        {
+                            "id": "chat-1",
+                            "title": "Toad",
+                            "avatar_url": avatar_url("agent-user-1", False),
+                            "updated_at": "2026-04-07T00:00:00Z",
+                            "unread_count": 3,
+                            "members": [
+                                {
+                                    "id": "thread-user-1",
+                                    "name": "Toad",
+                                    "type": "agent",
+                                    "avatar_url": avatar_url("agent-user-1", False),
+                                }
+                            ],
+                        }
+                    ],
+                    list_chats_for_user=lambda _user_id: (_ for _ in ()).throw(
+                        AssertionError("conversation sidebar must use lightweight chat summaries")
+                    ),
+                )
             ),
             user_repo=SimpleNamespace(
                 get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))
@@ -110,27 +112,29 @@ async def test_list_conversations_sorts_mixed_updated_at_types_without_type_erro
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={"thread-1": 1775540000.0},
-            messaging_service=SimpleNamespace(
-                list_conversation_summaries_for_user=lambda _user_id: [
-                    {
-                        "id": "chat-1",
-                        "title": "Toad",
-                        "avatar_url": avatar_url("agent-user-2", False),
-                        "updated_at": 1775540100.0,
-                        "unread_count": 0,
-                        "members": [
-                            {
-                                "id": "agent-user-2",
-                                "name": "Toad",
-                                "type": "agent",
-                                "avatar_url": avatar_url("agent-user-2", False),
-                            }
-                        ],
-                    }
-                ],
-                list_chats_for_user=lambda _user_id: (_ for _ in ()).throw(
-                    AssertionError("conversation sidebar must use lightweight chat summaries")
-                ),
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    list_conversation_summaries_for_user=lambda _user_id: [
+                        {
+                            "id": "chat-1",
+                            "title": "Toad",
+                            "avatar_url": avatar_url("agent-user-2", False),
+                            "updated_at": 1775540100.0,
+                            "unread_count": 0,
+                            "members": [
+                                {
+                                    "id": "agent-user-2",
+                                    "name": "Toad",
+                                    "type": "agent",
+                                    "avatar_url": avatar_url("agent-user-2", False),
+                                }
+                            ],
+                        }
+                    ],
+                    list_chats_for_user=lambda _user_id: (_ for _ in ()).throw(
+                        AssertionError("conversation sidebar must use lightweight chat summaries")
+                    ),
+                )
             ),
             user_repo=SimpleNamespace(
                 get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not batch resolve users"))
@@ -168,7 +172,7 @@ async def test_list_conversations_hire_entries_do_not_leak_template_member_ids()
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
-            messaging_service=None,
+            chat_runtime_state=SimpleNamespace(messaging_service=None),
         )
     )
 
@@ -217,7 +221,7 @@ async def test_list_conversations_marks_hire_thread_running_from_runtime_activit
                 )
             ),
             thread_last_active={},
-            messaging_service=None,
+            chat_runtime_state=SimpleNamespace(messaging_service=None),
         )
     )
 
@@ -265,7 +269,7 @@ async def test_list_conversations_collapses_hire_threads_to_one_visible_conversa
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={"thread-main": 1775540000.0, "thread-extra": 1775541000.0},
-            messaging_service=None,
+            chat_runtime_state=SimpleNamespace(messaging_service=None),
         )
     )
 
@@ -285,27 +289,29 @@ async def test_list_conversations_does_not_require_member_repo() -> None:
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
-            messaging_service=SimpleNamespace(
-                list_conversation_summaries_for_user=lambda _user_id: [
-                    {
-                        "id": "chat-1",
-                        "title": "Morel",
-                        "avatar_url": avatar_url("agent-user-1", True),
-                        "updated_at": "2026-04-07T00:00:00Z",
-                        "unread_count": 0,
-                        "members": [
-                            {
-                                "id": "thread-user-1",
-                                "name": "Morel",
-                                "type": "agent",
-                                "avatar_url": avatar_url("agent-user-1", True),
-                            }
-                        ],
-                    }
-                ],
-                list_chats_for_user=lambda _user_id: (_ for _ in ()).throw(
-                    AssertionError("conversation sidebar must use lightweight chat summaries")
-                ),
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(
+                    list_conversation_summaries_for_user=lambda _user_id: [
+                        {
+                            "id": "chat-1",
+                            "title": "Morel",
+                            "avatar_url": avatar_url("agent-user-1", True),
+                            "updated_at": "2026-04-07T00:00:00Z",
+                            "unread_count": 0,
+                            "members": [
+                                {
+                                    "id": "thread-user-1",
+                                    "name": "Morel",
+                                    "type": "agent",
+                                    "avatar_url": avatar_url("agent-user-1", True),
+                                }
+                            ],
+                        }
+                    ],
+                    list_chats_for_user=lambda _user_id: (_ for _ in ()).throw(
+                        AssertionError("conversation sidebar must use lightweight chat summaries")
+                    ),
+                )
             ),
             user_repo=SimpleNamespace(
                 get_by_id=lambda _uid: (_ for _ in ()).throw(AssertionError("router should not resolve visit participants"))
@@ -334,7 +340,7 @@ async def test_list_conversations_runs_sync_projection_off_event_loop(monkeypatc
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
-            messaging_service=messaging_service,
+            chat_runtime_state=SimpleNamespace(messaging_service=messaging_service),
         )
     )
     to_thread_calls: list[tuple[str, tuple[object, ...]]] = []
@@ -379,7 +385,9 @@ async def test_list_conversations_fetches_hire_and_visit_sources_in_parallel() -
             agent_pool={},
             threads_runtime_state=SimpleNamespace(activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])),
             thread_last_active={},
-            messaging_service=SimpleNamespace(list_conversation_summaries_for_user=_list_visit_summaries),
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(list_conversation_summaries_for_user=_list_visit_summaries)
+            ),
         )
     )
 
@@ -392,7 +400,9 @@ async def test_list_conversations_fails_loud_when_thread_activity_reader_missing
         state=SimpleNamespace(
             thread_repo=SimpleNamespace(list_by_owner_user_id=lambda _user_id: []),
             thread_last_active={},
-            messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: []),
+            chat_runtime_state=SimpleNamespace(
+                messaging_service=SimpleNamespace(list_conversation_summaries_for_user=lambda _user_id: [])
+            ),
         )
     )
 

--- a/tests/Integration/test_invite_codes_router.py
+++ b/tests/Integration/test_invite_codes_router.py
@@ -44,7 +44,14 @@ class _FakeInviteCodeRepo:
 
 
 def _request(repo: _FakeInviteCodeRepo):
-    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(_supabase_client=object(), invite_code_repo=repo)))
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                runtime_storage_state=SimpleNamespace(supabase_client=object()),
+                invite_code_repo=repo,
+            )
+        )
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/Integration/test_settings_persistence_contract.py
+++ b/tests/Integration/test_settings_persistence_contract.py
@@ -239,7 +239,7 @@ def test_update_provider_platform_source_removes_stored_user_key():
 def test_account_resources_route_returns_backend_quota_contract(monkeypatch):
     app = _settings_test_app(_FakeSettingsRepo())
     app.state.thread_repo = object()
-    app.state._supabase_client = object()
+    app.state.runtime_storage_state = SimpleNamespace(supabase_client=object())
     seen: dict[str, object] = {}
 
     def _fake_count_user_visible_sandboxes_by_provider(user_id: str, **kwargs):
@@ -287,7 +287,7 @@ def test_account_resources_route_returns_backend_quota_contract(monkeypatch):
     }
     assert seen == {
         "user_id": "user-1",
-        "kwargs": {"thread_repo": app.state.thread_repo, "supabase_client": app.state._supabase_client},
+        "kwargs": {"thread_repo": app.state.thread_repo, "supabase_client": app.state.runtime_storage_state.supabase_client},
     }
 
 

--- a/tests/Unit/backend/test_auth_runtime_bootstrap.py
+++ b/tests/Unit/backend/test_auth_runtime_bootstrap.py
@@ -58,7 +58,7 @@ def test_build_auth_runtime_state_requires_explicit_contact_repo():
         raise AssertionError("build_auth_runtime_state should require explicit contact_repo")
 
 
-def test_attach_auth_runtime_state_sets_app_state(monkeypatch):
+def test_attach_auth_runtime_state_returns_bundle_without_loose_state_mirrors(monkeypatch):
     fake_state = SimpleNamespace(auth_service=object(), supabase_auth_client_factory=object())
     app = type("_App", (), {"state": type("_State", (), {})()})()
 
@@ -67,5 +67,6 @@ def test_attach_auth_runtime_state_sets_app_state(monkeypatch):
     result = auth_runtime_bootstrap.attach_auth_runtime_state(app, storage_state=object(), contact_repo=object())
 
     assert result is fake_state
-    assert app.state.auth_service is fake_state.auth_service
-    assert app.state._supabase_auth_client_factory is fake_state.supabase_auth_client_factory
+    assert app.state.auth_runtime_state is fake_state
+    assert not hasattr(app.state, "auth_service")
+    assert not hasattr(app.state, "_supabase_auth_client_factory")

--- a/tests/Unit/backend/test_auth_user_resolution.py
+++ b/tests/Unit/backend/test_auth_user_resolution.py
@@ -16,7 +16,9 @@ class _Request:
         self.headers = {"Authorization": f"Bearer {token}"}
         self.app = SimpleNamespace(
             state=SimpleNamespace(
-                auth_service=SimpleNamespace(verify_token=lambda seen: payload if seen == token else None),
+                auth_runtime_state=SimpleNamespace(
+                    auth_service=SimpleNamespace(verify_token=lambda seen: payload if seen == token else None)
+                ),
                 user_repo=SimpleNamespace(get_by_id=lambda _user_id: object() if user_exists else None),
                 member_repo=SimpleNamespace(
                     get_by_id=lambda _user_id: (_ for _ in ()).throw(AssertionError("member_repo should not gate auth"))
@@ -58,7 +60,9 @@ async def test_get_current_user_returns_user_row_off_event_loop_thread():
         headers={"Authorization": "Bearer tok-1"},
         app=SimpleNamespace(
             state=SimpleNamespace(
-                auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"}),
+                auth_runtime_state=SimpleNamespace(
+                    auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"})
+                ),
                 user_repo=_UserRepo(),
             )
         ),
@@ -83,7 +87,9 @@ async def test_get_current_user_id_coalesces_concurrent_user_existence_checks():
     repo = CountingUserRepo()
     app = SimpleNamespace(
         state=SimpleNamespace(
-            auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"}),
+            auth_runtime_state=SimpleNamespace(
+                auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"})
+            ),
             user_repo=repo,
         )
     )

--- a/tests/Unit/backend/test_auth_user_resolution.py
+++ b/tests/Unit/backend/test_auth_user_resolution.py
@@ -60,9 +60,7 @@ async def test_get_current_user_returns_user_row_off_event_loop_thread():
         headers={"Authorization": "Bearer tok-1"},
         app=SimpleNamespace(
             state=SimpleNamespace(
-                auth_runtime_state=SimpleNamespace(
-                    auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"})
-                ),
+                auth_runtime_state=SimpleNamespace(auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"})),
                 user_repo=_UserRepo(),
             )
         ),
@@ -87,9 +85,7 @@ async def test_get_current_user_id_coalesces_concurrent_user_existence_checks():
     repo = CountingUserRepo()
     app = SimpleNamespace(
         state=SimpleNamespace(
-            auth_runtime_state=SimpleNamespace(
-                auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"})
-            ),
+            auth_runtime_state=SimpleNamespace(auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "user-1"})),
             user_repo=repo,
         )
     )

--- a/tests/Unit/backend/test_runtime_storage_bootstrap.py
+++ b/tests/Unit/backend/test_runtime_storage_bootstrap.py
@@ -23,7 +23,7 @@ def test_build_runtime_storage_state_uses_shared_supabase_client(monkeypatch):
     assert calls == [fake_client]
 
 
-def test_attach_runtime_storage_state_sets_app_state(monkeypatch):
+def test_attach_runtime_storage_state_returns_bundle_without_loose_state_mirrors(monkeypatch):
     fake_state = SimpleNamespace(supabase_client=object(), storage_container=object())
     app = type("_App", (), {"state": type("_State", (), {})()})()
 
@@ -32,5 +32,5 @@ def test_attach_runtime_storage_state_sets_app_state(monkeypatch):
     result = runtime_storage_bootstrap.attach_runtime_storage_state(app)
 
     assert result is fake_state
-    assert app.state._supabase_client is fake_state.supabase_client
-    assert app.state._storage_container is fake_state.storage_container
+    assert not hasattr(app.state, "_supabase_client")
+    assert not hasattr(app.state, "_storage_container")

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -50,8 +50,8 @@ def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyP
         lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
-                "auth_service",
-                SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+                "auth_runtime_state",
+                SimpleNamespace(auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"})),
             )
             or object()
         ),
@@ -86,8 +86,8 @@ def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatc
         lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
-                "auth_service",
-                SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+                "auth_runtime_state",
+                SimpleNamespace(auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"})),
             )
             or object()
         ),
@@ -116,8 +116,8 @@ def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPa
         lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
-                "auth_service",
-                SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+                "auth_runtime_state",
+                SimpleNamespace(auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"})),
             )
             or object()
         ),
@@ -158,8 +158,8 @@ def test_monitor_app_maps_missing_remote_execution_target_to_503(monkeypatch: py
         lambda app, *, storage_state, contact_repo: (
             setattr(
                 app.state,
-                "auth_service",
-                SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"}),
+                "auth_runtime_state",
+                SimpleNamespace(auth_service=SimpleNamespace(verify_token=lambda _token: {"user_id": "owner-1"})),
             )
             or object()
         ),


### PR DESCRIPTION
## Summary
- make `runtime_storage_state` the canonical storage runtime surface and route storage-backed consumers through it instead of `_supabase_client` / `_storage_container` mirrors
- make `auth_runtime_state` the canonical auth runtime surface and route auth consumers/tests through it instead of top-level `auth_service` mirrors
- finish followup test realignment for conversations/runtime fixtures so they consume bundled runtime state consistently

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_runtime_storage_bootstrap.py tests/Integration/test_invite_codes_router.py tests/Integration/test_settings_persistence_contract.py tests/Unit/backend/test_auth_runtime_bootstrap.py tests/Integration/test_auth_router.py tests/Unit/backend/test_auth_user_resolution.py tests/Unit/monitor/test_monitor_app_entrypoint.py tests/Unit/monitor/test_monitor_app_lifespan.py tests/Integration/test_conversations_router.py`
- `.venv/bin/python -m ruff check backend/bootstrap/storage.py backend/sandboxes/account.py backend/web/routers/invite_codes.py backend/identity/auth/runtime_bootstrap.py backend/identity/auth/dependencies.py tests/Unit/backend/test_runtime_storage_bootstrap.py tests/Integration/test_invite_codes_router.py tests/Integration/test_settings_persistence_contract.py tests/Unit/backend/test_auth_runtime_bootstrap.py tests/Integration/test_auth_router.py tests/Unit/backend/test_auth_user_resolution.py tests/Unit/monitor/test_monitor_app_entrypoint.py tests/Unit/monitor/test_monitor_app_lifespan.py tests/Integration/test_conversations_router.py`
- `git diff --check`
