### PR TITLE
refactor: simplify chat contact repo borrowing

### DIFF
--- a/backend/web/routers/contacts.py
+++ b/backend/web/routers/contacts.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.chat.runtime_access import get_contact_repo
+from backend.chat.api.http.dependencies import get_contact_repo
 from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow
 

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -5,8 +5,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.chat.api.http.dependencies import get_thread_repo
-from backend.chat.runtime_access import get_contact_repo
+from backend.chat.api.http.dependencies import get_contact_repo, get_thread_repo
 from backend.identity import profile as profile_owner
 from backend.library import service as library_service
 from backend.threads import agent_user_service
@@ -55,6 +54,15 @@ def _agent_config_repo(request: Request) -> Any | None:
     storage_container = getattr(runtime_storage, "storage_container", None)
     repo_factory = getattr(storage_container, "agent_config_repo", None)
     return repo_factory() if callable(repo_factory) else None
+
+
+def _borrow_contact_repo_or_503(request: Request) -> Any:
+    try:
+        return get_contact_repo(request.app)
+    except HTTPException as exc:
+        if exc.status_code == 503:
+            raise HTTPException(503, "chat bootstrap not attached: contact_repo") from exc
+        raise
 
 
 def _recipe_repo(request: Request) -> Any:
@@ -107,13 +115,10 @@ async def create_agent(
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     agent_config_repo = _agent_config_repo(request)
-    try:
-        # @@@panel-chat-consumer - panel owns the agent CRUD route, but contact
-        # edge cleanup is chat-owned truth. Borrow the repo explicitly so panel
-        # does not reach through request.app for chat runtime state.
-        contact_repo = get_contact_repo(request.app)
-    except RuntimeError as exc:
-        raise HTTPException(503, str(exc)) from exc
+    # @@@panel-chat-consumer - panel owns the agent CRUD route, but contact
+    # edge cleanup is chat-owned truth. Borrow the repo explicitly so panel
+    # does not reach through request.app for chat runtime state.
+    contact_repo = _borrow_contact_repo_or_503(request)
     return await asyncio.to_thread(
         agent_user_service.create_agent_user,
         req.name,
@@ -210,10 +215,7 @@ async def delete_agent(
         raise HTTPException(503, "Thread repo unavailable")
     await asyncio.to_thread(_ensure_agent_has_no_threads_or_409, agent_id, thread_repo)
     agent_config_repo = _agent_config_repo(request)
-    try:
-        contact_repo = get_contact_repo(request.app)
-    except RuntimeError as exc:
-        raise HTTPException(503, str(exc)) from exc
+    contact_repo = _borrow_contact_repo_or_503(request)
     ok = await asyncio.to_thread(
         agent_user_service.delete_agent_user,
         agent_id,

--- a/tests/Integration/test_contacts_schema_contract.py
+++ b/tests/Integration/test_contacts_schema_contract.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from backend.web.routers import contacts as contacts_router
 from storage.contracts import ContactEdgeRow
@@ -126,3 +127,24 @@ async def test_delete_contact_fails_loud_when_contact_repo_missing() -> None:
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"
+
+
+def test_contacts_http_surface_does_not_expose_query_app_param() -> None:
+    app = FastAPI()
+    app.include_router(contacts_router.router)
+    app.dependency_overrides[contacts_router.get_current_user_id] = lambda: "user-a"
+    app.state.chat_runtime_state = _FakeContactRepo()
+
+    with TestClient(app) as client:
+        openapi = client.get("/openapi.json").json()
+
+    assert openapi["paths"]["/api/contacts"]["get"].get("parameters", []) == []
+    assert openapi["paths"]["/api/contacts"]["post"].get("parameters", []) == []
+    assert openapi["paths"]["/api/contacts/{target_id}"]["delete"].get("parameters", []) == [
+        {
+            "name": "target_id",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string", "title": "Target Id"},
+        }
+    ]


### PR DESCRIPTION
## Summary
- route contacts.py onto chat HTTP dependency helpers instead of the raw runtime accessor
- keep panel.py on the same helper surface while preserving the existing fail-loud contact_repo detail
- add an HTTP/openapi regression test so /api/contacts no longer leaks a fake query `app` param

## Verification
- `.venv/bin/python -m pytest -q tests/Integration/test_contacts_schema_contract.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_users_router.py -k "contact or chat_candidates or panel or http_surface_does_not_expose_query_app_param"`
- `uv run ruff check backend/web/routers/contacts.py backend/web/routers/panel.py tests/Integration/test_contacts_schema_contract.py tests/Integration/test_panel_auth_shell_coherence.py tests/Integration/test_users_router.py`