### PR TITLE
fix: align hot thread history with display state

### DIFF
--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -80,6 +80,7 @@ def build_thread_history_payload_from_display_entries(
         if role == "user":
             if entry.get("showing", True) is False:
                 continue
+            visible_entries.append(entry)
             continue
         if role in {"assistant", "notice"}:
             visible_entries.append(entry)

--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -67,6 +67,89 @@ def _expand_history_message(msg: Any, truncate: int) -> list[dict[str, Any]]:
     return [{"role": "system", "text": _trunc(extract_text_content(msg.content), truncate)}]
 
 
+def build_thread_history_payload_from_display_entries(
+    *,
+    thread_id: str,
+    entries: list[dict[str, Any]],
+    limit: int = 20,
+    truncate: int = 300,
+) -> dict[str, Any]:
+    visible_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        role = entry.get("role")
+        if role == "user":
+            if entry.get("showing", True) is False:
+                continue
+            continue
+        if role in {"assistant", "notice"}:
+            visible_entries.append(entry)
+
+    selected_entries = visible_entries[-limit:] if limit > 0 else visible_entries
+    flat: list[dict[str, Any]] = []
+
+    for entry in selected_entries:
+        role = entry.get("role")
+        if role == "notice":
+            text = entry.get("content")
+            if isinstance(text, str) and text:
+                flat.append({"role": "notification", "text": _trunc(text, truncate)})
+            continue
+
+        if role == "user":
+            text = entry.get("content")
+            if isinstance(text, str) and text:
+                flat.append({"role": "human", "text": _trunc(text, truncate)})
+            continue
+
+        if role != "assistant":
+            continue
+
+        for segment in entry.get("segments", []):
+            segment_type = segment.get("type")
+            if segment_type == "notice":
+                text = segment.get("content")
+                if isinstance(text, str) and text:
+                    flat.append({"role": "notification", "text": _trunc(text, truncate)})
+                continue
+
+            if segment_type == "text":
+                text = segment.get("content")
+                if isinstance(text, str) and text:
+                    flat.append({"role": "assistant", "text": _trunc(text, truncate)})
+                continue
+
+            if segment_type != "tool":
+                continue
+
+            step = segment.get("step") or {}
+            tool_name = str(step.get("name") or "?")
+            flat.append(
+                {
+                    "role": "tool_call",
+                    "tool": tool_name,
+                    "args": _trunc(str(step.get("args", {})), truncate if truncate > 0 else 200),
+                }
+            )
+            result = step.get("result")
+            if isinstance(result, str) and result:
+                flat.append(
+                    {
+                        "role": "tool_result",
+                        "tool": tool_name,
+                        "text": _trunc(result, truncate),
+                    }
+                )
+
+    total = len(visible_entries)
+    messages = flat
+    return {
+        "thread_id": thread_id,
+        "total": total,
+        "showing": len(selected_entries),
+        "messages": messages,
+    }
+
+
 async def get_thread_history_payload(
     *,
     thread_id: str,

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -28,7 +28,11 @@ from backend.threads.convergence import delete_thread_in_db
 from backend.threads.events.buffer import ThreadEventBuffer
 from backend.threads.events.store import get_last_seq, get_latest_run_id, get_run_start_seq, read_events_after
 from backend.threads.file_channel import get_file_channel_binding
-from backend.threads.history import build_thread_history_transport, get_thread_history_payload
+from backend.threads.history import (
+    build_thread_history_payload_from_display_entries,
+    build_thread_history_transport,
+    get_thread_history_payload,
+)
 from backend.threads.interruption import repair_interrupted_tool_call_messages
 from backend.threads.launch_config import resolve_default_config
 from backend.threads.owner_reads import list_owner_thread_rows_for_auth_burst
@@ -1048,6 +1052,25 @@ async def get_thread_history(
         limit: Max messages to return, from the end (default 20)
         truncate: Truncate content to this many chars (default 300, 0 = no limit)
     """
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    display_builder = getattr(runtime_state, "display_builder", None)
+    agent_pool = getattr(app.state, "agent_pool", None)
+    sandbox_type = resolve_thread_sandbox(app, thread_id)
+    agent = agent_pool.get(f"{thread_id}:{sandbox_type}") if isinstance(agent_pool, dict) else None
+    runtime_state_value = getattr(getattr(agent, "runtime", None), "current_state", None)
+    if display_builder is not None and agent is not None and runtime_state_value is not None and runtime_state_value != AgentState.IDLE:
+        entries = display_builder.get_entries(thread_id)
+        if entries:
+            # @@@hot-history-same-truth - owner-facing detail and history should not
+            # diverge mid-run just because one reads display state and the other
+            # waits for LangGraph persistence to catch up.
+            _normalize_blocking_subagent_terminal_status(entries)
+            return build_thread_history_payload_from_display_entries(
+                thread_id=thread_id,
+                entries=entries,
+                limit=limit,
+                truncate=truncate,
+            )
 
     async def _load_live_messages(current_thread_id: str) -> list[Any] | None:
         agent_pool = getattr(app.state, "agent_pool", None)

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1061,9 +1061,9 @@ async def get_thread_history(
     if display_builder is not None and agent is not None and runtime_state_value is not None and runtime_state_value != AgentState.IDLE:
         entries = display_builder.get_entries(thread_id)
         if entries:
-            # @@@hot-history-same-truth - owner-facing detail and history should not
-            # diverge mid-run just because one reads display state and the other
-            # waits for LangGraph persistence to catch up.
+            # @@@hot-history-same-truth - this is hot owner-read truth, not the
+            # canonical durable ledger. Mid-run /history should match detail's
+            # display state instead of waiting for LangGraph persistence to catch up.
             _normalize_blocking_subagent_terminal_status(entries)
             return build_thread_history_payload_from_display_entries(
                 thread_id=thread_id,

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -1073,6 +1073,146 @@ async def test_get_thread_history_rebuilds_persisted_midrun_steer_message(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_get_thread_history_prefers_hot_display_builder_entries_for_active_thread():
+    display_builder = DisplayBuilder()
+    display_builder.set_entries(
+        "history-hot-display-thread",
+        [
+            {
+                "id": "turn-hot-1",
+                "role": "assistant",
+                "timestamp": 1,
+                "segments": [
+                    {
+                        "type": "notice",
+                        "content": "New message from owner in chat chat-1.",
+                        "notification_type": "chat",
+                    },
+                    {
+                        "type": "tool",
+                        "step": {
+                            "id": "tool-send-1",
+                            "name": "send_message",
+                            "args": {"chat_id": "chat-1", "content": "HOT_DISPLAY_REPLY"},
+                            "status": "done",
+                            "result": "Message sent to chat.",
+                        },
+                    },
+                    {
+                        "type": "text",
+                        "content": "Replied in chat with: HOT_DISPLAY_REPLY",
+                    },
+                ],
+            }
+        ],
+    )
+    fake_agent = SimpleNamespace(
+        agent=SimpleNamespace(aget_state=AsyncMock(return_value=SimpleNamespace(values={"messages": []}))),
+        runtime=SimpleNamespace(current_state=AgentState.ACTIVE),
+    )
+    fake_app = _app_with_display_builder(display_builder)
+    _put_local_agent_in_pool(fake_app, "history-hot-display-thread", fake_agent)
+
+    with patch("backend.web.routers.threads.resolve_thread_sandbox", return_value="local"):
+        history = await get_thread_history(
+            "history-hot-display-thread",
+            limit=20,
+            truncate=300,
+            user_id="u",
+            app=fake_app,
+        )
+
+    assert [item["role"] for item in history["messages"]] == [
+        "notification",
+        "tool_call",
+        "tool_result",
+        "assistant",
+    ]
+    assert history["messages"][0]["text"] == "New message from owner in chat chat-1."
+    assert history["messages"][1]["tool"] == "send_message"
+    assert history["messages"][2]["text"] == "Message sent to chat."
+    assert history["messages"][3]["text"] == "Replied in chat with: HOT_DISPLAY_REPLY"
+
+
+@pytest.mark.asyncio
+async def test_get_thread_history_hot_display_limit_keeps_whole_last_entry():
+    display_builder = DisplayBuilder()
+    display_builder.set_entries(
+        "history-hot-display-limit-thread",
+        [
+            {
+                "id": "turn-hot-old",
+                "role": "assistant",
+                "timestamp": 1,
+                "segments": [
+                    {
+                        "type": "notice",
+                        "content": "Old notice",
+                        "notification_type": "chat",
+                    },
+                    {
+                        "type": "text",
+                        "content": "Old reply",
+                    },
+                ],
+            },
+            {
+                "id": "turn-hot-new",
+                "role": "assistant",
+                "timestamp": 2,
+                "segments": [
+                    {
+                        "type": "notice",
+                        "content": "New notice",
+                        "notification_type": "chat",
+                    },
+                    {
+                        "type": "tool",
+                        "step": {
+                            "id": "tool-send-2",
+                            "name": "send_message",
+                            "args": {"chat_id": "chat-2", "content": "NEW_REPLY"},
+                            "status": "done",
+                            "result": "Message sent to chat.",
+                        },
+                    },
+                    {
+                        "type": "text",
+                        "content": "Replied in chat with: NEW_REPLY",
+                    },
+                ],
+            },
+        ],
+    )
+    fake_agent = SimpleNamespace(
+        agent=SimpleNamespace(aget_state=AsyncMock(return_value=SimpleNamespace(values={"messages": []}))),
+        runtime=SimpleNamespace(current_state=AgentState.ACTIVE),
+    )
+    fake_app = _app_with_display_builder(display_builder)
+    _put_local_agent_in_pool(fake_app, "history-hot-display-limit-thread", fake_agent)
+
+    with patch("backend.web.routers.threads.resolve_thread_sandbox", return_value="local"):
+        history = await get_thread_history(
+            "history-hot-display-limit-thread",
+            limit=1,
+            truncate=300,
+            user_id="u",
+            app=fake_app,
+        )
+
+    assert history["total"] == 2
+    assert history["showing"] == 1
+    assert [item["role"] for item in history["messages"]] == [
+        "notification",
+        "tool_call",
+        "tool_result",
+        "assistant",
+    ]
+    assert history["messages"][0]["text"] == "New notice"
+    assert history["messages"][3]["text"] == "Replied in chat with: NEW_REPLY"
+
+
+@pytest.mark.asyncio
 async def test_query_loop_adds_non_preemptive_steer_contract_before_terminal_reply(tmp_path):
     checkpointer = _MemoryCheckpointer()
     queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))


### PR DESCRIPTION
## Summary
- make hot `/api/threads/{id}/history` read `display_builder` entries for active runs instead of waiting on live/checkpoint state
- preserve cold-path limit semantics by slicing source entries before flattening history rows
- add integration coverage for active-run display-backed history and hot-path limit behavior

## Test Plan
- uv run pytest -q tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py tests/Integration/test_threads_router.py -k "history or messages or list_threads or resolve_main_thread"
- uv run ruff check backend/threads/history.py backend/web/routers/threads.py tests/Integration/test_query_loop_backend_contracts.py
- git diff --check
- real backend API probe against local worktree backend on :8010: owner chat send then compare `/api/threads/{id}` vs `/api/threads/{id}/history?truncate=0` visibility timing