### PR TITLE
refactor: clean threads runtime wording tail

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -551,7 +551,7 @@ def _create_thread_sandbox_resources(
     try:
         lease_id = f"lease-{uuid.uuid4().hex[:12]}"
         normalized_recipe = normalize_recipe_snapshot(provider_type_from_name(sandbox_type), recipe, provider_name=sandbox_type)
-        created_lease = sandbox_runtime_repo.create(
+        created_runtime = sandbox_runtime_repo.create(
             lease_id,
             sandbox_type,
             recipe_id=normalized_recipe["id"],
@@ -561,7 +561,7 @@ def _create_thread_sandbox_resources(
     finally:
         sandbox_runtime_repo.close()
 
-    sandbox_id = str((created_lease or {}).get("sandbox_id") or "").strip()
+    sandbox_id = str((created_runtime or {}).get("sandbox_id") or "").strip()
     if not sandbox_id:
         raise RuntimeError("sandbox_runtime_repo.create must return sandbox_id for thread sandbox resources")
 
@@ -611,7 +611,7 @@ def _materialize_workspace_for_sandbox(
     workspace_id = f"workspace-{uuid.uuid4().hex}"
     now = time.time()
     # @@@workspace-binding-write - Phase 2 cuts thread create writes to a real
-    # workspace row; lower lease_id remains terminal/runtime internals, not workspace authority.
+    # workspace row; lower sandbox runtime id remains terminal/runtime internals, not workspace authority.
     workspace_repo.create(
         WorkspaceRow(
             id=workspace_id,

--- a/tests/Unit/backend/web/routers/test_threads_router_naming.py
+++ b/tests/Unit/backend/web/routers/test_threads_router_naming.py
@@ -9,6 +9,8 @@ FORBIDDEN = (
     "bound_lease",
     "Create lease and terminal resources",
     "lower lease identity",
+    "created_lease",
+    "lower lease_id remains terminal/runtime internals",
 )
 
 


### PR DESCRIPTION
## Summary\n- clean the remaining threads router tail wording around sandbox runtime creation/binding\n- extend the focused threads router naming guard for the last stale local names\n- keep the slice tiny and behavior-preserving\n\n## Testing\n- uv run python -m pytest tests/Unit/backend/web/routers/test_threads_router_naming.py -q\n- uv run python -m pytest tests/Integration/test_threads_router.py tests/Integration/test_thread_launch_config_contract.py -q\n- git diff --check