### PR TITLE
refactor: rename runtime row helper

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Query
 from backend.sandboxes.inventory import init_providers_and_managers
 from backend.web.utils.helpers import extract_webhook_instance_id
 from sandbox.control_plane_repos import resolve_sandbox_db_path
-from sandbox.lease import lease_from_row as lower_runtime_from_row
+from sandbox.lease import sandbox_runtime_from_row as lower_runtime_from_row
 from storage.container_cache import get_storage_container as _get_container
 from storage.runtime import build_lease_repo as make_lower_runtime_repo
 

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -212,7 +212,7 @@ class ChatSessionManager:
         if not row:
             return None
 
-        from sandbox.lease import lease_from_row
+        from sandbox.lease import sandbox_runtime_from_row
         from sandbox.terminal import terminal_from_row
 
         _term_repo = self._terminal_repo
@@ -234,7 +234,7 @@ class ChatSessionManager:
         finally:
             if own_lease_repo:
                 _lease_repo.close()
-        lease = lease_from_row(_lease_row, self.db_path) if _lease_row else None
+        lease = sandbox_runtime_from_row(_lease_row, self.db_path) if _lease_row else None
         if not terminal or not lease:
             return None
 

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -538,7 +538,7 @@ class SQLiteLease(SandboxLease):
             finally:
                 event_repo.close()
                 repo.close()
-            self._sync_from(lease_from_row(row, self.db_path))
+            self._sync_from(sandbox_runtime_from_row(row, self.db_path))
             return
         self._persist_lease_metadata()
 
@@ -565,7 +565,7 @@ class SQLiteLease(SandboxLease):
         finally:
             event_repo.close()
             repo.close()
-        self._sync_from(lease_from_row(row, self.db_path))
+        self._sync_from(sandbox_runtime_from_row(row, self.db_path))
         if observed == "detached":
             self._sync_sandbox_runtime_binding(None, updated_at=row.get("updated_at") or row.get("observed_at"))
             self._sync_sandbox_observed_state("detached", updated_at=row.get("updated_at") or row.get("observed_at"))
@@ -625,7 +625,7 @@ class SQLiteLease(SandboxLease):
         finally:
             event_repo.close()
             repo.close()
-        self._sync_from(lease_from_row(final_row, self.db_path))
+        self._sync_from(sandbox_runtime_from_row(final_row, self.db_path))
 
     def _transition_instance_via_strategy_repos(
         self,
@@ -694,7 +694,7 @@ class SQLiteLease(SandboxLease):
         finally:
             event_repo.close()
             repo.close()
-        self._sync_from(lease_from_row(final_row, self.db_path))
+        self._sync_from(sandbox_runtime_from_row(final_row, self.db_path))
 
     def _reload_from_storage(self) -> None:
         repo = _make_lease_repo(self.db_path)
@@ -703,7 +703,7 @@ class SQLiteLease(SandboxLease):
         finally:
             repo.close()
         if row:
-            self._sync_from(lease_from_row(row, self.db_path))
+            self._sync_from(sandbox_runtime_from_row(row, self.db_path))
 
     def _sync_from(self, other: SQLiteLease) -> None:
         self._current_instance = other._current_instance
@@ -891,7 +891,7 @@ class SQLiteLease(SandboxLease):
                         )
                     finally:
                         repo.close()
-                    self._sync_from(lease_from_row(row, self.db_path))
+                    self._sync_from(sandbox_runtime_from_row(row, self.db_path))
                     self._sync_sandbox_runtime_binding(
                         row.get("current_instance_id"),
                         updated_at=row.get("updated_at") or row.get("observed_at"),
@@ -933,7 +933,7 @@ class SQLiteLease(SandboxLease):
                             )
                         finally:
                             repo.close()
-                        self._sync_from(lease_from_row(row, self.db_path))
+                        self._sync_from(sandbox_runtime_from_row(row, self.db_path))
                         self._sync_sandbox_runtime_binding(
                             row.get("current_instance_id"),
                             updated_at=row.get("updated_at") or row.get("observed_at"),
@@ -978,7 +978,7 @@ class SQLiteLease(SandboxLease):
                     )
                 finally:
                     repo.close()
-                self._sync_from(lease_from_row(row, self.db_path))
+                self._sync_from(sandbox_runtime_from_row(row, self.db_path))
                 self._sync_sandbox_runtime_binding(
                     row.get("current_instance_id"),
                     updated_at=row.get("updated_at") or row.get("observed_at"),
@@ -1105,7 +1105,7 @@ class SQLiteLease(SandboxLease):
         self._persist_lease_metadata()
 
 
-def lease_from_row(row: dict, db_path: Path) -> SQLiteLease:
+def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteLease:
     """Construct SQLiteLease from a dict returned by the repo."""
     instance = None
     inst_data = row.get("_instance")

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -15,7 +15,7 @@ from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
 from sandbox.clock import parse_runtime_datetime, utc_now
 from sandbox.control_plane_repos import make_chat_session_repo, make_lease_repo, make_terminal_repo
-from sandbox.lease import lease_from_row
+from sandbox.lease import sandbox_runtime_from_row
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.terminal import TerminalState, terminal_from_row
@@ -273,12 +273,12 @@ class SandboxManager:
         row = self.lease_store.get(lease_id)
         if row is None:
             return None
-        return lease_from_row(row, self.db_path)
+        return sandbox_runtime_from_row(row, self.db_path)
 
     def _create_sandbox_runtime(self, lease_id: str, provider_name: str):
         """Create sandbox runtime and return as domain object."""
         row = self.lease_store.create(lease_id, provider_name)
-        return lease_from_row(row, self.db_path)
+        return sandbox_runtime_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
         """Public API: get active terminal as domain object."""

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -12,7 +12,7 @@ import pytest
 
 from sandbox.chat_session import ChatSessionManager
 from sandbox.interfaces.executor import ExecuteResult
-from sandbox.lease import SandboxInstance, lease_from_row
+from sandbox.lease import SandboxInstance, sandbox_runtime_from_row
 from sandbox.provider import ProviderExecResult
 from sandbox.providers.local import LocalPersistentShellRuntime
 from sandbox.runtime import (
@@ -43,11 +43,11 @@ class _DomainLeaseStore:
 
     def create(self, lower_runtime_id, provider_name, **kw):
         row = self._repo.create(lower_runtime_id, provider_name, **kw)
-        return lease_from_row(row, self._repo.db_path)
+        return sandbox_runtime_from_row(row, self._repo.db_path)
 
     def get(self, lower_runtime_id):
         row = self._repo.get(lower_runtime_id)
-        return lease_from_row(row, self._repo.db_path) if row else None
+        return sandbox_runtime_from_row(row, self._repo.db_path) if row else None
 
     def __getattr__(self, name):
         return getattr(self._repo, name)


### PR DESCRIPTION
## Summary
- rename the runtime row construction helper from lease_from_row to sandbox_runtime_from_row
- realign direct imports in sandbox manager/chat session/webhooks and runtime tests
- keep SandboxLease class/PTy/terminal-table semantics untouched in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py`
- [x] `git diff --check`
