### PR TITLE
chore: delete summary test comment noise

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -182,15 +182,12 @@ def publish(
 
     new_version = bump_semver(meta.get("version", "0.1.0"), bump_type)
 
-    # Get slug from agent name
     slug = bundle.agent.name.lower().replace(" ", "-")
 
-    # Check for fork/parent relationship
     source = meta.get("source", {})
     parent_item_id = source.get("marketplace_item_id")
     parent_version = source.get("installed_version")
 
-    # Call Hub API
     result = _hub_api(
         "POST",
         "/publish",
@@ -211,7 +208,6 @@ def publish(
         },
     )
 
-    # Update local meta.json
     meta["version"] = new_version
     meta["status"] = "active"
     meta["updated_at"] = int(time.time() * 1000)

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -25,12 +25,10 @@ from backend.web.routers import (  # noqa: E402
     webhooks,
 )
 
-# Create FastAPI app
 app = FastAPI(title="Mycel Web Backend", lifespan=lifespan)
 
 add_permissive_cors(app)
 
-# Include routers
 app.include_router(auth.router)
 app.include_router(invite_codes.router)
 app.include_router(threads.router)

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -208,7 +208,6 @@ class SupabaseThreadRepo:
         user_map: dict[str, dict[str, Any]] = {r["id"]: r for r in user_rows}
         agent_user_ids = list(user_map.keys())
 
-        # Step 2: get threads for those agent users
         thread_cols = ", ".join(_COLS)
         thread_rows = q.rows_in_chunks(
             lambda: q.order(
@@ -230,7 +229,6 @@ class SupabaseThreadRepo:
             "list_by_owner_user_id:threads",
         )
 
-        # Step 3: enrich with agent display data from user_map
         result: list[dict[str, Any]] = []
         for raw in thread_rows:
             d = _to_dict(raw)

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -72,7 +72,6 @@ class TestAgentLoader:
         dict2 = {"api": {"temperature": None}}
 
         result = loader._deep_merge(dict1, dict2)
-        # None values should not override
         assert result["api"]["temperature"] == 0.5
 
     def test_deep_merge_multiple(self):
@@ -92,7 +91,6 @@ class TestAgentLoader:
         config2 = {"mcp": {"servers": {"server2": {}}}}
         config3 = {"mcp": {"servers": {"server3": {}}}}
 
-        # First found wins
         result = loader._lookup_merge("mcp", config1, config2, config3)
         assert "server1" in result["servers"]
         assert "server2" not in result["servers"]

--- a/tests/Integration/test_e2e_summary_persistence.py
+++ b/tests/Integration/test_e2e_summary_persistence.py
@@ -1,13 +1,3 @@
-"""
-End-to-end tests for summary persistence through the full agent stack.
-
-Tests the complete flow: Agent → MemoryMiddleware → SummaryStore → SQLite
-No mocks - uses real agent with all middleware layers.
-
-Note: These tests work around asyncio event loop limitations by creating
-fresh agents for each test phase.
-"""
-
 import os
 from pathlib import Path
 
@@ -43,24 +33,10 @@ def temp_workspace(tmp_path):
 
 
 class TestFullAgentSummaryPersistence:
-    """Test full agent lifecycle with compaction and restore."""
-
     def test_full_agent_summary_persistence(self, test_db_path, temp_workspace):
-        """
-        Test 1: Full agent lifecycle with compaction and restore.
-
-        Flow:
-        1. Create agent with memory enabled and LOW threshold
-        2. Send ONE message to trigger compaction
-        3. Verify summary is saved to store
-        4. Close agent
-        5. Create new agent with same thread_id
-        6. Verify summary is restored from store
-        """
         thread_id = "test-full-lifecycle"
         set_current_thread_id(thread_id)
 
-        # Create agent with memory enabled and LOW compaction threshold
         agent = create_leon_agent(
             workspace_root=temp_workspace,
             sandbox="local",
@@ -73,8 +49,6 @@ class TestFullAgentSummaryPersistence:
             memory._compaction_threshold = 0.01
             memory.compactor.keep_recent_tokens = 500
 
-            # Send ONE large message to exceed threshold and trigger compaction
-            # This avoids the event loop issue with multiple invoke() calls
             large_message = (
                 """
             Create multiple files with the following content:
@@ -86,13 +60,12 @@ class TestFullAgentSummaryPersistence:
             Then list all files in the workspace and show their contents.
             """
                 * 3
-            )  # Repeat to ensure we exceed 1000 tokens
+            )
 
             result = agent.invoke(large_message, thread_id=thread_id)
             assert result is not None
             assert "messages" in result
 
-            # Verify summary was saved to store
             memory = _memory_middleware(agent)
             store = memory.summary_store
             print(f"[Test] Checking summary store: {store}")
@@ -103,7 +76,6 @@ class TestFullAgentSummaryPersistence:
             summary = store.get_latest_summary(thread_id)
             print(f"[Test] Retrieved summary: {summary}")
 
-            # With low threshold and large message, summary should exist
             assert summary is not None, "Summary should exist after exceeding threshold"
             assert summary.thread_id == thread_id
             assert summary.summary_text is not None
@@ -114,7 +86,6 @@ class TestFullAgentSummaryPersistence:
         finally:
             agent.close()
 
-        # Create new agent with same thread_id to test restore
         agent2 = create_leon_agent(
             workspace_root=temp_workspace,
             sandbox="local",
@@ -125,7 +96,6 @@ class TestFullAgentSummaryPersistence:
             memory2 = _memory_middleware(agent2)
             memory2.summary_store = SummaryStore(Path(test_db_path))
 
-            # Continue conversation - should restore summary
             result = agent2.invoke(
                 "What files did we create earlier?",
                 thread_id=thread_id,
@@ -134,7 +104,6 @@ class TestFullAgentSummaryPersistence:
             assert result is not None
             assert "messages" in result
 
-            # Verify summary was restored
             assert memory2._cached_summary is not None, "Summary should be restored"
             assert memory2._compact_up_to_index >= 0
             print(f"[Test] Summary restored: compact_up_to_index={memory2._compact_up_to_index}")
@@ -144,19 +113,7 @@ class TestFullAgentSummaryPersistence:
 
 
 class TestAgentSplitTurnE2E:
-    """Test split turn through agent interface."""
-
     def test_agent_split_turn_e2e(self, test_db_path, temp_workspace):
-        """
-        Test 2: Split Turn through agent interface.
-
-        Flow:
-        1. Create agent with memory enabled and LOW threshold
-        2. Send a very large message that triggers split turn
-        3. Verify split turn summary is saved with prefix
-        4. Verify is_split_turn flag is set
-        5. Verify split_turn_prefix is saved
-        """
         thread_id = "test-split-turn"
         set_current_thread_id(thread_id)
 
@@ -172,20 +129,15 @@ class TestAgentSplitTurnE2E:
             memory._compaction_threshold = 0.01
             memory.compactor.keep_recent_tokens = 500
 
-            # Send a very large message to trigger split turn
-            # This simulates a scenario where the new turn is too large
             large_content = "x" * 50000  # 50KB of content
             large_message = f"Create a file with this content: {large_content}"
 
             result = agent.invoke(large_message, thread_id=thread_id)
             assert result is not None
 
-            # Check if split turn was triggered
             store = memory.summary_store
             summary = store.get_latest_summary(thread_id)
 
-            # Split turn may or may not be triggered depending on context size
-            # This test verifies the mechanism works if triggered
             if summary:
                 print(f"[Test] Summary exists: is_split_turn={summary.is_split_turn}")
                 if summary.is_split_turn:
@@ -202,22 +154,9 @@ class TestAgentSplitTurnE2E:
 
 
 class TestAgentConcurrentThreads:
-    """Test multiple agent instances with different threads (sequential execution)."""
-
     def test_agent_concurrent_threads(self, test_db_path, temp_workspace):
-        """
-        Test 3: Multiple agent instances with different threads.
-
-        Flow:
-        1. Create multiple agents with different thread_ids (one at a time)
-        2. Run conversations in each thread
-        3. Verify summaries are isolated by thread_id
-        4. Verify no cross-contamination between threads
-        5. Verify each thread can restore its own summary
-        """
         thread_ids = ["test-thread-1", "test-thread-2", "test-thread-3"]
 
-        # Process each thread sequentially to avoid event loop issues
         for thread_id in thread_ids:
             set_current_thread_id(thread_id)
             agent = create_leon_agent(
@@ -231,7 +170,6 @@ class TestAgentConcurrentThreads:
                 memory.summary_store = SummaryStore(Path(test_db_path))
                 memory._compaction_threshold = 0.01
 
-                # Each thread creates different files with ONE large message
                 large_message = (
                     f"""
                 Create multiple files for {thread_id}:
@@ -242,14 +180,13 @@ class TestAgentConcurrentThreads:
                 Then list all files.
                 """
                     * 2
-                )  # Repeat to exceed threshold
+                )
 
                 result = agent.invoke(large_message, thread_id=thread_id)
                 assert result is not None
             finally:
                 agent.close()
 
-        # Verify summaries are isolated
         store = SummaryStore(Path(test_db_path))
 
         for thread_id in thread_ids:
@@ -260,18 +197,15 @@ class TestAgentConcurrentThreads:
             else:
                 print(f"[Test] Thread {thread_id}: no summary yet")
 
-        # Verify no cross-contamination
         all_summaries = []
         for thread_id in thread_ids:
             summaries = store.list_summaries(thread_id)
             all_summaries.extend(summaries)
 
-        # Each summary should only belong to its own thread
         for summary in all_summaries:
             assert summary["thread_id"] in thread_ids
             print(f"[Test] Summary {summary['summary_id']} belongs to {summary['thread_id']}")
 
-        # Test restore for each thread (sequential)
         for thread_id in thread_ids:
             set_current_thread_id(thread_id)
             agent = create_leon_agent(
@@ -284,14 +218,12 @@ class TestAgentConcurrentThreads:
                 memory = _memory_middleware(agent)
                 memory.summary_store = SummaryStore(Path(test_db_path))
 
-                # Continue conversation - should restore correct summary
                 result = agent.invoke(
                     f"What files did we create in {thread_id}?",
                     thread_id=thread_id,
                 )
                 assert result is not None
 
-                # Verify correct summary was restored
                 if memory._cached_summary:
                     print(f"[Test] Thread {thread_id}: summary restored")
                 else:

--- a/tests/Integration/test_memory_middleware_integration.py
+++ b/tests/Integration/test_memory_middleware_integration.py
@@ -1,8 +1,3 @@
-"""Integration tests for MemoryMiddleware with SummaryStore persistence.
-
-Tests the complete flow: MemoryMiddleware → SummaryStore → SQLite → Checkpointer
-"""
-
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,7 +12,6 @@ from sandbox.thread_context import set_current_thread_id
 
 @pytest.fixture
 def mock_checkpointer():
-    """Create mock checkpointer for testing."""
     checkpointer = MagicMock()
 
     def mock_get(config):
@@ -25,7 +19,6 @@ def mock_checkpointer():
         if not thread_id:
             return None
 
-        # Return mock checkpoint with messages
         return {
             "channel_values": {
                 "messages": [
@@ -48,11 +41,9 @@ def mock_checkpointer():
 
 @pytest.fixture
 def mock_model():
-    """Create mock LLM model for testing."""
     model = MagicMock()
 
     async def mock_ainvoke(messages):
-        # Return a mock summary response
         response = MagicMock()
         response.content = "This is a test summary of the conversation."
         return response
@@ -64,12 +55,10 @@ def mock_model():
 
 @pytest.fixture
 def mock_request():
-    """Create mock ModelRequest for testing."""
     request = MagicMock()
     request.messages = []
     request.system_message = None
 
-    # Add config with thread_id
     config = MagicMock()
     config.configurable = {"thread_id": "test-thread-1"}
     request.config = config
@@ -78,7 +67,6 @@ def mock_request():
 
 
 def create_large_message_list(count: int = 50) -> list:
-    """Create a large list of messages to trigger compaction."""
     messages = []
     for i in range(count):
         messages.append(HumanMessage(content=f"User message {i}" * 100))  # ~1500 chars each
@@ -98,12 +86,8 @@ class _AsyncOnlyCheckpointer:
 
 
 class TestSummarySaveOnCompaction:
-    """Test 1: Verify summary is saved to store when compaction occurs."""
-
     @pytest.mark.asyncio
     async def test_summary_save_on_compaction(self, temp_db, mock_model, mock_request):
-        """Trigger compaction and verify summary is saved to store."""
-        # Create middleware with low threshold to trigger compaction
         middleware = MemoryMiddleware(
             context_limit=10000,
             compaction_threshold=0.5,
@@ -112,18 +96,14 @@ class TestSummarySaveOnCompaction:
         )
         middleware.set_model(mock_model)
 
-        # Create large message list to trigger compaction
         messages = create_large_message_list(30)
         mock_request.messages = messages
 
-        # Mock handler
         async def mock_handler(req):
             return MagicMock()
 
-        # Execute middleware
         await middleware.awrap_model_call(mock_request, mock_handler)
 
-        # Verify summary was saved to store
         store = SummaryStore(temp_db)
         summary = store.get_latest_summary("test-thread-1")
 
@@ -137,12 +117,8 @@ class TestSummarySaveOnCompaction:
 
 
 class TestSummaryRestoreOnStartup:
-    """Test 2: Verify summary is restored from store on middleware startup."""
-
     @pytest.mark.asyncio
     async def test_summary_restore_on_startup(self, temp_db, mock_model, mock_request):
-        """Restart middleware and verify summary is restored from store."""
-        # Step 1: Create middleware and trigger compaction
         middleware1 = MemoryMiddleware(
             context_limit=10000,
             compaction_threshold=0.5,
@@ -159,12 +135,10 @@ class TestSummaryRestoreOnStartup:
 
         await middleware1.awrap_model_call(mock_request, mock_handler)
 
-        # Verify summary was saved
         assert middleware1._cached_summary is not None
         original_summary = middleware1._cached_summary
         original_index = middleware1._compact_up_to_index
 
-        # Step 2: Create new middleware instance (simulating restart)
         middleware2 = MemoryMiddleware(
             context_limit=10000,
             compaction_threshold=0.5,
@@ -173,14 +147,11 @@ class TestSummaryRestoreOnStartup:
         )
         middleware2.set_model(mock_model)
 
-        # Create new request with fewer messages (below threshold)
         small_messages = create_large_message_list(5)
         mock_request.messages = small_messages
 
-        # Execute middleware - should restore summary
         await middleware2.awrap_model_call(mock_request, mock_handler)
 
-        # Verify summary was restored
         assert middleware2._cached_summary == original_summary
         assert middleware2._compact_up_to_index == original_index
         assert middleware2._summary_restored is True
@@ -242,8 +213,6 @@ class TestSummaryRestoreOnStartup:
 
 
 class TestRebuildFromCheckpointer:
-    """Test 4: Verify summary can be rebuilt from checkpointer when store data is corrupted."""
-
     @pytest.mark.asyncio
     async def test_late_bound_async_checkpointer_rebuilds_summary(self, temp_db, mock_model):
         """Late-bound async savers should be enough for rebuild; sync .get() is not required."""
@@ -274,8 +243,6 @@ class TestRebuildFromCheckpointer:
 
     @pytest.mark.asyncio
     async def test_rebuild_from_checkpointer(self, temp_db, mock_model, mock_checkpointer, mock_request):
-        """Test rebuilding summary from checkpointer when store is corrupted."""
-        # Create middleware with checkpointer
         middleware = MemoryMiddleware(
             context_limit=10000,
             compaction_threshold=0.5,
@@ -285,7 +252,6 @@ class TestRebuildFromCheckpointer:
         )
         middleware.set_model(mock_model)
 
-        # Manually corrupt the store by saving invalid data
         store = SummaryStore(temp_db)
         store.save_summary(
             thread_id="test-thread-1",
@@ -294,17 +260,14 @@ class TestRebuildFromCheckpointer:
             compacted_at=0,
         )
 
-        # Create request with messages
         messages = create_large_message_list(30)
         mock_request.messages = messages
 
         async def mock_handler(req):
             return MagicMock()
 
-        # Execute middleware - should detect corruption and rebuild
         await middleware.awrap_model_call(mock_request, mock_handler)
 
-        # Verify summary was rebuilt
         rebuilt_summary = store.get_latest_summary("test-thread-1")
         assert rebuilt_summary is not None
         assert rebuilt_summary.summary_text != ""
@@ -312,11 +275,8 @@ class TestRebuildFromCheckpointer:
 
 
 class TestMultipleThreadsIsolated:
-    """Test 5: Verify multiple thread_ids maintain isolated summaries."""
-
     @pytest.mark.asyncio
     async def test_multiple_threads_isolated(self, temp_db, mock_model):
-        """Test that multiple threads maintain separate summaries."""
         middleware = MemoryMiddleware(
             context_limit=10000,
             compaction_threshold=0.5,
@@ -325,11 +285,9 @@ class TestMultipleThreadsIsolated:
         )
         middleware.set_model(mock_model)
 
-        # Create different summaries for different threads
         async def mock_handler(req):
             return MagicMock()
 
-        # Thread 1
         request1 = MagicMock()
         request1.messages = create_large_message_list(30)
         request1.system_message = None
@@ -337,7 +295,6 @@ class TestMultipleThreadsIsolated:
         config1.configurable = {"thread_id": "thread-1"}
         request1.config = config1
 
-        # Thread 2
         request2 = MagicMock()
         request2.messages = create_large_message_list(30)
         request2.system_message = None
@@ -345,15 +302,12 @@ class TestMultipleThreadsIsolated:
         config2.configurable = {"thread_id": "thread-2"}
         request2.config = config2
 
-        # Execute for both threads
         await middleware.awrap_model_call(request1, mock_handler)
 
-        # Reset restoration flag for second thread
         middleware._summary_restored = False
 
         await middleware.awrap_model_call(request2, mock_handler)
 
-        # Verify both threads have separate summaries
         store = SummaryStore(temp_db)
         summary1 = store.get_latest_summary("thread-1")
         summary2 = store.get_latest_summary("thread-2")
@@ -420,12 +374,8 @@ class TestCompactionBreakerScope:
 
 
 class TestSummaryUpdateOnSecondCompaction:
-    """Test 8: Verify summary is updated correctly on second compaction."""
-
     @pytest.mark.asyncio
     async def test_summary_update_on_second_compaction(self, temp_db, mock_model, mock_request):
-        """Test that second compaction updates the summary correctly."""
-        # Create mock model that returns different summaries
         call_count = [0]
 
         async def mock_ainvoke_sequential(messages):
@@ -444,7 +394,6 @@ class TestSummaryUpdateOnSecondCompaction:
         )
         middleware.set_model(mock_model)
 
-        # First compaction
         messages1 = create_large_message_list(30)
         mock_request.messages = messages1
 
@@ -459,23 +408,18 @@ class TestSummaryUpdateOnSecondCompaction:
         # Summary may include split turn context, so check for version 1 presence
         assert "Summary version 1" in summary1.summary_text or "Summary version 2" in summary1.summary_text
 
-        # Second compaction with more messages
         messages2 = create_large_message_list(60)
         mock_request.messages = messages2
 
-        # Reset restoration flag to allow new compaction
         middleware._summary_restored = False
 
         await middleware.awrap_model_call(mock_request, mock_handler)
 
-        # Verify summary was updated
         summary2 = store.get_latest_summary("test-thread-1")
         assert summary2 is not None
-        # Check that a new summary version exists
         assert "Summary version" in summary2.summary_text
         assert summary2.summary_id != summary1.summary_id
 
-        # Verify old summary is marked inactive
         all_summaries = store.list_summaries("test-thread-1")
         assert len(all_summaries) == 2
         active_summaries = [s for s in all_summaries if s["is_active"]]


### PR DESCRIPTION
## Summary
- Delete redundant summary persistence test docstrings and step comments
- Delete a few obvious restatement comments in hub, web main, config, and Supabase thread repo code

## Line count
- 6 files changed, 2 insertions, 136 deletions
- Net -134 lines

## Verification
- uv run python -m pytest -q tests/Config/test_loader.py tests/Integration/test_memory_middleware_integration.py: 33 passed
- uv run ruff check backend/web/main.py backend/hub/client.py storage/providers/supabase/thread_repo.py tests/Config/test_loader.py tests/Integration/test_memory_middleware_integration.py tests/Integration/test_e2e_summary_persistence.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q: 1603 passed, 8 skipped
