### PR TITLE
Route agent config through runtime storage

### DIFF
--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -108,7 +108,10 @@ async def get_or_create_agent(
         bundle_dir = None
         agent_config_id = None
         memory_config_override = None
-        agent_config_repo = getattr(app_obj.state, "agent_config_repo", None)
+        runtime_storage = getattr(app_obj.state, "runtime_storage_state", None)
+        storage_container = getattr(runtime_storage, "storage_container", None)
+        agent_config_repo_factory = getattr(storage_container, "agent_config_repo", None)
+        agent_config_repo = agent_config_repo_factory() if callable(agent_config_repo_factory) else None
         if thread_data and thread_data.get("agent_user_id"):
             if user_repo is None:
                 raise RuntimeError(f"user_repo is required to resolve agent_config_id for thread {thread_id}")
@@ -147,7 +150,7 @@ async def get_or_create_agent(
                 "owner_id": owner_id,
                 "user_repo": user_repo,
                 "messaging_service": messaging_service,
-                "agent_config_repo": getattr(app_obj.state, "agent_config_repo", None),
+                "agent_config_repo": agent_config_repo,
             }
 
         try:

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -74,7 +74,6 @@ async def lifespan(app: FastAPI):
     # @@@web-auth-borrowed-chat-contact - auth startup still needs the
     # owner-agent contact repo, but web bootstrap should borrow the chat-owned
     # contact_repo returned by chat bootstrap instead of reopening storage.
-    app.state.agent_config_repo = storage_container.agent_config_repo()
     attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=chat_runtime.contact_repo)
     threads_runtime = attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)
     wire_chat_delivery(

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -18,6 +18,13 @@ from backend.web.models.marketplace import (
 router = APIRouter(prefix="/api/marketplace", tags=["marketplace"])
 
 
+def _agent_config_repo(request: Request) -> Any | None:
+    runtime_storage = getattr(request.app.state, "runtime_storage_state", None)
+    storage_container = getattr(runtime_storage, "storage_container", None)
+    repo_factory = getattr(storage_container, "agent_config_repo", None)
+    return repo_factory() if callable(repo_factory) else None
+
+
 async def _verify_user_ownership(agent_user_id: str, user_id: str, user_repo: Any) -> None:
     """Raise 403 if *user_id* does not own *agent_user_id*."""
 
@@ -72,7 +79,7 @@ async def publish_agent_user_to_marketplace(
     request: Request,
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     await _verify_user_ownership(req.user_id, user_id, user_repo)
 
     publisher_user = user_repo.get_by_id(user_id)
@@ -101,7 +108,7 @@ async def download_from_marketplace(
     request: Request,
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     if req.agent_user_id is not None:
         await _verify_user_ownership(req.agent_user_id, user_id, user_repo)
     return await asyncio.to_thread(
@@ -121,7 +128,7 @@ async def upgrade_from_marketplace(
     request: Request,
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     await _verify_user_ownership(req.user_id, user_id, user_repo)
 
     return await asyncio.to_thread(

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -50,6 +50,13 @@ def _ensure_agent_has_no_threads_or_409(agent_id: str, thread_repo: Any) -> None
         raise HTTPException(409, "Cannot delete agent with existing threads")
 
 
+def _agent_config_repo(request: Request) -> Any | None:
+    runtime_storage = getattr(request.app.state, "runtime_storage_state", None)
+    storage_container = getattr(runtime_storage, "storage_container", None)
+    repo_factory = getattr(storage_container, "agent_config_repo", None)
+    return repo_factory() if callable(repo_factory) else None
+
+
 # ── Agents ──
 
 
@@ -59,7 +66,7 @@ async def list_agents(
     request: Request,
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     items = await asyncio.to_thread(
         agent_user_service.list_agent_user_summaries,
         user_id,
@@ -80,7 +87,7 @@ async def get_agent(
         agent_id,
         user_id,
         request.app.state.user_repo,
-        getattr(request.app.state, "agent_config_repo", None),
+        _agent_config_repo(request),
     )
 
 
@@ -92,7 +99,7 @@ async def create_agent(
     contact_repo: Annotated[Any, Depends(get_contact_repo)],
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     try:
         # @@@panel-chat-consumer - panel owns the agent CRUD route, but contact
         # edge cleanup is chat-owned truth. Borrow the repo explicitly so panel
@@ -120,7 +127,7 @@ async def update_agent(
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     await asyncio.to_thread(_require_owned_agent_user, agent_id, user_id, user_repo)
     item = await asyncio.to_thread(
         agent_user_service.update_agent_user,
@@ -145,7 +152,7 @@ async def update_agent_config(
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     await asyncio.to_thread(_require_owned_agent_user, agent_id, user_id, user_repo)
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     item = await asyncio.to_thread(
         agent_user_service.update_agent_user_config,
         agent_id,
@@ -169,7 +176,7 @@ async def publish_agent(
         raise HTTPException(403, "Cannot publish builtin agent")
     user_repo = request.app.state.user_repo
     await asyncio.to_thread(_require_owned_agent_user, agent_id, user_id, user_repo)
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     item = await asyncio.to_thread(
         agent_user_service.publish_agent_user,
         agent_id,
@@ -197,7 +204,7 @@ async def delete_agent(
     if thread_repo is None:
         raise HTTPException(503, "Thread repo unavailable")
     await asyncio.to_thread(_ensure_agent_has_no_threads_or_409, agent_id, thread_repo)
-    agent_config_repo = getattr(request.app.state, "agent_config_repo", None)
+    agent_config_repo = _agent_config_repo(request)
     try:
         if contact_repo is None:
             raise RuntimeError("chat bootstrap not attached: contact_repo")
@@ -311,7 +318,7 @@ async def get_used_by(
         resource_name,
         user_id,
         user_repo=request.app.state.user_repo,
-        agent_config_repo=getattr(request.app.state, "agent_config_repo", None),
+        agent_config_repo=_agent_config_repo(request),
     )
     return {"count": len(users), "users": users}
 

--- a/tests/Integration/test_marketplace_router_user_shell.py
+++ b/tests/Integration/test_marketplace_router_user_shell.py
@@ -14,6 +14,10 @@ from backend.web.models.marketplace import (
 from backend.web.routers import marketplace as marketplace_router
 
 
+def _runtime_storage_state(agent_config_repo: object) -> SimpleNamespace:
+    return SimpleNamespace(storage_container=SimpleNamespace(agent_config_repo=lambda: agent_config_repo))
+
+
 def test_marketplace_router_exposes_agent_user_marketplace_routes() -> None:
     paths = {getattr(route, "path", "") for route in marketplace_router.router.routes}
 
@@ -51,7 +55,7 @@ async def test_publish_agent_user_to_marketplace_uses_user_repo_not_member_repo(
         app=SimpleNamespace(
             state=SimpleNamespace(
                 user_repo=user_repo,
-                agent_config_repo=agent_config_repo,
+                runtime_storage_state=_runtime_storage_state(agent_config_repo),
             )
         )
     )
@@ -80,7 +84,7 @@ async def test_upgrade_from_marketplace_uses_user_repo_not_member_repo(monkeypat
                 user_repo=SimpleNamespace(
                     get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-1") if user_id == "agent-1" else None
                 ),
-                agent_config_repo=SimpleNamespace(),
+                runtime_storage_state=_runtime_storage_state(SimpleNamespace()),
             )
         )
     )
@@ -92,7 +96,7 @@ async def test_upgrade_from_marketplace_uses_user_repo_not_member_repo(monkeypat
     assert seen["item_id"] == "item-1"
     assert seen["owner_user_id"] == "owner-1"
     assert seen["user_repo"] is request.app.state.user_repo
-    assert seen["agent_config_repo"] is request.app.state.agent_config_repo
+    assert seen["agent_config_repo"] is request.app.state.runtime_storage_state.storage_container.agent_config_repo()
 
 
 @pytest.mark.asyncio
@@ -106,7 +110,7 @@ async def test_download_from_marketplace_uses_user_and_agent_config_repos(monkey
         app=SimpleNamespace(
             state=SimpleNamespace(
                 user_repo=SimpleNamespace(get_by_id=lambda user_id: owner_agent if user_id == "agent-1" else None),
-                agent_config_repo=SimpleNamespace(),
+                runtime_storage_state=_runtime_storage_state(SimpleNamespace()),
             )
         )
     )
@@ -118,7 +122,7 @@ async def test_download_from_marketplace_uses_user_and_agent_config_repos(monkey
     assert seen["item_id"] == "item-1"
     assert seen["owner_user_id"] == "owner-1"
     assert seen["user_repo"] is request.app.state.user_repo
-    assert seen["agent_config_repo"] is request.app.state.agent_config_repo
+    assert seen["agent_config_repo"] is request.app.state.runtime_storage_state.storage_container.agent_config_repo()
     assert seen["agent_user_id"] == "agent-1"
 
 

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -13,6 +13,10 @@ from backend.web.routers import panel as panel_router
 from storage.contracts import UserRow, UserType
 
 
+def _runtime_storage_state(agent_config_repo: object) -> SimpleNamespace:
+    return SimpleNamespace(storage_container=SimpleNamespace(agent_config_repo=lambda: agent_config_repo))
+
+
 @pytest.mark.asyncio
 async def test_panel_agents_uses_injected_user_repo_for_owner_scope(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     agent = UserRow(
@@ -49,7 +53,11 @@ async def test_panel_agents_uses_injected_user_repo_for_owner_scope(monkeypatch:
 
     result = await panel_router.list_agents(
         user_id="user-1",
-        request=SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(user_repo=fake_repo, agent_config_repo=fake_agent_config_repo))),
+        request=SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(user_repo=fake_repo, runtime_storage_state=_runtime_storage_state(fake_agent_config_repo))
+            )
+        ),
     )
 
     assert seen == ["user-1"]
@@ -94,7 +102,11 @@ async def test_panel_agent_detail_keeps_full_config_for_owner_scope(monkeypatch:
     result = await panel_router.get_agent(
         "agent-1",
         user_id="user-1",
-        request=SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(user_repo=fake_repo, agent_config_repo=fake_agent_config_repo))),
+        request=SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(user_repo=fake_repo, runtime_storage_state=_runtime_storage_state(fake_agent_config_repo))
+            )
+        ),
     )
 
     assert result["id"] == "agent-1"
@@ -416,7 +428,7 @@ async def test_create_agent_route_fails_loud_when_contact_repo_missing():
         app=SimpleNamespace(
             state=SimpleNamespace(
                 user_repo=SimpleNamespace(),
-                agent_config_repo=SimpleNamespace(),
+                runtime_storage_state=_runtime_storage_state(SimpleNamespace()),
             )
         )
     )
@@ -439,7 +451,7 @@ async def test_delete_agent_route_fails_loud_when_contact_repo_missing(monkeypat
         app=SimpleNamespace(
             state=SimpleNamespace(
                 user_repo=SimpleNamespace(),
-                agent_config_repo=SimpleNamespace(),
+                runtime_storage_state=_runtime_storage_state(SimpleNamespace()),
                 thread_repo=SimpleNamespace(list_by_agent_user=lambda _agent_id: []),
             )
         )
@@ -465,7 +477,7 @@ async def test_delete_agent_route_fails_loud_when_thread_repo_missing(monkeypatc
         app=SimpleNamespace(
             state=SimpleNamespace(
                 user_repo=SimpleNamespace(),
-                agent_config_repo=SimpleNamespace(),
+                runtime_storage_state=_runtime_storage_state(SimpleNamespace()),
                 chat_runtime_state=SimpleNamespace(contact_repo=SimpleNamespace()),
             )
         )
@@ -816,7 +828,12 @@ async def test_panel_library_used_by_route_uses_user_scope(monkeypatch: pytest.M
         "skill",
         "skill-a",
         request=SimpleNamespace(
-            app=SimpleNamespace(state=SimpleNamespace(user_repo=fake_user_repo, agent_config_repo=fake_agent_config_repo))
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    user_repo=fake_user_repo,
+                    runtime_storage_state=_runtime_storage_state(fake_agent_config_repo),
+                )
+            )
         ),
         user_id="user-1",
     )

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -108,6 +108,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
         assert hasattr(app.state, "agent_pool")
         assert not hasattr(app.state, "invite_code_repo")
         assert not hasattr(app.state, "user_settings_repo")
+        assert not hasattr(app.state, "agent_config_repo")
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -19,6 +19,10 @@ class _EmptyAgentConfigRepo:
         return {}
 
 
+def _runtime_storage_state(agent_config_repo: object | None) -> SimpleNamespace:
+    return SimpleNamespace(storage_container=SimpleNamespace(agent_config_repo=lambda: agent_config_repo))
+
+
 @pytest.mark.asyncio
 async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
@@ -94,7 +98,7 @@ async def test_registry_get_or_create_agent_uses_explicit_messaging_service(
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -141,7 +145,7 @@ async def test_registry_get_or_create_agent_requires_explicit_messaging_service_
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -178,7 +182,7 @@ async def test_registry_get_or_create_agent_does_not_read_app_state_messaging_se
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -395,7 +399,7 @@ async def test_get_or_create_agent_prefers_repo_backed_runtime_startup_even_with
             ),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -407,7 +411,7 @@ async def test_get_or_create_agent_prefers_repo_backed_runtime_startup_even_with
     # for repo-backed agent users even when a stale member shell still exists on disk.
     assert captured["bundle_dir"] is None
     assert captured["agent_config_id"] == "cfg-1"
-    assert captured["agent_config_repo"] is app.state.agent_config_repo
+    assert captured["agent_config_repo"] is app.state.runtime_storage_state.storage_container.agent_config_repo()
 
 
 @pytest.mark.asyncio
@@ -455,7 +459,7 @@ async def test_get_or_create_agent_uses_thread_user_id_for_chat_identity(monkeyp
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -500,7 +504,7 @@ async def test_get_or_create_agent_fails_loud_when_chat_repos_need_missing_messa
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -547,7 +551,7 @@ async def test_get_or_create_agent_uses_binding_local_staging_root_for_extra_all
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -626,7 +630,7 @@ async def test_get_or_create_agent_keys_registry_by_agent_user_id(monkeypatch: p
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -691,8 +695,12 @@ async def test_get_or_create_agent_uses_repo_backed_default_model_contract(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            runtime_storage_state=SimpleNamespace(storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=SimpleNamespace(
+                storage_container=SimpleNamespace(
+                    user_settings_repo=lambda: _UserSettingsRepo(),
+                    agent_config_repo=lambda: _EmptyAgentConfigRepo(),
+                )
+            ),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -745,8 +753,12 @@ async def test_get_or_create_agent_passes_repo_backed_models_config_to_runtime(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            runtime_storage_state=SimpleNamespace(storage_container=SimpleNamespace(user_settings_repo=lambda: _UserSettingsRepo())),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=SimpleNamespace(
+                storage_container=SimpleNamespace(
+                    user_settings_repo=lambda: _UserSettingsRepo(),
+                    agent_config_repo=lambda: _EmptyAgentConfigRepo(),
+                )
+            ),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -795,7 +807,7 @@ async def test_get_or_create_agent_passes_repo_backed_compact_config_to_runtime(
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_AgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_AgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )
@@ -839,7 +851,7 @@ async def test_get_or_create_agent_does_not_use_local_preferences_when_repo_miss
             user_repo=_UserRepo(),
             messaging_service=SimpleNamespace(),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
-            agent_config_repo=_EmptyAgentConfigRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
         )


### PR DESCRIPTION
## Summary
- route panel, marketplace, and thread runtime agent-config reads through `runtime_storage_state.storage_container.agent_config_repo()` instead of the top-level `app.state.agent_config_repo` mirror
- drop the corresponding `agent_config_repo` top-level write from web lifespan
- realign focused panel/marketplace/agent-pool/web-lifespan tests to the same storage bundle contract

## Test Plan
- `.venv/bin/python -m pytest -q tests/Integration/test_marketplace_router_user_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Unit/core/test_agent_pool.py tests/Unit/backend/test_web_lifespan_ordering.py`
- `.venv/bin/python -m ruff check backend/web/routers/panel.py backend/web/routers/marketplace.py backend/threads/pool/registry.py backend/web/core/lifespan.py tests/Integration/test_marketplace_router_user_shell.py tests/Integration/test_panel_auth_shell_coherence.py tests/Unit/core/test_agent_pool.py tests/Unit/backend/test_web_lifespan_ordering.py`
- `git diff --check`
