### PR TITLE
refactor: delete streaming sse observer forwarders

### DIFF
--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -1,10 +1,9 @@
 """SSE streaming service for agent execution."""
 
 import logging
-from collections.abc import AsyncGenerator
 from typing import Any
 
-from backend.threads.events.buffer import RunEventBuffer, ThreadEventBuffer
+from backend.threads.events.buffer import ThreadEventBuffer
 from backend.threads.events.store import append_event as _append_event
 from backend.threads.events.store import cleanup_old_runs
 from backend.threads.run import buffer_wiring as _run_buffer_wiring
@@ -14,11 +13,8 @@ from backend.threads.run import entrypoints as _run_entrypoints
 from backend.threads.run import execution as _run_execution
 from backend.threads.run import followups as _run_followups
 from backend.threads.run import lifecycle as _run_lifecycle
-from backend.threads.run import observer as _run_observer
 
 logger = logging.getLogger(__name__)
-
-type SSEEvent = dict[str, str | int]
 
 
 def _log_captured_exception(message: str, err: BaseException) -> None:
@@ -200,34 +196,3 @@ async def run_child_thread_live(
         app,
         input_messages=input_messages,
     )
-
-
-# ---------------------------------------------------------------------------
-# Consumer: persistent thread event stream
-# ---------------------------------------------------------------------------
-
-
-async def observe_thread_events(
-    thread_buf: ThreadEventBuffer,
-    after: int = 0,
-) -> AsyncGenerator[SSEEvent, None]:
-    async for event in _run_observer.observe_thread_events(thread_buf, after=after):
-        yield event
-
-
-async def observe_run_events(
-    buf: RunEventBuffer,
-    after: int = 0,
-) -> AsyncGenerator[SSEEvent, None]:
-    async for event in _run_observer.observe_run_events(buf, after=after):
-        yield event
-
-
-async def _observe_sse_buffer(
-    buf: ThreadEventBuffer | RunEventBuffer,
-    *,
-    after: int,
-    stop_on_finish: bool,
-) -> AsyncGenerator[SSEEvent, None]:
-    async for event in _run_observer.observe_sse_buffer(buf, after=after, stop_on_finish=stop_on_finish):
-        yield event

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -186,7 +186,7 @@ def test_streaming_service_uses_thread_runtime_sse_observer_owner() -> None:
     assert owner_module.observe_thread_events is not None
     assert owner_module.observe_run_events is not None
     assert owner_module.observe_sse_buffer is not None
-    assert "from backend.threads.run import observer as _run_observer" in streaming_source
+    assert "from backend.threads.run import observer as _run_observer" not in streaming_source
     assert "backend.web.services.event_buffer" not in owner_source
 
 


### PR DESCRIPTION
## Summary
- delete the dead SSE observer forwarding shells from backend/threads/streaming.py
- remove the now-unused observer import and related wrapper-only types
- update the focused owner/source-guard test to reflect the new direct-owner truth

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -k "streaming or owner"
- uv run ruff check backend/threads/streaming.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- git diff --check -- backend/threads/streaming.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
