### PR TITLE
refactor: rename sandbox runtime manager tail

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -346,14 +346,14 @@ class SandboxManager:
         if self._on_session_ready:
             self._on_session_ready(session_id, reason)
 
-    def _ensure_bound_instance(self, lease) -> None:
-        if self.provider_capability.eager_instance_binding and not lease.get_instance():
-            lease.ensure_active_instance(self.provider)
+    def _ensure_sandbox_runtime_bound_instance(self, sandbox_runtime) -> None:
+        if self.provider_capability.eager_instance_binding and not sandbox_runtime.get_instance():
+            sandbox_runtime.ensure_active_instance(self.provider)
 
-    def _assert_lease_provider(self, lease, thread_id: str) -> None:
-        if lease.provider_name != self.provider.name:
+    def _assert_sandbox_runtime_provider(self, sandbox_runtime, thread_id: str) -> None:
+        if sandbox_runtime.provider_name != self.provider.name:
             raise RuntimeError(
-                f"Thread {thread_id} is bound to provider {lease.provider_name}, "
+                f"Thread {thread_id} is bound to provider {sandbox_runtime.provider_name}, "
                 f"but current manager provider is {self.provider.name}. "
                 "Use the matching sandbox type for this thread or recreate the thread."
             )
@@ -384,7 +384,7 @@ class SandboxManager:
         lease = self._get_sandbox_runtime(lease_id)
         if lease is None:
             return None
-        self._assert_lease_provider(lease, thread_id)
+        self._assert_sandbox_runtime_provider(lease, thread_id)
         return lease
 
     def _thread_belongs_to_provider(self, thread_id: str) -> bool:
@@ -462,7 +462,7 @@ class SandboxManager:
         terminal = self._get_active_terminal(thread_id)
         session = self.session_manager.get(thread_id, terminal.terminal_id) if terminal else None
         if session:
-            self._assert_lease_provider(session.sandbox_runtime, thread_id)
+            self._assert_sandbox_runtime_provider(session.sandbox_runtime, thread_id)
             # @@@activity-resume - Any new activity against a paused thread must resume before command execution.
             if session.status == "paused" or getattr(session.sandbox_runtime, "observed_state", None) == "paused":
                 if not self.resume_session(thread_id, source="auto_resume"):
@@ -470,11 +470,11 @@ class SandboxManager:
                 session = self.session_manager.get(thread_id, session.terminal.terminal_id)
                 if not session:
                     raise RuntimeError(f"Session disappeared after resume for thread {thread_id}")
-                self._assert_lease_provider(session.sandbox_runtime, thread_id)
+                self._assert_sandbox_runtime_provider(session.sandbox_runtime, thread_id)
             # Stamp bind_mounts on provider thread state so lazy create_session paths pick them up
             if bind_mounts:
                 self.provider.set_thread_bind_mounts(thread_id, bind_mounts)
-            self._ensure_bound_instance(session.sandbox_runtime)
+            self._ensure_sandbox_runtime_bound_instance(session.sandbox_runtime)
             return SandboxCapability(session, manager=self)
 
         if not terminal:
@@ -495,7 +495,7 @@ class SandboxManager:
             lease = self._get_sandbox_runtime(terminal.sandbox_runtime_id)
             if not lease:
                 lease = self._create_sandbox_runtime(terminal.sandbox_runtime_id, self.provider.name)
-            self._assert_lease_provider(lease, thread_id)
+            self._assert_sandbox_runtime_provider(lease, thread_id)
             if lease.observed_state == "paused":
                 # @@@paused-lease-rehydrate - a persisted thread can lose its in-memory chat session
                 # while the lease stays paused in storage; resume before reconstructing capability.
@@ -503,13 +503,13 @@ class SandboxManager:
                     raise RuntimeError(f"Failed to resume paused session for thread {thread_id}")
                 session = self.session_manager.get(thread_id, terminal.terminal_id)
                 if session:
-                    self._assert_lease_provider(session.sandbox_runtime, thread_id)
-                    self._ensure_bound_instance(session.sandbox_runtime)
+                    self._assert_sandbox_runtime_provider(session.sandbox_runtime, thread_id)
+                    self._ensure_sandbox_runtime_bound_instance(session.sandbox_runtime)
                     return SandboxCapability(session, manager=self)
                 lease = self._get_sandbox_runtime(terminal.sandbox_runtime_id)
                 if not lease:
                     raise RuntimeError(f"Sandbox runtime disappeared after resume for thread {thread_id}")
-                self._assert_lease_provider(lease, thread_id)
+                self._assert_sandbox_runtime_provider(lease, thread_id)
 
         # Stamp bind_mounts on provider thread state so lazy create_session paths pick them up
         if bind_mounts:
@@ -520,7 +520,7 @@ class SandboxManager:
             # @@@volume-strategy-gate - remote runtimes need volume mount/sync before first command.
             storage = self._setup_mounts(thread_id)
 
-        self._ensure_bound_instance(lease)
+        self._ensure_sandbox_runtime_bound_instance(lease)
 
         # @@@force-instance-for-sync - Non-eager providers (E2B, Daytona, etc.) create instances lazily.
         # Force instance creation here so workspace sync can upload files before tools run.
@@ -563,7 +563,7 @@ class SandboxManager:
         lease = self._get_sandbox_runtime(default_terminal.sandbox_runtime_id)
         if lease is None:
             raise RuntimeError(f"Missing sandbox runtime {default_terminal.sandbox_runtime_id} for thread {thread_id}")
-        self._assert_lease_provider(lease, thread_id)
+        self._assert_sandbox_runtime_provider(lease, thread_id)
 
         inherited = default_terminal.get_state()
         terminal_id = f"term-{uuid.uuid4().hex[:12]}"

--- a/tests/Unit/sandbox/test_sandbox_manager_tail_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_tail_naming.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FORBIDDEN = (
+    "_assert_lease_provider",
+    "def _ensure_bound_instance(self, lease)",
+    "Thread {thread_id} is bound to provider {lease.provider_name}",
+)
+
+
+def test_sandbox_manager_tail_avoids_remaining_lease_helper_names() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "sandbox/manager.py").read_text(encoding="utf-8")
+    offenders = [pattern for pattern in FORBIDDEN if pattern in source]
+    assert offenders == [], "Found remaining sandbox.manager lease tail residue:\n" + "\n".join(offenders)

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -784,7 +784,7 @@ def test_get_sandbox_auto_resumes_paused_lease_when_reconstructing_session():
     )
     manager._get_active_terminal = lambda _thread_id: terminal
     manager._get_sandbox_runtime = lambda _lease_id: lease
-    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager._assert_sandbox_runtime_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     resume_calls: list[tuple[str, str]] = []
     manager.resume_session = lambda thread_id, source="user_resume": resume_calls.append((thread_id, source)) or True
@@ -826,7 +826,7 @@ def test_get_sandbox_auto_resumes_live_session_when_lease_state_is_paused():
     manager.provider = SimpleNamespace(name="local")
     manager.provider_capability = SimpleNamespace(runtime_kind="local", eager_instance_binding=False)
     manager.volume = _FakeVolume()
-    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager._assert_sandbox_runtime_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     resume_calls: list[tuple[str, str]] = []
 
@@ -867,7 +867,7 @@ def test_get_sandbox_routes_bind_mounts_to_provider_thread_state():
     )
     manager.provider_capability = SimpleNamespace(runtime_kind="local", eager_instance_binding=False)
     manager._get_active_terminal = lambda _thread_id: terminal
-    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager._assert_sandbox_runtime_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     manager.session_manager = SimpleNamespace(get=lambda _thread_id, _terminal_id: session)
 
@@ -900,7 +900,7 @@ def test_get_sandbox_remote_bootstrap_syncs_with_path_source():
     manager.provider_capability = SimpleNamespace(runtime_kind="agentbay", eager_instance_binding=False)
     manager._get_active_terminal = lambda _thread_id: terminal
     manager._get_sandbox_runtime = lambda _lease_id: lease
-    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager._assert_sandbox_runtime_provider = lambda _lease, _thread_id: None
     manager._ensure_bound_instance = lambda _lease: None
     manager._setup_mounts = lambda _thread_id: {"source_path": expected_path, "remote_path": "/workspace"}
     manager._sync_to_sandbox = lambda thread_id, instance_id, source=None, files=None: sync_calls.append((thread_id, instance_id, source))
@@ -967,7 +967,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
         create=create_terminal,
     )
     manager._get_sandbox_runtime = lambda _lease_id: SimpleNamespace(sandbox_runtime_id="lease-1")
-    manager._assert_lease_provider = lambda _lease, _thread_id: None
+    manager._assert_sandbox_runtime_provider = lambda _lease, _thread_id: None
     manager.session_manager = SimpleNamespace(create=lambda **kwargs: created_background_commands.append(kwargs) or kwargs)
     monkeypatch.setattr(sandbox_manager_module, "terminal_from_row", from_row)
 


### PR DESCRIPTION
## Summary\n- rename the remaining sandbox.manager helper names from lease wording to sandbox-runtime wording\n- align the focused manager tests to the renamed helper methods\n- add a narrow source-guard so those old manager tail helper names do not return\n\n## Testing\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_tail_naming.py -q\n- uv run python -m pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q\n- git diff --check