### PR TITLE
refactor: rename runtime store inventory seam

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -200,7 +200,7 @@ def load_provider_orphan_runtimes(managers: dict) -> list[dict[str, Any]]:
 
         seen_instance_ids = {
             str(row.get("current_instance_id") or "").strip()
-            for row in manager.lease_store.list_by_provider(provider_slug)
+            for row in manager.sandbox_runtime_store.list_by_provider(provider_slug)
             if str(row.get("current_instance_id") or "").strip()
         }
         raw_provider_runtimes = list_provider_runtimes()

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -250,7 +250,7 @@ class SandboxManager:
 
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
         self.terminal_store = make_terminal_repo(db_path=self.db_path)
-        self.lease_store = make_lease_repo(db_path=self.db_path)
+        self.sandbox_runtime_store = make_lease_repo(db_path=self.db_path)
 
         self.session_manager = ChatSessionManager(
             provider=provider,
@@ -258,7 +258,7 @@ class SandboxManager:
             default_policy=ChatSessionPolicy(),
             chat_session_repo=make_chat_session_repo(db_path=self.db_path),
             terminal_repo=self.terminal_store,
-            lease_repo=self.lease_store,
+            lease_repo=self.sandbox_runtime_store,
         )
 
         from sandbox.volume import SandboxVolume
@@ -270,14 +270,14 @@ class SandboxManager:
 
     def _get_sandbox_runtime(self, lease_id: str):
         """Get sandbox runtime as domain object, or None."""
-        row = self.lease_store.get(lease_id)
+        row = self.sandbox_runtime_store.get(lease_id)
         if row is None:
             return None
         return sandbox_runtime_from_row(row, self.db_path)
 
     def _create_sandbox_runtime(self, lease_id: str, provider_name: str):
         """Create sandbox runtime and return as domain object."""
-        row = self.lease_store.create(lease_id, provider_name)
+        row = self.sandbox_runtime_store.create(lease_id, provider_name)
         return sandbox_runtime_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
@@ -452,7 +452,7 @@ class SandboxManager:
     def close(self):
         self.session_manager.close(reason="manager_close")
         self.terminal_store.close()
-        self.lease_store.close()
+        self.sandbox_runtime_store.close()
 
     def get_sandbox(self, thread_id: str, bind_mounts: list | None = None) -> SandboxCapability:
         from sandbox.thread_context import set_current_thread_id
@@ -891,7 +891,7 @@ class SandboxManager:
 
         seen_instance_ids: set[str] = set()
 
-        for lease_row in self.lease_store.list_by_provider(self.provider.name):
+        for lease_row in self.sandbox_runtime_store.list_by_provider(self.provider.name):
             lease_id = lease_row["lease_id"]
             lease = self._get_sandbox_runtime(lease_id)
             if not lease:

--- a/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
+++ b/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
@@ -12,7 +12,7 @@ LOWER_RUNTIME_KEY = "lease_" + "id"
 class _FailingManager:
     def __init__(self) -> None:
         self.provider = SimpleNamespace(name="daytona", list_provider_runtimes=lambda: [])
-        self.lease_store = SimpleNamespace(list_by_provider=lambda _provider_name: [])
+        self.sandbox_runtime_store = SimpleNamespace(list_by_provider=lambda _provider_name: [])
         self.provider_capability = SimpleNamespace(inspect_visible=True)
 
     def list_sessions(self):
@@ -40,7 +40,7 @@ def test_load_provider_orphan_runtimes_excludes_covered_provider_runtimes():
                 _provider_runtime("deleted-one", "deleted"),
             ],
         ),
-        lease_store=SimpleNamespace(list_by_provider=lambda _provider_name: [{"current_instance_id": "covered-runtime"}]),
+        sandbox_runtime_store=SimpleNamespace(list_by_provider=lambda _provider_name: [{"current_instance_id": "covered-runtime"}]),
         provider_capability=SimpleNamespace(inspect_visible=False),
     )
 
@@ -77,7 +77,7 @@ def test_load_provider_orphan_runtimes_excludes_covered_provider_runtimes():
 def test_load_provider_orphan_runtimes_rejects_non_list_provider_result():
     manager = SimpleNamespace(
         provider=SimpleNamespace(name="daytona", list_provider_runtimes=lambda: (_provider_runtime("orphan"),)),
-        lease_store=SimpleNamespace(list_by_provider=lambda _provider_name: []),
+        sandbox_runtime_store=SimpleNamespace(list_by_provider=lambda _provider_name: []),
         provider_capability=SimpleNamespace(inspect_visible=False),
     )
 

--- a/tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py
@@ -11,7 +11,7 @@ def _manager_for_provider(provider: SimpleNamespace) -> SandboxManager:
     manager.provider_capability = SimpleNamespace(inspect_visible=True)
     manager.terminal_store = SimpleNamespace(list_all=lambda: [])
     manager.session_manager = SimpleNamespace(list_all=lambda: [])
-    manager.lease_store = SimpleNamespace(list_by_provider=lambda _provider_name: [])
+    manager.sandbox_runtime_store = SimpleNamespace(list_by_provider=lambda _provider_name: [])
     return manager
 
 


### PR DESCRIPTION
## Summary
- rename the manager-held runtime store seam from lease_store to sandbox_runtime_store in the provider-orphan inventory path
- realign the focused sandbox manager provider-runtime tests to the new store name
- keep PTY and terminal/chat_session table semantics unchanged in this slice

## Test Plan
- [x] `.venv/bin/python -m pytest -q tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py`
- [x] `git diff --check`
