### PR TITLE
refactor: delete run done display alias

### DIFF
--- a/backend/threads/display/builder.py
+++ b/backend/threads/display/builder.py
@@ -636,7 +636,7 @@ def _handle_notice(td: ThreadDisplay, data: dict) -> dict | None:
     return {"type": "append_entry", "entry": entry}
 
 
-def _handle_finalize(td: ThreadDisplay) -> dict | None:
+def _handle_finalize(td: ThreadDisplay, _data: dict | None = None) -> dict | None:
     turn = _get_current_turn(td)
     if not turn:
         td.current_turn_id = None

--- a/backend/threads/display/builder.py
+++ b/backend/threads/display/builder.py
@@ -651,10 +651,6 @@ def _handle_finalize(td: ThreadDisplay) -> dict | None:
     return {"type": "finalize_turn", "timestamp": now}
 
 
-def _handle_run_done(td: ThreadDisplay, data: dict) -> dict | None:
-    return _handle_finalize(td)
-
-
 def _handle_error(td: ThreadDisplay, data: dict) -> dict | None:
     turn = _get_current_turn(td)
     if not turn:
@@ -782,7 +778,7 @@ def _extract_subagent_stream_identity(step_name: str | None, metadata: dict, con
 _EVENT_HANDLERS: dict[str, Any] = {
     "user_message": _handle_user_message,
     "run_start": _handle_run_start,
-    "run_done": _handle_run_done,
+    "run_done": _handle_finalize,
     "text": _handle_text,
     "tool_call": _handle_tool_call,
     "tool_result": _handle_tool_result,


### PR DESCRIPTION
## Summary
- delete the dead `_handle_run_done` display alias
- map `run_done` directly to `_handle_finalize` in the display event handler table
- keep the display/run epilogue behavior unchanged while shrinking the handler surface

## Verification
- uv run pytest -q tests/Unit/backend/thread_runtime/run/test_emit.py tests/Unit/backend/thread_runtime/run/test_epilogue.py tests/Unit/backend/web/services/test_streaming_eval_writer.py -k "run_done or finalize or display"
- uv run ruff check backend/threads/display/builder.py
- git diff --check -- backend/threads/display/builder.py
