### PR TITLE
refactor: strip sandbox runtime handle from public reads

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -221,7 +221,7 @@ def load_provider_orphan_runtimes(managers: dict) -> list[dict[str, Any]]:
                     "status": status,
                     "created_at": None,
                     "last_active": None,
-                    "lease_id": None,
+                    "sandbox_runtime_id": None,
                     "instance_id": instance_id,
                     "chat_session_id": None,
                     "source": "provider_orphan",

--- a/backend/sandboxes/user_reads.py
+++ b/backend/sandboxes/user_reads.py
@@ -154,7 +154,7 @@ def _list_user_runtime_rows(
 
 
 def _sandbox_summary(row: dict[str, Any]) -> dict[str, Any]:
-    return {key: value for key, value in row.items() if key != "lease_id"}
+    return {key: value for key, value in row.items() if key not in {"lease_id", "sandbox_runtime_id"}}
 
 
 def list_user_sandboxes(

--- a/tests/Integration/test_sandbox_router_user_shell.py
+++ b/tests/Integration/test_sandbox_router_user_shell.py
@@ -166,6 +166,7 @@ def test_list_user_sandboxes_projects_internal_runtime_rows(monkeypatch: pytest.
             return [
                 {
                     "lease_" + "id": "lease-1",
+                    "sandbox_runtime_id": "lease-1",
                     "sandbox_id": "sandbox-1",
                     "provider_name": "local",
                     "recipe_id": "local:default",
@@ -196,6 +197,7 @@ def test_list_user_sandboxes_projects_internal_runtime_rows(monkeypatch: pytest.
 
     assert len(result) == 1
     assert "lease_" + "id" not in result[0]
+    assert "sandbox_runtime_id" not in result[0]
     assert result[0]["sandbox_id"] == "sandbox-1"
     assert result[0]["provider_name"] == "local"
     assert result[0]["thread_ids"] == ["thread-1"]

--- a/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
+++ b/tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py
@@ -6,7 +6,7 @@ from backend.monitor.application.use_cases import provider_runtimes as monitor_p
 from backend.monitor.infrastructure.providers import provider_runtime_inventory_service as monitor_provider_runtime_inventory_service
 from backend.sandboxes import service as sandbox_service
 
-LOWER_RUNTIME_KEY = "lease_" + "id"
+LOWER_RUNTIME_KEY = "sandbox_runtime_" + "id"
 
 
 class _FailingManager:

--- a/tests/Unit/sandbox/test_sandbox_user_runtime_rows.py
+++ b/tests/Unit/sandbox/test_sandbox_user_runtime_rows.py
@@ -22,6 +22,7 @@ def _runtime_row(
 ):
     return {
         LOWER_RUNTIME_KEY: lower_runtime_id,
+        "sandbox_runtime_id": lower_runtime_id,
         "sandbox_id": sandbox_id or lower_runtime_id.replace("lease", "sandbox", 1),
         "provider_name": provider_name,
         "recipe_id": recipe_id or f"{provider_name}:default",
@@ -282,6 +283,7 @@ def test_list_user_sandboxes_returns_user_visible_runtime_fields(monkeypatch):
     assert len(sandboxes) == 1
     sandbox = sandboxes[0]
     assert LOWER_RUNTIME_KEY not in sandbox
+    assert "sandbox_runtime_id" not in sandbox
     assert sandbox["sandbox_id"] == "sandbox-1"
     assert sandbox["provider_name"] == "local"
     assert sandbox["recipe_id"] == "local:default"
@@ -314,6 +316,7 @@ def test_list_user_sandboxes_does_not_require_lower_runtime_identity(monkeypatch
     assert len(sandboxes) == 1
     assert sandboxes[0]["sandbox_id"] == "sandbox-1"
     assert LOWER_RUNTIME_KEY not in sandboxes[0]
+    assert "sandbox_runtime_id" not in sandboxes[0]
 
 
 def test_count_user_visible_sandboxes_by_provider_does_not_require_lower_runtime_identity(monkeypatch):


### PR DESCRIPTION
## Summary\n- keep sandbox runtime handles stripped from public/user-facing sandbox read surfaces\n- align provider orphan runtime rows to the sandbox_runtime_id key internally\n- strengthen user sandbox/public route tests so the lower runtime handle does not leak\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_user_runtime_rows.py tests/Unit/backend/web/services/test_monitor_provider_orphan_runtimes.py tests/Integration/test_sandbox_router_user_shell.py -q\n- git diff --check