### PR TITLE
Route recipe repo through runtime storage

### DIFF
--- a/backend/bootstrap/storage.py
+++ b/backend/bootstrap/storage.py
@@ -12,14 +12,17 @@ from storage.runtime import build_storage_container
 class RuntimeStorageState:
     supabase_client: object
     storage_container: object
+    recipe_repo: object
 
 
 def build_runtime_storage_state() -> RuntimeStorageState:
     supabase_client = create_supabase_client()
     storage_container = build_storage_container(supabase_client=supabase_client)
+    recipe_repo = storage_container.recipe_repo()
     return RuntimeStorageState(
         supabase_client=supabase_client,
         storage_container=storage_container,
+        recipe_repo=recipe_repo,
     )
 
 

--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -47,8 +47,12 @@ def build_new_launch_config(
 def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> dict[str, Any]:
     if available_sandbox_types is None or list_library is None:
         raise RuntimeError("thread_runtime.launch_config requires available_sandbox_types and list_library bindings")
+    runtime_storage = getattr(app.state, "runtime_storage_state", None)
+    recipe_repo = getattr(runtime_storage, "recipe_repo", None)
+    if recipe_repo is None:
+        raise RuntimeError("recipe_repo is required for launch config resolution")
     providers = [item for item in available_sandbox_types() if item.get("available")]
-    sandbox_templates = list_library("sandbox-template", owner_user_id=owner_user_id, recipe_repo=app.state.recipe_repo)
+    sandbox_templates = list_library("sandbox-template", owner_user_id=owner_user_id, recipe_repo=recipe_repo)
     agent_threads = app.state.thread_repo.list_by_agent_user(agent_user_id)
 
     return {
@@ -183,7 +187,8 @@ def _resolve_workspace_backed_sandbox_template(
             provider_name=template_provider_name,
         )
 
-    recipe_repo = getattr(app.state, "recipe_repo", None)
+    runtime_storage = getattr(app.state, "runtime_storage_state", None)
+    recipe_repo = getattr(runtime_storage, "recipe_repo", None)
     get = getattr(recipe_repo, "get", None)
     if not callable(get):
         raise RuntimeError("recipe_repo must support get")

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -56,7 +56,6 @@ async def lifespan(app: FastAPI):
     app.state.user_repo = storage_container.user_repo()
     app.state.thread_repo = storage_container.thread_repo()
     app.state.lease_repo = storage_container.lease_repo()
-    app.state.recipe_repo = storage_container.recipe_repo()
     app.state.workspace_repo = storage_container.workspace_repo()
     app.state.sandbox_repo = storage_container.sandbox_repo()
     from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery
@@ -112,7 +111,7 @@ async def lifespan(app: FastAPI):
                     pass
 
         if hasattr(app.state, "recipe_repo"):
-            app.state.recipe_repo.close()
+            runtime_storage.recipe_repo.close()
 
         checkpoint_saver_ctx = getattr(app.state, "_thread_checkpoint_saver_ctx", None)
         if checkpoint_saver_ctx is not None:

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -57,6 +57,14 @@ def _agent_config_repo(request: Request) -> Any | None:
     return repo_factory() if callable(repo_factory) else None
 
 
+def _recipe_repo(request: Request) -> Any:
+    runtime_storage = getattr(request.app.state, "runtime_storage_state", None)
+    recipe_repo = getattr(runtime_storage, "recipe_repo", None)
+    if recipe_repo is None:
+        raise RuntimeError("recipe_repo is required for panel library routes")
+    return recipe_repo
+
+
 # ── Agents ──
 
 
@@ -231,7 +239,7 @@ async def list_library(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
-    items = await asyncio.to_thread(library_service.list_library, resource_type, user_id, request.app.state.recipe_repo)
+    items = await asyncio.to_thread(library_service.list_library, resource_type, user_id, _recipe_repo(request))
     return {"items": items}
 
 
@@ -253,7 +261,7 @@ async def create_resource(
             req.features,
             req.provider_name,
             user_id,
-            request.app.state.recipe_repo,
+            _recipe_repo(request),
         )
     except ValueError as error:
         raise HTTPException(400, str(error)) from error
@@ -272,7 +280,7 @@ async def update_resource(
         resource_type,
         resource_id,
         user_id,
-        request.app.state.recipe_repo,
+        _recipe_repo(request),
         name=req.name,
         desc=req.desc,
         features=req.features,
@@ -289,7 +297,7 @@ async def delete_resource(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
-    ok = await asyncio.to_thread(library_service.delete_resource, resource_type, resource_id, user_id, request.app.state.recipe_repo)
+    ok = await asyncio.to_thread(library_service.delete_resource, resource_type, resource_id, user_id, _recipe_repo(request))
     if not ok:
         raise HTTPException(404, "Resource not found")
     return {"success": True}
@@ -301,7 +309,7 @@ async def list_library_names(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
-    items = await asyncio.to_thread(library_service.list_library_names, resource_type, user_id, request.app.state.recipe_repo)
+    items = await asyncio.to_thread(library_service.list_library_names, resource_type, user_id, _recipe_repo(request))
     return {"items": items}
 
 
@@ -335,7 +343,7 @@ async def get_resource_content(
         resource_type,
         resource_id,
         user_id,
-        request.app.state.recipe_repo,
+        _recipe_repo(request),
     )
     if content is None:
         raise HTTPException(404, "Resource not found")

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -699,7 +699,8 @@ def _resolve_owned_recipe_snapshot(
     if not resolved_recipe_id:
         raise HTTPException(400, "Recipe id is required")
 
-    recipe_repo = getattr(app.state, "recipe_repo", None)
+    runtime_storage = getattr(app.state, "runtime_storage_state", None)
+    recipe_repo = getattr(runtime_storage, "recipe_repo", None)
     if recipe_repo is None:
         raise RuntimeError("recipe_repo is required for thread recipe resolution")
 

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -137,11 +137,12 @@ class _FakeLeaseRepo:
 
 
 def _make_threads_app():
+    recipe_repo = _FakeRecipeRepo()
     return SimpleNamespace(
         state=SimpleNamespace(
             user_repo=_FakeUserRepo(),
             thread_repo=_FakeThreadRepo(),
-            recipe_repo=_FakeRecipeRepo(),
+            runtime_storage_state=SimpleNamespace(recipe_repo=recipe_repo),
             workspace_repo=_FakeWorkspaceRepo(),
             sandbox_repo=_FakeSandboxRepo(),
             lease_repo=_FakeLeaseRepo(),
@@ -149,6 +150,10 @@ def _make_threads_app():
             thread_cwd={},
         )
     )
+
+
+def _runtime_storage_state(recipe_repo: object) -> SimpleNamespace:
+    return SimpleNamespace(recipe_repo=recipe_repo)
 
 
 def _route_test_app(app_state: object) -> FastAPI:
@@ -233,7 +238,7 @@ def test_resolve_default_config_derives_existing_from_workspace_backed_current_w
         state=SimpleNamespace(
             thread_repo=thread_repo,
             user_repo=SimpleNamespace(),
-            recipe_repo=object(),
+            runtime_storage_state=_runtime_storage_state(object()),
             workspace_repo=workspace_repo,
             sandbox_repo=sandbox_repo,
         )
@@ -331,7 +336,7 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
         state=SimpleNamespace(
             thread_repo=thread_repo,
             user_repo=SimpleNamespace(),
-            recipe_repo=recipe_repo,
+            runtime_storage_state=_runtime_storage_state(recipe_repo),
             workspace_repo=workspace_repo,
             sandbox_repo=sandbox_repo,
         )
@@ -412,7 +417,7 @@ def test_resolve_default_config_fails_loudly_when_workspace_backed_template_sour
         state=SimpleNamespace(
             thread_repo=thread_repo,
             user_repo=SimpleNamespace(),
-            recipe_repo=_FakeRecipeRepo(),
+            runtime_storage_state=_runtime_storage_state(_FakeRecipeRepo()),
             workspace_repo=workspace_repo,
             sandbox_repo=sandbox_repo,
         )
@@ -453,7 +458,7 @@ def test_resolve_default_config_fails_loudly_when_thread_workspace_binding_is_mi
         state=SimpleNamespace(
             thread_repo=thread_repo,
             user_repo=SimpleNamespace(),
-            recipe_repo=object(),
+            runtime_storage_state=_runtime_storage_state(object()),
             workspace_repo=_FakeWorkspaceRepo(),
             sandbox_repo=_FakeSandboxRepo(),
         )
@@ -496,7 +501,7 @@ def test_resolve_default_config_fails_loudly_when_workspace_repo_cannot_read_bin
         state=SimpleNamespace(
             thread_repo=thread_repo,
             user_repo=SimpleNamespace(),
-            recipe_repo=object(),
+            runtime_storage_state=_runtime_storage_state(object()),
             workspace_repo=object(),
         )
     )
@@ -537,7 +542,7 @@ def test_resolve_default_config_fails_loudly_for_malformed_workspace_binding() -
         state=SimpleNamespace(
             thread_repo=thread_repo,
             user_repo=SimpleNamespace(),
-            recipe_repo=object(),
+            runtime_storage_state=_runtime_storage_state(object()),
             workspace_repo=workspace_repo,
         )
     )
@@ -771,7 +776,7 @@ async def test_create_thread_carries_recipe_snapshot_into_resources_without_laun
         "feature_options": [{"key": "lark_cli", "name": "Lark CLI", "description": "Install Lark CLI"}],
         "builtin": False,
     }
-    app.state.recipe_repo.rows[("owner-1", "local:custom:lark")] = {
+    app.state.runtime_storage_state.recipe_repo.rows[("owner-1", "local:custom:lark")] = {
         "owner_user_id": "owner-1",
         "recipe_id": "local:custom:lark",
         "kind": "custom",

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -405,11 +405,12 @@ def _make_threads_app(
     thread_repo=None,
     **state_overrides,
 ):
+    recipe_repo = state_overrides.pop("recipe_repo", _FakeRecipeRepo())
     return SimpleNamespace(
         state=SimpleNamespace(
             user_repo=state_overrides.pop("user_repo", _FakeUserRepo()),
             thread_repo=thread_repo or _FakeThreadRepo(),
-            recipe_repo=state_overrides.pop("recipe_repo", _FakeRecipeRepo()),
+            runtime_storage_state=SimpleNamespace(recipe_repo=recipe_repo),
             workspace_repo=state_overrides.pop("workspace_repo", _FakeWorkspaceRepo()),
             sandbox_repo=state_overrides.pop("sandbox_repo", _FakeSandboxRepo()),
             lease_repo=state_overrides.pop("lease_repo", _FakeLeaseRepo()),

--- a/tests/Unit/backend/test_runtime_storage_bootstrap.py
+++ b/tests/Unit/backend/test_runtime_storage_bootstrap.py
@@ -6,7 +6,8 @@ from backend.bootstrap import storage as runtime_storage_bootstrap
 def test_build_runtime_storage_state_uses_shared_supabase_client(monkeypatch):
     calls: list[object] = []
     fake_client = object()
-    fake_container = object()
+    fake_container = SimpleNamespace()
+    fake_recipe_repo = object()
 
     monkeypatch.setattr(runtime_storage_bootstrap, "create_supabase_client", lambda: fake_client)
 
@@ -15,16 +16,18 @@ def test_build_runtime_storage_state_uses_shared_supabase_client(monkeypatch):
         return fake_container
 
     monkeypatch.setattr(runtime_storage_bootstrap, "build_storage_container", _build_storage_container)
+    fake_container.recipe_repo = lambda: fake_recipe_repo
 
     state = runtime_storage_bootstrap.build_runtime_storage_state()
 
     assert state.supabase_client is fake_client
     assert state.storage_container is fake_container
+    assert state.recipe_repo is fake_recipe_repo
     assert calls == [fake_client]
 
 
 def test_attach_runtime_storage_state_returns_bundle_without_loose_state_mirrors(monkeypatch):
-    fake_state = SimpleNamespace(supabase_client=object(), storage_container=object())
+    fake_state = SimpleNamespace(supabase_client=object(), storage_container=object(), recipe_repo=object())
     app = type("_App", (), {"state": type("_State", (), {})()})()
 
     monkeypatch.setattr(runtime_storage_bootstrap, "build_runtime_storage_state", lambda: fake_state)

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -49,6 +49,7 @@ def _patch_lifespan_runtime_contract(
     runtime_storage = SimpleNamespace(
         supabase_client=object(),
         storage_container=storage_container,
+        recipe_repo=storage_container.recipe_repo(),
     )
 
     monkeypatch.setattr(
@@ -109,6 +110,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
         assert not hasattr(app.state, "invite_code_repo")
         assert not hasattr(app.state, "user_settings_repo")
         assert not hasattr(app.state, "agent_config_repo")
+        assert not hasattr(app.state, "recipe_repo")
 
 
 @pytest.mark.asyncio
@@ -187,6 +189,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     runtime_storage = SimpleNamespace(
         supabase_client=object(),
         storage_container=storage_container,
+        recipe_repo=storage_container.recipe_repo(),
     )
 
     monkeypatch.setattr("backend.bootstrap.storage.attach_runtime_storage_state", lambda _app: runtime_storage)


### PR DESCRIPTION
## Summary
- extend `runtime_storage_state` with a stable `recipe_repo` and route recipe consumers through that bundle instead of the top-level `app.state.recipe_repo` mirror
- remove the remaining top-level `recipe_repo` write from web lifespan while keeping shutdown close semantics on the bundled repo
- realign focused thread-launch and lifespan tests to the same runtime storage contract

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_runtime_storage_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_thread_launch_config_contract.py`
- `.venv/bin/python -m ruff check backend/bootstrap/storage.py backend/web/core/lifespan.py backend/web/routers/panel.py backend/threads/launch_config.py backend/web/routers/threads.py tests/Unit/backend/test_runtime_storage_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_thread_launch_config_contract.py`
- `git diff --check`
