### PR TITLE
refactor: inline run event read owner

### DIFF
--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.events.reads import _resolve_run_event_repo
+from backend.threads.events import reads as event_store_reads
 from backend.threads.history import get_thread_history_payload
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from sandbox.thread_context import set_current_thread_id
@@ -53,7 +53,10 @@ def build_monitor_trace_reader(app: Any) -> MonitorTraceReader:
         )
 
     def _load_latest_run_events(thread_id: str) -> tuple[str | None, list[dict[str, Any]]]:
-        repo = _resolve_run_event_repo(None)
+        repo = event_store_reads._default_run_event_repo
+        if repo is None:
+            repo = event_store_reads.build_storage_container().run_event_repo()
+            event_store_reads._default_run_event_repo = repo
         run_id = repo.latest_run_id(thread_id)
         if run_id is None:
             return None, []

--- a/backend/threads/events/reads.py
+++ b/backend/threads/events/reads.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from storage.contracts import RunEventRepo
-from storage.runtime import build_storage_container
 
 _default_run_event_repo: RunEventRepo | None = None
 
@@ -15,16 +14,3 @@ _default_run_event_repo: RunEventRepo | None = None
 class RunEventReadTransport:
     latest_run_id: Any
     list_events: Any
-
-
-def _resolve_run_event_repo(run_event_repo: RunEventRepo | None) -> RunEventRepo:
-    if run_event_repo is not None:
-        return run_event_repo
-
-    global _default_run_event_repo
-    if _default_run_event_repo is not None:
-        return _default_run_event_repo
-
-    container = build_storage_container()
-    _default_run_event_repo = container.run_event_repo()
-    return _default_run_event_repo

--- a/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
@@ -82,12 +82,13 @@ def test_monitor_trace_uses_trace_read_source_port():
     assert "get_thread_history_payload" in read_source
     assert "get_thread_history_payload(app=" not in read_source
     assert "load_live_messages=_load_live_messages" in read_source
-    assert "from backend.threads.events.reads import _resolve_run_event_repo" in read_source
+    assert "from backend.threads.events import reads as event_store_reads" in read_source
     assert "from backend.threads.sandbox_resolution import resolve_thread_sandbox" in read_source
     assert "backend.run_event_reads" not in read_source
     assert "backend.thread_sandbox" not in read_source
-    assert "build_storage_container" not in read_source
-    assert "repo = _resolve_run_event_repo(None)" in read_source
+    assert "from storage.runtime import build_storage_container" not in read_source
+    assert "repo = event_store_reads._default_run_event_repo" in read_source
+    assert "event_store_reads.build_storage_container().run_event_repo()" in read_source
     assert "backend.web.services.thread_history_service" not in read_source
     assert "backend.threads.activity_pool_service" not in read_source
     assert "backend.web.services.event_store" not in read_source


### PR DESCRIPTION
## Summary
- delete the remaining `_resolve_run_event_repo(...)` helper from backend/threads/events/reads.py
- have monitor trace reading resolve the cached/default repo directly through the reads owner module
- tighten the focused monitor boundary test to the new direct-owner truth

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_event_store.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py tests/Unit/backend/web/services/test_thread_runtime_owner.py -k "event_store or trace_read_service or monitor_trace"
- uv run ruff check backend/threads/events/reads.py backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
- git diff --check -- backend/threads/events/reads.py backend/monitor/infrastructure/read_models/trace_read_service.py tests/Unit/monitor/test_monitor_sandbox_read_boundary.py
