### PR TITLE
refactor: rename sandbox runtime storage seams

### DIFF
--- a/backend/threads/state.py
+++ b/backend/threads/state.py
@@ -44,7 +44,7 @@ def get_sandbox_info(app: Any, thread_id: str, sandbox_type: str) -> dict[str, A
             sandbox_repo=app.state.sandbox_repo,
             thread_id=thread_id,
         )
-        runtime_row = _runtime_row_from_binding(app.state.lease_repo, binding)
+        runtime_row = _runtime_row_from_binding(app.state.sandbox_runtime_repo, binding)
         if not runtime_row:
             return sandbox_info
         instance = runtime_row.get("_instance")

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
 
     app.state.user_repo = storage_container.user_repo()
     app.state.thread_repo = storage_container.thread_repo()
-    app.state.lease_repo = storage_container.lease_repo()
+    app.state.sandbox_runtime_repo = storage_container.sandbox_runtime_repo()
     app.state.workspace_repo = storage_container.workspace_repo()
     app.state.sandbox_repo = storage_container.sandbox_repo()
     from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -346,7 +346,7 @@ def _resolve_owned_existing_sandbox_request_lease(
         raise HTTPException(403, "Not authorized")
     return resolve_existing_sandbox_lease(
         sandbox,
-        lease_repo=getattr(app.state, "lease_repo", None),
+        lease_repo=getattr(app.state, "sandbox_runtime_repo", None),
     )
 
 
@@ -545,13 +545,13 @@ def _create_thread_sandbox_resources(
 ) -> str:
     """Create lease and terminal resources without pre-provisioning file-channel storage."""
     from sandbox.control_plane_repos import make_terminal_repo
-    from storage.runtime import build_lease_repo as make_lease_repo
+    from storage.runtime import build_sandbox_runtime_repo as make_sandbox_runtime_repo
 
-    lease_repo = make_lease_repo()
+    sandbox_runtime_repo = make_sandbox_runtime_repo()
     try:
         lease_id = f"lease-{uuid.uuid4().hex[:12]}"
         normalized_recipe = normalize_recipe_snapshot(provider_type_from_name(sandbox_type), recipe, provider_name=sandbox_type)
-        created_lease = lease_repo.create(
+        created_lease = sandbox_runtime_repo.create(
             lease_id,
             sandbox_type,
             recipe_id=normalized_recipe["id"],
@@ -559,11 +559,11 @@ def _create_thread_sandbox_resources(
             owner_user_id=owner_user_id,
         )
     finally:
-        lease_repo.close()
+        sandbox_runtime_repo.close()
 
     sandbox_id = str((created_lease or {}).get("sandbox_id") or "").strip()
     if not sandbox_id:
-        raise RuntimeError("lease_repo.create must return sandbox_id for thread sandbox resources")
+        raise RuntimeError("sandbox_runtime_repo.create must return sandbox_id for thread sandbox resources")
 
     terminal_repo = make_terminal_repo()
     if terminal_repo is None:
@@ -676,7 +676,7 @@ def _bind_existing_sandbox_for_thread(
         thread_id,
         sandbox,
         cwd=bind_cwd,
-        lease_repo=getattr(app.state, "lease_repo", None),
+        lease_repo=getattr(app.state, "sandbox_runtime_repo", None),
     )
     if bound_lease is None:
         raise HTTPException(403, "Sandbox not authorized")
@@ -1279,7 +1279,7 @@ async def get_thread_sandbox_status(
         app.state.thread_repo,
         app.state.workspace_repo,
         app.state.sandbox_repo,
-        app.state.lease_repo,
+        app.state.sandbox_runtime_repo,
         thread_id,
     )
 

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -10,7 +10,7 @@ from backend.web.utils.helpers import extract_webhook_instance_id
 from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.lease import sandbox_runtime_from_row as lower_runtime_from_row
 from storage.container_cache import get_storage_container as _get_container
-from storage.runtime import build_lease_repo as make_lower_runtime_repo
+from storage.runtime import build_sandbox_runtime_repo as make_lower_runtime_repo
 
 router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import (
-    build_lease_repo,
+    build_sandbox_runtime_repo,
     uses_supabase_runtime_defaults,
 )
 
@@ -25,7 +25,7 @@ def make_chat_session_repo(db_path: Path | None = None):
 
 def make_sandbox_runtime_repo(db_path: Path | None = None):
     if _use_strategy_control_plane_repo(db_path):
-        return build_lease_repo()
+        return build_sandbox_runtime_repo()
     from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
 
     return SQLiteLeaseRepo(db_path=resolve_sandbox_db_path(db_path))

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -29,7 +29,7 @@ from sandbox.lifecycle import (
     parse_lease_instance_state,
 )
 from storage.providers.sqlite.kernel import connect_sqlite
-from storage.runtime import build_lease_repo as _build_strategy_sandbox_runtime_repo
+from storage.runtime import build_sandbox_runtime_repo as _build_strategy_sandbox_runtime_repo
 from storage.runtime import build_provider_event_repo as _build_strategy_provider_event_repo
 from storage.runtime import build_sandbox_repo as _build_strategy_sandbox_repo
 from storage.runtime import uses_supabase_runtime_defaults

--- a/storage/container.py
+++ b/storage/container.py
@@ -42,7 +42,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "evaluation_batch_repo": ("storage.providers.supabase.eval_batch_repo", "SupabaseEvaluationBatchRepo"),
     "queue_repo": ("storage.providers.supabase.queue_repo", "SupabaseQueueRepo"),
     "provider_event_repo": ("storage.providers.supabase.provider_event_repo", "SupabaseProviderEventRepo"),
-    "lease_repo": ("storage.providers.supabase.lease_repo", "SupabaseLeaseRepo"),
+    "sandbox_runtime_repo": ("storage.providers.supabase.lease_repo", "SupabaseLeaseRepo"),
     "tool_task_repo": ("storage.providers.supabase.tool_task_repo", "SupabaseToolTaskRepo"),
     "resource_snapshot_repo": ("storage.providers.supabase.resource_snapshot_repo", "SupabaseResourceSnapshotRepo"),
     "user_repo": ("storage.providers.supabase.user_repo", "SupabaseUserRepo"),
@@ -105,8 +105,8 @@ class StorageContainer:
     def provider_event_repo(self) -> ProviderEventRepo:
         return self._build("provider_event_repo")
 
-    def lease_repo(self) -> LeaseRepo:
-        return self._build("lease_repo")
+    def sandbox_runtime_repo(self) -> LeaseRepo:
+        return self._build("sandbox_runtime_repo")
 
     def tool_task_repo(self) -> ToolTaskRepo:
         return self._build("tool_task_repo")

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -71,8 +71,12 @@ def build_schedule_repo(*, supabase_client: Any | None = None, supabase_client_f
     return _build_storage_repo("schedule_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
 
 
-def build_lease_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
-    return _build_storage_repo("lease_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
+def build_sandbox_runtime_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo(
+        "sandbox_runtime_repo",
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+    )
 
 
 def build_resource_snapshot_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -117,7 +117,7 @@ def _patch_runtime_storage_container(monkeypatch: pytest.MonkeyPatch):
         def terminal_repo(self) -> _FakeControlPlaneRepo:
             return self._terminal_repo
 
-        def lease_repo(self) -> _FakeControlPlaneRepo:
+        def sandbox_runtime_repo(self) -> _FakeControlPlaneRepo:
             return self._lease_repo
 
         def chat_session_repo(self) -> _FakeControlPlaneRepo:

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -666,7 +666,7 @@ async def test_create_thread_existing_sandbox_binds_without_launch_config_save()
         "provider_env_id": "instance-1",
         "config": {},
     }
-    app.state.lease_repo = _FakeLeaseRepo(
+    app.state.sandbox_runtime_repo = _FakeLeaseRepo(
         {
             "lease_" + "id": "lease-1",
             "provider_name": "daytona_selfhost",

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -413,7 +413,7 @@ def _make_threads_app(
             runtime_storage_state=SimpleNamespace(recipe_repo=recipe_repo),
             workspace_repo=state_overrides.pop("workspace_repo", _FakeWorkspaceRepo()),
             sandbox_repo=state_overrides.pop("sandbox_repo", _FakeSandboxRepo()),
-            lease_repo=state_overrides.pop("lease_repo", _FakeLeaseRepo()),
+            sandbox_runtime_repo=state_overrides.pop("sandbox_runtime_repo", _FakeLeaseRepo()),
             **state_overrides,
         )
     )
@@ -459,7 +459,7 @@ async def test_get_thread_sandbox_status_returns_null_when_thread_has_no_runtime
                     "config": {},
                 }
             ),
-            lease_repo=SimpleNamespace(),
+            sandbox_runtime_repo=SimpleNamespace(),
         )
     )
 
@@ -497,7 +497,7 @@ async def test_get_thread_sandbox_status_reads_repos_without_agent_bootstrap():
                     "config": {},
                 }
             ),
-            lease_repo=SimpleNamespace(
+            sandbox_runtime_repo=SimpleNamespace(
                 find_by_instance=lambda *, provider_name, instance_id: {
                     "lease_" + "id": "lease-1",
                     "provider_name": "daytona",
@@ -607,7 +607,7 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
         thread_cwd={},
         workspace_repo=workspace_repo,
         sandbox_repo=sandbox_repo,
-        lease_repo=_existing_sandbox_lease_repo(recipe=None),
+        sandbox_runtime_repo=_existing_sandbox_lease_repo(recipe=None),
     )
     payload = CreateThreadRequest.model_validate(
         {
@@ -660,7 +660,7 @@ async def test_create_thread_route_existing_sandbox_prefers_existing_workspace_p
         thread_cwd={},
         workspace_repo=workspace_repo,
         sandbox_repo=sandbox_repo,
-        lease_repo=_existing_sandbox_lease_repo(recipe=None),
+        sandbox_runtime_repo=_existing_sandbox_lease_repo(recipe=None),
     )
     payload = CreateThreadRequest.model_validate(
         {
@@ -759,7 +759,7 @@ async def test_create_thread_route_accepts_sandbox_shaped_existing_identity() ->
         thread_cwd={},
         workspace_repo=workspace_repo,
         sandbox_repo=sandbox_repo,
-        lease_repo=_existing_sandbox_lease_repo(recipe={"id": "local:default"}),
+        sandbox_runtime_repo=_existing_sandbox_lease_repo(recipe={"id": "local:default"}),
     )
     payload = CreateThreadRequest.model_validate(
         {
@@ -1034,7 +1034,7 @@ async def test_create_thread_route_rejects_unavailable_provider():
 async def test_create_thread_route_rejects_unavailable_provider_for_existing_sandbox():
     app = _make_threads_app(thread_sandbox={}, thread_cwd={})
     app.state.sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row(provider_name="daytona")
-    app.state.lease_repo = _existing_sandbox_lease_repo(provider_name="daytona", recipe=None)
+    app.state.sandbox_runtime_repo = _existing_sandbox_lease_repo(provider_name="daytona", recipe=None)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -35,7 +35,7 @@ def _patch_lifespan_runtime_contract(
     storage_container = SimpleNamespace(
         user_repo=lambda: object(),
         thread_repo=lambda: object(),
-        lease_repo=lambda: object(),
+        sandbox_runtime_repo=lambda: object(),
         recipe_repo=lambda: SimpleNamespace(close=lambda: None),
         workspace_repo=lambda: object(),
         sandbox_repo=lambda: object(),
@@ -178,7 +178,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     storage_container = SimpleNamespace(
         user_repo=lambda: object(),
         thread_repo=lambda: object(),
-        lease_repo=lambda: object(),
+        sandbox_runtime_repo=lambda: object(),
         recipe_repo=lambda: SimpleNamespace(close=lambda: None),
         workspace_repo=lambda: object(),
         sandbox_repo=lambda: object(),

--- a/tests/Unit/backend/web/routers/test_thread_resource_creation.py
+++ b/tests/Unit/backend/web/routers/test_thread_resource_creation.py
@@ -40,7 +40,7 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
     materialize_calls: list[dict[str, object]] = []
 
     monkeypatch.setattr(container_cache, "get_storage_container", lambda: _Container())
-    monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
+    monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: lease_repo)
     monkeypatch.setattr("sandbox.control_plane_repos.make_terminal_repo", lambda: terminal_repo)
     monkeypatch.setattr(
         threads_router,
@@ -76,7 +76,7 @@ def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_p
     workspace_repo = object()
 
     monkeypatch.setattr(container_cache, "get_storage_container", lambda: _Container())
-    monkeypatch.setattr("storage.runtime.build_lease_repo", lambda: lease_repo)
+    monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: lease_repo)
     monkeypatch.setattr("sandbox.control_plane_repos.make_terminal_repo", lambda: terminal_repo)
     monkeypatch.setattr(threads_router, "_materialize_workspace_for_sandbox", lambda *args, **kwargs: "workspace-new")
 

--- a/tests/Unit/backend/web/services/test_thread_state_service.py
+++ b/tests/Unit/backend/web/services/test_thread_state_service.py
@@ -35,7 +35,7 @@ def test_sandbox_info_does_not_expose_terminal_or_session_identity() -> None:
                     "config": {},
                 }
             ),
-            lease_repo=SimpleNamespace(
+            sandbox_runtime_repo=SimpleNamespace(
                 get=lambda _lower_runtime_id: (_ for _ in ()).throw(AssertionError("sandbox info should not read removed lease id")),
                 find_by_instance=lambda *, provider_name, instance_id: {
                     "lease_" + "id": "lease-1",


### PR DESCRIPTION
## Summary\n- rename the runtime storage builder and container accessor to sandbox-runtime language\n- rename app.state storage access from lease_repo to sandbox_runtime_repo\n- update affected sandbox/web/router tests without widening into protocol or provider class renames\n\n## Testing\n- uv run python -m pytest tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/backend/web/services/test_thread_state_service.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q\n- uv run python -m pytest tests/Integration/test_leon_agent.py tests/Unit/backend/test_web_lifespan_ordering.py -q\n- python3 -m compileall storage backend sandbox tests/Integration/test_leon_agent.py tests/Integration/test_threads_router.py tests/Unit/backend/web/services/test_thread_state_service.py tests/Unit/backend/web/routers/test_thread_resource_creation.py