### PR TITLE
test: delete legacy tombstone guards

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -646,9 +646,7 @@ def delete_agent_user(
 
     if user.agent_config_id is None:
         raise RuntimeError(f"Agent user {agent_user_id} is missing agent_config_id")
-    # @@@delete-agent-order - clear dependent rows before the config/user roots.
-    # If dependency cleanup fails, refusing the delete is safer than leaving an
-    # agent user pointing at a removed config.
+    # @@@delete-agent-order - fail before deleting roots if dependency cleanup fails.
     contact_repo.delete_for_user(agent_user_id)
     agent_config_repo.delete_config(user.agent_config_id)
 

--- a/backend/threads/convergence.py
+++ b/backend/threads/convergence.py
@@ -34,8 +34,7 @@ def delete_thread_in_db(thread_id: str) -> None:
 
 def purge_incomplete_owner_thread(app: Any, thread_id: str) -> None:
     # @@@incomplete-thread-purge - visible threads that cannot satisfy the
-    # current thread->workspace->sandbox runtime binding should be removed once,
-    # not kept alive behind endpoint-level repair guesses.
+    # current thread->workspace->sandbox runtime binding are purged at the source.
     delete_thread_in_db(thread_id)
     app.state.thread_repo.delete(thread_id)
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -1032,7 +1032,7 @@ def test_leon_agent_chat_tool_wiring_rejects_user_id_only_runtime_shape(monkeypa
         LeonAgent._init_services(agent)
 
 
-def test_leon_agent_chat_identity_prompt_accepts_chat_identity_id_without_removed_user_id():
+def test_leon_agent_chat_identity_prompt_accepts_chat_identity_id():
     from core.runtime.agent import LeonAgent
 
     agent = object.__new__(LeonAgent)
@@ -1052,34 +1052,6 @@ def test_leon_agent_chat_identity_prompt_accepts_chat_identity_id_without_remove
 
     assert "- Your chat identity id: agent-user-2" in prompt
     assert "- Your owner: Owner 2 (human user_id: human-user-2)" in prompt
-
-
-def test_leon_agent_chat_identity_prompt_ignores_removed_thread_user_id_lookup() -> None:
-    from core.runtime.agent import LeonAgent
-
-    agent = object.__new__(LeonAgent)
-    agent._build_system_prompt = lambda: "BASE"
-    cast(Any, agent).config = SimpleNamespace(system_prompt=None)
-    agent._thread_repo = SimpleNamespace(get_by_user_id=lambda _uid: pytest.fail("removed thread-user lookup should not be used"))
-    agent._chat_repos = {
-        "chat_identity_id": "thread-user-3",
-        "owner_id": "human-user-3",
-        "user_repo": SimpleNamespace(
-            get_by_id=lambda uid: (
-                None
-                if uid == "thread-user-3"
-                else SimpleNamespace(id=uid, display_name="Truffle")
-                if uid == "agent-user-3"
-                else SimpleNamespace(id=uid, display_name="Owner 3")
-            )
-        ),
-    }
-
-    prompt = LeonAgent._compose_system_prompt(agent)
-
-    assert "- Your name: thread-user-3" in prompt
-    assert "- Your chat identity id: thread-user-3" in prompt
-    assert "- Your owner: Owner 3 (human user_id: human-user-3)" in prompt
 
 
 def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:

--- a/tests/Integration/test_messaging_social_handle_contract.py
+++ b/tests/Integration/test_messaging_social_handle_contract.py
@@ -89,23 +89,6 @@ def test_messaging_display_user_resolver_prefers_direct_user_row() -> None:
     assert resolved.display_name == "Human"
 
 
-def test_messaging_display_user_resolver_does_not_read_removed_thread_user_id() -> None:
-    resolved = resolve_messaging_display_user(
-        user_repo=SimpleNamespace(
-            get_by_id=lambda uid: (
-                None
-                if uid == "thread-user-1"
-                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None)
-                if uid == "agent-user-1"
-                else None
-            )
-        ),
-        social_user_id="thread-user-1",
-    )
-
-    assert resolved is None
-
-
 def test_deliver_to_agents_does_not_require_main_thread_id():
     delivered: list[tuple[str, str]] = []
     dispatcher = ChatDeliveryDispatcher(
@@ -133,7 +116,6 @@ def test_relationship_revoke_deletes_hire_without_snapshot_side_channel() -> Non
     row = service.revoke("human-user-1", "agent-user-1")
 
     assert row.state == "none"
-    assert "hire_snapshot" not in repo._existing[("agent-user-1", "human-user-1")]
 
 
 def test_relationship_request_uses_single_pending_state_and_initiator() -> None:
@@ -158,44 +140,6 @@ def test_relationship_request_uses_single_pending_state_and_initiator() -> None:
 
     assert row.state == "pending"
     assert row.initiator_user_id == "human-user-1"
-
-
-def test_relationship_upgrade_does_not_write_removed_hire_timestamp_columns() -> None:
-    captured: dict[str, Any] = {}
-
-    class _UpgradeRepo:
-        def get(self, _actor_id: str, _target_id: str):
-            return {
-                "id": "hire_visit:agent-user-1:human-user-1",
-                "user_low": "agent-user-1",
-                "user_high": "human-user-1",
-                "kind": "hire_visit",
-                "state": "visit",
-                "initiator_user_id": "human-user-1",
-                "created_at": "2026-04-07T00:00:00Z",
-                "updated_at": "2026-04-07T00:00:01Z",
-            }
-
-        def upsert(self, _actor_id: str, _target_id: str, **fields: Any):
-            captured.update(fields)
-            return {
-                "id": "hire_visit:agent-user-1:human-user-1",
-                "user_low": "agent-user-1",
-                "user_high": "human-user-1",
-                "kind": "hire_visit",
-                "created_at": "2026-04-07T00:00:00Z",
-                "updated_at": "2026-04-07T00:00:02Z",
-                **fields,
-            }
-
-    service = RelationshipService(_UpgradeRepo())
-
-    row = service.upgrade("human-user-1", "agent-user-1")
-
-    assert row.state == "hire"
-    assert "hire_granted_at" not in captured
-    assert "hire_revoked_at" not in captured
-    assert "hire_snapshot" not in captured
 
 
 def test_relationship_list_for_user_fails_on_invalid_row() -> None:
@@ -246,9 +190,6 @@ def test_chat_tool_registry_exposes_final_contract_only() -> None:
 
     for tool_name in ("list_chats", "read_messages", "send_message", "search_messages"):
         assert registry.get(tool_name) is not None
-
-    for removed_name in ("chats", "chat_search", "directory", "wechat_send", "wechat_contacts"):
-        assert registry.get(removed_name) is None
 
 
 def test_send_message_schema_uses_participant_id_for_direct_chat() -> None:
@@ -729,17 +670,6 @@ def test_chat_tool_list_chats_unread_filter_requires_unread_count_contract() -> 
 
     with pytest.raises(RuntimeError, match="Chat summary chat-1 is missing unread_count"):
         list_chats.handler(unread_only=True)
-
-
-def test_chat_tool_service_rejects_removed_constructor_user_id() -> None:
-    registry = ToolRegistry()
-
-    with pytest.raises(TypeError, match="user_id"):
-        ChatToolService(
-            registry=registry,
-            user_id="agent-user-1",
-            messaging_service=_messaging_display_service(),
-        )
 
 
 @pytest.mark.parametrize("chat_identity_id", [None, ""])

--- a/tests/Integration/test_panel_auth_shell_coherence.py
+++ b/tests/Integration/test_panel_auth_shell_coherence.py
@@ -898,9 +898,6 @@ def test_builtin_agent_surface_exposes_chat_tools():
         assert tools[tool_name]["enabled"] is True
         assert tools[tool_name]["group"] == "chat"
 
-    for removed_name in ("chats", "read_message", "search_message", "directory", "wechat_send", "wechat_contacts"):
-        assert removed_name not in tools
-
 
 def _agent_user(*, user_id: str = "agent-1", owner_user_id: str = "user-1") -> UserRow:
     return UserRow(

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
-from pydantic import ValidationError
 
 from backend.chat.api.http import relationships_router as owner_relationship_router
 from messaging.contracts import RelationshipRow
@@ -45,8 +44,6 @@ async def test_request_relationship_accepts_owned_agent_actor_user_id() -> None:
     assert seen == [("agent-user-1", "requester-user-1")]
     assert result["other_user_id"] == "requester-user-1"
     assert result["is_requester"] is True
-    assert "hire_granted_at" not in result
-    assert "hire_revoked_at" not in result
 
 
 @pytest.mark.asyncio
@@ -78,8 +75,6 @@ async def test_approve_relationship_accepts_owned_agent_actor_user_id() -> None:
     assert seen == [("agent-user-1", "requester-user-1")]
     assert result["other_user_id"] == "requester-user-1"
     assert result["state"] == "visit"
-    assert "hire_granted_at" not in result
-    assert "hire_revoked_at" not in result
 
 
 @pytest.mark.asyncio
@@ -160,8 +155,3 @@ async def test_request_relationship_rejects_unowned_actor_user_id() -> None:
         )
 
     assert exc_info.value.status_code == 403
-
-
-def test_relationship_action_body_rejects_removed_hire_snapshot_field() -> None:
-    with pytest.raises(ValidationError):
-        owner_relationship_router.RelationshipActionBody(actor_user_id="agent-user-1", hire_snapshot={"probe": "live"})

--- a/tests/Unit/backend/test_thread_request_model.py
+++ b/tests/Unit/backend/test_thread_request_model.py
@@ -1,27 +1,10 @@
-import pytest
-
 from backend.web.models.requests import CreateThreadRequest, SendMessageRequest
 
 
-def test_create_thread_request_rejects_removed_sandbox_type_key() -> None:
-    with pytest.raises(Exception):
-        CreateThreadRequest.model_validate(
-            {
-                "agent_user_id": "agent-1",
-                "sandbox_type": "daytona_selfhost",
-                "model": "gpt-5.4-mini",
-            }
-        )
+def test_create_thread_request_accepts_current_agent_user_id() -> None:
+    payload = CreateThreadRequest.model_validate({"agent_user_id": "agent-1", "model": "gpt-5.4-mini"})
 
-
-def test_create_thread_request_rejects_removed_member_id_field() -> None:
-    with pytest.raises(Exception):
-        CreateThreadRequest.model_validate(
-            {
-                "member_id": "member-1",
-                "sandbox": "local",
-            }
-        )
+    assert payload.agent_user_id == "agent-1"
 
 
 def test_send_message_request_defaults_enable_trajectory_to_false() -> None:

--- a/tests/Unit/backend/web/services/test_thread_state_service.py
+++ b/tests/Unit/backend/web/services/test_thread_state_service.py
@@ -36,11 +36,9 @@ def test_sandbox_info_does_not_expose_terminal_or_session_identity() -> None:
                 }
             ),
             sandbox_runtime_repo=SimpleNamespace(
-                get=lambda _sandbox_runtime_id: (_ for _ in ()).throw(
-                    AssertionError("sandbox info should not read removed sandbox runtime id")
-                ),
+                get=lambda _sandbox_runtime_id: (_ for _ in ()).throw(AssertionError("sandbox info should resolve by provider env")),
                 find_by_instance=lambda *, provider_name, instance_id: {
-                    "lease_" + "id": "runtime-1",
+                    "sandbox_runtime_id": "runtime-1",
                     "provider_name": provider_name,
                     "current_instance_id": instance_id,
                     "observed_state": "running",
@@ -86,11 +84,9 @@ async def test_sandbox_status_resolves_runtime_from_provider_env_not_config() ->
         }
     )
     sandbox_runtime_repo = SimpleNamespace(
-        get=lambda _sandbox_runtime_id: (_ for _ in ()).throw(
-            AssertionError("thread sandbox status must not read removed sandbox runtime id")
-        ),
+        get=lambda _sandbox_runtime_id: (_ for _ in ()).throw(AssertionError("thread sandbox status should resolve by provider env")),
         find_by_instance=lambda *, provider_name, instance_id: {
-            "lease_" + "id": "runtime-1",
+            "sandbox_runtime_id": "runtime-1",
             "provider_name": provider_name,
             "current_instance_id": instance_id,
             "desired_state": "running",

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -138,7 +138,6 @@ def test_terminal_from_row_uses_sqlite_terminal_under_supabase_defaults(monkeypa
     try:
         row = terminal_store.create("term-1", "thread-1", sandbox_runtime_id="runtime-1", initial_cwd="/tmp")
         assert row["sandbox_runtime_id"] == "runtime-1"
-        assert "lease_id" not in row
         terminal = terminal_from_row(row, terminal_store.db_path)
     finally:
         terminal_store.close()
@@ -156,7 +155,6 @@ def test_terminal_repo_get_active_returns_sandbox_runtime_id(tmp_path):
 
     assert active is not None
     assert active["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in active
 
 
 def test_terminal_repo_schema_uses_sandbox_runtime_id_column(tmp_path):
@@ -167,7 +165,6 @@ def test_terminal_repo_schema_uses_sandbox_runtime_id_column(tmp_path):
         repo.close()
 
     assert "sandbox_runtime_id" in cols
-    assert "lease_id" not in cols
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="LocalPersistentShellRuntime requires a Unix shell")

--- a/tests/Unit/monitor/test_monitor_detail_contracts.py
+++ b/tests/Unit/monitor/test_monitor_detail_contracts.py
@@ -32,7 +32,6 @@ from backend.monitor.infrastructure.read_models import trace_read_service as mon
 
 SANDBOX_RUNTIME_KEY = "sandbox_runtime_" + "id"
 SANDBOX_RUNTIME_CAMEL_KEY = "".join(["lea", "se", "Id"])
-REMOVED_RUNTIME_IDS_KEY = "lease_" + "ids"
 
 
 @pytest.fixture(autouse=True)
@@ -257,10 +256,8 @@ def test_get_monitor_provider_detail_reads_current_resource_snapshot(monkeypatch
 
     assert payload["provider"]["id"] == "daytona"
     assert payload["sandbox_ids"] == ["sandbox-1", "sandbox-2"]
-    assert REMOVED_RUNTIME_IDS_KEY not in payload
     assert "thread_ids" not in payload
     assert payload["runtime_ids"] == ["runtime-1"]
-    assert "runtime_" + "session_ids" not in payload
 
     assert monitor_provider_runtime_service._resource_row_values(
         [

--- a/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
+++ b/tests/Unit/monitor/test_monitor_resource_overview_uniqueness.py
@@ -6,7 +6,6 @@ from backend.monitor.infrastructure.read_models import resource_read_service as 
 from storage import runtime as storage_runtime
 
 SANDBOX_RUNTIME_KEY = "sandbox_runtime_" + "id"
-REMOVED_RUNTIME_FIELD = "runtime" + "SessionId"
 
 
 class _FakeRepo:
@@ -674,7 +673,6 @@ def test_list_resource_providers_keeps_remote_runtime_id_actor_first(monkeypatch
 
     assert provider["consoleUrl"] == "https://example.com/daytona"
     assert resource_row["runtimeId"] == "provider-session-1"
-    assert REMOVED_RUNTIME_FIELD not in resource_row
     assert resource_row["agentUserId"] == "agent-remote"
     assert resource_row["agentName"] == "Remote Agent"
     assert resource_row["avatarUrl"] == "/api/users/agent-remote/avatar"
@@ -726,7 +724,6 @@ def test_list_resource_providers_uses_batch_runtime_lookup_for_remote_sandboxes(
     resource_rows = payload["providers"][0]["resource_rows"]
 
     assert [resource_row["runtimeId"] for resource_row in resource_rows] == ["runtime-a", "runtime-b"]
-    assert all(REMOVED_RUNTIME_FIELD not in resource_row for resource_row in resource_rows)
     assert repo.batch_calls == [["sandbox-a", "sandbox-b"]]
 
 

--- a/tests/Unit/monitor/test_monitor_sandbox_repo.py
+++ b/tests/Unit/monitor/test_monitor_sandbox_repo.py
@@ -1,23 +1,7 @@
-import pytest
-
 from storage.providers.supabase.sandbox_monitor_repo import SupabaseSandboxMonitorRepo
 from tests.fakes.supabase import FakeSupabaseClient, FakeSupabaseQuery
 
 SANDBOX_RUNTIME_KEY = "sandbox_runtime_" + "id"
-
-
-class _BrokenSandboxInstancesClient(FakeSupabaseClient):
-    def table(self, table_name: str):
-        if table_name == "sandbox_instances":
-            raise RuntimeError("sandbox_instances exploded")
-        return super().table(table_name)
-
-
-class _BrokenChatSessionsClient(FakeSupabaseClient):
-    def table(self, table_name: str):
-        if table_name == "chat_sessions":
-            raise RuntimeError("chat_sessions exploded")
-        return super().table(table_name)
 
 
 class _MaxInFilterQuery(FakeSupabaseQuery):
@@ -354,65 +338,6 @@ def test_query_sandbox_allows_missing_sandbox_runtime_handle() -> None:
         "last_error": None,
         "updated_at": "2026-04-05T10:10:00",
     }
-
-
-def test_query_thread_runtime_rows_ignores_removed_chat_sessions_rows() -> None:
-    repo = _repo(
-        {
-            "container.sandboxes": [
-                _sandbox(
-                    "sandbox-1",
-                    provider_name="daytona_selfhost",
-                    provider_env_id="instance-1",
-                    desired_state="paused",
-                    observed_state="paused",
-                    sandbox_runtime_handle="runtime-1",
-                    last_error="last boom",
-                )
-            ],
-            "chat_sessions": [
-                {
-                    **_chat_session("sess-1", "thread-1", "runtime-1", started_at="2026-04-05T10:01:00"),
-                    "ended_at": None,
-                    "close_reason": None,
-                }
-            ],
-        }
-    )
-
-    assert repo.query_thread_runtime_rows("thread-1") == []
-
-
-def test_chat_session_monitor_surfaces_do_not_read_removed_chat_sessions_table() -> None:
-    repo = SupabaseSandboxMonitorRepo(
-        _BrokenChatSessionsClient(
-            {
-                "container.sandboxes": [
-                    _sandbox("sandbox-1", provider_env_id="instance-1", sandbox_runtime_handle="runtime-1"),
-                ],
-                "container.workspaces": [
-                    _workspace("workspace-1", "sandbox-1", updated_at="2026-04-05T10:05:00"),
-                ],
-                "agent.threads": [
-                    _thread("thread-1", "workspace-1", updated_at="2026-04-05T10:05:00"),
-                ],
-            }
-        )
-    )
-
-    assert repo.query_thread_runtime_rows("thread-1") == []
-    assert repo.query_sandbox_runtime_rows("sandbox-1") == []
-    assert repo.query_resource_rows() == [
-        {
-            "provider": "local",
-            "session_id": None,
-            "thread_id": "thread-1",
-            "sandbox_id": "sandbox-1",
-            "observed_state": "running",
-            "desired_state": "running",
-            "created_at": "2026-04-05T09:00:00",
-        }
-    ]
 
 
 def test_query_sandboxes_uses_latest_workspace_thread_binding() -> None:
@@ -794,44 +719,6 @@ def test_list_probe_targets_use_sandbox_runtime_identity() -> None:
             "observed_state": "detached",
         },
     ]
-
-
-@pytest.mark.parametrize(
-    ("include_updated_at", "caller"),
-    [
-        (False, lambda repo: repo.query_sandbox_instance_id("sandbox-1")),
-        (True, lambda repo: repo.list_probe_targets()),
-    ],
-    ids=["query-sandbox-instance-id", "list-probe-targets"],
-)
-def test_instance_lookup_does_not_read_removed_instances_table(include_updated_at, caller) -> None:
-    tables = {
-        "container.sandboxes": [
-            _sandbox(
-                "sandbox-1",
-                provider_name="daytona_selfhost",
-                provider_env_id="instance-runtime",
-                observed_state="detached",
-                updated_at="2026-04-05T10:10:00" if include_updated_at else "2026-04-05T10:00:00",
-                sandbox_runtime_handle="runtime-1",
-            )
-        ]
-    }
-    repo = SupabaseSandboxMonitorRepo(_BrokenSandboxInstancesClient(tables))
-
-    result = caller(repo)
-
-    if include_updated_at:
-        assert result == [
-            {
-                "sandbox_id": "sandbox-1",
-                "provider_name": "daytona_selfhost",
-                "instance_id": "instance-runtime",
-                "observed_state": "detached",
-            }
-        ]
-    else:
-        assert result == "instance-runtime"
 
 
 def test_query_resource_rows_uses_sandbox_thread_rows_without_session_rows() -> None:

--- a/tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py
@@ -32,15 +32,3 @@ def test_provider_runtime_listing_rejects_non_list_provider_result() -> None:
 
     with pytest.raises(TypeError, match="daytona.list_provider_runtimes must return list"):
         manager.list_sessions()
-
-
-def test_provider_runtime_listing_omits_removed_runtime_id_field() -> None:
-    manager = _manager_for_provider(
-        SimpleNamespace(name="daytona", list_provider_runtimes=lambda: [SimpleNamespace(session_id="runtime-1", status="running")])
-    )
-
-    sessions = manager.list_sessions()
-
-    assert len(sessions) == 1
-    assert sessions[0]["source"] == "provider_orphan"
-    assert "lease_id" not in sessions[0]

--- a/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
+++ b/tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
@@ -52,11 +52,8 @@ def test_chat_session_uses_sandbox_runtime_attribute(tmp_path: Path) -> None:
     )
 
     assert session.sandbox_runtime is sandbox_runtime
-    assert not hasattr(session, "lease")
     assert terminal.sandbox_runtime_id == "runtime-1"
-    assert not hasattr(terminal, "lease_id")
     assert session.sandbox_runtime.sandbox_runtime_id == "runtime-1"
-    assert not hasattr(session.sandbox_runtime, "lease_id")
 
 
 def test_runtime_uses_sandbox_runtime_attribute(tmp_path: Path) -> None:
@@ -66,8 +63,5 @@ def test_runtime_uses_sandbox_runtime_attribute(tmp_path: Path) -> None:
     runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
     assert terminal.sandbox_runtime_id == "runtime-1"
-    assert not hasattr(terminal, "lease_id")
     assert runtime.sandbox_runtime is sandbox_runtime
-    assert not hasattr(runtime, "lease")
     assert runtime.sandbox_runtime.sandbox_runtime_id == "runtime-1"
-    assert not hasattr(runtime.sandbox_runtime, "lease_id")

--- a/tests/Unit/storage/test_chat_session_row_contract.py
+++ b/tests/Unit/storage/test_chat_session_row_contract.py
@@ -14,7 +14,6 @@ def test_chat_session_repo_create_returns_sandbox_runtime_id(tmp_path):
         repo.close()
 
     assert created["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in created
 
 
 def test_chat_session_repo_get_returns_sandbox_runtime_id(tmp_path):
@@ -32,7 +31,6 @@ def test_chat_session_repo_get_returns_sandbox_runtime_id(tmp_path):
 
     assert row is not None
     assert row["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in row
 
 
 def test_chat_session_repo_schema_uses_sandbox_runtime_id_column(tmp_path):
@@ -43,4 +41,3 @@ def test_chat_session_repo_schema_uses_sandbox_runtime_id_column(tmp_path):
         repo.close()
 
     assert "sandbox_runtime_id" in cols
-    assert "lease_id" not in cols

--- a/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
+++ b/tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py
@@ -1,21 +1,6 @@
 from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
 
 
-def test_sqlite_sandbox_runtime_repo_schema_does_not_create_removed_volume_id(tmp_path):
-    repo = SQLiteSandboxRuntimeRepo(tmp_path / "sandbox.db")
-    try:
-        table_names = {row[0] for row in repo._conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
-        cols = {row[1] for row in repo._conn.execute("PRAGMA table_info(sandbox_runtimes)").fetchall()}
-    finally:
-        repo.close()
-
-    assert "sandbox_runtimes" in table_names
-    assert "sandbox_leases" not in table_names
-    assert "sandbox_runtime_id" in cols
-    assert "lease_id" not in cols
-    assert "volume_id" not in cols
-
-
 def test_sqlite_sandbox_runtime_repo_returns_sandbox_runtime_id(tmp_path):
     repo = SQLiteSandboxRuntimeRepo(tmp_path / "sandbox.db")
     try:
@@ -24,7 +9,6 @@ def test_sqlite_sandbox_runtime_repo_returns_sandbox_runtime_id(tmp_path):
         repo.close()
 
     assert created["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in created
 
 
 def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_sandbox_instances(tmp_path):
@@ -35,7 +19,6 @@ def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_sandbox_i
         repo.close()
 
     assert "sandbox_runtime_id" in cols
-    assert "lease_id" not in cols
 
 
 def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_sandbox_runtime_events(tmp_path):
@@ -47,9 +30,7 @@ def test_sqlite_sandbox_runtime_repo_schema_uses_sandbox_runtime_id_in_sandbox_r
         repo.close()
 
     assert "sandbox_runtime_events" in table_names
-    assert "lease_events" not in table_names
     assert "sandbox_runtime_id" in cols
-    assert "lease_id" not in cols
 
 
 def test_sqlite_sandbox_runtime_repo_delete_removes_runtime(tmp_path):

--- a/tests/Unit/storage/test_supabase_sandbox_runtime_repo.py
+++ b/tests/Unit/storage/test_supabase_sandbox_runtime_repo.py
@@ -65,7 +65,6 @@ def test_supabase_sandbox_runtime_repo_get_reads_container_sandbox_runtime_state
     assert sandbox_runtime is not None
     assert sandbox_runtime["sandbox_id"] == "sandbox-1"
     assert sandbox_runtime["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in sandbox_runtime
     assert sandbox_runtime["provider_name"] == "local"
     assert sandbox_runtime["recipe_id"] == "local:default"
     assert sandbox_runtime["recipe_json"] == '{"id":"local:default"}'
@@ -120,7 +119,6 @@ def test_supabase_sandbox_runtime_repo_create_writes_container_sandbox_runtime_s
     row = tables["container.sandboxes"][0]
     assert created["sandbox_id"] == row["id"]
     assert created["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in created
     assert row["owner_user_id"] == "owner-1"
     assert row["provider_name"] == "local"
     assert row["sandbox_template_id"] == "local:default"
@@ -176,7 +174,6 @@ def test_supabase_sandbox_runtime_repo_persist_metadata_updates_container_runtim
     row = tables["container.sandboxes"][0]
     runtime_state = row["config"]["runtime_state"]
     assert updated["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in updated
     assert row["sandbox_template_id"] == "local:python"
     assert row["observed_state"] == "unknown"
     assert row["last_error"] == "provider boom"
@@ -200,7 +197,6 @@ def test_supabase_sandbox_runtime_repo_observe_status_detaches_instance_from_con
     row = tables["container.sandboxes"][0]
     runtime_state = row["config"]["runtime_state"]
     assert updated["sandbox_runtime_id"] == "runtime-1"
-    assert "lease_id" not in updated
     assert row["provider_env_id"] is None
     assert row["observed_state"] == "detached"
     assert runtime_state["status"] == "expired"


### PR DESCRIPTION
## Summary
- delete legacy/tombstone negative guards around old request fields, old runtime/session tables, and old tool aliases
- remove old lease/hire field absence assertions while keeping current runtime id, relationship, monitor, and chat behavior checks
- trim stale comments without changing runtime behavior

## Verification
- uv run python -m pytest -q tests/Integration/test_relationship_router.py tests/Integration/test_messaging_social_handle_contract.py tests/Integration/test_leon_agent.py tests/Unit/backend/test_thread_request_model.py tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py tests/Unit/core/test_runtime.py tests/Unit/storage/test_sqlite_sandbox_runtime_repo.py tests/Unit/storage/test_chat_session_row_contract.py tests/Unit/storage/test_supabase_sandbox_runtime_repo.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q