### PR TITLE
chore: trim stale migration comments

### DIFF
--- a/backend/sandboxes/resources/projection.py
+++ b/backend/sandboxes/resources/projection.py
@@ -101,11 +101,7 @@ def _project_user_visible_resource_rows(repo: Any, rows: list[dict[str, Any]]) -
             projected.extend(visible_rows)
             continue
 
-        # @@@resource-visible-parent-projection - visible resource cards are now
-        # sandbox-first. If the raw monitor row lands on a hidden/subagent
-        # thread, only sandbox truth can authorize a visible-parent projection.
-        # Rows without sandbox truth are no longer eligible for
-        # visible-parent projection on the user-facing resource surface.
+        # @@@resource-visible-parent-projection - hidden/subagent rows need sandbox truth for visible-parent projection.
         thread_rows = repo.query_sandbox_threads(sandbox_id)
         preferred_thread_id = next(
             (str(item.get("thread_id") or "").strip() for item in thread_rows if _is_resource_visible_thread(item.get("thread_id"))),

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -559,8 +559,6 @@ def _sync_repo_children(agent_config_id: str, config_patch: dict[str, Any], agen
 def _sync_agent_config_patch_to_repo(
     agent_user_id: str, config_patch: dict[str, Any], user_repo: Any, agent_config_repo: Any
 ) -> dict[str, Any] | None:
-    # @@@repo-only-agent-shell - fresh register now creates DB-only agents. Owner-scoped
-    # panel edits must use the repo config even when no stale local agent dir exists.
     user, current_config = _resolve_repo_backed_agent(agent_user_id, user_repo, agent_config_repo)
     if user is None or current_config is None:
         return None
@@ -621,8 +619,6 @@ def _resolve_repo_backed_agent(
     user = user_repo.get_by_id(agent_user_id)
     if user is None or user.agent_config_id is None:
         return None, None
-    # @@@repo-backed-agent-wins - repo-backed agent users must not silently write
-    # to stale local agent dirs just because an old shell still exists.
     config = agent_config_repo.get_config(user.agent_config_id)
     if config is None:
         raise RuntimeError(f"Agent config {user.agent_config_id} is missing for {agent_user_id}")

--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -139,9 +139,6 @@ def _resolve_workspace_backed_existing_config(
         raise PermissionError(f"sandbox owner mismatch: expected {owner_user_id}, got {sandbox_owner_user_id}")
     provider_env_id = sandbox.get("provider_env_id") if isinstance(sandbox, dict) else getattr(sandbox, "provider_env_id", None)
     if not str(provider_env_id or "").strip():
-        # @@@stale-existing-default-guard - launch-config should not steer the UI
-        # into existing-sandbox mode when the persisted sandbox row no longer carries
-        # the runtime identity required by the existing-sandbox bind path.
         return None
     sandbox_template = _resolve_workspace_backed_sandbox_template(
         app=app,

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -142,8 +142,6 @@ async def get_or_create_agent(
             if messaging_service is None:
                 raise RuntimeError(f"messaging_service is required for agent chat runtime: {thread_id}")
             agent_user = agent_user or user_repo.get_by_id(agent_user_id)
-            # @@@thread-chat-identity-source - agent users are now the stable social
-            # identity root. Runtime threads no longer carry a second dedicated user_id.
             owner_id = agent_user.owner_user_id or ""
             chat_repos = {
                 "chat_identity_id": agent_user_id,

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -115,9 +115,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     _run_execution.log_captured_exception = _log_captured_exception
     _run_emit.append_event = _append_event
     _run_buffer_wiring._append_event = _append_event
-    # @@@run-buffer-borrowed-typing-tracker - execution cleanup still needs
-    # chat-owned typing state, but the borrow happens at the streaming wrapper
-    # so the deeper execution helper no longer reopens app.state on its own.
+    # @@@run-buffer-borrowed-typing-tracker - borrow chat-owned typing state at the wrapper boundary.
     return await _run_execution.run_agent_to_buffer(
         agent=agent,
         thread_id=thread_id,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -587,8 +587,6 @@ class LeonAgent:
                 cli_overrides=models_cli or None,
             )
 
-        # @@@runtime-agent-config-root - web/runtime live agent startup must resolve from
-        # the repo-rooted agent_config_id path, not stale local filesystem shells.
         if agent_config_id is not None:
             if agent_config_repo is None:
                 raise RuntimeError("agent_config_repo is required when agent_config_id is provided")

--- a/core/runtime/middleware/monitor/usage_patches.py
+++ b/core/runtime/middleware/monitor/usage_patches.py
@@ -11,14 +11,12 @@ from __future__ import annotations
 
 from typing import Any
 
-# ---------------------------------------------------------------------------
 # @@@langchain-anthropic-streaming-usage-regression
 # langchain-anthropic >= 1.0 dropped usage extraction from message_start,
 # assuming message_delta carries complete info. But Anthropic API only puts
 # input_tokens (+ cache tokens) in message_start and output_tokens in
 # message_delta. This patch restores the v0.2.4 behavior.
 # Remove this once upstream is fixed.
-# ---------------------------------------------------------------------------
 
 _anthropic_patched = False
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -298,8 +298,6 @@ class SandboxManager:
         return self.provider_capability.runtime_kind != "local"
 
     def _destroy_daytona_managed_volume(self, sandbox_runtime_id: str) -> None:
-        # @@@daytona-managed-volume-ref - daytona managed volumes now derive their backend
-        # ref from sandbox runtime identity directly, so cleanup no longer depends on dropped volume rows.
         self.provider.delete_managed_volume(f"leon-volume-{sandbox_runtime_id}")
 
     def _setup_mounts(self, thread_id: str) -> dict:
@@ -395,8 +393,6 @@ class SandboxManager:
         return bool(sandbox_runtime and sandbox_runtime.provider_name == self.provider.name)
 
     def _resolve_sync_source_path(self, thread_id: str) -> Path:
-        # @@@sync-source-truth - sync no longer needs dropped volume-row truth; it only needs
-        # the workspace-owned local file root that backs the current file channel.
         container = build_storage_container()
         thread_repo = container.thread_repo()
         try:

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -230,7 +230,6 @@ class DaytonaProvider(SandboxProvider):
             logger.warning("[DaytonaProvider] destroy_session error for %s, verifying actual state", session_id)
             actual = self.get_session_status(session_id)
             if actual == "unknown":
-                # Sandbox no longer findable — delete succeeded
                 logger.info("[DaytonaProvider] sandbox %s no longer exists — destroy succeeded", session_id)
                 self._sandboxes.pop(session_id, None)
                 return True

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -75,8 +75,7 @@ class SupabaseSandboxMonitorRepo:
         return results[0] if results else None
 
     def query_thread_runtime_rows(self, thread_id: str) -> list[dict]:
-        # @@@monitor-session-demotion - Supabase no longer owns runtime-local chat
-        # session history; remote monitor detail must not read runtime-local chat_sessions.
+        # @@@runtime-local-chat - remote monitor detail must not read runtime-local chat_sessions.
         return []
 
     def query_sandboxes(self) -> list[dict]:
@@ -122,8 +121,7 @@ class SupabaseSandboxMonitorRepo:
         return None
 
     def query_sandbox_runtime_rows(self, sandbox_id: str) -> list[dict]:
-        # @@@monitor-session-demotion - sandbox detail still has sandbox/thread
-        # facts, but Supabase session rows are no longer admitted remote truth.
+        # @@@runtime-local-chat - sandbox detail must not admit Supabase session rows.
         return []
 
     def query_sandbox_threads(self, sandbox_id: str) -> list[dict]:

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -1,11 +1,5 @@
 from __future__ import annotations
 
-# NOTE: User is the only identity table. The old EntityRow layer was removed;
-# this router projects user rows into chat-candidate payloads for contacts and
-# group-chat creation. The test below verifies the current production behaviour:
-#   • current user is excluded
-#   • other humans and agents are all included (no branch filtering)
-#   • chat/contact eligibility is computed by backend ownership + relationship state
 from types import SimpleNamespace
 
 import pytest

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -543,12 +543,6 @@ def test_docker_provider_create_runtime(terminal_store, sandbox_runtime_store):
     assert isinstance(runtime, DockerPtyRuntimeDirect)
 
 
-def test_docker_provider_no_longer_advertises_managed_volume_support():
-    from sandbox.providers.docker import DockerProvider
-
-    assert DockerProvider.CAPABILITY.mount.supports_managed_volume is False
-
-
 def test_docker_provider_managed_volume_hooks_fail_loudly():
     from sandbox.providers.docker import DockerProvider
 


### PR DESCRIPTION
## Summary
- remove historical migration comments around sandbox/runtime/chat ownership
- delete a redundant Docker provider negative capability guard
- keep current fail-loud behavior and runtime boundaries unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
