### PR TITLE
refactor: rename runtime handle classes

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -3,7 +3,7 @@
 Architecture:
     Thread (durable) -> ChatSession (policy window) -> PhysicalTerminalRuntime (ephemeral)
                      -> AbstractTerminal (reference)
-                     -> SandboxLease (reference)
+                     -> SandboxRuntimeHandle (reference)
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ from sandbox.lifecycle import (
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.provider import SandboxProvider
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
@@ -70,7 +70,7 @@ class ChatSession:
         session_id: str,
         thread_id: str,
         terminal: AbstractTerminal,
-        lease: SandboxLease,
+        lease: SandboxRuntimeHandle,
         runtime: PhysicalTerminalRuntime,
         policy: ChatSessionPolicy,
         started_at: datetime,
@@ -179,7 +179,7 @@ class ChatSessionManager:
         if error:
             raise error[0]
 
-    def _build_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def _build_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         return self.provider.create_runtime(terminal, lease)
 
     def get(self, thread_id: str, terminal_id: str | None = None) -> ChatSession | None:
@@ -271,7 +271,7 @@ class ChatSessionManager:
         session_id: str,
         thread_id: str,
         terminal: AbstractTerminal,
-        lease: SandboxLease,
+        lease: SandboxRuntimeHandle,
         policy: ChatSessionPolicy | None = None,
     ) -> ChatSession:
         policy = policy or self.default_policy

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -1,10 +1,10 @@
-"""SandboxLease - durable compute handle with lease-level state machine.
+"""SandboxRuntimeHandle - durable compute handle with lease-level state machine.
 
 Architecture:
-    SandboxLease (durable) -> SandboxInstance (ephemeral)
+    SandboxRuntimeHandle (durable) -> SandboxInstance (ephemeral)
 
 State machine contract:
-- Physical lifecycle writes must go through SQLiteLease.apply(event).
+- Physical lifecycle writes must go through SQLiteSandboxRuntimeHandle.apply(event).
 - Lease snapshot stores desired_state + observed_state + version.
 """
 
@@ -110,7 +110,7 @@ class SandboxInstance:
     created_at: datetime
 
 
-class SandboxLease(ABC):
+class SandboxRuntimeHandle(ABC):
     """Durable shared compute handle."""
 
     def __init__(
@@ -186,7 +186,7 @@ class SandboxLease(ABC):
     ) -> dict[str, Any]: ...
 
 
-class SQLiteLease(SandboxLease):
+class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
     """SQLite-backed lease implementation."""
 
     _lock_guard = threading.Lock()
@@ -705,7 +705,7 @@ class SQLiteLease(SandboxLease):
         if row:
             self._sync_from(sandbox_runtime_from_row(row, self.db_path))
 
-    def _sync_from(self, other: SQLiteLease) -> None:
+    def _sync_from(self, other: SQLiteSandboxRuntimeHandle) -> None:
         self._current_instance = other._current_instance
         self.status = other.status
         self.workspace_key = other.workspace_key
@@ -1105,8 +1105,8 @@ class SQLiteLease(SandboxLease):
         self._persist_lease_metadata()
 
 
-def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteLease:
-    """Construct SQLiteLease from a dict returned by the repo."""
+def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteSandboxRuntimeHandle:
+    """Construct SQLiteSandboxRuntimeHandle from a dict returned by the repo."""
     instance = None
     inst_data = row.get("_instance")
     if inst_data:
@@ -1132,7 +1132,7 @@ def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteLease:
     if row.get("refresh_hint_at"):
         refresh_hint_at = parse_runtime_datetime(str(row["refresh_hint_at"]))
 
-    return SQLiteLease(
+    return SQLiteSandboxRuntimeHandle(
         lease_id=row["lease_id"],
         provider_name=row["provider_name"],
         recipe_id=row.get("recipe_id"),

--- a/sandbox/provider.py
+++ b/sandbox/provider.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
 
@@ -194,7 +194,7 @@ class SandboxProvider(ABC):
         pass
 
     @abstractmethod
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         """Create the appropriate PhysicalTerminalRuntime for this provider."""
 
     def get_metrics_via_commands(self, session_id: str) -> Metrics | None:

--- a/sandbox/providers/agentbay.py
+++ b/sandbox/providers/agentbay.py
@@ -24,7 +24,7 @@ from sandbox.provider import (
 )
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
 
@@ -482,7 +482,7 @@ class AgentBayProvider(SandboxProvider):
             setattr(session, "mcp_tools", tools)
             setattr(session, "mcpTools", tools)
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.runtime import RemoteWrappedRuntime
 
         return RemoteWrappedRuntime(terminal, lease, self)

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -54,7 +54,7 @@ def _is_daytona_not_found_error(exc: Exception) -> bool:
 if TYPE_CHECKING:
     from daytona_sdk._sync.sandbox import Sandbox as DaytonaSandbox
 
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
 
@@ -511,7 +511,7 @@ class DaytonaProvider(SandboxProvider):
                 time.sleep(2)
         raise RuntimeError(f"Timed out waiting for Daytona sandbox {sandbox_id} to reach started state")
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.providers.daytona import DaytonaSessionRuntime
 
         return DaytonaSessionRuntime(terminal, lease, self)

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -38,7 +38,7 @@ from sandbox.runtime import (
 )
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
 
@@ -408,7 +408,7 @@ class DockerProvider(SandboxProvider):
             return
         raise RuntimeError(f"Unsupported copy source path type: {source}")
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         return DockerPtyRuntime(terminal, lease, self)
 
     @overload

--- a/sandbox/providers/e2b.py
+++ b/sandbox/providers/e2b.py
@@ -26,7 +26,7 @@ from sandbox.provider import (
 )
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
 
@@ -375,7 +375,7 @@ class E2BProvider(SandboxProvider):
         """Expose native SDK sandbox for runtime-level persistent terminal handling."""
         return self._get_sandbox(session_id)
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.providers.e2b import E2BPtyRuntime
 
         return E2BPtyRuntime(terminal, lease, self)

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -23,7 +23,7 @@ from sandbox.provider import (
 )
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.runtime import PhysicalTerminalRuntime
     from sandbox.terminal import AbstractTerminal
 
@@ -282,7 +282,7 @@ class LocalSessionProvider(SandboxProvider):
         idle = values[3] + values[4]
         return total, idle
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxLease) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.providers.local import LocalPersistentShellRuntime
 
         return LocalPersistentShellRuntime(terminal, lease)

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sandbox.lease import SandboxLease
+    from sandbox.lease import SandboxRuntimeHandle
     from sandbox.provider import SandboxProvider
     from sandbox.terminal import AbstractTerminal, TerminalState
 
@@ -325,14 +325,14 @@ class PhysicalTerminalRuntime(ABC):
 
     Does NOT:
     - Own terminal identity (that's AbstractTerminal)
-    - Own compute lifecycle (that's SandboxLease)
+    - Own compute lifecycle (that's SandboxRuntimeHandle)
     - Outlive ChatSession
     """
 
     def __init__(
         self,
         terminal: AbstractTerminal,
-        lease: SandboxLease,
+        lease: SandboxRuntimeHandle,
     ):
         self.terminal = terminal
         self.lease = lease
@@ -838,7 +838,7 @@ class _RemoteRuntimeBase(PhysicalTerminalRuntime):
     def __init__(
         self,
         terminal: AbstractTerminal,
-        lease: SandboxLease,
+        lease: SandboxRuntimeHandle,
         provider: SandboxProvider,
     ):
         super().__init__(terminal, lease)
@@ -905,7 +905,7 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
     def __init__(
         self,
         terminal: AbstractTerminal,
-        lease: SandboxLease,
+        lease: SandboxRuntimeHandle,
         provider: SandboxProvider,
     ):
         super().__init__(terminal, lease, provider)

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -4,7 +4,7 @@ This module implements the terminal abstraction layer that separates
 durable terminal state (cwd, env_delta) from ephemeral runtime processes.
 
 Architecture:
-    Thread → AbstractTerminal (durable state) → SandboxLease → Instance
+    Thread → AbstractTerminal (durable state) → SandboxRuntimeHandle → Instance
     Thread → ChatSession → PhysicalTerminalRuntime (ephemeral process)
 """
 

--- a/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
+++ b/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
@@ -2,7 +2,7 @@ import uuid
 from pathlib import Path
 
 import sandbox.lease as sandbox_lease_module
-from sandbox.lease import SandboxInstance, SQLiteLease
+from sandbox.lease import SandboxInstance, SQLiteSandboxRuntimeHandle
 
 
 class _FakeLeaseRepo:
@@ -157,7 +157,7 @@ def test_observe_status_detached_clears_sandbox_provider_env(monkeypatch) -> Non
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: fake_event_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
 
-    lease = SQLiteLease(
+    lease = SQLiteSandboxRuntimeHandle(
         lease_id="lease-1",
         provider_name="local",
         current_instance=SandboxInstance(
@@ -228,7 +228,7 @@ def test_ensure_active_instance_sets_sandbox_provider_env_from_adopted_instance(
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: _FakeEventRepo())
 
-    lease = SQLiteLease(
+    lease = SQLiteSandboxRuntimeHandle(
         lease_id="lease-1",
         provider_name="local",
         db_path=Path("/tmp/fake-sandbox.db"),


### PR DESCRIPTION
## Summary
- rename SandboxLease / SQLiteLease class names to sandbox runtime handle wording
- realign direct provider/runtime/chat-session/type-hint consumers to the new class names
- keep PTY and terminal table semantics unchanged in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py`
- [x] `git diff --check`
