### PR TITLE
refactor: delete thread history transport shell

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.events.reads import build_run_event_read_transport
-from backend.threads.history import build_thread_history_transport, get_thread_history_payload
+from backend.threads.history import ThreadHistoryTransport, get_thread_history_payload
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
 
@@ -42,7 +42,7 @@ def build_monitor_trace_reader(app: Any) -> MonitorTraceReader:
         checkpoint_state = await checkpoint_store.load(thread_id)
         return list(checkpoint_state.messages) if checkpoint_state is not None else []
 
-    history_transport = build_thread_history_transport(
+    history_transport = ThreadHistoryTransport(
         load_live_messages=_load_live_messages,
         load_checkpoint_messages=_load_checkpoint_messages,
     )

--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -14,6 +14,8 @@ from backend.threads.message_content import extract_text_content
 class ThreadHistoryTransport:
     load_live_messages: Callable[[str], Awaitable[list[Any] | None]]
     load_checkpoint_messages: Callable[[str], Awaitable[list[Any]]]
+
+
 def _trunc(text: str, truncate: int) -> str:
     if truncate > 0 and len(text) > truncate:
         return text[:truncate] + f"…[+{len(text) - truncate}]"

--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -14,19 +14,6 @@ from backend.threads.message_content import extract_text_content
 class ThreadHistoryTransport:
     load_live_messages: Callable[[str], Awaitable[list[Any] | None]]
     load_checkpoint_messages: Callable[[str], Awaitable[list[Any]]]
-
-
-def build_thread_history_transport(
-    *,
-    load_live_messages: Callable[[str], Awaitable[list[Any] | None]],
-    load_checkpoint_messages: Callable[[str], Awaitable[list[Any]]],
-) -> ThreadHistoryTransport:
-    return ThreadHistoryTransport(
-        load_live_messages=load_live_messages,
-        load_checkpoint_messages=load_checkpoint_messages,
-    )
-
-
 def _trunc(text: str, truncate: int) -> str:
     if truncate > 0 and len(text) > truncate:
         return text[:truncate] + f"…[+{len(text) - truncate}]"

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -29,8 +29,8 @@ from backend.threads.events.buffer import ThreadEventBuffer
 from backend.threads.events.store import get_last_seq, get_latest_run_id, get_run_start_seq, read_events_after
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.history import (
+    ThreadHistoryTransport,
     build_thread_history_payload_from_display_entries,
-    build_thread_history_transport,
     get_thread_history_payload,
 )
 from backend.threads.interruption import repair_interrupted_tool_call_messages
@@ -1095,7 +1095,7 @@ async def get_thread_history(
         checkpoint_state = await checkpoint_store.load(current_thread_id)
         return list(checkpoint_state.messages) if checkpoint_state is not None else []
 
-    history_transport = build_thread_history_transport(
+    history_transport = ThreadHistoryTransport(
         load_live_messages=_load_live_messages,
         load_checkpoint_messages=_load_checkpoint_messages,
     )

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -13,7 +13,7 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     reads_owner = importlib.import_module("backend.threads.events.reads")
     buffer_owner = importlib.import_module("backend.threads.events.buffer")
 
-    assert history_owner.build_thread_history_transport is not None
+    assert history_owner.ThreadHistoryTransport is not None
     assert projection_owner.canonical_owner_threads is not None
     assert convergence_owner.inspect_owner_thread_runtime is not None
     assert sandbox_owner.resolve_thread_sandbox is not None

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -28,7 +28,7 @@ def test_trace_read_service_uses_thread_runtime_history_owner() -> None:
     trace_source = inspect.getsource(importlib.import_module("backend.monitor.infrastructure.read_models.trace_read_service"))
 
     assert "from backend.thread_history import build_thread_history_transport, get_thread_history_payload" not in trace_source
-    assert "from backend.threads.history import build_thread_history_transport, get_thread_history_payload" in trace_source
+    assert "from backend.threads.history import ThreadHistoryTransport, get_thread_history_payload" in trace_source
 
 
 def test_thread_runtime_convergence_does_not_import_web_compat_shell() -> None:

--- a/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
@@ -81,7 +81,7 @@ def test_monitor_trace_uses_trace_read_source_port():
     assert "trace_read_service" in trace_source
     assert "get_thread_history_payload" in read_source
     assert "get_thread_history_payload(app=" not in read_source
-    assert "build_thread_history_transport" in read_source
+    assert "ThreadHistoryTransport(" in read_source
     assert "from backend.threads.events.reads import build_run_event_read_transport" in read_source
     assert "from backend.threads.sandbox_resolution import resolve_thread_sandbox" in read_source
     assert "backend.run_event_reads" not in read_source


### PR DESCRIPTION
## Summary
- delete the `build_thread_history_transport(...)` constructor shell from backend/threads/history.py
- instantiate `ThreadHistoryTransport(...)` directly at the two remaining production call sites
- update the focused owner/source-guard tests to reflect the smaller history surface

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Integration/test_query_loop_backend_contracts.py -k "thread_history or trace_read_service or event_buffer_owner or launch_config or get_thread_history"
- uv run ruff check backend/threads/history.py backend/monitor/infrastructure/read_models/trace_read_service.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
- git diff --check -- backend/threads/history.py backend/monitor/infrastructure/read_models/trace_read_service.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
