### PR TITLE
chore: delete test step comments

### DIFF
--- a/tests/Unit/core/test_queue_formatters.py
+++ b/tests/Unit/core/test_queue_formatters.py
@@ -29,11 +29,9 @@ class TestFormatCommandNotification:
             output="hello\n",
         )
 
-        # Should be valid XML
         root = ET.fromstring(result)
         assert root.tag == "system-reminder"
 
-        # Check CommandNotification structure
         notif = root.find("CommandNotification")
         assert notif is not None
         assert _require_text(_require_child(notif, "CommandId")) == "cmd-123"
@@ -99,11 +97,9 @@ class TestFormatCommandNotification:
             output="<output>&</output>",
         )
 
-        # Should parse without error
         root = ET.fromstring(result)
         notif = _require_child(root, "CommandNotification")
 
-        # Check escaped content is preserved
         cmd_line = _require_text(_require_child(notif, "CommandLine"))
         assert "<tag>" in cmd_line
         assert "&" in cmd_line

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -192,10 +192,8 @@ class TestLocalPersistentShellRuntime:
 
         runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
-        # Execute cd command
         await runtime.execute("cd /")
 
-        # Verify cwd updated
         state = runtime.get_terminal_state()
         assert state.cwd == "/"
 
@@ -207,11 +205,9 @@ class TestLocalPersistentShellRuntime:
 
         runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
-        # Change directory
         await runtime.execute("cd /")
         assert runtime.get_terminal_state().cwd == "/"
 
-        # Execute another command - should still be in /
         result = await runtime.execute("pwd")
         assert "/" in result.stdout.strip()
 
@@ -223,7 +219,6 @@ class TestLocalPersistentShellRuntime:
 
         runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
-        # Execute long-running command with short timeout
         result = await runtime.execute("sleep 10", timeout=0.1)
 
         assert result.timed_out
@@ -237,15 +232,12 @@ class TestLocalPersistentShellRuntime:
 
         runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
-        # Execute command to start session
         await runtime.execute("echo 'test'")
         assert runtime._pty_session is not None
         proc = runtime._pty_session.process
 
-        # Close
         await runtime.close()
 
-        # Session should be terminated
         assert proc is not None and proc.returncode is not None
 
     @pytest.mark.asyncio
@@ -258,11 +250,9 @@ class TestLocalPersistentShellRuntime:
 
         assert runtime.get_terminal_state().state_version == 0
 
-        # Execute command that changes cwd
         await runtime.execute("cd /")
         assert runtime.get_terminal_state().state_version == 1
 
-        # Execute another command
         await runtime.execute("cd /tmp")
         assert runtime.get_terminal_state().state_version == 2
 
@@ -314,7 +304,6 @@ class TestRemoteWrappedRuntime:
 
         await runtime.execute("echo 'test'")
 
-        # Should have called cd to hydrate cwd
         calls = [str(call) for call in mock_provider.execute.call_args_list]
         assert any("cd /home/user" in str(call) for call in calls)
 
@@ -324,11 +313,9 @@ class TestRemoteWrappedRuntime:
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/root"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "test-provider")
 
-        # Mock sandbox_runtime to return instance
         instance = _make_instance()
         sandbox_runtime.ensure_active_instance = MagicMock(return_value=instance)
 
-        # Mock provider execute
         def mock_execute(instance_id, command, **kwargs):
             start_match = re.search(r"__LEON_STATE_START_[a-f0-9]{8}__", command)
             end_match = re.search(r"__LEON_STATE_END_[a-f0-9]{8}__", command)
@@ -343,7 +330,6 @@ class TestRemoteWrappedRuntime:
 
         await runtime.execute("cd /home/user")
 
-        # Verify cwd updated
         state = runtime.get_terminal_state()
         assert state.cwd == "/home/user"
 
@@ -355,7 +341,6 @@ class TestRemoteWrappedRuntime:
 
         runtime = RemoteWrappedRuntime(terminal, sandbox_runtime, mock_provider)
 
-        # Close should not raise
         await runtime.close()
 
     @pytest.mark.asyncio
@@ -457,7 +442,6 @@ class TestRuntimeIntegration:
 
         runtime = LocalPersistentShellRuntime(terminal, sandbox_runtime)
 
-        # Execute multiple commands
         result1 = await runtime.execute("echo 'first'")
         assert "first" in result1.stdout
 
@@ -467,13 +451,11 @@ class TestRuntimeIntegration:
         result3 = await runtime.execute("pwd")
         assert "/" in result3.stdout
 
-        # Verify state persisted
         state = runtime.get_terminal_state()
         assert state.cwd == "/"
         # State version increments: initial=0, after first execute=1, after cd=2, after pwd=3
         assert state.state_version >= 2
 
-        # Close
         await runtime.close()
 
     @pytest.mark.asyncio
@@ -482,16 +464,13 @@ class TestRuntimeIntegration:
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
-        # First runtime
         runtime1 = LocalPersistentShellRuntime(terminal, sandbox_runtime)
         await runtime1.execute("cd /")
         await runtime1.close()
 
-        # Retrieve terminal again
         terminal2 = terminal_from_row(terminal_store.get_active("thread-1"), terminal_store.db_path)
         assert terminal2.get_state().cwd == "/"
 
-        # Second runtime should start with persisted state
         runtime2 = LocalPersistentShellRuntime(terminal2, sandbox_runtime)
         result = await runtime2.execute("pwd")
         assert "/" in result.stdout

--- a/tests/Unit/core/test_spill_buffer.py
+++ b/tests/Unit/core/test_spill_buffer.py
@@ -85,16 +85,13 @@ class TestSpillIfNeeded:
             workspace_root="/workspace",
         )
 
-        # Verify write_file was called with the correct spill path.
         expected_path = posixpath.join("/workspace", ".leon", "tool-results", "call_big.txt")
         fs.write_file.assert_called_once_with(expected_path, large)
 
-        # Result must mention the file path and include a preview.
         assert expected_path in result
         assert result.startswith("<persisted-output")
         assert f"{len(large.encode('utf-8'))} bytes" in result
         assert f"Preview (first {PREVIEW_BYTES} bytes)" in result
-        # Preview text is the first PREVIEW_BYTES chars of the original.
         assert large[:PREVIEW_BYTES] in result
 
     @pytest.mark.parametrize(
@@ -125,12 +122,9 @@ class TestSpillIfNeeded:
     def test_preview_length_capped(self):
         """Preview contains at most PREVIEW_BYTES characters of the original."""
         fs = _make_fs_backend()
-        # Create content much larger than PREVIEW_BYTES.
         large = "X" * (PREVIEW_BYTES * 5)
         result = _spill(large, threshold_bytes=100, tool_call_id="call_prev", fs_backend=fs)
-        # The preview portion should be exactly PREVIEW_BYTES chars of "X".
         assert ("X" * PREVIEW_BYTES) in result
-        # But not the full content.
         assert large not in result
 
     def test_large_output_uses_persisted_output_wrapper(self):
@@ -326,13 +320,11 @@ class TestSpillBufferMiddleware:
         large_content = "A" * 100
         original_msg = ToolMessage(content=large_content, tool_call_id="call_async")
 
-        # Create a mock coroutine-returning handler.
         import asyncio
 
         async def async_handler(req):
             return original_msg
 
-        # Run the async method synchronously via a fresh event loop.
         loop = asyncio.new_event_loop()
         try:
             result = loop.run_until_complete(mw.awrap_tool_call(request, async_handler))

--- a/tests/Unit/platform/test_search_tools.py
+++ b/tests/Unit/platform/test_search_tools.py
@@ -67,7 +67,6 @@ class TestGrepContent:
         result = _grep(mw, pattern="hello", output_mode="content")
         # Python implementation format: <filepath>:<lineno>:<line>
         assert ":2:" in result or ":5:" in result  # line2 or line5 in data.txt
-        # The actual line text should be present
         assert "hello" in result
 
     def test_content_line_numbers(self, mw: SearchService, workspace: Path):
@@ -161,7 +160,6 @@ class TestGrepPagination:
         assert len(lines) == 1
 
     def test_offset(self, mw: SearchService, workspace: Path):
-        # Get all matches first
         full = _grep(
             mw,
             pattern="hello",
@@ -215,9 +213,7 @@ class TestGrepTypeFilter:
     """type filter parameter (Python implementation ignores type, only ripgrep uses it)."""
 
     def test_type_filter_no_crash(self, mw: SearchService):
-        # Python implementation does not implement --type, but should not crash
         result = _grep(mw, pattern="hello", type="py")
-        # Should still return results (type is ignored in Python implementation)
         assert isinstance(result, str)
 
 
@@ -320,7 +316,6 @@ class TestGlobMtimeSorting:
     """Results sorted by modification time, newest first."""
 
     def test_sorted_by_mtime_descending(self, mw: SearchService, workspace: Path):
-        # Create files with distinct mtimes
         old = workspace / "old.txt"
         old.write_text("old")
         time.sleep(0.05)
@@ -367,7 +362,6 @@ class TestGlobPathParameter:
 
     def test_defaults_to_workspace(self, mw: SearchService, workspace: Path):
         result = _glob(mw, pattern="**/*.py")
-        # Should find files under workspace
         assert "main.py" in result
 
     def test_subdirectory(self, mw: SearchService, workspace: Path):

--- a/tests/Unit/sandbox/test_e2b_provider.py
+++ b/tests/Unit/sandbox/test_e2b_provider.py
@@ -60,60 +60,49 @@ def test_e2b_provider():
 
     provider = E2BProvider(api_key=api_key, timeout=60)
 
-    # Create
     print("Creating session...")
     info = provider.create_session()
     print(f"  session_id: {info.session_id}")
     sid = info.session_id
 
-    # Execute
     print("\nExecuting command...")
     result = provider.execute(sid, "echo hello && uname -a")
     print(f"  output: {result.output}")
     assert result.exit_code == 0
 
-    # Write file
     print("\nWriting file...")
     provider.write_file(sid, "/home/user/test.txt", "hello from leon")
 
-    # Read file
     print("\nReading file...")
     content = provider.read_file(sid, "/home/user/test.txt")
     print(f"  content: {content}")
     assert content == "hello from leon"
 
-    # List dir
     print("\nListing /home/user...")
     items = provider.list_dir(sid, "/home/user")
     names = [i["name"] for i in items]
     print(f"  entries: {names}")
     assert "test.txt" in names
 
-    # Status
     print("\nChecking status...")
     status = provider.get_session_status(sid)
     print(f"  status: {status}")
     assert status == "running"
 
-    # Pause
     print("\nPausing...")
     assert provider.pause_session(sid)
 
-    # Status after pause
     status = provider.get_session_status(sid)
     print(f"  status after pause: {status}")
     assert status == "paused"
 
-    # Resume
     print("\nResuming...")
     assert provider.resume_session(sid)
 
-    # Verify state survived
     content = provider.read_file(sid, "/home/user/test.txt")
     print(f"  content after resume: {content}")
     assert content == "hello from leon"
 
-    # Destroy
     print("\nDestroying...")
     assert provider.destroy_session(sid)
 

--- a/tests/Unit/sandbox/test_terminal_persistence.py
+++ b/tests/Unit/sandbox/test_terminal_persistence.py
@@ -17,11 +17,9 @@ def test_bash_env_persistence():
     async def run():
         executor = BashExecutor()
 
-        # Set environment variable
         result1 = await executor.execute("export TEST_VAR=hello")
         assert result1.exit_code == 0
 
-        # Check it persists
         result2 = await executor.execute("echo $TEST_VAR")
         assert result2.exit_code == 0
         assert "hello" in result2.stdout
@@ -36,17 +34,14 @@ def test_bash_cwd_persistence():
     async def run():
         executor = BashExecutor()
 
-        # Create and change to test directory
         result1 = await executor.execute("mkdir -p /tmp/test_leon_bash && cd /tmp/test_leon_bash && pwd")
         assert result1.exit_code == 0
         assert "/tmp/test_leon_bash" in result1.stdout
 
-        # Check we're still in that directory
         result2 = await executor.execute("pwd")
         assert result2.exit_code == 0
         assert "/tmp/test_leon_bash" in result2.stdout
 
-        # Cleanup
         await executor.execute("cd /tmp && rm -rf /tmp/test_leon_bash")
 
     asyncio.run(run())
@@ -59,11 +54,9 @@ def test_zsh_env_persistence():
     async def run():
         executor = ZshExecutor()
 
-        # Set environment variable
         result1 = await executor.execute("export TEST_VAR=world")
         assert result1.exit_code == 0
 
-        # Check it persists
         result2 = await executor.execute("echo $TEST_VAR")
         assert result2.exit_code == 0
         assert "world" in result2.stdout
@@ -78,17 +71,14 @@ def test_zsh_cwd_persistence():
     async def run():
         executor = ZshExecutor()
 
-        # Create and change to test directory
         result1 = await executor.execute("mkdir -p /tmp/test_leon_zsh && cd /tmp/test_leon_zsh && pwd")
         assert result1.exit_code == 0
         assert "/tmp/test_leon_zsh" in result1.stdout
 
-        # Check we're still in that directory
         result2 = await executor.execute("pwd")
         assert result2.exit_code == 0
         assert "/tmp/test_leon_zsh" in result2.stdout
 
-        # Cleanup
         await executor.execute("cd /tmp && rm -rf /tmp/test_leon_zsh")
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- delete redundant step comments from unit tests
- keep behavior unchanged while reducing code volume

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
