### PR TITLE
refactor: clean sandbox runtime repo wording

### DIFF
--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -45,7 +45,7 @@ class SQLiteSandboxRuntimeRepo:
 
     def _require_lease(self, row: dict[str, Any] | None, *, lease_id: str, operation: str) -> dict[str, Any]:
         if row is None:
-            raise RuntimeError(f"SQLite lease repo failed to load lease after {operation}: {lease_id}")
+            raise RuntimeError(f"SQLite sandbox runtime repo failed to load runtime after {operation}: {lease_id}")
         return row
 
     def get(self, lease_id: str) -> dict[str, Any] | None:

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from storage.providers.supabase import _query as q
 
-_REPO = "lease repo"
+_REPO = "sandbox runtime repo"
 _SCHEMA = "container"
 _TABLE = "sandboxes"
 _SANDBOX_COLS = (
@@ -130,7 +130,7 @@ class SupabaseSandboxRuntimeRepo:
 
     def _require_lease(self, row: dict[str, Any] | None, *, lease_id: str, operation: str) -> dict[str, Any]:
         if row is None:
-            raise RuntimeError(f"Supabase lease repo failed to load lease after {operation}: {lease_id}")
+            raise RuntimeError(f"Supabase sandbox runtime repo failed to load runtime after {operation}: {lease_id}")
         return row
 
     def _sandbox_rows(self) -> list[dict[str, Any]]:
@@ -159,7 +159,7 @@ class SupabaseSandboxRuntimeRepo:
         owner_user_id: str | None = None,
     ) -> dict[str, Any]:
         if not owner_user_id:
-            raise RuntimeError("Supabase lease repo create requires owner_user_id for container.sandboxes")
+            raise RuntimeError("Supabase sandbox runtime repo create requires owner_user_id for container.sandboxes")
         now = _utc_now_iso()
         self._sandboxes().insert(
             {

--- a/tests/Unit/storage/test_sandbox_runtime_repo_wording.py
+++ b/tests/Unit/storage/test_sandbox_runtime_repo_wording.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TARGETS = (
+    "storage/providers/sqlite/sandbox_runtime_repo.py",
+    "storage/providers/supabase/sandbox_runtime_repo.py",
+)
+
+
+def test_provider_runtime_repo_modules_do_not_use_lease_repo_wording() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+
+    for rel_path in TARGETS:
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        if "lease repo" in source:
+            offenders.append(rel_path)
+
+    assert offenders == [], "Found lease repo wording in provider runtime repos:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- remove remaining provider runtime repo internal wording that still said lease repo\n- align the runtime repo error messages to sandbox-runtime language\n- add a focused wording guard for the provider runtime repo modules\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_sandbox_runtime_repo_wording.py -q\n- uv run python -m pytest tests/Unit/storage/test_sqlite_lease_repo.py tests/Unit/storage/test_supabase_lease_repo.py tests/Unit/core/test_runtime.py -q\n- git diff --check