### PR TITLE
refactor: rename runtime object attributes

### DIFF
--- a/backend/threads/run/lifecycle.py
+++ b/backend/threads/run/lifecycle.py
@@ -16,9 +16,9 @@ async def prime_sandbox(agent: Any, thread_id: str) -> None:
         mgr = agent._sandbox.manager
         mgr.enforce_idle_timeouts()
         capability = mgr.get_sandbox(thread_id)
-        lease = getattr(getattr(capability, "_session", None), "lease", None)
-        if lease:
-            lease_status = lease.refresh_instance_status(mgr.provider)
+        sandbox_runtime = getattr(getattr(capability, "_session", None), "sandbox_runtime", None)
+        if sandbox_runtime:
+            lease_status = sandbox_runtime.refresh_instance_status(mgr.provider)
             if lease_status == "paused" and mgr.provider_capability.can_resume and not agent._sandbox.resume_thread(thread_id):
                 raise RuntimeError(f"Failed to auto-resume paused sandbox for thread {thread_id}")
 

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -58,10 +58,10 @@ class SandboxCapability:
         """Resolve current session info without exposing internal session object."""
         from sandbox.provider import SessionInfo
 
-        instance = self._session.lease.get_instance()
+        instance = self._session.sandbox_runtime.get_instance()
         provider = getattr(self._session.runtime, "provider", None)
         if not instance and provider is not None:
-            instance = self._session.lease.ensure_active_instance(provider)
+            instance = self._session.sandbox_runtime.ensure_active_instance(provider)
         return SessionInfo(
             session_id=instance.instance_id if instance else "local",
             provider=provider_name,
@@ -168,7 +168,7 @@ class _CommandWrapper(BaseExecutor):
             session_id=f"sess-{uuid.uuid4().hex[:12]}",
             thread_id=self._session.thread_id,
             terminal=terminal,
-            lease=lease,
+            sandbox_runtime=lease,
         )
 
     def _resolve_session_for_command(self, command_id: str):
@@ -212,15 +212,15 @@ class _FileSystemWrapper(FileSystemBackend):
         provider = getattr(self._session.runtime, "provider", None)
         if provider is not None:
             try:
-                instance = self._session.lease.ensure_active_instance(provider)
+                instance = self._session.sandbox_runtime.ensure_active_instance(provider)
             except RuntimeError:
-                if self._manager is None or getattr(self._session.lease, "observed_state", None) != "paused":
+                if self._manager is None or getattr(self._session.sandbox_runtime, "observed_state", None) != "paused":
                     raise
                 if not self._manager.resume_session(self._session.thread_id, source="auto_resume"):
                     raise
-                instance = self._session.lease.ensure_active_instance(provider)
+                instance = self._session.sandbox_runtime.ensure_active_instance(provider)
         else:
-            instance = self._session.lease.get_instance()
+            instance = self._session.sandbox_runtime.get_instance()
             if not instance:
                 raise RuntimeError("No active instance")
         return instance.instance_id

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -87,7 +87,7 @@ class ChatSession:
         self.session_id = session_id
         self.thread_id = thread_id
         self.terminal = terminal
-        self.lease = sandbox_runtime
+        self.sandbox_runtime = sandbox_runtime
         self.runtime = runtime
         self.policy = policy
         self.started_at = started_at
@@ -242,7 +242,7 @@ class ChatSessionManager:
             session_id=row["session_id"],
             thread_id=row["thread_id"],
             terminal=terminal,
-            lease=sandbox_runtime,
+            sandbox_runtime=sandbox_runtime,
             runtime=self._build_runtime(terminal, sandbox_runtime),
             policy=ChatSessionPolicy(
                 idle_ttl_sec=row["idle_ttl_sec"],

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -250,7 +250,7 @@ class SandboxManager:
 
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
         self.terminal_store = make_terminal_repo(db_path=self.db_path)
-        self.sandbox_runtime_store = make_lease_repo(db_path=self.db_path)
+        self.lease_store = make_lease_repo(db_path=self.db_path)
 
         self.session_manager = ChatSessionManager(
             provider=provider,
@@ -258,7 +258,7 @@ class SandboxManager:
             default_policy=ChatSessionPolicy(),
             chat_session_repo=make_chat_session_repo(db_path=self.db_path),
             terminal_repo=self.terminal_store,
-            lease_repo=self.sandbox_runtime_store,
+            lease_repo=self.lease_store,
         )
 
         from sandbox.volume import SandboxVolume
@@ -270,14 +270,14 @@ class SandboxManager:
 
     def _get_sandbox_runtime(self, lease_id: str):
         """Get sandbox runtime as domain object, or None."""
-        row = self.sandbox_runtime_store.get(lease_id)
+        row = self.lease_store.get(lease_id)
         if row is None:
             return None
         return sandbox_runtime_from_row(row, self.db_path)
 
     def _create_sandbox_runtime(self, lease_id: str, provider_name: str):
         """Create sandbox runtime and return as domain object."""
-        row = self.sandbox_runtime_store.create(lease_id, provider_name)
+        row = self.lease_store.create(lease_id, provider_name)
         return sandbox_runtime_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
@@ -452,7 +452,7 @@ class SandboxManager:
     def close(self):
         self.session_manager.close(reason="manager_close")
         self.terminal_store.close()
-        self.sandbox_runtime_store.close()
+        self.lease_store.close()
 
     def get_sandbox(self, thread_id: str, bind_mounts: list | None = None) -> SandboxCapability:
         from sandbox.thread_context import set_current_thread_id
@@ -891,7 +891,7 @@ class SandboxManager:
 
         seen_instance_ids: set[str] = set()
 
-        for lease_row in self.sandbox_runtime_store.list_by_provider(self.provider.name):
+        for lease_row in self.lease_store.list_by_provider(self.provider.name):
             lease_id = lease_row["lease_id"]
             lease = self._get_sandbox_runtime(lease_id)
             if not lease:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -250,7 +250,7 @@ class SandboxManager:
 
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
         self.terminal_store = make_terminal_repo(db_path=self.db_path)
-        self.lease_store = make_lease_repo(db_path=self.db_path)
+        self.sandbox_runtime_store = make_lease_repo(db_path=self.db_path)
 
         self.session_manager = ChatSessionManager(
             provider=provider,
@@ -258,7 +258,7 @@ class SandboxManager:
             default_policy=ChatSessionPolicy(),
             chat_session_repo=make_chat_session_repo(db_path=self.db_path),
             terminal_repo=self.terminal_store,
-            lease_repo=self.lease_store,
+            lease_repo=self.sandbox_runtime_store,
         )
 
         from sandbox.volume import SandboxVolume
@@ -270,14 +270,14 @@ class SandboxManager:
 
     def _get_sandbox_runtime(self, lease_id: str):
         """Get sandbox runtime as domain object, or None."""
-        row = self.lease_store.get(lease_id)
+        row = self.sandbox_runtime_store.get(lease_id)
         if row is None:
             return None
         return sandbox_runtime_from_row(row, self.db_path)
 
     def _create_sandbox_runtime(self, lease_id: str, provider_name: str):
         """Create sandbox runtime and return as domain object."""
-        row = self.lease_store.create(lease_id, provider_name)
+        row = self.sandbox_runtime_store.create(lease_id, provider_name)
         return sandbox_runtime_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
@@ -443,7 +443,7 @@ class SandboxManager:
         session = self.session_manager.get(thread_id, terminal.terminal_id)
         if not session:
             return False
-        instance = session.lease.get_instance()
+        instance = session.sandbox_runtime.get_instance()
         if not instance:
             return False
         self._sync_to_sandbox(thread_id, instance.instance_id, files=files)
@@ -452,7 +452,7 @@ class SandboxManager:
     def close(self):
         self.session_manager.close(reason="manager_close")
         self.terminal_store.close()
-        self.lease_store.close()
+        self.sandbox_runtime_store.close()
 
     def get_sandbox(self, thread_id: str, bind_mounts: list | None = None) -> SandboxCapability:
         from sandbox.thread_context import set_current_thread_id
@@ -462,19 +462,19 @@ class SandboxManager:
         terminal = self._get_active_terminal(thread_id)
         session = self.session_manager.get(thread_id, terminal.terminal_id) if terminal else None
         if session:
-            self._assert_lease_provider(session.lease, thread_id)
+            self._assert_lease_provider(session.sandbox_runtime, thread_id)
             # @@@activity-resume - Any new activity against a paused thread must resume before command execution.
-            if session.status == "paused" or getattr(session.lease, "observed_state", None) == "paused":
+            if session.status == "paused" or getattr(session.sandbox_runtime, "observed_state", None) == "paused":
                 if not self.resume_session(thread_id, source="auto_resume"):
                     raise RuntimeError(f"Failed to resume paused session for thread {thread_id}")
                 session = self.session_manager.get(thread_id, session.terminal.terminal_id)
                 if not session:
                     raise RuntimeError(f"Session disappeared after resume for thread {thread_id}")
-                self._assert_lease_provider(session.lease, thread_id)
+                self._assert_lease_provider(session.sandbox_runtime, thread_id)
             # Stamp bind_mounts on provider thread state so lazy create_session paths pick them up
             if bind_mounts:
                 self.provider.set_thread_bind_mounts(thread_id, bind_mounts)
-            self._ensure_bound_instance(session.lease)
+            self._ensure_bound_instance(session.sandbox_runtime)
             return SandboxCapability(session, manager=self)
 
         if not terminal:
@@ -503,8 +503,8 @@ class SandboxManager:
                     raise RuntimeError(f"Failed to resume paused session for thread {thread_id}")
                 session = self.session_manager.get(thread_id, terminal.terminal_id)
                 if session:
-                    self._assert_lease_provider(session.lease, thread_id)
-                    self._ensure_bound_instance(session.lease)
+                    self._assert_lease_provider(session.sandbox_runtime, thread_id)
+                    self._ensure_bound_instance(session.sandbox_runtime)
                     return SandboxCapability(session, manager=self)
                 lease = self._get_sandbox_runtime(terminal.lease_id)
                 if not lease:
@@ -776,10 +776,10 @@ class SandboxManager:
         for terminal in terminals:
             session = self.session_manager.get(thread_id, terminal.terminal_id)
             if session:
-                session.lease = lease
+                session.sandbox_runtime = lease
                 runtime = getattr(session, "runtime", None)
                 if runtime is not None:
-                    runtime.lease = lease
+                    runtime.sandbox_runtime = lease
                 self.session_manager.resume(session.session_id)
                 resumed_any = True
 
@@ -891,7 +891,7 @@ class SandboxManager:
 
         seen_instance_ids: set[str] = set()
 
-        for lease_row in self.lease_store.list_by_provider(self.provider.name):
+        for lease_row in self.sandbox_runtime_store.list_by_provider(self.provider.name):
             lease_id = lease_row["lease_id"]
             lease = self._get_sandbox_runtime(lease_id)
             if not lease:

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -658,7 +658,7 @@ class DaytonaSessionRuntime(_RemoteRuntimeBase):
                         on_stdout_chunk(delta)
 
     def _ensure_session_sync(self, timeout: float | None):
-        instance = self.lease.ensure_active_instance(self.provider)
+        instance = self.sandbox_runtime.ensure_active_instance(self.provider)
         if self._bound_instance_id != instance.instance_id:
             self._close_shell_sync()
             self._bound_instance_id = instance.instance_id

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -533,7 +533,7 @@ class DockerPtyRuntime(_RemoteRuntimeBase):
         self._pty_session = None
 
     def _ensure_shell_sync(self, timeout: float | None) -> _SubprocessPtySession:
-        instance = self.lease.ensure_active_instance(self.provider)
+        instance = self.sandbox_runtime.ensure_active_instance(self.provider)
         if self._bound_instance_id != instance.instance_id:
             self._close_shell_sync()
             self._bound_instance_id = instance.instance_id

--- a/sandbox/providers/e2b.py
+++ b/sandbox/providers/e2b.py
@@ -440,7 +440,7 @@ class E2BPtyRuntime(_RemoteRuntimeBase):
         return cast(_E2BSandboxHandle, super()._provider_sandbox(instance_id))
 
     def _ensure_shell_sync(self, timeout: float | None) -> tuple[_E2BSandboxHandle, int]:
-        instance = self.lease.ensure_active_instance(self.provider)
+        instance = self.sandbox_runtime.ensure_active_instance(self.provider)
         if self._bound_instance_id != instance.instance_id:
             self._bound_instance_id = instance.instance_id
             self._pty_pid = None

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -380,8 +380,8 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
         timeout: float | None,
         on_stdout_chunk: Callable[[str], None] | None = None,
     ) -> ExecuteResult:
-        if self.lease.observed_state == "paused":
-            raise RuntimeError(f"Sandbox lease {self.lease.lease_id} is paused. Resume before executing commands.")
+        if self.sandbox_runtime.observed_state == "paused":
+            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.lease_id} is paused. Resume before executing commands.")
 
         state = self.terminal.get_state()
         start, end, script = _build_windows_shell_script(command, cwd=state.cwd, env_delta=state.env_delta)
@@ -427,8 +427,8 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
         if self._use_windows_shell:
             return self._execute_windows_once_sync(command, timeout, on_stdout_chunk=on_stdout_chunk)
 
-        if self.lease.observed_state == "paused":
-            raise RuntimeError(f"Sandbox lease {self.lease.lease_id} is paused. Resume before executing commands.")
+        if self.sandbox_runtime.observed_state == "paused":
+            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.lease_id} is paused. Resume before executing commands.")
 
         state = self.terminal.get_state()
         pty_session = self._ensure_session_sync(timeout)

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -335,7 +335,7 @@ class PhysicalTerminalRuntime(ABC):
         sandbox_runtime: SandboxRuntimeHandle,
     ):
         self.terminal = terminal
-        self.lease = sandbox_runtime
+        self.sandbox_runtime = sandbox_runtime
         self.runtime_id = f"runtime-{uuid.uuid4().hex[:12]}"
         self.chat_session_id: str | None = None
         self._commands: dict[str, AsyncCommand] = {}
@@ -877,13 +877,13 @@ class _RemoteRuntimeBase(PhysicalTerminalRuntime):
 
     def _recover_infra(self) -> None:
         # @@@infra-recovery - Refresh provider truth once, then resume/recreate and retry command exactly once.
-        status = self.lease.refresh_instance_status(self.provider, force=True, max_age_sec=0)
+        status = self.sandbox_runtime.refresh_instance_status(self.provider, force=True, max_age_sec=0)
         if status == "paused":
-            if not self.lease.resume_instance(self.provider):
-                raise RuntimeError(f"Failed to resume paused lease {self.lease.lease_id}")
+            if not self.sandbox_runtime.resume_instance(self.provider):
+                raise RuntimeError(f"Failed to resume paused lease {self.sandbox_runtime.lease_id}")
             return
         if status in {"detached", "unknown"}:
-            self.lease.ensure_active_instance(self.provider)
+            self.sandbox_runtime.ensure_active_instance(self.provider)
 
     def _provider_sandbox(self, instance_id: str):
         getter = getattr(self.provider, "get_runtime_sandbox", None)
@@ -911,13 +911,13 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
         super().__init__(terminal, sandbox_runtime, provider)
 
     def _execute_once(self, command: str, timeout: float | None = None) -> ExecuteResult:
-        instance = self.lease.ensure_active_instance(self.provider)
+        instance = self.sandbox_runtime.ensure_active_instance(self.provider)
         state = self.terminal.get_state()
         timeout_ms = int(timeout * 1000) if timeout else 30000
         print(
             "[RemoteWrappedRuntime._execute_once] "
             f"thread_id={self.terminal.thread_id} "
-            f"lease_id={self.lease.lease_id} "
+            f"lease_id={self.sandbox_runtime.lease_id} "
             f"instance_id={instance.instance_id} "
             f"provider={getattr(self.provider, 'name', '?')} "
             f"cwd={state.cwd!r} "

--- a/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
+++ b/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from backend.monitor.application.use_cases import provider_runtimes as monitor_provider_runtime_service
+from backend.monitor.infrastructure.providers import provider_runtime_inventory_service as monitor_provider_runtime_inventory_service
 from backend.sandboxes import service as sandbox_service
 
 LOWER_RUNTIME_KEY = "lease_" + "id"
@@ -23,7 +24,7 @@ def _provider_runtime(runtime_id: str, status: str = "paused"):
 
 
 def test_monitor_provider_orphan_runtimes_do_not_refresh_all_managed_runtime_rows(monkeypatch):
-    monkeypatch.setattr(sandbox_service, "list_provider_orphan_runtimes", lambda: [])
+    monkeypatch.setattr(monitor_provider_runtime_inventory_service, "load_provider_orphan_runtime_rows", lambda: [])
 
     assert monitor_provider_runtime_service.list_monitor_provider_orphan_runtimes() == {"count": 0, "runtimes": []}
 

--- a/tests/Unit/backend/web/services/test_streaming_prime_sandbox.py
+++ b/tests/Unit/backend/web/services/test_streaming_prime_sandbox.py
@@ -11,7 +11,7 @@ from backend.threads.streaming import prime_sandbox
 async def test_prime_sandbox_uses_capability_session_not_terminal_lookup() -> None:
     resume_calls: list[str] = []
     lease = SimpleNamespace(refresh_instance_status=lambda _provider: "running")
-    capability = SimpleNamespace(_session=SimpleNamespace(lease=lease))
+    capability = SimpleNamespace(_session=SimpleNamespace(sandbox_runtime=lease))
     manager = SimpleNamespace(
         enforce_idle_timeouts=lambda: None,
         get_sandbox=lambda thread_id: capability,
@@ -35,7 +35,7 @@ async def test_prime_sandbox_uses_capability_session_not_terminal_lookup() -> No
 async def test_prime_sandbox_resumes_paused_lease_from_capability_session() -> None:
     resume_calls: list[str] = []
     lease = SimpleNamespace(refresh_instance_status=lambda _provider: "paused")
-    capability = SimpleNamespace(_session=SimpleNamespace(lease=lease))
+    capability = SimpleNamespace(_session=SimpleNamespace(sandbox_runtime=lease))
     manager = SimpleNamespace(
         enforce_idle_timeouts=lambda: None,
         get_sandbox=lambda thread_id: capability,

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1103,7 +1103,7 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
 
     parent_capability = manager.get_sandbox(parent_thread_id)
     parent_terminal_id = parent_capability._session.terminal.terminal_id
-    parent_lower_runtime_id = getattr(parent_capability._session.lease, lower_runtime_key)
+    parent_lower_runtime_id = getattr(parent_capability._session.sandbox_runtime, lower_runtime_key)
 
     class _LeaseCapturingChild(_FakeChildAgent):
         async def _astream(self, *args, **kwargs):
@@ -1111,7 +1111,7 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
             assert current_thread_id is not None
             child_capability = manager.get_sandbox(current_thread_id)
             observed["child_terminal_id"] = child_capability._session.terminal.terminal_id
-            observed["child_lower_runtime_id"] = getattr(child_capability._session.lease, lower_runtime_key)
+            observed["child_lower_runtime_id"] = getattr(child_capability._session.sandbox_runtime, lower_runtime_key)
             if False:
                 yield None
             return
@@ -1121,7 +1121,7 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
     async def _fake_run_child_thread_live(agent, thread_id, message, app, *, input_messages):
         child_capability = manager.get_sandbox(thread_id)
         observed["child_terminal_id"] = child_capability._session.terminal.terminal_id
-        observed["child_lower_runtime_id"] = getattr(child_capability._session.lease, lower_runtime_key)
+        observed["child_lower_runtime_id"] = getattr(child_capability._session.sandbox_runtime, lower_runtime_key)
         return "(Agent completed with no text output)"
 
     set_current_thread_id(parent_thread_id)

--- a/tests/Unit/core/test_capability_async.py
+++ b/tests/Unit/core/test_capability_async.py
@@ -182,7 +182,7 @@ def test_filesystem_wrapper_auto_resumes_paused_lease_before_listing():
         def __init__(self):
             self.thread_id = "thread-paused"
             self.terminal = _DummyTerminal()
-            self.lease = lease
+            self.sandbox_runtime = lease
             self.runtime = SimpleNamespace(provider=provider)
             self.touches = 0
 
@@ -225,7 +225,7 @@ def test_filesystem_wrapper_derives_remote_file_size_from_parent_listing():
         def __init__(self):
             self.thread_id = "thread-size"
             self.terminal = _DummyTerminal()
-            self.lease = _Lease()
+            self.sandbox_runtime = _Lease()
             self.runtime = SimpleNamespace(provider=_RemoteProvider())
             self.touches = 0
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -705,7 +705,7 @@ def test_sync_uploads_skips_local_volume_sync_without_volume_metadata():
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: SimpleNamespace(
-            lease=SimpleNamespace(get_instance=lambda: SimpleNamespace(instance_id="instance-1"))
+            sandbox_runtime=SimpleNamespace(get_instance=lambda: SimpleNamespace(instance_id="instance-1"))
         )
     )
 
@@ -752,7 +752,7 @@ def test_get_sandbox_local_provider_does_not_require_volume_bootstrap(tmp_path, 
     assert capability.command.runtime_owns_cwd is True
     session = manager.session_manager.get("thread-local")
     assert session is not None
-    assert session.lease.provider_name == "local"
+    assert session.sandbox_runtime.provider_name == "local"
 
 
 def test_get_sandbox_auto_resumes_paused_lease_when_reconstructing_session():
@@ -781,7 +781,7 @@ def test_get_sandbox_auto_resumes_paused_lease_when_reconstructing_session():
     manager.resume_session = lambda thread_id, source="user_resume": resume_calls.append((thread_id, source)) or True
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: None,
-        create=lambda **_kwargs: SimpleNamespace(session_id="sess-1", terminal=terminal, lease=lease),
+        create=lambda **_kwargs: SimpleNamespace(session_id="sess-1", terminal=terminal, sandbox_runtime=lease),
     )
 
     manager.get_sandbox("thread-1")
@@ -810,7 +810,7 @@ def test_get_sandbox_auto_resumes_live_session_when_lease_state_is_paused():
     )
     live_session = SimpleNamespace(
         terminal=terminal,
-        lease=paused_lease,
+        sandbox_runtime=paused_lease,
         status="active",
     )
 
@@ -823,7 +823,7 @@ def test_get_sandbox_auto_resumes_live_session_when_lease_state_is_paused():
 
     def _get_session(_thread_id, _terminal_id):
         if resume_calls:
-            return SimpleNamespace(terminal=terminal, lease=resumed_lease, status="active")
+            return SimpleNamespace(terminal=terminal, sandbox_runtime=resumed_lease, status="active")
         return live_session
 
     manager._get_active_terminal = lambda _thread_id: terminal
@@ -833,7 +833,7 @@ def test_get_sandbox_auto_resumes_live_session_when_lease_state_is_paused():
     capability = manager.get_sandbox("thread-1")
 
     assert resume_calls == [("thread-1", "auto_resume")]
-    assert capability._session.lease is resumed_lease
+    assert capability._session.sandbox_runtime is resumed_lease
 
 
 def test_get_sandbox_routes_bind_mounts_to_provider_thread_state():
@@ -850,7 +850,7 @@ def test_get_sandbox_routes_bind_mounts_to_provider_thread_state():
         observed_state="running",
         get_instance=lambda: SimpleNamespace(instance_id="instance-1"),
     )
-    session = SimpleNamespace(terminal=terminal, lease=lease, status="active")
+    session = SimpleNamespace(terminal=terminal, sandbox_runtime=lease, status="active")
 
     manager.provider = SimpleNamespace(
         name="local",
@@ -898,7 +898,7 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
     manager._fire_session_ready = lambda *_args, **_kwargs: None
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: None,
-        create=lambda **_kwargs: SimpleNamespace(terminal=terminal, lease=lease, status="active"),
+        create=lambda **_kwargs: SimpleNamespace(terminal=terminal, sandbox_runtime=lease, status="active"),
     )
 
     manager.get_sandbox("thread-1")
@@ -983,7 +983,7 @@ def test_resume_session_rebinds_live_session_lease_after_resume():
         resume_instance=lambda _provider, source="user_resume": True,
     )
     stale_lease = SimpleNamespace(lease_id="lease-1", observed_state="paused")
-    runtime = SimpleNamespace(lease=stale_lease)
+    runtime = SimpleNamespace(sandbox_runtime=stale_lease)
     live_session = SimpleNamespace(
         session_id="sess-1",
         terminal=terminal,
@@ -1004,8 +1004,8 @@ def test_resume_session_rebinds_live_session_lease_after_resume():
     ok = manager.resume_session("thread-1", source="auto_resume")
 
     assert ok is True
-    assert live_session.lease is resumed_lease
-    assert runtime.lease is resumed_lease
+    assert live_session.sandbox_runtime is resumed_lease
+    assert runtime.sandbox_runtime is resumed_lease
 
 
 def test_upgrade_to_daytona_volume_uses_lease_id_for_provider_backend_ref(monkeypatch, tmp_path):

--- a/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sandbox.chat_session import ChatSession, ChatSessionPolicy
+from sandbox.lease import SandboxInstance, SQLiteSandboxRuntimeHandle
+from sandbox.providers.local import LocalPersistentShellRuntime
+from sandbox.terminal import SQLiteTerminal, TerminalState
+
+
+def _sandbox_runtime() -> SQLiteSandboxRuntimeHandle:
+    return SQLiteSandboxRuntimeHandle(
+        lease_id="lease-1",
+        provider_name="local",
+        current_instance=SandboxInstance(
+            instance_id="inst-1",
+            provider_name="local",
+            status="running",
+            created_at=__import__("datetime").datetime.now(__import__("datetime").UTC),
+        ),
+        db_path=Path("/tmp/fake-sandbox.db"),
+        observed_state="running",
+        status="active",
+    )
+
+
+def _terminal() -> SQLiteTerminal:
+    return SQLiteTerminal(
+        terminal_id="term-1",
+        thread_id="thread-1",
+        lease_id="lease-1",
+        state=TerminalState(cwd="/tmp"),
+        db_path=Path("/tmp/fake-sandbox.db"),
+    )
+
+
+def test_chat_session_uses_sandbox_runtime_attribute() -> None:
+    terminal = _terminal()
+    sandbox_runtime = _sandbox_runtime()
+    runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
+    session = ChatSession(
+        session_id="sess-1",
+        thread_id="thread-1",
+        terminal=terminal,
+        sandbox_runtime=sandbox_runtime,
+        runtime=runtime,
+        policy=ChatSessionPolicy(),
+        started_at=__import__("datetime").datetime.now(__import__("datetime").UTC),
+        last_active_at=__import__("datetime").datetime.now(__import__("datetime").UTC),
+        db_path=Path("/tmp/fake-sandbox.db"),
+    )
+
+    assert session.sandbox_runtime is sandbox_runtime
+    assert not hasattr(session, "lease")
+
+
+def test_runtime_uses_sandbox_runtime_attribute() -> None:
+    terminal = _terminal()
+    sandbox_runtime = _sandbox_runtime()
+    runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
+
+    assert runtime.sandbox_runtime is sandbox_runtime
+    assert not hasattr(runtime, "lease")

--- a/tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py
+++ b/tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py
@@ -38,10 +38,10 @@ class _FakeManager:
         self.db_path = Path("/tmp/sandbox.db")
         self.provider = _FakeProvider()
         self.lease_store = _FakeLeaseStore()
-        self.lease = None
+        self.sandbox_runtime = None
 
     def get_sandbox_runtime(self, lower_runtime_id):
-        return self.lease if lower_runtime_id == "lease-1" else None
+        return self.sandbox_runtime if lower_runtime_id == "lease-1" else None
 
 
 def test_mutate_sandbox_runtime_destroys_provider_orphan_without_fake_lease(monkeypatch):
@@ -73,7 +73,7 @@ def test_mutate_sandbox_runtime_destroys_provider_orphan_without_fake_lease(monk
 
 def test_mutate_sandbox_runtime_reports_manager_runtime_for_sandbox_runtime_handle(monkeypatch):
     manager = _FakeManager()
-    manager.lease = _FakeLease()
+    manager.sandbox_runtime = _FakeLease()
     runtimes = [
         {
             "session_id": "sandbox-1",
@@ -96,4 +96,4 @@ def test_mutate_sandbox_runtime_reports_manager_runtime_for_sandbox_runtime_hand
     assert payload["ok"] is True
     assert payload["mode"] == "manager_runtime"
     assert payload[LOWER_RUNTIME_KEY] == "lease-1"
-    assert manager.lease.paused == [(manager.provider, "api")]
+    assert manager.sandbox_runtime.paused == [(manager.provider, "api")]


### PR DESCRIPTION
## Summary
- rename ChatSession / runtime object attributes from lease wording to sandbox runtime wording
- realign direct manager/capability/streaming/test consumers to the new object attribute names
- keep PTY and terminal table semantics unchanged in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py tests/Unit/core/test_capability_async.py tests/Unit/core/test_runtime.py tests/Unit/core/test_agent_service.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py`
- [x] `git diff --check`
