### PR TITLE
refactor: rename sandbox runtime events table

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -366,7 +366,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         try:
             target.execute(
                 """
-                INSERT INTO lease_events (event_id, sandbox_runtime_id, event_type, source, payload_json, error, created_at)
+                INSERT INTO sandbox_runtime_events (event_id, sandbox_runtime_id, event_type, source, payload_json, error, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -230,7 +230,7 @@ class SQLiteSandboxRuntimeRepo:
             )
             self._conn.execute(
                 """
-                INSERT INTO lease_events (event_id, sandbox_runtime_id, event_type, source, payload_json, error, created_at)
+                INSERT INTO sandbox_runtime_events (event_id, sandbox_runtime_id, event_type, source, payload_json, error, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
@@ -390,7 +390,7 @@ class SQLiteSandboxRuntimeRepo:
     def delete(self, sandbox_runtime_id: str) -> None:
         with self._lock:
             self._conn.execute("DELETE FROM sandbox_instances WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
-            self._conn.execute("DELETE FROM lease_events WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
+            self._conn.execute("DELETE FROM sandbox_runtime_events WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
             self._conn.execute("DELETE FROM sandbox_leases WHERE lease_id = ?", (sandbox_runtime_id,))
             self._conn.commit()
 
@@ -472,7 +472,7 @@ class SQLiteSandboxRuntimeRepo:
         )
         self._conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS lease_events (
+            CREATE TABLE IF NOT EXISTS sandbox_runtime_events (
                 event_id TEXT PRIMARY KEY,
                 sandbox_runtime_id TEXT NOT NULL,
                 event_type TEXT NOT NULL,
@@ -485,8 +485,8 @@ class SQLiteSandboxRuntimeRepo:
         )
         self._conn.execute(
             """
-            CREATE INDEX IF NOT EXISTS idx_lease_events_runtime_created
-            ON lease_events(sandbox_runtime_id, created_at DESC)
+            CREATE INDEX IF NOT EXISTS idx_sandbox_runtime_events_runtime_created
+            ON sandbox_runtime_events(sandbox_runtime_id, created_at DESC)
             """
         )
         self._conn.commit()
@@ -495,7 +495,7 @@ class SQLiteSandboxRuntimeRepo:
 
         lease_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_leases)").fetchall()}
         instance_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_instances)").fetchall()}
-        event_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(lease_events)").fetchall()}
+        event_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_runtime_events)").fetchall()}
 
         missing_lease = REQUIRED_LEASE_COLUMNS - lease_cols
         if missing_lease:
@@ -507,4 +507,6 @@ class SQLiteSandboxRuntimeRepo:
             )
         missing_events = REQUIRED_EVENT_COLUMNS - event_cols
         if missing_events:
-            raise RuntimeError(f"lease_events schema mismatch: missing {sorted(missing_events)}. Purge ~/.leon/sandbox.db and retry.")
+            raise RuntimeError(
+                f"sandbox_runtime_events schema mismatch: missing {sorted(missing_events)}. Purge ~/.leon/sandbox.db and retry."
+            )

--- a/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
+++ b/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
@@ -33,12 +33,15 @@ def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_sandbox_i
     assert "lease_id" not in cols
 
 
-def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_lease_events(tmp_path):
+def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_sandbox_runtime_events(tmp_path):
     repo = SQLiteSandboxRuntimeRepo(tmp_path / "sandbox.db")
     try:
-        cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(lease_events)").fetchall()}
+        table_names = {row[0] for row in repo._conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
+        cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_runtime_events)").fetchall()}
     finally:
         repo.close()
 
+    assert "sandbox_runtime_events" in table_names
+    assert "lease_events" not in table_names
     assert "sandbox_runtime_id" in cols
     assert "lease_id" not in cols


### PR DESCRIPTION
## Summary\n- rename the local sqlite lease_events table to sandbox_runtime_events\n- align sqlite sandbox runtime repo SQL plus sandbox lease persistence SQL to the renamed table/index\n- keep sandbox_leases and its root identifier unchanged in this slice\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py -q\n- uv run python -m pytest tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/core/test_runtime.py -q\n- git diff --check