### PR TITLE
refactor: rename sqlite sandbox runtime helpers

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -605,7 +605,7 @@ class SandboxManager:
             return False
         if not self.db_path.exists():
             return False
-        return self.session_manager._repo.lease_has_running_command(lease_id)
+        return self.session_manager._repo.sandbox_runtime_has_running_command(lease_id)
 
     def _is_expired(self, session_row: dict, now: datetime) -> bool:
         started_at_raw = session_row.get("started_at")

--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -571,7 +571,7 @@ class SQLiteChatSessionRepo:
             ).fetchone()
             return row is not None
 
-    def lease_has_running_command(self, lease_id: str) -> bool:
+    def sandbox_runtime_has_running_command(self, sandbox_runtime_id: str) -> bool:
         with self._lock:
             row = self._conn.execute(
                 """
@@ -581,7 +581,7 @@ class SQLiteChatSessionRepo:
                 WHERE at.sandbox_runtime_id = ? AND tc.status = 'running'
                 LIMIT 1
                 """,
-                (lease_id,),
+                (sandbox_runtime_id,),
             ).fetchone()
             return row is not None
 

--- a/storage/providers/sqlite/terminal_repo.py
+++ b/storage/providers/sqlite/terminal_repo.py
@@ -221,7 +221,7 @@ class SQLiteTerminalRepo:
                 bucket["latest_terminal_id"] = terminal_id
         return summary
 
-    def get_latest_by_lease(self, lease_id: str) -> dict[str, Any] | None:
+    def get_latest_by_sandbox_runtime(self, sandbox_runtime_id: str) -> dict[str, Any] | None:
         with self._lock:
             self._conn.row_factory = sqlite3.Row
             row = self._conn.execute(
@@ -233,7 +233,7 @@ class SQLiteTerminalRepo:
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
-                (lease_id,),
+                (sandbox_runtime_id,),
             ).fetchone()
             self._conn.row_factory = None
             return dict(row) if row else None

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -61,7 +61,7 @@ class _FakeTerminalRepo:
         self.closed = False
         self.requested_lease_ids: list[str] = []
 
-    def get_latest_by_lease(self, lease_id: str):
+    def get_latest_by_sandbox_runtime(self, lease_id: str):
         self.requested_lease_ids.append(lease_id)
         return self._row
 
@@ -78,7 +78,7 @@ class _FakeBindTerminalRepo:
         self.requested_active_threads: list[str] = []
         self.created: list[dict[str, Any]] = []
 
-    def get_latest_by_lease(self, lease_id: str):
+    def get_latest_by_sandbox_runtime(self, lease_id: str):
         self.requested_lease_ids.append(lease_id)
         return self._latest_by_lease
 


### PR DESCRIPTION
## Summary\n- rename sqlite helper methods from lease wording to sandbox-runtime wording\n- align sandbox.manager and focused manager tests to the renamed helper APIs\n- keep the remaining runtime/storage semantics unchanged in this slice\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q\n- git diff --check