### PR TITLE
refactor: inline cancelled run input check

### DIFF
--- a/backend/threads/run/cancellation.py
+++ b/backend/threads/run/cancellation.py
@@ -33,20 +33,6 @@ def partition_terminal_followups(items: list[Any]) -> tuple[list[Any], list[Any]
         else:
             passthrough.append(item)
     return terminal, passthrough
-
-
-def _message_metadata_dict(message_metadata: dict[str, Any] | None) -> dict[str, Any]:
-    return dict(message_metadata or {})
-
-
-def _message_already_persisted(message: Any, *, content: str, metadata: dict[str, Any]) -> bool:
-    if message.__class__.__name__ != "HumanMessage":
-        return False
-    if getattr(message, "content", None) != content:
-        return False
-    return (getattr(message, "metadata", None) or {}) == metadata
-
-
 async def persist_cancelled_run_input_if_missing(
     *,
     agent: Any,
@@ -60,10 +46,15 @@ async def persist_cancelled_run_input_if_missing(
 
     from langchain_core.messages import HumanMessage
 
-    metadata = _message_metadata_dict(message_metadata)
+    metadata = dict(message_metadata or {})
     state = await graph.aget_state(config)
     persisted = list((getattr(state, "values", None) or {}).get("messages", []))
-    if persisted and _message_already_persisted(persisted[-1], content=message, metadata=metadata):
+    if (
+        persisted
+        and persisted[-1].__class__.__name__ == "HumanMessage"
+        and getattr(persisted[-1], "content", None) == message
+        and (getattr(persisted[-1], "metadata", None) or {}) == metadata
+    ):
         return
 
     # @@@cancelled-run-input-persist - a started run has already accepted this

--- a/backend/threads/run/cancellation.py
+++ b/backend/threads/run/cancellation.py
@@ -33,6 +33,8 @@ def partition_terminal_followups(items: list[Any]) -> tuple[list[Any], list[Any]
         else:
             passthrough.append(item)
     return terminal, passthrough
+
+
 async def persist_cancelled_run_input_if_missing(
     *,
     agent: Any,


### PR DESCRIPTION
## Summary
- inline the tiny `_message_metadata_dict(...)` and `_message_already_persisted(...)` helpers into `persist_cancelled_run_input_if_missing(...)`
- keep cancellation persistence behavior unchanged while shrinking one internal helper layer
- leave the rest of the cancellation surface untouched

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_streaming_eval_writer.py tests/Integration/test_query_loop_backend_contracts.py -k "cancellation or persist_cancelled_run_input_if_missing or terminal_notifications or owner_steer"
- uv run ruff check backend/threads/run/cancellation.py
- git diff --check -- backend/threads/run/cancellation.py
