### PR TITLE
refactor: clean sandbox runtime core wording

### DIFF
--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -161,14 +161,14 @@ class _CommandWrapper(BaseExecutor):
         terminal = terminal_from_row(terminal_row, self._manager.db_path)
         if terminal.thread_id != self._session.thread_id:
             raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal.thread_id}, not {self._session.thread_id}")
-        lease = self._manager.get_sandbox_runtime(terminal.lease_id)
-        if lease is None:
-            raise RuntimeError(f"Lease {terminal.lease_id} not found for terminal {terminal_id}")
+        sandbox_runtime = self._manager.get_sandbox_runtime(terminal.lease_id)
+        if sandbox_runtime is None:
+            raise RuntimeError(f"Sandbox runtime {terminal.lease_id} not found for terminal {terminal_id}")
         return self._manager.session_manager.create(
             session_id=f"sess-{uuid.uuid4().hex[:12]}",
             thread_id=self._session.thread_id,
             terminal=terminal,
-            sandbox_runtime=lease,
+            sandbox_runtime=sandbox_runtime,
         )
 
     def _resolve_session_for_command(self, command_id: str):
@@ -191,7 +191,7 @@ class _CommandWrapper(BaseExecutor):
 
 
 class _FileSystemWrapper(FileSystemBackend):
-    """Wrapper that delegates to provider via lease."""
+    """Wrapper that delegates to provider via sandbox runtime."""
 
     is_remote = True
 
@@ -200,7 +200,7 @@ class _FileSystemWrapper(FileSystemBackend):
         self._manager = manager
 
     def _get_provider(self):
-        """Get provider from session's lease."""
+        """Get provider from session's sandbox runtime."""
         provider = getattr(self._session.runtime, "provider", None)
         if provider is None:
             raise RuntimeError("FileSystem operations only supported for remote runtimes")
@@ -208,7 +208,7 @@ class _FileSystemWrapper(FileSystemBackend):
 
     def _get_instance_id(self) -> str:
         """Get active instance ID."""
-        # @@@lease-convergence - File operations can also wake paused instances; always converge through lease.
+        # @@@runtime-convergence - File operations can also wake paused instances; always converge through sandbox runtime.
         provider = getattr(self._session.runtime, "provider", None)
         if provider is not None:
             try:

--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -1,11 +1,11 @@
-"""SandboxRuntimeHandle - durable compute handle with lease-level state machine.
+"""SandboxRuntimeHandle - durable compute handle with sandbox-runtime state machine.
 
 Architecture:
     SandboxRuntimeHandle (durable) -> SandboxInstance (ephemeral)
 
 State machine contract:
 - Physical lifecycle writes must go through SQLiteSandboxRuntimeHandle.apply(event).
-- Lease snapshot stores desired_state + observed_state + version.
+- Sandbox runtime snapshot stores desired_state + observed_state + version.
 """
 
 from __future__ import annotations
@@ -261,7 +261,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             if observed == "unknown":
                 self.observed_state = observed
                 return
-            raise RuntimeError(f"Lease {self.sandbox_runtime_id}: cannot set observed={observed} without bound instance ({reason})")
+            raise RuntimeError(
+                f"Sandbox runtime {self.sandbox_runtime_id}: cannot set observed={observed} without bound instance ({reason})"
+            )
 
         if observed == "running":
             assert_lease_instance_transition(self._instance_state(), LeaseInstanceState.RUNNING, reason=reason)
@@ -291,7 +293,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             self.observed_state = "unknown"
             return
 
-        raise RuntimeError(f"Lease {self.sandbox_runtime_id}: invalid observed state '{observed}'")
+        raise RuntimeError(f"Sandbox runtime {self.sandbox_runtime_id}: invalid observed state '{observed}'")
 
     def _snapshot(self) -> dict[str, Any]:
         return {
@@ -580,9 +582,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             try:
                 ok = provider.destroy_session(instance_id)
             except Exception as exc:
-                raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}: {exc}") from exc
+                raise RuntimeError(f"Failed to destroy sandbox runtime {self.sandbox_runtime_id}: {exc}") from exc
             if not ok:
-                raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}")
+                raise RuntimeError(f"Failed to destroy sandbox runtime {self.sandbox_runtime_id}")
         self.desired_state = "destroyed"
         self._set_observed_state("detached", reason="intent.destroy")
         self.status = "expired"
@@ -642,16 +644,18 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         if not getattr(capability, capability_name):
             raise RuntimeError(f"Provider {provider.name} does not support {event_type.split('.')[-1]}")
         if not self._current_instance:
-            raise RuntimeError(f"Lease {self.sandbox_runtime_id} has no instance to {event_type.split('.')[-1]}")
+            raise RuntimeError(f"Sandbox runtime {self.sandbox_runtime_id} has no instance to {event_type.split('.')[-1]}")
 
         instance_id = self._current_instance.instance_id
         provider_method = getattr(provider, provider_method_name)
         try:
             ok = provider_method(instance_id)
         except Exception as exc:
-            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.sandbox_runtime_id}: {exc}") from exc
+            raise RuntimeError(
+                f"Failed to {event_type.split('.')[-1]} sandbox runtime {self.sandbox_runtime_id}: {exc}"
+            ) from exc
         if not ok:
-            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} lease {self.sandbox_runtime_id}")
+            raise RuntimeError(f"Failed to {event_type.split('.')[-1]} sandbox runtime {self.sandbox_runtime_id}")
 
         self.desired_state = desired_state
         self._set_observed_state(observed_state, reason=event_type)
@@ -742,13 +746,13 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     if not capability.can_pause:
                         raise RuntimeError(f"Provider {provider.name} does not support pause")
                     if not self._current_instance:
-                        raise RuntimeError(f"Lease {self.sandbox_runtime_id} has no instance to pause")
+                        raise RuntimeError(f"Sandbox runtime {self.sandbox_runtime_id} has no instance to pause")
                     try:
                         ok = provider.pause_session(self._current_instance.instance_id)
                     except Exception as exc:
-                        raise RuntimeError(f"Failed to pause lease {self.sandbox_runtime_id}: {exc}") from exc
+                        raise RuntimeError(f"Failed to pause sandbox runtime {self.sandbox_runtime_id}: {exc}") from exc
                     if not ok:
-                        raise RuntimeError(f"Failed to pause lease {self.sandbox_runtime_id}")
+                        raise RuntimeError(f"Failed to pause sandbox runtime {self.sandbox_runtime_id}")
                     self.desired_state = "paused"
                     self._set_observed_state("paused", reason="intent.pause")
                     self.status = "active"
@@ -761,13 +765,13 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     if not capability.can_resume:
                         raise RuntimeError(f"Provider {provider.name} does not support resume")
                     if not self._current_instance:
-                        raise RuntimeError(f"Lease {self.sandbox_runtime_id} has no instance to resume")
+                        raise RuntimeError(f"Sandbox runtime {self.sandbox_runtime_id} has no instance to resume")
                     try:
                         ok = provider.resume_session(self._current_instance.instance_id)
                     except Exception as exc:
-                        raise RuntimeError(f"Failed to resume lease {self.sandbox_runtime_id}: {exc}") from exc
+                        raise RuntimeError(f"Failed to resume sandbox runtime {self.sandbox_runtime_id}: {exc}") from exc
                     if not ok:
-                        raise RuntimeError(f"Failed to resume lease {self.sandbox_runtime_id}")
+                        raise RuntimeError(f"Failed to resume sandbox runtime {self.sandbox_runtime_id}")
                     self.desired_state = "running"
                     self._set_observed_state("running", reason="intent.resume")
                     self.status = "active"
@@ -783,9 +787,11 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                         try:
                             ok = provider.destroy_session(self._current_instance.instance_id)
                         except Exception as exc:
-                            raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}: {exc}") from exc
+                            raise RuntimeError(
+                                f"Failed to destroy sandbox runtime {self.sandbox_runtime_id}: {exc}"
+                            ) from exc
                         if not ok:
-                            raise RuntimeError(f"Failed to destroy lease {self.sandbox_runtime_id}")
+                            raise RuntimeError(f"Failed to destroy sandbox runtime {self.sandbox_runtime_id}")
                     self.desired_state = "destroyed"
                     self._set_observed_state("detached", reason="intent.destroy")
                     self.status = "expired"
@@ -795,7 +801,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
 
                 elif event_type == "intent.ensure_running":
                     if not self._current_instance:
-                        raise RuntimeError(f"Lease {self.sandbox_runtime_id}: intent.ensure_running requires bound instance")
+                        raise RuntimeError(
+                            f"Sandbox runtime {self.sandbox_runtime_id}: intent.ensure_running requires bound instance"
+                        )
                     self.desired_state = "running"
                     self._set_observed_state("running", reason="intent.ensure_running")
                     self.status = "active"
@@ -818,7 +826,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     self.refresh_hint_at = now
 
                 else:
-                    raise RuntimeError(f"Unsupported lease event type: {event_type}")
+                    raise RuntimeError(f"Unsupported sandbox runtime event type: {event_type}")
 
                 self.observed_at = now
                 self.version += 1
@@ -867,7 +875,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             if not self._current_instance:
                 return None
             if self.observed_state == "paused":
-                raise RuntimeError(f"Sandbox lease {self.sandbox_runtime_id} is paused. Resume before executing commands.")
+                raise RuntimeError(
+                    f"Sandbox runtime {self.sandbox_runtime_id} is paused. Resume before executing commands."
+                )
             if self.observed_state == "running" and not self.needs_refresh:
                 return self._current_instance
             self._current_instance = None
@@ -906,7 +916,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                 if self.observed_state == "running" and self._current_instance:
                     return self._current_instance
                 if self.observed_state == "paused":
-                    raise RuntimeError(f"Sandbox lease {self.sandbox_runtime_id} is paused. Resume before executing commands.")
+                    raise RuntimeError(
+                        f"Sandbox runtime {self.sandbox_runtime_id} is paused. Resume before executing commands."
+                    )
             except RuntimeError:
                 raise
             except Exception as exc:
@@ -948,7 +960,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     if self.observed_state == "running" and self._current_instance:
                         return self._current_instance
                     if self.observed_state == "paused":
-                        raise RuntimeError(f"Sandbox lease {self.sandbox_runtime_id} is paused. Resume before executing commands.")
+                        raise RuntimeError(
+                            f"Sandbox runtime {self.sandbox_runtime_id} is paused. Resume before executing commands."
+                        )
                 except RuntimeError:
                     raise
                 except Exception as exc:
@@ -991,7 +1005,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
                     payload={"created": True, "instance_id": session_info.session_id},
                 )
             if not self._current_instance:
-                raise RuntimeError(f"Lease {self.sandbox_runtime_id}: failed to bind created instance")
+                raise RuntimeError(f"Sandbox runtime {self.sandbox_runtime_id}: failed to bind created instance")
             return self._current_instance
 
     def destroy_instance(self, provider: SandboxProvider, *, source: str = "api") -> None:

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -381,7 +381,9 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
         on_stdout_chunk: Callable[[str], None] | None = None,
     ) -> ExecuteResult:
         if self.sandbox_runtime.observed_state == "paused":
-            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.sandbox_runtime_id} is paused. Resume before executing commands.")
+            raise RuntimeError(
+                f"Sandbox runtime {self.sandbox_runtime.sandbox_runtime_id} is paused. Resume before executing commands."
+            )
 
         state = self.terminal.get_state()
         start, end, script = _build_windows_shell_script(command, cwd=state.cwd, env_delta=state.env_delta)
@@ -428,7 +430,9 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
             return self._execute_windows_once_sync(command, timeout, on_stdout_chunk=on_stdout_chunk)
 
         if self.sandbox_runtime.observed_state == "paused":
-            raise RuntimeError(f"Sandbox lease {self.sandbox_runtime.sandbox_runtime_id} is paused. Resume before executing commands.")
+            raise RuntimeError(
+                f"Sandbox runtime {self.sandbox_runtime.sandbox_runtime_id} is paused. Resume before executing commands."
+            )
 
         state = self.terminal.get_state()
         pty_session = self._ensure_session_sync(timeout)

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -321,7 +321,7 @@ class PhysicalTerminalRuntime(ABC):
     - Execute commands
     - Hydrate state from AbstractTerminal on startup
     - Persist state to AbstractTerminal after commands
-    - Provide access to lease for I/O operations
+    - Provide access to sandbox runtime for I/O operations
 
     Does NOT:
     - Own terminal identity (that's AbstractTerminal)
@@ -880,7 +880,9 @@ class _RemoteRuntimeBase(PhysicalTerminalRuntime):
         status = self.sandbox_runtime.refresh_instance_status(self.provider, force=True, max_age_sec=0)
         if status == "paused":
             if not self.sandbox_runtime.resume_instance(self.provider):
-                raise RuntimeError(f"Failed to resume paused lease {self.sandbox_runtime.sandbox_runtime_id}")
+                raise RuntimeError(
+                    f"Failed to resume paused sandbox runtime {self.sandbox_runtime.sandbox_runtime_id}"
+                )
             return
         if status in {"detached", "unknown"}:
             self.sandbox_runtime.ensure_active_instance(self.provider)

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -164,7 +164,9 @@ class SQLiteSandboxRuntimeRepo:
                 operation="adopt_instance bootstrap",
             )
         if existing["provider_name"] != provider_name:
-            raise RuntimeError(f"Lease provider mismatch during adopt: lease={existing['provider_name']}, requested={provider_name}")
+            raise RuntimeError(
+                f"Sandbox runtime provider mismatch during adopt: runtime={existing['provider_name']}, requested={provider_name}"
+            )
 
         now = datetime.now().isoformat()
         normalized = parse_lease_instance_state(status).value
@@ -235,7 +237,7 @@ class SQLiteSandboxRuntimeRepo:
 
         adopted = self.get(lease_id)
         if adopted is None:
-            raise RuntimeError(f"Failed to load adopted lease: {lease_id}")
+            raise RuntimeError(f"Failed to load adopted sandbox runtime: {lease_id}")
         return adopted
 
     def observe_status(

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -217,7 +217,9 @@ class SupabaseSandboxRuntimeRepo:
 
         existing = self._require_lease(self.get(lease_id), lease_id=lease_id, operation="adopt_instance")
         if existing["provider_name"] != provider_name:
-            raise RuntimeError(f"Lease provider mismatch during adopt: lease={existing['provider_name']}, requested={provider_name}")
+            raise RuntimeError(
+                f"Sandbox runtime provider mismatch during adopt: runtime={existing['provider_name']}, requested={provider_name}"
+            )
 
         row = self._require_lease(self._sandbox_by_lease_id(lease_id), lease_id=lease_id, operation="adopt_instance sandbox")
         now = _utc_now_iso()

--- a/tests/Unit/sandbox/test_sandbox_runtime_core_wording.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_core_wording.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TARGETS = (
+    "sandbox/lease.py",
+    "sandbox/capability.py",
+    "sandbox/providers/local.py",
+    "sandbox/runtime.py",
+    "storage/providers/sqlite/sandbox_runtime_repo.py",
+    "storage/providers/supabase/sandbox_runtime_repo.py",
+)
+
+FORBIDDEN = (
+    "lease-level state machine",
+    "Lease snapshot stores",
+    "Lease provider mismatch",
+    "Unsupported lease event type",
+    "Sandbox lease ",
+    "Failed to destroy lease ",
+    "Failed to pause lease ",
+    "Failed to resume lease ",
+    "Failed to load adopted lease",
+    " delegates to provider via lease",
+    "session's lease",
+    "Failed to resume paused lease ",
+    "Lease ",
+)
+
+
+def test_runtime_core_surfaces_avoid_lease_wording() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+
+    for rel_path in TARGETS:
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        for pattern in FORBIDDEN:
+            if pattern in source:
+                offenders.append(f"{rel_path} -> {pattern}")
+
+    assert offenders == [], "Found runtime core lease wording residue:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- remove remaining lease-wording from targeted runtime core docstrings/errors/comments\n- align capability/local/runtime/provider-repo messages to sandbox-runtime language\n- add a focused core-wording guard over the touched runtime files\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_runtime_core_wording.py -q\n- uv run python -m pytest tests/Unit/core/test_capability_async.py tests/Unit/core/test_runtime.py tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/storage/test_supabase_sandbox_runtime_repo.py -q\n- git diff --check