### PR TITLE
fix: keep cli complete-register token off argv

### DIFF
--- a/cli/agent/commands.py
+++ b/cli/agent/commands.py
@@ -77,8 +77,8 @@ def build_parser() -> argparse.ArgumentParser:
     auth_verify_otp.add_argument("email")
     auth_verify_otp.add_argument("token")
     auth_complete_register = auth_sub.add_parser("complete-register", parents=[shared])
-    auth_complete_register.add_argument("temp_token")
     auth_complete_register.add_argument("invite_code")
+    auth_complete_register.add_argument("--temp-token-stdin", action="store_true")
     auth_login = auth_sub.add_parser("login", parents=[shared])
     auth_login.add_argument("identifier")
     auth_login.add_argument("--password-stdin", action="store_true")
@@ -110,6 +110,15 @@ def _resolve_login_password(args: argparse.Namespace, stdin: TextIO) -> str:
             raise RuntimeError("stdin password is required")
         return password
     return getpass.getpass("Password: ")
+
+
+def _resolve_temp_token(args: argparse.Namespace, stdin: TextIO) -> str:
+    if args.temp_token_stdin:
+        temp_token = stdin.readline().rstrip("\r\n")
+        if not temp_token:
+            raise RuntimeError("stdin temp token is required")
+        return temp_token
+    return getpass.getpass("Temp token: ")
 
 
 def run_cli(
@@ -191,7 +200,7 @@ def run_cli(
     elif args.command == "auth" and args.auth_command == "verify-otp":
         payload = client.verify_otp(args.email, args.token)
     elif args.command == "auth" and args.auth_command == "complete-register":
-        payload = client.complete_register(args.temp_token, args.invite_code)
+        payload = client.complete_register(_resolve_temp_token(args, in_stream), args.invite_code)
     elif args.command == "auth" and args.auth_command == "login":
         payload = client.login(args.identifier, _resolve_login_password(args, in_stream))
     elif args.command == "agents" and args.agents_command == "list":

--- a/tests/Unit/cli/test_agent_cli.py
+++ b/tests/Unit/cli/test_agent_cli.py
@@ -482,11 +482,12 @@ def test_agent_cli_auth_complete_register_calls_auth_client() -> None:
 
     out = StringIO()
     exit_code = commands.run_cli(
-        ["auth", "complete-register", "temp-token-1", "INVITE-1", "--app-base-url", "http://backend"],
+        ["auth", "complete-register", "INVITE-1", "--temp-token-stdin", "--app-base-url", "http://backend"],
         messaging_client=SimpleNamespace(),
         identity_client=SimpleNamespace(create_external_user=lambda **_: None, list_users=lambda **_: []),
         runtime_read_client=SimpleNamespace(),
         auth_client=SimpleNamespace(complete_register=lambda temp_token, invite_code: {"token": f"{temp_token}:{invite_code}"}),
+        stdin=StringIO("temp-token-1\n"),
         stdout=out,
     )
 


### PR DESCRIPTION
## Summary
- remove the temp_token positional arg from `mycel-agent auth complete-register`
- read the temp token from stdin or an interactive prompt instead, matching the existing secret-handling bar used for login/send-otp passwords
- keep the registration flow otherwise unchanged

## Verification
- `.venv/bin/python -m pytest -q tests/Unit/cli/test_agent_cli.py tests/Unit/cli/test_agent_http.py -k "auth_"`
- `uv run ruff check cli/agent/commands.py cli/agent/client.py cli/agent/http.py tests/Unit/cli/test_agent_cli.py tests/Unit/cli/test_agent_http.py`
- backend/API YATU on `:8017`: full `send-otp -> verify-otp -> complete-register -> login` CLI flow still succeeds when `complete-register` receives the temp token through stdin