### PR TITLE
refactor: rename sandbox runtime manager internals

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -372,7 +372,7 @@ class SandboxManager:
         rows = self.terminal_store.list_by_thread(thread_id)
         return [terminal_from_row(row, self.db_path) for row in rows]
 
-    def _get_thread_lease(self, thread_id: str):
+    def _get_thread_sandbox_runtime(self, thread_id: str):
         terminals = self._get_thread_terminals(thread_id)
         if not terminals:
             return None
@@ -414,23 +414,23 @@ class SandboxManager:
             raise ValueError("thread.current_workspace_id is required")
         return user_home_path("file_channels", str(workspace_id)).expanduser().resolve()
 
-    def _skip_volume_sync_for_local_lease(self, lease) -> bool:
+    def _skip_volume_sync_for_local_sandbox_runtime(self, lease) -> bool:
         # @@@local-no-volume-sync - local sessions execute directly in host cwd, so upload/download
         # must always no-op there rather than reactivating volume-backed sync.
         return lease is not None and not self._requires_volume_bootstrap()
 
     def _sync_to_sandbox(self, thread_id: str, instance_id: str, source=None, files: list[str] | None = None) -> None:
         if source is None:
-            lease = self._get_thread_lease(thread_id)
-            if self._skip_volume_sync_for_local_lease(lease):
+            lease = self._get_thread_sandbox_runtime(thread_id)
+            if self._skip_volume_sync_for_local_sandbox_runtime(lease):
                 return
             source = self._resolve_sync_source_path(thread_id)
         self.volume.sync_upload(thread_id, instance_id, source, self.volume.resolve_mount_path(), files=files)
 
     def _sync_from_sandbox(self, thread_id: str, instance_id: str, source=None) -> None:
         if source is None:
-            lease = self._get_thread_lease(thread_id)
-            if self._skip_volume_sync_for_local_lease(lease):
+            lease = self._get_thread_sandbox_runtime(thread_id)
+            if self._skip_volume_sync_for_local_sandbox_runtime(lease):
                 return
             source = self._resolve_sync_source_path(thread_id)
         self.volume.sync_download(thread_id, instance_id, source, self.volume.resolve_mount_path())
@@ -599,7 +599,7 @@ class SandboxManager:
             return False
         return self.session_manager._repo.terminal_has_running_command(terminal_id)
 
-    def _lease_is_busy(self, lease_id: str) -> bool:
+    def _sandbox_runtime_is_busy(self, lease_id: str) -> bool:
         """Return True if any terminal under this lease has a running command."""
         if not lease_id:
             return False
@@ -684,7 +684,7 @@ class SandboxManager:
                     break
 
                 if not has_other_active:
-                    if self._lease_is_busy(lease.sandbox_runtime_id):
+                    if self._sandbox_runtime_is_busy(lease.sandbox_runtime_id):
                         continue
                     status = lease.refresh_instance_status(self.provider)
                     capability = self.provider.get_capability()
@@ -724,7 +724,7 @@ class SandboxManager:
         if not terminals:
             return False
 
-        lease = self._get_thread_lease(thread_id)
+        lease = self._get_thread_sandbox_runtime(thread_id)
         if not lease:
             return False
 
@@ -760,7 +760,7 @@ class SandboxManager:
         if not terminals:
             return False
 
-        lease = self._get_thread_lease(thread_id)
+        lease = self._get_thread_sandbox_runtime(thread_id)
         if not lease:
             return False
 
@@ -825,7 +825,7 @@ class SandboxManager:
             return False
 
         # @@@workspace-download-before-destroy - sync files before destroy
-        lease = self._get_thread_lease(thread_id)
+        lease = self._get_thread_sandbox_runtime(thread_id)
         if lease and lease.observed_state == "running":
             instance = lease.get_instance()
             if instance:

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -373,7 +373,7 @@ def test_destroy_thread_resources_daytona_does_not_require_volume_row(tmp_path):
 
     lease = _Lease()
     all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
-    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
@@ -432,7 +432,7 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
     destroy_calls: list[bool] = []
     manager._get_sandbox_runtime = lambda _lease_id: fake_lease
     manager._terminal_is_busy = lambda _terminal_id: False
-    manager._lease_is_busy = lambda _lease_id: False
+    manager._sandbox_runtime_is_busy = lambda _lease_id: False
     monkeypatch.setattr(
         sandbox_manager_module,
         "terminal_from_row",
@@ -470,7 +470,7 @@ def test_destroy_thread_resources_skips_local_sync_without_volume_metadata():
     manager.provider_capability = SimpleNamespace(runtime_kind="local")
     manager.provider = SimpleNamespace(name="local")
     manager.volume = _FakeVolume()
-    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
@@ -532,7 +532,7 @@ def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_termi
             destroyed_leases.append("lease-1")
 
     lease = _Lease()
-    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
@@ -580,7 +580,7 @@ def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
             destroyed_leases.append("lease-1")
 
     lease = _Lease()
-    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
@@ -627,7 +627,7 @@ def test_destroy_thread_resources_deletes_daytona_managed_volume_from_lease_id(t
 
     lease = _Lease()
     all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
-    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
@@ -673,7 +673,7 @@ def test_destroy_thread_resources_derives_daytona_volume_name_from_lease_id(tmp_
 
     lease = _Lease()
     all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
-    manager._get_thread_lease = lambda _thread_id: lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
         list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
@@ -701,7 +701,7 @@ def test_sync_uploads_skips_local_volume_sync_without_volume_metadata():
     manager.volume = _FakeVolume()
     manager._get_active_terminal = lambda _thread_id: SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
-    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_thread_sandbox_runtime = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: SimpleNamespace(
@@ -717,7 +717,7 @@ def test_sync_paths_use_workspace_file_channel_root_instead_of_volume_source(mon
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
-    manager._get_thread_lease = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_thread_sandbox_runtime = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
     manager.resolve_volume_source = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume source should stay unused"))
 
     class _ThreadRepo:
@@ -994,7 +994,7 @@ def test_resume_session_rebinds_live_session_lease_after_resume():
     )
     manager.provider = SimpleNamespace(name="local")
     manager._get_thread_terminals = lambda _thread_id: [terminal]
-    manager._get_thread_lease = lambda _thread_id: resumed_lease
+    manager._get_thread_sandbox_runtime = lambda _thread_id: resumed_lease
     manager._sync_to_sandbox = lambda *_args, **_kwargs: None
     manager._ensure_chat_session = lambda _thread_id: None
     manager.session_manager = SimpleNamespace(

--- a/tests/Unit/sandbox/test_sandbox_runtime_manager_internal_names.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_manager_internal_names.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FORBIDDEN = (
+    "def _get_thread_lease(",
+    "def _lease_is_busy(",
+    "def _skip_volume_sync_for_local_lease(",
+)
+
+
+def test_sandbox_manager_internal_helpers_use_sandbox_runtime_wording() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "sandbox/manager.py").read_text(encoding="utf-8")
+    offenders = [pattern for pattern in FORBIDDEN if pattern in source]
+    assert offenders == [], "Found sandbox.manager internal lease helper names:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- rename remaining sandbox.manager internal helper names to sandbox-runtime wording\n- align focused manager tests to the renamed helpers\n- add a focused internal-helper guard so the old manager helper names do not return\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_runtime_manager_internal_names.py -q\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_runtime_manager_naming.py tests/Unit/sandbox/test_sandbox_runtime_manager_internal_names.py -q\n- git diff --check