### PR TITLE
fix: respect provider hint in runtime metrics

### DIFF
--- a/backend/sandboxes/runtime/metrics.py
+++ b/backend/sandboxes/runtime/metrics.py
@@ -35,11 +35,11 @@ def get_runtime_metrics(
     except RuntimeError as exc:
         if "Ambiguous runtime id" not in str(exc) or not provider_hint:
             raise
-        exact = [
-            row
-            for row in runtimes
-            if row.get("provider") == provider_hint and str(row.get("session_id") or "") == runtime_id
-        ]
+        exact = _exact_rows_for_provider_runtime(
+            runtimes,
+            runtime_id=runtime_id,
+            provider_name=provider_hint,
+        )
         if not exact:
             raise
         runtime = exact[0]

--- a/backend/sandboxes/runtime/metrics.py
+++ b/backend/sandboxes/runtime/metrics.py
@@ -35,6 +35,10 @@ def get_runtime_metrics(
     except RuntimeError as exc:
         if "Ambiguous runtime id" not in str(exc) or not provider_hint:
             raise
+        # @@@provider-hinted-runtime-collapse - metrics reads should treat duplicate
+        # rows for the same provider/session as one runtime when the caller already
+        # supplied the provider hint; the ambiguity is cross-thread residue, not a
+        # reason to fail the high-level metrics surface.
         exact = _exact_rows_for_provider_runtime(
             runtimes,
             runtime_id=runtime_id,

--- a/backend/sandboxes/runtime/metrics.py
+++ b/backend/sandboxes/runtime/metrics.py
@@ -7,6 +7,19 @@ from typing import Any
 from backend.sandboxes.inventory import init_providers_and_managers
 
 
+def _exact_rows_for_provider_runtime(
+    runtimes: list[dict[str, Any]],
+    *,
+    runtime_id: str,
+    provider_name: str,
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in runtimes
+        if row.get("provider") == provider_name and str(row.get("session_id") or "") == runtime_id
+    ]
+
+
 def get_runtime_metrics(
     runtime_id: str,
     provider_hint: str | None = None,
@@ -17,7 +30,20 @@ def get_runtime_metrics(
 ) -> dict[str, Any]:
     _, managers = init_providers_and_managers_fn()
     runtimes = load_all_sandbox_runtimes_fn(managers)
-    runtime, manager = find_runtime_and_manager_fn(runtimes, managers, runtime_id, provider_name=provider_hint)
+    try:
+        runtime, manager = find_runtime_and_manager_fn(runtimes, managers, runtime_id, provider_name=provider_hint)
+    except RuntimeError as exc:
+        if "Ambiguous runtime id" not in str(exc) or not provider_hint:
+            raise
+        exact = [
+            row
+            for row in runtimes
+            if row.get("provider") == provider_hint and str(row.get("session_id") or "") == runtime_id
+        ]
+        if not exact:
+            raise
+        runtime = exact[0]
+        manager = managers.get(provider_hint)
     if not runtime:
         raise RuntimeError(f"Runtime not found: {runtime_id}")
     if manager is None:

--- a/backend/sandboxes/runtime/metrics.py
+++ b/backend/sandboxes/runtime/metrics.py
@@ -13,11 +13,7 @@ def _exact_rows_for_provider_runtime(
     runtime_id: str,
     provider_name: str,
 ) -> list[dict[str, Any]]:
-    return [
-        row
-        for row in runtimes
-        if row.get("provider") == provider_name and str(row.get("session_id") or "") == runtime_id
-    ]
+    return [row for row in runtimes if row.get("provider") == provider_name and str(row.get("session_id") or "") == runtime_id]
 
 
 def get_runtime_metrics(

--- a/tests/Integration/test_sandbox_router_user_shell.py
+++ b/tests/Integration/test_sandbox_router_user_shell.py
@@ -139,6 +139,27 @@ async def test_sandbox_runtime_mutation_response_strips_lower_runtime_identity(m
     assert seen["runtime_id"] == "runtime-1"
 
 
+@pytest.mark.asyncio
+async def test_get_sandbox_runtime_metrics_passes_provider_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_get_runtime_metrics(*args: object, **kwargs: object) -> dict[str, object]:
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return {"session_id": "runtime-1", "provider": "local", "metrics": None}
+
+    monkeypatch.setattr(
+        sandbox_router.sandbox_runtime_metrics,
+        "get_runtime_metrics",
+        fake_get_runtime_metrics,
+    )
+
+    result = await sandbox_router.get_sandbox_runtime_metrics("runtime-1", provider="local")
+
+    assert result == {"session_id": "runtime-1", "provider": "local", "metrics": None}
+    assert seen["args"] == ("runtime-1", "local")
+
+
 def test_list_user_sandboxes_projects_internal_runtime_rows(monkeypatch: pytest.MonkeyPatch) -> None:
     class _MonitorRepo:
         def query_sandboxes(self) -> list[dict[str, object]]:

--- a/tests/Unit/sandbox/test_sandbox_runtime_metrics.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_metrics.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.sandboxes.runtime.metrics import get_runtime_metrics
+from backend.sandboxes.runtime.reads import find_runtime_and_manager
+
+
+def test_get_runtime_metrics_tolerates_duplicate_session_rows_with_provider_hint() -> None:
+    managers = {
+        "local": SimpleNamespace(
+            provider=SimpleNamespace(
+                get_metrics=lambda runtime_id: SimpleNamespace(
+                    cpu_percent=1.0,
+                    memory_used_mb=2.0,
+                    memory_total_mb=3.0,
+                    disk_used_gb=4.0,
+                    disk_total_gb=5.0,
+                    network_rx_kbps=6.0,
+                    network_tx_kbps=7.0,
+                )
+            )
+        )
+    }
+    runtimes = [
+        {
+            "session_id": "sess-1",
+            "thread_id": "thread-1",
+            "provider": "local",
+            "instance_id": "sess-1",
+        },
+        {
+            "session_id": "sess-1",
+            "thread_id": "thread-2",
+            "provider": "local",
+            "instance_id": "sess-1",
+        },
+    ]
+
+    result = get_runtime_metrics(
+        "sess-1",
+        provider_hint="local",
+        init_providers_and_managers_fn=lambda: ({}, managers),
+        load_all_sandbox_runtimes_fn=lambda _managers: runtimes,
+        find_runtime_and_manager_fn=find_runtime_and_manager,
+    )
+
+    assert result == {
+        "session_id": "sess-1",
+        "provider": "local",
+        "metrics": {
+            "cpu_percent": 1.0,
+            "memory_used_mb": 2.0,
+            "memory_total_mb": 3.0,
+            "disk_used_gb": 4.0,
+            "disk_total_gb": 5.0,
+            "network_rx_kbps": 6.0,
+            "network_tx_kbps": 7.0,
+        },
+    }


### PR DESCRIPTION
## Summary
- add focused coverage for duplicate runtime session ids and router provider-hint forwarding
- collapse duplicate runtime rows inside the metrics read path when the caller already supplied a provider hint
- preserve the existing fail-loud behavior for truly unresolved or cross-provider ambiguous runtime ids

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_runtime_metrics.py tests/Integration/test_sandbox_router_user_shell.py -k 'duplicate_session_ids or provider_hint or list_sandbox_runtimes_strips_lower_runtime_identity or sandbox_runtime_mutation_response_strips_lower_runtime_identity'`
- [x] caller proof on current shared head: `GET /api/sandbox/runtimes/{runtime_id}/metrics?provider=local` now returns `200` with metrics instead of the old `409 Ambiguous runtime id`
