### PR TITLE
refactor: drop monitor thread get_app shell

### DIFF
--- a/backend/web/routers/monitor_threads.py
+++ b/backend/web/routers/monitor_threads.py
@@ -1,8 +1,8 @@
 """Web-owned monitor-local thread routes."""
 
-from typing import Annotated, Any
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.identity.auth.user_resolution import get_current_user_id
 from backend.monitor.application.use_cases import threads as monitor_thread_service
@@ -13,18 +13,14 @@ from backend.monitor.infrastructure.read_models import trace_read_service as mon
 router = APIRouter()
 
 
-async def get_app(request: Request) -> FastAPI:
-    return request.app
-
-
 @router.get("/threads")
 def threads_snapshot(
+    request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
-    app: Annotated[Any, Depends(get_app)] = None,
 ):
     return monitor_thread_service.list_monitor_threads(
         user_id,
-        workbench_reader=monitor_thread_workbench_read_service.build_owner_thread_workbench_reader(app),
+        workbench_reader=monitor_thread_workbench_read_service.build_owner_thread_workbench_reader(request.app),
     )
 
 


### PR DESCRIPTION
## Summary
- delete the tiny local `get_app()` helper from `backend/web/routers/monitor_threads.py`
- pass `Request` directly into the threads snapshot route and read `request.app` there
- keep the slice monitor-router-local and behavior-preserving

## Verification
- uv run pytest tests/Unit/monitor/test_monitor_app_entrypoint.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py -q
- uv run ruff check backend/web/routers/monitor_threads.py
- git diff --check
