### PR TITLE
refactor: delete agent config shell

### DIFF
--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -23,11 +23,3 @@ async def get_or_create_agent(*args, **kwargs):
         if messaging_service is not None:
             kwargs["messaging_service"] = messaging_service
     return await _registry.get_or_create_agent(*args, **kwargs)
-
-
-async def update_agent_config(*args, **kwargs):
-    _registry.create_agent_sync = create_agent_sync
-    _registry.get_or_create_agent_id = get_or_create_agent_id
-    _registry.get_file_channel_binding = get_file_channel_binding
-    _registry.resolve_thread_sandbox = resolve_thread_sandbox
-    return await _registry.update_agent_config(*args, **kwargs)

--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -308,7 +308,7 @@ class ModelConfigRequest(BaseModel):
 @router.post("/config")
 async def update_model_config(request: ModelConfigRequest, req: Request) -> dict[str, Any]:
     """Update model configuration for agent (hot-reload) and persist per-thread."""
-    from backend.threads.activity_pool_service import update_agent_config
+    from backend.threads.pool.registry import update_agent_config
 
     # Persist model per-thread if thread_id provided
     if request.thread_id:

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -77,10 +77,8 @@ def test_agent_pool_uses_thread_runtime_pool_registry_owner() -> None:
     owner_source = inspect.getsource(owner_module)
 
     assert hasattr(agent_pool_module, "get_or_create_agent")
-    assert hasattr(agent_pool_module, "update_agent_config")
     assert "from backend.threads.pool import registry as _registry" in source
     assert "async def get_or_create_agent(" in source
-    assert "async def update_agent_config(" in source
     assert hasattr(agent_pool_module, "get_or_create_agent_id")
     assert hasattr(agent_pool_module, "get_file_channel_binding")
     assert owner_module.get_or_create_agent.__module__ == "backend.threads.pool.registry"


### PR DESCRIPTION
## Summary
- delete the empty `activity_pool_service.update_agent_config(...)` shell
- point the settings router directly at `backend.threads.pool.registry.update_agent_config`
- tighten the owner/source-guard test to reflect that only `get_or_create_agent` still lives in the service shim

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/test_threads_bootstrap.py tests/Integration/test_query_loop_backend_contracts.py -k "thread_runtime_pool_registry_owner or update_model_config or settings or gateway"
- uv run ruff check backend/threads/activity_pool_service.py backend/web/routers/settings.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- git diff --check -- backend/threads/activity_pool_service.py backend/web/routers/settings.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
