### PR TITLE
refactor: inline webhook instance id

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -23,21 +23,13 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
     """Ingest provider webhook and converge matched sandbox runtime state."""
     direct_keys = ("session_id", "sandbox_id", "instance_id", "id")
     instance_id = next(
-        (
-            value
-            for key in direct_keys
-            if isinstance((value := payload.get(key)), str) and value
-        ),
+        (value for key in direct_keys if isinstance((value := payload.get(key)), str) and value),
         None,
     )
     if instance_id is None and isinstance(payload.get("data"), dict):
         nested = payload["data"]
         instance_id = next(
-            (
-                value
-                for key in direct_keys
-                if isinstance((value := nested.get(key)), str) and value
-            ),
+            (value for key in direct_keys if isinstance((value := nested.get(key)), str) and value),
             None,
         )
     if not instance_id:

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -6,7 +6,6 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 
 from backend.sandboxes.inventory import init_providers_and_managers
-from backend.web.utils.helpers import extract_webhook_instance_id
 from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.runtime_handle import sandbox_runtime_from_row
 from storage.container_cache import get_storage_container as _get_container
@@ -22,7 +21,25 @@ def _public_provider_event(row: dict[str, Any]) -> dict[str, Any]:
 @router.post("/{provider_name}")
 async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Ingest provider webhook and converge matched sandbox runtime state."""
-    instance_id = extract_webhook_instance_id(payload)
+    direct_keys = ("session_id", "sandbox_id", "instance_id", "id")
+    instance_id = next(
+        (
+            value
+            for key in direct_keys
+            if isinstance((value := payload.get(key)), str) and value
+        ),
+        None,
+    )
+    if instance_id is None and isinstance(payload.get("data"), dict):
+        nested = payload["data"]
+        instance_id = next(
+            (
+                value
+                for key in direct_keys
+                if isinstance((value := nested.get(key)), str) and value
+            ),
+            None,
+        )
     if not instance_id:
         raise HTTPException(400, "Webhook payload missing instance/session id")
 

--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -9,25 +9,6 @@ from storage.runtime import (
     build_thread_repo,
 )
 
-
-def extract_webhook_instance_id(payload: dict[str, Any]) -> str | None:
-    """Extract provider sandbox-runtime instance id from webhook payload."""
-    direct_keys = ("session_id", "sandbox_id", "instance_id", "id")
-    for key in direct_keys:
-        value = payload.get(key)
-        if isinstance(value, str) and value:
-            return value
-
-    nested = payload.get("data")
-    if isinstance(nested, dict):
-        for key in direct_keys:
-            value = nested.get(key)
-            if isinstance(value, str) and value:
-                return value
-
-    return None
-
-
 _cached_thread_repo = None
 
 


### PR DESCRIPTION
## Summary
- inline `extract_webhook_instance_id(...)` into the only production caller in backend/web/routers/webhooks.py
- delete the now-unused single-purpose helper from backend/web/utils/helpers.py
- keep webhook behavior unchanged while shrinking one helper layer

## Verification
- uv run pytest -q tests/Integration/test_webhooks_router_contract.py tests/Unit/backend/web/routers/test_webhooks_naming.py
- uv run ruff check backend/web/routers/webhooks.py backend/web/utils/helpers.py
- git diff --check -- backend/web/routers/webhooks.py backend/web/utils/helpers.py
