### PR TITLE
refactor: rename sandbox runtime repo local wording

### DIFF
--- a/backend/threads/state.py
+++ b/backend/threads/state.py
@@ -70,7 +70,7 @@ async def get_sandbox_status_from_repos(
     thread_repo: Any,
     workspace_repo: Any,
     sandbox_repo: Any,
-    lease_repo: Any,
+    sandbox_runtime_repo: Any,
     thread_id: str,
 ) -> dict[str, Any] | None:
     """Get thread sandbox status from storage repos without bootstrapping an agent."""
@@ -81,7 +81,7 @@ async def get_sandbox_status_from_repos(
         sandbox_repo=sandbox_repo,
         thread_id=thread_id,
     )
-    runtime_row = await asyncio.to_thread(_runtime_row_from_binding, lease_repo, binding)
+    runtime_row = await asyncio.to_thread(_runtime_row_from_binding, sandbox_runtime_repo, binding)
     if not runtime_row:
         return None
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -346,7 +346,7 @@ def _resolve_owned_existing_sandbox_request_lease(
         raise HTTPException(403, "Not authorized")
     return resolve_existing_sandbox_lease(
         sandbox,
-        lease_repo=getattr(app.state, "sandbox_runtime_repo", None),
+        sandbox_runtime_repo=getattr(app.state, "sandbox_runtime_repo", None),
     )
 
 
@@ -676,7 +676,7 @@ def _bind_existing_sandbox_for_thread(
         thread_id,
         sandbox,
         cwd=bind_cwd,
-        lease_repo=getattr(app.state, "sandbox_runtime_repo", None),
+        sandbox_runtime_repo=getattr(app.state, "sandbox_runtime_repo", None),
     )
     if bound_lease is None:
         raise HTTPException(403, "Sandbox not authorized")

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -142,7 +142,7 @@ class ChatSessionManager:
         default_policy: ChatSessionPolicy | None = None,
         chat_session_repo=None,
         terminal_repo=None,
-        lease_repo=None,
+        sandbox_runtime_repo=None,
     ):
         self.provider = provider
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
@@ -153,7 +153,7 @@ class ChatSessionManager:
         else:
             self._repo = make_chat_session_repo(db_path=self.db_path)
         self._terminal_repo = terminal_repo
-        self._lease_repo = lease_repo
+        self._sandbox_runtime_repo = sandbox_runtime_repo
 
     def _close_runtime(self, session: ChatSession, reason: str) -> None:
         try:
@@ -225,15 +225,15 @@ class ChatSessionManager:
             if own_term_repo:
                 _term_repo.close()
         terminal = terminal_from_row(_term_row, self.db_path) if _term_row else None
-        _lease_repo = self._lease_repo
-        own_lease_repo = _lease_repo is None
-        if _lease_repo is None:
-            _lease_repo = make_sandbox_runtime_repo(db_path=self.db_path)
+        _sandbox_runtime_repo = self._sandbox_runtime_repo
+        own_sandbox_runtime_repo = _sandbox_runtime_repo is None
+        if _sandbox_runtime_repo is None:
+            _sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=self.db_path)
         try:
-            _lease_row = _lease_repo.get(row["lease_id"])
+            _lease_row = _sandbox_runtime_repo.get(row["lease_id"])
         finally:
-            if own_lease_repo:
-                _lease_repo.close()
+            if own_sandbox_runtime_repo:
+                _sandbox_runtime_repo.close()
         sandbox_runtime = sandbox_runtime_from_row(_lease_row, self.db_path) if _lease_row else None
         if not terminal or not sandbox_runtime:
             return None

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -45,33 +45,33 @@ def lookup_sandbox_for_thread(
     db_path: Path | None = None,
     *,
     terminal_repo: Any | None = None,
-    lease_repo: Any | None = None,
+    sandbox_runtime_repo: Any | None = None,
 ) -> str | None:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
     uses_strategy_default_sandbox = uses_supabase_runtime_defaults() and target_db == resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    if terminal_repo is None and lease_repo is None and not target_db.exists() and not uses_strategy_default_sandbox:
+    if terminal_repo is None and sandbox_runtime_repo is None and not target_db.exists() and not uses_strategy_default_sandbox:
         return None
 
     _terminal_repo = terminal_repo
     own_terminal_repo = _terminal_repo is None
     if _terminal_repo is None:
         _terminal_repo = make_terminal_repo(db_path=target_db)
-    _lease_repo = lease_repo
-    own_lease_repo = _lease_repo is None
-    if _lease_repo is None:
-        _lease_repo = make_sandbox_runtime_repo(db_path=target_db)
+    _sandbox_runtime_repo = sandbox_runtime_repo
+    own_sandbox_runtime_repo = _sandbox_runtime_repo is None
+    if _sandbox_runtime_repo is None:
+        _sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=target_db)
     try:
         terminals = _terminal_repo.list_by_thread(thread_id)
         if not terminals:
             return None
         lease_id = str(terminals[0]["lease_id"])
-        lease = _lease_repo.get(lease_id)
+        lease = _sandbox_runtime_repo.get(lease_id)
         return str(lease["provider_name"]) if lease else None
     finally:
         if own_terminal_repo:
             _terminal_repo.close()
-        if own_lease_repo:
-            _lease_repo.close()
+        if own_sandbox_runtime_repo:
+            _sandbox_runtime_repo.close()
 
 
 def resolve_existing_lease_cwd(
@@ -79,21 +79,21 @@ def resolve_existing_lease_cwd(
     requested_cwd: str | None = None,
     db_path: Path | None = None,
     *,
-    lease_repo: Any | None = None,
+    sandbox_runtime_repo: Any | None = None,
 ) -> str:
     if requested_cwd:
         return requested_cwd
 
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    _lease_repo = lease_repo
-    own_lease_repo = _lease_repo is None
-    if _lease_repo is None:
-        _lease_repo = make_sandbox_runtime_repo(db_path=target_db)
+    _sandbox_runtime_repo = sandbox_runtime_repo
+    own_sandbox_runtime_repo = _sandbox_runtime_repo is None
+    if _sandbox_runtime_repo is None:
+        _sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=target_db)
     try:
-        lease = _lease_repo.get(lease_id)
+        lease = _sandbox_runtime_repo.get(lease_id)
     finally:
-        if own_lease_repo:
-            _lease_repo.close()
+        if own_sandbox_runtime_repo:
+            _sandbox_runtime_repo.close()
     provider_name = str((lease or {}).get("provider_name") or "").strip()
     provider = _build_provider_from_name(provider_name) if provider_name else None
     if provider is not None:
@@ -108,7 +108,7 @@ def bind_thread_to_existing_lease(
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
-    lease_repo: Any | None = None,
+    sandbox_runtime_repo: Any | None = None,
 ) -> str:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
     _terminal_repo = terminal_repo
@@ -123,7 +123,7 @@ def bind_thread_to_existing_lease(
             lease_id,
             cwd,
             db_path=target_db,
-            lease_repo=lease_repo,
+            sandbox_runtime_repo=sandbox_runtime_repo,
         )
         _terminal_repo.create(
             terminal_id=f"term-{uuid.uuid4().hex[:12]}",
@@ -141,7 +141,7 @@ def resolve_existing_sandbox_lease(
     sandbox: Any,
     *,
     db_path: Path | None = None,
-    lease_repo: Any | None = None,
+    sandbox_runtime_repo: Any | None = None,
 ) -> dict[str, Any] | None:
     provider_name = str(
         (sandbox.get("provider_name") if isinstance(sandbox, dict) else getattr(sandbox, "provider_name", None)) or ""
@@ -157,17 +157,17 @@ def resolve_existing_sandbox_lease(
     # @@@existing-sandbox-runtime-identity - existing-sandbox reuse must bind
     # through live runtime identity; stored runtime config is not a resolution source.
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    _lease_repo = lease_repo
-    own_lease_repo = _lease_repo is None
-    if _lease_repo is None:
-        _lease_repo = make_sandbox_runtime_repo(db_path=target_db)
+    _sandbox_runtime_repo = sandbox_runtime_repo
+    own_sandbox_runtime_repo = _sandbox_runtime_repo is None
+    if _sandbox_runtime_repo is None:
+        _sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=target_db)
     try:
-        lease = _lease_repo.find_by_instance(provider_name=provider_name, instance_id=provider_env_id)
+        lease = _sandbox_runtime_repo.find_by_instance(provider_name=provider_name, instance_id=provider_env_id)
         if lease is not None:
             return lease
     finally:
-        if own_lease_repo:
-            _lease_repo.close()
+        if own_sandbox_runtime_repo:
+            _sandbox_runtime_repo.close()
     raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
 
 
@@ -178,12 +178,12 @@ def bind_thread_to_existing_sandbox(
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
-    lease_repo: Any | None = None,
+    sandbox_runtime_repo: Any | None = None,
 ) -> tuple[str, dict[str, Any]]:
     lease = resolve_existing_sandbox_lease(
         sandbox,
         db_path=db_path,
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
     if lease is None:
         raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
@@ -196,7 +196,7 @@ def bind_thread_to_existing_sandbox(
         cwd=cwd,
         db_path=db_path,
         terminal_repo=terminal_repo,
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
     return initial_cwd, lease
 
@@ -208,7 +208,7 @@ def bind_thread_to_existing_thread_lease(
     cwd: str | None = None,
     db_path: Path | None = None,
     terminal_repo: Any | None = None,
-    lease_repo: Any | None = None,
+    sandbox_runtime_repo: Any | None = None,
 ) -> str | None:
     target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
     if not cwd:
@@ -233,7 +233,7 @@ def bind_thread_to_existing_thread_lease(
         cwd=cwd,
         db_path=target_db,
         terminal_repo=terminal_repo,
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
 
 
@@ -258,7 +258,7 @@ class SandboxManager:
             default_policy=ChatSessionPolicy(),
             chat_session_repo=make_chat_session_repo(db_path=self.db_path),
             terminal_repo=self.terminal_store,
-            lease_repo=self.sandbox_runtime_store,
+            sandbox_runtime_repo=self.sandbox_runtime_store,
         )
 
         from sandbox.volume import SandboxVolume

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -181,7 +181,7 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
     cwd = sandbox_manager_module.resolve_existing_lease_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=lease_repo,
     )
 
     assert cwd == "/providers/local"
@@ -200,7 +200,7 @@ def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_prov
     cwd = sandbox_manager_module.resolve_existing_lease_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=lease_repo,
     )
 
     assert cwd == "/providers/local"
@@ -219,7 +219,7 @@ def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavaila
         sandbox_manager_module.resolve_existing_lease_cwd(
             "lease-1",
             db_path=Path("/tmp/fake-sandbox.db"),
-            lease_repo=lease_repo,
+            sandbox_runtime_repo=lease_repo,
         )
 
     assert lease_repo.requested_ids == ["lease-1"]
@@ -244,7 +244,7 @@ def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider
         },
         db_path=Path("/tmp/fake-sandbox.db"),
         terminal_repo=terminal_repo,
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=lease_repo,
     )
 
     assert initial_cwd == "/providers/local"
@@ -271,7 +271,7 @@ def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monk
             "thread-parent",
             db_path=Path("/tmp/fake-sandbox.db"),
             terminal_repo=terminal_repo,
-            lease_repo=lease_repo,
+            sandbox_runtime_repo=lease_repo,
         )
     except ValueError as exc:
         assert str(exc) == "thread reuse cwd is required"
@@ -1082,7 +1082,7 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
             "provider_env_id": "sandbox-env-1",
             "config": {"runtime_handle": "stored-runtime"},
         },
-        lease_repo=lease_repo,
+        sandbox_runtime_repo=lease_repo,
     )
 
     assert lease == {
@@ -1105,5 +1105,5 @@ def test_resolve_existing_sandbox_lease_fails_when_instance_lookup_misses() -> N
                 "provider_env_id": "sandbox-env-1",
                 "config": {"runtime_handle": "stored-runtime"},
             },
-            lease_repo=lease_repo,
+            sandbox_runtime_repo=lease_repo,
         )

--- a/tests/Unit/sandbox/test_sandbox_runtime_repo_local_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_repo_local_naming.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TARGETS = (
+    "sandbox/chat_session.py",
+    "sandbox/manager.py",
+    "backend/threads/state.py",
+    "backend/web/routers/threads.py",
+)
+
+
+def test_target_runtime_surfaces_do_not_use_lease_repo_local_wording() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+
+    for rel_path in TARGETS:
+        path = repo_root / rel_path
+        source = path.read_text(encoding="utf-8")
+        if "lease_repo" in source:
+            offenders.append(rel_path)
+
+    assert offenders == [], "Found lease_repo residue in runtime surfaces:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- rename remaining production-local lease_repo parameter/local wording to sandbox_runtime_repo\n- update the focused sandbox manager tests to the renamed keyword args\n- add a source-guard test to keep lease_repo wording out of the targeted runtime surfaces\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_runtime_repo_local_naming.py -q\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/backend/web/services/test_thread_state_service.py tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py tests/Unit/sandbox/test_sandbox_runtime_repo_local_naming.py -q\n- rg -n \blease_repo\b backend sandbox storage --glob '!tests/**'\n- git diff --check