### PR TITLE
test: delete owner name guards

### DIFF
--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -65,14 +65,6 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
     assert thread_input_handler.called_with is thread_envelope
 
 
-def test_split_handler_modules_are_the_behavior_owners() -> None:
-    from backend.threads.chat_adapters.chat_handler import NativeAgentChatDeliveryHandler
-    from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
-
-    assert NativeAgentChatDeliveryHandler.__name__ == "NativeAgentChatDeliveryHandler"
-    assert NativeAgentThreadInputHandler.__name__ == "NativeAgentThreadInputHandler"
-
-
 def test_gateway_rejects_single_chat_handler_entrypoint() -> None:
     constructor: Any = NativeAgentRuntimeGateway
     with pytest.raises(TypeError, match="chat_handler"):

--- a/tests/Unit/backend/web/services/test_event_store.py
+++ b/tests/Unit/backend/web/services/test_event_store.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import importlib
-
 import pytest
 
 from backend.threads.events import reads as event_store_reads
@@ -63,17 +61,3 @@ def test_run_event_read_transport_uses_repo_boundary() -> None:
         ("latest_run_id", ("thread-1",), {}),
         ("list_events", ("thread-1", "run-1"), {"after": 3, "limit": 50}),
     ]
-
-
-def test_run_event_store_write_owner_lives_under_backend_thread_runtime_events() -> None:
-    owner_module = importlib.import_module("backend.threads.events.store")
-    read_owner_module = importlib.import_module("backend.threads.events.reads")
-
-    assert owner_module.__name__ == "backend.threads.events.store"
-    assert hasattr(owner_module, "append_event")
-    assert hasattr(owner_module, "read_events_after")
-    assert hasattr(owner_module, "get_last_seq")
-    assert hasattr(owner_module, "get_run_start_seq")
-    assert hasattr(owner_module, "get_latest_run_id")
-    assert hasattr(owner_module, "cleanup_old_runs")
-    assert hasattr(read_owner_module, "RunEventReadTransport")

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -14,10 +14,6 @@ from backend.monitor.infrastructure.web import gateway as monitor_gateway
 app = monitor_app_main.app
 
 
-def test_monitor_app_module_path_is_internalized():
-    assert monitor_app_main.__name__ == "backend.monitor.app.main"
-
-
 def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.MonkeyPatch):
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: object(), contact_repo=lambda: object()),


### PR DESCRIPTION
## Summary
- Delete tests that only assert module/class names or owner locations.
- Keep behavior tests for monitor app routing, agent runtime delegation, and event store fail-loud/transport behavior.

Net: +0 / -28.

## Verification
- uv run python -m pytest -q
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check