### PR TITLE
refactor(chat): split internal send message schema title

### DIFF
--- a/backend/chat/api/http/internal_messaging_router.py
+++ b/backend/chat/api/http/internal_messaging_router.py
@@ -22,7 +22,7 @@ class FindOrCreateChatBody(BaseModel):
     title: str | None = None
 
 
-class SendMessageBody(BaseModel):
+class InternalSendMessageBody(BaseModel):
     sender_id: str
     content: str
     message_type: str = "human"
@@ -116,7 +116,7 @@ def list_unread_messages(
 @router.post("/chats/{chat_id}/messages/send")
 def send_message(
     chat_id: str,
-    body: SendMessageBody,
+    body: InternalSendMessageBody,
     messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ) -> dict[str, Any]:
     return messaging_service.send(

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -21,3 +21,17 @@ def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> N
     assert "/api/chats" in paths
     assert "/api/relationships" in paths
     assert "/api/conversations" in paths
+
+
+def test_chat_openapi_keeps_public_and_internal_send_message_schemas_distinct() -> None:
+    app = FastAPI()
+    app.include_router(owner_chat_app_router.router)
+
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    schemas = response.json()["components"]["schemas"]
+
+    assert schemas["SendMessageBody"]["title"] == "SendMessageBody"
+    assert schemas["InternalSendMessageBody"]["title"] == "InternalSendMessageBody"


### PR DESCRIPTION
## Summary
- rename the internal messaging send request model so its OpenAPI title no longer collides with the public chat send request model
- add an OpenAPI integration assertion that public and internal send-message schemas stay distinct

## Verification
- uv run python -m pytest -q tests/Integration/test_chat_app_router.py -k distinct
- uv run python -m pytest -q tests/Integration/test_chat_app_router.py tests/Integration/test_chat_internal_messaging_router.py
- uv run ruff check backend/chat/api/http/internal_messaging_router.py tests/Integration/test_chat_app_router.py tests/Integration/test_chat_internal_messaging_router.py