### PR TITLE
refactor: remove monitor thread detail key fallbacks

### DIFF
--- a/backend/monitor/application/use_cases/threads.py
+++ b/backend/monitor/application/use_cases/threads.py
@@ -47,8 +47,8 @@ def _normalize_thread_owner(owner: dict[str, Any] | None) -> dict[str, Any] | No
     if owner is None:
         return None
     return {
-        "user_id": owner.get("user_id") or owner.get("agent_user_id"),
-        "display_name": owner.get("display_name") or owner.get("agent_name"),
+        "user_id": owner.get("user_id"),
+        "display_name": owner.get("display_name"),
         "email": owner.get("email"),
         "avatar_url": owner.get("avatar_url"),
     }
@@ -57,7 +57,7 @@ def _normalize_thread_owner(owner: dict[str, Any] | None) -> dict[str, Any] | No
 def _normalize_monitor_thread(thread: dict[str, Any], requested_thread_id: str) -> dict[str, Any]:
     return {
         **thread,
-        "thread_id": thread.get("thread_id") or thread.get("id") or requested_thread_id,
+        "thread_id": thread.get("thread_id") or requested_thread_id,
     }
 
 

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -1126,7 +1126,7 @@ async def test_get_monitor_thread_detail_normalizes_owner_shape_for_frontend(mon
     _use_monitor_repo(monkeypatch, FakeMonitorThreadRepo())
     _stub_thread_detail(
         monkeypatch,
-        owner={"agent_user_id": "agent-1", "agent_name": "Toad", "avatar_url": "/api/users/agent-1/avatar"},
+        owner={"user_id": "agent-1", "display_name": "Toad", "avatar_url": "/api/users/agent-1/avatar"},
     )
     app = SimpleNamespace(state=SimpleNamespace(thread_repo=FakeThreadRepo({"status": "active"}), user_repo=None))
 
@@ -1150,7 +1150,7 @@ async def test_get_monitor_thread_detail_normalizes_thread_shape_for_frontend(mo
     _stub_thread_detail(monkeypatch, owner=None)
     app = SimpleNamespace(
         state=SimpleNamespace(
-            thread_repo=FakeThreadRepo({"id": "thread-1", "title": "Investigate drift", "status": "active"}),
+            thread_repo=FakeThreadRepo({"thread_id": "thread-1", "title": "Investigate drift", "status": "active"}),
             user_repo=None,
         )
     )


### PR DESCRIPTION
## Summary
- remove legacy dual-key fallback reads from monitor thread detail normalization
- make owner payload normalization use only the current  /  contract
- keep thread payload pass-through honest while stopping  fallback to old keys

## Verification
- ....                                                                     [100%]
4 passed, 26 deselected in 0.11s
- All checks passed!
- 