### PR TITLE
refactor: delete run event read shell

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.events.reads import build_run_event_read_transport
+from backend.threads.events.reads import _resolve_run_event_repo
 from backend.threads.history import get_thread_history_payload
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
@@ -53,11 +53,11 @@ def build_monitor_trace_reader(app: Any) -> MonitorTraceReader:
         )
 
     def _load_latest_run_events(thread_id: str) -> tuple[str | None, list[dict[str, Any]]]:
-        transport = build_run_event_read_transport()
-        run_id = transport.latest_run_id(thread_id)
+        repo = _resolve_run_event_repo(None)
+        run_id = repo.latest_run_id(thread_id)
         if run_id is None:
             return None, []
-        return run_id, transport.list_events(thread_id, run_id, after=0, limit=1000)
+        return run_id, repo.list_events(thread_id, run_id, after=0, limit=1000)
 
     return MonitorTraceReader(
         load_thread_history_payload=_load_thread_history_payload,

--- a/backend/threads/events/reads.py
+++ b/backend/threads/events/reads.py
@@ -28,16 +28,3 @@ def _resolve_run_event_repo(run_event_repo: RunEventRepo | None) -> RunEventRepo
     container = build_storage_container()
     _default_run_event_repo = container.run_event_repo()
     return _default_run_event_repo
-
-
-def build_run_event_read_transport(run_event_repo: RunEventRepo | None = None) -> RunEventReadTransport:
-    repo = _resolve_run_event_repo(run_event_repo)
-    return RunEventReadTransport(
-        latest_run_id=lambda thread_id: repo.latest_run_id(thread_id),
-        list_events=lambda thread_id, run_id, *, after=0, limit=1000: repo.list_events(
-            thread_id,
-            run_id,
-            after=after,
-            limit=limit,
-        ),
-    )

--- a/tests/Unit/backend/web/services/test_event_buffer_owner.py
+++ b/tests/Unit/backend/web/services/test_event_buffer_owner.py
@@ -17,7 +17,7 @@ def test_thread_runtime_namespace_exports_legacy_helpers() -> None:
     assert projection_owner.canonical_owner_threads is not None
     assert convergence_owner.inspect_owner_thread_runtime is not None
     assert sandbox_owner.resolve_thread_sandbox is not None
-    assert reads_owner.build_run_event_read_transport is not None
+    assert reads_owner.RunEventReadTransport is not None
     assert buffer_owner.ThreadEventBuffer is not None
     assert buffer_owner.RunEventBuffer is not None
 

--- a/tests/Unit/backend/web/services/test_event_store.py
+++ b/tests/Unit/backend/web/services/test_event_store.py
@@ -42,7 +42,7 @@ async def test_read_events_after_fails_loudly_when_default_run_event_repo_is_una
         await event_store.read_events_after("thread-1", "run-1")
 
 
-def test_build_run_event_read_transport_uses_repo_boundary() -> None:
+def test_run_event_read_transport_uses_repo_boundary() -> None:
     calls: list[tuple[str, tuple, dict]] = []
 
     class _Repo:
@@ -54,7 +54,8 @@ def test_build_run_event_read_transport_uses_repo_boundary() -> None:
             calls.append(("list_events", (thread_id, run_id), {"after": after, "limit": limit}))
             return [{"seq": 1, "event_type": "delta", "data": {"text": "hello"}}]
 
-    transport = event_store_reads.build_run_event_read_transport(_Repo())
+    repo = _Repo()
+    transport = event_store_reads.RunEventReadTransport(latest_run_id=repo.latest_run_id, list_events=repo.list_events)
 
     assert transport.latest_run_id("thread-1") == "run-1"
     assert transport.list_events("thread-1", "run-1", after=3, limit=50) == [{"seq": 1, "event_type": "delta", "data": {"text": "hello"}}]
@@ -75,4 +76,4 @@ def test_run_event_store_write_owner_lives_under_backend_thread_runtime_events()
     assert hasattr(owner_module, "get_run_start_seq")
     assert hasattr(owner_module, "get_latest_run_id")
     assert hasattr(owner_module, "cleanup_old_runs")
-    assert hasattr(read_owner_module, "build_run_event_read_transport")
+    assert hasattr(read_owner_module, "RunEventReadTransport")

--- a/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
@@ -82,12 +82,12 @@ def test_monitor_trace_uses_trace_read_source_port():
     assert "get_thread_history_payload" in read_source
     assert "get_thread_history_payload(app=" not in read_source
     assert "load_live_messages=_load_live_messages" in read_source
-    assert "from backend.threads.events.reads import build_run_event_read_transport" in read_source
+    assert "from backend.threads.events.reads import _resolve_run_event_repo" in read_source
     assert "from backend.threads.sandbox_resolution import resolve_thread_sandbox" in read_source
     assert "backend.run_event_reads" not in read_source
     assert "backend.thread_sandbox" not in read_source
     assert "build_storage_container" not in read_source
-    assert "build_run_event_read_transport" in read_source
+    assert "repo = _resolve_run_event_repo(None)" in read_source
     assert "backend.web.services.thread_history_service" not in read_source
     assert "backend.threads.activity_pool_service" not in read_source
     assert "backend.web.services.event_store" not in read_source


### PR DESCRIPTION
## Summary
- delete the `build_run_event_read_transport(...)` constructor shell from backend/threads/events/reads.py
- have monitor trace reading talk to the run-event read owner directly via `_resolve_run_event_repo(...)`
- tighten the focused event-store / monitor boundary tests to reflect the smaller read surface

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_event_store.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Integration/test_query_loop_backend_contracts.py -k "event_store or thread_history or trace_read_service or event_buffer_owner or get_thread_history"
- uv run ruff check backend/threads/events/reads.py backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_event_store.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
- git diff --check -- backend/threads/events/reads.py backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/backend/web/services/test_event_buffer_owner.py tests/Unit/backend/web/services/test_event_store.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
