### PR TITLE
Route display builder through threads runtime

### DIFF
--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -15,6 +15,7 @@ class ThreadsRuntimeState:
     queue_manager: Any
     agent_runtime_gateway: Any
     activity_reader: Any
+    display_builder: Any | None = None
 
 
 def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> ThreadsRuntimeState:

--- a/backend/threads/run/buffer_wiring.py
+++ b/backend/threads/run/buffer_wiring.py
@@ -38,7 +38,10 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
 
     thread_buf = get_or_create_thread_buffer(app, thread_id)
 
-    display_builder_ref = app.state.display_builder
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    display_builder_ref = getattr(runtime_state, "display_builder", None)
+    if display_builder_ref is None:
+        raise RuntimeError("display_builder is required for thread buffer wiring")
 
     async def activity_sink(event: dict) -> None:
         if _append_event is None:

--- a/backend/threads/run/execution.py
+++ b/backend/threads/run/execution.py
@@ -54,7 +54,10 @@ async def run_agent_to_buffer(
     typing_tracker: Any | None = None,
 ) -> str:
     run_event_repo = _run_emit.resolve_run_event_repo(agent)
-    display_builder = app.state.display_builder
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    display_builder = getattr(runtime_state, "display_builder", None)
+    if display_builder is None:
+        raise RuntimeError("display_builder is required for thread run execution")
     emit = _run_emit.build_emit(
         thread_id=thread_id,
         run_id=run_id,

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -3,6 +3,8 @@
 import asyncio
 import os
 from contextlib import asynccontextmanager
+from dataclasses import is_dataclass, replace
+from types import SimpleNamespace
 
 from fastapi import FastAPI
 from psycopg import AsyncConnection
@@ -85,7 +87,12 @@ async def lifespan(app: FastAPI):
     # ---- Existing state ----
     from backend.threads.display.builder import DisplayBuilder
 
-    app.state.display_builder = DisplayBuilder()
+    display_builder = DisplayBuilder()
+    if is_dataclass(threads_runtime):
+        threads_runtime = replace(threads_runtime, display_builder=display_builder)
+    else:
+        threads_runtime = SimpleNamespace(**vars(threads_runtime), display_builder=display_builder)
+    app.state.threads_runtime_state = threads_runtime
     app.state.idle_reaper_task = None
     app.state._event_loop = asyncio.get_running_loop()
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -393,7 +393,10 @@ def _checkpoint_tail_is_pending_owner_turn(messages: list[dict[str, Any]]) -> bo
 
 
 async def _get_thread_display_entries(app: Any, thread_id: str) -> list[dict[str, Any]]:
-    display_builder = app.state.display_builder
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    display_builder = getattr(runtime_state, "display_builder", None)
+    if display_builder is None:
+        raise RuntimeError("display_builder is required for thread display entries")
     entries = display_builder.get_entries(thread_id)
     if entries is not None:
         _normalize_blocking_subagent_terminal_status(entries)
@@ -917,7 +920,10 @@ async def get_thread_messages(
     Hot path: return in-memory state.  Cold path: rebuild from checkpoint.
     """
     sandbox_type = resolve_thread_sandbox(app, thread_id)
-    display_builder = app.state.display_builder
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    display_builder = getattr(runtime_state, "display_builder", None)
+    if display_builder is None:
+        raise RuntimeError("display_builder is required for thread runtime surface")
     entries = await _get_thread_display_entries(app, thread_id)
     sandbox_info = get_sandbox_info(app, thread_id, sandbox_type)
     return {

--- a/tests/Integration/test_child_thread_live_contract.py
+++ b/tests/Integration/test_child_thread_live_contract.py
@@ -58,6 +58,14 @@ def _fake_storage_container() -> SimpleNamespace:
     return SimpleNamespace(run_event_repo=lambda: repo)
 
 
+def _app_state_with_display_builder(display_builder: object, **kwargs: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        display_builder=display_builder,
+        threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+        **kwargs,
+    )
+
+
 class _FakeRuntime:
     def __init__(self) -> None:
         self.current_state = AgentState.IDLE
@@ -229,8 +237,8 @@ def _make_router_app(
     fake_agent = SimpleNamespace(runtime=SimpleNamespace(current_state=AgentState.ACTIVE), agent=SimpleNamespace(aget_state=None))
     monkeypatch.setattr(threads_router, "get_or_create_agent", AsyncMock(return_value=fake_agent))
     return SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=builder,
+        state=_app_state_with_display_builder(
+            builder,
             agent_pool={},
             thread_sandbox={thread_id: "local"},
         )
@@ -251,8 +259,8 @@ async def test_run_child_thread_live_rebinds_from_parent_sink_and_surfaces_runti
 
     agent.runtime.bind_thread(_parent_sink)
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_app_state_with_display_builder(
+            DisplayBuilder(),
             queue_manager=MessageQueueManager(),
             _event_loop=asyncio.get_running_loop(),
             thread_event_buffers={},
@@ -306,8 +314,8 @@ async def test_run_child_thread_live_closes_and_detaches_completed_child_agent_w
     child_thread_id = "subagent-live-detach"
     agent = _BlockingChildAgent()
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_app_state_with_display_builder(
+            DisplayBuilder(),
             queue_manager=MessageQueueManager(),
             _event_loop=asyncio.get_running_loop(),
             thread_event_buffers={},
@@ -388,8 +396,8 @@ async def test_run_child_thread_live_raises_when_child_run_emits_error_event(mon
     child_thread_id = "subagent-live-error"
     agent = _BlockingChildAgent()
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_app_state_with_display_builder(
+            DisplayBuilder(),
             queue_manager=MessageQueueManager(),
             _event_loop=asyncio.get_running_loop(),
             thread_event_buffers={},
@@ -428,8 +436,8 @@ async def test_run_child_thread_live_raises_when_child_never_makes_a_model_call(
     child_thread_id = "subagent-live-no-call"
     agent = _BlockingChildAgent()
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_app_state_with_display_builder(
+            DisplayBuilder(),
             queue_manager=MessageQueueManager(),
             _event_loop=asyncio.get_running_loop(),
             thread_event_buffers={},

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -84,6 +84,23 @@ class _FakeRunEventRepo:
         return 0
 
 
+def _app_with_display_builder(display_builder: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            display_builder=display_builder,
+            threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+        )
+    )
+
+
+def _state_with_display_builder(display_builder: object, **kwargs: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        display_builder=display_builder,
+        threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+        **kwargs,
+    )
+
+
 def _fake_storage_container() -> SimpleNamespace:
     repo = _FakeRunEventRepo()
     return SimpleNamespace(run_event_repo=lambda: repo)
@@ -503,8 +520,9 @@ def _make_streaming_app(
         start_chat=lambda *_args, **_kwargs: None,
         stop=lambda *_args, **_kwargs: None,
     )
-    state = SimpleNamespace(
-        display_builder=DisplayBuilder(),
+    display_builder = DisplayBuilder()
+    state = _state_with_display_builder(
+        display_builder,
         thread_repo=SimpleNamespace(
             get_by_id=lambda target_thread_id: {"id": target_thread_id, "sandbox_type": "local"},
             get_by_user_id=lambda _user_id: None,
@@ -532,6 +550,7 @@ def _make_streaming_app(
     state.threads_runtime_state = SimpleNamespace(
         agent_runtime_gateway=gateway,
         activity_reader=runtime_state.activity_reader,
+        display_builder=state.display_builder,
     )
     return app, queue_manager
 
@@ -584,7 +603,7 @@ async def _run_direct_notification_followthrough(
         message_metadata=message_metadata,
     )
 
-    entries = app.state.display_builder.get_entries(thread_id)
+    entries = app.state.threads_runtime_state.display_builder.get_entries(thread_id)
     assert entries is not None
     return entries
 
@@ -779,7 +798,7 @@ async def test_cold_detail_and_history_share_interrupted_tool_call_repair():
         agent=loop,
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
     _put_local_agent_in_pool(fake_app, "cold-repair-thread", fake_agent)
 
     with (
@@ -1135,8 +1154,8 @@ async def test_cancelled_midrun_steer_persists_and_does_not_poison_next_turn(mon
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -1293,7 +1312,7 @@ async def test_get_thread_messages_rebuilds_idle_thread_when_cached_entries_are_
         agent=loop,
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=display_builder))
+    fake_app = _app_with_display_builder(display_builder)
 
     with (
         patch("backend.web.routers.threads.get_or_create_agent", return_value=fake_agent),
@@ -1320,7 +1339,7 @@ async def test_get_thread_messages_idle_rebuild_replays_latest_run_error_from_ev
         agent=SimpleNamespace(aget_state=AsyncMock(return_value=SimpleNamespace(values={"messages": [human]}))),
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
     run_events = [
         {
             "seq": 1,
@@ -1403,7 +1422,7 @@ async def test_cold_rebuild_surfaces_persisted_compaction_notice_in_detail_and_h
         agent=loop,
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
     _put_local_agent_in_pool(fake_app, "compact-thread", fake_agent)
 
     with (
@@ -1454,7 +1473,7 @@ async def test_cold_rebuild_surfaces_persisted_prompt_too_long_notice_after_reco
         agent=loop,
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
     _put_local_agent_in_pool(fake_app, "prompt-too-long-thread", fake_agent)
 
     with (
@@ -1534,7 +1553,7 @@ async def test_get_thread_messages_idle_rebuild_keeps_terminal_subagent_stream_s
         agent=SimpleNamespace(aget_state=AsyncMock(return_value=SimpleNamespace(values={"messages": [ai, tool, notice]}))),
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
 
     with (
         patch("backend.web.routers.threads.get_or_create_agent", return_value=fake_agent),
@@ -1587,7 +1606,7 @@ async def test_compaction_clear_then_recovery_notice_rebuilds_honestly(tmp_path)
     assert memory.summary_store is not None
     assert memory.summary_store.get_latest_summary("compaction-lifecycle-thread") is not None
 
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
     fake_agent = SimpleNamespace(
         agent=compact_loop,
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
@@ -1737,7 +1756,7 @@ async def test_cold_rebuild_surfaces_compaction_breaker_notice_after_repeated_fa
         agent=loop,
         runtime=SimpleNamespace(current_state=AgentState.IDLE),
     )
-    fake_app = SimpleNamespace(state=SimpleNamespace(display_builder=DisplayBuilder()))
+    fake_app = _app_with_display_builder(DisplayBuilder())
     _put_local_agent_in_pool(fake_app, "compaction-breaker-thread", fake_agent)
 
     with (
@@ -1796,8 +1815,8 @@ async def test_run_agent_to_buffer_emits_notice_for_system_agent_notifications(m
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -1822,7 +1841,7 @@ async def test_run_agent_to_buffer_emits_notice_for_system_agent_notifications(m
         message_metadata={"source": "system", "notification_type": "agent"},
     )
 
-    entries = app.state.display_builder.get_entries("thread-notice")
+    entries = app.state.threads_runtime_state.display_builder.get_entries("thread-notice")
     assert entries is not None
     assert entries[0]["segments"] == [
         {
@@ -1865,8 +1884,8 @@ async def test_run_agent_to_buffer_persists_terminal_notifications_before_assist
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -1926,8 +1945,8 @@ async def test_run_agent_to_buffer_resumes_graph_for_terminal_background_notific
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -2291,8 +2310,8 @@ async def test_run_agent_to_buffer_logs_real_stream_error_without_none_traceback
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -2335,8 +2354,8 @@ async def test_run_agent_to_buffer_drains_activity_notice_before_stream_error(mo
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -2411,8 +2430,8 @@ async def test_run_agent_to_buffer_batches_additional_terminal_notifications(mon
         storage_container=_fake_storage_container(),
     )
     app = SimpleNamespace(
-        state=SimpleNamespace(
-            display_builder=DisplayBuilder(),
+        state=_state_with_display_builder(
+            DisplayBuilder(),
             thread_tasks={},
             thread_event_buffers={},
             subagent_buffers={},
@@ -2437,7 +2456,7 @@ async def test_run_agent_to_buffer_batches_additional_terminal_notifications(mon
         message_metadata={"source": "system", "notification_type": "agent"},
     )
 
-    entries = app.state.display_builder.get_entries("thread-batch-notice")
+    entries = app.state.threads_runtime_state.display_builder.get_entries("thread-batch-notice")
     assert entries is not None
     notice_segments = [segment for segment in entries[0]["segments"] if segment.get("type") == "notice"]
     assert len(notice_segments) == 3

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -46,6 +46,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.queue_manager is queue_manager
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
+    assert state.display_builder is None
     assert not hasattr(app.state, "agent_runtime_gateway")
     assert seen == [
         ("queue_manager", queue_repo),

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -107,6 +107,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
 
     async with web_lifespan.lifespan(app):
         assert hasattr(app.state, "agent_pool")
+        assert not hasattr(app.state, "display_builder")
         assert not hasattr(app.state, "invite_code_repo")
         assert not hasattr(app.state, "user_settings_repo")
         assert not hasattr(app.state, "agent_config_repo")

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -162,9 +162,11 @@ def _fake_storage_container() -> SimpleNamespace:
 
 
 def _make_app() -> SimpleNamespace:
+    display_builder = _FakeDisplayBuilder()
     return SimpleNamespace(
         state=SimpleNamespace(
-            display_builder=_FakeDisplayBuilder(),
+            display_builder=display_builder,
+            threads_runtime_state=SimpleNamespace(display_builder=display_builder),
             thread_tasks={},
             thread_last_active={},
             typing_tracker=None,


### PR DESCRIPTION
## Summary
- move threads-owned `display_builder` reads onto `threads_runtime_state` instead of the top-level `app.state.display_builder` mirror
- let web lifespan enrich the threads runtime bundle with the display builder instead of publishing a loose top-level mirror
- realign focused query-loop/child-thread/threads-router/streaming-eval tests to the same bundle contract

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py`
- `.venv/bin/python -m ruff check backend/threads/bootstrap.py backend/web/core/lifespan.py backend/threads/run/execution.py backend/threads/run/buffer_wiring.py backend/web/routers/threads.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py`
- `git diff --check`
