### PR TITLE
refactor: invert sandboxes monitor runtime dependency

### DIFF
--- a/backend/sandboxes/resources/projection.py
+++ b/backend/sandboxes/resources/projection.py
@@ -6,8 +6,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 import backend.sandboxes.resources.provider_boundary as resource_provider_boundary
-from backend.monitor.infrastructure.read_models import resource_runtime_service
 from backend.sandboxes.paths import SANDBOXES_DIR
+from backend.sandboxes.resources import runtime_service as resource_runtime_service
 from backend.sandboxes.resources.common import CATALOG as _CATALOG
 from backend.sandboxes.resources.common import CatalogEntry as _CatalogEntry
 from backend.sandboxes.resources.common import aggregate_provider_telemetry as _aggregate_provider_telemetry

--- a/backend/sandboxes/resources/runtime_service.py
+++ b/backend/sandboxes/resources/runtime_service.py
@@ -1,4 +1,4 @@
-"""Monitor resource runtime read-source boundary."""
+"""Shared runtime read helpers for sandbox resource projections."""
 
 from __future__ import annotations
 

--- a/backend/sandboxes/resources/user_projection.py
+++ b/backend/sandboxes/resources/user_projection.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import backend.sandboxes.resources.provider_boundary as resource_provider_boundary
-from backend.monitor.infrastructure.read_models import resource_runtime_service
+from backend.sandboxes.resources import runtime_service as resource_runtime_service
 from storage.models import map_sandbox_state_to_display_status
 
 


### PR DESCRIPTION
## Summary
- move shared resource runtime read helpers out of backend/monitor and into backend/sandboxes/resources
- flip sandbox resource projections to import the shared runtime helper from the sandbox-owned side
- delete the old monitor-owned runtime helper module

## Verification
- uv run pytest -q tests/Integration/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py tests/Unit/monitor/test_monitor_resource_cache_boundary.py
- uv run ruff check backend/sandboxes/resources/projection.py backend/sandboxes/resources/user_projection.py backend/sandboxes/resources/runtime_service.py
- git diff --check
