### PR TITLE
fix: refresh chat summary timestamps on send

### DIFF
--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -93,6 +93,7 @@ class SupabaseMessagesRepo:
 
     def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
         """Insert a new message. Returns the created row."""
+        now = time.time()
         if expected_read_seq is None:
             seq_response = q.schema_rpc(
                 self._client,
@@ -116,7 +117,7 @@ class SupabaseMessagesRepo:
             next_seq = int(expected_read_seq) + 1
             update_res = (
                 self._chats_t()
-                .update({"next_message_seq": next_seq})
+                .update({"next_message_seq": next_seq, "updated_at": now})
                 .eq("id", row["chat_id"])
                 .eq("next_message_seq", int(expected_read_seq))
                 .execute()
@@ -126,6 +127,8 @@ class SupabaseMessagesRepo:
             seq = next_seq
         payload = {**row, "seq": int(seq)}
         res = self._t().insert(payload).execute()
+        if expected_read_seq is None:
+            self._chats_t().update({"updated_at": now}).eq("id", row["chat_id"]).execute()
         return res.data[0] if res.data else payload
 
     def get_by_id(self, message_id: str) -> dict[str, Any] | None:

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -382,7 +382,9 @@ def test_supabase_messages_repo_create_with_expected_read_seq_uses_chat_cas() ->
 
     assert client.rpc_calls == []
     chats = client.tables["chat.chats"]
-    assert chats.update_payload == {"next_message_seq": 7}
+    assert chats.update_payload is not None
+    assert chats.update_payload["next_message_seq"] == 7
+    assert isinstance(chats.update_payload["updated_at"], float)
     assert ("id", "chat-1") in chats.eq_calls
     assert ("next_message_seq", 6) in chats.eq_calls
     payload = client.tables["chat.messages"].insert_payload
@@ -408,6 +410,73 @@ def test_supabase_messages_repo_create_with_stale_expected_read_seq_fails_loudly
             },
             expected_read_seq=6,
         )
+
+
+def test_supabase_messages_repo_create_bumps_chat_updated_at_on_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient()
+    client.schema("chat").table("messages").rows = [
+        {
+            "id": "msg-1",
+            "chat_id": "chat-1",
+            "seq": 7,
+            "sender_user_id": "user-1",
+            "content": "hello",
+            "mentions_json": [],
+            "created_at": 123.0,
+        }
+    ]
+    monkeypatch.setattr("storage.providers.supabase.messaging_repo.time.time", lambda: 456.0)
+    repo = SupabaseMessagesRepo(client)
+
+    repo.create(
+        {
+            "id": "msg-1",
+            "chat_id": "chat-1",
+            "sender_user_id": "user-1",
+            "content": "hello",
+            "mentions_json": [],
+            "created_at": 123.0,
+        }
+    )
+
+    chats = client.tables["chat.chats"]
+    assert chats.update_payload == {"updated_at": 456.0}
+    assert ("id", "chat-1") in chats.eq_calls
+
+
+def test_supabase_messages_repo_create_with_expected_read_seq_bumps_chat_updated_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient()
+    client.schema("chat").table("chats").rows = [{"id": "chat-1", "next_message_seq": 6}]
+    client.schema("chat").table("messages").rows = [
+        {
+            "id": "msg-7",
+            "chat_id": "chat-1",
+            "seq": 7,
+            "sender_user_id": "user-1",
+            "content": "hello",
+            "mentions_json": [],
+            "created_at": 123.0,
+        }
+    ]
+    monkeypatch.setattr("storage.providers.supabase.messaging_repo.time.time", lambda: 789.0)
+    repo = SupabaseMessagesRepo(client)
+
+    repo.create(
+        {
+            "id": "msg-7",
+            "chat_id": "chat-1",
+            "sender_user_id": "user-1",
+            "content": "hello",
+            "mentions_json": [],
+            "created_at": 123.0,
+        },
+        expected_read_seq=6,
+    )
+
+    chats = client.tables["chat.chats"]
+    assert chats.update_payload == {"next_message_seq": 7, "updated_at": 789.0}
+    assert ("id", "chat-1") in chats.eq_calls
+    assert ("next_message_seq", 6) in chats.eq_calls
 
 
 def test_supabase_messages_repo_list_by_chat_uses_seq_ordering() -> None:


### PR DESCRIPTION
## Summary
- bump `chat.chats.updated_at` whenever a chat message is created
- cover both normal send and caught-up send paths in the Supabase messaging repo tests
- restore visit conversation/sidebar freshness so `/api/conversations` reorders after sends instead of staying frozen on stale chat creation timestamps

## Test Plan
- uv run pytest -q tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Integration/test_conversations_router.py tests/Integration/test_messaging_social_handle_contract.py -k "conversation or chat or updated_at or list_conversation_summaries_for_user"
- uv run ruff check storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
- git diff --check
- real backend API probe on :8010: send into an old direct chat and verify `/api/conversations` target moves from the tail to index 0 with fresh `updated_at`