### PR TITLE
refactor: rename sandbox runtime status wording

### DIFF
--- a/backend/threads/run/lifecycle.py
+++ b/backend/threads/run/lifecycle.py
@@ -18,8 +18,12 @@ async def prime_sandbox(agent: Any, thread_id: str) -> None:
         capability = mgr.get_sandbox(thread_id)
         sandbox_runtime = getattr(getattr(capability, "_session", None), "sandbox_runtime", None)
         if sandbox_runtime:
-            lease_status = sandbox_runtime.refresh_instance_status(mgr.provider)
-            if lease_status == "paused" and mgr.provider_capability.can_resume and not agent._sandbox.resume_thread(thread_id):
+            sandbox_runtime_status = sandbox_runtime.refresh_instance_status(mgr.provider)
+            if (
+                sandbox_runtime_status == "paused"
+                and mgr.provider_capability.can_resume
+                and not agent._sandbox.resume_thread(thread_id)
+            ):
                 raise RuntimeError(f"Failed to auto-resume paused sandbox for thread {thread_id}")
 
     await asyncio.to_thread(_prime_sandbox)

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -287,14 +287,14 @@ class SupabaseSandboxRuntimeRepo:
         )
         now = observed_at.isoformat() if isinstance(observed_at, datetime) else (observed_at or _utc_now_iso())
         normalized = parse_sandbox_runtime_instance_state(status).value
-        lease_status = "expired" if normalized == "detached" else "active"
+        sandbox_runtime_status = "expired" if normalized == "detached" else "active"
         self._sandboxes().update(
             {
                 "provider_env_id": None if normalized == "detached" else existing.get("current_instance_id"),
                 "observed_state": normalized,
                 "observed_at": now,
                 "last_error": None,
-                "status": lease_status,
+                "status": sandbox_runtime_status,
                 "updated_at": _utc_now_iso(),
                 "config": _patched_config(
                     row,
@@ -303,7 +303,7 @@ class SupabaseSandboxRuntimeRepo:
                         "version": int(existing.get("version") or 0) + 1,
                         "needs_refresh": 0,
                         "refresh_hint_at": None,
-                        "status": lease_status,
+                        "status": sandbox_runtime_status,
                     },
                 ),
             }

--- a/tests/Unit/core/test_runtime_status_wording.py
+++ b/tests/Unit/core/test_runtime_status_wording.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TARGETS = (
+    "storage/providers/supabase/sandbox_runtime_repo.py",
+    "backend/threads/run/lifecycle.py",
+)
+
+
+def test_runtime_status_wording_avoids_lease_status_name() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+
+    for rel_path in TARGETS:
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        if "lease_status" in source:
+            offenders.append(rel_path)
+
+    assert offenders == [], "Found lease_status residue:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary\n- rename the remaining lease_status locals to sandbox_runtime_status in the direct runtime flow\n- add a focused wording guard for that specific residue\n- keep the slice tiny and behavior-preserving\n\n## Testing\n- uv run python -m pytest tests/Unit/core/test_runtime_status_wording.py -q\n- uv run python -m pytest tests/Unit/storage/test_supabase_sandbox_runtime_repo.py -q\n- uv run python -m pytest tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Integration/test_query_loop_backend_contracts.py -q -k 'prime_sandbox or threads_runtime_state or event_loop or checkpoint_store or runtime'\n- git diff --check