### PR TITLE
refactor: delete unused thread workbench summary hook

### DIFF
--- a/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
-from backend.threads.convergence import converge_owner_thread_runtime, summarize_owner_thread_runtime
+from backend.threads.convergence import converge_owner_thread_runtime
 from backend.threads.projection import canonical_owner_threads
 from core.runtime.middleware.monitor import AgentState
 
@@ -16,7 +16,6 @@ from core.runtime.middleware.monitor import AgentState
 @dataclass(frozen=True)
 class OwnerThreadWorkbenchReader:
     list_owner_thread_rows: Callable[[str], list[dict[str, Any]]]
-    summarize_runtime_states: Callable[[list[dict[str, Any]]], dict[str, str]]
     converge_runtime_state: Callable[[str], str]
     is_runtime_active: Callable[[str, str], bool]
     last_active_at: Callable[[str], str | None]
@@ -27,7 +26,6 @@ class OwnerThreadWorkbenchReader:
 def build_owner_thread_workbench_reader(app: Any) -> OwnerThreadWorkbenchReader:
     return OwnerThreadWorkbenchReader(
         list_owner_thread_rows=lambda user_id: list_owner_thread_rows(app, user_id),
-        summarize_runtime_states=lambda raw: summarize_runtime_states(app, raw),
         converge_runtime_state=lambda thread_id: converge_runtime_state(app, thread_id),
         is_runtime_active=lambda thread_id, sandbox_type: is_runtime_active(app, thread_id, sandbox_type),
         last_active_at=lambda thread_id: last_active_at(app, thread_id),
@@ -38,10 +36,6 @@ def build_owner_thread_workbench_reader(app: Any) -> OwnerThreadWorkbenchReader:
 
 def list_owner_thread_rows(app: Any, user_id: str) -> list[dict[str, Any]]:
     return app.state.thread_repo.list_by_owner_user_id(user_id)
-
-
-def summarize_runtime_states(app: Any, raw: list[dict[str, Any]]) -> dict[str, str]:
-    return summarize_owner_thread_runtime(app, [str(thread.get("id") or "") for thread in raw if thread.get("id")])
 
 
 def converge_runtime_state(app: Any, thread_id: str) -> str:

--- a/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
@@ -25,28 +25,18 @@ class OwnerThreadWorkbenchReader:
 
 def build_owner_thread_workbench_reader(app: Any) -> OwnerThreadWorkbenchReader:
     return OwnerThreadWorkbenchReader(
-        list_owner_thread_rows=lambda user_id: list_owner_thread_rows(app, user_id),
-        converge_runtime_state=lambda thread_id: converge_runtime_state(app, thread_id),
-        is_runtime_active=lambda thread_id, sandbox_type: is_runtime_active(app, thread_id, sandbox_type),
-        last_active_at=lambda thread_id: last_active_at(app, thread_id),
+        list_owner_thread_rows=lambda user_id: app.state.thread_repo.list_by_owner_user_id(user_id),
+        converge_runtime_state=lambda thread_id: converge_owner_thread_runtime(app, thread_id),
+        is_runtime_active=lambda thread_id, sandbox_type: bool(
+            (agent := app.state.agent_pool.get(f"{thread_id}:{sandbox_type}"))
+            and hasattr(agent, "runtime")
+            and agent.runtime.current_state == AgentState.ACTIVE
+        ),
+        last_active_at=lambda thread_id: (
+            datetime.fromtimestamp(last_active, tz=UTC).isoformat()
+            if (last_active := app.state.thread_last_active.get(thread_id))
+            else None
+        ),
         canonical_owner_threads=canonical_owner_threads,
         avatar_url=avatar_url,
     )
-
-
-def list_owner_thread_rows(app: Any, user_id: str) -> list[dict[str, Any]]:
-    return app.state.thread_repo.list_by_owner_user_id(user_id)
-
-
-def converge_runtime_state(app: Any, thread_id: str) -> str:
-    return converge_owner_thread_runtime(app, thread_id)
-
-
-def is_runtime_active(app: Any, thread_id: str, sandbox_type: str) -> bool:
-    agent = app.state.agent_pool.get(f"{thread_id}:{sandbox_type}")
-    return bool(agent and hasattr(agent, "runtime") and agent.runtime.current_state == AgentState.ACTIVE)
-
-
-def last_active_at(app: Any, thread_id: str) -> str | None:
-    last_active = app.state.thread_last_active.get(thread_id)
-    return datetime.fromtimestamp(last_active, tz=UTC).isoformat() if last_active else None

--- a/tests/Unit/monitor/test_thread_workbench_projection.py
+++ b/tests/Unit/monitor/test_thread_workbench_projection.py
@@ -11,7 +11,6 @@ def _reader(
 ):
     return SimpleNamespace(
         list_owner_thread_rows=lambda _user_id: rows,
-        summarize_runtime_states=lambda _raw: (_ for _ in ()).throw(AssertionError("should not eagerly summarize all runtime states")),
         converge_runtime_state=lambda thread_id: converge_calls.append(thread_id) or runtime_states[thread_id],
         is_runtime_active=lambda _thread_id, _sandbox_type: False,
         last_active_at=lambda _thread_id: None,


### PR DESCRIPTION
## Summary
- remove the unused `summarize_runtime_states` reader field from the owner thread workbench read boundary
- delete the dead helper wiring that built that field but never fed current workbench behavior
- tighten the projection test fixture to match the slimmer reader contract

## Verification
- uv run pytest tests/Unit/monitor/test_thread_workbench_projection.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py -q
- uv run ruff check backend/monitor/infrastructure/read_models/thread_workbench_read_service.py tests/Unit/monitor/test_thread_workbench_projection.py
- git diff --check
