### PR TITLE
refactor: inline sandbox status display

### DIFF
--- a/backend/threads/state.py
+++ b/backend/threads/state.py
@@ -6,18 +6,6 @@ from typing import Any
 from backend.threads.binding import resolve_thread_runtime_binding
 
 
-def _display_repo_sandbox_status(runtime_row: dict[str, Any], instance: dict[str, Any]) -> str:
-    observed = runtime_row.get("observed_state")
-    if observed in {None, "", "detached"}:
-        status = instance.get("status")
-        if not isinstance(status, str) or not status:
-            raise RuntimeError("Sandbox instance missing status")
-        return status
-    if not isinstance(observed, str):
-        raise RuntimeError("Sandbox runtime observed_state must be a string when present")
-    return observed
-
-
 def _runtime_row_from_binding(runtime_repo: Any, binding: Any) -> dict[str, Any] | None:
     provider_env_id = str(binding.provider_env_id or "").strip()
     if not provider_env_id:
@@ -49,7 +37,16 @@ def get_sandbox_info(app: Any, thread_id: str, sandbox_type: str) -> dict[str, A
             return sandbox_info
         instance = runtime_row.get("_instance")
         if instance:
-            sandbox_info["status"] = _display_repo_sandbox_status(runtime_row, instance)
+            observed = runtime_row.get("observed_state")
+            if observed in {None, "", "detached"}:
+                status = instance.get("status")
+                if not isinstance(status, str) or not status:
+                    raise RuntimeError("Sandbox instance missing status")
+                sandbox_info["status"] = status
+            elif not isinstance(observed, str):
+                raise RuntimeError("Sandbox runtime observed_state must be a string when present")
+            else:
+                sandbox_info["status"] = observed
         else:
             sandbox_info["status"] = "detached"
     except Exception as exc:


### PR DESCRIPTION
## Summary
- inline the tiny `_display_repo_sandbox_status(...)` helper into `get_sandbox_info(...)`
- keep thread sandbox state behavior unchanged while shrinking one internal helper layer
- leave the rest of the thread state surface untouched

## Verification
- uv run pytest -q tests/Unit/backend/web/services/test_thread_state_service.py
- uv run ruff check backend/threads/state.py
- git diff --check -- backend/threads/state.py
