### PR TITLE
chore: trim test and router comment noise

### DIFF
--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -76,9 +76,7 @@ def _load_workspace_settings(repo: Any, user_id: str) -> WorkspaceSettings:
     )
 
 
-# ============================================================================
 # Models config (models.json)
-# ============================================================================
 
 
 def _load_merged_models_for_storage(repo: Any, user_id: str) -> ModelsConfig:

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1310,9 +1310,7 @@ SSE_HEADERS = {
 }
 
 
-# ---------------------------------------------------------------------------
 # Persistent thread event stream (replaces /runs/events + /activity/events)
-# ---------------------------------------------------------------------------
 
 
 @router.get("/{thread_id}/events")
@@ -1386,9 +1384,7 @@ async def cancel_run(
     return {"ok": True, "message": "Run cancellation requested"}
 
 
-# ---------------------------------------------------------------------------
 # Background Run API - exposes agent._background_runs to the frontend
-# ---------------------------------------------------------------------------
 
 
 def _get_background_runs(app: Any, thread_id: str) -> dict:

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -121,11 +121,6 @@ async def delete_avatar(
     return {"status": "ok"}
 
 
-# ---------------------------------------------------------------------------
-# User chat candidates
-# ---------------------------------------------------------------------------
-
-
 def _relationship_states_for_user(relationship_service: Any, user_id: str) -> dict[str, str]:
     if relationship_service is None:
         raise HTTPException(503, "chat bootstrap not attached: relationship_service")

--- a/tests/Integration/test_e2e_summary_persistence.py
+++ b/tests/Integration/test_e2e_summary_persistence.py
@@ -31,14 +31,12 @@ def _memory_middleware(agent):
 
 @pytest.fixture
 def test_db_path(tmp_path):
-    """Create a temporary database for testing."""
     db_path = tmp_path / "test_e2e_summary.db"
     return str(db_path)
 
 
 @pytest.fixture
 def temp_workspace(tmp_path):
-    """Create a temporary workspace."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     return str(workspace)

--- a/tests/Integration/test_followup_requeue.py
+++ b/tests/Integration/test_followup_requeue.py
@@ -16,7 +16,6 @@ from core.runtime.middleware.queue.manager import MessageQueueManager
 
 @pytest.fixture()
 def queue_manager(tmp_path):
-    """Real MessageQueueManager backed by a temp SQLite DB."""
     qm = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
     yield qm
 

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -12,10 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, SystemMessage, ToolMessage
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _mock_model(text="Integration test response"):
     """Create a mock LangChain model that returns a plain AIMessage."""
@@ -298,11 +294,6 @@ def test_create_leon_agent_defaults_to_process_local_agent_registry(monkeypatch,
         assert "agent_registry" not in captured
     finally:
         agent.close()
-
-
-# ---------------------------------------------------------------------------
-# Integration Tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -29,7 +29,6 @@ from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
 @pytest.fixture
 def terminal_store(temp_db):
-    """Create SQLiteTerminalRepo with temp database."""
     repo = SQLiteTerminalRepo(db_path=temp_db)
     yield repo
     repo.close()

--- a/tests/Unit/core/test_tool_registry_runner.py
+++ b/tests/Unit/core/test_tool_registry_runner.py
@@ -40,10 +40,6 @@ from core.tools.tool_search.service import ToolSearchService
 from core.tools.web.service import WebService
 from sandbox.interfaces.filesystem import DirListResult, FileReadResult, FileSystemBackend, FileWriteResult
 
-# ---------------------------------------------------------------------------
-# ToolRegistry
-# ---------------------------------------------------------------------------
-
 
 class TestToolRegistry:
     def _make_entry(self, name: str, mode: ToolMode = ToolMode.INLINE) -> ToolEntry:
@@ -166,11 +162,6 @@ def test_inline_schemas_strip_runtime_only_schema_metadata():
     [schema] = reg.get_inline_schemas()
 
     assert "x-leon-required-any-of" not in schema["parameters"]
-
-
-# ---------------------------------------------------------------------------
-# ToolValidator
-# ---------------------------------------------------------------------------
 
 
 class TestToolValidator:
@@ -351,11 +342,6 @@ class TestToolValidator:
         assert "at most" in str(exc_info.value)
         assert exc_info.value.error_code == "NUMBER_TOO_LARGE"
         assert exc_info.value.details[0]["field"] == "timeout"
-
-
-# ---------------------------------------------------------------------------
-# ToolRunner — P0 error normalization
-# ---------------------------------------------------------------------------
 
 
 def _make_runner(entries: list[ToolEntry]) -> ToolRunner:
@@ -2184,11 +2170,6 @@ class TestToolRunnerInlineInjection:
         runner = _make_runner([deferred])
         schemas = runner._registry.get_inline_schemas()
         assert all(s["name"] != "TaskCreate" for s in schemas)
-
-
-# ---------------------------------------------------------------------------
-# P1: service-declared tool modes
-# ---------------------------------------------------------------------------
 
 
 class TestServiceDeclaredToolModes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,6 @@ def _unlink_db(db_path: Path) -> None:
 
 @pytest.fixture
 def temp_db(tmp_path):
-    """Provide a temporary SQLite database path with Windows-safe cleanup."""
     db_path = tmp_path / "test.db"
     yield db_path
     _unlink_db(db_path)


### PR DESCRIPTION
## Summary
- delete decorative section banners in router and tool tests
- remove fixture docstrings that only restated the fixture name
- keep behavior and @@@ navigation comments unchanged

## Verification
- uv run python -m pytest -q tests/Integration/test_leon_agent.py tests/Unit/core/test_tool_registry_runner.py tests/Integration/test_e2e_summary_persistence.py tests/Integration/test_followup_requeue.py tests/Unit/core/test_runtime.py tests/Integration/test_threads_router.py tests/Integration/test_settings_persistence_contract.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
