### PR TITLE
refactor: delete channel file shells

### DIFF
--- a/backend/threads/file_channel.py
+++ b/backend/threads/file_channel.py
@@ -69,23 +69,6 @@ def save_file(*, thread_id: str, relative_path: str, content: bytes) -> dict:
     result = source.save_file(relative_path, content)
     result["thread_id"] = thread_id
     return result
-
-
-def list_channel_files(*, thread_id: str) -> list[dict]:
-    """List files in the thread's file channel."""
-    return get_file_channel_source(thread_id).list_files()
-
-
-def resolve_channel_file(*, thread_id: str, relative_path: str):
-    """Resolve file path in the thread's file channel."""
-    return get_file_channel_source(thread_id).resolve_file(relative_path)
-
-
-def delete_channel_file(*, thread_id: str, relative_path: str) -> None:
-    """Delete file from the thread's file channel."""
-    get_file_channel_source(thread_id).delete_file(relative_path)
-
-
 def _row_value(row, key: str):
     if isinstance(row, dict):
         return row.get(key)

--- a/backend/threads/file_channel.py
+++ b/backend/threads/file_channel.py
@@ -69,6 +69,8 @@ def save_file(*, thread_id: str, relative_path: str, content: bytes) -> dict:
     result = source.save_file(relative_path, content)
     result["thread_id"] = thread_id
     return result
+
+
 def _row_value(row, key: str):
     if isinstance(row, dict):
         return row.get(key)

--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -1,7 +1,6 @@
 """Thread file browsing endpoints."""
 
 import asyncio
-from collections.abc import Callable
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
@@ -23,16 +22,21 @@ _public = APIRouter(prefix="/api/threads/{thread_id}/files", tags=["thread-files
 
 
 async def _call_channel_file_service(
-    method: Callable[..., Any],
+    method_name: str | Any,
     *,
     thread_id: str,
     relative_path: str | None = None,
     missing_status: int | None = None,
 ) -> Any:
     try:
+        if callable(method_name):
+            method = method_name
+        else:
+            source = file_channel_service.get_file_channel_source(thread_id)
+            method = getattr(source, method_name)
         if relative_path is None:
-            return await asyncio.to_thread(method, thread_id=thread_id)
-        return await asyncio.to_thread(method, thread_id=thread_id, relative_path=relative_path)
+            return await asyncio.to_thread(method)
+        return await asyncio.to_thread(method, relative_path)
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
     except FileNotFoundError as e:
@@ -217,7 +221,7 @@ async def download_file(
 ) -> FileResponse:
     """Download a file from thread-scoped files directory."""
     target = await _call_channel_file_service(
-        file_channel_service.resolve_channel_file,
+        "resolve_file",
         thread_id=thread_id,
         relative_path=path,
         missing_status=404,
@@ -232,7 +236,7 @@ async def delete_channel_file(
 ) -> dict[str, Any]:
     """Delete a file from the thread file channel."""
     await _call_channel_file_service(
-        file_channel_service.delete_channel_file,
+        "delete_file",
         thread_id=thread_id,
         relative_path=path,
         missing_status=404,
@@ -246,7 +250,7 @@ async def list_channel_files(
 ) -> dict[str, Any]:
     """List files under thread-scoped files directory."""
     entries = await _call_channel_file_service(
-        file_channel_service.list_channel_files,
+        "list_files",
         thread_id=thread_id,
     )
     return {"thread_id": thread_id, "entries": entries}


### PR DESCRIPTION
## Summary
- delete the thread file-channel service shells for list/resolve/delete
- make the thread-files router call the file-channel source directly for those operations
- keep the existing router test seam by letting `_call_channel_file_service(...)` still accept a callable in tests

## Verification
- uv run pytest -q tests/Integration/test_thread_files_channel_shell.py tests/Unit/backend/web/services/test_file_channel_service.py -k "channel_file or file_channel"
- uv run ruff check backend/threads/file_channel.py backend/web/routers/thread_files.py
- git diff --check -- backend/threads/file_channel.py backend/web/routers/thread_files.py
