### PR TITLE
refactor: delete monitor evaluation read shell

### DIFF
--- a/backend/monitor/application/use_cases/evaluation.py
+++ b/backend/monitor/application/use_cases/evaluation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from backend.monitor.infrastructure.evaluation import evaluation_execution_service, evaluation_read_service
+from backend.monitor.infrastructure.evaluation import evaluation_execution_service, evaluation_storage_service
 from backend.monitor.infrastructure.evaluation.evaluation_scheduler import EvaluationJobScheduler, EvaluationJobSpec
 
 
@@ -41,7 +41,7 @@ def _build_monitor_evaluation_run_row(run: dict[str, Any], metrics_rows: list[di
 
 
 def get_monitor_evaluation_workbench() -> dict[str, Any]:
-    store = evaluation_read_service.make_trajectory_store()
+    store = evaluation_storage_service.make_trajectory_store()
     runs = store.list_runs(limit=25)
     if not runs:
         return {
@@ -88,18 +88,18 @@ def get_monitor_evaluation_workbench() -> dict[str, Any]:
 
 
 def get_monitor_evaluation_run_detail(run_id: str) -> dict[str, Any]:
-    store = evaluation_read_service.make_trajectory_store()
+    store = evaluation_storage_service.make_trajectory_store()
     run = store.get_run(run_id)
     if run is None:
         raise KeyError(f"Evaluation run not found: {run_id}")
     run_row = _build_monitor_evaluation_run_row(run, store.get_metrics(run_id))
     detail = {"run": run_row, "facts": run_row["facts"], "limitations": []}
-    detail["batch_run"] = evaluation_read_service.make_eval_batch_service().get_batch_run_for_eval_run(run_id)
+    detail["batch_run"] = evaluation_storage_service.make_eval_batch_service().get_batch_run_for_eval_run(run_id)
     return detail
 
 
 def get_monitor_evaluation_batches(limit: int = 50) -> dict[str, Any]:
-    items = evaluation_read_service.make_eval_batch_service().list_batches(limit=limit)
+    items = evaluation_storage_service.make_eval_batch_service().list_batches(limit=limit)
     return {
         "items": items,
         "count": len(items),
@@ -129,7 +129,7 @@ def create_monitor_evaluation_batch(
     sandbox: str,
     max_concurrent: int,
 ) -> dict[str, Any]:
-    batch = evaluation_read_service.make_eval_batch_service().create_batch(
+    batch = evaluation_storage_service.make_eval_batch_service().create_batch(
         submitted_by_user_id=submitted_by_user_id,
         agent_user_id=agent_user_id,
         scenario_ids=scenario_ids,
@@ -146,7 +146,7 @@ def start_monitor_evaluation_batch(
     token: str,
     scheduler: EvaluationJobScheduler,
 ) -> dict[str, Any]:
-    batch_service = evaluation_read_service.make_eval_batch_service()
+    batch_service = evaluation_storage_service.make_eval_batch_service()
     detail = batch_service.get_batch_detail(batch_id)
     batch = detail["batch"]
     config = batch.get("config_json") or {}
@@ -177,4 +177,4 @@ def start_monitor_evaluation_batch(
 
 
 def get_monitor_evaluation_batch_detail(batch_id: str) -> dict[str, Any]:
-    return evaluation_read_service.make_eval_batch_service().get_batch_detail(batch_id)
+    return evaluation_storage_service.make_eval_batch_service().get_batch_detail(batch_id)

--- a/backend/monitor/infrastructure/evaluation/background_task_scheduler.py
+++ b/backend/monitor/infrastructure/evaluation/background_task_scheduler.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from backend.monitor.infrastructure.evaluation.evaluation_execution_service import run_monitor_evaluation_batch
-from backend.monitor.infrastructure.evaluation.evaluation_read_service import make_eval_batch_service
 from backend.monitor.infrastructure.evaluation.evaluation_scheduler import EvaluationJobScheduler, EvaluationJobSpec
+from backend.monitor.infrastructure.evaluation.evaluation_storage_service import make_eval_batch_service
 
 
 class BackgroundTaskEvaluationScheduler(EvaluationJobScheduler):

--- a/backend/monitor/infrastructure/evaluation/evaluation_read_service.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_read_service.py
@@ -1,13 +1,1 @@
 """Monitor evaluation read-source boundary."""
-
-from __future__ import annotations
-
-from backend.monitor.infrastructure.evaluation import evaluation_storage_service
-
-
-def make_trajectory_store():
-    return evaluation_storage_service.make_trajectory_store()
-
-
-def make_eval_batch_service():
-    return evaluation_storage_service.make_eval_batch_service()

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -17,7 +17,7 @@ from backend.monitor.infrastructure.evaluation import (
     evaluation_execution_service as monitor_evaluation_execution_service,
 )
 from backend.monitor.infrastructure.evaluation import (
-    evaluation_read_service as monitor_evaluation_read_service,
+    evaluation_storage_service as monitor_evaluation_storage_service,
 )
 from backend.monitor.infrastructure.persistence import operation_repo as monitor_operation_repo_service
 from backend.monitor.infrastructure.providers import (
@@ -50,7 +50,7 @@ def _default_eval_batch_service(monkeypatch):
         def list_batch_runs_for_thread(self, _thread_id):
             return []
 
-    monkeypatch.setattr(monitor_evaluation_read_service, "make_eval_batch_service", lambda: FakeBatchService())
+    monkeypatch.setattr(monitor_evaluation_storage_service, "make_eval_batch_service", lambda: FakeBatchService())
 
 
 @pytest.fixture(autouse=True)
@@ -369,7 +369,7 @@ def test_create_monitor_evaluation_batch_uses_batch_service(monkeypatch):
             calls.append(kwargs)
             return {"batch_id": "batch-created", "status": "pending"}
 
-    monkeypatch.setattr(monitor_evaluation_read_service, "make_eval_batch_service", lambda: FakeBatchService())
+    monkeypatch.setattr(monitor_evaluation_storage_service, "make_eval_batch_service", lambda: FakeBatchService())
 
     payload = monitor_evaluation_service.create_monitor_evaluation_batch(
         submitted_by_user_id="owner-1",
@@ -425,7 +425,7 @@ def test_start_monitor_evaluation_batch_schedules_runner_with_explicit_execution
             return {"batch_id": batch_id, "status": status}
 
     monkeypatch.setattr(monitor_evaluation_execution_service, "EVAL_SCENARIO_DIR", scenario_dir)
-    monkeypatch.setattr(monitor_evaluation_read_service, "make_eval_batch_service", lambda: FakeBatchService())
+    monkeypatch.setattr(monitor_evaluation_storage_service, "make_eval_batch_service", lambda: FakeBatchService())
 
     class _Scheduler:
         def submit(self, spec):

--- a/tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
+++ b/tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
@@ -28,7 +28,7 @@ class _FakeBatchSvc:
 
 
 def test_start_batch_submits_typed_spec_to_scheduler(monkeypatch):
-    monkeypatch.setattr(monitor_evaluation_service.evaluation_read_service, "make_eval_batch_service", lambda: _FakeBatchSvc())
+    monkeypatch.setattr(monitor_evaluation_service.evaluation_storage_service, "make_eval_batch_service", lambda: _FakeBatchSvc())
     monkeypatch.setattr(
         monitor_evaluation_service.evaluation_execution_service,
         "select_monitor_eval_scenarios",


### PR DESCRIPTION
## Summary
- delete the empty `monitor/infrastructure/evaluation/evaluation_read_service.py` wrappers
- point monitor evaluation reads and the background-task scheduler directly at `evaluation_storage_service`
- update the focused monitor tests to patch the real owner instead of the deleted shell

## Verification
- uv run pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py -k "evaluation"
- uv run ruff check backend/monitor/infrastructure/evaluation/evaluation_read_service.py backend/monitor/application/use_cases/evaluation.py backend/monitor/infrastructure/evaluation/background_task_scheduler.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
- git diff --check -- backend/monitor/infrastructure/evaluation/evaluation_read_service.py backend/monitor/application/use_cases/evaluation.py backend/monitor/infrastructure/evaluation/background_task_scheduler.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
