### PR TITLE
refactor: delete launch config shell

### DIFF
--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -23,6 +23,8 @@ def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "model": str(payload.get("model") or "").strip() or None,
         "workspace": str(payload.get("workspace") or "").strip() or None,
     }
+
+
 def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> dict[str, Any]:
     if available_sandbox_types is None or list_library is None:
         raise RuntimeError("thread_runtime.launch_config requires available_sandbox_types and list_library bindings")

--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -23,27 +23,6 @@ def normalize_launch_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "model": str(payload.get("model") or "").strip() or None,
         "workspace": str(payload.get("workspace") or "").strip() or None,
     }
-
-
-def build_new_launch_config(
-    *,
-    provider_config: str,
-    sandbox_template_id: str | None,
-    model: str | None,
-    workspace: str | None,
-) -> dict[str, Any]:
-    return normalize_launch_config_payload(
-        {
-            "create_mode": "new",
-            "provider_config": provider_config,
-            "sandbox_template_id": sandbox_template_id,
-            "existing_sandbox_id": None,
-            "model": model,
-            "workspace": workspace,
-        }
-    )
-
-
 def resolve_default_config(app: Any, owner_user_id: str, agent_user_id: str) -> dict[str, Any]:
     if available_sandbox_types is None or list_library is None:
         raise RuntimeError("thread_runtime.launch_config requires available_sandbox_types and list_library bindings")

--- a/tests/Integration/test_thread_launch_config_contract.py
+++ b/tests/Integration/test_thread_launch_config_contract.py
@@ -180,12 +180,16 @@ def _recipe_library_entry(provider_type: str) -> dict[str, object]:
     }
 
 
-def test_build_new_launch_config_uses_sandbox_template_id() -> None:
-    config = thread_launch_config_service.build_new_launch_config(
-        provider_config="local",
-        sandbox_template_id="local:custom",
-        model="gpt-5.4-mini",
-        workspace="/tmp/custom",
+def test_normalize_launch_config_payload_uses_sandbox_template_id() -> None:
+    config = thread_launch_config_service.normalize_launch_config_payload(
+        {
+            "create_mode": "new",
+            "provider_config": "local",
+            "sandbox_template_id": "local:custom",
+            "existing_sandbox_id": None,
+            "model": "gpt-5.4-mini",
+            "workspace": "/tmp/custom",
+        }
     )
 
     assert config == {

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -93,7 +93,6 @@ def test_thread_launch_config_uses_thread_runtime_launch_config_owner() -> None:
     owner_source = inspect.getsource(owner_module)
 
     assert owner_module.normalize_launch_config_payload is not None
-    assert owner_module.build_new_launch_config is not None
     assert owner_module.resolve_default_config is not None
     assert "sandbox_service.available_sandbox_types" not in owner_source
     assert "available_sandbox_types is None or list_library is None" in owner_source


### PR DESCRIPTION
## Summary
- delete the test-only `build_new_launch_config(...)` wrapper from backend/threads/launch_config.py
- point the launch-config contract test directly at `normalize_launch_config_payload(...)`
- tighten the owner/source-guard test to reflect the smaller launch-config surface

## Verification
- uv run pytest -q tests/Integration/test_thread_launch_config_contract.py tests/Unit/backend/web/services/test_thread_runtime_owner.py -k "launch_config or normalize_launch_config_payload or thread_launch_config_uses_thread_runtime_launch_config_owner"
- uv run ruff check backend/threads/launch_config.py tests/Integration/test_thread_launch_config_contract.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- git diff --check -- backend/threads/launch_config.py tests/Integration/test_thread_launch_config_contract.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
