### PR TITLE
refactor: drop monitor thread base loader shell

### DIFF
--- a/backend/monitor/infrastructure/read_models/thread_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_read_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from backend.threads.projection import canonical_owner_threads, thread_owners
@@ -49,7 +48,3 @@ def load_monitor_thread_base(app: Any, thread_id: str) -> dict[str, Any]:
         "thread": thread,
         "owner": owners.get(thread_id),
     }
-
-
-def build_monitor_thread_base_loader(app: Any) -> Callable[[str], dict[str, Any]]:
-    return lambda thread_id: load_monitor_thread_base(app, thread_id)

--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -48,27 +48,22 @@ def build_monitor_trace_reader(app: Any) -> MonitorTraceReader:
     )
 
     async def _load_thread_history_payload(thread_id: str) -> dict[str, Any]:
-        return await load_thread_history_payload(thread_id, history_transport=history_transport)
+        set_current_thread_id(thread_id)
+        return await get_thread_history_payload(
+            thread_id=thread_id,
+            history_transport=history_transport,
+            limit=200,
+            truncate=0,
+        )
+
+    def _load_latest_run_events(thread_id: str) -> tuple[str | None, list[dict[str, Any]]]:
+        transport = build_run_event_read_transport()
+        run_id = transport.latest_run_id(thread_id)
+        if run_id is None:
+            return None, []
+        return run_id, transport.list_events(thread_id, run_id, after=0, limit=1000)
 
     return MonitorTraceReader(
         load_thread_history_payload=_load_thread_history_payload,
-        load_latest_run_events=load_latest_run_events,
+        load_latest_run_events=_load_latest_run_events,
     )
-
-
-async def load_thread_history_payload(thread_id: str, *, history_transport) -> dict[str, Any]:
-    set_current_thread_id(thread_id)
-    return await get_thread_history_payload(
-        thread_id=thread_id,
-        history_transport=history_transport,
-        limit=200,
-        truncate=0,
-    )
-
-
-def load_latest_run_events(thread_id: str) -> tuple[str | None, list[dict[str, Any]]]:
-    transport = build_run_event_read_transport()
-    run_id = transport.latest_run_id(thread_id)
-    if run_id is None:
-        return None, []
-    return run_id, transport.list_events(thread_id, run_id, after=0, limit=1000)

--- a/backend/web/routers/monitor_threads.py
+++ b/backend/web/routers/monitor_threads.py
@@ -29,9 +29,7 @@ async def thread_detail_snapshot(request: Request, thread_id: str):
     try:
         return await monitor_thread_service.get_monitor_thread_detail(
             thread_id,
-            load_thread_base=lambda target_thread_id: monitor_thread_read_service.load_monitor_thread_base(
-                request.app, target_thread_id
-            ),
+            load_thread_base=lambda target_thread_id: monitor_thread_read_service.load_monitor_thread_base(request.app, target_thread_id),
             trace_reader=monitor_trace_read_service.build_monitor_trace_reader(request.app),
         )
     except KeyError as exc:

--- a/backend/web/routers/monitor_threads.py
+++ b/backend/web/routers/monitor_threads.py
@@ -29,7 +29,9 @@ async def thread_detail_snapshot(request: Request, thread_id: str):
     try:
         return await monitor_thread_service.get_monitor_thread_detail(
             thread_id,
-            load_thread_base=monitor_thread_read_service.build_monitor_thread_base_loader(request.app),
+            load_thread_base=lambda target_thread_id: monitor_thread_read_service.load_monitor_thread_base(
+                request.app, target_thread_id
+            ),
             trace_reader=monitor_trace_read_service.build_monitor_trace_reader(request.app),
         )
     except KeyError as exc:

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -993,7 +993,7 @@ async def test_get_monitor_thread_detail_exposes_trajectory_state(monkeypatch):
 
     payload = await monitor_thread_service.get_monitor_thread_detail(
         "thread-1",
-        load_thread_base=monitor_thread_read_service.build_monitor_thread_base_loader(app),
+        load_thread_base=lambda thread_id: monitor_thread_read_service.load_monitor_thread_base(app, thread_id),
         trace_reader=monitor_trace_read_service.build_monitor_trace_reader(app),
     )
 
@@ -1046,7 +1046,7 @@ async def test_get_monitor_thread_detail_derives_summary_from_runtime_row_when_r
 
     payload = await monitor_thread_service.get_monitor_thread_detail(
         "thread-1",
-        load_thread_base=monitor_thread_read_service.build_monitor_thread_base_loader(app),
+        load_thread_base=lambda thread_id: monitor_thread_read_service.load_monitor_thread_base(app, thread_id),
         trace_reader=monitor_trace_read_service.build_monitor_trace_reader(app),
     )
 
@@ -1132,7 +1132,7 @@ async def test_get_monitor_thread_detail_normalizes_owner_shape_for_frontend(mon
 
     payload = await monitor_thread_service.get_monitor_thread_detail(
         "thread-1",
-        load_thread_base=monitor_thread_read_service.build_monitor_thread_base_loader(app),
+        load_thread_base=lambda thread_id: monitor_thread_read_service.load_monitor_thread_base(app, thread_id),
         trace_reader=monitor_trace_read_service.build_monitor_trace_reader(app),
     )
 
@@ -1157,7 +1157,7 @@ async def test_get_monitor_thread_detail_normalizes_thread_shape_for_frontend(mo
 
     payload = await monitor_thread_service.get_monitor_thread_detail(
         "thread-1",
-        load_thread_base=monitor_thread_read_service.build_monitor_thread_base_loader(app),
+        load_thread_base=lambda thread_id: monitor_thread_read_service.load_monitor_thread_base(app, thread_id),
         trace_reader=monitor_trace_read_service.build_monitor_trace_reader(app),
     )
 


### PR DESCRIPTION
## Summary
- delete the dead `build_monitor_thread_base_loader(...)` shell from the monitor thread read boundary
- pass the `load_monitor_thread_base(...)` lambda directly at the remaining call sites
- keep the change monitor-local and behavior-preserving

## Verification
- uv run pytest tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Unit/monitor/test_thread_workbench_projection.py -q
- uv run ruff check backend/monitor/infrastructure/read_models/thread_read_service.py backend/web/routers/monitor_threads.py tests/Unit/monitor/test_monitor_detail_contracts.py
- git diff --check
