### PR TITLE
refactor: rename terminal sandbox runtime attribute

### DIFF
--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -161,9 +161,9 @@ class _CommandWrapper(BaseExecutor):
         terminal = terminal_from_row(terminal_row, self._manager.db_path)
         if terminal.thread_id != self._session.thread_id:
             raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal.thread_id}, not {self._session.thread_id}")
-        sandbox_runtime = self._manager.get_sandbox_runtime(terminal.lease_id)
+        sandbox_runtime = self._manager.get_sandbox_runtime(terminal.sandbox_runtime_id)
         if sandbox_runtime is None:
-            raise RuntimeError(f"Sandbox runtime {terminal.lease_id} not found for terminal {terminal_id}")
+            raise RuntimeError(f"Sandbox runtime {terminal.sandbox_runtime_id} not found for terminal {terminal_id}")
         return self._manager.session_manager.create(
             session_id=f"sess-{uuid.uuid4().hex[:12]}",
             thread_id=self._session.thread_id,

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -307,7 +307,7 @@ class SandboxManager:
         terminal = self._get_active_terminal(thread_id)
         if not terminal:
             raise ValueError(f"No active terminal for thread {thread_id}")
-        lease = self._get_sandbox_runtime(terminal.lease_id)
+        lease = self._get_sandbox_runtime(terminal.sandbox_runtime_id)
         if not lease:
             raise ValueError(f"No sandbox runtime for thread {thread_id}")
         remote_path = self.volume.resolve_mount_path()
@@ -492,9 +492,9 @@ class SandboxManager:
                 self.db_path,
             )
         else:
-            lease = self._get_sandbox_runtime(terminal.lease_id)
+            lease = self._get_sandbox_runtime(terminal.sandbox_runtime_id)
             if not lease:
-                lease = self._create_sandbox_runtime(terminal.lease_id, self.provider.name)
+                lease = self._create_sandbox_runtime(terminal.sandbox_runtime_id, self.provider.name)
             self._assert_lease_provider(lease, thread_id)
             if lease.observed_state == "paused":
                 # @@@paused-lease-rehydrate - a persisted thread can lose its in-memory chat session
@@ -506,7 +506,7 @@ class SandboxManager:
                     self._assert_lease_provider(session.sandbox_runtime, thread_id)
                     self._ensure_bound_instance(session.sandbox_runtime)
                     return SandboxCapability(session, manager=self)
-                lease = self._get_sandbox_runtime(terminal.lease_id)
+                lease = self._get_sandbox_runtime(terminal.sandbox_runtime_id)
                 if not lease:
                     raise RuntimeError(f"Sandbox runtime disappeared after resume for thread {thread_id}")
                 self._assert_lease_provider(lease, thread_id)
@@ -560,9 +560,9 @@ class SandboxManager:
         if default_row is None:
             raise RuntimeError(f"Thread {thread_id} has no default terminal")
         default_terminal = terminal_from_row(default_row, self.db_path)
-        lease = self._get_sandbox_runtime(default_terminal.lease_id)
+        lease = self._get_sandbox_runtime(default_terminal.sandbox_runtime_id)
         if lease is None:
-            raise RuntimeError(f"Missing sandbox runtime {default_terminal.lease_id} for thread {thread_id}")
+            raise RuntimeError(f"Missing sandbox runtime {default_terminal.sandbox_runtime_id} for thread {thread_id}")
         self._assert_lease_provider(lease, thread_id)
 
         inherited = default_terminal.get_state()
@@ -659,7 +659,7 @@ class SandboxManager:
             terminal_id = row.get("terminal_id")
             terminal_row = self.terminal_store.get_by_id(str(terminal_id)) if terminal_id else None
             terminal = terminal_from_row(terminal_row, self.db_path) if terminal_row else None
-            lease = self._get_sandbox_runtime(terminal.lease_id) if terminal else None
+            lease = self._get_sandbox_runtime(terminal.sandbox_runtime_id) if terminal else None
             if lease and lease.provider_name != self.provider.name:
                 continue
 
@@ -836,7 +836,7 @@ class SandboxManager:
                     raise
         self.volume.clear_sync_state(thread_id)
 
-        lease_ids = {terminal.lease_id for terminal in terminals}
+        lease_ids = {terminal.sandbox_runtime_id for terminal in terminals}
 
         self.session_manager.delete_thread(thread_id, reason="thread_deleted")
 

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -83,7 +83,7 @@ class AbstractTerminal(ABC):
     It does NOT own the physical process - that's owned by PhysicalTerminalRuntime.
 
     Responsibilities:
-    - Store terminal identity (terminal_id, thread_id, lease_id)
+    - Store terminal identity (terminal_id, thread_id, sandbox_runtime_id)
     - Maintain state snapshot (cwd, env_delta, state_version)
     - Persist state to database
     - Provide state to PhysicalTerminalRuntime for hydration
@@ -98,12 +98,12 @@ class AbstractTerminal(ABC):
         self,
         terminal_id: str,
         thread_id: str,
-        lease_id: str,
+        sandbox_runtime_id: str,
         state: TerminalState,
     ):
         self.terminal_id = terminal_id
         self.thread_id = thread_id
-        self.lease_id = lease_id
+        self.sandbox_runtime_id = sandbox_runtime_id
         self._state = state
 
     def get_state(self) -> TerminalState:
@@ -133,11 +133,11 @@ class SQLiteTerminal(AbstractTerminal):
         self,
         terminal_id: str,
         thread_id: str,
-        lease_id: str,
+        sandbox_runtime_id: str,
         state: TerminalState,
         db_path: Path | None = None,
     ):
-        super().__init__(terminal_id, thread_id, lease_id, state)
+        super().__init__(terminal_id, thread_id, sandbox_runtime_id, state)
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
     def _persist_state(self) -> None:
@@ -170,7 +170,7 @@ def terminal_from_row(row: dict, db_path: Path) -> AbstractTerminal:
     return SQLiteTerminal(
         terminal_id=row["terminal_id"],
         thread_id=row["thread_id"],
-        lease_id=row["sandbox_runtime_id"],
+        sandbox_runtime_id=row["sandbox_runtime_id"],
         state=state,
         db_path=db_path,
     )

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -291,7 +291,7 @@ def test_setup_mounts_uses_workspace_sync_source_for_non_daytona_runtime(tmp_pat
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
-    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     result = manager._setup_mounts("thread-1")
@@ -305,7 +305,7 @@ def test_setup_mounts_reports_missing_lease_not_missing_volume():
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
-    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: None
 
     with pytest.raises(ValueError, match="No sandbox runtime for thread thread-1"):
@@ -329,7 +329,7 @@ def test_setup_mounts_uses_workspace_source_without_remote_volume_metadata(monke
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
-    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     lease = SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: lease
@@ -346,7 +346,7 @@ def test_setup_mounts_daytona_uses_lease_id_for_managed_volume(monkeypatch, tmp_
     manager.provider_capability = SimpleNamespace(runtime_kind="daytona_pty")
     manager.provider = _FakeDaytonaProvider()
     manager.volume = _FakeVolume()
-    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._resolve_sync_source_path = lambda _thread_id: Path(tmp_path) / "channel-root"
     lease = SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: lease
@@ -444,7 +444,7 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
     monkeypatch.setattr(
         sandbox_manager_module,
         "terminal_from_row",
-        lambda _row, _db_path: SimpleNamespace(terminal_id="term-1", lease_id="lease-1"),
+        lambda _row, _db_path: SimpleNamespace(terminal_id="term-1", sandbox_runtime_id="lease-1"),
     )
 
     manager.enforce_idle_timeouts()
@@ -707,9 +707,9 @@ def test_sync_uploads_skips_local_volume_sync_without_volume_metadata():
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="local")
     manager.volume = _FakeVolume()
-    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
+    manager._get_active_terminal = lambda _thread_id: SimpleNamespace(terminal_id="term-1", sandbox_runtime_id="lease-1")
     manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
-    manager._get_thread_sandbox_runtime = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_thread_sandbox_runtime = lambda _thread_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager._resolve_volume_entry = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume lookup should not happen"))
     manager.session_manager = SimpleNamespace(
         get=lambda _thread_id, _terminal_id: SimpleNamespace(
@@ -725,7 +725,7 @@ def test_sync_paths_use_workspace_file_channel_root_instead_of_volume_source(mon
     manager = _new_test_manager()
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay")
     manager.volume = _FakeVolume()
-    manager._get_thread_sandbox_runtime = lambda _thread_id: SimpleNamespace(lease_id="lease-1")
+    manager._get_thread_sandbox_runtime = lambda _thread_id: SimpleNamespace(sandbox_runtime_id="lease-1")
     manager.resolve_volume_source = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("volume source should stay unused"))
 
     class _ThreadRepo:
@@ -770,7 +770,7 @@ def test_get_sandbox_auto_resumes_paused_lease_when_reconstructing_session():
     manager.volume = _FakeVolume()
     terminal = SimpleNamespace(
         terminal_id="term-1",
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         get_state=lambda: SimpleNamespace(cwd="/tmp", env_delta={}, state_version=0),
         update_state=lambda _state: None,
     )
@@ -802,7 +802,7 @@ def test_get_sandbox_auto_resumes_live_session_when_lease_state_is_paused():
     manager = _new_test_manager()
     terminal = SimpleNamespace(
         terminal_id="term-1",
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         get_state=lambda: SimpleNamespace(cwd="/tmp", env_delta={}, state_version=0),
     )
     paused_lease = SimpleNamespace(
@@ -850,11 +850,11 @@ def test_get_sandbox_routes_bind_mounts_to_provider_thread_state():
     bind_mount_calls: list[tuple[str, list[dict[str, str]]]] = []
     terminal = SimpleNamespace(
         terminal_id="term-1",
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         get_state=lambda: SimpleNamespace(cwd="/tmp", env_delta={}, state_version=0),
     )
     lease = SimpleNamespace(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="local",
         observed_state="running",
         get_instance=lambda: SimpleNamespace(instance_id="instance-1"),
@@ -882,12 +882,12 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
     manager = _new_test_manager()
     terminal = SimpleNamespace(
         terminal_id="term-1",
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         get_state=lambda: SimpleNamespace(cwd="/tmp", env_delta={}, state_version=0),
         update_state=lambda _state: None,
     )
     lease = SimpleNamespace(
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         provider_name="agentbay",
         observed_state="running",
         recipe=None,
@@ -931,7 +931,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
     manager = _new_test_manager()
     default_state = SimpleNamespace(cwd="/default", env_delta={"TOKEN": "value"}, state_version=7)
     created_terminal = SimpleNamespace(updated_state=None)
-    default_terminal = SimpleNamespace(lease_id="lease-1", get_state=lambda: default_state)
+    default_terminal = SimpleNamespace(sandbox_runtime_id="lease-1", get_state=lambda: default_state)
     created_rows: list[dict[str, str]] = []
     created_background_commands: list[dict[str, Any]] = []
 
@@ -984,7 +984,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
 
 def test_resume_session_rebinds_live_session_lease_after_resume():
     manager = _new_test_manager()
-    terminal = SimpleNamespace(terminal_id="term-1", lease_id="lease-1")
+    terminal = SimpleNamespace(terminal_id="term-1", sandbox_runtime_id="lease-1")
     resumed_lease = SimpleNamespace(
         sandbox_runtime_id="lease-1",
         observed_state="running",

--- a/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
@@ -28,7 +28,7 @@ def _terminal(db_path: Path) -> SQLiteTerminal:
     return SQLiteTerminal(
         terminal_id="term-1",
         thread_id="thread-1",
-        lease_id="lease-1",
+        sandbox_runtime_id="lease-1",
         state=TerminalState(cwd="/tmp"),
         db_path=db_path,
     )
@@ -53,6 +53,8 @@ def test_chat_session_uses_sandbox_runtime_attribute(tmp_path: Path) -> None:
 
     assert session.sandbox_runtime is sandbox_runtime
     assert not hasattr(session, "lease")
+    assert terminal.sandbox_runtime_id == "lease-1"
+    assert not hasattr(terminal, "lease_id")
     assert session.sandbox_runtime.sandbox_runtime_id == "lease-1"
     assert not hasattr(session.sandbox_runtime, "lease_id")
 
@@ -63,6 +65,8 @@ def test_runtime_uses_sandbox_runtime_attribute(tmp_path: Path) -> None:
     sandbox_runtime = _sandbox_runtime(db_path)
     runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
+    assert terminal.sandbox_runtime_id == "lease-1"
+    assert not hasattr(terminal, "lease_id")
     assert runtime.sandbox_runtime is sandbox_runtime
     assert not hasattr(runtime, "lease")
     assert runtime.sandbox_runtime.sandbox_runtime_id == "lease-1"


### PR DESCRIPTION
## Summary\n- rename AbstractTerminal/SQLiteTerminal object attribute from lease_id to sandbox_runtime_id\n- align direct capability/manager consumers to the renamed terminal attribute\n- update focused attribute/manager tests to the renamed object boundary\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py -q\n- uv run python -m pytest tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py tests/Unit/sandbox/test_sandbox_runtime_interface_naming.py -q\n- git diff --check