### PR TITLE
refactor: rename sandbox runtime lifecycle symbols

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -24,9 +24,9 @@ from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
 from sandbox.control_plane_repos import make_sandbox_runtime_repo as _make_sqlite_sandbox_runtime_repo
 from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.lifecycle import (
-    LeaseInstanceState,
-    assert_lease_instance_transition,
-    parse_lease_instance_state,
+    SandboxRuntimeInstanceState,
+    assert_sandbox_runtime_instance_transition,
+    parse_sandbox_runtime_instance_state,
 )
 from storage.providers.sqlite.kernel import connect_sqlite
 from storage.runtime import build_sandbox_runtime_repo as _build_strategy_sandbox_runtime_repo
@@ -243,10 +243,10 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             return False
         return (utc_now() - self.observed_at).total_seconds() <= max_age_sec
 
-    def _instance_state(self) -> LeaseInstanceState:
+    def _instance_state(self) -> SandboxRuntimeInstanceState:
         if not self._current_instance:
-            return LeaseInstanceState.DETACHED
-        return parse_lease_instance_state(self._current_instance.status)
+            return SandboxRuntimeInstanceState.DETACHED
+        return parse_sandbox_runtime_instance_state(self._current_instance.status)
 
     def _normalize_provider_state(self, raw: str) -> str:
         lowered = raw.lower().strip()
@@ -266,21 +266,27 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             )
 
         if observed == "running":
-            assert_lease_instance_transition(self._instance_state(), LeaseInstanceState.RUNNING, reason=reason)
+            assert_sandbox_runtime_instance_transition(
+                self._instance_state(), SandboxRuntimeInstanceState.RUNNING, reason=reason
+            )
             if self._current_instance:
                 self._current_instance.status = "running"
             self.observed_state = "running"
             return
 
         if observed == "paused":
-            assert_lease_instance_transition(self._instance_state(), LeaseInstanceState.PAUSED, reason=reason)
+            assert_sandbox_runtime_instance_transition(
+                self._instance_state(), SandboxRuntimeInstanceState.PAUSED, reason=reason
+            )
             if self._current_instance:
                 self._current_instance.status = "paused"
             self.observed_state = "paused"
             return
 
         if observed == "detached":
-            assert_lease_instance_transition(self._instance_state(), LeaseInstanceState.DETACHED, reason=reason)
+            assert_sandbox_runtime_instance_transition(
+                self._instance_state(), SandboxRuntimeInstanceState.DETACHED, reason=reason
+            )
             self._detached_instance = self._current_instance
             self._current_instance = None
             self.observed_state = "detached"
@@ -288,7 +294,9 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
 
         if observed == "unknown":
             if self._current_instance:
-                assert_lease_instance_transition(self._instance_state(), LeaseInstanceState.UNKNOWN, reason=reason)
+                assert_sandbox_runtime_instance_transition(
+                    self._instance_state(), SandboxRuntimeInstanceState.UNKNOWN, reason=reason
+                )
                 self._current_instance.status = "unknown"
             self.observed_state = "unknown"
             return

--- a/sandbox/lifecycle.py
+++ b/sandbox/lifecycle.py
@@ -1,4 +1,4 @@
-"""Lifecycle state machine contracts for chat sessions and lease instances.
+"""Lifecycle state machine contracts for chat sessions and sandbox runtime instances.
 
 Fail-loud policy:
 - Invalid state strings raise immediately.
@@ -18,7 +18,7 @@ class ChatSessionState(StrEnum):
     FAILED = "failed"
 
 
-class LeaseInstanceState(StrEnum):
+class SandboxRuntimeInstanceState(StrEnum):
     RUNNING = "running"
     PAUSED = "paused"
     DETACHED = "detached"
@@ -34,16 +34,16 @@ def parse_chat_session_state(value: str | None) -> ChatSessionState:
         raise RuntimeError(f"Invalid ChatSession state: {value}") from e
 
 
-def parse_lease_instance_state(value: str | None) -> LeaseInstanceState:
+def parse_sandbox_runtime_instance_state(value: str | None) -> SandboxRuntimeInstanceState:
     if value is None:
-        return LeaseInstanceState.DETACHED
+        return SandboxRuntimeInstanceState.DETACHED
     lowered = value.lower()
     if lowered in {"deleted", "dead", "stopped"}:
-        return LeaseInstanceState.DETACHED
+        return SandboxRuntimeInstanceState.DETACHED
     try:
-        return LeaseInstanceState(lowered)
+        return SandboxRuntimeInstanceState(lowered)
     except ValueError as e:
-        raise RuntimeError(f"Invalid LeaseInstance state: {value}") from e
+        raise RuntimeError(f"Invalid SandboxRuntimeInstance state: {value}") from e
 
 
 def assert_chat_session_transition(
@@ -77,29 +77,29 @@ def assert_chat_session_transition(
         raise RuntimeError(f"Illegal chat session transition: {current} -> {target} ({reason})")
 
 
-def assert_lease_instance_transition(
-    current: LeaseInstanceState | None,
-    target: LeaseInstanceState,
+def assert_sandbox_runtime_instance_transition(
+    current: SandboxRuntimeInstanceState | None,
+    target: SandboxRuntimeInstanceState,
     *,
     reason: str,
 ) -> None:
     if current is None:
-        current = LeaseInstanceState.DETACHED
+        current = SandboxRuntimeInstanceState.DETACHED
     if current == target:
         return
 
-    allowed: set[tuple[LeaseInstanceState, LeaseInstanceState]] = {
-        (LeaseInstanceState.DETACHED, LeaseInstanceState.RUNNING),
-        (LeaseInstanceState.DETACHED, LeaseInstanceState.UNKNOWN),
-        (LeaseInstanceState.RUNNING, LeaseInstanceState.PAUSED),
-        (LeaseInstanceState.RUNNING, LeaseInstanceState.DETACHED),
-        (LeaseInstanceState.RUNNING, LeaseInstanceState.UNKNOWN),
-        (LeaseInstanceState.PAUSED, LeaseInstanceState.RUNNING),
-        (LeaseInstanceState.PAUSED, LeaseInstanceState.DETACHED),
-        (LeaseInstanceState.PAUSED, LeaseInstanceState.UNKNOWN),
-        (LeaseInstanceState.UNKNOWN, LeaseInstanceState.RUNNING),
-        (LeaseInstanceState.UNKNOWN, LeaseInstanceState.PAUSED),
-        (LeaseInstanceState.UNKNOWN, LeaseInstanceState.DETACHED),
+    allowed: set[tuple[SandboxRuntimeInstanceState, SandboxRuntimeInstanceState]] = {
+        (SandboxRuntimeInstanceState.DETACHED, SandboxRuntimeInstanceState.RUNNING),
+        (SandboxRuntimeInstanceState.DETACHED, SandboxRuntimeInstanceState.UNKNOWN),
+        (SandboxRuntimeInstanceState.RUNNING, SandboxRuntimeInstanceState.PAUSED),
+        (SandboxRuntimeInstanceState.RUNNING, SandboxRuntimeInstanceState.DETACHED),
+        (SandboxRuntimeInstanceState.RUNNING, SandboxRuntimeInstanceState.UNKNOWN),
+        (SandboxRuntimeInstanceState.PAUSED, SandboxRuntimeInstanceState.RUNNING),
+        (SandboxRuntimeInstanceState.PAUSED, SandboxRuntimeInstanceState.DETACHED),
+        (SandboxRuntimeInstanceState.PAUSED, SandboxRuntimeInstanceState.UNKNOWN),
+        (SandboxRuntimeInstanceState.UNKNOWN, SandboxRuntimeInstanceState.RUNNING),
+        (SandboxRuntimeInstanceState.UNKNOWN, SandboxRuntimeInstanceState.PAUSED),
+        (SandboxRuntimeInstanceState.UNKNOWN, SandboxRuntimeInstanceState.DETACHED),
     }
     if (current, target) not in allowed:
-        raise RuntimeError(f"Illegal lease transition: {current} -> {target} ({reason})")
+        raise RuntimeError(f"Illegal sandbox runtime transition: {current} -> {target} ({reason})")

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from sandbox.lifecycle import parse_lease_instance_state
+from sandbox.lifecycle import parse_sandbox_runtime_instance_state
 from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
 
 
@@ -169,7 +169,7 @@ class SQLiteSandboxRuntimeRepo:
             )
 
         now = datetime.now().isoformat()
-        normalized = parse_lease_instance_state(status).value
+        normalized = parse_sandbox_runtime_instance_state(status).value
         desired = "paused" if normalized == "paused" else "running"
 
         with self._lock:
@@ -249,7 +249,7 @@ class SQLiteSandboxRuntimeRepo:
     ) -> dict[str, Any]:
         existing = self._require_lease(self.get(lease_id), lease_id=lease_id, operation="observe_status")
         now = observed_at.isoformat() if isinstance(observed_at, datetime) else (observed_at or datetime.now().isoformat())
-        normalized = parse_lease_instance_state(status).value
+        normalized = parse_sandbox_runtime_instance_state(status).value
         current_instance_id = existing.get("current_instance_id")
 
         with self._lock:

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -213,7 +213,7 @@ class SupabaseSandboxRuntimeRepo:
         instance_id: str,
         status: str = "unknown",
     ) -> dict[str, Any]:
-        from sandbox.lifecycle import parse_lease_instance_state
+        from sandbox.lifecycle import parse_sandbox_runtime_instance_state
 
         existing = self._require_lease(self.get(lease_id), lease_id=lease_id, operation="adopt_instance")
         if existing["provider_name"] != provider_name:
@@ -223,7 +223,7 @@ class SupabaseSandboxRuntimeRepo:
 
         row = self._require_lease(self._sandbox_by_lease_id(lease_id), lease_id=lease_id, operation="adopt_instance sandbox")
         now = _utc_now_iso()
-        normalized = parse_lease_instance_state(status).value
+        normalized = parse_sandbox_runtime_instance_state(status).value
         desired = "paused" if normalized == "paused" else "running"
         self._sandboxes().update(
             {
@@ -255,12 +255,12 @@ class SupabaseSandboxRuntimeRepo:
         status: str,
         observed_at: Any = None,
     ) -> dict[str, Any]:
-        from sandbox.lifecycle import parse_lease_instance_state
+        from sandbox.lifecycle import parse_sandbox_runtime_instance_state
 
         existing = self._require_lease(self.get(lease_id), lease_id=lease_id, operation="observe_status")
         row = self._require_lease(self._sandbox_by_lease_id(lease_id), lease_id=lease_id, operation="observe_status sandbox")
         now = observed_at.isoformat() if isinstance(observed_at, datetime) else (observed_at or _utc_now_iso())
-        normalized = parse_lease_instance_state(status).value
+        normalized = parse_sandbox_runtime_instance_state(status).value
         lease_status = "expired" if normalized == "detached" else "active"
         self._sandboxes().update(
             {

--- a/tests/Unit/sandbox/test_lifecycle.py
+++ b/tests/Unit/sandbox/test_lifecycle.py
@@ -2,11 +2,11 @@ import pytest
 
 from sandbox.lifecycle import (
     ChatSessionState,
-    LeaseInstanceState,
+    SandboxRuntimeInstanceState,
     assert_chat_session_transition,
-    assert_lease_instance_transition,
+    assert_sandbox_runtime_instance_transition,
     parse_chat_session_state,
-    parse_lease_instance_state,
+    parse_sandbox_runtime_instance_state,
 )
 
 
@@ -15,10 +15,15 @@ def test_parse_chat_session_state_rejects_invalid():
         parse_chat_session_state("weird")
 
 
-def test_parse_lease_instance_state_maps_deleted_like_values():
-    assert parse_lease_instance_state("deleted") == LeaseInstanceState.DETACHED
-    assert parse_lease_instance_state("dead") == LeaseInstanceState.DETACHED
-    assert parse_lease_instance_state("stopped") == LeaseInstanceState.DETACHED
+def test_parse_sandbox_runtime_instance_state_rejects_invalid():
+    with pytest.raises(RuntimeError, match="Invalid SandboxRuntimeInstance state"):
+        parse_sandbox_runtime_instance_state("weird")
+
+
+def test_parse_sandbox_runtime_instance_state_maps_deleted_like_values():
+    assert parse_sandbox_runtime_instance_state("deleted") == SandboxRuntimeInstanceState.DETACHED
+    assert parse_sandbox_runtime_instance_state("dead") == SandboxRuntimeInstanceState.DETACHED
+    assert parse_sandbox_runtime_instance_state("stopped") == SandboxRuntimeInstanceState.DETACHED
 
 
 def test_chat_session_transition_rejects_closed_to_active():
@@ -30,10 +35,10 @@ def test_chat_session_transition_rejects_closed_to_active():
         )
 
 
-def test_lease_transition_rejects_detached_to_paused():
-    with pytest.raises(RuntimeError, match="Illegal lease transition"):
-        assert_lease_instance_transition(
-            LeaseInstanceState.DETACHED,
-            LeaseInstanceState.PAUSED,
+def test_sandbox_runtime_transition_rejects_detached_to_paused():
+    with pytest.raises(RuntimeError, match="Illegal sandbox runtime transition"):
+        assert_sandbox_runtime_instance_transition(
+            SandboxRuntimeInstanceState.DETACHED,
+            SandboxRuntimeInstanceState.PAUSED,
             reason="test",
         )


### PR DESCRIPTION
## Summary\n- rename lease lifecycle symbols to sandbox-runtime lifecycle symbols\n- align direct runtime/storage call sites to the renamed lifecycle functions and enum\n- extend lifecycle tests to cover the new symbol names and error wording\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_lifecycle.py -q\n- uv run python -m pytest tests/Unit/core/test_runtime.py tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/storage/test_supabase_sandbox_runtime_repo.py -q\n- git diff --check