### PR TITLE
refactor: delete thread history transport state

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.events.reads import build_run_event_read_transport
-from backend.threads.history import ThreadHistoryTransport, get_thread_history_payload
+from backend.threads.history import get_thread_history_payload
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
 
@@ -42,16 +42,12 @@ def build_monitor_trace_reader(app: Any) -> MonitorTraceReader:
         checkpoint_state = await checkpoint_store.load(thread_id)
         return list(checkpoint_state.messages) if checkpoint_state is not None else []
 
-    history_transport = ThreadHistoryTransport(
-        load_live_messages=_load_live_messages,
-        load_checkpoint_messages=_load_checkpoint_messages,
-    )
-
     async def _load_thread_history_payload(thread_id: str) -> dict[str, Any]:
         set_current_thread_id(thread_id)
         return await get_thread_history_payload(
             thread_id=thread_id,
-            history_transport=history_transport,
+            load_live_messages=_load_live_messages,
+            load_checkpoint_messages=_load_checkpoint_messages,
             limit=200,
             truncate=0,
         )

--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -3,17 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.interruption import repair_interrupted_tool_call_messages
 from backend.threads.message_content import extract_text_content
-
-
-@dataclass(frozen=True)
-class ThreadHistoryTransport:
-    load_live_messages: Callable[[str], Awaitable[list[Any] | None]]
-    load_checkpoint_messages: Callable[[str], Awaitable[list[Any]]]
 
 
 def _trunc(text: str, truncate: int) -> str:
@@ -143,13 +136,14 @@ def build_thread_history_payload_from_display_entries(
 async def get_thread_history_payload(
     *,
     thread_id: str,
-    history_transport: ThreadHistoryTransport,
+    load_live_messages: Callable[[str], Awaitable[list[Any] | None]],
+    load_checkpoint_messages: Callable[[str], Awaitable[list[Any]]],
     limit: int = 20,
     truncate: int = 300,
 ) -> dict[str, Any]:
-    live_messages = await history_transport.load_live_messages(thread_id)
+    live_messages = await load_live_messages(thread_id)
     if live_messages is None:
-        all_messages = await history_transport.load_checkpoint_messages(thread_id)
+        all_messages = await load_checkpoint_messages(thread_id)
     else:
         all_messages = live_messages
     all_messages = repair_interrupted_tool_call_messages(list(all_messages))

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -29,7 +29,6 @@ from backend.threads.events.buffer import ThreadEventBuffer
 from backend.threads.events.store import get_last_seq, get_latest_run_id, get_run_start_seq, read_events_after
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.history import (
-    ThreadHistoryTransport,
     build_thread_history_payload_from_display_entries,
     get_thread_history_payload,
 )
@@ -1095,14 +1094,11 @@ async def get_thread_history(
         checkpoint_state = await checkpoint_store.load(current_thread_id)
         return list(checkpoint_state.messages) if checkpoint_state is not None else []
 
-    history_transport = ThreadHistoryTransport(
-        load_live_messages=_load_live_messages,
-        load_checkpoint_messages=_load_checkpoint_messages,
-    )
     set_current_thread_id(thread_id)
     return await get_thread_history_payload(
         thread_id=thread_id,
-        history_transport=history_transport,
+        load_live_messages=_load_live_messages,
+        load_checkpoint_messages=_load_checkpoint_messages,
         limit=limit,
         truncate=truncate,
     )

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -13,7 +13,7 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     reads_owner = importlib.import_module("backend.threads.events.reads")
     buffer_owner = importlib.import_module("backend.threads.events.buffer")
 
-    assert history_owner.ThreadHistoryTransport is not None
+    assert history_owner.get_thread_history_payload is not None
     assert projection_owner.canonical_owner_threads is not None
     assert convergence_owner.inspect_owner_thread_runtime is not None
     assert sandbox_owner.resolve_thread_sandbox is not None

--- a/tests/Unit/backend/web/services/test_thread_runtime_owner.py
+++ b/tests/Unit/backend/web/services/test_thread_runtime_owner.py
@@ -28,7 +28,7 @@ def test_trace_read_service_uses_thread_runtime_history_owner() -> None:
     trace_source = inspect.getsource(importlib.import_module("backend.monitor.infrastructure.read_models.trace_read_service"))
 
     assert "from backend.thread_history import build_thread_history_transport, get_thread_history_payload" not in trace_source
-    assert "from backend.threads.history import ThreadHistoryTransport, get_thread_history_payload" in trace_source
+    assert "from backend.threads.history import get_thread_history_payload" in trace_source
 
 
 def test_thread_runtime_convergence_does_not_import_web_compat_shell() -> None:

--- a/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
@@ -81,7 +81,7 @@ def test_monitor_trace_uses_trace_read_source_port():
     assert "trace_read_service" in trace_source
     assert "get_thread_history_payload" in read_source
     assert "get_thread_history_payload(app=" not in read_source
-    assert "ThreadHistoryTransport(" in read_source
+    assert "load_live_messages=_load_live_messages" in read_source
     assert "from backend.threads.events.reads import build_run_event_read_transport" in read_source
     assert "from backend.threads.sandbox_resolution import resolve_thread_sandbox" in read_source
     assert "backend.run_event_reads" not in read_source


### PR DESCRIPTION
## Summary
- delete the remaining `ThreadHistoryTransport` state wrapper from backend/threads/history.py
- have the two production call sites pass the live/checkpoint loaders directly into `get_thread_history_payload(...)`
- tighten the focused owner/source-guard tests to reflect the smaller history read surface

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Integration/test_query_loop_backend_contracts.py -k "thread_history or trace_read_service or event_buffer_owner or get_thread_history"
- uv run ruff check backend/threads/history.py backend/monitor/infrastructure/read_models/trace_read_service.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
- git diff --check -- backend/threads/history.py backend/monitor/infrastructure/read_models/trace_read_service.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_thread_runtime_owner.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
