### PR TITLE
refactor: rename terminal row contract

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -229,7 +229,7 @@ def bind_thread_to_existing_thread_sandbox_runtime(
     # parent's lower sandbox binding instead of silently provisioning a new one.
     return bind_thread_to_existing_sandbox_runtime(
         thread_id,
-        str(source_terminal["lease_id"]),
+        str(source_terminal["sandbox_runtime_id"]),
         cwd=cwd,
         db_path=target_db,
         terminal_repo=terminal_repo,
@@ -846,7 +846,7 @@ class SandboxManager:
         for lease_id in lease_ids:
             # @@@shared-lease-destroy-boundary - destroying one thread must not tear down
             # a lease that still has surviving terminals bound to it.
-            lease_in_use = any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all())
+            lease_in_use = any(row.get("sandbox_runtime_id") == lease_id for row in self.terminal_store.list_all())
             if lease_in_use:
                 continue
             if not self.destroy_sandbox_runtime_resources(lease_id):
@@ -857,7 +857,7 @@ class SandboxManager:
         lease = self._get_sandbox_runtime(lease_id)
         if not lease:
             return False
-        if any(row.get("lease_id") == lease_id for row in self.terminal_store.list_all()):
+        if any(row.get("sandbox_runtime_id") == lease_id for row in self.terminal_store.list_all()):
             raise RuntimeError(f"Sandbox runtime {lease_id} still has bound terminals")
         lease.destroy_instance(self.provider)
         if self.provider_capability.runtime_kind == "daytona_pty":
@@ -871,7 +871,7 @@ class SandboxManager:
         terminals = self.terminal_store.list_all()
         threads_by_lease: dict[str, list[str]] = {}
         for term in terminals:
-            lease_id = term.get("lease_id")
+            lease_id = term.get("sandbox_runtime_id")
             thread_id = term.get("thread_id")
             if lease_id and thread_id:
                 threads_by_lease.setdefault(lease_id, []).append(thread_id)

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -170,7 +170,7 @@ def terminal_from_row(row: dict, db_path: Path) -> AbstractTerminal:
     return SQLiteTerminal(
         terminal_id=row["terminal_id"],
         thread_id=row["thread_id"],
-        lease_id=row["lease_id"],
+        lease_id=row["sandbox_runtime_id"],
         state=state,
         db_path=db_path,
     )

--- a/storage/providers/sqlite/terminal_repo.py
+++ b/storage/providers/sqlite/terminal_repo.py
@@ -44,6 +44,11 @@ class SQLiteTerminalRepo:
         if self._own_conn:
             self._conn.close()
 
+    def _terminal_row_from_db_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        result = dict(row)
+        result["sandbox_runtime_id"] = str(result.pop("lease_id"))
+        return result
+
     # ------------------------------------------------------------------
     # Table setup
     # ------------------------------------------------------------------
@@ -170,7 +175,7 @@ class SQLiteTerminalRepo:
                 (terminal_id,),
             ).fetchone()
             self._conn.row_factory = None
-            return dict(row) if row else None
+            return self._terminal_row_from_db_row(row) if row else None
 
     def summarize_threads(self, thread_ids: list[str]) -> dict[str, dict[str, str | None]]:
         normalized_ids = [str(thread_id or "").strip() for thread_id in thread_ids if str(thread_id or "").strip()]
@@ -255,7 +260,7 @@ class SQLiteTerminalRepo:
                 (thread_id,),
             ).fetchall()
             self._conn.row_factory = None
-            return [dict(row) for row in rows]
+            return [self._terminal_row_from_db_row(row) for row in rows]
 
     def list_all(self) -> list[dict[str, Any]]:
         with self._lock:
@@ -268,7 +273,7 @@ class SQLiteTerminalRepo:
                 """
             ).fetchall()
             self._conn.row_factory = None
-            return [dict(row) for row in rows]
+            return [self._terminal_row_from_db_row(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Writes
@@ -358,7 +363,7 @@ class SQLiteTerminalRepo:
         return {
             "terminal_id": terminal_id,
             "thread_id": thread_id,
-            "lease_id": lease_id,
+            "sandbox_runtime_id": lease_id,
             "cwd": initial_cwd,
             "env_delta_json": env_delta_json,
             "state_version": state_version,

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -137,11 +137,26 @@ def test_terminal_from_row_uses_sqlite_terminal_under_supabase_defaults(monkeypa
     terminal_store = SQLiteTerminalRepo(db_path=resolve_role_db_path(SQLiteDBRole.SANDBOX))
     try:
         row = terminal_store.create("term-1", "thread-1", "lease-1", "/tmp")
+        assert row["sandbox_runtime_id"] == "lease-1"
+        assert "lease_id" not in row
         terminal = terminal_from_row(row, terminal_store.db_path)
     finally:
         terminal_store.close()
 
     assert isinstance(terminal, SQLiteTerminal)
+
+
+def test_terminal_repo_get_active_returns_sandbox_runtime_id_not_lease_id(tmp_path):
+    repo = SQLiteTerminalRepo(db_path=tmp_path / "sandbox.db")
+    try:
+        repo.create("term-1", "thread-1", "lease-1", "/tmp")
+        active = repo.get_active("thread-1")
+    finally:
+        repo.close()
+
+    assert active is not None
+    assert active["sandbox_runtime_id"] == "lease-1"
+    assert "lease_id" not in active
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="LocalPersistentShellRuntime requires a Unix shell")

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -192,7 +192,9 @@ def test_resolve_existing_sandbox_runtime_cwd_prefers_provider_default_when_no_w
 
 
 def test_resolve_existing_sandbox_runtime_cwd_ignores_latest_terminal_cwd_and_prefers_provider_default(monkeypatch):
-    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(
+        row={"sandbox_runtime_id": "lease-1", "provider_name": "local", "provider_env_id": "env-1"}
+    )
     monkeypatch.setattr(
         sandbox_manager_module,
         "_build_provider_from_name",
@@ -210,7 +212,9 @@ def test_resolve_existing_sandbox_runtime_cwd_ignores_latest_terminal_cwd_and_pr
 
 
 def test_resolve_existing_sandbox_runtime_cwd_fails_loud_when_provider_default_is_unavailable(monkeypatch):
-    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "missing-provider"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(
+        row={"sandbox_runtime_id": "lease-1", "provider_name": "missing-provider"}
+    )
     monkeypatch.setattr(
         sandbox_manager_module,
         "_build_provider_from_name",
@@ -259,9 +263,9 @@ def test_bind_thread_to_existing_sandbox_skips_latest_terminal_cwd_when_provider
 def test_bind_thread_to_existing_thread_sandbox_runtime_requires_parent_workspace_cwd(monkeypatch):
     terminal_repo = _FakeBindTerminalRepo(
         latest_by_lease={"cwd": "/terminal/latest"},
-        active_by_thread={"thread-parent": {"lease_id": "lease-1"}},
+        active_by_thread={"thread-parent": {"sandbox_runtime_id": "lease-1"}},
     )
-    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"lease_id": "lease-1", "provider_name": "local"})
+    sandbox_runtime_repo = _FakeSandboxRuntimeRepo(row={"sandbox_runtime_id": "lease-1", "provider_name": "local"})
 
     monkeypatch.setattr(
         sandbox_manager_module,
@@ -376,7 +380,7 @@ def test_destroy_thread_resources_daytona_does_not_require_volume_row(tmp_path):
             destroyed_leases.append("lease-1")
 
     lease = _Lease()
-    all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
+    all_terminals = [{"terminal_id": "term-1", "sandbox_runtime_id": "lease-1", "thread_id": "thread-1"}]
     manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
@@ -410,14 +414,14 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
     )
     manager.terminal_store = SimpleNamespace(
         db_path=Path("/tmp/fake-sandbox.db"),
-        get_by_id=lambda _terminal_id: {"terminal_id": "term-1", "lease_id": "lease-1"},
+        get_by_id=lambda _terminal_id: {"terminal_id": "term-1", "sandbox_runtime_id": "lease-1"},
     )
     active_rows = [
         {
             "session_id": "sess-1",
             "thread_id": "thread-1",
             "terminal_id": "term-1",
-            "lease_id": "lease-1",
+            "sandbox_runtime_id": "lease-1",
             "started_at": "2026-04-04T00:00:00",
             "last_active_at": "2026-04-04T00:00:00",
             "idle_ttl_sec": 1,
@@ -478,7 +482,7 @@ def test_destroy_thread_resources_skips_local_sync_without_volume_metadata():
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
-        list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}],
+        list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "sandbox_runtime_id": "lease-1", "thread_id": "thread-1"}],
         delete=lambda _terminal_id: deleted_terminals.append(_terminal_id),
         list_all=lambda: [],
         db_path=Path("/tmp/fake-sandbox.db"),
@@ -540,7 +544,7 @@ def test_destroy_thread_resources_hard_deletes_thread_chat_sessions_before_termi
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.terminal_store = SimpleNamespace(
-        list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}],
+        list_by_thread=lambda _thread_id: [{"terminal_id": "term-1", "sandbox_runtime_id": "lease-1", "thread_id": "thread-1"}],
         delete=lambda terminal_id: (delete_order.append(f"terminal:{terminal_id}"), deleted_terminals.append(terminal_id)),
         list_all=lambda: [],
         db_path=Path("/tmp/fake-sandbox.db"),
@@ -569,8 +573,8 @@ def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
     destroyed_leases: list[str] = []
     deleted_leases: list[str] = []
     all_terminals = [
-        {"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"},
-        {"terminal_id": "term-2", "lease_id": "lease-1", "thread_id": "thread-2"},
+        {"terminal_id": "term-1", "sandbox_runtime_id": "lease-1", "thread_id": "thread-1"},
+        {"terminal_id": "term-2", "sandbox_runtime_id": "lease-1", "thread_id": "thread-2"},
     ]
 
     class _Lease:
@@ -630,7 +634,7 @@ def test_destroy_thread_resources_deletes_daytona_managed_volume_from_lease_id(t
             destroyed_leases.append("lease-1")
 
     lease = _Lease()
-    all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
+    all_terminals = [{"terminal_id": "term-1", "sandbox_runtime_id": "lease-1", "thread_id": "thread-1"}]
     manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
@@ -676,7 +680,7 @@ def test_destroy_thread_resources_derives_daytona_volume_name_from_lease_id(tmp_
             destroyed_leases.append("lease-1")
 
     lease = _Lease()
-    all_terminals = [{"terminal_id": "term-1", "lease_id": "lease-1", "thread_id": "thread-1"}]
+    all_terminals = [{"terminal_id": "term-1", "sandbox_runtime_id": "lease-1", "thread_id": "thread-1"}]
     manager._get_thread_sandbox_runtime = lambda _thread_id: lease
     manager._get_sandbox_runtime = lambda _lease_id: lease
     manager.terminal_store = SimpleNamespace(
@@ -941,7 +945,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
         return {
             "terminal_id": kwargs["terminal_id"],
             "thread_id": kwargs["thread_id"],
-            "lease_id": kwargs["lease_id"],
+            "sandbox_runtime_id": kwargs["lease_id"],
             "cwd": kwargs["initial_cwd"],
             "env_delta_json": "{}",
             "state_version": 0,
@@ -955,7 +959,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
         get_default=lambda _thread_id: {
             "terminal_id": "term-default",
             "thread_id": "thread-1",
-            "lease_id": "lease-1",
+            "sandbox_runtime_id": "lease-1",
             "cwd": "/default",
             "env_delta_json": '{"TOKEN": "value"}',
             "state_version": 7,


### PR DESCRIPTION
## Summary\n- change sqlite terminal repo row dicts to expose sandbox_runtime_id instead of lease_id\n- align terminal_from_row and direct manager consumers to the renamed row key\n- keep the physical terminal table column and create() signature unchanged in this slice\n\n## Testing\n- uv run python -m pytest tests/Unit/core/test_runtime.py -q -k 'terminal_from_row_uses_sqlite_terminal_under_supabase_defaults or terminal_repo_get_active_returns_sandbox_runtime_id_not_lease_id'\n- uv run python -m pytest tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py tests/Unit/sandbox/test_sandbox_runtime_interface_naming.py -q\n- git diff --check