### PR TITLE
refactor: borrow chat runtime through threads bundle

### DIFF
--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -1,4 +1,5 @@
 """Agent pool management service."""
+
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.pool import registry as _registry
 from backend.threads.pool.factory import create_agent_sync

--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -1,6 +1,4 @@
 """Agent pool management service."""
-
-from backend.chat.runtime_access import get_optional_messaging_service
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.pool import registry as _registry
 from backend.threads.pool.factory import create_agent_sync
@@ -15,11 +13,12 @@ async def get_or_create_agent(*args, **kwargs):
     _registry.get_file_channel_binding = get_file_channel_binding
     _registry.resolve_thread_sandbox = resolve_thread_sandbox
     if "messaging_service" not in kwargs and app is not None:
-        # @@@agent-pool-chat-borrow - registry owns thread-runtime lifecycle,
-        # but chat-owned messaging_service is still needed when chat_repos are
-        # constructed. Borrow it here so registry does not reach back through
-        # app state for chat truth on its own.
-        messaging_service = get_optional_messaging_service(app)
+        # @@@agent-pool-borrowed-runtime-bundle - thread runtime still needs a
+        # chat-owned messaging service for chat_repos construction, but the
+        # borrow now happens through threads_runtime_state rather than a
+        # cross-package chat.runtime_access import.
+        runtime_state = getattr(app.state, "threads_runtime_state", None)
+        messaging_service = getattr(runtime_state, "messaging_service", None)
         if messaging_service is not None:
             kwargs["messaging_service"] = messaging_service
     return await _registry.get_or_create_agent(*args, **kwargs)

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -15,12 +15,20 @@ class ThreadsRuntimeState:
     queue_manager: Any
     agent_runtime_gateway: Any
     activity_reader: Any
+    messaging_service: Any | None = None
+    typing_tracker: Any | None = None
     display_builder: Any | None = None
     event_loop: Any | None = None
     checkpoint_store: Any | None = None
 
 
-def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: Any) -> ThreadsRuntimeState:
+def attach_threads_runtime(
+    app: Any,
+    storage_container: Any,
+    *,
+    typing_tracker: Any,
+    messaging_service: Any,
+) -> ThreadsRuntimeState:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.agent_pool = {}
     app.state.thread_sandbox = {}
@@ -43,6 +51,8 @@ def attach_threads_runtime(app: Any, storage_container: Any, *, typing_tracker: 
         queue_manager=app.state.queue_manager,
         agent_runtime_gateway=runtime_state.gateway,
         activity_reader=runtime_state.activity_reader,
+        messaging_service=messaging_service,
+        typing_tracker=typing_tracker,
     )
     app.state.threads_runtime_state = state
     return state

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from backend.chat.runtime_access import get_optional_typing_tracker
 from backend.threads.events.buffer import RunEventBuffer, ThreadEventBuffer
 from backend.threads.events.store import append_event as _append_event
 from backend.threads.events.store import cleanup_old_runs
@@ -23,6 +22,11 @@ from storage.contracts import RunEventRepo
 logger = logging.getLogger(__name__)
 
 type SSEEvent = dict[str, str | int]
+
+
+def _get_threads_runtime_typing_tracker(app: Any) -> Any | None:
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    return getattr(runtime_state, "typing_tracker", None) if runtime_state is not None else None
 
 
 def _log_captured_exception(message: str, err: BaseException) -> None:
@@ -211,7 +215,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
         run_id=run_id,
         message_metadata=message_metadata,
         input_messages=input_messages,
-        typing_tracker=get_optional_typing_tracker(app),
+        typing_tracker=_get_threads_runtime_typing_tracker(app),
     )
 
 

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -76,7 +76,12 @@ async def lifespan(app: FastAPI):
     # owner-agent contact repo, but web bootstrap should borrow the chat-owned
     # contact_repo returned by chat bootstrap instead of reopening storage.
     attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=chat_runtime.contact_repo)
-    threads_runtime = attach_threads_runtime(app, storage_container, typing_tracker=chat_runtime.typing_tracker)
+    threads_runtime = attach_threads_runtime(
+        app,
+        storage_container,
+        typing_tracker=chat_runtime.typing_tracker,
+        messaging_service=chat_runtime.messaging_service,
+    )
     wire_chat_delivery(
         app,
         messaging_service=chat_runtime.messaging_service,

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -12,6 +12,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     gateway = object()
     activity_reader = object()
     typing_tracker = object()
+    messaging_service = object()
     seen: list[tuple[str, object]] = []
 
     storage_container = SimpleNamespace(queue_repo=lambda: queue_repo)
@@ -32,7 +33,12 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
         ),
     )
 
-    state = threads_bootstrap.attach_threads_runtime(app, storage_container, typing_tracker=typing_tracker)
+    state = threads_bootstrap.attach_threads_runtime(
+        app,
+        storage_container,
+        typing_tracker=typing_tracker,
+        messaging_service=messaging_service,
+    )
 
     assert app.state.queue_manager is queue_manager
     assert app.state.agent_pool == {}
@@ -46,6 +52,8 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.queue_manager is queue_manager
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
+    assert state.messaging_service is messaging_service
+    assert state.typing_tracker is typing_tracker
     assert state.display_builder is None
     assert state.event_loop is None
     assert state.checkpoint_store is None

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -80,18 +80,19 @@ def _patch_lifespan_runtime_contract(
 @pytest.mark.asyncio
 async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeypatch):
     returned_typing_tracker = object()
+    returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         contact_repo = object()
-        messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
         return SimpleNamespace(
             contact_repo=contact_repo,
             typing_tracker=returned_typing_tracker,
-            messaging_service=messaging_service,
+            messaging_service=returned_messaging_service,
         )
 
-    def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
+    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service):
         assert typing_tracker is returned_typing_tracker
+        assert messaging_service is returned_messaging_service
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=object())
 
@@ -137,9 +138,10 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert contact_repo is returned_contact_repo
         return object()
 
-    def _attach_threads_runtime(app, _storage_container, *, typing_tracker):
+    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service):
         call_log.append("threads")
         assert typing_tracker is returned_typing_tracker
+        assert messaging_service is returned_messaging_service
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=returned_activity_reader)
 

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -166,11 +166,9 @@ def _make_app() -> SimpleNamespace:
     return SimpleNamespace(
         state=SimpleNamespace(
             display_builder=display_builder,
-            threads_runtime_state=SimpleNamespace(display_builder=display_builder),
+            threads_runtime_state=SimpleNamespace(display_builder=display_builder, typing_tracker=None),
             thread_tasks={},
             thread_last_active={},
-            typing_tracker=None,
-            chat_runtime_state=SimpleNamespace(typing_tracker=None),
             queue_manager=SimpleNamespace(peek=lambda _thread_id: False),
         )
     )
@@ -303,7 +301,7 @@ async def test_streaming_run_agent_to_buffer_borrows_optional_typing_tracker(mon
     monkeypatch.setattr("backend.threads.streaming._run_execution.run_agent_to_buffer", _fake_run_agent_to_buffer)
 
     app = _make_app()
-    app.state.chat_runtime_state.typing_tracker = typing_tracker
+    app.state.threads_runtime_state.typing_tracker = typing_tracker
 
     result = await _run_agent_to_buffer(
         SimpleNamespace(),
@@ -334,6 +332,7 @@ async def test_streaming_run_agent_to_buffer_passes_none_when_optional_typing_tr
     app = SimpleNamespace(
         state=SimpleNamespace(
             display_builder=_FakeDisplayBuilder(),
+            threads_runtime_state=SimpleNamespace(typing_tracker=None),
             thread_tasks={},
             thread_last_active={},
             queue_manager=SimpleNamespace(peek=lambda _thread_id: False),

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -34,9 +34,7 @@ async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkey
         return SimpleNamespace()
 
     monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
-    monkeypatch.setattr(agent_pool, "get_optional_messaging_service", lambda app: messaging_service, raising=False)
-
-    app = SimpleNamespace(state=SimpleNamespace())
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(messaging_service=messaging_service)))
 
     await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-borrowed")
 
@@ -54,7 +52,7 @@ async def test_get_or_create_agent_skips_borrow_when_chat_bootstrap_missing(monk
         return SimpleNamespace()
 
     monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
-    app = SimpleNamespace(state=SimpleNamespace())
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=None))
 
     await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-no-chat")
 
@@ -142,8 +140,7 @@ async def test_registry_get_or_create_agent_requires_explicit_messaging_service_
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -179,8 +176,7 @@ async def test_registry_get_or_create_agent_does_not_read_app_state_messaging_se
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -396,8 +392,7 @@ async def test_get_or_create_agent_prefers_repo_backed_runtime_startup_even_with
             user_repo=SimpleNamespace(
                 get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1", owner_user_id="owner-1")
             ),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -456,8 +451,7 @@ async def test_get_or_create_agent_uses_thread_user_id_for_chat_identity(monkeyp
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -548,8 +542,7 @@ async def test_get_or_create_agent_uses_binding_local_staging_root_for_extra_all
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -627,8 +620,7 @@ async def test_get_or_create_agent_keys_registry_by_agent_user_id(monkeypatch: p
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -692,8 +684,7 @@ async def test_get_or_create_agent_uses_repo_backed_default_model_contract(
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=SimpleNamespace(
                 storage_container=SimpleNamespace(
                     user_settings_repo=lambda: _UserSettingsRepo(),
@@ -750,8 +741,7 @@ async def test_get_or_create_agent_passes_repo_backed_models_config_to_runtime(
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=SimpleNamespace(
                 storage_container=SimpleNamespace(
                     user_settings_repo=lambda: _UserSettingsRepo(),
@@ -804,8 +794,7 @@ async def test_get_or_create_agent_passes_repo_backed_compact_config_to_runtime(
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_AgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},
@@ -848,8 +837,7 @@ async def test_get_or_create_agent_does_not_use_local_preferences_when_repo_miss
             agent_pool={},
             thread_repo=_ThreadRepo(),
             user_repo=_UserRepo(),
-            messaging_service=SimpleNamespace(),
-            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
+            threads_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace()),
             runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
             thread_cwd={},
             thread_sandbox={},


### PR DESCRIPTION
## Summary
- carry chat-owned messaging_service and typing_tracker through threads_runtime_state
- remove threads-side imports of backend.chat.runtime_access
- make thread runtime startup borrow chat runtime through the threads bundle instead of cross-package accessors

## Verification
- uv run pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/core/test_agent_pool.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
- uv run ruff check backend/threads/bootstrap.py backend/web/core/lifespan.py backend/threads/activity_pool_service.py backend/threads/streaming.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/core/test_agent_pool.py tests/Unit/backend/web/services/test_streaming_eval_writer.py
- git diff --check
