### PR TITLE
refactor: rename runtime id attribute

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -32,7 +32,7 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
     try:
         runtime_row = await asyncio.to_thread(runtime_repo.find_by_instance, provider_name=provider_name, instance_id=instance_id)
         lower_runtime = lower_runtime_from_row(runtime_row, resolve_sandbox_db_path()) if runtime_row else None
-        matched_sandbox_runtime_handle = lower_runtime.lease_id if lower_runtime else None
+        matched_sandbox_runtime_handle = lower_runtime.sandbox_runtime_id if lower_runtime else None
         matched_sandbox_id = str((runtime_row or {}).get("sandbox_id") or "").strip() or None
 
         # @@@webhook-runtime-observation - Webhook is optimization only: persist event + observe lower-runtime state.

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -289,7 +289,7 @@ class ChatSessionManager:
             session_id=session_id,
             thread_id=thread_id,
             terminal_id=terminal.terminal_id,
-            lease_id=sandbox_runtime.lease_id,
+            lease_id=sandbox_runtime.sandbox_runtime_id,
             runtime_id=runtime_id,
             status="active",
             idle_ttl_sec=policy.idle_ttl_sec,

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -115,7 +115,7 @@ class SandboxRuntimeHandle(ABC):
 
     def __init__(
         self,
-        lease_id: str,
+        sandbox_runtime_id: str,
         provider_name: str,
         recipe_id: str | None = None,
         recipe: dict[str, Any] | None = None,
@@ -131,7 +131,7 @@ class SandboxRuntimeHandle(ABC):
         refresh_hint_at: datetime | None = None,
         bind_mounts: list[dict[str, str]] | None = None,
     ):
-        self.lease_id = lease_id
+        self.sandbox_runtime_id = sandbox_runtime_id
         self.provider_name = provider_name
         self.recipe = recipe
         self.recipe_id = recipe_id or (str(recipe.get("id")) if isinstance(recipe, dict) and recipe.get("id") else None)
@@ -194,7 +194,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
 
     def __init__(
         self,
-        lease_id: str,
+        sandbox_runtime_id: str,
         provider_name: str,
         recipe_id: str | None = None,
         recipe: dict[str, Any] | None = None,
@@ -211,7 +211,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         refresh_hint_at: datetime | None = None,
     ):
         super().__init__(
-            lease_id=lease_id,
+            sandbox_runtime_id=sandbox_runtime_id,
             provider_name=provider_name,
             recipe_id=recipe_id,
             recipe=recipe,
@@ -231,11 +231,11 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
 
     def _instance_lock(self) -> threading.RLock:
         with self._lock_guard:
-            lock = self._lease_locks.get(self.lease_id)
+            lock = self._lease_locks.get(self.sandbox_runtime_id)
             if lock is None:
                 # @@@reentrant-lease-lock - apply() may be called inside ensure_active_instance critical sections.
                 lock = threading.RLock()
-                self._lease_locks[self.lease_id] = lock
+                self._lease_locks[self.sandbox_runtime_id] = lock
             return lock
 
     def _is_fresh(self, max_age_sec: float = LEASE_FRESHNESS_TTL_SEC) -> bool:
@@ -261,7 +261,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             if observed == "unknown":
                 self.observed_state = observed
                 return
-            raise RuntimeError(f"Lease {self.lease_id}: cannot set observed={observed} without bound instance ({reason})")
+            raise RuntimeError(f"Lease {self.sandbox_runtime_id}: cannot set observed={observed} without bound instance ({reason})")
 
         if observed == "running":
             assert_lease_instance_transition(self._instance_state(), LeaseInstanceState.RUNNING, reason=reason)
@@ -291,11 +291,11 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             self.observed_state = "unknown"
             return
 
-        raise RuntimeError(f"Lease {self.lease_id}: invalid observed state '{observed}'")
+        raise RuntimeError(f"Lease {self.sandbox_runtime_id}: invalid observed state '{observed}'")
 
     def _snapshot(self) -> dict[str, Any]:
         return {
-            "lease_id": self.lease_id,
+            "lease_id": self.sandbox_runtime_id,
             "provider_name": self.provider_name,
             "status": self.status,
             "desired_state": self.desired_state,
@@ -313,7 +313,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         }
 
     def _sandbox_runtime_id(self) -> str:
-        return f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, f'mycel-runtime:{self.lease_id}').hex}"
+        return f"sandbox-{uuid.uuid5(uuid.NAMESPACE_URL, f'mycel-runtime:{self.sandbox_runtime_id}').hex}"
 
     def _sync_sandbox_runtime_binding(self, provider_env_id: str | None, *, updated_at: Any) -> None:
         if not _use_supabase_storage(self.db_path):
@@ -361,7 +361,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 """,
                 (
                     event_id,
-                    self.lease_id,
+                    self.sandbox_runtime_id,
                     event_type,
                     source,
                     json.dumps(payload),
@@ -414,7 +414,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     self.refresh_hint_at.isoformat() if self.refresh_hint_at else None,
                     self.status,
                     utc_now_iso(),
-                    self.lease_id,
+                    self.sandbox_runtime_id,
                 ),
             )
 
@@ -430,7 +430,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     """,
                     (
                         self._current_instance.instance_id,
-                        self.lease_id,
+                        self.sandbox_runtime_id,
                         self._current_instance.instance_id,
                         self._current_instance.status,
                         self._current_instance.created_at.isoformat(),
@@ -494,7 +494,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     self.refresh_hint_at.isoformat() if self.refresh_hint_at else None,
                     self.status,
                     utc_now_iso(),
-                    self.lease_id,
+                    self.sandbox_runtime_id,
                 ),
             )
             if should_commit:
@@ -514,7 +514,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             event_repo = _make_provider_event_repo()
             try:
                 row = repo.persist_metadata(
-                    lease_id=self.lease_id,
+                    lease_id=self.sandbox_runtime_id,
                     recipe_id=self.recipe_id,
                     recipe_json=json.dumps(self.recipe, ensure_ascii=False) if self.recipe is not None else None,
                     desired_state=self.desired_state,
@@ -532,7 +532,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                         instance_id=self._current_instance.instance_id,
                         event_type="provider.error",
                         payload={"error": self.last_error, "source": source},
-                        matched_runtime_handle=self.lease_id,
+                        matched_runtime_handle=self.sandbox_runtime_id,
                         matched_sandbox_id=self._sandbox_runtime_id(),
                     )
             finally:
@@ -549,7 +549,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         event_repo = _make_provider_event_repo()
         try:
             row = repo.observe_status(
-                lease_id=self.lease_id,
+                lease_id=self.sandbox_runtime_id,
                 status=observed,
                 observed_at=utc_now_iso(),
             )
@@ -559,7 +559,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     instance_id=instance_id,
                     event_type="observe.status",
                     payload={"status": observed, "instance_id": instance_id},
-                    matched_runtime_handle=self.lease_id,
+                    matched_runtime_handle=self.sandbox_runtime_id,
                     matched_sandbox_id=self._sandbox_runtime_id(),
                 )
         finally:
@@ -580,9 +580,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             try:
                 ok = provider.destroy_session(instance_id)
             except Exception as exc:
-                raise RuntimeError(f"Failed to destroy lease {self.lease_id}: {exc}") from exc
+                raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}: {exc}") from exc
             if not ok:
-                raise RuntimeError(f"Failed to destroy lease {self.lease_id}")
+                raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}")
         self.desired_state = "destroyed"
         self._set_observed_state("detached", reason="intent.destroy")
         self.status = "expired"
@@ -594,13 +594,13 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         event_repo = _make_provider_event_repo()
         try:
             observed_row = repo.observe_status(
-                lease_id=self.lease_id,
+                lease_id=self.sandbox_runtime_id,
                 status="detached",
                 observed_at=utc_now_iso(),
             )
             self.version = int(observed_row.get("version") or self.version)
             final_row = repo.persist_metadata(
-                lease_id=self.lease_id,
+                lease_id=self.sandbox_runtime_id,
                 recipe_id=observed_row.get("recipe_id"),
                 recipe_json=observed_row.get("recipe_json"),
                 desired_state="destroyed",
@@ -619,7 +619,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     instance_id=instance_id,
                     event_type="intent.destroy",
                     payload={"instance_id": instance_id, "source": source},
-                    matched_runtime_handle=self.lease_id,
+                    matched_runtime_handle=self.sandbox_runtime_id,
                     matched_sandbox_id=self._sandbox_runtime_id(),
                 )
         finally:
@@ -642,16 +642,16 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         if not getattr(capability, capability_name):
             raise RuntimeError(f"Provider {provider.name} does not support {event_type.split('.')[-1]}")
         if not self._current_instance:
-            raise RuntimeError(f"Lease {self.lease_id} has no instance to {event_type.split('.')[-1]}")
+            raise RuntimeError(f"Lease {self.sandbox_runtime_id} has no instance to {event_type.split('.')[-1]}")
 
         instance_id = self._current_instance.instance_id
         provider_method = getattr(provider, provider_method_name)
         try:
             ok = provider_method(instance_id)
         except Exception as exc:
-            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.lease_id}: {exc}") from exc
+            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.sandbox_runtime_id}: {exc}") from exc
         if not ok:
-            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.lease_id}")
+            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.sandbox_runtime_id}")
 
         self.desired_state = desired_state
         self._set_observed_state(observed_state, reason=event_type)
@@ -664,13 +664,13 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         event_repo = _make_provider_event_repo()
         try:
             observed_row = repo.observe_status(
-                lease_id=self.lease_id,
+                lease_id=self.sandbox_runtime_id,
                 status=observed_state,
                 observed_at=utc_now_iso(),
             )
             self.version = int(observed_row.get("version") or self.version)
             final_row = repo.persist_metadata(
-                lease_id=self.lease_id,
+                lease_id=self.sandbox_runtime_id,
                 recipe_id=observed_row.get("recipe_id"),
                 recipe_json=observed_row.get("recipe_json"),
                 desired_state=desired_state,
@@ -688,7 +688,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 instance_id=instance_id,
                 event_type=event_type,
                 payload={"instance_id": instance_id, "source": source},
-                matched_runtime_handle=self.lease_id,
+                matched_runtime_handle=self.sandbox_runtime_id,
                 matched_sandbox_id=self._sandbox_runtime_id(),
             )
         finally:
@@ -699,7 +699,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
     def _reload_from_storage(self) -> None:
         repo = _make_lease_repo(self.db_path)
         try:
-            row = repo.get(self.lease_id)
+            row = repo.get(self.sandbox_runtime_id)
         finally:
             repo.close()
         if row:
@@ -742,13 +742,13 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     if not capability.can_pause:
                         raise RuntimeError(f"Provider {provider.name} does not support pause")
                     if not self._current_instance:
-                        raise RuntimeError(f"Lease {self.lease_id} has no instance to pause")
+                        raise RuntimeError(f"Lease {self.sandbox_runtime_id} has no instance to pause")
                     try:
                         ok = provider.pause_session(self._current_instance.instance_id)
                     except Exception as exc:
-                        raise RuntimeError(f"Failed to pause lease {self.lease_id}: {exc}") from exc
+                        raise RuntimeError(f"Failed to pause lease {self.sandbox_runtime_id}: {exc}") from exc
                     if not ok:
-                        raise RuntimeError(f"Failed to pause lease {self.lease_id}")
+                        raise RuntimeError(f"Failed to pause lease {self.sandbox_runtime_id}")
                     self.desired_state = "paused"
                     self._set_observed_state("paused", reason="intent.pause")
                     self.status = "active"
@@ -761,13 +761,13 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     if not capability.can_resume:
                         raise RuntimeError(f"Provider {provider.name} does not support resume")
                     if not self._current_instance:
-                        raise RuntimeError(f"Lease {self.lease_id} has no instance to resume")
+                        raise RuntimeError(f"Lease {self.sandbox_runtime_id} has no instance to resume")
                     try:
                         ok = provider.resume_session(self._current_instance.instance_id)
                     except Exception as exc:
-                        raise RuntimeError(f"Failed to resume lease {self.lease_id}: {exc}") from exc
+                        raise RuntimeError(f"Failed to resume lease {self.sandbox_runtime_id}: {exc}") from exc
                     if not ok:
-                        raise RuntimeError(f"Failed to resume lease {self.lease_id}")
+                        raise RuntimeError(f"Failed to resume lease {self.sandbox_runtime_id}")
                     self.desired_state = "running"
                     self._set_observed_state("running", reason="intent.resume")
                     self.status = "active"
@@ -783,9 +783,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                         try:
                             ok = provider.destroy_session(self._current_instance.instance_id)
                         except Exception as exc:
-                            raise RuntimeError(f"Failed to destroy lease {self.lease_id}: {exc}") from exc
+                            raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}: {exc}") from exc
                         if not ok:
-                            raise RuntimeError(f"Failed to destroy lease {self.lease_id}")
+                            raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}")
                     self.desired_state = "destroyed"
                     self._set_observed_state("detached", reason="intent.destroy")
                     self.status = "expired"
@@ -795,7 +795,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
 
                 elif event_type == "intent.ensure_running":
                     if not self._current_instance:
-                        raise RuntimeError(f"Lease {self.lease_id}: intent.ensure_running requires bound instance")
+                        raise RuntimeError(f"Lease {self.sandbox_runtime_id}: intent.ensure_running requires bound instance")
                     self.desired_state = "running"
                     self._set_observed_state("running", reason="intent.ensure_running")
                     self.status = "active"
@@ -867,7 +867,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             if not self._current_instance:
                 return None
             if self.observed_state == "paused":
-                raise RuntimeError(f"Sandbox lease {self.lease_id} is paused. Resume before executing commands.")
+                raise RuntimeError(f"Sandbox lease {self.sandbox_runtime_id} is paused. Resume before executing commands.")
             if self.observed_state == "running" and not self.needs_refresh:
                 return self._current_instance
             self._current_instance = None
@@ -884,7 +884,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     repo = _make_lease_repo(self.db_path)
                     try:
                         row = repo.adopt_instance(
-                            lease_id=self.lease_id,
+                            lease_id=self.sandbox_runtime_id,
                             provider_name=self.provider_name,
                             instance_id=self._current_instance.instance_id,
                             status=self._normalize_provider_state(status),
@@ -906,7 +906,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 if self.observed_state == "running" and self._current_instance:
                     return self._current_instance
                 if self.observed_state == "paused":
-                    raise RuntimeError(f"Sandbox lease {self.lease_id} is paused. Resume before executing commands.")
+                    raise RuntimeError(f"Sandbox lease {self.sandbox_runtime_id} is paused. Resume before executing commands.")
             except RuntimeError:
                 raise
             except Exception as exc:
@@ -926,7 +926,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                         repo = _make_lease_repo(self.db_path)
                         try:
                             row = repo.adopt_instance(
-                                lease_id=self.lease_id,
+                                lease_id=self.sandbox_runtime_id,
                                 provider_name=self.provider_name,
                                 instance_id=self._current_instance.instance_id,
                                 status=self._normalize_provider_state(status),
@@ -948,7 +948,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     if self.observed_state == "running" and self._current_instance:
                         return self._current_instance
                     if self.observed_state == "paused":
-                        raise RuntimeError(f"Sandbox lease {self.lease_id} is paused. Resume before executing commands.")
+                        raise RuntimeError(f"Sandbox lease {self.sandbox_runtime_id} is paused. Resume before executing commands.")
                 except RuntimeError:
                     raise
                 except Exception as exc:
@@ -960,7 +960,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             from sandbox.thread_context import get_current_thread_id
 
             thread_id = get_current_thread_id()
-            session_info = provider.create_session(context_id=f"leon-{self.lease_id}", thread_id=thread_id)
+            session_info = provider.create_session(context_id=f"leon-{self.sandbox_runtime_id}", thread_id=thread_id)
             self._current_instance = SandboxInstance(
                 instance_id=session_info.session_id,
                 provider_name=self.provider_name,
@@ -971,7 +971,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 repo = _make_lease_repo(self.db_path)
                 try:
                     row = repo.adopt_instance(
-                        lease_id=self.lease_id,
+                        lease_id=self.sandbox_runtime_id,
                         provider_name=self.provider_name,
                         instance_id=session_info.session_id,
                         status="running",
@@ -991,7 +991,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     payload={"created": True, "instance_id": session_info.session_id},
                 )
             if not self._current_instance:
-                raise RuntimeError(f"Lease {self.lease_id}: failed to bind created instance")
+                raise RuntimeError(f"Lease {self.sandbox_runtime_id}: failed to bind created instance")
             return self._current_instance
 
     def destroy_instance(self, provider: SandboxProvider, *, source: str = "api") -> None:
@@ -1098,7 +1098,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         if _use_supabase_storage(self.db_path):
             repo = _make_lease_repo(self.db_path)
             try:
-                repo.mark_needs_refresh(self.lease_id, hint_at=self.refresh_hint_at)
+                repo.mark_needs_refresh(self.sandbox_runtime_id, hint_at=self.refresh_hint_at)
             finally:
                 repo.close()
             return
@@ -1133,7 +1133,7 @@ def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteSandboxRuntimeHa
         refresh_hint_at = parse_runtime_datetime(str(row["refresh_hint_at"]))
 
     return SQLiteSandboxRuntimeHandle(
-        lease_id=row["lease_id"],
+        sandbox_runtime_id=row["lease_id"],
         provider_name=row["provider_name"],
         recipe_id=row.get("recipe_id"),
         recipe=json.loads(str(row["recipe_json"])) if row.get("recipe_json") else None,

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -189,7 +189,7 @@ def bind_thread_to_existing_sandbox(
         raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
     lease_id = str(lease.get("lease_id") or "").strip()
     if not lease_id:
-        raise RuntimeError("lease.lease_id is required")
+        raise RuntimeError("lease.sandbox_runtime_id is required")
     initial_cwd = bind_thread_to_existing_lease(
         thread_id,
         lease_id,
@@ -320,7 +320,7 @@ class SandboxManager:
         # @@@daytona-upgrade - first startup creates managed volume
         volume_name = self._upgrade_to_daytona_volume(
             thread_id,
-            lease.lease_id,
+            lease.sandbox_runtime_id,
             remote_path,
         )
         self.volume.mount_managed_volume(thread_id, volume_name, remote_path)
@@ -376,7 +376,7 @@ class SandboxManager:
         terminals = self._get_thread_terminals(thread_id)
         if not terminals:
             return None
-        lease_ids = {terminal.lease_id for terminal in terminals}
+        lease_ids = {terminal.sandbox_runtime_id for terminal in terminals}
         # @@@thread-single-lease-invariant - Terminals created via non-block must share one lease per thread.
         if len(lease_ids) != 1:
             raise RuntimeError(f"Thread {thread_id} has inconsistent lease_ids: {sorted(lease_ids)}")
@@ -391,7 +391,7 @@ class SandboxManager:
         terminals = self._get_thread_terminals(thread_id)
         if not terminals:
             return False
-        lease = self._get_sandbox_runtime(terminals[0].lease_id)
+        lease = self._get_sandbox_runtime(terminals[0].sandbox_runtime_id)
         return bool(lease and lease.provider_name == self.provider.name)
 
     def _resolve_sync_source_path(self, thread_id: str) -> Path:
@@ -571,7 +571,7 @@ class SandboxManager:
             self.terminal_store.create(
                 terminal_id=terminal_id,
                 thread_id=thread_id,
-                lease_id=lease.lease_id,
+                lease_id=lease.sandbox_runtime_id,
                 initial_cwd=initial_cwd,
             ),
             self.db_path,
@@ -669,7 +669,7 @@ class SandboxManager:
             if lease:
                 # @@@idle-reaper-shared-lease - non-blocking commands fork background terminals but share one lease.
                 # Do not pause the underlying lease if another session on the same lease is still active/idle.
-                lease_id = str(row.get("lease_id") or lease.lease_id)
+                lease_id = str(row.get("lease_id") or lease.sandbox_runtime_id)
                 has_other_active = False
                 for other in active_rows:
                     if str(other.get("lease_id") or "") != lease_id:
@@ -684,7 +684,7 @@ class SandboxManager:
                     break
 
                 if not has_other_active:
-                    if self._lease_is_busy(lease.lease_id):
+                    if self._lease_is_busy(lease.sandbox_runtime_id):
                         continue
                     status = lease.refresh_instance_status(self.provider)
                     capability = self.provider.get_capability()
@@ -699,14 +699,14 @@ class SandboxManager:
                             else:
                                 print(
                                     f"[idle-reaper] provider {self.provider.name} cannot reclaim expired lease "
-                                    f"{lease.lease_id} for thread {thread_id}"
+                                    f"{lease.sandbox_runtime_id} for thread {thread_id}"
                                 )
                                 continue
                         except Exception as exc:
-                            print(f"[idle-reaper] failed to reclaim expired lease {lease.lease_id} for thread {thread_id}: {exc}")
+                            print(f"[idle-reaper] failed to reclaim expired lease {lease.sandbox_runtime_id} for thread {thread_id}: {exc}")
                             continue
                         if not reclaimed:
-                            print(f"[idle-reaper] failed to reclaim expired lease {lease.lease_id} for thread {thread_id}")
+                            print(f"[idle-reaper] failed to reclaim expired lease {lease.sandbox_runtime_id} for thread {thread_id}")
                             continue
 
             self.session_manager.delete(session_id, reason="idle_timeout")

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -381,7 +381,7 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
         on_stdout_chunk: Callable[[str], None] | None = None,
     ) -> ExecuteResult:
         if self.sandbox_runtime.observed_state == "paused":
-            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.lease_id} is paused. Resume before executing commands.")
+            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.sandbox_runtime_id} is paused. Resume before executing commands.")
 
         state = self.terminal.get_state()
         start, end, script = _build_windows_shell_script(command, cwd=state.cwd, env_delta=state.env_delta)
@@ -428,7 +428,7 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
             return self._execute_windows_once_sync(command, timeout, on_stdout_chunk=on_stdout_chunk)
 
         if self.sandbox_runtime.observed_state == "paused":
-            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.lease_id} is paused. Resume before executing commands.")
+            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.sandbox_runtime_id} is paused. Resume before executing commands.")
 
         state = self.terminal.get_state()
         pty_session = self._ensure_session_sync(timeout)

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -880,7 +880,7 @@ class _RemoteRuntimeBase(PhysicalTerminalRuntime):
         status = self.sandbox_runtime.refresh_instance_status(self.provider, force=True, max_age_sec=0)
         if status == "paused":
             if not self.sandbox_runtime.resume_instance(self.provider):
-                raise RuntimeError(f"Failed to resume paused lease {self.sandbox_runtime.lease_id}")
+                raise RuntimeError(f"Failed to resume paused lease {self.sandbox_runtime.sandbox_runtime_id}")
             return
         if status in {"detached", "unknown"}:
             self.sandbox_runtime.ensure_active_instance(self.provider)
@@ -917,7 +917,7 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
         print(
             "[RemoteWrappedRuntime._execute_once] "
             f"thread_id={self.terminal.thread_id} "
-            f"lease_id={self.sandbox_runtime.lease_id} "
+            f"sandbox_runtime_id={self.sandbox_runtime.sandbox_runtime_id} "
             f"instance_id={instance.instance_id} "
             f"provider={getattr(self.provider, 'name', '?')} "
             f"cwd={state.cwd!r} "

--- a/tests/Integration/test_webhooks_router_contract.py
+++ b/tests/Integration/test_webhooks_router_contract.py
@@ -94,7 +94,7 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_lo
             return self._event_repo
 
     class _LowerRuntime:
-        locals()["lease_" + "id"] = "lease-1"
+        sandbox_runtime_id = "lease-1"
 
         def __init__(self) -> None:
             self.applied: list[dict[str, object]] = []

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1091,7 +1091,7 @@ async def test_run_agent_reuses_parent_lower_runtime_for_child_thread_terminal(m
     observed: dict[str, str] = {}
     parent_thread_id = "parent-thread"
     child_thread_id = "subagent-child"
-    lower_runtime_key = "lease_" + "id"
+    lower_runtime_key = "sandbox_runtime_" + "id"
 
     manager = SandboxManager(
         provider=LocalSessionProvider(default_cwd=str(tmp_path)),

--- a/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
+++ b/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
@@ -158,7 +158,7 @@ def test_observe_status_detached_clears_sandbox_provider_env(monkeypatch) -> Non
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
 
     lease = SQLiteSandboxRuntimeHandle(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         current_instance=SandboxInstance(
             instance_id="inst-1",
@@ -229,7 +229,7 @@ def test_ensure_active_instance_sets_sandbox_provider_env_from_adopted_instance(
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: _FakeEventRepo())
 
     lease = SQLiteSandboxRuntimeHandle(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         db_path=Path("/tmp/fake-sandbox.db"),
         observed_state="detached",

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -284,7 +284,7 @@ def test_setup_mounts_uses_workspace_sync_source_for_non_daytona_runtime(tmp_pat
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
-    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     result = manager._setup_mounts("thread-1")
 
@@ -323,7 +323,7 @@ def test_setup_mounts_uses_workspace_source_without_remote_volume_metadata(monke
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
-    lease = SimpleNamespace(lease_id="lease-1")
+    lease = SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.lease_store = _FakeLeaseStore()
 
@@ -340,7 +340,7 @@ def test_setup_mounts_daytona_uses_lease_id_for_managed_volume(monkeypatch, tmp_
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
-    lease = SimpleNamespace(lease_id="lease-1")
+    lease = SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.lease_store = _FakeLeaseStore()
 
@@ -423,7 +423,7 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
     ]
     manager.session_manager = _FakeSessionManager(active_rows)
     fake_lease = SimpleNamespace(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="agentbay",
         refresh_instance_status=lambda _provider: "running",
         pause_instance=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("pause should not be used")),
@@ -700,7 +700,7 @@ def test_sync_uploads_skips_local_volume_sync_without_volume_metadata():
     manager.provider_capability = SimpleNamespace(runtime_kind="local")
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
-    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_thread_lease = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.session_manager = SimpleNamespace(
@@ -767,6 +767,7 @@ def test_get_sandbox_auto_resumes_paused_lease_when_reconstructing_session():
         update_state=lambda _state: None,
     )
     lease = SimpleNamespace(
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         observed_state="paused",
         bind_mounts=None,
@@ -797,13 +798,13 @@ def test_get_sandbox_auto_resumes_live_session_when_lease_state_is_paused():
         get_state=lambda: SimpleNamespace(cwd="/tmp", env_delta={}, state_version=0),
     )
     paused_lease = SimpleNamespace(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         observed_state="paused",
         bind_mounts=None,
     )
     resumed_lease = SimpleNamespace(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         observed_state="running",
         bind_mounts=None,
@@ -957,7 +958,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
         },
         create=create_terminal,
     )
-    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._assert_lease_provider = lambda _lease, _thread_id: None
     manager.session_manager = SimpleNamespace(create=lambda **kwargs: created_background_commands.append(kwargs) or kwargs)
     monkeypatch.setattr(sandbox_manager_module, "terminal_from_row", from_row)
@@ -977,12 +978,12 @@ def test_resume_session_rebinds_live_session_lease_after_resume():
     manager = _new_test_manager()
     terminal = SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
     resumed_lease = SimpleNamespace(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         observed_state="running",
         get_instance=lambda: SimpleNamespace(instance_id="instance-1"),
         resume_instance=lambda _provider, source="user_resume": True,
     )
-    stale_lease = SimpleNamespace(lease_id="lease-1", observed_state="paused")
+    stale_lease = SimpleNamespace(sandbox_runtime_id="lease-1", observed_state="paused")
     runtime = SimpleNamespace(sandbox_runtime=stale_lease)
     live_session = SimpleNamespace(
         session_id="sess-1",

--- a/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
@@ -10,7 +10,7 @@ from sandbox.terminal import SQLiteTerminal, TerminalState
 
 def _sandbox_runtime() -> SQLiteSandboxRuntimeHandle:
     return SQLiteSandboxRuntimeHandle(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         current_instance=SandboxInstance(
             instance_id="inst-1",
@@ -52,6 +52,8 @@ def test_chat_session_uses_sandbox_runtime_attribute() -> None:
 
     assert session.sandbox_runtime is sandbox_runtime
     assert not hasattr(session, "lease")
+    assert session.sandbox_runtime.sandbox_runtime_id == "lease-1"
+    assert not hasattr(session.sandbox_runtime, "lease_id")
 
 
 def test_runtime_uses_sandbox_runtime_attribute() -> None:
@@ -61,3 +63,5 @@ def test_runtime_uses_sandbox_runtime_attribute() -> None:
 
     assert runtime.sandbox_runtime is sandbox_runtime
     assert not hasattr(runtime, "lease")
+    assert runtime.sandbox_runtime.sandbox_runtime_id == "lease-1"
+    assert not hasattr(runtime.sandbox_runtime, "lease_id")


### PR DESCRIPTION
## Summary
- rename SandboxRuntimeHandle object id attribute from lease_id to sandbox_runtime_id
- keep SQLite/terminal/chat_session table column names unchanged in this slice
- realign direct object-id consumers and focused runtime/id tests

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py tests/Unit/core/test_capability_async.py tests/Unit/core/test_runtime.py tests/Unit/core/test_agent_service.py tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/sandbox/test_sandbox_service_runtime_mutation.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_sandbox_mutations.py tests/Unit/storage/test_supabase_provider_event_repo.py tests/Integration/test_webhooks_router_contract.py`
- [x] `git diff --check`
