### PR TITLE
test: delete implementation location guards

### DIFF
--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -4,10 +4,6 @@ from fastapi.testclient import TestClient
 from backend.chat.api.http import app_router as owner_chat_app_router
 
 
-def test_chat_app_router_owner_module_lives_under_backend_chat() -> None:
-    assert owner_chat_app_router.__name__ == "backend.chat.api.http.app_router"
-
-
 def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> None:
     app = FastAPI()
     app.include_router(owner_chat_app_router.router)

--- a/tests/Integration/test_chat_first_screen_owner_threads.py
+++ b/tests/Integration/test_chat_first_screen_owner_threads.py
@@ -11,10 +11,6 @@ from backend.chat.api.http import conversations_router as owner_conversations_ro
 from backend.web.routers import threads as threads_router
 
 
-def test_first_screen_conversations_router_owner_module_lives_under_backend_chat() -> None:
-    assert owner_conversations_router.__name__ == "backend.chat.api.http.conversations_router"
-
-
 class _CountingOwnerThreadRepo:
     def __init__(self) -> None:
         self.calls = 0

--- a/tests/Integration/test_conversations_router.py
+++ b/tests/Integration/test_conversations_router.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib
 import threading
 from types import SimpleNamespace
 
@@ -8,15 +7,6 @@ import pytest
 
 from backend.chat.api.http import conversations_router as owner_conversations_router
 from backend.identity.avatar.urls import avatar_url
-
-
-def test_conversations_http_owner_module_lives_under_backend_chat() -> None:
-    assert owner_conversations_router.__name__ == "backend.chat.api.http.conversations_router"
-
-
-def test_conversations_router_shell_is_deleted() -> None:
-    with pytest.raises(ModuleNotFoundError):
-        importlib.import_module("backend.web.routers.conversations")
 
 
 async def _list_conversations(app: SimpleNamespace, user_id: str = "human-user-1"):

--- a/tests/Integration/test_messaging_router.py
+++ b/tests/Integration/test_messaging_router.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib
 import inspect
 from types import SimpleNamespace
 
@@ -120,15 +119,6 @@ def test_messaging_crud_routes_are_sync_threadpool_boundaries() -> None:
 
     assert [fn.__name__ for fn in sync_routes if inspect.iscoroutinefunction(fn)] == []
     assert inspect.iscoroutinefunction(chats_router.stream_chat_events)
-
-
-def test_chat_http_owner_module_lives_under_backend_chat() -> None:
-    assert chats_router.__name__ == "backend.chat.api.http.chats_router"
-
-
-def test_messaging_router_shell_is_deleted() -> None:
-    with pytest.raises(ModuleNotFoundError):
-        importlib.import_module("backend.web.routers.messaging")
 
 
 def test_get_accessible_chat_or_404_returns_chat():

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -63,21 +63,3 @@ def test_agent_runtime_gateway_handler_injection_is_typed() -> None:
     assert "app" not in constructor_hints
     assert "AgentChatRuntimeHandler" in str(constructor_hints["chat_handlers"])
     assert constructor_hints["thread_input_handler"] == gateway_module.AgentThreadInputRuntimeHandler | None
-
-
-def test_agent_runtime_implementation_lives_under_backend_agent_runtime() -> None:
-    gateway_impl = importlib.import_module("backend.threads.chat_adapters.gateway")
-    bootstrap_impl = importlib.import_module("backend.threads.chat_adapters.bootstrap")
-    port_impl = importlib.import_module("backend.threads.chat_adapters.port")
-    chat_handler_impl = importlib.import_module("backend.threads.chat_adapters.chat_handler")
-    thread_handler_impl = importlib.import_module("backend.threads.chat_adapters.thread_handler")
-
-    assert gateway_impl.NativeAgentRuntimeGateway.__module__ == "backend.threads.chat_adapters.gateway"
-    assert bootstrap_impl.build_agent_runtime_state.__module__ == "backend.threads.chat_adapters.bootstrap"
-    assert port_impl.get_agent_runtime_gateway.__module__ == "backend.threads.chat_adapters.port"
-    assert chat_handler_impl.NativeAgentChatDeliveryHandler.__module__ == "backend.threads.chat_adapters.chat_handler"
-    assert thread_handler_impl.NativeAgentThreadInputHandler.__module__ == "backend.threads.chat_adapters.thread_handler"
-    assert gateway_impl.NativeAgentRuntimeGateway is not None
-    assert port_impl.get_agent_runtime_gateway is not None
-    assert chat_handler_impl.NativeAgentChatDeliveryHandler is not None
-    assert thread_handler_impl.NativeAgentThreadInputHandler is not None


### PR DESCRIPTION
## Summary
- Remove tests that only assert modules/classes live under specific implementation paths.
- Remove old router shell deletion tombstones from chat integration tests.
- Keep route behavior, OpenAPI, protocol typing, and E2B SDK error behavior tests.

Net: +0 / -46.

## Verification
- uv run python -m pytest -q
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check