### PR TITLE
refactor: drop web app port shell

### DIFF
--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -51,14 +51,9 @@ app.include_router(resources.router)
 app.include_router(marketplace.router)
 
 
-def _resolve_port() -> int:
-    """Resolve backend port: env var > git worktree config > default 8001."""
-    return resolve_app_port("LEON_BACKEND_PORT", "worktree.ports.backend", 8001)
-
-
 if __name__ == "__main__":
     # @@@port-precedence - git worktree config > LEON_BACKEND_PORT > PORT > 8001
-    port = _resolve_port()
+    port = resolve_app_port("LEON_BACKEND_PORT", "worktree.ports.backend", 8001)
     # @@@module-launch-target - Package-qualified target keeps module launch (`python -m backend.web.main`) import-safe.
     # @@@reload-dirs - restrict file watching to backend + core + config + storage only.
     # Without this, StatReload scans .venv/, node_modules/, .git/ etc. and burns 50-80% CPU.


### PR DESCRIPTION
## Summary
- delete the dead `_resolve_port()` shell from `backend/web/main.py`
- call the shared `resolve_app_port(...)` helper directly from the web backend entrypoint
- keep the slice behavior-preserving and net-negative

## Verification
- uv run pytest tests/Unit/backend/test_app_entrypoint.py -q
- uv run ruff check backend/web/main.py tests/Unit/backend/test_app_entrypoint.py
- git diff --check
