### PR TITLE
refactor: delete message class name helper

### DIFF
--- a/backend/threads/interruption.py
+++ b/backend/threads/interruption.py
@@ -9,22 +9,17 @@ from langchain_core.messages import ToolMessage
 _INTERRUPTED_RESULT = "Error: task was interrupted (server restart or timeout). Results unavailable."
 
 
-def _message_class_name(message: Any) -> str:
-    cls = getattr(message, "__class__", None)
-    return getattr(cls, "__name__", "")
-
-
 def repair_interrupted_tool_call_messages(messages: list[Any]) -> list[Any]:
     matched_tool_call_ids = {
         str(getattr(msg, "tool_call_id"))
         for msg in messages
-        if _message_class_name(msg) == "ToolMessage" and getattr(msg, "tool_call_id", None)
+        if getattr(getattr(msg, "__class__", None), "__name__", "") == "ToolMessage" and getattr(msg, "tool_call_id", None)
     }
     repaired: list[Any] = []
 
     for msg in messages:
         repaired.append(msg)
-        if _message_class_name(msg) != "AIMessage":
+        if getattr(getattr(msg, "__class__", None), "__name__", "") != "AIMessage":
             continue
         tool_calls = getattr(msg, "tool_calls", []) or []
         # @@@interrupted-tool-repair-order - insert synthetic interrupted ToolMessages


### PR DESCRIPTION
## Summary
- delete the tiny `_message_class_name(...)` helper from backend/threads/interruption.py
- inline the class-name check at the two actual use sites
- keep interruption repair behavior unchanged while shrinking one internal helper layer

## Verification
- uv run pytest -q tests/Integration/test_query_loop_backend_contracts.py tests/Integration/test_child_thread_live_contract.py -k "get_thread_history or interrupted or cold_rebuild or terminal_notifications"
- uv run ruff check backend/threads/interruption.py
- git diff --check -- backend/threads/interruption.py
