### PR TITLE
refactor: drop observation dead return values

### DIFF
--- a/backend/threads/run/execution.py
+++ b/backend/threads/run/execution.py
@@ -90,7 +90,7 @@ async def run_agent_to_buffer(
         if trajectory_scope is not None:
             trajectory_scope.inject_callback(config)
 
-        _obs_handler, _obs_active, flush_observation = _run_observation.build_observation(app, thread_id, config)
+        flush_observation = _run_observation.build_observation(app, thread_id, config)
 
         drain_activity_events, attach_activity_bridge, detach_activity_bridge = _run_activity_bridge.build_activity_bridge(
             runtime=getattr(agent, "runtime", None),

--- a/backend/threads/run/observation.py
+++ b/backend/threads/run/observation.py
@@ -9,7 +9,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def build_observation(app: Any, thread_id: str, config: dict[str, Any]) -> tuple[Any, str | None, Callable[[], None]]:
+def build_observation(app: Any, thread_id: str, config: dict[str, Any]) -> Callable[[], None]:
     """Build an observation handler and its flush callback."""
     obs_handler = None
     obs_active = None
@@ -93,4 +93,4 @@ def build_observation(app: Any, thread_id: str, config: dict[str, Any]) -> tuple
         except Exception as flush_err:
             logger.warning("Observation flush error: %s", flush_err)
 
-    return obs_handler, obs_active, flush
+    return flush


### PR DESCRIPTION
## Summary
- narrow  to return only the flush callback
- stop  from unpacking two unused observation values
- keep behavior unchanged while deleting a dead internal interface

## Verification
- ..............                                                           [100%]
14 passed, 63 deselected in 0.55s
- All checks passed!
- 
