### PR TITLE
refactor: rename sandbox runtime root table

### DIFF
--- a/sandbox/lease.py
+++ b/sandbox/lease.py
@@ -392,7 +392,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         try:
             target.execute(
                 """
-                UPDATE sandbox_leases
+                UPDATE sandbox_runtimes
                 SET current_instance_id = ?,
                     instance_created_at = ?,
                     recipe_id = ?,
@@ -476,7 +476,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         try:
             target.execute(
                 """
-                UPDATE sandbox_leases
+                UPDATE sandbox_runtimes
                 SET recipe_id = ?,
                     recipe_json = ?,
                     desired_state = ?,

--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -67,7 +67,7 @@ class SQLiteChatSessionRepo:
                 ended_at TIMESTAMP,
                 close_reason TEXT,
                 FOREIGN KEY (terminal_id) REFERENCES abstract_terminals(terminal_id),
-                FOREIGN KEY (sandbox_runtime_id) REFERENCES sandbox_leases(lease_id)
+                FOREIGN KEY (sandbox_runtime_id) REFERENCES sandbox_runtimes(sandbox_runtime_id)
             )
             """
         )

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -63,7 +63,7 @@ class SQLiteSandboxRuntimeRepo:
                        observed_at, last_error, needs_refresh,
                        refresh_hint_at, status,
                        created_at, updated_at
-                FROM sandbox_leases
+                FROM sandbox_runtimes
                 WHERE sandbox_runtime_id = ?
                 """,
                 (sandbox_runtime_id,),
@@ -110,7 +110,7 @@ class SQLiteSandboxRuntimeRepo:
         with self._lock:
             self._conn.execute(
                 """
-                INSERT INTO sandbox_leases (
+                INSERT INTO sandbox_runtimes (
                     sandbox_runtime_id, provider_name, recipe_id, recipe_json, desired_state, observed_state,
                     instance_status, version, observed_at, last_error,
                     needs_refresh, refresh_hint_at, status, created_at, updated_at
@@ -144,7 +144,7 @@ class SQLiteSandboxRuntimeRepo:
             row = self._conn.execute(
                 """
                 SELECT sandbox_runtime_id
-                FROM sandbox_leases
+                FROM sandbox_runtimes
                 WHERE provider_name = ? AND current_instance_id = ?
                 LIMIT 1
                 """,
@@ -183,7 +183,7 @@ class SQLiteSandboxRuntimeRepo:
         with self._lock:
             self._conn.execute(
                 """
-                UPDATE sandbox_leases
+                UPDATE sandbox_runtimes
                 SET current_instance_id = ?,
                     instance_created_at = ?,
                     desired_state = ?,
@@ -263,7 +263,7 @@ class SQLiteSandboxRuntimeRepo:
         with self._lock:
             self._conn.execute(
                 """
-                UPDATE sandbox_leases
+                UPDATE sandbox_runtimes
                 SET current_instance_id = ?,
                     instance_created_at = ?,
                     observed_state = ?,
@@ -334,7 +334,7 @@ class SQLiteSandboxRuntimeRepo:
         with self._lock:
             self._conn.execute(
                 """
-                UPDATE sandbox_leases
+                UPDATE sandbox_runtimes
                 SET recipe_id = ?,
                     recipe_json = ?,
                     desired_state = ?,
@@ -373,7 +373,7 @@ class SQLiteSandboxRuntimeRepo:
         with self._lock:
             cursor = self._conn.execute(
                 """
-                UPDATE sandbox_leases
+                UPDATE sandbox_runtimes
                 SET needs_refresh = 1,
                     refresh_hint_at = ?,
                     version = version + 1,
@@ -389,7 +389,7 @@ class SQLiteSandboxRuntimeRepo:
         with self._lock:
             self._conn.execute("DELETE FROM sandbox_instances WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
             self._conn.execute("DELETE FROM sandbox_runtime_events WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
-            self._conn.execute("DELETE FROM sandbox_leases WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
+            self._conn.execute("DELETE FROM sandbox_runtimes WHERE sandbox_runtime_id = ?", (sandbox_runtime_id,))
             self._conn.commit()
 
         # Clean up per-lease locks in SQLiteLease
@@ -406,7 +406,7 @@ class SQLiteSandboxRuntimeRepo:
                 SELECT sandbox_runtime_id, provider_name, recipe_id, recipe_json, current_instance_id,
                        desired_state, observed_state, version,
                        created_at, updated_at
-                FROM sandbox_leases
+                FROM sandbox_runtimes
                 ORDER BY created_at DESC
                 """,
             ).fetchall()
@@ -421,7 +421,7 @@ class SQLiteSandboxRuntimeRepo:
                 SELECT sandbox_runtime_id, provider_name, recipe_id, recipe_json, current_instance_id,
                        desired_state, observed_state, version,
                        created_at, updated_at
-                FROM sandbox_leases
+                FROM sandbox_runtimes
                 WHERE provider_name = ?
                 ORDER BY created_at DESC
                 """,
@@ -434,7 +434,7 @@ class SQLiteSandboxRuntimeRepo:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS sandbox_leases (
+            CREATE TABLE IF NOT EXISTS sandbox_runtimes (
                 sandbox_runtime_id TEXT PRIMARY KEY,
                 provider_name TEXT NOT NULL,
                 recipe_id TEXT,
@@ -491,13 +491,13 @@ class SQLiteSandboxRuntimeRepo:
 
         from sandbox.lease import REQUIRED_EVENT_COLUMNS, REQUIRED_INSTANCE_COLUMNS, REQUIRED_LEASE_COLUMNS
 
-        lease_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_leases)").fetchall()}
+        lease_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_runtimes)").fetchall()}
         instance_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_instances)").fetchall()}
         event_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sandbox_runtime_events)").fetchall()}
 
         missing_lease = REQUIRED_LEASE_COLUMNS - lease_cols
         if missing_lease:
-            raise RuntimeError(f"sandbox_leases schema mismatch: missing {sorted(missing_lease)}. Purge ~/.leon/sandbox.db and retry.")
+            raise RuntimeError(f"sandbox_runtimes schema mismatch: missing {sorted(missing_lease)}. Purge ~/.leon/sandbox.db and retry.")
         missing_instances = REQUIRED_INSTANCE_COLUMNS - instance_cols
         if missing_instances:
             raise RuntimeError(

--- a/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
+++ b/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
@@ -4,10 +4,13 @@ from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRe
 def test_sqlite_sandbox_runtime_repo_schema_does_not_create_removed_volume_id(tmp_path):
     repo = SQLiteSandboxRuntimeRepo(tmp_path / "sandbox.db")
     try:
-        cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_leases)").fetchall()}
+        table_names = {row[0] for row in repo._conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
+        cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_runtimes)").fetchall()}
     finally:
         repo.close()
 
+    assert "sandbox_runtimes" in table_names
+    assert "sandbox_leases" not in table_names
     assert "sandbox_runtime_id" in cols
     assert "lease_id" not in cols
     assert "volume_id" not in cols


### PR DESCRIPTION
## Summary\n- rename the local sqlite sandbox_leases table to sandbox_runtimes\n- align sqlite sandbox runtime repo SQL, sandbox lease persistence SQL, and chat-session FK references to the renamed table\n- keep Supabase and non-sqlite storage untouched in this slice\n\n## Testing\n- uv run python -m pytest tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py -q\n- uv run python -m pytest tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/sandbox/test_sandbox_lease_provider_env_sync.py tests/Unit/core/test_runtime.py tests/Unit/storage/test_chat_session_row_contract.py tests/Unit/storage/test_runtime_terminal_session_demotion.py -q\n- git diff --check