### PR TITLE
refactor: rename manager runtime accessors

### DIFF
--- a/backend/sandboxes/runtime/mutations.py
+++ b/backend/sandboxes/runtime/mutations.py
@@ -46,7 +46,7 @@ def mutate_sandbox_runtime(
         else:
             raise RuntimeError(f"Unknown action: {action}")
     else:
-        lease = manager.get_lease(lease_id) if lease_id else None
+        lease = manager.get_sandbox_runtime(lease_id) if lease_id else None
         if not lease:
             mode = "provider_orphan_direct"
             if action == "pause":
@@ -132,7 +132,7 @@ def destroy_sandbox_runtime(
     if manager is None:
         raise RuntimeError(f"Provider manager unavailable: {provider_name}")
 
-    lease = manager.get_lease(sandbox_runtime_handle)
+    lease = manager.get_sandbox_runtime(sandbox_runtime_handle)
     if lease is None:
         raise RuntimeError(f"Sandbox runtime not found: {sandbox_runtime_handle}")
 

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -161,7 +161,7 @@ class _CommandWrapper(BaseExecutor):
         terminal = terminal_from_row(terminal_row, self._manager.db_path)
         if terminal.thread_id != self._session.thread_id:
             raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal.thread_id}, not {self._session.thread_id}")
-        lease = self._manager.get_lease(terminal.lease_id)
+        lease = self._manager.get_sandbox_runtime(terminal.lease_id)
         if lease is None:
             raise RuntimeError(f"Lease {terminal.lease_id} not found for terminal {terminal_id}")
         return self._manager.session_manager.create(

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -268,15 +268,15 @@ class SandboxManager:
             provider_capability=self.provider_capability,
         )
 
-    def _get_lease(self, lease_id: str):
-        """Get lease as domain object, or None."""
+    def _get_sandbox_runtime(self, lease_id: str):
+        """Get sandbox runtime as domain object, or None."""
         row = self.lease_store.get(lease_id)
         if row is None:
             return None
         return lease_from_row(row, self.db_path)
 
-    def _create_lease(self, lease_id: str, provider_name: str):
-        """Create lease and return as domain object."""
+    def _create_sandbox_runtime(self, lease_id: str, provider_name: str):
+        """Create sandbox runtime and return as domain object."""
         row = self.lease_store.create(lease_id, provider_name)
         return lease_from_row(row, self.db_path)
 
@@ -284,9 +284,9 @@ class SandboxManager:
         """Public API: get active terminal as domain object."""
         return self._get_active_terminal(thread_id)
 
-    def get_lease(self, lease_id: str):
-        """Public API: get lease as domain object."""
-        return self._get_lease(lease_id)
+    def get_sandbox_runtime(self, lease_id: str):
+        """Public API: get sandbox runtime as domain object."""
+        return self._get_sandbox_runtime(lease_id)
 
     def _default_terminal_cwd(self) -> str:
         return resolve_provider_cwd(self.provider)
@@ -307,7 +307,7 @@ class SandboxManager:
         terminal = self._get_active_terminal(thread_id)
         if not terminal:
             raise ValueError(f"No active terminal for thread {thread_id}")
-        lease = self._get_lease(terminal.lease_id)
+        lease = self._get_sandbox_runtime(terminal.lease_id)
         if not lease:
             raise ValueError(f"No lease for thread {thread_id}")
         remote_path = self.volume.resolve_mount_path()
@@ -381,7 +381,7 @@ class SandboxManager:
         if len(lease_ids) != 1:
             raise RuntimeError(f"Thread {thread_id} has inconsistent lease_ids: {sorted(lease_ids)}")
         lease_id = next(iter(lease_ids))
-        lease = self._get_lease(lease_id)
+        lease = self._get_sandbox_runtime(lease_id)
         if lease is None:
             return None
         self._assert_lease_provider(lease, thread_id)
@@ -391,7 +391,7 @@ class SandboxManager:
         terminals = self._get_thread_terminals(thread_id)
         if not terminals:
             return False
-        lease = self._get_lease(terminals[0].lease_id)
+        lease = self._get_sandbox_runtime(terminals[0].lease_id)
         return bool(lease and lease.provider_name == self.provider.name)
 
     def _resolve_sync_source_path(self, thread_id: str) -> Path:
@@ -480,7 +480,7 @@ class SandboxManager:
         if not terminal:
             terminal_id = f"term-{uuid.uuid4().hex[:12]}"
             lease_id = f"lease-{uuid.uuid4().hex[:12]}"
-            lease = self._create_lease(lease_id, self.provider.name)
+            lease = self._create_sandbox_runtime(lease_id, self.provider.name)
             initial_cwd = self._default_terminal_cwd()
             terminal = terminal_from_row(
                 self.terminal_store.create(
@@ -492,9 +492,9 @@ class SandboxManager:
                 self.db_path,
             )
         else:
-            lease = self._get_lease(terminal.lease_id)
+            lease = self._get_sandbox_runtime(terminal.lease_id)
             if not lease:
-                lease = self._create_lease(terminal.lease_id, self.provider.name)
+                lease = self._create_sandbox_runtime(terminal.lease_id, self.provider.name)
             self._assert_lease_provider(lease, thread_id)
             if lease.observed_state == "paused":
                 # @@@paused-lease-rehydrate - a persisted thread can lose its in-memory chat session
@@ -506,7 +506,7 @@ class SandboxManager:
                     self._assert_lease_provider(session.lease, thread_id)
                     self._ensure_bound_instance(session.lease)
                     return SandboxCapability(session, manager=self)
-                lease = self._get_lease(terminal.lease_id)
+                lease = self._get_sandbox_runtime(terminal.lease_id)
                 if not lease:
                     raise RuntimeError(f"Lease disappeared after resume for thread {thread_id}")
                 self._assert_lease_provider(lease, thread_id)
@@ -560,7 +560,7 @@ class SandboxManager:
         if default_row is None:
             raise RuntimeError(f"Thread {thread_id} has no default terminal")
         default_terminal = terminal_from_row(default_row, self.db_path)
-        lease = self._get_lease(default_terminal.lease_id)
+        lease = self._get_sandbox_runtime(default_terminal.lease_id)
         if lease is None:
             raise RuntimeError(f"Missing lease {default_terminal.lease_id} for thread {thread_id}")
         self._assert_lease_provider(lease, thread_id)
@@ -659,7 +659,7 @@ class SandboxManager:
             terminal_id = row.get("terminal_id")
             terminal_row = self.terminal_store.get_by_id(str(terminal_id)) if terminal_id else None
             terminal = terminal_from_row(terminal_row, self.db_path) if terminal_row else None
-            lease = self._get_lease(terminal.lease_id) if terminal else None
+            lease = self._get_sandbox_runtime(terminal.lease_id) if terminal else None
             if lease and lease.provider_name != self.provider.name:
                 continue
 
@@ -854,7 +854,7 @@ class SandboxManager:
         return True
 
     def destroy_sandbox_runtime_resources(self, lease_id: str) -> bool:
-        lease = self._get_lease(lease_id)
+        lease = self._get_sandbox_runtime(lease_id)
         if not lease:
             return False
         if any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all()):
@@ -893,7 +893,7 @@ class SandboxManager:
 
         for lease_row in self.lease_store.list_by_provider(self.provider.name):
             lease_id = lease_row["lease_id"]
-            lease = self._get_lease(lease_id)
+            lease = self._get_sandbox_runtime(lease_id)
             if not lease:
                 continue
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -284,7 +284,7 @@ def test_setup_mounts_uses_workspace_sync_source_for_non_daytona_runtime(tmp_pat
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     result = manager._setup_mounts("thread-1")
 
@@ -298,7 +298,7 @@ def test_setup_mounts_reports_missing_lease_not_missing_volume():
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: None
+    manager._get_sandbox_runtime = lambda _lease_id: None
 
     with pytest.raises(ValueError, match="No lease for thread thread-1"):
         manager._setup_mounts("thread-1")
@@ -324,7 +324,7 @@ def test_setup_mounts_uses_workspace_source_without_remote_volume_metadata(monke
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     lease = SimpleNamespace(lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.lease_store = _FakeLeaseStore()
 
     result = manager._setup_mounts("thread-1")
@@ -341,7 +341,7 @@ def test_setup_mounts_daytona_uses_lease_id_for_managed_volume(monkeypatch, tmp_
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     lease = SimpleNamespace(lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.lease_store = _FakeLeaseStore()
 
     result = manager._setup_mounts("thread-1")
@@ -374,7 +374,7 @@ def test_destroy_thread_resources_daytona_does_not_require_volume_row(tmp_path):
     lease = _Lease()
     all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
     manager._get_thread_lease = lambda _thread_id: lease
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
         delete=lambda terminal_id: (
@@ -430,7 +430,7 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
         destroy_instance=lambda *_args, **_kwargs: destroy_calls.append(True),
     )
     destroy_calls: list[bool] = []
-    manager._get_lease = lambda _lease_id: fake_lease
+    manager._get_sandbox_runtime = lambda _lease_id: fake_lease
     manager._terminal_is_busy = lambda _terminal_id: False
     manager._lease_is_busy = lambda _lease_id: False
     monkeypatch.setattr(
@@ -471,7 +471,7 @@ def test_destroy_thread_resources_skips_local_sync_without_volume_metadata():
     manager.provider = SimpleNamespace(name="local")
     manager.volume = _FakeVolume()
     manager._get_thread_lease = lambda _thread_id: lease
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}],
@@ -533,7 +533,7 @@ def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_termi
 
     lease = _Lease()
     manager._get_thread_lease = lambda _thread_id: lease
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}],
@@ -581,7 +581,7 @@ def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
 
     lease = _Lease()
     manager._get_thread_lease = lambda _thread_id: lease
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
@@ -628,7 +628,7 @@ def test_destroy_thread_resources_deletes_daytona_managed_volume_from_lease_id(t
     lease = _Lease()
     all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
     manager._get_thread_lease = lambda _thread_id: lease
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
         delete=lambda terminal_id: (
@@ -674,7 +674,7 @@ def test_destroy_thread_resources_derives_daytona_volume_name_from_lease_id(tmp_
     lease = _Lease()
     all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
     manager._get_thread_lease = lambda _thread_id: lease
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
         delete=lambda terminal_id: (
@@ -700,7 +700,7 @@ def test_sync_uploads_skips_local_volume_sync_without_volume_metadata():
     manager.provider_capability = SimpleNamespace(runtime_kind="local")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
-    manager._get_lease = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
     manager._get_thread_lease = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.session_manager = SimpleNamespace(
@@ -774,7 +774,7 @@ def test_get_sandbox_auto_resumes_paused_lease_when_reconstructing_session():
         get_instance=lambda: SimpleNamespace(instance_id="instance-1"),
     )
     manager._get_active_terminal = lambda _thread_id: terminal
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._assert_lease_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     resume_calls: list[tuple[str, str]] = []
@@ -890,7 +890,7 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
     manager.provider = SimpleNamespace(name="agentbay")
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay", eager_instance_binding=False)
     manager._get_active_terminal = lambda _thread_id: terminal
-    manager._get_lease = lambda _lease_id: lease
+    manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._assert_lease_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     manager._setup_mounts = lambda _thread_id: {"source_path": expected_path, "remote_path": "/workspace"}
@@ -957,7 +957,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
         },
         create=create_terminal,
     )
-    manager._get_lease = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
     manager._assert_lease_provider = lambda _lease, _thread_id: None
     manager.session_manager = SimpleNamespace(create=lambda **kwargs: created_background_commands.append(kwargs) or kwargs)
     monkeypatch.setattr(sandbox_manager_module, "terminal_from_row", from_row)

--- a/tests/Unit/sandbox/test_sandbox_service_cleanup.py
+++ b/tests/Unit/sandbox/test_sandbox_service_cleanup.py
@@ -11,7 +11,7 @@ def test_destroy_sandbox_runtime_uses_manager_destroy_resources(monkeypatch):
     class _Manager:
         terminal_store = SimpleNamespace(list_all=lambda: [], delete=lambda _terminal_id: None)
 
-        def get_lease(self, lower_runtime_id: str):
+        def get_sandbox_runtime(self, lower_runtime_id: str):
             return SimpleNamespace(**{LOWER_RUNTIME_KEY: lower_runtime_id})
 
         def destroy_sandbox_runtime_resources(self, lower_runtime_id: str) -> bool:
@@ -58,7 +58,7 @@ def test_destroy_sandbox_runtime_prunes_stale_terminals_before_destroy(monkeypat
             delete_thread=lambda thread_id, reason="thread_deleted": deleted_thread_chats.append((thread_id, reason))
         )
 
-        def get_lease(self, lower_runtime_id: str):
+        def get_sandbox_runtime(self, lower_runtime_id: str):
             return SimpleNamespace(**{LOWER_RUNTIME_KEY: lower_runtime_id})
 
         def destroy_sandbox_runtime_resources(self, lower_runtime_id: str) -> bool:
@@ -108,7 +108,7 @@ def test_destroy_sandbox_runtime_detaches_threads_with_sandbox_cleanup_reason(mo
             delete_thread=lambda thread_id, reason="thread_deleted": deleted_thread_chats.append((thread_id, reason))
         )
 
-        def get_lease(self, lower_runtime_id: str):
+        def get_sandbox_runtime(self, lower_runtime_id: str):
             return SimpleNamespace(**{LOWER_RUNTIME_KEY: lower_runtime_id})
 
         def destroy_sandbox_runtime_resources(self, lower_runtime_id: str) -> bool:

--- a/tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py
+++ b/tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py
@@ -40,7 +40,7 @@ class _FakeManager:
         self.lease_store = _FakeLeaseStore()
         self.lease = None
 
-    def get_lease(self, lower_runtime_id):
+    def get_sandbox_runtime(self, lower_runtime_id):
         return self.lease if lower_runtime_id == "lease-1" else None
 
 


### PR DESCRIPTION
## Summary
- rename sandbox manager runtime accessor methods from lease wording to sandbox runtime wording
- realign sandbox capability and runtime mutation consumers to the new manager API
- keep PTY and terminal table semantics unchanged in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py`
- [x] `git diff --check`
