### PR TITLE
Route checkpoint store through threads runtime

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -35,7 +35,8 @@ def build_monitor_trace_reader(app: Any) -> MonitorTraceReader:
         return list(messages)
 
     async def _load_checkpoint_messages(thread_id: str) -> list[Any]:
-        checkpoint_store = getattr(app.state, "thread_checkpoint_store", None)
+        runtime_state = getattr(app.state, "threads_runtime_state", None)
+        checkpoint_store = getattr(runtime_state, "checkpoint_store", None)
         if checkpoint_store is None:
             raise RuntimeError("thread_checkpoint_store is required for cold thread history reads")
         checkpoint_state = await checkpoint_store.load(thread_id)

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -17,6 +17,7 @@ class ThreadsRuntimeState:
     activity_reader: Any
     display_builder: Any | None = None
     event_loop: Any | None = None
+    checkpoint_store: Any | None = None
 
 
 def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> ThreadsRuntimeState:

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
     app.state._thread_checkpoint_saver_ctx = agent_checkpoint_saver_from_conn_string(pg_url)
     app.state._thread_checkpoint_saver = await app.state._thread_checkpoint_saver_ctx.__aenter__()
     await app.state._thread_checkpoint_saver.setup()
-    app.state.thread_checkpoint_store = LangGraphCheckpointStore(app.state._thread_checkpoint_saver)
+    thread_checkpoint_store = LangGraphCheckpointStore(app.state._thread_checkpoint_saver)
 
     app.state.user_repo = storage_container.user_repo()
     app.state.thread_repo = storage_container.thread_repo()
@@ -90,9 +90,19 @@ async def lifespan(app: FastAPI):
     display_builder = DisplayBuilder()
     event_loop = asyncio.get_running_loop()
     if is_dataclass(threads_runtime):
-        threads_runtime = replace(threads_runtime, display_builder=display_builder, event_loop=event_loop)
+        threads_runtime = replace(
+            threads_runtime,
+            display_builder=display_builder,
+            event_loop=event_loop,
+            checkpoint_store=thread_checkpoint_store,
+        )
     else:
-        threads_runtime = SimpleNamespace(**vars(threads_runtime), display_builder=display_builder, event_loop=event_loop)
+        threads_runtime = SimpleNamespace(
+            **vars(threads_runtime),
+            display_builder=display_builder,
+            event_loop=event_loop,
+            checkpoint_store=thread_checkpoint_store,
+        )
     app.state.threads_runtime_state = threads_runtime
     app.state.idle_reaper_task = None
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1065,7 +1065,8 @@ async def get_thread_history(
         return list(messages)
 
     async def _load_checkpoint_messages(current_thread_id: str) -> list[Any]:
-        checkpoint_store = getattr(app.state, "thread_checkpoint_store", None)
+        runtime_state = getattr(app.state, "threads_runtime_state", None)
+        checkpoint_store = getattr(runtime_state, "checkpoint_store", None)
         if checkpoint_store is None:
             raise RuntimeError("thread_checkpoint_store is required for cold thread history reads")
         checkpoint_state = await checkpoint_store.load(current_thread_id)

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -722,7 +722,7 @@ async def test_get_thread_history_reads_checkpoint_without_creating_agent():
     fake_app = SimpleNamespace(
         state=SimpleNamespace(
             agent_pool={},
-            thread_checkpoint_store=_CheckpointStore(),
+            threads_runtime_state=SimpleNamespace(checkpoint_store=_CheckpointStore()),
         )
     )
 

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -48,6 +48,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.activity_reader is activity_reader
     assert state.display_builder is None
     assert state.event_loop is None
+    assert state.checkpoint_store is None
     assert not hasattr(app.state, "agent_runtime_gateway")
     assert seen == [
         ("queue_manager", queue_repo),

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -109,6 +109,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
         assert hasattr(app.state, "agent_pool")
         assert not hasattr(app.state, "display_builder")
         assert not hasattr(app.state, "_event_loop")
+        assert not hasattr(app.state, "thread_checkpoint_store")
         assert not hasattr(app.state, "invite_code_repo")
         assert not hasattr(app.state, "user_settings_repo")
         assert not hasattr(app.state, "agent_config_repo")


### PR DESCRIPTION
## Summary
- move `thread_checkpoint_store` reads onto `threads_runtime_state.checkpoint_store` instead of the top-level `app.state.thread_checkpoint_store` mirror
- let web lifespan enrich the threads runtime bundle with the checkpoint store instead of publishing a loose top-level mirror
- realign focused history/trace tests to the same threads runtime contract

## Test Plan
- `.venv/bin/python -m pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py`
- `.venv/bin/python -m ruff check backend/threads/bootstrap.py backend/web/core/lifespan.py backend/web/routers/threads.py backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py`
- `git diff --check`
