### PR TITLE
refactor: rename sandbox runtime repo factory seam

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
-from sandbox.control_plane_repos import make_chat_session_repo, make_lease_repo, make_terminal_repo
+from sandbox.control_plane_repos import make_chat_session_repo, make_sandbox_runtime_repo, make_terminal_repo
 from sandbox.lifecycle import (
     ChatSessionState,
     assert_chat_session_transition,
@@ -228,7 +228,7 @@ class ChatSessionManager:
         _lease_repo = self._lease_repo
         own_lease_repo = _lease_repo is None
         if _lease_repo is None:
-            _lease_repo = make_lease_repo(db_path=self.db_path)
+            _lease_repo = make_sandbox_runtime_repo(db_path=self.db_path)
         try:
             _lease_row = _lease_repo.get(row["lease_id"])
         finally:

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -23,7 +23,7 @@ def make_chat_session_repo(db_path: Path | None = None):
     return SQLiteChatSessionRepo(db_path=resolve_sandbox_db_path(db_path))
 
 
-def make_lease_repo(db_path: Path | None = None):
+def make_sandbox_runtime_repo(db_path: Path | None = None):
     if _use_strategy_control_plane_repo(db_path):
         return build_lease_repo()
     from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
-from sandbox.control_plane_repos import make_lease_repo as _make_sqlite_lease_repo
+from sandbox.control_plane_repos import make_sandbox_runtime_repo as _make_sqlite_sandbox_runtime_repo
 from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.lifecycle import (
     LeaseInstanceState,
@@ -29,7 +29,7 @@ from sandbox.lifecycle import (
     parse_lease_instance_state,
 )
 from storage.providers.sqlite.kernel import connect_sqlite
-from storage.runtime import build_lease_repo as _build_strategy_lease_repo
+from storage.runtime import build_lease_repo as _build_strategy_sandbox_runtime_repo
 from storage.runtime import build_provider_event_repo as _build_strategy_provider_event_repo
 from storage.runtime import build_sandbox_repo as _build_strategy_sandbox_repo
 from storage.runtime import uses_supabase_runtime_defaults
@@ -86,10 +86,10 @@ def _use_supabase_storage(db_path: Path | None = None) -> bool:
     return uses_supabase_runtime_defaults() and resolve_sandbox_db_path(db_path) == resolve_sandbox_db_path()
 
 
-def _make_lease_repo(db_path: Path | None = None):
+def _make_sandbox_runtime_repo(db_path: Path | None = None):
     if _use_supabase_storage(db_path):
-        return _build_strategy_lease_repo()
-    return _make_sqlite_lease_repo(db_path)
+        return _build_strategy_sandbox_runtime_repo()
+    return _make_sqlite_sandbox_runtime_repo(db_path)
 
 
 def _make_provider_event_repo():
@@ -510,7 +510,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         self.observed_at = utc_now()
         self.version += 1
         if _use_supabase_storage(self.db_path):
-            repo = _make_lease_repo(self.db_path)
+            repo = _make_sandbox_runtime_repo(self.db_path)
             event_repo = _make_provider_event_repo()
             try:
                 row = repo.persist_metadata(
@@ -545,7 +545,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
     def _observe_status_via_strategy_repo(self, raw_status: str, *, source: str) -> None:
         observed = self._normalize_provider_state(raw_status)
         instance_id = self._current_instance.instance_id if self._current_instance else ""
-        repo = _make_lease_repo(self.db_path)
+        repo = _make_sandbox_runtime_repo(self.db_path)
         event_repo = _make_provider_event_repo()
         try:
             row = repo.observe_status(
@@ -590,7 +590,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         self.needs_refresh = False
         self.refresh_hint_at = None
 
-        repo = _make_lease_repo(self.db_path)
+        repo = _make_sandbox_runtime_repo(self.db_path)
         event_repo = _make_provider_event_repo()
         try:
             observed_row = repo.observe_status(
@@ -660,7 +660,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         self.needs_refresh = False
         self.refresh_hint_at = None
 
-        repo = _make_lease_repo(self.db_path)
+        repo = _make_sandbox_runtime_repo(self.db_path)
         event_repo = _make_provider_event_repo()
         try:
             observed_row = repo.observe_status(
@@ -697,7 +697,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         self._sync_from(sandbox_runtime_from_row(final_row, self.db_path))
 
     def _reload_from_storage(self) -> None:
-        repo = _make_lease_repo(self.db_path)
+        repo = _make_sandbox_runtime_repo(self.db_path)
         try:
             row = repo.get(self.sandbox_runtime_id)
         finally:
@@ -881,7 +881,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             try:
                 status = provider.get_session_status(self._current_instance.instance_id)
                 if _use_supabase_storage(self.db_path):
-                    repo = _make_lease_repo(self.db_path)
+                    repo = _make_sandbox_runtime_repo(self.db_path)
                     try:
                         row = repo.adopt_instance(
                             lease_id=self.sandbox_runtime_id,
@@ -923,7 +923,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 try:
                     status = provider.get_session_status(self._current_instance.instance_id)
                     if _use_supabase_storage(self.db_path):
-                        repo = _make_lease_repo(self.db_path)
+                        repo = _make_sandbox_runtime_repo(self.db_path)
                         try:
                             row = repo.adopt_instance(
                                 lease_id=self.sandbox_runtime_id,
@@ -968,7 +968,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 created_at=utc_now(),
             )
             if _use_supabase_storage(self.db_path):
-                repo = _make_lease_repo(self.db_path)
+                repo = _make_sandbox_runtime_repo(self.db_path)
                 try:
                     row = repo.adopt_instance(
                         lease_id=self.sandbox_runtime_id,
@@ -1096,7 +1096,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         self.refresh_hint_at = hint_at or utc_now()
         self.version += 1
         if _use_supabase_storage(self.db_path):
-            repo = _make_lease_repo(self.db_path)
+            repo = _make_sandbox_runtime_repo(self.db_path)
             try:
                 repo.mark_needs_refresh(self.sandbox_runtime_id, hint_at=self.refresh_hint_at)
             finally:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -14,7 +14,7 @@ from config.user_paths import user_home_path
 from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
 from sandbox.clock import parse_runtime_datetime, utc_now
-from sandbox.control_plane_repos import make_chat_session_repo, make_lease_repo, make_terminal_repo
+from sandbox.control_plane_repos import make_chat_session_repo, make_sandbox_runtime_repo, make_terminal_repo
 from sandbox.lease import sandbox_runtime_from_row
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
@@ -59,7 +59,7 @@ def lookup_sandbox_for_thread(
     _lease_repo = lease_repo
     own_lease_repo = _lease_repo is None
     if _lease_repo is None:
-        _lease_repo = make_lease_repo(db_path=target_db)
+        _lease_repo = make_sandbox_runtime_repo(db_path=target_db)
     try:
         terminals = _terminal_repo.list_by_thread(thread_id)
         if not terminals:
@@ -88,7 +88,7 @@ def resolve_existing_lease_cwd(
     _lease_repo = lease_repo
     own_lease_repo = _lease_repo is None
     if _lease_repo is None:
-        _lease_repo = make_lease_repo(db_path=target_db)
+        _lease_repo = make_sandbox_runtime_repo(db_path=target_db)
     try:
         lease = _lease_repo.get(lease_id)
     finally:
@@ -160,7 +160,7 @@ def resolve_existing_sandbox_lease(
     _lease_repo = lease_repo
     own_lease_repo = _lease_repo is None
     if _lease_repo is None:
-        _lease_repo = make_lease_repo(db_path=target_db)
+        _lease_repo = make_sandbox_runtime_repo(db_path=target_db)
     try:
         lease = _lease_repo.find_by_instance(provider_name=provider_name, instance_id=provider_env_id)
         if lease is not None:
@@ -250,7 +250,7 @@ class SandboxManager:
 
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
         self.terminal_store = make_terminal_repo(db_path=self.db_path)
-        self.sandbox_runtime_store = make_lease_repo(db_path=self.db_path)
+        self.sandbox_runtime_store = make_sandbox_runtime_repo(db_path=self.db_path)
 
         self.session_manager = ChatSessionManager(
             provider=provider,

--- a/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
+++ b/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
@@ -153,7 +153,7 @@ def test_observe_status_detached_clears_sandbox_provider_env(monkeypatch) -> Non
     fake_sandbox_repo = _FakeSandboxRepo()
 
     monkeypatch.setattr(sandbox_lease_module, "_use_supabase_storage", lambda _db_path=None: True)
-    monkeypatch.setattr(sandbox_lease_module, "_make_lease_repo", lambda _db_path=None: fake_lease_repo)
+    monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_runtime_repo", lambda _db_path=None: fake_lease_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: fake_event_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
 
@@ -224,7 +224,7 @@ def test_ensure_active_instance_sets_sandbox_provider_env_from_adopted_instance(
     fake_sandbox_repo = _FakeSandboxRepo()
 
     monkeypatch.setattr(sandbox_lease_module, "_use_supabase_storage", lambda _db_path=None: True)
-    monkeypatch.setattr(sandbox_lease_module, "_make_lease_repo", lambda _db_path=None: fake_lease_repo)
+    monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_runtime_repo", lambda _db_path=None: fake_lease_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: _FakeEventRepo())
 


### PR DESCRIPTION
## Summary\n- rename the sandbox control-plane repo factory to sandbox-runtime language\n- update sandbox manager, chat session, and runtime-handle helpers to use the renamed factory\n- keep storage/provider repo protocols and table fields unchanged in this narrow slice\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q\n- python3 -m compileall sandbox tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py