### PR TITLE
refactor: drop monitor app task state mirror

### DIFF
--- a/backend/monitor/app/lifespan.py
+++ b/backend/monitor/app/lifespan.py
@@ -23,15 +23,14 @@ def _require_monitor_runtime_contract(app: FastAPI) -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _require_monitor_runtime_contract(app)
-    app.state.monitor_resources_task = None
+    monitor_resources_task = None
     try:
-        app.state.monitor_resources_task = asyncio.create_task(resource_overview_refresh_loop())
+        monitor_resources_task = asyncio.create_task(resource_overview_refresh_loop())
         yield
     finally:
-        task = getattr(app.state, "monitor_resources_task", None)
-        if task:
-            task.cancel()
+        if monitor_resources_task:
+            monitor_resources_task.cancel()
             try:
-                await task
+                await monitor_resources_task
             except asyncio.CancelledError:
                 pass

--- a/tests/Unit/monitor/test_monitor_app_lifespan.py
+++ b/tests/Unit/monitor/test_monitor_app_lifespan.py
@@ -40,8 +40,6 @@ async def test_monitor_app_lifespan_starts_and_cancels_resource_refresh_loop(mon
 
     async with monitor_app_lifespan.lifespan(app):
         await asyncio.wait_for(started.wait(), timeout=1)
-        assert app.state.monitor_resources_task is not None
-        assert not app.state.monitor_resources_task.done()
         assert app.state.user_repo is user_repo
 
     await asyncio.wait_for(cancelled.wait(), timeout=1)


### PR DESCRIPTION
## Summary
- stop mirroring `monitor_resources_task` onto `app.state` inside `backend/monitor/app/lifespan.py`
- keep the refresh task local to the lifespan that creates and cancels it
- tighten the lifespan test to assert start/cancel behavior without depending on that extra app-state key

## Verification
- uv run pytest tests/Unit/monitor/test_monitor_app_lifespan.py tests/Unit/monitor/test_monitor_app_entrypoint.py -q
- uv run ruff check backend/monitor/app/lifespan.py tests/Unit/monitor/test_monitor_app_lifespan.py tests/Unit/monitor/test_monitor_app_entrypoint.py
- git diff --check
