### PR TITLE
refactor: rename sandbox runtime handle service layer

### DIFF
--- a/backend/sandboxes/runtime/mutations.py
+++ b/backend/sandboxes/runtime/mutations.py
@@ -83,24 +83,29 @@ def mutate_sandbox_runtime(
     }
 
 
-def _detach_runtime_terminals(manager: Any, lower_runtime_handle: str) -> None:
+def _detach_runtime_terminals(manager: Any, sandbox_runtime_handle: str) -> None:
     for row in list(manager.terminal_store.list_all()):
-        if str(row.get("lease_id") or "") != lower_runtime_handle:
+        if str(row.get("lease_id") or "") != sandbox_runtime_handle:
             continue
         thread_id = str(row.get("thread_id") or "").strip()
         terminal_id = str(row.get("terminal_id") or "").strip()
         if not terminal_id:
-            raise RuntimeError(f"Lower runtime {lower_runtime_handle} has terminal row without terminal_id")
+            raise RuntimeError(f"Sandbox runtime {sandbox_runtime_handle} has terminal row without terminal_id")
         if thread_id:
             manager.session_manager.delete_thread(thread_id, reason="detached_sandbox_cleanup")
         manager.terminal_store.delete(terminal_id)
 
 
-def _prune_stale_runtime_terminals(manager: Any, lower_runtime_handle: str, *, build_storage_container_fn=build_storage_container) -> None:
+def _prune_stale_runtime_terminals(
+    manager: Any,
+    sandbox_runtime_handle: str,
+    *,
+    build_storage_container_fn=build_storage_container,
+) -> None:
     thread_repo = build_storage_container_fn().thread_repo()
     try:
         for row in list(manager.terminal_store.list_all()):
-            if str(row.get("lease_id") or "") != lower_runtime_handle:
+            if str(row.get("lease_id") or "") != sandbox_runtime_handle:
                 continue
             thread_id = str(row.get("thread_id") or "").strip()
             terminal_id = str(row.get("terminal_id") or "").strip()
@@ -116,7 +121,7 @@ def _prune_stale_runtime_terminals(manager: Any, lower_runtime_handle: str, *, b
 
 def destroy_sandbox_runtime(
     *,
-    lower_runtime_handle: str,
+    sandbox_runtime_handle: str,
     provider_name: str,
     detach_thread_bindings: bool = False,
     init_providers_and_managers_fn=init_providers_and_managers,
@@ -127,19 +132,19 @@ def destroy_sandbox_runtime(
     if manager is None:
         raise RuntimeError(f"Provider manager unavailable: {provider_name}")
 
-    lease = manager.get_lease(lower_runtime_handle)
+    lease = manager.get_lease(sandbox_runtime_handle)
     if lease is None:
-        raise RuntimeError(f"Lower runtime not found: {lower_runtime_handle}")
+        raise RuntimeError(f"Sandbox runtime not found: {sandbox_runtime_handle}")
 
-    _prune_stale_runtime_terminals(manager, lower_runtime_handle, build_storage_container_fn=build_storage_container_fn)
+    _prune_stale_runtime_terminals(manager, sandbox_runtime_handle, build_storage_container_fn=build_storage_container_fn)
     if detach_thread_bindings:
-        _detach_runtime_terminals(manager, lower_runtime_handle)
-    if not manager.destroy_lease_resources(lower_runtime_handle):
-        raise RuntimeError(f"Lower runtime not found: {lower_runtime_handle}")
+        _detach_runtime_terminals(manager, sandbox_runtime_handle)
+    if not manager.destroy_lease_resources(sandbox_runtime_handle):
+        raise RuntimeError(f"Sandbox runtime not found: {sandbox_runtime_handle}")
     return {
         "ok": True,
         "action": "destroy",
-        "lower_runtime_handle": lower_runtime_handle,
+        "sandbox_runtime_handle": sandbox_runtime_handle,
         "provider": provider_name,
         "mode": "manager_runtime",
     }

--- a/backend/sandboxes/service.py
+++ b/backend/sandboxes/service.py
@@ -142,9 +142,9 @@ def mutate_sandbox_runtime(
     )
 
 
-def destroy_sandbox_runtime(*, lower_runtime_handle: str, provider_name: str, detach_thread_bindings: bool = False) -> dict[str, Any]:
+def destroy_sandbox_runtime(*, sandbox_runtime_handle: str, provider_name: str, detach_thread_bindings: bool = False) -> dict[str, Any]:
     return _sandbox_runtime_mutations.destroy_sandbox_runtime(
-        lower_runtime_handle=lower_runtime_handle,
+        sandbox_runtime_handle=sandbox_runtime_handle,
         provider_name=provider_name,
         detach_thread_bindings=detach_thread_bindings,
         init_providers_and_managers_fn=init_providers_and_managers,

--- a/tests/Unit/sandbox/test_sandbox_service_cleanup.py
+++ b/tests/Unit/sandbox/test_sandbox_service_cleanup.py
@@ -29,12 +29,12 @@ def test_destroy_sandbox_runtime_uses_manager_destroy_resources(monkeypatch):
         lambda: SimpleNamespace(thread_repo=lambda: SimpleNamespace(close=lambda: None)),
     )
 
-    result = sandbox_service.destroy_sandbox_runtime(lower_runtime_handle="lease-1", provider_name="daytona_selfhost")
+    result = sandbox_service.destroy_sandbox_runtime(sandbox_runtime_handle="lease-1", provider_name="daytona_selfhost")
 
     assert result == {
         "ok": True,
         "action": "destroy",
-        "lower_runtime_handle": "lease-1",
+        "sandbox_runtime_handle": "lease-1",
         "provider": "daytona_selfhost",
         "mode": "manager_runtime",
     }
@@ -83,7 +83,7 @@ def test_destroy_sandbox_runtime_prunes_stale_terminals_before_destroy(monkeypat
     )
     monkeypatch.setattr(sandbox_service, "build_storage_container", lambda: _Container())
 
-    result = sandbox_service.destroy_sandbox_runtime(lower_runtime_handle="lease-1", provider_name="daytona_selfhost")
+    result = sandbox_service.destroy_sandbox_runtime(sandbox_runtime_handle="lease-1", provider_name="daytona_selfhost")
 
     assert result["ok"] is True
     assert deleted_thread_chats == [("thread-missing", "stale_terminal_pruned")]
@@ -134,7 +134,7 @@ def test_destroy_sandbox_runtime_detaches_threads_with_sandbox_cleanup_reason(mo
     monkeypatch.setattr(sandbox_service, "build_storage_container", lambda: _Container())
 
     result = sandbox_service.destroy_sandbox_runtime(
-        lower_runtime_handle="lease-1",
+        sandbox_runtime_handle="lease-1",
         provider_name="daytona_selfhost",
         detach_thread_bindings=True,
     )

--- a/tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py
+++ b/tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py
@@ -71,7 +71,7 @@ def test_mutate_sandbox_runtime_destroys_provider_orphan_without_fake_lease(monk
     assert manager.provider.destroyed == [("sandbox-1", True)]
 
 
-def test_mutate_sandbox_runtime_reports_manager_runtime_for_lower_runtime_handle(monkeypatch):
+def test_mutate_sandbox_runtime_reports_manager_runtime_for_sandbox_runtime_handle(monkeypatch):
     manager = _FakeManager()
     manager.lease = _FakeLease()
     runtimes = [


### PR DESCRIPTION
## Summary
- rename sandbox service/runtime mutation vocabulary from lower runtime handle to sandbox runtime handle
- keep terminal/PTy and deeper manager/runtime internals unchanged in this slice
- realign focused sandbox service tests to the new naming

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_repo.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/monitor/test_monitor_resource_probe.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py`
- [x] `git diff --check`
