### PR TITLE
refactor: clean runtime comment tail

### DIFF
--- a/backend/sandboxes/__init__.py
+++ b/backend/sandboxes/__init__.py
@@ -20,7 +20,7 @@ IN:
 
 OUT:
     - Provider implementation details (sandbox/providers/)
-    - Lease state machine (sandbox/lease.py, sandbox/lifecycle.py)
+    - Sandbox runtime state machine (sandbox/lease.py, sandbox/lifecycle.py)
     - Volume engine (sandbox/volume.py)
     - Thread-sandbox binding (backend/threads/sandbox_resolution.py)
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -299,7 +299,7 @@ class SandboxManager:
 
     def _destroy_daytona_managed_volume(self, lease_id: str) -> None:
         # @@@daytona-managed-volume-ref - daytona managed volumes now derive their backend
-        # ref from lease identity directly, so cleanup no longer depends on dropped volume rows.
+        # ref from sandbox runtime identity directly, so cleanup no longer depends on dropped volume rows.
         self.provider.delete_managed_volume(f"leon-volume-{lease_id}")
 
     def _setup_mounts(self, thread_id: str) -> dict:

--- a/tests/Unit/core/test_runtime_comment_tail.py
+++ b/tests/Unit/core/test_runtime_comment_tail.py
@@ -6,6 +6,7 @@ from pathlib import Path
 TARGETS = (
     "backend/sandboxes/__init__.py",
     "backend/threads/__init__.py",
+    "sandbox/manager.py",
     "sandbox/runtime.py",
     "sandbox/resource_snapshot.py",
     "core/runtime/agent.py",
@@ -17,6 +18,8 @@ FORBIDDEN = (
     "managed by lease",
     "lease/session creation",
     "shared lease",
+    "Lease state machine",
+    "lease identity directly",
 )
 
 


### PR DESCRIPTION
## Summary\n- clean the last obvious runtime/package lease comment phrasing in the touched files\n- extend the focused runtime comment-tail guard to cover those exact phrases\n- keep the slice text-only and behavior-preserving\n\n## Testing\n- uv run python -m pytest tests/Unit/core/test_runtime_comment_tail.py -q\n- python3 -m compileall backend/sandboxes/__init__.py sandbox/manager.py\n- git diff --check