### PR TITLE
refactor: clean runtime comment tail

### DIFF
--- a/backend/sandboxes/__init__.py
+++ b/backend/sandboxes/__init__.py
@@ -1,6 +1,6 @@
 """Sandboxes domain — HTTP/service layer for sandbox lifecycle.
 
-Aggregate root: `sandbox_lease` (schema-side; owned via storage/ + sandbox/).
+Aggregate root: `sandbox_runtime` (schema-side; owned via storage/ + sandbox/).
 This package wraps the top-level sandbox/ provider abstraction with
 app.state-aware caching, user-scoped views, and resource projections.
 

--- a/backend/threads/__init__.py
+++ b/backend/threads/__init__.py
@@ -6,7 +6,7 @@ Aggregate root: `thread`. Subordinate entities: `run`, `run_event`,
 IN:
     - Threads, runs, run events, checkpoints
     - Runtime bindings and runtime state
-    - Sandbox resolution per thread (which lease binds, not how provisioned)
+    - Sandbox resolution per thread (which sandbox runtime binds, not how provisioned)
     - Chat adapters (chat -> runtime, runtime -> chat) in chat_adapters/
     - Thread history projection for chat
     - Thread launch configuration and visibility

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -902,7 +902,7 @@ class LeonAgent:
         """
         # @@@close-idempotent - child agents may explicitly skip sandbox cleanup
         # and later still hit __del__ on GC; never let a second close silently
-        # re-enable default sandbox teardown on a shared lease.
+        # re-enable default sandbox teardown on a shared sandbox runtime.
         if getattr(self, "_closed", False) or getattr(self, "_closing", False):
             return
 

--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -118,7 +118,7 @@ def probe_and_upsert_for_instance(
         probe_error = "metrics unavailable"
 
     try:
-        # @@@snapshot-write-nonblocking - runtime startup truth belongs to lease/session creation;
+        # @@@snapshot-write-nonblocking - runtime startup truth belongs to runtime/session creation;
         # snapshot persistence is auxiliary monitor data and must report write failure
         # without turning local sandbox bringup into a Supabase-config contract.
         if repo is not None and hasattr(repo, "upsert_resource_snapshot_for_sandbox"):

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -1008,4 +1008,4 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
         return first
 
     async def close(self) -> None:
-        """No-op for remote runtime - instance lifecycle managed by lease."""
+        """No-op for remote runtime - instance lifecycle managed by sandbox runtime."""

--- a/tests/Unit/core/test_runtime_comment_tail.py
+++ b/tests/Unit/core/test_runtime_comment_tail.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TARGETS = (
+    "backend/sandboxes/__init__.py",
+    "backend/threads/__init__.py",
+    "sandbox/runtime.py",
+    "sandbox/resource_snapshot.py",
+    "core/runtime/agent.py",
+)
+
+FORBIDDEN = (
+    "sandbox_lease",
+    "which lease binds",
+    "managed by lease",
+    "lease/session creation",
+    "shared lease",
+)
+
+
+def test_runtime_comment_tail_avoids_lease_phrasing() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+
+    for rel_path in TARGETS:
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        for pattern in FORBIDDEN:
+            if pattern in source:
+                offenders.append(f"{rel_path} -> {pattern}")
+
+    assert offenders == [], "Found runtime comment tail lease residue:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- clean the remaining runtime comment/docstring tail wording away from lease phrasing\n- add a focused source-guard over the touched files\n- keep this slice text-only and behavior-preserving\n\n## Testing\n- uv run python -m pytest tests/Unit/core/test_runtime_comment_tail.py -q\n- python3 -m compileall backend/sandboxes/__init__.py backend/threads/__init__.py sandbox/runtime.py sandbox/resource_snapshot.py core/runtime/agent.py\n- git diff --check