### PR TITLE
refactor: delete sandbox resolution re-export

### DIFF
--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -3,7 +3,7 @@
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.pool import registry as _registry
 from backend.threads.pool.factory import create_agent_sync
-from backend.threads.sandbox_resolution import resolve_thread_sandbox
+from backend.threads.sandbox_resolution import resolve_thread_sandbox as _resolve_thread_sandbox
 from core.identity.agent_registry import get_or_create_agent_id
 
 
@@ -12,7 +12,7 @@ async def get_or_create_agent(*args, **kwargs):
     _registry.create_agent_sync = create_agent_sync
     _registry.get_or_create_agent_id = get_or_create_agent_id
     _registry.get_file_channel_binding = get_file_channel_binding
-    _registry.resolve_thread_sandbox = resolve_thread_sandbox
+    _registry.resolve_thread_sandbox = _resolve_thread_sandbox
     if "messaging_service" not in kwargs and app is not None:
         # @@@agent-pool-borrowed-runtime-bundle - thread runtime still needs a
         # chat-owned messaging service for chat_repos construction, but the

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -6,12 +6,13 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.monitor.infrastructure.resources.resource_overview_cache import clear_resource_overview_cache
-from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
+from backend.threads.activity_pool_service import get_or_create_agent
 from backend.threads.chat_adapters.activity_reader import AppRuntimeThreadActivityReader
 from backend.threads.chat_adapters.chat_handler import NativeAgentChatDeliveryHandler
 from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
 from backend.threads.chat_adapters.gateway import NativeAgentRuntimeGateway
 from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
+from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from backend.threads.streaming import _ensure_thread_handlers, start_agent_run
 
 

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -181,7 +181,7 @@ async def run_child_thread_live(
     *,
     input_messages: list[Any],
 ) -> str:
-    from backend.threads.activity_pool_service import resolve_thread_sandbox
+    from backend.threads.sandbox_resolution import resolve_thread_sandbox
     from backend.web.utils.serializers import extract_text_content
 
     _run_entrypoints._start_agent_run = start_agent_run

--- a/backend/web/core/dependencies.py
+++ b/backend/web/core/dependencies.py
@@ -9,7 +9,8 @@ from backend.identity.auth.dependencies import _get_auth_service as _get_auth_se
 from backend.identity.auth.user_resolution import get_current_user as get_current_user
 from backend.identity.auth.user_resolution import get_current_user_id as get_current_user_id
 from backend.threads import convergence as thread_runtime_convergence
-from backend.threads.activity_pool_service import get_or_create_agent, resolve_thread_sandbox
+from backend.threads.activity_pool_service import get_or_create_agent
+from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
 
 inspect_owner_thread_runtime = thread_runtime_convergence.inspect_owner_thread_runtime

--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 
 from backend.threads import file_channel as file_channel_service
-from backend.threads.activity_pool_service import resolve_thread_sandbox
+from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from backend.web.core.dependencies import get_app, verify_thread_owner
 from backend.web.utils.helpers import resolve_local_workspace_path
 from sandbox.thread_context import set_current_thread_id

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -15,16 +15,6 @@ def test_thread_runtime_namespace_exports_binding_and_state_helpers() -> None:
     assert "backend.web.services.thread_runtime_binding_service" not in inspect.getsource(state_owner)
 
 
-def test_agent_pool_uses_thread_runtime_sandbox_owner() -> None:
-    sandbox_owner = importlib.import_module("backend.threads.sandbox_resolution")
-    agent_pool_module = importlib.import_module("backend.threads.activity_pool_service")
-    source = inspect.getsource(agent_pool_module)
-
-    assert agent_pool_module.resolve_thread_sandbox is sandbox_owner.resolve_thread_sandbox
-    assert "from backend.threads.sandbox_resolution import resolve_thread_sandbox" in source
-    assert "def resolve_thread_sandbox(" not in source
-
-
 def test_thread_runtime_history_uses_thread_runtime_message_repair_owner() -> None:
     history_source = inspect.getsource(importlib.import_module("backend.threads.history"))
     owner_module = importlib.import_module("backend.threads.interruption")
@@ -77,7 +67,9 @@ def test_agent_pool_uses_thread_runtime_pool_registry_owner() -> None:
     owner_source = inspect.getsource(owner_module)
 
     assert hasattr(agent_pool_module, "get_or_create_agent")
+    assert not hasattr(agent_pool_module, "resolve_thread_sandbox")
     assert "from backend.threads.pool import registry as _registry" in source
+    assert "from backend.threads.sandbox_resolution import resolve_thread_sandbox as _resolve_thread_sandbox" in source
     assert "async def get_or_create_agent(" in source
     assert hasattr(agent_pool_module, "get_or_create_agent_id")
     assert hasattr(agent_pool_module, "get_file_channel_binding")
@@ -85,6 +77,7 @@ def test_agent_pool_uses_thread_runtime_pool_registry_owner() -> None:
     assert owner_module.update_agent_config.__module__ == "backend.threads.pool.registry"
     assert "backend.web.services.file_channel_service" not in owner_source
     assert "from backend.threads.file_channel import get_file_channel_binding" in source
+    assert "_registry.resolve_thread_sandbox = _resolve_thread_sandbox" in source
     assert "backend.web.services.file_channel_service" not in source
 
 


### PR DESCRIPTION
## Summary
- stop re-exporting `resolve_thread_sandbox` through `backend.threads.activity_pool_service`
- point the remaining callers directly at the real owner `backend.threads.sandbox_resolution`
- keep `activity_pool_service` focused on the still-meaningful `get_or_create_agent` shim only

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Integration/test_thread_files_channel_shell.py tests/Integration/test_query_loop_backend_contracts.py -k "sandbox_owner or gateway or dispatch_chat or dispatch_thread_input or thread_files or run_child_thread_live or thread_runtime_pool_registry_owner"
- uv run ruff check backend/threads/activity_pool_service.py backend/threads/chat_adapters/bootstrap.py backend/web/core/dependencies.py backend/web/routers/thread_files.py backend/threads/streaming.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
- git diff --check -- backend/threads/activity_pool_service.py backend/threads/chat_adapters/bootstrap.py backend/web/core/dependencies.py backend/web/routers/thread_files.py backend/threads/streaming.py tests/Unit/backend/web/services/test_thread_runtime_owner.py
