### PR TITLE
refactor: rename chat session row contract

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -230,7 +230,7 @@ class ChatSessionManager:
         if _sandbox_runtime_repo is None:
             _sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=self.db_path)
         try:
-            _lease_row = _sandbox_runtime_repo.get(row["lease_id"])
+            _lease_row = _sandbox_runtime_repo.get(row["sandbox_runtime_id"])
         finally:
             if own_sandbox_runtime_repo:
                 _sandbox_runtime_repo.close()

--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -41,6 +41,11 @@ class SQLiteChatSessionRepo:
         if self._own_conn:
             self._conn.close()
 
+    def _session_row_from_db_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        result = dict(row)
+        result["sandbox_runtime_id"] = str(result.pop("lease_id"))
+        return result
+
     # ------------------------------------------------------------------
     # Table setup
     # ------------------------------------------------------------------
@@ -178,7 +183,7 @@ class SQLiteChatSessionRepo:
                     (thread_id,),
                 ).fetchone()
             self._conn.row_factory = None
-            return dict(row) if row else None
+            return self._session_row_from_db_row(row) if row else None
 
     def get_session_by_id(self, session_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -195,7 +200,7 @@ class SQLiteChatSessionRepo:
                 (session_id,),
             ).fetchone()
             self._conn.row_factory = None
-            return dict(row) if row else None
+            return self._session_row_from_db_row(row) if row else None
 
     def load_status(self, session_id: str) -> str | None:
         with self._lock:
@@ -239,7 +244,7 @@ class SQLiteChatSessionRepo:
                 """
             ).fetchall()
             self._conn.row_factory = None
-            return [dict(row) for row in rows]
+            return [self._session_row_from_db_row(row) for row in rows]
 
     def list_all(self) -> list[dict[str, Any]]:
         with self._lock:
@@ -254,7 +259,7 @@ class SQLiteChatSessionRepo:
                 """
             ).fetchall()
             self._conn.row_factory = None
-            return [dict(row) for row in rows]
+            return [self._session_row_from_db_row(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Writes
@@ -317,7 +322,7 @@ class SQLiteChatSessionRepo:
             "session_id": session_id,
             "thread_id": thread_id,
             "terminal_id": terminal_id,
-            "lease_id": lease_id,
+            "sandbox_runtime_id": lease_id,
             "runtime_id": runtime_id,
             "status": status,
             "idle_ttl_sec": idle_ttl_sec,

--- a/tests/Unit/storage/test_chat_session_row_contract.py
+++ b/tests/Unit/storage/test_chat_session_row_contract.py
@@ -1,0 +1,35 @@
+from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
+
+
+def test_chat_session_repo_create_returns_sandbox_runtime_id_not_lease_id(tmp_path):
+    repo = SQLiteChatSessionRepo(tmp_path / "sandbox.db")
+    try:
+        created = repo.create_session(
+            session_id="sess-1",
+            thread_id="thread-1",
+            terminal_id="term-1",
+            lease_id="lease-1",
+        )
+    finally:
+        repo.close()
+
+    assert created["sandbox_runtime_id"] == "lease-1"
+    assert "lease_id" not in created
+
+
+def test_chat_session_repo_get_returns_sandbox_runtime_id_not_lease_id(tmp_path):
+    repo = SQLiteChatSessionRepo(tmp_path / "sandbox.db")
+    try:
+        repo.create_session(
+            session_id="sess-1",
+            thread_id="thread-1",
+            terminal_id="term-1",
+            lease_id="lease-1",
+        )
+        row = repo.get_session("thread-1", "term-1")
+    finally:
+        repo.close()
+
+    assert row is not None
+    assert row["sandbox_runtime_id"] == "lease-1"
+    assert "lease_id" not in row


### PR DESCRIPTION
## Summary\n- change sqlite chat session repo row dicts to expose sandbox_runtime_id instead of lease_id\n- align chat session manager reads to the renamed row key\n- keep the physical chat_sessions column and create_session(..., lease_id=...) signature unchanged in this slice\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_chat_session_row_contract.py -q\n- uv run python -m pytest tests/Unit/storage/test_chat_session_row_contract.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py tests/Unit/sandbox/test_sandbox_runtime_interface_naming.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q\n- git diff --check