### PR TITLE
refactor: delete empty evaluation read file

### DIFF
--- a/backend/monitor/infrastructure/evaluation/evaluation_read_service.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_read_service.py
@@ -1,1 +1,0 @@
-"""Monitor evaluation read-source boundary."""


### PR DESCRIPTION
## Summary
- delete the now-empty `backend/monitor/infrastructure/evaluation/evaluation_read_service.py`
- keep monitor evaluation read paths unchanged because all live callers already moved to `evaluation_storage_service`
- leave the focused evaluation tests unchanged

## Verification
- uv run pytest -q tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py -k "evaluation"
- uv run ruff check backend/monitor/application/use_cases/evaluation.py backend/monitor/infrastructure/evaluation/background_task_scheduler.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/monitor/test_monitor_evaluation_scheduler_boundary.py
- git diff --check -- backend/monitor/infrastructure/evaluation/evaluation_read_service.py
