### PR TITLE
chore: delete test docstring noise

### DIFF
--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -1,5 +1,3 @@
-"""Comprehensive tests for config.loader module."""
-
 import json
 import os
 import sys
@@ -12,8 +10,6 @@ from config.schema import LeonSettings
 
 
 class TestAgentLoader:
-    """Tests for AgentLoader."""
-
     def test_init(self, tmp_path):
         loader = AgentLoader(workspace_root=str(tmp_path))
         assert loader.workspace_root == tmp_path
@@ -180,8 +176,6 @@ class TestAgentLoader:
 
 
 class TestLoadConfigFunction:
-    """Tests for load_config convenience function."""
-
     def test_load_config_with_workspace(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
 

--- a/tests/Unit/core/test_queue_formatters.py
+++ b/tests/Unit/core/test_queue_formatters.py
@@ -1,5 +1,3 @@
-"""Tests for core/queue/formatters.py"""
-
 import xml.etree.ElementTree as ET
 
 from core.runtime.middleware.queue.formatters import format_command_notification
@@ -17,10 +15,7 @@ def _require_text(element: ET.Element) -> str:
 
 
 class TestFormatCommandNotification:
-    """Test format_command_notification XML generation."""
-
     def test_basic_format(self):
-        """Test basic XML structure."""
         result = format_command_notification(
             command_id="cmd-123",
             status="completed",
@@ -41,7 +36,6 @@ class TestFormatCommandNotification:
         assert _require_text(_require_child(notif, "Output")) == "hello\n"
 
     def test_failed_status(self):
-        """Test failed command notification."""
         result = format_command_notification(
             command_id="cmd-456",
             status="failed",
@@ -56,7 +50,6 @@ class TestFormatCommandNotification:
         assert _require_text(_require_child(notif, "ExitCode")) == "1"
 
     def test_output_truncation(self):
-        """Test output is truncated to 1000 characters."""
         long_output = "x" * 2000
         result = format_command_notification(
             command_id="cmd-789",
@@ -73,7 +66,6 @@ class TestFormatCommandNotification:
         assert output_text == "x" * 1000
 
     def test_empty_output(self):
-        """Test empty output is handled correctly."""
         result = format_command_notification(
             command_id="cmd-empty",
             status="completed",
@@ -88,7 +80,6 @@ class TestFormatCommandNotification:
         assert output_elem.text is None or output_elem.text == ""
 
     def test_xml_special_characters_escaped(self):
-        """Test XML special characters are properly escaped."""
         result = format_command_notification(
             command_id="cmd-special",
             status="completed",
@@ -109,7 +100,6 @@ class TestFormatCommandNotification:
         assert "&" in output
 
     def test_multiline_output(self):
-        """Test multiline output is preserved."""
         result = format_command_notification(
             command_id="cmd-multi",
             status="completed",

--- a/tests/Unit/core/test_runtime.py
+++ b/tests/Unit/core/test_runtime.py
@@ -1,5 +1,3 @@
-"""Unit tests for PhysicalTerminalRuntime."""
-
 import asyncio
 import re
 import sqlite3
@@ -54,7 +52,6 @@ class _DomainSandboxRuntimeStore:
 
 @pytest.fixture
 def sandbox_runtime_store(temp_db):
-    """Create SQLiteSandboxRuntimeRepo with domain-object conversion for tests."""
     repo = SQLiteSandboxRuntimeRepo(db_path=temp_db)
     store = _DomainSandboxRuntimeStore(repo)
     yield store
@@ -63,7 +60,6 @@ def sandbox_runtime_store(temp_db):
 
 @pytest.fixture
 def mock_provider():
-    """Create mock SandboxProvider."""
     provider = MagicMock()
     provider.name = "test-provider"
     return provider
@@ -168,11 +164,8 @@ def test_terminal_repo_schema_uses_sandbox_runtime_id_column(tmp_path):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="LocalPersistentShellRuntime requires a Unix shell")
 class TestLocalPersistentShellRuntime:
-    """Test LocalPersistentShellRuntime."""
-
     @pytest.mark.asyncio
     async def test_execute_simple_command(self, terminal_store, sandbox_runtime_store):
-        """Test executing a simple command."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -186,7 +179,6 @@ class TestLocalPersistentShellRuntime:
 
     @pytest.mark.asyncio
     async def test_execute_updates_cwd(self, terminal_store, sandbox_runtime_store):
-        """Test that cwd is updated after command execution."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -199,7 +191,6 @@ class TestLocalPersistentShellRuntime:
 
     @pytest.mark.asyncio
     async def test_state_persists_across_commands(self, terminal_store, sandbox_runtime_store):
-        """Test that state persists across multiple commands."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -213,7 +204,6 @@ class TestLocalPersistentShellRuntime:
 
     @pytest.mark.asyncio
     async def test_execute_with_timeout(self, terminal_store, sandbox_runtime_store):
-        """Test command timeout."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -226,7 +216,6 @@ class TestLocalPersistentShellRuntime:
 
     @pytest.mark.asyncio
     async def test_close_terminates_session(self, terminal_store, sandbox_runtime_store):
-        """Test that close terminates the shell session."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -242,7 +231,6 @@ class TestLocalPersistentShellRuntime:
 
     @pytest.mark.asyncio
     async def test_state_version_increments(self, terminal_store, sandbox_runtime_store):
-        """Test that state version increments after updates."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -258,15 +246,11 @@ class TestLocalPersistentShellRuntime:
 
 
 class TestRemoteWrappedRuntime:
-    """Test RemoteWrappedRuntime."""
-
     @pytest.mark.asyncio
     async def test_execute_simple_command(self, terminal_store, sandbox_runtime_store, mock_provider):
-        """Test executing a simple command via provider."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/root"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "test-provider")
 
-        # Mock sandbox_runtime to return instance
         instance = _make_instance()
         sandbox_runtime.ensure_active_instance = MagicMock(return_value=instance)
 
@@ -286,11 +270,9 @@ class TestRemoteWrappedRuntime:
 
     @pytest.mark.asyncio
     async def test_hydrate_state_on_first_execution(self, terminal_store, sandbox_runtime_store, mock_provider):
-        """Test that state is hydrated on first execution."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/home/user"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "test-provider")
 
-        # Mock sandbox_runtime to return instance
         instance = _make_instance()
         sandbox_runtime.ensure_active_instance = MagicMock(return_value=instance)
 
@@ -309,7 +291,6 @@ class TestRemoteWrappedRuntime:
 
     @pytest.mark.asyncio
     async def test_execute_updates_cwd(self, terminal_store, sandbox_runtime_store, mock_provider):
-        """Test that cwd is updated after command execution."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/root"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "test-provider")
 
@@ -335,7 +316,6 @@ class TestRemoteWrappedRuntime:
 
     @pytest.mark.asyncio
     async def test_close_is_noop(self, terminal_store, sandbox_runtime_store, mock_provider):
-        """Test that close is a no-op for remote runtime."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/root"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "test-provider")
 
@@ -432,11 +412,8 @@ class TestRemoteWrappedRuntime:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="LocalPersistentShellRuntime requires a Unix shell")
 class TestRuntimeIntegration:
-    """Integration tests for runtime lifecycle."""
-
     @pytest.mark.asyncio
     async def test_local_runtime_full_lifecycle(self, terminal_store, sandbox_runtime_store):
-        """Test complete local runtime lifecycle."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 
@@ -460,7 +437,6 @@ class TestRuntimeIntegration:
 
     @pytest.mark.asyncio
     async def test_state_persists_across_runtime_instances(self, terminal_store, sandbox_runtime_store):
-        """Test that terminal state persists when runtime is recreated."""
         terminal = terminal_from_row(terminal_store.create("term-1", "thread-1", "runtime-1", "/tmp"), terminal_store.db_path)
         sandbox_runtime = sandbox_runtime_store.create("runtime-1", "local")
 

--- a/tests/Unit/sandbox/test_sandbox_state.py
+++ b/tests/Unit/sandbox/test_sandbox_state.py
@@ -1,48 +1,38 @@
-"""Tests for sandbox state mapping logic."""
-
 from storage.models import (
     map_sandbox_state_to_display_status,
 )
 
 
 def test_map_running_state():
-    """Test mapping of running state (detached + running)."""
     assert map_sandbox_state_to_display_status("detached", "running") == "running"
 
 
 def test_map_pausing_state():
-    """Test mapping of pausing in progress (detached + paused)."""
     assert map_sandbox_state_to_display_status("detached", "paused") == "paused"
 
 
 def test_map_paused_state():
-    """Test mapping of paused state (paused + paused)."""
     assert map_sandbox_state_to_display_status("paused", "paused") == "paused"
 
 
 def test_map_stopped_state():
-    """Test mapping of stopped state (None)."""
     assert map_sandbox_state_to_display_status(None, None) == "stopped"
     assert map_sandbox_state_to_display_status(None, "running") == "stopped"
 
 
 def test_map_destroying_state():
-    """Test mapping of destroying state (any + destroyed)."""
     assert map_sandbox_state_to_display_status("detached", "destroyed") == "destroying"
     assert map_sandbox_state_to_display_status("paused", "destroyed") == "destroying"
 
 
 def test_case_insensitive():
-    """Test that mapping is case-insensitive."""
     assert map_sandbox_state_to_display_status("DETACHED", "RUNNING") == "running"
     assert map_sandbox_state_to_display_status("Paused", "Paused") == "paused"
 
 
 def test_whitespace_handling():
-    """Test that mapping handles whitespace."""
     assert map_sandbox_state_to_display_status(" detached ", " running ") == "running"
 
 
 def test_unknown_state():
-    """Test that unknown states are treated as stopped."""
     assert map_sandbox_state_to_display_status("unknown", "running") == "stopped"

--- a/tests/Unit/sandbox/test_terminal_persistence.py
+++ b/tests/Unit/sandbox/test_terminal_persistence.py
@@ -1,5 +1,3 @@
-"""Tests for terminal persistence (env/cwd across commands)."""
-
 import asyncio
 import shutil
 import sys
@@ -12,8 +10,6 @@ from core.tools.command.zsh.executor import ZshExecutor
 
 @pytest.mark.skipif(sys.platform == "win32" or shutil.which("bash") is None, reason="bash persistence tests require a Unix shell")
 def test_bash_env_persistence():
-    """Test that environment variables persist across commands in bash."""
-
     async def run():
         executor = BashExecutor()
 
@@ -29,8 +25,6 @@ def test_bash_env_persistence():
 
 @pytest.mark.skipif(sys.platform == "win32" or shutil.which("bash") is None, reason="bash persistence tests require a Unix shell")
 def test_bash_cwd_persistence():
-    """Test that working directory persists across commands in bash."""
-
     async def run():
         executor = BashExecutor()
 
@@ -49,8 +43,6 @@ def test_bash_cwd_persistence():
 
 @pytest.mark.skipif(sys.platform == "win32" or shutil.which("zsh") is None, reason="zsh persistence tests require a Unix shell")
 def test_zsh_env_persistence():
-    """Test that environment variables persist across commands in zsh."""
-
     async def run():
         executor = ZshExecutor()
 
@@ -66,8 +58,6 @@ def test_zsh_env_persistence():
 
 @pytest.mark.skipif(sys.platform == "win32" or shutil.which("zsh") is None, reason="zsh persistence tests require a Unix shell")
 def test_zsh_cwd_persistence():
-    """Test that working directory persists across commands in zsh."""
-
     async def run():
         executor = ZshExecutor()
 


### PR DESCRIPTION
## Summary
- Delete redundant test module/class/function docstrings that repeat names
- Delete two stale mock comments in runtime tests

## Line count
- 5 files changed, 60 deletions
- Net -60 lines

## Verification
- uv run python -m pytest -q tests/Config/test_loader.py tests/Unit/core/test_queue_formatters.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_state.py tests/Unit/sandbox/test_terminal_persistence.py: 74 passed, 1 skipped
- uv run ruff check tests/Config/test_loader.py tests/Unit/core/test_queue_formatters.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_state.py tests/Unit/sandbox/test_terminal_persistence.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q: 1603 passed, 8 skipped
