### PR TITLE
refactor: rename sandbox runtime interfaces

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -70,7 +70,7 @@ class ChatSession:
         session_id: str,
         thread_id: str,
         terminal: AbstractTerminal,
-        lease: SandboxRuntimeHandle,
+        sandbox_runtime: SandboxRuntimeHandle,
         runtime: PhysicalTerminalRuntime,
         policy: ChatSessionPolicy,
         started_at: datetime,
@@ -87,7 +87,7 @@ class ChatSession:
         self.session_id = session_id
         self.thread_id = thread_id
         self.terminal = terminal
-        self.lease = lease
+        self.lease = sandbox_runtime
         self.runtime = runtime
         self.policy = policy
         self.started_at = started_at
@@ -179,8 +179,8 @@ class ChatSessionManager:
         if error:
             raise error[0]
 
-    def _build_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
-        return self.provider.create_runtime(terminal, lease)
+    def _build_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+        return self.provider.create_runtime(terminal, sandbox_runtime)
 
     def get(self, thread_id: str, terminal_id: str | None = None) -> ChatSession | None:
         if terminal_id is None:
@@ -234,16 +234,16 @@ class ChatSessionManager:
         finally:
             if own_lease_repo:
                 _lease_repo.close()
-        lease = sandbox_runtime_from_row(_lease_row, self.db_path) if _lease_row else None
-        if not terminal or not lease:
+        sandbox_runtime = sandbox_runtime_from_row(_lease_row, self.db_path) if _lease_row else None
+        if not terminal or not sandbox_runtime:
             return None
 
         session = ChatSession(
             session_id=row["session_id"],
             thread_id=row["thread_id"],
             terminal=terminal,
-            lease=lease,
-            runtime=self._build_runtime(terminal, lease),
+            lease=sandbox_runtime,
+            runtime=self._build_runtime(terminal, sandbox_runtime),
             policy=ChatSessionPolicy(
                 idle_ttl_sec=row["idle_ttl_sec"],
                 max_duration_sec=row["max_duration_sec"],
@@ -271,7 +271,7 @@ class ChatSessionManager:
         session_id: str,
         thread_id: str,
         terminal: AbstractTerminal,
-        lease: SandboxRuntimeHandle,
+        sandbox_runtime: SandboxRuntimeHandle,
         policy: ChatSessionPolicy | None = None,
     ) -> ChatSession:
         policy = policy or self.default_policy
@@ -282,14 +282,14 @@ class ChatSessionManager:
             self._close_runtime(existing, reason="superseded")
             self._live_sessions.pop(terminal.terminal_id, None)
 
-        runtime = self._build_runtime(terminal, lease)
+        runtime = self._build_runtime(terminal, sandbox_runtime)
         runtime_id = getattr(runtime, "runtime_id", None)
 
         self._repo.create_session(
             session_id=session_id,
             thread_id=thread_id,
             terminal_id=terminal.terminal_id,
-            lease_id=lease.lease_id,
+            lease_id=sandbox_runtime.lease_id,
             runtime_id=runtime_id,
             status="active",
             idle_ttl_sec=policy.idle_ttl_sec,
@@ -302,7 +302,7 @@ class ChatSessionManager:
             session_id=session_id,
             thread_id=thread_id,
             terminal=terminal,
-            lease=lease,
+            sandbox_runtime=sandbox_runtime,
             runtime=runtime,
             policy=policy,
             started_at=now,

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -588,7 +588,7 @@ class SandboxManager:
             session_id=f"sess-{uuid.uuid4().hex[:12]}",
             thread_id=thread_id,
             terminal=terminal,
-            lease=lease,
+            sandbox_runtime=lease,
         )
 
     def _terminal_is_busy(self, terminal_id: str) -> bool:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -545,7 +545,7 @@ class SandboxManager:
             session_id=session_id,
             thread_id=thread_id,
             terminal=terminal,
-            lease=lease,
+            sandbox_runtime=lease,
         )
 
         if instance and storage is not None:

--- a/sandbox/provider.py
+++ b/sandbox/provider.py
@@ -194,7 +194,7 @@ class SandboxProvider(ABC):
         pass
 
     @abstractmethod
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         """Create the appropriate PhysicalTerminalRuntime for this provider."""
 
     def get_metrics_via_commands(self, session_id: str) -> Metrics | None:

--- a/sandbox/providers/agentbay.py
+++ b/sandbox/providers/agentbay.py
@@ -482,7 +482,7 @@ class AgentBayProvider(SandboxProvider):
             setattr(session, "mcp_tools", tools)
             setattr(session, "mcpTools", tools)
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.runtime import RemoteWrappedRuntime
 
-        return RemoteWrappedRuntime(terminal, lease, self)
+        return RemoteWrappedRuntime(terminal, sandbox_runtime, self)

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -511,10 +511,10 @@ class DaytonaProvider(SandboxProvider):
                 time.sleep(2)
         raise RuntimeError(f"Timed out waiting for Daytona sandbox {sandbox_id} to reach started state")
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.providers.daytona import DaytonaSessionRuntime
 
-        return DaytonaSessionRuntime(terminal, lease, self)
+        return DaytonaSessionRuntime(terminal, sandbox_runtime, self)
 
 
 # ── Runtime ──────────────────────────────────────────────────────────────────
@@ -541,8 +541,8 @@ from sandbox.runtime import (  # noqa: E402
 class DaytonaSessionRuntime(_RemoteRuntimeBase):
     """Daytona runtime using native PTY session API (persistent terminal semantics)."""
 
-    def __init__(self, terminal, lease, provider):
-        super().__init__(terminal, lease, provider)
+    def __init__(self, terminal, sandbox_runtime, provider):
+        super().__init__(terminal, sandbox_runtime, provider)
         self._session_lock = asyncio.Lock()
         self._pty_session_id = f"leon-pty-{terminal.terminal_id[-12:]}"
         self._bound_instance_id: str | None = None

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -408,8 +408,8 @@ class DockerProvider(SandboxProvider):
             return
         raise RuntimeError(f"Unsupported copy source path type: {source}")
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
-        return DockerPtyRuntime(terminal, lease, self)
+    def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+        return DockerPtyRuntime(terminal, sandbox_runtime, self)
 
     @overload
     def _get_container_id(self, session_id: str, allow_missing: Literal[False] = False) -> str: ...
@@ -520,8 +520,8 @@ class DockerProvider(SandboxProvider):
 class DockerPtyRuntime(_RemoteRuntimeBase):
     """Docker runtime using a persistent PTY shell inside container."""
 
-    def __init__(self, terminal, lease, provider):
-        super().__init__(terminal, lease, provider)
+    def __init__(self, terminal, sandbox_runtime, provider):
+        super().__init__(terminal, sandbox_runtime, provider)
         self._session_lock = asyncio.Lock()
         self._bound_instance_id: str | None = None
         self._pty_session: _SubprocessPtySession | None = None

--- a/sandbox/providers/e2b.py
+++ b/sandbox/providers/e2b.py
@@ -375,10 +375,10 @@ class E2BProvider(SandboxProvider):
         """Expose native SDK sandbox for runtime-level persistent terminal handling."""
         return self._get_sandbox(session_id)
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.providers.e2b import E2BPtyRuntime
 
-        return E2BPtyRuntime(terminal, lease, self)
+        return E2BPtyRuntime(terminal, sandbox_runtime, self)
 
 
 # ── Runtime ──────────────────────────────────────────────────────────────────
@@ -402,8 +402,8 @@ from sandbox.runtime import (  # noqa: E402
 class E2BPtyRuntime(_RemoteRuntimeBase):
     """E2B runtime using native SDK PTY handle for persistent shell."""
 
-    def __init__(self, terminal, lease, provider):
-        super().__init__(terminal, lease, provider)
+    def __init__(self, terminal, sandbox_runtime, provider):
+        super().__init__(terminal, sandbox_runtime, provider)
         self._session_lock = asyncio.Lock()
         self._bound_instance_id: str | None = None
         self._pty_pid: int | None = None

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -282,10 +282,10 @@ class LocalSessionProvider(SandboxProvider):
         idle = values[3] + values[4]
         return total, idle
 
-    def create_runtime(self, terminal: AbstractTerminal, lease: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
+    def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
         from sandbox.providers.local import LocalPersistentShellRuntime
 
-        return LocalPersistentShellRuntime(terminal, lease)
+        return LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
 
 # ── Runtime ──────────────────────────────────────────────────────────────────
@@ -348,10 +348,10 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
     def __init__(
         self,
         terminal,
-        lease,
+        sandbox_runtime,
         shell_command: tuple[str, ...] = ("/bin/bash",),
     ):
-        super().__init__(terminal, lease)
+        super().__init__(terminal, sandbox_runtime)
         self.shell_command = shell_command
         self._pty_session: _SubprocessPtySession | None = None
         self._session_lock = asyncio.Lock()

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -332,10 +332,10 @@ class PhysicalTerminalRuntime(ABC):
     def __init__(
         self,
         terminal: AbstractTerminal,
-        lease: SandboxRuntimeHandle,
+        sandbox_runtime: SandboxRuntimeHandle,
     ):
         self.terminal = terminal
-        self.lease = lease
+        self.lease = sandbox_runtime
         self.runtime_id = f"runtime-{uuid.uuid4().hex[:12]}"
         self.chat_session_id: str | None = None
         self._commands: dict[str, AsyncCommand] = {}
@@ -838,10 +838,10 @@ class _RemoteRuntimeBase(PhysicalTerminalRuntime):
     def __init__(
         self,
         terminal: AbstractTerminal,
-        lease: SandboxRuntimeHandle,
+        sandbox_runtime: SandboxRuntimeHandle,
         provider: SandboxProvider,
     ):
-        super().__init__(terminal, lease)
+        super().__init__(terminal, sandbox_runtime)
         self.provider = provider
 
     @staticmethod
@@ -905,10 +905,10 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
     def __init__(
         self,
         terminal: AbstractTerminal,
-        lease: SandboxRuntimeHandle,
+        sandbox_runtime: SandboxRuntimeHandle,
         provider: SandboxProvider,
     ):
-        super().__init__(terminal, lease, provider)
+        super().__init__(terminal, sandbox_runtime, provider)
 
     def _execute_once(self, command: str, timeout: float | None = None) -> ExecuteResult:
         instance = self.lease.ensure_active_instance(self.provider)

--- a/tests/Unit/sandbox/test_sandbox_runtime_interface_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_interface_naming.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import inspect
+
+from sandbox.provider import SandboxProvider
+from sandbox.providers.agentbay import AgentBayProvider
+from sandbox.providers.daytona import DaytonaProvider
+from sandbox.providers.docker import DockerProvider
+from sandbox.providers.e2b import E2BProvider
+from sandbox.providers.local import LocalSessionProvider
+
+
+def test_create_runtime_interface_uses_sandbox_runtime_parameter_name() -> None:
+    parameter_names = list(inspect.signature(SandboxProvider.create_runtime).parameters)
+
+    assert parameter_names == ["self", "terminal", "sandbox_runtime"]
+
+
+def test_concrete_providers_use_sandbox_runtime_parameter_name() -> None:
+    for provider_cls in [LocalSessionProvider, DockerProvider, E2BProvider, DaytonaProvider, AgentBayProvider]:
+        parameter_names = list(inspect.signature(provider_cls.create_runtime).parameters)
+        assert parameter_names == ["self", "terminal", "sandbox_runtime"]


### PR DESCRIPTION
## Summary
- rename sandbox runtime interface parameter names from lease wording to sandbox runtime wording
- realign direct provider/runtime/chat-session constructor chains to the new parameter names
- add an interface naming regression test without changing PTY or terminal-table semantics

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_runtime_interface_naming.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py`
- [x] `git diff --check`
