### PR TITLE
refactor: rename sandbox runtime handle surfaces

### DIFF
--- a/backend/monitor/application/use_cases/operations.py
+++ b/backend/monitor/application/use_cases/operations.py
@@ -166,8 +166,8 @@ def request_sandbox_cleanup(
         threads=threads,
     )
 
-    lower_runtime = sandbox_detail.get("lower_runtime") or {}
-    lower_runtime_handle = str(lower_runtime.get("handle") or "")
+    sandbox_runtime = sandbox_detail.get("sandbox_runtime") or {}
+    sandbox_runtime_handle = str(sandbox_runtime.get("handle") or "")
     sandbox_id = str(sandbox.get("sandbox_id") or "")
     current_truth = _cleanup_current_truth(
         sandbox_id=sandbox_id,
@@ -180,7 +180,7 @@ def request_sandbox_cleanup(
             "operation": None,
             "current_truth": current_truth,
         }
-    if not lower_runtime_handle:
+    if not sandbox_runtime_handle:
         return {
             "accepted": False,
             "message": "Sandbox cleanup requires a managed runtime handle.",
@@ -215,7 +215,7 @@ def request_sandbox_cleanup(
         result = runtime_mutation_executor.cleanup_sandbox(
             SandboxCleanupRequest(
                 sandbox_id=sandbox_id,
-                lower_runtime_handle=lower_runtime_handle,
+                sandbox_runtime_handle=sandbox_runtime_handle,
                 provider_name=provider_name,
                 detach_thread_bindings=detach_before_cleanup,
             )

--- a/backend/monitor/application/use_cases/sandbox_detail.py
+++ b/backend/monitor/application/use_cases/sandbox_detail.py
@@ -34,8 +34,8 @@ def _sandbox_detail_cleanup_truth(
     runtime_rows: list[dict[str, object]],
     threads: list[dict[str, str]],
 ) -> dict[str, object]:
-    lower_runtime_handle = str(cleanup_target.get("lower_runtime_handle") or "").strip()
-    if not lower_runtime_handle:
+    sandbox_runtime_handle = str(cleanup_target.get("sandbox_runtime_handle") or "").strip()
+    if not sandbox_runtime_handle:
         return {
             "allowed": False,
             "recommended_action": None,
@@ -124,7 +124,7 @@ def get_monitor_sandbox_detail(sandbox_id: str) -> dict[str, object]:
 
 def _sandbox_cleanup_target(sandbox_id: str) -> dict[str, object]:
     cleanup_target = sandbox_read_service.load_sandbox_cleanup_target(sandbox_id)
-    if not str(cleanup_target.get("lower_runtime_handle") or "").strip():
+    if not str(cleanup_target.get("sandbox_runtime_handle") or "").strip():
         raise RuntimeError("monitor sandbox cleanup target missing managed runtime handle")
     return cleanup_target
 
@@ -142,10 +142,10 @@ def request_monitor_sandbox_cleanup(
     runtime_rows = payload.get("runtime_rows") or []
 
     cleanup_target = _sandbox_cleanup_target(sandbox_id)
-    lower_runtime_handle = str(cleanup_target.get("lower_runtime_handle") or "").strip()
+    sandbox_runtime_handle = str(cleanup_target.get("sandbox_runtime_handle") or "").strip()
     sandbox_detail = {
         "sandbox": sandbox,
-        "lower_runtime": {"handle": lower_runtime_handle},
+        "sandbox_runtime": {"handle": sandbox_runtime_handle},
         "triage": payload.get("triage"),
         "provider": provider,
         "runtime": runtime,

--- a/backend/monitor/mutations/contracts.py
+++ b/backend/monitor/mutations/contracts.py
@@ -9,7 +9,7 @@ from typing import Any
 @dataclass(frozen=True)
 class SandboxCleanupRequest:
     sandbox_id: str
-    lower_runtime_handle: str
+    sandbox_runtime_handle: str
     provider_name: str
     detach_thread_bindings: bool
 

--- a/backend/monitor/mutations/sandbox_mutations.py
+++ b/backend/monitor/mutations/sandbox_mutations.py
@@ -16,11 +16,7 @@ from storage.runtime import build_workspace_repo
 def _public_destroy_result(result: Any) -> Any:
     if not isinstance(result, dict):
         return result
-    return {
-        key: value
-        for key, value in result.items()
-        if key not in {"lease_id", "lower_runtime_handle", "sandbox_runtime_handle"}
-    }
+    return {key: value for key, value in result.items() if key not in {"lease_id", "lower_runtime_handle", "sandbox_runtime_handle"}}
 
 
 def cleanup_sandbox(request: SandboxCleanupRequest) -> RuntimeMutationResult:

--- a/backend/monitor/mutations/sandbox_mutations.py
+++ b/backend/monitor/mutations/sandbox_mutations.py
@@ -16,12 +16,16 @@ from storage.runtime import build_workspace_repo
 def _public_destroy_result(result: Any) -> Any:
     if not isinstance(result, dict):
         return result
-    return {key: value for key, value in result.items() if key not in {"lease_id", "lower_runtime_handle"}}
+    return {
+        key: value
+        for key, value in result.items()
+        if key not in {"lease_id", "lower_runtime_handle", "sandbox_runtime_handle"}
+    }
 
 
 def cleanup_sandbox(request: SandboxCleanupRequest) -> RuntimeMutationResult:
     result = destroy_sandbox_runtime(
-        lower_runtime_handle=request.lower_runtime_handle,
+        lower_runtime_handle=request.sandbox_runtime_handle,
         provider_name=request.provider_name,
         detach_thread_bindings=request.detach_thread_bindings,
     )

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 
 
 def _public_provider_event(row: dict[str, Any]) -> dict[str, Any]:
-    return {key: value for key, value in row.items() if key != "matched_runtime_handle"}
+    return {key: value for key, value in row.items() if key != "matched_sandbox_runtime_handle"}
 
 
 @router.post("/{provider_name}")
@@ -32,7 +32,7 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
     try:
         runtime_row = await asyncio.to_thread(runtime_repo.find_by_instance, provider_name=provider_name, instance_id=instance_id)
         lower_runtime = lower_runtime_from_row(runtime_row, resolve_sandbox_db_path()) if runtime_row else None
-        matched_runtime_handle = lower_runtime.lease_id if lower_runtime else None
+        matched_sandbox_runtime_handle = lower_runtime.lease_id if lower_runtime else None
         matched_sandbox_id = str((runtime_row or {}).get("sandbox_id") or "").strip() or None
 
         # @@@webhook-runtime-observation - Webhook is optimization only: persist event + observe lower-runtime state.
@@ -42,7 +42,7 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
             instance_id=instance_id,
             event_type=event_type,
             payload=payload,
-            matched_runtime_handle=matched_runtime_handle,
+            matched_sandbox_runtime_handle=matched_sandbox_runtime_handle,
             matched_sandbox_id=matched_sandbox_id,
         )
     finally:

--- a/storage/providers/supabase/provider_event_repo.py
+++ b/storage/providers/supabase/provider_event_repo.py
@@ -31,7 +31,7 @@ class SupabaseProviderEventRepo:
         instance_id: str,
         event_type: str,
         payload: dict[str, Any],
-        matched_runtime_handle: str | None,
+        matched_sandbox_runtime_handle: str | None,
         matched_sandbox_id: str | None,
     ) -> None:
         self._t().insert(
@@ -40,7 +40,7 @@ class SupabaseProviderEventRepo:
                 "instance_id": instance_id,
                 "event_type": event_type,
                 "payload_json": json.dumps(payload, ensure_ascii=False),
-                "matched_runtime_handle": matched_runtime_handle,
+                "matched_sandbox_runtime_handle": matched_sandbox_runtime_handle,
                 "matched_sandbox_id": matched_sandbox_id,
                 "created_at": datetime.now().isoformat(),
             }
@@ -51,7 +51,7 @@ class SupabaseProviderEventRepo:
             q.limit(
                 q.order(
                     self._t().select(
-                        "event_id,provider_name,instance_id,event_type,payload_json,matched_runtime_handle,matched_sandbox_id,created_at"
+                        "event_id,provider_name,instance_id,event_type,payload_json,matched_sandbox_runtime_handle,matched_sandbox_id,created_at"
                     ),
                     "created_at",
                     desc=True,

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -117,7 +117,7 @@ class SupabaseSandboxMonitorRepo:
                 "sandbox_id": sandbox_key,
                 "provider_name": str(sandbox.get("provider_name") or "").strip(),
                 "provider_env_id": str(sandbox.get("provider_env_id") or "").strip() or None,
-                "lower_runtime_handle": str(config.get("runtime_handle") or "").strip() or None,
+                "sandbox_runtime_handle": str(config.get("runtime_handle") or "").strip() or None,
             }
         return None
 

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -57,7 +57,7 @@ async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch
             "instance_id": "inst-1",
             "event_type": "provider.updated",
             "payload": {"instance_id": "inst-1", "event": "provider.updated"},
-            "matched_runtime_handle": None,
+            "matched_sandbox_runtime_handle": None,
             "matched_sandbox_id": None,
         }
     ]
@@ -142,7 +142,7 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_lo
             "instance_id": "inst-2",
             "event_type": "provider.running",
             "payload": {"instance_id": "inst-2", "event": "provider.running"},
-            "matched_runtime_handle": "lease-1",
+            "matched_sandbox_runtime_handle": "lease-1",
             "matched_sandbox_id": "sandbox-1",
         }
     ]
@@ -167,7 +167,7 @@ async def test_list_provider_events_strips_lower_runtime_match_identity(monkeypa
                     "provider_name": "daytona",
                     "instance_id": "instance-1",
                     "event_type": "started",
-                    "matched_runtime_handle": "lease-1",
+                    "matched_sandbox_runtime_handle": "lease-1",
                     "matched_sandbox_id": "sandbox-1",
                     "payload": {"ok": True},
                 }

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -116,7 +116,7 @@ class FakeSandboxMonitorRepo:
             "sandbox_id": sandbox.get("sandbox_id") or sandbox_id,
             "provider_name": sandbox.get("provider_name"),
             "provider_env_id": sandbox.get("current_instance_id"),
-            "lower_runtime_handle": str(sandbox.get(LOWER_RUNTIME_KEY) or "").strip() or None,
+            "sandbox_runtime_handle": str(sandbox.get(LOWER_RUNTIME_KEY) or "").strip() or None,
         }
 
     def query_sandboxes(self):
@@ -186,7 +186,7 @@ def _record_destroy(calls):
         return {
             "ok": True,
             "action": "destroy",
-            "lower_runtime_handle": lower_runtime_handle,
+            "sandbox_runtime_handle": lower_runtime_handle,
             "provider": provider_name,
             "mode": "manager_runtime",
         }
@@ -567,7 +567,7 @@ def test_get_monitor_sandbox_detail_exposes_cleanup_state(monkeypatch):
     assert payload["cleanup"] == _cleanup_state("Sandbox is orphan cleanup residue and can enter managed cleanup.")
 
 
-def test_get_monitor_sandbox_detail_allows_missing_lower_runtime_handle_for_readonly_detail(monkeypatch):
+def test_get_monitor_sandbox_detail_allows_missing_sandbox_runtime_handle_for_readonly_detail(monkeypatch):
     _use_monitor_repo(
         monkeypatch,
         FakeSandboxMonitorRepo(
@@ -640,7 +640,7 @@ def test_request_monitor_sandbox_cleanup_uses_canonical_sandbox_target(monkeypat
         runtime_mutation_executor=_runtime_mutation_executor(
             cleanup_sandbox=lambda request: SimpleNamespace(
                 destroy_result=_record_destroy(calls)(
-                    lower_runtime_handle=request.lower_runtime_handle,
+                    lower_runtime_handle=request.sandbox_runtime_handle,
                     provider_name=request.provider_name,
                     detach_thread_bindings=request.detach_thread_bindings,
                 )
@@ -676,7 +676,7 @@ def test_request_monitor_sandbox_cleanup_passes_sandbox_id_to_mutation_executor(
                 captured.append(
                     (
                         request.sandbox_id,
-                        request.lower_runtime_handle,
+                        request.sandbox_runtime_handle,
                         request.provider_name,
                         request.detach_thread_bindings,
                     )
@@ -690,7 +690,7 @@ def test_request_monitor_sandbox_cleanup_passes_sandbox_id_to_mutation_executor(
     assert captured == [("sandbox-1", "lease-1", "daytona", False)]
 
 
-def test_request_monitor_sandbox_cleanup_keeps_lower_handle_out_of_sandbox_payload(monkeypatch):
+def test_request_monitor_sandbox_cleanup_keeps_runtime_handle_out_of_sandbox_payload(monkeypatch):
     captured: dict[str, object] = {}
     _use_monitor_repo(monkeypatch, FakeSandboxMonitorRepo(sandbox=_detached_sandbox(), runtime_id="runtime-1"))
 
@@ -707,10 +707,10 @@ def test_request_monitor_sandbox_cleanup_keeps_lower_handle_out_of_sandbox_paylo
 
     assert "lease" not in captured
     assert LOWER_RUNTIME_KEY not in captured["sandbox"]
-    assert captured["lower_runtime"] == {"handle": "lease-1"}
+    assert captured["sandbox_runtime"] == {"handle": "lease-1"}
 
 
-def test_sandbox_cleanup_operation_rejects_missing_lower_runtime_handle(monkeypatch):
+def test_sandbox_cleanup_operation_rejects_missing_sandbox_runtime_handle(monkeypatch):
     calls: list[tuple[str, str, bool]] = []
     monkeypatch.setattr(
         "backend.sandboxes.service.destroy_sandbox_runtime",
@@ -721,7 +721,7 @@ def test_sandbox_cleanup_operation_rejects_missing_lower_runtime_handle(monkeypa
     payload = monitor_operation_service.request_sandbox_cleanup(
         {
             "sandbox": _detached_sandbox(),
-            "lower_runtime": {"handle": ""},
+            "sandbox_runtime": {"handle": ""},
             "triage": {"category": "orphan_cleanup"},
             "provider": {"id": "daytona"},
             "runtime": {"runtime_id": "runtime-1"},
@@ -763,7 +763,7 @@ def test_get_monitor_sandbox_detail_shows_recent_sandbox_cleanup_operation(monke
         runtime_mutation_executor=_runtime_mutation_executor(
             cleanup_sandbox=lambda request: SimpleNamespace(
                 destroy_result=_record_destroy(calls)(
-                    lower_runtime_handle=request.lower_runtime_handle,
+                    lower_runtime_handle=request.sandbox_runtime_handle,
                     provider_name=request.provider_name,
                     detach_thread_bindings=request.detach_thread_bindings,
                 )
@@ -1080,7 +1080,7 @@ def test_request_monitor_sandbox_cleanup_records_sandbox_target_without_thread_l
         runtime_mutation_executor=_runtime_mutation_executor(
             cleanup_sandbox=lambda request: SimpleNamespace(
                 destroy_result=_record_destroy(calls)(
-                    lower_runtime_handle=request.lower_runtime_handle,
+                    lower_runtime_handle=request.sandbox_runtime_handle,
                     provider_name=request.provider_name,
                     detach_thread_bindings=request.detach_thread_bindings,
                 )

--- a/tests/Unit/monitor/test_monitor_resource_probe.py
+++ b/tests/Unit/monitor/test_monitor_resource_probe.py
@@ -79,7 +79,7 @@ def test_upsert_resource_snapshot_for_sandbox_requires_repo_sandbox_wrapper(monk
         )
 
 
-def test_upsert_resource_snapshot_for_sandbox_uses_sandbox_write_without_lower_runtime_handle(monkeypatch) -> None:
+def test_upsert_resource_snapshot_for_sandbox_uses_sandbox_write_without_sandbox_runtime_handle(monkeypatch) -> None:
     repo = _FakeSandboxSnapshotRepo()
     monkeypatch.setattr(storage_runtime, "build_resource_snapshot_repo", lambda **_kwargs: repo)
 

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -93,7 +93,7 @@ def _repo(tables: dict) -> SupabaseSandboxMonitorRepo:
 def _chat_session(
     session_id: str,
     thread_id: str,
-    lower_runtime_handle: str,
+    sandbox_runtime_handle: str,
     *,
     status: str = "active",
     started_at: str | None = None,
@@ -102,7 +102,7 @@ def _chat_session(
     row = {
         "chat_session_id": session_id,
         "thread_id": thread_id,
-        LOWER_RUNTIME_KEY: lower_runtime_handle,
+        LOWER_RUNTIME_KEY: sandbox_runtime_handle,
         "status": status,
     }
     if started_at is not None:
@@ -112,10 +112,10 @@ def _chat_session(
     return row
 
 
-def _terminal(terminal_id: str, lower_runtime_handle: str, thread_id: str, created_at: str) -> dict:
+def _terminal(terminal_id: str, sandbox_runtime_handle: str, thread_id: str, created_at: str) -> dict:
     return {
         "terminal_id": terminal_id,
-        LOWER_RUNTIME_KEY: lower_runtime_handle,
+        LOWER_RUNTIME_KEY: sandbox_runtime_handle,
         "thread_id": thread_id,
         "created_at": created_at,
     }
@@ -153,12 +153,12 @@ def _sandbox(
     updated_at: str = "2026-04-05T10:00:00",
     created_at: str = "2026-04-05T09:00:00",
     last_error: str | None = None,
-    lower_runtime_handle: str | None = None,
+    sandbox_runtime_handle: str | None = None,
     **config_extra,
 ) -> dict:
     config = dict(config_extra)
-    if lower_runtime_handle is not None:
-        config["runtime_handle"] = lower_runtime_handle
+    if sandbox_runtime_handle is not None:
+        config["runtime_handle"] = sandbox_runtime_handle
     return {
         "id": sandbox_id,
         "owner_user_id": owner_user_id,
@@ -183,7 +183,7 @@ def test_query_threads_accepts_optional_thread_filter() -> None:
                 _sandbox(
                     "sandbox-1",
                     provider_env_id="instance-1",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
             "container.workspaces": [
@@ -218,7 +218,7 @@ def test_query_threads_projects_workspace_backed_sandbox_rows() -> None:
                 _sandbox(
                     "sandbox-1",
                     provider_env_id="instance-1",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
             "container.workspaces": [
@@ -246,7 +246,7 @@ def test_query_threads_projects_workspace_backed_sandbox_rows() -> None:
 
 def test_query_threads_chunks_sandbox_lookup() -> None:
     sandboxes = [
-        _sandbox(f"sandbox-{index}", provider_env_id=f"instance-{index}", lower_runtime_handle=f"lease-{index}") for index in range(175)
+        _sandbox(f"sandbox-{index}", provider_env_id=f"instance-{index}", sandbox_runtime_handle=f"lease-{index}") for index in range(175)
     ]
     workspaces = [
         _workspace(f"workspace-{index}", f"sandbox-{index}", updated_at=f"2026-04-05T10:{index % 60:02d}:00") for index in range(175)
@@ -274,7 +274,7 @@ def test_query_sandbox_threads_returns_workspace_thread_ids() -> None:
             "container.sandboxes": [
                 _sandbox(
                     "sandbox-1",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
             "container.workspaces": [
@@ -305,7 +305,7 @@ def test_query_sandbox_reads_container_sandbox_row_by_id() -> None:
                     desired_state="paused",
                     observed_state="paused",
                     updated_at="2026-04-05T10:10:00",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                     sandbox_template_id="template-1",
                 )
             ]
@@ -325,7 +325,7 @@ def test_query_sandbox_reads_container_sandbox_row_by_id() -> None:
     }
 
 
-def test_query_sandbox_allows_missing_lower_runtime_handle() -> None:
+def test_query_sandbox_allows_missing_sandbox_runtime_handle() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -337,7 +337,7 @@ def test_query_sandbox_allows_missing_lower_runtime_handle() -> None:
                     observed_state="running",
                     updated_at="2026-04-05T10:10:00",
                     sandbox_template_id="local:default",
-                    lower_runtime_handle=None,
+                    sandbox_runtime_handle=None,
                 )
             ]
         }
@@ -366,7 +366,7 @@ def test_query_thread_runtime_rows_ignores_removed_chat_sessions_rows() -> None:
                     provider_env_id="instance-1",
                     desired_state="paused",
                     observed_state="paused",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                     last_error="last boom",
                 )
             ],
@@ -388,7 +388,7 @@ def test_chat_session_monitor_surfaces_do_not_read_removed_chat_sessions_table()
         _BrokenChatSessionsClient(
             {
                 "container.sandboxes": [
-                    _sandbox("sandbox-1", provider_env_id="instance-1", lower_runtime_handle="lease-1"),
+                    _sandbox("sandbox-1", provider_env_id="instance-1", sandbox_runtime_handle="lease-1"),
                 ],
                 "container.workspaces": [
                     _workspace("workspace-1", "sandbox-1", updated_at="2026-04-05T10:05:00"),
@@ -426,7 +426,7 @@ def test_query_sandboxes_uses_latest_workspace_thread_binding() -> None:
                     desired_state="paused",
                     observed_state="paused",
                     updated_at="2026-04-05T10:10:00",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
             "container.workspaces": [
@@ -467,7 +467,7 @@ def test_query_sandboxes_reads_container_sandboxes_with_workspace_binding() -> N
                     desired_state="paused",
                     observed_state="paused",
                     updated_at="2026-04-05T10:10:00",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
             "container.workspaces": [
@@ -506,7 +506,7 @@ def test_query_sandboxes_does_not_depend_on_workspace_sandbox_id_in_filter() -> 
                         "sandbox-1",
                         provider_env_id="instance-1",
                         updated_at="2026-04-05T10:10:00",
-                        lower_runtime_handle="lease-1",
+                        sandbox_runtime_handle="lease-1",
                     )
                 ],
                 "container.workspaces": [_workspace("workspace-1", "sandbox-1")],
@@ -524,7 +524,7 @@ def test_query_sandboxes_handles_many_workspace_thread_bindings() -> None:
             f"sandbox-{index}",
             provider_env_id=f"instance-{index}",
             updated_at=f"2026-04-05T10:{index % 60:02d}:00",
-            lower_runtime_handle=f"lease-{index}",
+            sandbox_runtime_handle=f"lease-{index}",
         )
         for index in range(175)
     ]
@@ -553,7 +553,7 @@ def test_query_sandbox_instance_id_uses_sandbox_provider_env_id() -> None:
                     provider_name="daytona_selfhost",
                     observed_state="detached",
                     provider_env_id="instance-sandbox",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
             "sandbox_instances": [
@@ -574,7 +574,7 @@ def test_query_sandbox_cleanup_target_reads_structured_sandbox_target() -> None:
                     provider_name="daytona_selfhost",
                     provider_env_id="instance-sandbox",
                     observed_state="detached",
-                    lower_runtime_handle="lease-1",
+                    sandbox_runtime_handle="lease-1",
                 )
             ],
         }
@@ -584,11 +584,11 @@ def test_query_sandbox_cleanup_target_reads_structured_sandbox_target() -> None:
         "sandbox_id": "sandbox-1",
         "provider_name": "daytona_selfhost",
         "provider_env_id": "instance-sandbox",
-        "lower_runtime_handle": "lease-1",
+        "sandbox_runtime_handle": "lease-1",
     }
 
 
-def test_query_sandbox_instance_id_falls_back_without_lower_runtime_handle() -> None:
+def test_query_sandbox_instance_id_falls_back_without_sandbox_runtime_handle() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -597,7 +597,7 @@ def test_query_sandbox_instance_id_falls_back_without_lower_runtime_handle() -> 
                     provider_name="local",
                     provider_env_id="sandbox-instance-1",
                     observed_state="running",
-                    lower_runtime_handle=None,
+                    sandbox_runtime_handle=None,
                 )
             ],
         }
@@ -615,7 +615,7 @@ def test_query_sandbox_instance_ids_chunks_large_lookup() -> None:
                     _sandbox(
                         f"sandbox-{index}",
                         provider_env_id=f"sandbox-instance-sandbox-{index}",
-                        lower_runtime_handle=f"lease-{index}",
+                        sandbox_runtime_handle=f"lease-{index}",
                     )
                     for index in range(175)
                 ],
@@ -634,8 +634,8 @@ def test_query_sandbox_instance_ids_use_sandbox_provider_env_id() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
-                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", lower_runtime_handle="lease-1"),
-                _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", lower_runtime_handle="lease-2"),
+                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", sandbox_runtime_handle="lease-1"),
+                _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", sandbox_runtime_handle="lease-2"),
             ],
             "sandbox_instances": [
                 {LOWER_RUNTIME_KEY: "lease-2", "provider_session_id": "stale-instance-2"},
@@ -653,8 +653,8 @@ def test_query_sandbox_instance_ids_use_sandbox_runtime_identity() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
-                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", lower_runtime_handle="lease-1"),
-                _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", lower_runtime_handle="lease-2"),
+                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", sandbox_runtime_handle="lease-1"),
+                _sandbox("sandbox-2", provider_env_id="sandbox-instance-2", sandbox_runtime_handle="lease-2"),
             ],
             "sandbox_instances": [
                 {LOWER_RUNTIME_KEY: "lease-2", "provider_session_id": "stale-instance-2"},
@@ -672,7 +672,7 @@ def test_query_sandbox_instance_id_uses_sandbox_runtime_identity() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
-                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", lower_runtime_handle="lease-1"),
+                _sandbox("sandbox-1", provider_env_id="sandbox-instance-1", sandbox_runtime_handle="lease-1"),
             ],
             "sandbox_instances": [
                 {LOWER_RUNTIME_KEY: "lease-1", "provider_session_id": "instance-lease"},
@@ -693,7 +693,7 @@ def test_list_probe_targets_use_sandbox_provider_env_id() -> None:
                     provider_env_id="instance-sandbox",
                     observed_state="detached",
                     updated_at="2026-04-05T10:10:00",
-                    lower_runtime_handle="lease-running",
+                    sandbox_runtime_handle="lease-running",
                 ),
                 _sandbox(
                     "sandbox-paused",
@@ -701,7 +701,7 @@ def test_list_probe_targets_use_sandbox_provider_env_id() -> None:
                     desired_state="paused",
                     observed_state="paused",
                     updated_at="2026-04-05T10:11:00",
-                    lower_runtime_handle="lease-paused",
+                    sandbox_runtime_handle="lease-paused",
                 ),
                 _sandbox(
                     "sandbox-stopped",
@@ -710,7 +710,7 @@ def test_list_probe_targets_use_sandbox_provider_env_id() -> None:
                     desired_state="stopped",
                     observed_state="stopped",
                     updated_at="2026-04-05T10:12:00",
-                    lower_runtime_handle="lease-stopped",
+                    sandbox_runtime_handle="lease-stopped",
                 ),
             ],
             "sandbox_instances": [
@@ -744,7 +744,7 @@ def test_list_probe_targets_skips_sandbox_without_provider_env_id() -> None:
                     provider_name="local",
                     provider_env_id=None,
                     observed_state="running",
-                    lower_runtime_handle=None,
+                    sandbox_runtime_handle=None,
                 ),
             ],
         }
@@ -763,7 +763,7 @@ def test_list_probe_targets_use_sandbox_runtime_identity() -> None:
                     provider_env_id="instance-sandbox",
                     observed_state="detached",
                     updated_at="2026-04-05T10:10:00",
-                    lower_runtime_handle="lease-running",
+                    sandbox_runtime_handle="lease-running",
                 ),
                 _sandbox(
                     "sandbox-paused",
@@ -771,7 +771,7 @@ def test_list_probe_targets_use_sandbox_runtime_identity() -> None:
                     desired_state="paused",
                     observed_state="paused",
                     updated_at="2026-04-05T10:11:00",
-                    lower_runtime_handle="lease-paused",
+                    sandbox_runtime_handle="lease-paused",
                 ),
             ],
             "sandbox_instances": [
@@ -813,7 +813,7 @@ def test_instance_lookup_does_not_read_removed_instances_table(include_updated_a
                 provider_env_id="instance-lease",
                 observed_state="detached",
                 updated_at="2026-04-05T10:10:00" if include_updated_at else "2026-04-05T10:00:00",
-                lower_runtime_handle="lease-1",
+                sandbox_runtime_handle="lease-1",
             )
         ]
     }
@@ -838,14 +838,14 @@ def test_query_resource_rows_uses_sandbox_thread_rows_without_session_rows() -> 
     repo = _repo(
         {
             "container.sandboxes": [
-                _sandbox("sandbox-active", created_at="2026-04-05T10:00:00", lower_runtime_handle="lease-active"),
+                _sandbox("sandbox-active", created_at="2026-04-05T10:00:00", sandbox_runtime_handle="lease-active"),
                 _sandbox(
                     "sandbox-terminal",
                     provider_name="daytona_selfhost",
                     desired_state="paused",
                     observed_state="paused",
                     created_at="2026-04-05T11:00:00",
-                    lower_runtime_handle="lease-terminal",
+                    sandbox_runtime_handle="lease-terminal",
                 ),
                 _sandbox(
                     "sandbox-recent",
@@ -853,7 +853,7 @@ def test_query_resource_rows_uses_sandbox_thread_rows_without_session_rows() -> 
                     desired_state="paused",
                     observed_state="paused",
                     created_at="2026-04-05T12:00:00",
-                    lower_runtime_handle="lease-recent",
+                    sandbox_runtime_handle="lease-recent",
                 ),
             ],
             "container.workspaces": [
@@ -912,7 +912,7 @@ def test_query_resource_rows_uses_sandbox_thread_rows_without_session_rows() -> 
     ]
 
 
-def test_query_resource_rows_does_not_require_lower_runtime_handle() -> None:
+def test_query_resource_rows_does_not_require_sandbox_runtime_handle() -> None:
     repo = _repo(
         {
             "container.sandboxes": [
@@ -922,7 +922,7 @@ def test_query_resource_rows_does_not_require_lower_runtime_handle() -> None:
                     desired_state="running",
                     observed_state="running",
                     created_at="2026-04-05T13:00:00",
-                    lower_runtime_handle=None,
+                    sandbox_runtime_handle=None,
                 ),
             ],
             "container.workspaces": [
@@ -951,14 +951,14 @@ def test_query_resource_rows_projects_sandbox_rows_without_session_rows() -> Non
     repo = _repo(
         {
             "container.sandboxes": [
-                _sandbox("sandbox-active", created_at="2026-04-05T10:00:00", lower_runtime_handle="lease-active"),
+                _sandbox("sandbox-active", created_at="2026-04-05T10:00:00", sandbox_runtime_handle="lease-active"),
                 _sandbox(
                     "sandbox-terminal",
                     provider_name="daytona_selfhost",
                     desired_state="paused",
                     observed_state="paused",
                     created_at="2026-04-05T11:00:00",
-                    lower_runtime_handle="lease-terminal",
+                    sandbox_runtime_handle="lease-terminal",
                 ),
             ],
             "container.workspaces": [

--- a/tests/Unit/monitor/test_sandbox_mutations.py
+++ b/tests/Unit/monitor/test_sandbox_mutations.py
@@ -20,7 +20,7 @@ def test_cleanup_sandbox_prunes_workspace_rows_after_runtime_destroy(monkeypatch
         "destroy_sandbox_runtime",
         lambda *, lower_runtime_handle, provider_name, detach_thread_bindings: (
             destroyed.append((lower_runtime_handle, provider_name, detach_thread_bindings))
-            or {"ok": True, "action": "destroy", "provider": provider_name, "lower_runtime_handle": lower_runtime_handle}
+            or {"ok": True, "action": "destroy", "provider": provider_name, "sandbox_runtime_handle": lower_runtime_handle}
         ),
     )
     monkeypatch.setattr(sandbox_mutations, "build_workspace_repo", lambda: _FakeWorkspaceRepo())
@@ -28,7 +28,7 @@ def test_cleanup_sandbox_prunes_workspace_rows_after_runtime_destroy(monkeypatch
     payload = sandbox_mutations.cleanup_sandbox(
         SandboxCleanupRequest(
             sandbox_id="sandbox-1",
-            lower_runtime_handle="lease-1",
+            sandbox_runtime_handle="lease-1",
             provider_name="local",
             detach_thread_bindings=False,
         )

--- a/tests/Unit/storage/test_supabase_provider_event_repo.py
+++ b/tests/Unit/storage/test_supabase_provider_event_repo.py
@@ -11,12 +11,12 @@ def test_supabase_provider_event_repo_uses_observability_schema_table() -> None:
         instance_id="instance-1",
         event_type="started",
         payload={"ok": True},
-        matched_runtime_handle="lease-1",
+        matched_sandbox_runtime_handle="lease-1",
         matched_sandbox_id="sandbox-1",
     )
 
     row = tables["observability.provider_events"][0]
     assert row["provider_name"] == "daytona"
-    assert row["matched_runtime_handle"] == "lease-1"
+    assert row["matched_sandbox_runtime_handle"] == "lease-1"
     assert row["matched_sandbox_id"] == "sandbox-1"
     assert "provider_events" not in tables


### PR DESCRIPTION
## Summary
- rename monitor cleanup target vocabulary from lower runtime handle to sandbox runtime handle
- rename webhook/provider-event matched runtime handle vocabulary to matched sandbox runtime handle
- keep deeper internal runtime/terminal implementation unchanged in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py`
- [x] `git diff --check`
