### PR TITLE
refactor: rename runtime destroy helper

### DIFF
--- a/backend/sandboxes/runtime/mutations.py
+++ b/backend/sandboxes/runtime/mutations.py
@@ -139,7 +139,7 @@ def destroy_sandbox_runtime(
     _prune_stale_runtime_terminals(manager, sandbox_runtime_handle, build_storage_container_fn=build_storage_container_fn)
     if detach_thread_bindings:
         _detach_runtime_terminals(manager, sandbox_runtime_handle)
-    if not manager.destroy_lease_resources(sandbox_runtime_handle):
+    if not manager.destroy_sandbox_runtime_resources(sandbox_runtime_handle):
         raise RuntimeError(f"Sandbox runtime not found: {sandbox_runtime_handle}")
     return {
         "ok": True,

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -849,11 +849,11 @@ class SandboxManager:
             lease_in_use = any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all())
             if lease_in_use:
                 continue
-            if not self.destroy_lease_resources(lease_id):
+            if not self.destroy_sandbox_runtime_resources(lease_id):
                 raise RuntimeError(f"Missing lease {lease_id} for thread {thread_id}")
         return True
 
-    def destroy_lease_resources(self, lease_id: str) -> bool:
+    def destroy_sandbox_runtime_resources(self, lease_id: str) -> bool:
         lease = self._get_lease(lease_id)
         if not lease:
             return False

--- a/tests/Unit/sandbox/test_sandbox_service_cleanup.py
+++ b/tests/Unit/sandbox/test_sandbox_service_cleanup.py
@@ -14,7 +14,7 @@ def test_destroy_sandbox_runtime_uses_manager_destroy_resources(monkeypatch):
         def get_lease(self, lower_runtime_id: str):
             return SimpleNamespace(**{LOWER_RUNTIME_KEY: lower_runtime_id})
 
-        def destroy_lease_resources(self, lower_runtime_id: str) -> bool:
+        def destroy_sandbox_runtime_resources(self, lower_runtime_id: str) -> bool:
             calls.append(lower_runtime_id)
             return True
 
@@ -61,7 +61,7 @@ def test_destroy_sandbox_runtime_prunes_stale_terminals_before_destroy(monkeypat
         def get_lease(self, lower_runtime_id: str):
             return SimpleNamespace(**{LOWER_RUNTIME_KEY: lower_runtime_id})
 
-        def destroy_lease_resources(self, lower_runtime_id: str) -> bool:
+        def destroy_sandbox_runtime_resources(self, lower_runtime_id: str) -> bool:
             destroyed.append(lower_runtime_id)
             return True
 
@@ -111,7 +111,7 @@ def test_destroy_sandbox_runtime_detaches_threads_with_sandbox_cleanup_reason(mo
         def get_lease(self, lower_runtime_id: str):
             return SimpleNamespace(**{LOWER_RUNTIME_KEY: lower_runtime_id})
 
-        def destroy_lease_resources(self, lower_runtime_id: str) -> bool:
+        def destroy_sandbox_runtime_resources(self, lower_runtime_id: str) -> bool:
             destroyed.append(lower_runtime_id)
             return True
 


### PR DESCRIPTION
## Summary
- rename sandbox manager destroy helper from lease wording to sandbox runtime wording
- realign sandbox runtime mutation destroy path to the new helper name
- keep PTY and terminal table semantics untouched in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py`
- [x] `git diff --check`
