### PR TITLE
refactor: tighten runtime wording drift

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -615,7 +615,7 @@ def _materialize_workspace_for_sandbox(
     workspace_id = f"workspace-{uuid.uuid4().hex}"
     now = time.time()
     # @@@workspace-binding-write - Phase 2 cuts thread create writes to a real
-    # workspace row; lower sandbox runtime id remains terminal/runtime internals, not workspace authority.
+    # workspace row; sandbox runtime id remains terminal/runtime internals, not workspace authority.
     workspace_repo.create(
         WorkspaceRow(
             id=workspace_id,
@@ -685,7 +685,7 @@ def _bind_existing_sandbox_for_thread(
     if bound_runtime is None:
         raise HTTPException(403, "Sandbox not authorized")
 
-    # @@@existing-sandbox-binding-boundary - lower sandbox runtime identity is only the
+    # @@@existing-sandbox-binding-boundary - sandbox runtime identity is only the
     # mechanism used by sandbox.manager to attach a terminal; router control
     # flow should stay sandbox/workspace-shaped after this point.
     return _ExistingSandboxThreadBinding(

--- a/config/loader.py
+++ b/config/loader.py
@@ -268,7 +268,7 @@ class AgentLoader:
             if skill_md.exists():
                 skills.append({"name": skill_dir.name, "path": str(skill_dir)})
             elif any(skill_dir.glob("*.md")):
-                # Fallback: any .md in skill dir
+                # Accept any markdown file in the skill dir.
                 skills.append({"name": skill_dir.name, "path": str(skill_dir)})
         return skills
 

--- a/eval/tracer.py
+++ b/eval/tracer.py
@@ -182,7 +182,7 @@ class TrajectoryTracer(BaseTracer):
                     resp_meta = getattr(message, "response_metadata", {}) or {}
                     model_name = resp_meta.get("model_name", "") or resp_meta.get("model", "") or ""
 
-            # Fallback: extract from llm_output (OpenAI format)
+            # OpenAI llm_output token usage path.
             if total_tokens == 0:
                 llm_output = run.outputs.get("llm_output") or {}
                 token_usage = llm_output.get("token_usage") or {}

--- a/frontend/monitor/README.md
+++ b/frontend/monitor/README.md
@@ -19,7 +19,7 @@ Local ports resolve in this order:
 - monitor backend proxy target:
   - `LEON_MONITOR_BACKEND_PORT`
   - `git config --worktree --get worktree.ports.monitor-backend`
-  - fallback to the resolved main backend port
+  - otherwise use the resolved main backend port
 - monitor dev server:
   - `LEON_MONITOR_PORT`
   - `git config --worktree --get worktree.ports.monitor-frontend`

--- a/messaging/actor_ownership.py
+++ b/messaging/actor_ownership.py
@@ -11,6 +11,6 @@ def is_owned_by_viewer(viewer_user_id: str, candidate_user: Any | None) -> bool:
     )
 
 
-def access_scope_targets(actor_user: Any | None, fallback_actor_id: str) -> list[str]:
+def access_scope_targets(actor_user: Any | None, actor_user_id: str) -> list[str]:
     owner_user_id = getattr(actor_user, "owner_user_id", None) if actor_user is not None else None
-    return [fallback_actor_id, str(owner_user_id)] if owner_user_id else [fallback_actor_id]
+    return [actor_user_id, str(owner_user_id)] if owner_user_id else [actor_user_id]

--- a/messaging/social_access.py
+++ b/messaging/social_access.py
@@ -55,7 +55,7 @@ def can_group_chat_with_participant(
     contact_repo: Any,
     relationship_service: Any,
 ) -> bool:
-    targets = access_scope_targets(participant_user, fallback_actor_id=participant_user_id)
+    targets = access_scope_targets(participant_user, actor_user_id=participant_user_id)
     if any(has_active_contact(contact_repo, viewer_user_id, target_id) for target_id in targets):
         return True
     return any(relationship_service.get_state(viewer_user_id, target_id) in ACTIVE_CHAT_RELATIONSHIP_STATES for target_id in targets)

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -1,6 +1,6 @@
 """Sandbox session manager.
 
-Orchestrates: Thread → ChatSession → Runtime with lower sandbox bindings.
+Orchestrates: Thread → ChatSession → Runtime with sandbox runtime bindings.
 """
 
 import logging
@@ -226,7 +226,7 @@ def bind_thread_to_existing_thread_sandbox_runtime(
         return None
     # @@@subagent-runtime-reuse
     # Child threads need their own terminal/session state while reusing the
-    # parent's lower sandbox binding instead of silently provisioning a new one.
+    # parent's sandbox runtime binding instead of silently provisioning a new one.
     return bind_thread_to_existing_sandbox_runtime(
         thread_id,
         str(source_terminal["sandbox_runtime_id"]),

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -16,7 +16,7 @@ NotificationType = Literal["steer", "command", "agent", "chat"]
 
 
 class SandboxRuntimeRepo(Protocol):
-    """Lower sandbox runtime persistence. Returns raw dicts for domain object construction."""
+    """Sandbox runtime persistence. Returns raw dicts for domain object construction."""
 
     def close(self) -> None: ...
     def get(self, sandbox_runtime_id: str) -> dict[str, Any] | None: ...

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -15,7 +15,7 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolv
 
 
 class SQLiteSandboxRuntimeRepo:
-    """Lower sandbox runtime persistence backed by SQLite.
+    """Sandbox runtime persistence backed by SQLite.
 
     Thread-safe: all connection access is serialized via a lock.
     Returns raw dicts — domain object construction is the consumer's job.

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -117,7 +117,7 @@ def _patched_config(row: dict[str, Any], updates: dict[str, Any]) -> dict[str, A
 
 
 class SupabaseSandboxRuntimeRepo:
-    """Container-backed SandboxRuntimeRepo for lower sandbox runtime contracts."""
+    """Container-backed SandboxRuntimeRepo for sandbox runtime contracts."""
 
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)

--- a/tests/Unit/messaging/test_actor_ownership.py
+++ b/tests/Unit/messaging/test_actor_ownership.py
@@ -30,10 +30,10 @@ def test_is_owned_by_viewer_rejects_missing_candidate() -> None:
 def test_access_scope_targets_expands_owned_actor_scope() -> None:
     user = SimpleNamespace(id="agent-user-1", owner_user_id="viewer-1")
 
-    assert access_scope_targets(user, fallback_actor_id="agent-user-1") == ["agent-user-1", "viewer-1"]
+    assert access_scope_targets(user, actor_user_id="agent-user-1") == ["agent-user-1", "viewer-1"]
 
 
-def test_access_scope_targets_falls_back_to_raw_actor_id() -> None:
+def test_access_scope_targets_uses_actor_id_without_owner_scope() -> None:
     user = SimpleNamespace(id="human-user-2", owner_user_id=None)
 
-    assert access_scope_targets(user, fallback_actor_id="human-user-2") == ["human-user-2"]
+    assert access_scope_targets(user, actor_user_id="human-user-2") == ["human-user-2"]


### PR DESCRIPTION
## Summary
- remove misleading `lower sandbox` wording from runtime/storage/thread-binding surfaces
- rename `fallback_actor_id` to `actor_user_id` so owner-scope expansion matches the actual behavior
- tighten a few doc/comment strings that still described current behavior as fallback-driven

## Verification
- uv run pytest tests/Unit/messaging/test_actor_ownership.py tests/Unit/backend/web/routers/test_threads_router_naming.py tests/Unit/sandbox/test_sandbox_runtime_lower_identity_wording.py tests/Unit/storage/test_sqlite_sandbox_runtime_repo_naming.py tests/Unit/storage/test_supabase_sandbox_runtime_repo_naming.py
- uv run ruff check storage/contracts.py sandbox/manager.py storage/providers/sqlite/sandbox_runtime_repo.py storage/providers/supabase/sandbox_runtime_repo.py backend/web/routers/threads.py messaging/actor_ownership.py messaging/social_access.py config/loader.py eval/tracer.py tests/Unit/messaging/test_actor_ownership.py
- git diff --check
