### PR TITLE
refactor: delete web virtual thread duplicate

### DIFF
--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -10,11 +10,6 @@ from storage.runtime import (
 )
 
 
-def is_virtual_thread_id(thread_id: str | None) -> bool:
-    """Check if thread_id is a virtual thread (wrapped in parentheses)."""
-    return bool(thread_id) and thread_id.startswith("(") and thread_id.endswith(")")
-
-
 def extract_webhook_instance_id(payload: dict[str, Any]) -> str | None:
     """Extract provider sandbox-runtime instance id from webhook payload."""
     direct_keys = ("session_id", "sandbox_id", "instance_id", "id")


### PR DESCRIPTION
## Summary
- delete the unused duplicate `is_virtual_thread_id(...)` helper from backend/web/utils/helpers.py
- keep the neutral owner only under backend/threads/virtual_threads.py
- preserve behavior because no remaining production or test call sites depend on the web duplicate

## Verification
- rg -n "helpers\.is_virtual_thread_id|from backend\.web\.utils\.helpers import is_virtual_thread_id|def is_virtual_thread_id\(" backend tests
- uv run ruff check backend/web/utils/helpers.py
- git diff --check -- backend/web/utils/helpers.py
