### PR TITLE
refactor: delete streaming lifecycle forwarders

### DIFF
--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -28,36 +28,6 @@ def _log_captured_exception(message: str, err: BaseException) -> None:
     )
 
 
-async def prime_sandbox(agent: Any, thread_id: str) -> None:
-    await _run_lifecycle.prime_sandbox(agent, thread_id)
-
-
-async def write_cancellation_markers(
-    agent: Any,
-    config: dict[str, Any],
-    pending_tool_calls: dict[str, dict],
-) -> list[str]:
-    return await _run_lifecycle.write_cancellation_markers(agent, config, pending_tool_calls)
-
-
-async def _repair_incomplete_tool_calls(agent: Any, config: dict[str, Any]) -> None:
-    await _run_lifecycle.repair_incomplete_tool_calls(agent, config)
-
-
-# ---------------------------------------------------------------------------
-# Thread event buffer management
-# ---------------------------------------------------------------------------
-
-
-def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
-    return _run_buffer_wiring.get_or_create_thread_buffer(app, thread_id)
-
-
-# ---------------------------------------------------------------------------
-# Per-thread handler setup (idempotent, survives across runs)
-# ---------------------------------------------------------------------------
-
-
 def _ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
     _run_buffer_wiring._append_event = _append_event
     _run_buffer_wiring._start_agent_run = start_agent_run
@@ -138,9 +108,9 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
 ) -> str:
     """Run agent execution and write all SSE events into *thread_buf*."""
     _run_execution.ensure_thread_handlers = _ensure_thread_handlers
-    _run_execution.prime_sandbox = prime_sandbox
-    _run_execution.repair_incomplete_tool_calls = _repair_incomplete_tool_calls
-    _run_execution.write_cancellation_markers = write_cancellation_markers
+    _run_execution.prime_sandbox = _run_lifecycle.prime_sandbox
+    _run_execution.repair_incomplete_tool_calls = _run_lifecycle.repair_incomplete_tool_calls
+    _run_execution.write_cancellation_markers = _run_lifecycle.write_cancellation_markers
     _run_execution.persist_cancelled_run_input_if_missing = _persist_cancelled_run_input_if_missing
     _run_execution.flush_cancelled_owner_steers = _flush_cancelled_owner_steers
     _run_execution.emit_queued_terminal_followups = _emit_queued_terminal_followups
@@ -195,7 +165,7 @@ def start_agent_run(
     input_messages: list[Any] | None = None,
 ) -> str:
     _run_entrypoints._run_agent_to_buffer = _run_agent_to_buffer
-    _run_entrypoints._get_or_create_thread_buffer = get_or_create_thread_buffer
+    _run_entrypoints._get_or_create_thread_buffer = _run_buffer_wiring.get_or_create_thread_buffer
     return _run_entrypoints.start_agent_run(
         agent,
         thread_id,
@@ -221,7 +191,7 @@ async def run_child_thread_live(
     _run_entrypoints._start_agent_run = start_agent_run
     _run_entrypoints._resolve_thread_sandbox = resolve_thread_sandbox
     _run_entrypoints._ensure_thread_handlers = _ensure_thread_handlers
-    _run_entrypoints._get_or_create_thread_buffer = get_or_create_thread_buffer
+    _run_entrypoints._get_or_create_thread_buffer = _run_buffer_wiring.get_or_create_thread_buffer
     _run_entrypoints._extract_text_content = extract_text_content
     return await _run_entrypoints.run_child_thread_live(
         agent,

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -15,9 +15,9 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway, build_agent_runtime_state
 from backend.threads.display.builder import DisplayBuilder
 from backend.threads.events.buffer import ThreadEventBuffer
+from backend.threads.run.lifecycle import repair_incomplete_tool_calls
 from backend.threads.streaming import (
     _ensure_thread_handlers,
-    _repair_incomplete_tool_calls,
     _run_agent_to_buffer,
     start_agent_run,
 )
@@ -656,7 +656,7 @@ async def test_repair_incomplete_tool_calls_uses_query_loop_state():
     trailing.id = "human-after"
     checkpointer.store["repair-live-thread"] = {"channel_values": {"messages": [broken_ai, trailing]}}
 
-    await _repair_incomplete_tool_calls(
+    await repair_incomplete_tool_calls(
         SimpleNamespace(agent=loop),
         {"configurable": {"thread_id": "repair-live-thread"}},
     )

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -7,7 +7,8 @@ from types import SimpleNamespace
 import pytest
 
 from backend.threads.events.buffer import ThreadEventBuffer
-from backend.threads.streaming import _run_agent_to_buffer, write_cancellation_markers
+from backend.threads.run.lifecycle import write_cancellation_markers
+from backend.threads.streaming import _run_agent_to_buffer
 from core.runtime.middleware.monitor import AgentState
 from eval.models import RunTrajectory
 
@@ -186,7 +187,7 @@ def _install_runtime_writer_test_doubles(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr("backend.threads.streaming.cleanup_old_runs", _noop_async)
     monkeypatch.setattr("backend.threads.streaming._ensure_thread_handlers", lambda *args, **kwargs: None)
     monkeypatch.setattr("backend.threads.streaming._consume_followup_queue", _noop_async)
-    monkeypatch.setattr("backend.threads.streaming.write_cancellation_markers", _noop_async)
+    monkeypatch.setattr("backend.threads.streaming._run_lifecycle.write_cancellation_markers", _noop_async)
     monkeypatch.setattr("backend.threads.streaming._persist_cancelled_run_input_if_missing", _noop_async)
     monkeypatch.setattr("backend.threads.streaming._flush_cancelled_owner_steers", _noop_async)
     monkeypatch.setattr("eval.storage.TrajectoryStore", _FakeTrajectoryStore)

--- a/tests/Unit/backend/web/services/test_streaming_prime_sandbox.py
+++ b/tests/Unit/backend/web/services/test_streaming_prime_sandbox.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from backend.threads.streaming import prime_sandbox
+from backend.threads.run.lifecycle import prime_sandbox
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- delete the remaining lifecycle/buffer forwarding shells from backend/threads/streaming.py
- bind execution/entrypoint helpers directly to backend.threads.run.lifecycle and backend.threads.run.buffer_wiring owners
- update focused tests to import and patch the real owners instead of the deleted streaming wrappers

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py -k "streaming or cancellation or owner or repair_incomplete_tool_calls or prime_sandbox"
- uv run ruff check backend/threads/streaming.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py
- git diff --check -- backend/threads/streaming.py tests/Unit/backend/web/services/test_streaming_prime_sandbox.py tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py
