### PR TITLE
chore: delete decorative comments

### DIFF
--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -86,9 +86,7 @@ async def _emit_queued_terminal_followups(
     )
 
 
-# ---------------------------------------------------------------------------
 # Producer: runs agent, writes events to ThreadEventBuffer
-# ---------------------------------------------------------------------------
 
 
 async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @@@nu59-complexity-honesty
@@ -134,9 +132,7 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     )
 
 
-# ---------------------------------------------------------------------------
 # Followup queue consumption (extracted for testability)
-# ---------------------------------------------------------------------------
 
 
 async def _consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
@@ -144,9 +140,7 @@ async def _consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
     await _run_followups.consume_followup_queue(agent, thread_id, app)
 
 
-# ---------------------------------------------------------------------------
 # Orchestrator: creates run on persistent ThreadEventBuffer
-# ---------------------------------------------------------------------------
 
 
 def start_agent_run(

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -35,9 +35,7 @@ class MessageQueueManager:
         self._wake_handlers: dict[str, Callable[[QueueItem], None]] = {}
         self._wake_lock = threading.Lock()
 
-    # ------------------------------------------------------------------
     # Core operations
-    # ------------------------------------------------------------------
 
     def enqueue(
         self,
@@ -93,9 +91,7 @@ class MessageQueueManager:
         """List all pending messages (for API queries)."""
         return self._repo.list_queue(thread_id)
 
-    # ------------------------------------------------------------------
     # Wake handler registration
-    # ------------------------------------------------------------------
 
     def register_wake(self, thread_id: str, handler: Callable[[QueueItem], None]) -> None:
         """Register a wake handler for a thread.
@@ -111,9 +107,7 @@ class MessageQueueManager:
         with self._wake_lock:
             self._wake_handlers.pop(thread_id, None)
 
-    # ------------------------------------------------------------------
     # Cleanup
-    # ------------------------------------------------------------------
 
     def clear_queue(self, thread_id: str) -> None:
         """Clear persisted queue for a thread."""
@@ -124,9 +118,7 @@ class MessageQueueManager:
         self.clear_queue(thread_id)
         self.unregister_wake(thread_id)
 
-    # ------------------------------------------------------------------
     # Diagnostics
-    # ------------------------------------------------------------------
 
     def queue_sizes(self, thread_id: str) -> dict[str, int]:
         """Return persisted queue sizes."""

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -10,9 +10,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 NotificationType = Literal["steer", "command", "agent", "chat"]
 
 
-# ---------------------------------------------------------------------------
 # Sandbox — repo protocols
-# ---------------------------------------------------------------------------
 
 
 class SandboxRuntimeRepo(Protocol):
@@ -98,9 +96,7 @@ class SandboxMonitorRepo(Protocol):
     def list_probe_targets(self) -> list[dict[str, Any]]: ...
 
 
-# ---------------------------------------------------------------------------
 # User / Agent / Chat — enums + row types
-# ---------------------------------------------------------------------------
 
 
 class UserType(StrEnum):
@@ -407,9 +403,7 @@ class RelationshipRow(BaseModel):
         return self
 
 
-# ---------------------------------------------------------------------------
 # Delivery strategy — contact relationships + delivery actions
-# ---------------------------------------------------------------------------
 
 
 class DeliveryAction(StrEnum):

--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -44,10 +44,6 @@ class SQLiteChatSessionRepo:
     def _session_row_from_db_row(self, row: sqlite3.Row) -> dict[str, Any]:
         return dict(row)
 
-    # ------------------------------------------------------------------
-    # Table setup
-    # ------------------------------------------------------------------
-
     def _ensure_tables(self) -> None:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(
@@ -144,12 +140,7 @@ class SQLiteChatSessionRepo:
         if any(cols == {"thread_id"} for cols in unique_index_columns.values()):
             raise RuntimeError("chat_sessions still has UNIQUE index on thread_id from old schema. Purge ~/.leon/sandbox.db and retry.")
 
-    # Alias for protocol compliance
     ensure_tables = _ensure_tables
-
-    # ------------------------------------------------------------------
-    # Reads
-    # ------------------------------------------------------------------
 
     def get_session(self, thread_id: str, terminal_id: str | None = None) -> dict[str, Any] | None:
         with self._lock:
@@ -258,10 +249,6 @@ class SQLiteChatSessionRepo:
             ).fetchall()
             self._conn.row_factory = None
             return [self._session_row_from_db_row(row) for row in rows]
-
-    # ------------------------------------------------------------------
-    # Writes
-    # ------------------------------------------------------------------
 
     def create_session(
         self,

--- a/storage/providers/sqlite/terminal_repo.py
+++ b/storage/providers/sqlite/terminal_repo.py
@@ -47,10 +47,6 @@ class SQLiteTerminalRepo:
     def _terminal_row_from_db_row(self, row: sqlite3.Row) -> dict[str, Any]:
         return dict(row)
 
-    # ------------------------------------------------------------------
-    # Table setup
-    # ------------------------------------------------------------------
-
     def _ensure_tables(self) -> None:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(
@@ -112,10 +108,6 @@ class SQLiteTerminalRepo:
 
         if any(cols == {"thread_id"} for cols in unique_index_columns.values()):
             raise RuntimeError("abstract_terminals still has UNIQUE index from single-terminal schema. Purge ~/.leon/sandbox.db and retry.")
-
-    # ------------------------------------------------------------------
-    # Reads
-    # ------------------------------------------------------------------
 
     def _get_pointer_row(self, thread_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -272,10 +264,6 @@ class SQLiteTerminalRepo:
             ).fetchall()
             self._conn.row_factory = None
             return [self._terminal_row_from_db_row(row) for row in rows]
-
-    # ------------------------------------------------------------------
-    # Writes
-    # ------------------------------------------------------------------
 
     def _ensure_thread_pointer(self, thread_id: str, terminal_id: str) -> None:
         now = datetime.now().isoformat()

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -22,10 +22,6 @@ class SupabaseAgentConfigRepo:
     def _table(self, table: str) -> Any:
         return q.schema_table(self._client, _SCHEMA, table, _REPO)
 
-    # ------------------------------------------------------------------
-    # agent_configs (1:1 with agent_config id)
-    # ------------------------------------------------------------------
-
     def get_config(self, agent_config_id: str) -> dict[str, Any] | None:
         rows = q.rows(
             self._table("agent_configs").select("*").eq("id", agent_config_id).execute(),
@@ -80,10 +76,6 @@ class SupabaseAgentConfigRepo:
     def delete_config(self, agent_config_id: str) -> None:
         self._table("agent_configs").delete().eq("id", agent_config_id).execute()
 
-    # ------------------------------------------------------------------
-    # agent_rules
-    # ------------------------------------------------------------------
-
     def list_rules(self, agent_config_id: str) -> list[dict[str, Any]]:
         rows = q.rows(
             self._table("agent_rules").select("*").eq("agent_config_id", agent_config_id).execute(),
@@ -100,10 +92,6 @@ class SupabaseAgentConfigRepo:
 
     def delete_rule(self, rule_id: str) -> None:
         self._table("agent_rules").delete().eq("id", rule_id).execute()
-
-    # ------------------------------------------------------------------
-    # agent_skills
-    # ------------------------------------------------------------------
 
     def list_skills(self, agent_config_id: str) -> list[dict[str, Any]]:
         rows = q.rows(
@@ -125,10 +113,6 @@ class SupabaseAgentConfigRepo:
 
     def delete_skill(self, skill_id: str) -> None:
         self._table("agent_skills").delete().eq("id", skill_id).execute()
-
-    # ------------------------------------------------------------------
-    # agent_sub_agents
-    # ------------------------------------------------------------------
 
     def list_sub_agents(self, agent_config_id: str) -> list[dict[str, Any]]:
         rows = q.rows(

--- a/storage/providers/supabase/user_settings_repo.py
+++ b/storage/providers/supabase/user_settings_repo.py
@@ -63,9 +63,7 @@ class SupabaseUserSettingsRepo:
     def set_default_model(self, user_id: str, model: str) -> None:
         self._upsert(user_id, {"default_model": model})
 
-    # ------------------------------------------------------------------
     # Models config (JSONB)
-    # ------------------------------------------------------------------
 
     def get_models_config(self, user_id: str) -> dict[str, Any] | None:
         rows = q.rows(self._table().select("models_config").eq("user_id", user_id).execute(), _REPO, "get_models_config")

--- a/tests/fakes/supabase.py
+++ b/tests/fakes/supabase.py
@@ -1,8 +1,3 @@
-"""In-memory fake Supabase client for unit tests.
-
-Supports: select, insert, upsert, update, delete, eq, neq, in_, gt, gte, order, limit.
-"""
-
 from __future__ import annotations
 
 
@@ -94,7 +89,6 @@ class FakeSupabaseQuery:
     def execute(self) -> FakeSupabaseResponse:
         table = self._tables.setdefault(self._table_name, [])
 
-        # INSERT
         if self._insert_payload is not None:
             rows_to_insert = self._insert_payload if isinstance(self._insert_payload, list) else [self._insert_payload]
             inserted = []
@@ -107,7 +101,6 @@ class FakeSupabaseQuery:
                 inserted.append(dict(row))
             return FakeSupabaseResponse(inserted)
 
-        # UPSERT
         if self._upsert_payload is not None:
             conflict_col = self._upsert_conflict or "id"
             conflict_val = self._upsert_payload.get(conflict_col)
@@ -119,19 +112,15 @@ class FakeSupabaseQuery:
             table.append(row)
             return FakeSupabaseResponse([dict(row)])
 
-        # Filter
         matching = [r for r in table if self._match(r)]
 
-        # ORDER
         if self._order_by is not None:
             column, desc = self._order_by
             matching = sorted(matching, key=lambda r: r.get(column), reverse=desc)
 
-        # LIMIT
         if self._limit_value is not None:
             matching = matching[: self._limit_value]
 
-        # UPDATE
         if self._update_payload is not None:
             updated = []
             for row in table:
@@ -140,23 +129,14 @@ class FakeSupabaseQuery:
                     updated.append(dict(row))
             return FakeSupabaseResponse(updated)
 
-        # DELETE
         if self._delete_requested:
             self._tables[self._table_name] = [r for r in table if not self._match(r)]
             return FakeSupabaseResponse([dict(r) for r in matching])
 
-        # SELECT
         return FakeSupabaseResponse([dict(r) for r in matching])
 
 
 class FakeSupabaseClient:
-    """In-memory Supabase client for tests.
-
-    Args:
-        tables: shared mutable dict of table_name -> list[dict].
-        auto_seq_tables: set of table names that auto-generate a `seq` column on insert.
-    """
-
     def __init__(
         self,
         tables: dict[str, list[dict]] | None = None,


### PR DESCRIPTION
## Summary
- delete decorative section banners from storage/runtime helpers
- remove redundant operation labels from the in-memory Supabase test client
- keep runtime behavior unchanged while reducing code volume

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
