### PR TITLE
feat: add stage1 cli auth register commands

### DIFF
--- a/cli/agent/client.py
+++ b/cli/agent/client.py
@@ -89,6 +89,15 @@ class AgentCliClient:
     def login(self, identifier: str, password: str) -> dict[str, Any]:
         return self.auth.login(identifier, password)
 
+    def send_otp(self, email: str, password: str, invite_code: str) -> dict[str, Any]:
+        return self.auth.send_otp(email, password, invite_code)
+
+    def verify_otp(self, email: str, token: str) -> dict[str, Any]:
+        return self.auth.verify_otp(email, token)
+
+    def complete_register(self, temp_token: str, invite_code: str) -> dict[str, Any]:
+        return self.auth.complete_register(temp_token, invite_code)
+
     def list_agents(self) -> dict[str, Any]:
         return self.panel.list_agents()
 

--- a/cli/agent/commands.py
+++ b/cli/agent/commands.py
@@ -69,6 +69,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     auth = sub.add_parser("auth", parents=[shared])
     auth_sub = auth.add_subparsers(dest="auth_command", required=True)
+    auth_send_otp = auth_sub.add_parser("send-otp", parents=[shared])
+    auth_send_otp.add_argument("email")
+    auth_send_otp.add_argument("invite_code")
+    auth_send_otp.add_argument("--password-stdin", action="store_true")
+    auth_verify_otp = auth_sub.add_parser("verify-otp", parents=[shared])
+    auth_verify_otp.add_argument("email")
+    auth_verify_otp.add_argument("token")
+    auth_complete_register = auth_sub.add_parser("complete-register", parents=[shared])
+    auth_complete_register.add_argument("temp_token")
+    auth_complete_register.add_argument("invite_code")
     auth_login = auth_sub.add_parser("login", parents=[shared])
     auth_login.add_argument("identifier")
     auth_login.add_argument("--password-stdin", action="store_true")
@@ -176,6 +186,12 @@ def run_cli(
         )
     elif args.command == "profile" and args.profile_command == "list":
         payload = [{"name": name, **profile} for name, profile in sorted(load_profiles().items())]
+    elif args.command == "auth" and args.auth_command == "send-otp":
+        payload = client.send_otp(args.email, _resolve_login_password(args, in_stream), args.invite_code)
+    elif args.command == "auth" and args.auth_command == "verify-otp":
+        payload = client.verify_otp(args.email, args.token)
+    elif args.command == "auth" and args.auth_command == "complete-register":
+        payload = client.complete_register(args.temp_token, args.invite_code)
     elif args.command == "auth" and args.auth_command == "login":
         payload = client.login(args.identifier, _resolve_login_password(args, in_stream))
     elif args.command == "agents" and args.agents_command == "list":

--- a/cli/agent/http.py
+++ b/cli/agent/http.py
@@ -159,6 +159,30 @@ class AuthHttpClient:
             response.raise_for_status()
             return response.json()
 
+    def send_otp(self, email: str, password: str, invite_code: str) -> dict[str, Any]:
+        with self._client() as client:
+            response = client.post(
+                "/api/auth/send-otp",
+                json={"email": email, "password": password, "invite_code": invite_code},
+            )
+            response.raise_for_status()
+            return response.json()
+
+    def verify_otp(self, email: str, token: str) -> dict[str, Any]:
+        with self._client() as client:
+            response = client.post("/api/auth/verify-otp", json={"email": email, "token": token})
+            response.raise_for_status()
+            return response.json()
+
+    def complete_register(self, temp_token: str, invite_code: str) -> dict[str, Any]:
+        with self._client() as client:
+            response = client.post(
+                "/api/auth/complete-register",
+                json={"temp_token": temp_token, "invite_code": invite_code},
+            )
+            response.raise_for_status()
+            return response.json()
+
 
 class PanelHttpClient:
     def __init__(self, *, base_url: str, auth_token: str | None, timeout: float = 10.0) -> None:

--- a/tests/Unit/cli/test_agent_cli.py
+++ b/tests/Unit/cli/test_agent_cli.py
@@ -433,6 +433,67 @@ def test_agent_cli_auth_login_can_read_password_from_stdin() -> None:
     assert json.loads(out.getvalue()) == {"token": "tok-login"}
 
 
+def test_agent_cli_auth_send_otp_reads_password_from_stdin() -> None:
+    from cli.agent import commands
+
+    captured: dict[str, str] = {}
+    out = StringIO()
+
+    def _send_otp(email: str, password: str, invite_code: str) -> dict[str, bool]:
+        captured["email"] = email
+        captured["password"] = password
+        captured["invite_code"] = invite_code
+        return {"ok": True}
+
+    exit_code = commands.run_cli(
+        ["auth", "send-otp", "fresh@example.com", "INVITE-1", "--password-stdin", "--app-base-url", "http://backend"],
+        messaging_client=SimpleNamespace(),
+        identity_client=SimpleNamespace(create_external_user=lambda **_: None, list_users=lambda **_: []),
+        runtime_read_client=SimpleNamespace(),
+        auth_client=SimpleNamespace(send_otp=_send_otp),
+        stdin=StringIO("pw-signup\n"),
+        stdout=out,
+    )
+
+    assert exit_code == 0
+    assert captured == {"email": "fresh@example.com", "password": "pw-signup", "invite_code": "INVITE-1"}
+    assert json.loads(out.getvalue()) == {"ok": True}
+
+
+def test_agent_cli_auth_verify_otp_calls_auth_client() -> None:
+    from cli.agent import commands
+
+    out = StringIO()
+    exit_code = commands.run_cli(
+        ["auth", "verify-otp", "fresh@example.com", "123456", "--app-base-url", "http://backend"],
+        messaging_client=SimpleNamespace(),
+        identity_client=SimpleNamespace(create_external_user=lambda **_: None, list_users=lambda **_: []),
+        runtime_read_client=SimpleNamespace(),
+        auth_client=SimpleNamespace(verify_otp=lambda email, token: {"temp_token": f"{email}:{token}"}),
+        stdout=out,
+    )
+
+    assert exit_code == 0
+    assert json.loads(out.getvalue()) == {"temp_token": "fresh@example.com:123456"}
+
+
+def test_agent_cli_auth_complete_register_calls_auth_client() -> None:
+    from cli.agent import commands
+
+    out = StringIO()
+    exit_code = commands.run_cli(
+        ["auth", "complete-register", "temp-token-1", "INVITE-1", "--app-base-url", "http://backend"],
+        messaging_client=SimpleNamespace(),
+        identity_client=SimpleNamespace(create_external_user=lambda **_: None, list_users=lambda **_: []),
+        runtime_read_client=SimpleNamespace(),
+        auth_client=SimpleNamespace(complete_register=lambda temp_token, invite_code: {"token": f"{temp_token}:{invite_code}"}),
+        stdout=out,
+    )
+
+    assert exit_code == 0
+    assert json.loads(out.getvalue()) == {"token": "temp-token-1:INVITE-1"}
+
+
 def test_agent_cli_agents_list_uses_panel_client_without_agent_identity() -> None:
     from cli.agent import commands
 

--- a/tests/Unit/cli/test_agent_http.py
+++ b/tests/Unit/cli/test_agent_http.py
@@ -179,3 +179,47 @@ def test_panel_http_client_uses_bearer_token(monkeypatch):
     assert payload == {"items": [{"id": "agent-1"}]}
     assert captured["path"] == "/api/panel/agents"
     assert captured["headers"] == {"Authorization": "Bearer tok-1"}
+
+
+def test_auth_http_client_supports_registration_flow(monkeypatch):
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _Client:
+        def __init__(self, *, base_url: str, timeout: float, trust_env: bool) -> None:
+            assert base_url == "http://backend"
+            assert trust_env is False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def post(self, path: str, *, json: dict[str, object]) -> _Response:
+            captured.append((path, json))
+            payload = {"ok": True} if path.endswith("/send-otp") else {"token": "tok-1"}
+            if path.endswith("/verify-otp"):
+                payload = {"temp_token": "temp-1"}
+            return _Response(payload)
+
+    monkeypatch.setattr(http.httpx, "Client", _Client)
+    client = http.AuthHttpClient(base_url="http://backend")
+
+    assert client.send_otp("fresh@example.com", "pw-1", "INVITE-1") == {"ok": True}
+    assert client.verify_otp("fresh@example.com", "123456") == {"temp_token": "temp-1"}
+    assert client.complete_register("temp-1", "INVITE-1") == {"token": "tok-1"}
+    assert captured == [
+        ("/api/auth/send-otp", {"email": "fresh@example.com", "password": "pw-1", "invite_code": "INVITE-1"}),
+        ("/api/auth/verify-otp", {"email": "fresh@example.com", "token": "123456"}),
+        ("/api/auth/complete-register", {"temp_token": "temp-1", "invite_code": "INVITE-1"}),
+    ]


### PR DESCRIPTION
## Summary
- add `auth send-otp`, `auth verify-otp`, and `auth complete-register` to the Stage-1 CLI
- keep registration passwords off argv by reusing prompt/`--password-stdin`
- extend the auth HTTP/client layer so the CLI can drive the real OTP registration flow

## Verification
- `.venv/bin/python -m pytest -q tests/Unit/cli/test_agent_cli.py tests/Unit/cli/test_agent_http.py -k "auth_"`
- `uv run ruff check cli/agent/commands.py cli/agent/client.py cli/agent/http.py tests/Unit/cli/test_agent_cli.py tests/Unit/cli/test_agent_http.py`
- backend/API YATU on `:8017`: `send-otp -> verify-otp -> complete-register -> login` via `mycel-agent`, using a freshly generated invite code and admin-only OTP retrieval for the test harness