### PR TITLE
refactor: drop monitor app port shell

### DIFF
--- a/backend/monitor/app/main.py
+++ b/backend/monitor/app/main.py
@@ -15,13 +15,9 @@ add_permissive_cors(app)
 app.include_router(global_router.router, prefix="/api/monitor")
 
 
-def _resolve_port() -> int:
-    return resolve_app_port("LEON_MONITOR_BACKEND_PORT", "worktree.ports.monitor-backend", 8011)
-
-
 if __name__ == "__main__":
     run_reloadable_app(
         "backend.monitor.app.main:app",
-        port=_resolve_port(),
+        port=resolve_app_port("LEON_MONITOR_BACKEND_PORT", "worktree.ports.monitor-backend", 8011),
         reload_dirs=["backend", "storage", "eval"],
     )

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -180,7 +180,7 @@ def test_monitor_app_resolve_port_prefers_monitor_backend_env(monkeypatch: pytes
     monkeypatch.setenv("LEON_MONITOR_BACKEND_PORT", "55417")
     monkeypatch.setenv("PORT", "9000")
 
-    assert monitor_app_main._resolve_port() == 55417
+    assert app_entrypoint.resolve_app_port("LEON_MONITOR_BACKEND_PORT", "worktree.ports.monitor-backend", 8011) == 55417
 
 
 def test_monitor_app_resolve_port_uses_worktree_config_when_env_missing(monkeypatch: pytest.MonkeyPatch):
@@ -197,7 +197,7 @@ def test_monitor_app_resolve_port_uses_worktree_config_when_env_missing(monkeypa
 
     monkeypatch.setattr(app_entrypoint.subprocess, "run", _run)
 
-    assert monitor_app_main._resolve_port() == 55418
+    assert app_entrypoint.resolve_app_port("LEON_MONITOR_BACKEND_PORT", "worktree.ports.monitor-backend", 8011) == 55418
 
 
 def test_monitor_app_includes_permissive_cors_middleware():


### PR DESCRIPTION
## Summary
- delete the dead `_resolve_port()` shell from `backend/monitor/app/main.py`
- call the shared `resolve_app_port(...)` helper directly from the monitor app entrypoint
- tighten the entrypoint tests to assert the shared helper contract directly

## Verification
- uv run pytest tests/Unit/monitor/test_monitor_app_lifespan.py tests/Unit/monitor/test_monitor_app_entrypoint.py -q
- uv run ruff check backend/monitor/app/main.py tests/Unit/monitor/test_monitor_app_entrypoint.py
- git diff --check
