### PR TITLE
Route storage repos through runtime bundle

### DIFF
--- a/backend/sandboxes/account.py
+++ b/backend/sandboxes/account.py
@@ -25,7 +25,10 @@ class AccountResourceLimitExceededError(RuntimeError):
 
 
 def _settings_repo(app: Any) -> Any:
-    repo = getattr(app.state, "user_settings_repo", None)
+    runtime_storage = getattr(app.state, "runtime_storage_state", None)
+    storage_container = getattr(runtime_storage, "storage_container", None)
+    repo_factory = getattr(storage_container, "user_settings_repo", None)
+    repo = repo_factory() if callable(repo_factory) else None
     if repo is None:
         raise RuntimeError("user_settings_repo is required for account resource limits")
     return repo

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -89,7 +89,10 @@ async def get_or_create_agent(
         # Look up model for this thread (thread override -> repo-backed user settings)
         model_name = thread_data.get("model") if thread_data else None
         models_config_override = None
-        user_settings_repo = getattr(app_obj.state, "user_settings_repo", None)
+        runtime_storage = getattr(app_obj.state, "runtime_storage_state", None)
+        storage_container = getattr(runtime_storage, "storage_container", None)
+        user_settings_repo_factory = getattr(storage_container, "user_settings_repo", None)
+        user_settings_repo = user_settings_repo_factory() if callable(user_settings_repo_factory) else None
         owner_user_id = getattr(agent_user, "owner_user_id", None) if agent_user is not None else None
         if user_settings_repo is not None and owner_user_id is not None:
             settings_row = user_settings_repo.get(owner_user_id) or {}

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -59,8 +59,6 @@ async def lifespan(app: FastAPI):
     app.state.recipe_repo = storage_container.recipe_repo()
     app.state.workspace_repo = storage_container.workspace_repo()
     app.state.sandbox_repo = storage_container.sandbox_repo()
-    app.state.invite_code_repo = storage_container.invite_code_repo()
-    app.state.user_settings_repo = storage_container.user_settings_repo()
     from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery
     from backend.threads.bootstrap import attach_threads_runtime
 

--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -22,7 +22,9 @@ def _invite_code_repo(request: Request) -> InviteCodeRepo:
     sb_client = getattr(runtime_storage, "supabase_client", None)
     if sb_client is None:
         raise HTTPException(503, "邀请码服务不可用（当前为 SQLite 模式）")
-    repo = getattr(request.app.state, "invite_code_repo", None)
+    storage_container = getattr(runtime_storage, "storage_container", None)
+    repo_factory = getattr(storage_container, "invite_code_repo", None)
+    repo = repo_factory() if callable(repo_factory) else None
     if repo is None:
         raise HTTPException(503, "邀请码仓库未初始化")
     return repo

--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -56,7 +56,10 @@ def _resolve_workspace_path_or_400(
 
 
 def _get_settings_repo(request: Request):
-    repo = getattr(request.app.state, "user_settings_repo", None)
+    runtime_storage = getattr(request.app.state, "runtime_storage_state", None)
+    storage_container = getattr(runtime_storage, "storage_container", None)
+    repo_factory = getattr(storage_container, "user_settings_repo", None)
+    repo = repo_factory() if callable(repo_factory) else None
     if repo is None:
         raise RuntimeError("user_settings_repo is required for backend web settings routes")
     return repo

--- a/tests/Integration/test_invite_codes_router.py
+++ b/tests/Integration/test_invite_codes_router.py
@@ -47,8 +47,10 @@ def _request(repo: _FakeInviteCodeRepo):
     return SimpleNamespace(
         app=SimpleNamespace(
             state=SimpleNamespace(
-                runtime_storage_state=SimpleNamespace(supabase_client=object()),
-                invite_code_repo=repo,
+                runtime_storage_state=SimpleNamespace(
+                    supabase_client=object(),
+                    storage_container=SimpleNamespace(invite_code_repo=lambda: repo),
+                ),
             )
         )
     )

--- a/tests/Integration/test_settings_persistence_contract.py
+++ b/tests/Integration/test_settings_persistence_contract.py
@@ -38,9 +38,7 @@ class _FakeSettingsRepo:
 
 def _settings_test_app(repo: _FakeSettingsRepo | None) -> FastAPI:
     app = FastAPI()
-    app.state.runtime_storage_state = SimpleNamespace(
-        storage_container=SimpleNamespace(user_settings_repo=lambda: repo)
-    )
+    app.state.runtime_storage_state = SimpleNamespace(storage_container=SimpleNamespace(user_settings_repo=lambda: repo))
     app.dependency_overrides[settings_router.get_current_user_id] = lambda: "user-1"
     app.include_router(settings_router.router)
     return app

--- a/tests/Integration/test_settings_persistence_contract.py
+++ b/tests/Integration/test_settings_persistence_contract.py
@@ -38,7 +38,9 @@ class _FakeSettingsRepo:
 
 def _settings_test_app(repo: _FakeSettingsRepo | None) -> FastAPI:
     app = FastAPI()
-    app.state.user_settings_repo = repo
+    app.state.runtime_storage_state = SimpleNamespace(
+        storage_container=SimpleNamespace(user_settings_repo=lambda: repo)
+    )
     app.dependency_overrides[settings_router.get_current_user_id] = lambda: "user-1"
     app.include_router(settings_router.router)
     return app
@@ -237,9 +239,13 @@ def test_update_provider_platform_source_removes_stored_user_key():
 
 
 def test_account_resources_route_returns_backend_quota_contract(monkeypatch):
-    app = _settings_test_app(_FakeSettingsRepo())
+    repo = _FakeSettingsRepo()
+    app = _settings_test_app(repo)
     app.state.thread_repo = object()
-    app.state.runtime_storage_state = SimpleNamespace(supabase_client=object())
+    app.state.runtime_storage_state = SimpleNamespace(
+        supabase_client=object(),
+        storage_container=SimpleNamespace(user_settings_repo=lambda: repo),
+    )
     seen: dict[str, object] = {}
 
     def _fake_count_user_visible_sandboxes_by_provider(user_id: str, **kwargs):

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -106,6 +106,8 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
 
     async with web_lifespan.lifespan(app):
         assert hasattr(app.state, "agent_pool")
+        assert not hasattr(app.state, "invite_code_repo")
+        assert not hasattr(app.state, "user_settings_repo")
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -691,9 +691,7 @@ async def test_get_or_create_agent_uses_repo_backed_default_model_contract(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            runtime_storage_state=SimpleNamespace(
-                storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())
-            ),
+            runtime_storage_state=SimpleNamespace(storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())),
             agent_config_repo=_EmptyAgentConfigRepo(),
             thread_cwd={},
             thread_sandbox={},
@@ -747,9 +745,7 @@ async def test_get_or_create_agent_passes_repo_backed_models_config_to_runtime(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            runtime_storage_state=SimpleNamespace(
-                storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())
-            ),
+            runtime_storage_state=SimpleNamespace(storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())),
             agent_config_repo=_EmptyAgentConfigRepo(),
             thread_cwd={},
             thread_sandbox={},

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -691,7 +691,9 @@ async def test_get_or_create_agent_uses_repo_backed_default_model_contract(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            user_settings_repo=_UserSettingsRepo(),
+            runtime_storage_state=SimpleNamespace(
+                storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())
+            ),
             agent_config_repo=_EmptyAgentConfigRepo(),
             thread_cwd={},
             thread_sandbox={},
@@ -745,7 +747,9 @@ async def test_get_or_create_agent_passes_repo_backed_models_config_to_runtime(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            user_settings_repo=_UserSettingsRepo(),
+            runtime_storage_state=SimpleNamespace(
+                storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())
+            ),
             agent_config_repo=_EmptyAgentConfigRepo(),
             thread_cwd={},
             thread_sandbox={},


### PR DESCRIPTION
## Summary
- route settings/invite-code/user-settings consumers through `runtime_storage_state.storage_container` instead of top-level storage repo mirrors
- remove the corresponding top-level `invite_code_repo` / `user_settings_repo` writes from web lifespan
- keep thread pool model-config lookup aligned to the same storage bundle contract

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_settings_persistence_contract.py tests/Integration/test_invite_codes_router.py tests/Unit/core/test_agent_pool.py`
- `.venv/bin/python -m ruff check backend/web/core/lifespan.py backend/web/routers/settings.py backend/web/routers/invite_codes.py backend/sandboxes/account.py backend/threads/pool/registry.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_settings_persistence_contract.py tests/Integration/test_invite_codes_router.py tests/Unit/core/test_agent_pool.py`
- `git diff --check`
