### PR TITLE
test: rename sandbox runtime repo test residue

### DIFF
--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -122,7 +122,7 @@ class _FakeSandboxRepo:
         self.by_id[row.id] = row
 
 
-class _FakeLeaseRepo:
+class _FakeSandboxRuntimeRepo:
     def __init__(self, row: dict[str, object] | None = None) -> None:
         self._row = row
         self.instance_queries: list[tuple[str, str]] = []
@@ -145,7 +145,7 @@ def _make_threads_app():
             runtime_storage_state=SimpleNamespace(recipe_repo=recipe_repo),
             workspace_repo=_FakeWorkspaceRepo(),
             sandbox_repo=_FakeSandboxRepo(),
-            lease_repo=_FakeLeaseRepo(),
+            sandbox_runtime_repo=_FakeSandboxRuntimeRepo(),
             thread_sandbox={},
             thread_cwd={},
         )
@@ -666,7 +666,7 @@ async def test_create_thread_existing_sandbox_binds_without_launch_config_save()
         "provider_env_id": "instance-1",
         "config": {},
     }
-    app.state.sandbox_runtime_repo = _FakeLeaseRepo(
+    app.state.sandbox_runtime_repo = _FakeSandboxRuntimeRepo(
         {
             "lease_" + "id": "lease-1",
             "provider_name": "daytona_selfhost",

--- a/tests/Integration/test_threads_router.py
+++ b/tests/Integration/test_threads_router.py
@@ -96,7 +96,7 @@ class _FakeSandboxRepo:
         self.by_id[row.id] = row
 
 
-class _FakeLeaseRepo:
+class _FakeSandboxRuntimeRepo:
     def __init__(self, row: dict[str, Any] | None = None) -> None:
         self._row = row
         self.instance_queries: list[tuple[str, str]] = []
@@ -124,7 +124,7 @@ def _existing_sandbox_row(
     }
 
 
-def _existing_sandbox_lease_repo(
+def _existing_sandbox_runtime_repo(
     *,
     lower_runtime_id: str = "lease-1",
     sandbox_id: str = "sandbox-1",
@@ -132,8 +132,8 @@ def _existing_sandbox_lease_repo(
     provider_env_id: str = "instance-1",
     cwd: str = "/workspace/reused",
     recipe: dict[str, Any] | None = None,
-) -> _FakeLeaseRepo:
-    return _FakeLeaseRepo(
+) -> _FakeSandboxRuntimeRepo:
+    return _FakeSandboxRuntimeRepo(
         {
             "lease_" + "id": lower_runtime_id,
             "sandbox_id": sandbox_id,
@@ -413,7 +413,7 @@ def _make_threads_app(
             runtime_storage_state=SimpleNamespace(recipe_repo=recipe_repo),
             workspace_repo=state_overrides.pop("workspace_repo", _FakeWorkspaceRepo()),
             sandbox_repo=state_overrides.pop("sandbox_repo", _FakeSandboxRepo()),
-            sandbox_runtime_repo=state_overrides.pop("sandbox_runtime_repo", _FakeLeaseRepo()),
+            sandbox_runtime_repo=state_overrides.pop("sandbox_runtime_repo", _FakeSandboxRuntimeRepo()),
             **state_overrides,
         )
     )
@@ -607,7 +607,7 @@ async def test_create_thread_route_persists_workspace_id_for_existing_sandbox() 
         thread_cwd={},
         workspace_repo=workspace_repo,
         sandbox_repo=sandbox_repo,
-        sandbox_runtime_repo=_existing_sandbox_lease_repo(recipe=None),
+        sandbox_runtime_repo=_existing_sandbox_runtime_repo(recipe=None),
     )
     payload = CreateThreadRequest.model_validate(
         {
@@ -660,7 +660,7 @@ async def test_create_thread_route_existing_sandbox_prefers_existing_workspace_p
         thread_cwd={},
         workspace_repo=workspace_repo,
         sandbox_repo=sandbox_repo,
-        sandbox_runtime_repo=_existing_sandbox_lease_repo(recipe=None),
+        sandbox_runtime_repo=_existing_sandbox_runtime_repo(recipe=None),
     )
     payload = CreateThreadRequest.model_validate(
         {
@@ -759,7 +759,7 @@ async def test_create_thread_route_accepts_sandbox_shaped_existing_identity() ->
         thread_cwd={},
         workspace_repo=workspace_repo,
         sandbox_repo=sandbox_repo,
-        sandbox_runtime_repo=_existing_sandbox_lease_repo(recipe={"id": "local:default"}),
+        sandbox_runtime_repo=_existing_sandbox_runtime_repo(recipe={"id": "local:default"}),
     )
     payload = CreateThreadRequest.model_validate(
         {
@@ -1034,7 +1034,7 @@ async def test_create_thread_route_rejects_unavailable_provider():
 async def test_create_thread_route_rejects_unavailable_provider_for_existing_sandbox():
     app = _make_threads_app(thread_sandbox={}, thread_cwd={})
     app.state.sandbox_repo.by_id["sandbox-1"] = _existing_sandbox_row(provider_name="daytona")
-    app.state.sandbox_runtime_repo = _existing_sandbox_lease_repo(provider_name="daytona", recipe=None)
+    app.state.sandbox_runtime_repo = _existing_sandbox_runtime_repo(provider_name="daytona", recipe=None)
     payload = CreateThreadRequest.model_validate(
         {
             "agent_user_id": "agent-user-1",

--- a/tests/Unit/backend/web/routers/test_thread_resource_creation.py
+++ b/tests/Unit/backend/web/routers/test_thread_resource_creation.py
@@ -8,7 +8,7 @@ class _Container:
     pass
 
 
-class _LeaseRepo:
+class _SandboxRuntimeRepo:
     def __init__(self) -> None:
         self.created: list[dict[str, str]] = []
         self.closed = False
@@ -34,13 +34,13 @@ class _TerminalRepo:
 
 
 def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(monkeypatch, tmp_path):
-    lease_repo = _LeaseRepo()
+    sandbox_runtime_repo = _SandboxRuntimeRepo()
     terminal_repo = _TerminalRepo()
     workspace_repo = object()
     materialize_calls: list[dict[str, object]] = []
 
     monkeypatch.setattr(container_cache, "get_storage_container", lambda: _Container())
-    monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: lease_repo)
+    monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: sandbox_runtime_repo)
     monkeypatch.setattr("sandbox.control_plane_repos.make_terminal_repo", lambda: terminal_repo)
     monkeypatch.setattr(
         threads_router,
@@ -58,25 +58,25 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
     )
 
     assert workspace_id == "workspace-1"
-    assert len(lease_repo.created) == 1
-    assert lease_repo.created[0]["provider_name"] == "local"
-    assert "volume_id" not in lease_repo.created[0]
+    assert len(sandbox_runtime_repo.created) == 1
+    assert sandbox_runtime_repo.created[0]["provider_name"] == "local"
+    assert "volume_id" not in sandbox_runtime_repo.created[0]
     assert len(terminal_repo.created) == 1
     assert terminal_repo.created[0]["thread_id"] == "thread-1"
-    assert terminal_repo.created[0][LOWER_RUNTIME_KEY] == lease_repo.created[0][LOWER_RUNTIME_KEY]
+    assert terminal_repo.created[0][LOWER_RUNTIME_KEY] == sandbox_runtime_repo.created[0][LOWER_RUNTIME_KEY]
     assert terminal_repo.created[0]["initial_cwd"] == "/tmp/workspace"
     assert materialize_calls[0]["sandbox_id"] == "sandbox-from-lease-create"
-    assert lease_repo.closed
+    assert sandbox_runtime_repo.closed
     assert terminal_repo.closed
 
 
 def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_path):
-    lease_repo = _LeaseRepo()
+    sandbox_runtime_repo = _SandboxRuntimeRepo()
     terminal_repo = _TerminalRepo()
     workspace_repo = object()
 
     monkeypatch.setattr(container_cache, "get_storage_container", lambda: _Container())
-    monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: lease_repo)
+    monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: sandbox_runtime_repo)
     monkeypatch.setattr("sandbox.control_plane_repos.make_terminal_repo", lambda: terminal_repo)
     monkeypatch.setattr(threads_router, "_materialize_workspace_for_sandbox", lambda *args, **kwargs: "workspace-new")
 
@@ -90,4 +90,4 @@ def test_create_thread_sandbox_resources_returns_workspace_id(monkeypatch, tmp_p
     )
 
     assert workspace_id == "workspace-new"
-    assert "volume_id" not in lease_repo.created[0]
+    assert "volume_id" not in sandbox_runtime_repo.created[0]

--- a/tests/Unit/backend/web/services/test_thread_state_service.py
+++ b/tests/Unit/backend/web/services/test_thread_state_service.py
@@ -83,7 +83,7 @@ async def test_sandbox_status_resolves_runtime_from_provider_env_not_config() ->
             "config": {},
         }
     )
-    lease_repo = SimpleNamespace(
+    sandbox_runtime_repo = SimpleNamespace(
         get=lambda _lower_runtime_id: (_ for _ in ()).throw(AssertionError("thread sandbox status must not read removed lease id")),
         find_by_instance=lambda *, provider_name, instance_id: {
             "lease_" + "id": "lease-1",
@@ -103,7 +103,13 @@ async def test_sandbox_status_resolves_runtime_from_provider_env_not_config() ->
         },
     )
 
-    result = await get_sandbox_status_from_repos(thread_repo, workspace_repo, sandbox_repo, lease_repo, "thread-1")
+    result = await get_sandbox_status_from_repos(
+        thread_repo,
+        workspace_repo,
+        sandbox_repo,
+        sandbox_runtime_repo,
+        "thread-1",
+    )
 
     assert result == {
         "thread_id": "thread-1",

--- a/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
+++ b/tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py
@@ -5,7 +5,7 @@ import sandbox.lease as sandbox_lease_module
 from sandbox.lease import SandboxInstance, SQLiteSandboxRuntimeHandle
 
 
-class _FakeLeaseRepo:
+class _FakeSandboxRuntimeRepo:
     def __init__(self, row):
         self.row = row
         self.observe_calls = []
@@ -25,7 +25,7 @@ class _FakeLeaseRepo:
         self.closed = True
 
 
-class _FakeAdoptLeaseRepo:
+class _FakeAdoptSandboxRuntimeRepo:
     def __init__(self, row):
         self.row = row
         self.adopt_calls = []
@@ -125,7 +125,7 @@ class _FakeProvider:
 
 
 def test_observe_status_detached_clears_sandbox_provider_env(monkeypatch) -> None:
-    fake_lease_repo = _FakeLeaseRepo(
+    fake_sandbox_runtime_repo = _FakeSandboxRuntimeRepo(
         {
             "lease_id": "lease-1",
             "provider_name": "local",
@@ -153,7 +153,7 @@ def test_observe_status_detached_clears_sandbox_provider_env(monkeypatch) -> Non
     fake_sandbox_repo = _FakeSandboxRepo()
 
     monkeypatch.setattr(sandbox_lease_module, "_use_supabase_storage", lambda _db_path=None: True)
-    monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_runtime_repo", lambda _db_path=None: fake_lease_repo)
+    monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_runtime_repo", lambda _db_path=None: fake_sandbox_runtime_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: fake_event_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
 
@@ -190,7 +190,7 @@ def test_observe_status_detached_clears_sandbox_provider_env(monkeypatch) -> Non
 
 
 def test_ensure_active_instance_sets_sandbox_provider_env_from_adopted_instance(monkeypatch) -> None:
-    fake_lease_repo = _FakeAdoptLeaseRepo(
+    fake_sandbox_runtime_repo = _FakeAdoptSandboxRuntimeRepo(
         {
             "lease_id": "lease-1",
             "provider_name": "local",
@@ -224,7 +224,7 @@ def test_ensure_active_instance_sets_sandbox_provider_env_from_adopted_instance(
     fake_sandbox_repo = _FakeSandboxRepo()
 
     monkeypatch.setattr(sandbox_lease_module, "_use_supabase_storage", lambda _db_path=None: True)
-    monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_runtime_repo", lambda _db_path=None: fake_lease_repo)
+    monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_runtime_repo", lambda _db_path=None: fake_sandbox_runtime_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_sandbox_repo", lambda: fake_sandbox_repo)
     monkeypatch.setattr(sandbox_lease_module, "_make_provider_event_repo", lambda: _FakeEventRepo())
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -100,7 +100,7 @@ class _FakeBindTerminalRepo:
         self.closed = True
 
 
-class _FakeLeaseRepo:
+class _FakeSandboxRuntimeRepo:
     def __init__(self, row: dict[str, Any] | None = None) -> None:
         self._row = row
         self.closed = False
@@ -167,7 +167,7 @@ def _new_test_manager() -> Any:
 
 
 def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_truth(monkeypatch):
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
 
     def build_provider(name: str):
         return SimpleNamespace(default_cwd=f"/providers/{name}") if name == "local" else None
@@ -181,16 +181,16 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
     cwd = sandbox_manager_module.resolve_existing_lease_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
-        sandbox_runtime_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
 
     assert cwd == "/providers/local"
-    assert lease_repo.requested_ids == ["lease-1"]
-    assert lease_repo.closed is False
+    assert sandbox_runtime_repo.requested_ids == ["lease-1"]
+    assert sandbox_runtime_repo.closed is False
 
 
 def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_provider_default(monkeypatch):
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
     monkeypatch.setattr(
         sandbox_manager_module,
         "_build_provider_from_name",
@@ -200,15 +200,15 @@ def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_prov
     cwd = sandbox_manager_module.resolve_existing_lease_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
-        sandbox_runtime_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
 
     assert cwd == "/providers/local"
-    assert lease_repo.requested_ids == ["lease-1"]
+    assert sandbox_runtime_repo.requested_ids == ["lease-1"]
 
 
 def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavailable(monkeypatch):
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "missing-provider"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "missing-provider"})
     monkeypatch.setattr(
         sandbox_manager_module,
         "_build_provider_from_name",
@@ -219,15 +219,15 @@ def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavaila
         sandbox_manager_module.resolve_existing_lease_cwd(
             "lease-1",
             db_path=Path("/tmp/fake-sandbox.db"),
-            sandbox_runtime_repo=lease_repo,
+            sandbox_runtime_repo=sandbox_runtime_repo,
         )
 
-    assert lease_repo.requested_ids == ["lease-1"]
+    assert sandbox_runtime_repo.requested_ids == ["lease-1"]
 
 
 def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider_default_exists(monkeypatch):
     terminal_repo = _FakeBindTerminalRepo(latest_by_lease={"cwd": "/terminal/latest"})
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
 
     monkeypatch.setattr(
         sandbox_manager_module,
@@ -244,7 +244,7 @@ def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider
         },
         db_path=Path("/tmp/fake-sandbox.db"),
         terminal_repo=terminal_repo,
-        sandbox_runtime_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
 
     assert initial_cwd == "/providers/local"
@@ -257,7 +257,7 @@ def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monk
         latest_by_lease={"cwd": "/terminal/latest"},
         active_by_thread={"thread-parent": {"lease_id": "lease-1"}},
     )
-    lease_repo = _FakeLeaseRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local"})
 
     monkeypatch.setattr(
         sandbox_manager_module,
@@ -271,7 +271,7 @@ def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monk
             "thread-parent",
             db_path=Path("/tmp/fake-sandbox.db"),
             terminal_repo=terminal_repo,
-            sandbox_runtime_repo=lease_repo,
+            sandbox_runtime_repo=sandbox_runtime_repo,
         )
     except ValueError as exc:
         assert str(exc) == "thread reuse cwd is required"
@@ -1067,7 +1067,7 @@ def test_make_sandbox_monitor_repo_returns_supabase(monkeypatch):
 
 
 def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
-    lease_repo = SimpleNamespace(
+    sandbox_runtime_repo = SimpleNamespace(
         find_by_instance=lambda **kwargs: {
             "lease_id": "lease-live",
             "provider_name": kwargs["provider_name"],
@@ -1082,7 +1082,7 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
             "provider_env_id": "sandbox-env-1",
             "config": {"runtime_handle": "stored-runtime"},
         },
-        sandbox_runtime_repo=lease_repo,
+        sandbox_runtime_repo=sandbox_runtime_repo,
     )
 
     assert lease == {
@@ -1093,7 +1093,7 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
 
 
 def test_resolve_existing_sandbox_lease_fails_when_instance_lookup_misses() -> None:
-    lease_repo = SimpleNamespace(
+    sandbox_runtime_repo = SimpleNamespace(
         find_by_instance=lambda **_kwargs: None,
         close=lambda: None,
     )
@@ -1105,5 +1105,5 @@ def test_resolve_existing_sandbox_lease_fails_when_instance_lookup_misses() -> N
                 "provider_env_id": "sandbox-env-1",
                 "config": {"runtime_handle": "stored-runtime"},
             },
-            sandbox_runtime_repo=lease_repo,
+            sandbox_runtime_repo=sandbox_runtime_repo,
         )

--- a/tests/Unit/storage/test_sandbox_runtime_test_residue.py
+++ b/tests/Unit/storage/test_sandbox_runtime_test_residue.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TARGETS = (
+    "tests/Integration/test_thread_launch_config_contract.py",
+    "tests/Integration/test_threads_router.py",
+    "tests/Unit/backend/web/routers/test_thread_resource_creation.py",
+    "tests/Unit/backend/web/services/test_thread_state_service.py",
+    "tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py",
+    "tests/Unit/sandbox/test_sandbox_manager_volume_repo.py",
+)
+
+FORBIDDEN = (
+    "_FakeLeaseRepo",
+    "_LeaseRepo",
+)
+
+FORBIDDEN_FILENAMES = (
+    "tests/Unit/storage/test_sqlite_lease_repo.py",
+    "tests/Unit/storage/test_supabase_lease_repo.py",
+)
+
+
+def test_target_runtime_tests_do_not_use_legacy_lease_repo_helper_names() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+
+    for rel_path in TARGETS:
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        for pattern in FORBIDDEN:
+            if pattern in source:
+                offenders.append(f"{rel_path} -> {pattern}")
+
+    for rel_path in FORBIDDEN_FILENAMES:
+        if (repo_root / rel_path).exists():
+            offenders.append(f"{rel_path} -> filename")
+
+    assert offenders == [], "Found legacy lease repo test residue:\n" + "\n".join(offenders)

--- a/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
+++ b/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
@@ -1,7 +1,7 @@
 from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
 
 
-def test_sqlite_lease_repo_schema_does_not_create_removed_volume_id(tmp_path):
+def test_sqlite_sandbox_runtime_repo_schema_does_not_create_removed_volume_id(tmp_path):
     repo = SQLiteSandboxRuntimeRepo(tmp_path / "sandbox.db")
     try:
         cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_leases)").fetchall()}

--- a/tests/Unit/storage/test_supabase_sandbox_runtime_repo.py
+++ b/tests/Unit/storage/test_supabase_sandbox_runtime_repo.py
@@ -57,7 +57,7 @@ def _sandbox_row(
     }
 
 
-def test_supabase_lease_repo_get_reads_container_sandbox_runtime_state():
+def test_supabase_sandbox_runtime_repo_get_reads_container_sandbox_runtime_state():
     repo = SupabaseSandboxRuntimeRepo(client=_client({"container.sandboxes": [_sandbox_row()]}))
 
     lease = repo.get("lease-1")
@@ -76,14 +76,14 @@ def test_supabase_lease_repo_get_reads_container_sandbox_runtime_state():
     assert lease["_instance"]["instance_id"] == "inst-1"
 
 
-def test_supabase_lease_repo_create_requires_owner_user_id():
+def test_supabase_sandbox_runtime_repo_create_requires_owner_user_id():
     repo = SupabaseSandboxRuntimeRepo(client=_client())
 
     with pytest.raises(RuntimeError, match="requires owner_user_id"):
         repo.create("lease-1", "local")
 
 
-def test_supabase_lease_repo_get_fails_loudly_when_runtime_state_is_missing():
+def test_supabase_sandbox_runtime_repo_get_fails_loudly_when_runtime_state_is_missing():
     row = _sandbox_row()
     row["config"].pop("runtime_state")
     repo = SupabaseSandboxRuntimeRepo(client=_client({"container.sandboxes": [row]}))
@@ -92,7 +92,7 @@ def test_supabase_lease_repo_get_fails_loudly_when_runtime_state_is_missing():
         repo.get("lease-1")
 
 
-def test_supabase_lease_repo_provider_list_ignores_stale_rows_without_runtime_state():
+def test_supabase_sandbox_runtime_repo_provider_list_ignores_stale_rows_without_runtime_state():
     stale = _sandbox_row(sandbox_id="sandbox-stale", lease_id="lease-stale")
     stale["config"].pop("runtime_state")
     repo = SupabaseSandboxRuntimeRepo(client=_client({"container.sandboxes": [_sandbox_row(), stale]}))
@@ -104,7 +104,7 @@ def test_supabase_lease_repo_provider_list_ignores_stale_rows_without_runtime_st
         repo.get("lease-stale")
 
 
-def test_supabase_lease_repo_create_writes_container_sandbox_runtime_state():
+def test_supabase_sandbox_runtime_repo_create_writes_container_sandbox_runtime_state():
     tables: dict[str, list[dict]] = {}
     repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
@@ -134,7 +134,7 @@ def test_supabase_lease_repo_create_writes_container_sandbox_runtime_state():
     assert "volume_id" not in row
 
 
-def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and_state():
+def test_supabase_sandbox_runtime_repo_adopt_instance_updates_container_runtime_fields_and_state():
     tables = {"container.sandboxes": [_sandbox_row(provider_env_id=None, observed_state="detached", version=0, needs_refresh=0)]}
     repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
@@ -153,7 +153,7 @@ def test_supabase_lease_repo_adopt_instance_updates_container_runtime_fields_and
     assert updated["_instance"]["instance_id"] == "inst-1"
 
 
-def test_supabase_lease_repo_persist_metadata_updates_container_runtime_state_fields():
+def test_supabase_sandbox_runtime_repo_persist_metadata_updates_container_runtime_state_fields():
     tables = {"container.sandboxes": [_sandbox_row(provider_env_id=None, observed_state="detached", version=0, needs_refresh=0)]}
     repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
@@ -184,7 +184,7 @@ def test_supabase_lease_repo_persist_metadata_updates_container_runtime_state_fi
     assert runtime_state["status"] == "recovering"
 
 
-def test_supabase_lease_repo_observe_status_detaches_instance_from_container_sandbox():
+def test_supabase_sandbox_runtime_repo_observe_status_detaches_instance_from_container_sandbox():
     tables = {"container.sandboxes": [_sandbox_row()]}
     repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
@@ -206,7 +206,7 @@ def test_supabase_lease_repo_observe_status_detaches_instance_from_container_san
     assert updated["_instance"] is None
 
 
-def test_supabase_lease_repo_mark_needs_refresh_updates_runtime_state_only():
+def test_supabase_sandbox_runtime_repo_mark_needs_refresh_updates_runtime_state_only():
     tables = {"container.sandboxes": [_sandbox_row(needs_refresh=0, refresh_hint_at=None)]}
     repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 
@@ -217,7 +217,7 @@ def test_supabase_lease_repo_mark_needs_refresh_updates_runtime_state_only():
     assert runtime_state["refresh_hint_at"] == "2026-04-07T00:00:06+00:00"
 
 
-def test_supabase_lease_repo_delete_removes_container_sandbox_runtime_row():
+def test_supabase_sandbox_runtime_repo_delete_removes_container_sandbox_runtime_row():
     tables = {"container.sandboxes": [_sandbox_row()]}
     repo = SupabaseSandboxRuntimeRepo(client=_client(tables))
 


### PR DESCRIPTION
## Summary\n- rename remaining lease-repo helper names in targeted runtime/storage tests\n- rename the sqlite/supabase storage test files to sandbox-runtime wording\n- add a focused residue guard to keep these legacy helper/file names from returning\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_sandbox_runtime_test_residue.py -q\n- uv run python -m pytest tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/storage/test_supabase_sandbox_runtime_repo.py tests/Unit/storage/test_sandbox_runtime_test_residue.py -q\n- uv run python -m pytest tests/Unit/backend/web/services/test_thread_state_service.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/storage/test_sandbox_runtime_test_residue.py tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/storage/test_supabase_sandbox_runtime_repo.py -q\n- git diff --check