### PR TITLE
refactor: rename sandbox runtime manager wording

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -56,7 +56,7 @@ from backend.web.utils.serializers import serialize_message
 from core.agents.service import _background_run_cancelled, _background_run_result, request_background_run_stop
 from core.runtime.middleware.monitor import AgentState
 from sandbox.config import MountSpec
-from sandbox.manager import bind_thread_to_existing_sandbox, resolve_existing_sandbox_lease
+from sandbox.manager import bind_thread_to_existing_sandbox, resolve_existing_sandbox_runtime
 from sandbox.recipes import default_recipe_id, normalize_recipe_snapshot, provider_type_from_name
 from sandbox.thread_context import set_current_thread_id
 from storage.contracts import WorkspaceRow
@@ -344,7 +344,7 @@ def _resolve_owned_existing_sandbox_request_lease(
     sandbox_owner_user_id = _request_row_text(sandbox, "owner_user_id", label="sandbox")
     if sandbox_owner_user_id != owner_user_id:
         raise HTTPException(403, "Not authorized")
-    return resolve_existing_sandbox_lease(
+    return resolve_existing_sandbox_runtime(
         sandbox,
         sandbox_runtime_repo=getattr(app.state, "sandbox_runtime_repo", None),
     )

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -892,10 +892,10 @@ class AgentService:
             prompt = _normalize_child_workspace_prompt(prompt, child_workspace_root)
 
             if parent_thread_id and parent_thread_id != thread_id:
-                from sandbox.manager import bind_thread_to_existing_thread_lease
+                from sandbox.manager import bind_thread_to_existing_thread_sandbox_runtime
 
                 parent_workspace_cwd = self._resolve_parent_workspace_path(parent_thread_id) or str(child_workspace_root)
-                bind_thread_to_existing_thread_lease(
+                bind_thread_to_existing_thread_sandbox_runtime(
                     thread_id,
                     parent_thread_id,
                     cwd=parent_workspace_cwd,

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -74,7 +74,7 @@ def lookup_sandbox_for_thread(
             _sandbox_runtime_repo.close()
 
 
-def resolve_existing_lease_cwd(
+def resolve_existing_sandbox_runtime_cwd(
     lease_id: str,
     requested_cwd: str | None = None,
     db_path: Path | None = None,
@@ -101,7 +101,7 @@ def resolve_existing_lease_cwd(
     raise ValueError("provider default cwd is required")
 
 
-def bind_thread_to_existing_lease(
+def bind_thread_to_existing_sandbox_runtime(
     thread_id: str,
     lease_id: str,
     *,
@@ -119,7 +119,7 @@ def bind_thread_to_existing_lease(
         existing = _terminal_repo.get_active(thread_id)
         if existing is not None:
             return str(existing["cwd"])
-        initial_cwd = resolve_existing_lease_cwd(
+        initial_cwd = resolve_existing_sandbox_runtime_cwd(
             lease_id,
             cwd,
             db_path=target_db,
@@ -137,7 +137,7 @@ def bind_thread_to_existing_lease(
             _terminal_repo.close()
 
 
-def resolve_existing_sandbox_lease(
+def resolve_existing_sandbox_runtime(
     sandbox: Any,
     *,
     db_path: Path | None = None,
@@ -168,7 +168,7 @@ def resolve_existing_sandbox_lease(
     finally:
         if own_sandbox_runtime_repo:
             _sandbox_runtime_repo.close()
-    raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
+    raise RuntimeError("sandbox provider_env_id did not resolve to a sandbox runtime")
 
 
 def bind_thread_to_existing_sandbox(
@@ -180,17 +180,17 @@ def bind_thread_to_existing_sandbox(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> tuple[str, dict[str, Any]]:
-    lease = resolve_existing_sandbox_lease(
+    lease = resolve_existing_sandbox_runtime(
         sandbox,
         db_path=db_path,
         sandbox_runtime_repo=sandbox_runtime_repo,
     )
     if lease is None:
-        raise RuntimeError("sandbox provider_env_id did not resolve to a lease")
+        raise RuntimeError("sandbox provider_env_id did not resolve to a sandbox runtime")
     lease_id = str(lease.get("lease_id") or "").strip()
     if not lease_id:
         raise RuntimeError("lease.sandbox_runtime_id is required")
-    initial_cwd = bind_thread_to_existing_lease(
+    initial_cwd = bind_thread_to_existing_sandbox_runtime(
         thread_id,
         lease_id,
         cwd=cwd,
@@ -201,7 +201,7 @@ def bind_thread_to_existing_sandbox(
     return initial_cwd, lease
 
 
-def bind_thread_to_existing_thread_lease(
+def bind_thread_to_existing_thread_sandbox_runtime(
     thread_id: str,
     source_thread_id: str,
     *,
@@ -227,7 +227,7 @@ def bind_thread_to_existing_thread_lease(
     # @@@subagent-lease-reuse
     # Child threads need their own terminal/session state while reusing the
     # parent's lower sandbox binding instead of silently provisioning a new one.
-    return bind_thread_to_existing_lease(
+    return bind_thread_to_existing_sandbox_runtime(
         thread_id,
         str(source_terminal["lease_id"]),
         cwd=cwd,
@@ -309,7 +309,7 @@ class SandboxManager:
             raise ValueError(f"No active terminal for thread {thread_id}")
         lease = self._get_sandbox_runtime(terminal.lease_id)
         if not lease:
-            raise ValueError(f"No lease for thread {thread_id}")
+            raise ValueError(f"No sandbox runtime for thread {thread_id}")
         remote_path = self.volume.resolve_mount_path()
         source_path = self._resolve_sync_source_path(thread_id)
 
@@ -508,7 +508,7 @@ class SandboxManager:
                     return SandboxCapability(session, manager=self)
                 lease = self._get_sandbox_runtime(terminal.lease_id)
                 if not lease:
-                    raise RuntimeError(f"Lease disappeared after resume for thread {thread_id}")
+                    raise RuntimeError(f"Sandbox runtime disappeared after resume for thread {thread_id}")
                 self._assert_lease_provider(lease, thread_id)
 
         # Stamp bind_mounts on provider thread state so lazy create_session paths pick them up
@@ -562,7 +562,7 @@ class SandboxManager:
         default_terminal = terminal_from_row(default_row, self.db_path)
         lease = self._get_sandbox_runtime(default_terminal.lease_id)
         if lease is None:
-            raise RuntimeError(f"Missing lease {default_terminal.lease_id} for thread {thread_id}")
+            raise RuntimeError(f"Missing sandbox runtime {default_terminal.lease_id} for thread {thread_id}")
         self._assert_lease_provider(lease, thread_id)
 
         inherited = default_terminal.get_state()
@@ -850,7 +850,7 @@ class SandboxManager:
             if lease_in_use:
                 continue
             if not self.destroy_sandbox_runtime_resources(lease_id):
-                raise RuntimeError(f"Missing lease {lease_id} for thread {thread_id}")
+                raise RuntimeError(f"Missing sandbox runtime {lease_id} for thread {thread_id}")
         return True
 
     def destroy_sandbox_runtime_resources(self, lease_id: str) -> bool:
@@ -858,7 +858,7 @@ class SandboxManager:
         if not lease:
             return False
         if any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all()):
-            raise RuntimeError(f"Lease {lease_id} still has bound terminals")
+            raise RuntimeError(f"Sandbox runtime {lease_id} still has bound terminals")
         lease.destroy_instance(self.provider)
         if self.provider_capability.runtime_kind == "daytona_pty":
             self._destroy_daytona_managed_volume(lease_id)

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1208,7 +1208,7 @@ async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(mon
         captured["cwd"] = cwd
         return "/workspace/parent"
 
-    monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_lease", fake_bind)
+    monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_sandbox_runtime", fake_bind)
 
     service = _make_service(
         tmp_path,
@@ -1294,7 +1294,7 @@ async def test_run_agent_falls_back_to_child_workspace_root_when_parent_workspac
         captured["cwd"] = cwd
         return cwd
 
-    monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_lease", fake_bind)
+    monkeypatch.setattr("sandbox.manager.bind_thread_to_existing_thread_sandbox_runtime", fake_bind)
 
     service = _make_service(
         tmp_path,

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -166,7 +166,7 @@ def _new_test_manager() -> Any:
     return manager
 
 
-def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_truth(monkeypatch):
+def test_resolve_existing_sandbox_runtime_cwd_prefers_provider_default_when_no_workspace_truth(monkeypatch):
     sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
 
     def build_provider(name: str):
@@ -178,7 +178,7 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
         build_provider,
     )
 
-    cwd = sandbox_manager_module.resolve_existing_lease_cwd(
+    cwd = sandbox_manager_module.resolve_existing_sandbox_runtime_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
         sandbox_runtime_repo=sandbox_runtime_repo,
@@ -189,7 +189,7 @@ def test_resolve_existing_lease_cwd_prefers_provider_default_when_no_workspace_t
     assert sandbox_runtime_repo.closed is False
 
 
-def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_provider_default(monkeypatch):
+def test_resolve_existing_sandbox_runtime_cwd_ignores_latest_terminal_cwd_and_prefers_provider_default(monkeypatch):
     sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
     monkeypatch.setattr(
         sandbox_manager_module,
@@ -197,7 +197,7 @@ def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_prov
         lambda name: SimpleNamespace(default_cwd=f"/providers/{name}"),
     )
 
-    cwd = sandbox_manager_module.resolve_existing_lease_cwd(
+    cwd = sandbox_manager_module.resolve_existing_sandbox_runtime_cwd(
         "lease-1",
         db_path=Path("/tmp/fake-sandbox.db"),
         sandbox_runtime_repo=sandbox_runtime_repo,
@@ -207,7 +207,7 @@ def test_resolve_existing_lease_cwd_ignores_latest_terminal_cwd_and_prefers_prov
     assert sandbox_runtime_repo.requested_ids == ["lease-1"]
 
 
-def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavailable(monkeypatch):
+def test_resolve_existing_sandbox_runtime_cwd_fails_loud_when_provider_default_is_unavailable(monkeypatch):
     sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "missing-provider"})
     monkeypatch.setattr(
         sandbox_manager_module,
@@ -216,7 +216,7 @@ def test_resolve_existing_lease_cwd_fails_loud_when_provider_default_is_unavaila
     )
 
     with pytest.raises(ValueError, match="provider default cwd is required"):
-        sandbox_manager_module.resolve_existing_lease_cwd(
+        sandbox_manager_module.resolve_existing_sandbox_runtime_cwd(
             "lease-1",
             db_path=Path("/tmp/fake-sandbox.db"),
             sandbox_runtime_repo=sandbox_runtime_repo,
@@ -252,7 +252,7 @@ def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider
     assert terminal_repo.created[0]["initial_cwd"] == "/providers/local"
 
 
-def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monkeypatch):
+def test_bind_thread_to_existing_thread_sandbox_runtime_requires_parent_workspace_cwd(monkeypatch):
     terminal_repo = _FakeBindTerminalRepo(
         latest_by_lease={"cwd": "/terminal/latest"},
         active_by_thread={"thread-parent": {"lease_id": "lease-1"}},
@@ -266,7 +266,7 @@ def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monk
     )
 
     try:
-        sandbox_manager_module.bind_thread_to_existing_thread_lease(
+        sandbox_manager_module.bind_thread_to_existing_thread_sandbox_runtime(
             "thread-child",
             "thread-parent",
             db_path=Path("/tmp/fake-sandbox.db"),
@@ -276,7 +276,7 @@ def test_bind_thread_to_existing_thread_lease_requires_parent_workspace_cwd(monk
     except ValueError as exc:
         assert str(exc) == "thread reuse cwd is required"
     else:
-        raise AssertionError("expected bind_thread_to_existing_thread_lease to fail loudly without cwd")
+        raise AssertionError("expected bind_thread_to_existing_thread_sandbox_runtime to fail loudly without cwd")
 
 
 def test_setup_mounts_uses_workspace_sync_source_for_non_daytona_runtime(tmp_path):
@@ -300,7 +300,7 @@ def test_setup_mounts_reports_missing_lease_not_missing_volume():
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: None
 
-    with pytest.raises(ValueError, match="No lease for thread thread-1"):
+    with pytest.raises(ValueError, match="No sandbox runtime for thread thread-1"):
         manager._setup_mounts("thread-1")
 
 
@@ -1066,7 +1066,7 @@ def test_make_sandbox_monitor_repo_returns_supabase(monkeypatch):
         repo.close()
 
 
-def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
+def test_resolve_existing_sandbox_runtime_prefers_provider_env_binding() -> None:
     sandbox_runtime_repo = SimpleNamespace(
         find_by_instance=lambda **kwargs: {
             "lease_id": "lease-live",
@@ -1076,7 +1076,7 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
         close=lambda: None,
     )
 
-    lease = sandbox_manager_module.resolve_existing_sandbox_lease(
+    lease = sandbox_manager_module.resolve_existing_sandbox_runtime(
         {
             "provider_name": "daytona",
             "provider_env_id": "sandbox-env-1",
@@ -1092,14 +1092,14 @@ def test_resolve_existing_sandbox_lease_prefers_provider_env_binding() -> None:
     }
 
 
-def test_resolve_existing_sandbox_lease_fails_when_instance_lookup_misses() -> None:
+def test_resolve_existing_sandbox_runtime_fails_when_instance_lookup_misses() -> None:
     sandbox_runtime_repo = SimpleNamespace(
         find_by_instance=lambda **_kwargs: None,
         close=lambda: None,
     )
 
-    with pytest.raises(RuntimeError, match="sandbox provider_env_id did not resolve to a lease"):
-        sandbox_manager_module.resolve_existing_sandbox_lease(
+    with pytest.raises(RuntimeError, match="sandbox provider_env_id did not resolve to a sandbox runtime"):
+        sandbox_manager_module.resolve_existing_sandbox_runtime(
             {
                 "provider_name": "daytona",
                 "provider_env_id": "sandbox-env-1",

--- a/tests/Unit/sandbox/test_sandbox_runtime_manager_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_manager_naming.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FORBIDDEN = (
+    "def resolve_existing_lease_cwd(",
+    "def bind_thread_to_existing_lease(",
+    "def resolve_existing_sandbox_lease(",
+    "def bind_thread_to_existing_thread_lease(",
+    "No lease for thread",
+    "Missing lease ",
+    "Lease disappeared after resume",
+    "Lease ",
+)
+
+
+def test_sandbox_manager_runtime_surface_avoids_lease_wording() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "sandbox/manager.py").read_text(encoding="utf-8")
+    offenders = [pattern for pattern in FORBIDDEN if pattern in source]
+    assert offenders == [], "Found sandbox.manager lease wording residue:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- rename sandbox.manager helper names from lease wording to sandbox-runtime wording\n- align direct imports/callers in thread router and agent service\n- replace targeted sandbox.manager runtime errors with sandbox-runtime wording and guard the file against those old helper/error names\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_runtime_manager_naming.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/core/test_agent_service.py tests/Integration/test_thread_launch_config_contract.py tests/Integration/test_threads_router.py -q\n- git diff --check