### PR TITLE
Route thread event loop through runtime bundle

### DIFF
--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -16,6 +16,7 @@ class ThreadsRuntimeState:
     agent_runtime_gateway: Any
     activity_reader: Any
     display_builder: Any | None = None
+    event_loop: Any | None = None
 
 
 def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> ThreadsRuntimeState:

--- a/backend/threads/run/buffer_wiring.py
+++ b/backend/threads/run/buffer_wiring.py
@@ -71,7 +71,7 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
                 )
 
     qm = app.state.queue_manager
-    loop = getattr(app.state, "_event_loop", None)
+    loop = getattr(runtime_state, "event_loop", None)
 
     def wake_handler(item: Any) -> None:
         """Called by enqueue() with the newly-enqueued QueueItem — may run in any thread."""

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -88,13 +88,13 @@ async def lifespan(app: FastAPI):
     from backend.threads.display.builder import DisplayBuilder
 
     display_builder = DisplayBuilder()
+    event_loop = asyncio.get_running_loop()
     if is_dataclass(threads_runtime):
-        threads_runtime = replace(threads_runtime, display_builder=display_builder)
+        threads_runtime = replace(threads_runtime, display_builder=display_builder, event_loop=event_loop)
     else:
-        threads_runtime = SimpleNamespace(**vars(threads_runtime), display_builder=display_builder)
+        threads_runtime = SimpleNamespace(**vars(threads_runtime), display_builder=display_builder, event_loop=event_loop)
     app.state.threads_runtime_state = threads_runtime
     app.state.idle_reaper_task = None
-    app.state._event_loop = asyncio.get_running_loop()
 
     try:
         from backend.sandboxes.service import init_providers_and_managers

--- a/tests/Integration/test_child_thread_live_contract.py
+++ b/tests/Integration/test_child_thread_live_contract.py
@@ -59,9 +59,10 @@ def _fake_storage_container() -> SimpleNamespace:
 
 
 def _app_state_with_display_builder(display_builder: object, **kwargs: object) -> SimpleNamespace:
+    event_loop = kwargs.get("_event_loop")
     return SimpleNamespace(
         display_builder=display_builder,
-        threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+        threads_runtime_state=SimpleNamespace(display_builder=display_builder, event_loop=event_loop),
         **kwargs,
     )
 

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -84,19 +84,19 @@ class _FakeRunEventRepo:
         return 0
 
 
-def _app_with_display_builder(display_builder: object) -> SimpleNamespace:
+def _app_with_display_builder(display_builder: object, *, event_loop: object | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         state=SimpleNamespace(
             display_builder=display_builder,
-            threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+            threads_runtime_state=SimpleNamespace(display_builder=display_builder, event_loop=event_loop),
         )
     )
 
 
-def _state_with_display_builder(display_builder: object, **kwargs: object) -> SimpleNamespace:
+def _state_with_display_builder(display_builder: object, *, event_loop: object | None = None, **kwargs: object) -> SimpleNamespace:
     return SimpleNamespace(
         display_builder=display_builder,
-        threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+        threads_runtime_state=SimpleNamespace(display_builder=display_builder, event_loop=event_loop),
         **kwargs,
     )
 
@@ -539,10 +539,12 @@ def _make_streaming_app(
         queue_manager=queue_manager,
         thread_last_active={},
     )
+    event_loop = None
     if thread_id is not None and agent is not None:
         state.agent_pool = {f"{thread_id}:local": agent}
         state.thread_sandbox = {thread_id: "local"}
-        state._event_loop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
+        state._event_loop = event_loop
     app = SimpleNamespace(state=state)
     runtime_state = build_agent_runtime_state(app, typing_tracker=typing_tracker)
     gateway = runtime_state.gateway
@@ -551,6 +553,7 @@ def _make_streaming_app(
         agent_runtime_gateway=gateway,
         activity_reader=runtime_state.activity_reader,
         display_builder=state.display_builder,
+        event_loop=event_loop,
     )
     return app, queue_manager
 

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -47,6 +47,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
     assert state.display_builder is None
+    assert state.event_loop is None
     assert not hasattr(app.state, "agent_runtime_gateway")
     assert seen == [
         ("queue_manager", queue_repo),

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -108,6 +108,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
     async with web_lifespan.lifespan(app):
         assert hasattr(app.state, "agent_pool")
         assert not hasattr(app.state, "display_builder")
+        assert not hasattr(app.state, "_event_loop")
         assert not hasattr(app.state, "invite_code_repo")
         assert not hasattr(app.state, "user_settings_repo")
         assert not hasattr(app.state, "agent_config_repo")


### PR DESCRIPTION
## Summary
- move threads-owned event loop access onto `threads_runtime_state.event_loop` instead of the top-level `app.state._event_loop` mirror
- let web lifespan enrich the threads runtime bundle with the running loop instead of publishing a loose top-level mirror
- realign focused query-loop/child-thread tests to the same bundle contract

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py`
- `.venv/bin/python -m ruff check backend/threads/bootstrap.py backend/web/core/lifespan.py backend/threads/run/buffer_wiring.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_streaming_eval_writer.py`
- `git diff --check`
