### PR TITLE
refactor: inline thread projection comparison

### DIFF
--- a/backend/threads/projection.py
+++ b/backend/threads/projection.py
@@ -7,16 +7,6 @@ from typing import Any
 from storage.runtime import build_thread_repo, build_user_repo
 
 
-def _branch_index(row: dict[str, Any]) -> int:
-    return int(row.get("branch_index") or 0)
-
-
-def _is_better_canonical_thread(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
-    if bool(candidate.get("is_main")) != bool(current.get("is_main")):
-        return bool(candidate.get("is_main"))
-    return _branch_index(candidate) < _branch_index(current)
-
-
 def canonical_owner_threads(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return one user-visible thread per agent user, preserving first agent order."""
     order: list[str] = []
@@ -29,7 +19,12 @@ def canonical_owner_threads(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             order.append(agent_user_id)
             by_agent[agent_user_id] = row
             continue
-        if _is_better_canonical_thread(row, by_agent[agent_user_id]):
+        current = by_agent[agent_user_id]
+        if bool(row.get("is_main")) != bool(current.get("is_main")):
+            if bool(row.get("is_main")):
+                by_agent[agent_user_id] = row
+            continue
+        if int(row.get("branch_index") or 0) < int(current.get("branch_index") or 0):
             by_agent[agent_user_id] = row
     return [by_agent[agent_user_id] for agent_user_id in order]
 


### PR DESCRIPTION
## Summary
- inline the tiny `_branch_index(...)` / `_is_better_canonical_thread(...)` helpers into `canonical_owner_threads(...)`
- keep thread projection behavior unchanged while shrinking one internal comparison layer
- leave the public projection surface untouched

## Verification
- uv run pytest -q tests/Unit/monitor/test_thread_workbench_projection.py tests/Integration/test_schema_redesign_baseline_contract.py -k "canonical_owner_threads or thread_owners or workbench"
- uv run ruff check backend/threads/projection.py
- git diff --check -- backend/threads/projection.py
