### PR TITLE
refactor: delete agent runtime gateway shell

### DIFF
--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -59,7 +59,3 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
     # runtime handles without mirroring them onto loose app.state attrs, so
     # callers must keep borrowing through the bundle they just built.
     return AgentRuntimeGatewayState(gateway=gateway, activity_reader=activity_reader)
-
-
-def build_agent_runtime_gateway(app: Any, *, typing_tracker: Any) -> NativeAgentRuntimeGateway:
-    return build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway

--- a/tests/Integration/test_query_loop_backend_contracts.py
+++ b/tests/Integration/test_query_loop_backend_contracts.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway, build_agent_runtime_state
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from backend.threads.display.builder import DisplayBuilder
 from backend.threads.events.buffer import ThreadEventBuffer
 from backend.threads.run.lifecycle import repair_incomplete_tool_calls
@@ -1461,7 +1461,7 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
     typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
 
     startup_task = asyncio.create_task(
-        build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(
+        build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(
             AgentThreadInputEnvelope(
                 thread_id=thread_id,
                 sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -75,20 +75,6 @@ def test_attach_threads_runtime_requires_explicit_typing_tracker():
         threads_bootstrap.attach_threads_runtime(app, storage_container)
 
 
-def test_build_agent_runtime_gateway_returns_gateway_from_runtime_state(monkeypatch):
-    gateway = object()
-    activity_reader = object()
-    app = SimpleNamespace(state=SimpleNamespace())
-
-    monkeypatch.setattr(
-        runtime_bootstrap,
-        "build_agent_runtime_state",
-        lambda target_app, *, typing_tracker: SimpleNamespace(gateway=gateway, activity_reader=activity_reader),
-    )
-
-    assert runtime_bootstrap.build_agent_runtime_gateway(app, typing_tracker=object()) is gateway
-
-
 def test_build_agent_runtime_state_does_not_write_top_level_activity_reader(monkeypatch):
     gateway = object()
     activity_reader = object()

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -56,7 +56,7 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
         message=AgentRuntimeMessage(content="hello", signal="ping"),
     )
 
-    result = await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_chat(envelope)
+    result = await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_chat(envelope)
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-preselected"

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -76,7 +76,7 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
     app, started, unread_calls, enqueued = _app()
     typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
-    result = await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_chat(_envelope())
+    result = await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_chat(_envelope())
 
     assert result.status == "accepted"
     assert result.thread_id == "thread-1"
@@ -94,7 +94,7 @@ async def test_gateway_dispatch_chat_raises_for_missing_thread(monkeypatch: pyte
     typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
     with pytest.raises(RuntimeError, match="Agent chat recipient has no runtime thread: agent-user-1"):
-        await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_chat(_envelope(thread_id=None))
+        await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_chat(_envelope(thread_id=None))
 
     assert started == []
     assert unread_calls == []
@@ -113,7 +113,7 @@ async def test_gateway_dispatch_chat_uses_explicit_typing_tracker(monkeypatch: p
     started: list[tuple[str, str, str]] = []
     explicit_typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
 
-    result = await build_agent_runtime_gateway(app, typing_tracker=explicit_typing_tracker).dispatch_chat(_envelope())
+    result = await build_agent_runtime_state(app, typing_tracker=explicit_typing_tracker).gateway.dispatch_chat(_envelope())
 
     assert result.status == "accepted"
     assert started == [("thread-1", "chat-1", "agent-user-1")]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -73,7 +73,7 @@ def test_agent_runtime_implementation_lives_under_backend_agent_runtime() -> Non
     thread_handler_impl = importlib.import_module("backend.threads.chat_adapters.thread_handler")
 
     assert gateway_impl.NativeAgentRuntimeGateway.__module__ == "backend.threads.chat_adapters.gateway"
-    assert bootstrap_impl.build_agent_runtime_gateway.__module__ == "backend.threads.chat_adapters.bootstrap"
+    assert bootstrap_impl.build_agent_runtime_state.__module__ == "backend.threads.chat_adapters.bootstrap"
     assert port_impl.get_agent_runtime_gateway.__module__ == "backend.threads.chat_adapters.port"
     assert chat_handler_impl.NativeAgentChatDeliveryHandler.__module__ == "backend.threads.chat_adapters.chat_handler"
     assert thread_handler_impl.NativeAgentThreadInputHandler.__module__ == "backend.threads.chat_adapters.thread_handler"

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -103,6 +103,8 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
-        await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_thread_input(enable_trajectory=True))
+        await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(
+            _thread_input(enable_trajectory=True)
+        )
 
     assert start_run.call_args.kwargs["enable_trajectory"] is True

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from backend.threads.chat_adapters.bootstrap import build_agent_runtime_gateway
+from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from core.runtime.middleware.monitor import AgentState
 from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
 
@@ -70,7 +70,7 @@ async def test_gateway_thread_input_clears_resource_overview_cache_when_starting
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache") as clear_cache,
     ):
-        result = await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(_thread_input())
+        result = await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_thread_input())
 
     assert result == AgentThreadInputResult(status="started", routing="direct", run_id="run-123", thread_id="thread-1")
     clear_cache.assert_called_once_with()
@@ -88,7 +88,7 @@ async def test_gateway_thread_input_requires_agent_runtime() -> None:
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
         with pytest.raises(AttributeError):
-            await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(_thread_input())
+            await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_thread_input())
 
 
 @pytest.mark.asyncio
@@ -103,6 +103,6 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
     ):
-        await build_agent_runtime_gateway(app, typing_tracker=typing_tracker).dispatch_thread_input(_thread_input(enable_trajectory=True))
+        await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_thread_input(enable_trajectory=True))
 
     assert start_run.call_args.kwargs["enable_trajectory"] is True


### PR DESCRIPTION
## Summary
- delete the now-unused `build_agent_runtime_gateway(...)` shell from backend/threads/chat_adapters/bootstrap.py
- point the remaining tests and one integration call site directly at `build_agent_runtime_state(...).gateway`
- keep runtime behavior unchanged while narrowing the bootstrap surface to the real owner

## Verification
- uv run pytest -q tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Integration/test_query_loop_backend_contracts.py -k "gateway or dispatch_thread_input or dispatch_chat or protocol_boundary"
- uv run ruff check backend/threads/chat_adapters/bootstrap.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Integration/test_query_loop_backend_contracts.py
- git diff --check -- backend/threads/chat_adapters/bootstrap.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Integration/test_query_loop_backend_contracts.py
