### PR TITLE
refactor: rename sandbox runtime repo protocol and providers

### DIFF
--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -26,9 +26,9 @@ def make_chat_session_repo(db_path: Path | None = None):
 def make_sandbox_runtime_repo(db_path: Path | None = None):
     if _use_strategy_control_plane_repo(db_path):
         return build_sandbox_runtime_repo()
-    from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+    from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
 
-    return SQLiteLeaseRepo(db_path=resolve_sandbox_db_path(db_path))
+    return SQLiteSandboxRuntimeRepo(db_path=resolve_sandbox_db_path(db_path))
 
 
 def make_terminal_repo(db_path: Path | None = None):

--- a/storage/container.py
+++ b/storage/container.py
@@ -14,13 +14,13 @@ from .contracts import (
     EvaluationBatchRepo,
     FileOperationRepo,
     InviteCodeRepo,
-    LeaseRepo,
     MonitorOperationRepo,
     ProviderEventRepo,
     QueueRepo,
     RecipeRepo,
     ResourceSnapshotRepo,
     RunEventRepo,
+    SandboxRuntimeRepo,
     SandboxMonitorRepo,
     SandboxRepo,
     SummaryRepo,
@@ -42,7 +42,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "evaluation_batch_repo": ("storage.providers.supabase.eval_batch_repo", "SupabaseEvaluationBatchRepo"),
     "queue_repo": ("storage.providers.supabase.queue_repo", "SupabaseQueueRepo"),
     "provider_event_repo": ("storage.providers.supabase.provider_event_repo", "SupabaseProviderEventRepo"),
-    "sandbox_runtime_repo": ("storage.providers.supabase.lease_repo", "SupabaseLeaseRepo"),
+    "sandbox_runtime_repo": ("storage.providers.supabase.sandbox_runtime_repo", "SupabaseSandboxRuntimeRepo"),
     "tool_task_repo": ("storage.providers.supabase.tool_task_repo", "SupabaseToolTaskRepo"),
     "resource_snapshot_repo": ("storage.providers.supabase.resource_snapshot_repo", "SupabaseResourceSnapshotRepo"),
     "user_repo": ("storage.providers.supabase.user_repo", "SupabaseUserRepo"),
@@ -105,7 +105,7 @@ class StorageContainer:
     def provider_event_repo(self) -> ProviderEventRepo:
         return self._build("provider_event_repo")
 
-    def sandbox_runtime_repo(self) -> LeaseRepo:
+    def sandbox_runtime_repo(self) -> SandboxRuntimeRepo:
         return self._build("sandbox_runtime_repo")
 
     def tool_task_repo(self) -> ToolTaskRepo:

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -15,7 +15,7 @@ NotificationType = Literal["steer", "command", "agent", "chat"]
 # ---------------------------------------------------------------------------
 
 
-class LeaseRepo(Protocol):
+class SandboxRuntimeRepo(Protocol):
     """Lower sandbox runtime persistence. Returns raw dicts for domain object construction."""
 
     def close(self) -> None: ...

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -1,4 +1,4 @@
-"""SQLite repository for sandbox lease persistence."""
+"""SQLite repository for sandbox runtime persistence."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from sandbox.lifecycle import parse_lease_instance_state
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
 
 
-class SQLiteLeaseRepo:
+class SQLiteSandboxRuntimeRepo:
     """Lower sandbox runtime persistence backed by SQLite.
 
     Thread-safe: all connection access is serialized via a lock.

--- a/storage/providers/supabase/__init__.py
+++ b/storage/providers/supabase/__init__.py
@@ -7,7 +7,7 @@ from .contact_repo import SupabaseContactRepo
 from .eval_repo import SupabaseEvalRepo
 from .file_operation_repo import SupabaseFileOperationRepo
 from .invite_code_repo import SupabaseInviteCodeRepo
-from .lease_repo import SupabaseLeaseRepo
+from .sandbox_runtime_repo import SupabaseSandboxRuntimeRepo
 from .monitor_operation_repo import SupabaseMonitorOperationRepo
 from .provider_event_repo import SupabaseProviderEventRepo
 from .queue_repo import SupabaseQueueRepo
@@ -30,7 +30,7 @@ __all__ = [
     "SupabaseEvalRepo",
     "SupabaseFileOperationRepo",
     "SupabaseInviteCodeRepo",
-    "SupabaseLeaseRepo",
+    "SupabaseSandboxRuntimeRepo",
     "SupabaseMonitorOperationRepo",
     "SupabaseProviderEventRepo",
     "SupabaseQueueRepo",

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -1,4 +1,4 @@
-"""Supabase repository for sandbox lease persistence."""
+"""Supabase repository for sandbox runtime persistence."""
 
 from __future__ import annotations
 
@@ -116,8 +116,8 @@ def _patched_config(row: dict[str, Any], updates: dict[str, Any]) -> dict[str, A
     return config
 
 
-class SupabaseLeaseRepo:
-    """Container-backed LeaseRepo for lower sandbox runtime contracts."""
+class SupabaseSandboxRuntimeRepo:
+    """Container-backed SandboxRuntimeRepo for lower sandbox runtime contracts."""
 
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -23,7 +23,7 @@ from sandbox.runtime import (
 )
 from sandbox.terminal import SQLiteTerminal, TerminalState, terminal_from_row
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
 from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
 
@@ -38,7 +38,7 @@ def terminal_store(temp_db):
 class _DomainLeaseStore:
     """Thin wrapper: repo returns dicts, tests expect domain objects from create/get."""
 
-    def __init__(self, repo: SQLiteLeaseRepo):
+    def __init__(self, repo: SQLiteSandboxRuntimeRepo):
         self._repo = repo
 
     def create(self, lower_runtime_id, provider_name, **kw):
@@ -55,8 +55,8 @@ class _DomainLeaseStore:
 
 @pytest.fixture
 def lease_store(temp_db):
-    """Create SQLiteLeaseRepo with domain-object conversion for tests."""
-    repo = SQLiteLeaseRepo(db_path=temp_db)
+    """Create SQLiteSandboxRuntimeRepo with domain-object conversion for tests."""
+    repo = SQLiteSandboxRuntimeRepo(db_path=temp_db)
     store = _DomainLeaseStore(repo)
     yield store
     repo.close()

--- a/tests/Unit/storage/test_sqlite_lease_repo.py
+++ b/tests/Unit/storage/test_sqlite_lease_repo.py
@@ -1,8 +1,8 @@
-from storage.providers.sqlite.lease_repo import SQLiteLeaseRepo
+from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
 
 
 def test_sqlite_lease_repo_schema_does_not_create_removed_volume_id(tmp_path):
-    repo = SQLiteLeaseRepo(tmp_path / "sandbox.db")
+    repo = SQLiteSandboxRuntimeRepo(tmp_path / "sandbox.db")
     try:
         cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_leases)").fetchall()}
     finally:

--- a/tests/Unit/storage/test_supabase_lease_repo.py
+++ b/tests/Unit/storage/test_supabase_lease_repo.py
@@ -1,6 +1,6 @@
 import pytest
 
-from storage.providers.supabase.lease_repo import SupabaseLeaseRepo
+from storage.providers.supabase.sandbox_runtime_repo import SupabaseSandboxRuntimeRepo
 from tests.fakes.supabase import FakeSupabaseClient
 
 
@@ -58,7 +58,7 @@ def _sandbox_row(
 
 
 def test_supabase_lease_repo_get_reads_container_sandbox_runtime_state():
-    repo = SupabaseLeaseRepo(client=_client({"container.sandboxes": [_sandbox_row()]}))
+    repo = SupabaseSandboxRuntimeRepo(client=_client({"container.sandboxes": [_sandbox_row()]}))
 
     lease = repo.get("lease-1")
 
@@ -77,7 +77,7 @@ def test_supabase_lease_repo_get_reads_container_sandbox_runtime_state():
 
 
 def test_supabase_lease_repo_create_requires_owner_user_id():
-    repo = SupabaseLeaseRepo(client=_client())
+    repo = SupabaseSandboxRuntimeRepo(client=_client())
 
     with pytest.raises(RuntimeError, match="requires owner_user_id"):
         repo.create("lease-1", "local")
@@ -86,7 +86,7 @@ def test_supabase_lease_repo_create_requires_owner_user_id():
 def test_supabase_lease_repo_get_fails_loudly_when_runtime_state_is_missing():
     row = _sandbox_row()
     row["config"].pop("runtime_state")
-    repo = SupabaseLeaseRepo(client=_client({"container.sandboxes": [row]}))
+    repo = SupabaseSandboxRuntimeRepo(client=_client({"container.sandboxes": [row]}))
 
     with pytest.raises(RuntimeError, match="missing config.runtime_state"):
         repo.get("lease-1")
@@ -95,7 +95,7 @@ def test_supabase_lease_repo_get_fails_loudly_when_runtime_state_is_missing():
 def test_supabase_lease_repo_provider_list_ignores_stale_rows_without_runtime_state():
     stale = _sandbox_row(sandbox_id="sandbox-stale", lease_id="lease-stale")
     stale["config"].pop("runtime_state")
-    repo = SupabaseLeaseRepo(client=_client({"container.sandboxes": [_sandbox_row(), stale]}))
+    repo = SupabaseSandboxRuntimeRepo(client=_client({"container.sandboxes": [_sandbox_row(), stale]}))
 
     leases = repo.list_by_provider("local")
 
@@ -106,7 +106,7 @@ def test_supabase_lease_repo_provider_list_ignores_stale_rows_without_runtime_st
 
 def test_supabase_lease_repo_create_writes_container_sandbox_runtime_state():
     tables: dict[str, list[dict]] = {}
-    repo = SupabaseLeaseRepo(client=_client(tables))
+    repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
     created = repo.create(
         "lease-1",
@@ -136,7 +136,7 @@ def test_supabase_lease_repo_create_writes_container_sandbox_runtime_state():
 
 def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and_state():
     tables = {"container.sandboxes": [_sandbox_row(provider_env_id=None, observed_state="detached", version=0, needs_refresh=0)]}
-    repo = SupabaseLeaseRepo(client=_client(tables))
+    repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
     updated = repo.adopt_instance(
         lease_id="lease-1",
@@ -155,7 +155,7 @@ def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and
 
 def test_supabase_lease_repo_persist_metadata_updates_container_runtime_state_fields():
     tables = {"container.sandboxes": [_sandbox_row(provider_env_id=None, observed_state="detached", version=0, needs_refresh=0)]}
-    repo = SupabaseLeaseRepo(client=_client(tables))
+    repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
     updated = repo.persist_metadata(
         lease_id="lease-1",
@@ -186,7 +186,7 @@ def test_supabase_lease_repo_persist_metadata_updates_container_runtime_state_fi
 
 def test_supabase_lease_repo_observe_status_detaches_instance_from_container_sandbox():
     tables = {"container.sandboxes": [_sandbox_row()]}
-    repo = SupabaseLeaseRepo(client=_client(tables))
+    repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
     updated = repo.observe_status(
         lease_id="lease-1",
@@ -208,7 +208,7 @@ def test_supabase_lease_repo_observe_status_detaches_instance_from_container_san
 
 def test_supabase_lease_repo_mark_needs_refresh_updates_runtime_state_only():
     tables = {"container.sandboxes": [_sandbox_row(needs_refresh=0, refresh_hint_at=None)]}
-    repo = SupabaseLeaseRepo(client=_client(tables))
+    repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
     assert repo.mark_needs_refresh("lease-1", hint_at="2026-04-07T00:00:06+00:00") is True
 
@@ -219,7 +219,7 @@ def test_supabase_lease_repo_mark_needs_refresh_updates_runtime_state_only():
 
 def test_supabase_lease_repo_delete_removes_container_sandbox_runtime_row():
     tables = {"container.sandboxes": [_sandbox_row()]}
-    repo = SupabaseLeaseRepo(client=_client(tables))
+    repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
     repo.delete("lease-1")
 


### PR DESCRIPTION
## Summary\n- rename the storage protocol from LeaseRepo to SandboxRuntimeRepo\n- rename provider repo modules/classes to sandbox_runtime_repo / *SandboxRuntimeRepo\n- realign direct imports in control-plane and focused storage/runtime tests\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_sqlite_lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/core/test_runtime.py -q\n- uv run python -m pytest tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/backend/web/services/test_thread_state_service.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py tests/Unit/storage/test_sqlite_lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/core/test_runtime.py -q\n- python3 -m compileall storage backend sandbox tests/Unit/storage/test_sqlite_lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/core/test_runtime.py