### PR TITLE
fix: skip stale existing sandbox defaults in launch config

### DIFF
--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -83,7 +83,8 @@ def _derive_default_config(
             current_workspace_id=thread["current_workspace_id"],
             owner_user_id=owner_user_id,
         )
-        return config
+        if config is not None:
+            return config
 
     provider_names = [str(item["name"]) for item in providers]
     provider_config = "local" if "local" in provider_names else (provider_names[0] if provider_names else "local")
@@ -131,7 +132,7 @@ def _resolve_workspace_backed_existing_config(
     app: Any,
     current_workspace_id: str,
     owner_user_id: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     workspace_repo = getattr(app.state, "workspace_repo", None)
     get_by_id = getattr(workspace_repo, "get_by_id", None)
     if not callable(get_by_id):

--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -156,6 +156,9 @@ def _resolve_workspace_backed_existing_config(
     sandbox_owner_user_id = _required_row_text(sandbox, "owner_user_id", "sandbox")
     if sandbox_owner_user_id != owner_user_id:
         raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
+    provider_env_id = sandbox.get("provider_env_id") if isinstance(sandbox, dict) else getattr(sandbox, "provider_env_id", None)
+    if not str(provider_env_id or "").strip():
+        return None
     sandbox_template = _resolve_workspace_backed_sandbox_template(
         app=app,
         owner_user_id=owner_user_id,

--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -158,6 +158,9 @@ def _resolve_workspace_backed_existing_config(
         raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
     provider_env_id = sandbox.get("provider_env_id") if isinstance(sandbox, dict) else getattr(sandbox, "provider_env_id", None)
     if not str(provider_env_id or "").strip():
+        # @@@stale-existing-default-fallback - launch-config should not steer the UI
+        # into existing-sandbox mode when the persisted sandbox row no longer carries
+        # the runtime identity required by the existing-sandbox bind path.
         return None
     sandbox_template = _resolve_workspace_backed_sandbox_template(
         app=app,

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -377,7 +377,8 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
     }
 
 
-def test_resolve_default_config_falls_back_to_new_when_workspace_sandbox_lacks_provider_env_id() -> None:
+@pytest.mark.parametrize("provider_env_id", ["", None])
+def test_resolve_default_config_falls_back_to_new_when_workspace_sandbox_lacks_provider_env_id(provider_env_id: str | None) -> None:
     thread_repo = _FakeThreadRepo()
     thread_repo.rows["agent-user-1-1"] = {
         "thread_id": "agent-user-1-1",
@@ -402,7 +403,7 @@ def test_resolve_default_config_falls_back_to_new_when_workspace_sandbox_lacks_p
         id="sandbox-stale",
         owner_user_id="owner-1",
         provider_name="local",
-        provider_env_id="",
+        provider_env_id=provider_env_id,
         sandbox_template_id="local:default",
         desired_state="stopped",
         observed_state="stopped",

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -377,6 +377,84 @@ def test_resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_w
     }
 
 
+def test_resolve_default_config_falls_back_to_new_when_workspace_sandbox_lacks_provider_env_id() -> None:
+    thread_repo = _FakeThreadRepo()
+    thread_repo.rows["agent-user-1-1"] = {
+        "thread_id": "agent-user-1-1",
+        "agent_user_id": "agent-user-1",
+        "current_workspace_id": "ws-stale",
+        "is_main": True,
+        "branch_index": 0,
+        "created_at": 4.0,
+    }
+    workspace_repo = _FakeWorkspaceRepo()
+    workspace_repo.by_id["ws-stale"] = SimpleNamespace(
+        id="ws-stale",
+        sandbox_id="sandbox-stale",
+        owner_user_id="owner-1",
+        workspace_path="/workspace/stale",
+        name=None,
+        created_at=4.0,
+        updated_at=4.0,
+    )
+    sandbox_repo = _FakeSandboxRepo()
+    sandbox_repo.by_id["sandbox-stale"] = SimpleNamespace(
+        id="sandbox-stale",
+        owner_user_id="owner-1",
+        provider_name="local",
+        provider_env_id="",
+        sandbox_template_id="local:default",
+        desired_state="stopped",
+        observed_state="stopped",
+        status="stopped",
+        observed_at=4.0,
+        last_error=None,
+        config={},
+        created_at=4.0,
+        updated_at=4.0,
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            thread_repo=thread_repo,
+            user_repo=SimpleNamespace(),
+            runtime_storage_state=_runtime_storage_state(_FakeRecipeRepo()),
+            workspace_repo=workspace_repo,
+            sandbox_repo=sandbox_repo,
+        )
+    )
+
+    with (
+        patch.object(
+            thread_launch_config_service,
+            "available_sandbox_types",
+            return_value=[{"name": "local", "available": True}],
+        ),
+        patch.object(
+            thread_launch_config_service,
+            "list_library",
+            return_value=[_recipe_library_entry("local")],
+        ),
+    ):
+        result = thread_launch_config_service.resolve_default_config(
+            app=app,
+            owner_user_id="owner-1",
+            agent_user_id="agent-user-1",
+        )
+
+    assert result == {
+        "source": "derived",
+        "config": {
+            "create_mode": "new",
+            "provider_config": "local",
+            "sandbox_template_id": "local:default",
+            "sandbox_template": default_recipe_snapshot("local"),
+            "existing_sandbox_id": None,
+            "model": None,
+            "workspace": None,
+        },
+    }
+
+
 def test_resolve_default_config_fails_loudly_when_workspace_backed_template_source_is_missing() -> None:
     thread_repo = _FakeThreadRepo()
     thread_repo.rows["agent-user-1-1"] = {


### PR DESCRIPTION
## Summary
- add launch-config contract coverage for stale workspace-backed sandboxes with missing `provider_env_id`
- let workspace-backed existing-config resolution decline invalid stale sandboxes instead of forcing `create_mode=existing`
- preserve the fail-loud existing-sandbox path while allowing the UI to fall back to a fresh `local:default` launch config

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Integration/test_thread_launch_config_contract.py -k 'resolve_default_config_derives_existing_from_workspace_backed_current_workspace_id or resolve_default_config_uses_sandbox_template_id_over_lease_recipe_for_workspace_backed_existing_mode or falls_back_to_new_when_workspace_sandbox_lacks_provider_env_id'`
- [x] Playwright caller proof on the rebased branch: `/chat -> 新建对话 -> 创建 Agent 新线程 -> Morel` no longer shows the old `API 500`; sending `Reply with exactly OK.` lands on `/chat/hire/thread/m_jKDZlEnP5hpD-12` with `OK` visible
- [x] backend readback for `/api/threads/m_jKDZlEnP5hpD-12/history` returns the same human/assistant pair
