### PR TITLE
chore: delete more test comment noise

### DIFF
--- a/tests/Integration/test_background_task_cleanup.py
+++ b/tests/Integration/test_background_task_cleanup.py
@@ -1,5 +1,3 @@
-"""Integration tests for background task cleanup across command/agent surfaces."""
-
 import asyncio
 import json
 import shlex

--- a/tests/Integration/test_daytona_e2e.py
+++ b/tests/Integration/test_daytona_e2e.py
@@ -1,5 +1,3 @@
-"""End-to-end tests for Daytona sandbox."""
-
 import asyncio
 import os
 import tempfile
@@ -18,7 +16,6 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def daytona_sandbox():
-    """Create a Daytona sandbox for testing."""
     config = SandboxConfig(
         provider="daytona",
         on_exit="destroy",
@@ -34,8 +31,6 @@ def daytona_sandbox():
 
 
 class TestDaytonaSandboxE2E:
-    """End-to-end tests for Daytona sandbox."""
-
     def test_file_operations(self, daytona_sandbox):
         thread_id = "test-daytona-files"
         set_current_thread_id(thread_id)

--- a/tests/Integration/test_followup_requeue.py
+++ b/tests/Integration/test_followup_requeue.py
@@ -1,11 +1,3 @@
-"""Tests for followup queue re-enqueue logic in streaming_service.
-
-Covers the _consume_followup_queue function:
-- Normal path: dequeue + start_agent_run succeeds
-- Re-enqueue on failure: message is put back when start_agent_run raises
-- No followup: dequeue returns None, nothing happens
-"""
-
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +14,6 @@ def queue_manager(tmp_path):
 
 @pytest.fixture()
 def mock_app(queue_manager):
-    """Minimal app stub with state.queue_manager and state.thread_event_buffers/thread_tasks."""
     state = SimpleNamespace(
         queue_manager=queue_manager,
         thread_event_buffers={},
@@ -33,7 +24,6 @@ def mock_app(queue_manager):
 
 @pytest.fixture()
 def mock_agent():
-    """Minimal agent stub with runtime that supports transition()."""
     runtime = MagicMock()
     runtime.transition.return_value = True
     runtime._activity_sink = None
@@ -43,25 +33,19 @@ def mock_agent():
 
 @pytest.mark.asyncio
 class TestConsumeFollowupQueue:
-    """Tests for _consume_followup_queue re-enqueue logic."""
-
     async def test_no_followup_does_nothing(self, mock_agent, mock_app):
-        """When queue is empty, nothing happens."""
         from backend.threads.streaming import _consume_followup_queue
 
         await _consume_followup_queue(mock_agent, "thread-1", mock_app)
-        # Queue is still empty
         assert mock_app.state.queue_manager.dequeue("thread-1") is None
-        # Runtime transition was never called
         mock_agent.runtime.transition.assert_not_called()
 
     async def test_successful_followup_consumes_message(self, mock_agent, mock_app, queue_manager):
-        """When followup succeeds, message is consumed and not re-enqueued."""
         queue_manager.enqueue("do something", "thread-1")
         from backend.threads.streaming import _consume_followup_queue
 
         with patch("backend.threads.streaming.start_agent_run") as mock_start:
-            mock_start.return_value = "run-123"  # start_agent_run returns str run_id
+            mock_start.return_value = "run-123"
 
             await _consume_followup_queue(mock_agent, "thread-1", mock_app)
 
@@ -78,24 +62,20 @@ class TestConsumeFollowupQueue:
                     "is_steer": False,
                 },
             )
-        # Message was consumed, queue is empty
         assert queue_manager.dequeue("thread-1") is None
 
     async def test_exception_re_enqueues_message(self, mock_agent, mock_app, queue_manager):
-        """When start_agent_run raises, the dequeued message is re-enqueued."""
         queue_manager.enqueue("important followup", "thread-1")
         from backend.threads.streaming import _consume_followup_queue
 
         with patch("backend.threads.streaming.start_agent_run", side_effect=RuntimeError("boom")):
             await _consume_followup_queue(mock_agent, "thread-1", mock_app)
 
-        # Message was re-enqueued — it should be available again
         item = queue_manager.dequeue("thread-1")
         assert item is not None
         assert item.content == "important followup"
 
     async def test_transition_failure_skips_start(self, mock_agent, mock_app, queue_manager):
-        """When runtime.transition returns False, followup stays queued."""
         queue_manager.enqueue("wont run", "thread-1")
         mock_agent.runtime.transition.return_value = False
         from backend.threads.streaming import _consume_followup_queue

--- a/tests/Integration/test_leon_agent.py
+++ b/tests/Integration/test_leon_agent.py
@@ -1,8 +1,3 @@
-"""Integration tests for LeonAgent with QueryLoop.
-
-Uses mock model to verify the full astream pipeline without real API calls.
-"""
-
 import json
 import os
 from types import SimpleNamespace
@@ -14,12 +9,10 @@ from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, Sys
 
 
 def _mock_model(text="Integration test response"):
-    """Create a mock LangChain model that returns a plain AIMessage."""
     ai_msg = AIMessage(content=text)
     model = MagicMock()
     model.bind_tools.return_value = model
     model.ainvoke = AsyncMock(return_value=ai_msg)
-    # configurable_fields support
     model.configurable_fields.return_value = model
     model.with_config.return_value = model
     return model
@@ -44,7 +37,6 @@ def _empty_stream_model():
 
 
 def _patch_env_api_key():
-    """Ensure ANTHROPIC_API_KEY is set for LeonAgent init (uses a fake value)."""
     return patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test-integration"})
 
 

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1,5 +1,3 @@
-"""Unit tests for AgentService sub-agent boundaries and policy."""
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/Unit/core/test_command_service.py
+++ b/tests/Unit/core/test_command_service.py
@@ -1,5 +1,3 @@
-"""Tests for command executors, hooks, and CommandService."""
-
 import asyncio
 from unittest.mock import MagicMock
 

--- a/tests/Unit/core/test_event_bus.py
+++ b/tests/Unit/core/test_event_bus.py
@@ -1,5 +1,3 @@
-"""Tests for backend/web/event_bus.py (P2 multi-agent event routing)."""
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/Unit/core/test_loop.py
+++ b/tests/Unit/core/test_loop.py
@@ -1,5 +1,3 @@
-"""Unit tests for core.runtime.loop QueryLoop."""
-
 import asyncio
 import importlib
 import json
@@ -1014,9 +1012,6 @@ async def test_tool_call_yields_agent_then_tools():
     async for chunk in loop.astream({"messages": [{"role": "user", "content": "call echo"}]}):
         chunks.append(chunk)
 
-    # First chunk: agent (with tool_calls)
-    # Second chunk: tools (ToolMessage results)
-    # Third chunk: agent (final text response)
     agent_chunks = [c for c in chunks if "agent" in c]
     tools_chunks = [c for c in chunks if "tools" in c]
 
@@ -1086,7 +1081,6 @@ async def test_max_turns_stops_loop():
         is_concurrency_safe=True,
     )
 
-    # Build a model that always returns a tool call
     tool_call_msg = AIMessage(
         content="",
         tool_calls=[{"name": "noop", "args": {}, "id": "tc-1"}],

--- a/tests/Unit/core/test_spill_buffer.py
+++ b/tests/Unit/core/test_spill_buffer.py
@@ -1,5 +1,3 @@
-"""Tests for core.spill_buffer: spill_if_needed() and SpillBufferMiddleware."""
-
 import posixpath
 from dataclasses import dataclass
 from typing import Any, cast
@@ -56,8 +54,6 @@ def _spill(content: Any, *, threshold_bytes: int, tool_call_id: str = "call", fs
 
 
 class TestSpillIfNeeded:
-    """Unit tests for the core spill function."""
-
     @pytest.mark.parametrize(
         ("content", "threshold"),
         [
@@ -197,8 +193,6 @@ class TestSpillIfNeeded:
 
 
 class TestSpillBufferMiddleware:
-    """Tests for the middleware that wraps tool calls."""
-
     def _make_middleware(self, thresholds=None, default_threshold=50_000):
         fs = _make_fs_backend()
         mw = SpillBufferMiddleware(

--- a/tests/Unit/core/test_tool_registry_runner.py
+++ b/tests/Unit/core/test_tool_registry_runner.py
@@ -1,11 +1,3 @@
-"""Tests for ToolRegistry, ToolRunner, and ToolValidator (P0/P1 verification).
-
-Covers:
-- P0: Three-tier error normalization (Layer 1: validation, Layer 2: execution, Layer 3: soft)
-- P1: ToolRegistry inline/deferred mode
-- P1: ToolRunner dispatches registered tools and normalizes errors
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -2140,7 +2132,6 @@ class TestToolRunnerInlineInjection:
         )
         runner = _make_runner([entry])
 
-        # Build a mock ModelRequest
         request = MagicMock()
         request.tools = []
 

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -1,5 +1,3 @@
-"""Tests for marketplace_client business logic (publish/download)."""
-
 import importlib
 import json
 from types import SimpleNamespace
@@ -11,8 +9,6 @@ from fastapi import HTTPException
 
 import backend.library.paths as _lib_paths
 from backend.hub.versioning import bump_semver
-
-# ── Version Bump (tested via publish internals) ──
 
 
 class TestVersionBump:
@@ -140,7 +136,6 @@ class TestDownloadSkill:
             with pytest.raises(ValueError, match="Invalid slug"):
                 download("item-evil")
 
-        # Ensure no files written outside library
         assert not (tmp_path / "evil").exists()
 
     def test_installs_skill_to_agent_config_when_agent_user_id_is_provided(self):

--- a/tests/Unit/platform/test_marketplace_models.py
+++ b/tests/Unit/platform/test_marketplace_models.py
@@ -1,5 +1,3 @@
-"""Tests for Marketplace Pydantic models."""
-
 import pytest
 from pydantic import ValidationError
 

--- a/tests/Unit/platform/test_model_config_enrichment.py
+++ b/tests/Unit/platform/test_model_config_enrichment.py
@@ -1,5 +1,3 @@
-"""Tests for model config enrichment (based_on + context_limit)."""
-
 import importlib
 
 import pytest
@@ -10,7 +8,6 @@ from core.runtime.middleware.monitor import cost as cost_module
 from core.runtime.middleware.monitor.cost import fetch_openrouter_pricing, get_model_context_limit
 from core.runtime.middleware.monitor.middleware import MonitorMiddleware
 
-# Ensure OpenRouter cache is populated (same as MonitorMiddleware.__init__)
 fetch_openrouter_pricing()
 SONNET_LIMIT = get_model_context_limit("claude-sonnet-4.5")
 DEFAULT_LIMIT = 128000

--- a/tests/Unit/platform/test_model_params.py
+++ b/tests/Unit/platform/test_model_params.py
@@ -1,5 +1,3 @@
-"""Tests for model parameter normalization."""
-
 from core.model_params import normalize_model_kwargs
 
 

--- a/tests/Unit/platform/test_search_tools.py
+++ b/tests/Unit/platform/test_search_tools.py
@@ -1,5 +1,3 @@
-"""Tests for SearchService Grep and Glob tools."""
-
 from __future__ import annotations
 
 import time
@@ -13,45 +11,33 @@ from core.tools.search.service import DEFAULT_EXCLUDES, SearchService
 
 @pytest.fixture()
 def workspace(tmp_path: Path) -> Path:
-    """Create a temporary workspace with sample files for search tests."""
-    # src/main.py
     src = tmp_path / "src"
     src.mkdir()
     (src / "main.py").write_text("import os\nimport sys\n\ndef main():\n    print('hello world')\n")
-    # src/utils.py
     (src / "utils.py").write_text("def helper():\n    return 42\n\ndef another():\n    return 'HELLO'\n")
-    # src/app.js
     (src / "app.js").write_text("const app = () => console.log('hello');\n")
-    # README.md at root
     (tmp_path / "README.md").write_text("# Project\nHello World\n")
-    # data.txt at root
     (tmp_path / "data.txt").write_text("line1\nline2 hello\nline3\nline4 hello\nline5\n")
     return tmp_path
 
 
 @pytest.fixture()
 def mw(workspace: Path) -> SearchService:
-    """SearchService instance using the Python implementation (no ripgrep)."""
     with patch("shutil.which", return_value=None):
         return SearchService(MagicMock(), workspace_root=workspace)
 
 
 def _grep(mw: SearchService, **kwargs) -> str:
-    """Shortcut: invoke _grep directly and return content."""
     return mw._grep(**kwargs)
 
 
 def _glob(mw: SearchService, **kwargs) -> str:
-    """Shortcut: invoke _glob directly and return content."""
     return mw._glob(**kwargs)
 
 
 class TestGrepFilesWithMatches:
-    """Default output_mode = 'files_with_matches'."""
-
     def test_basic_search(self, mw: SearchService, workspace: Path):
         result = _grep(mw, pattern="hello")
-        # Should match data.txt, app.js, and main.py (print('hello world'))
         assert "data.txt" in result
         assert "main.py" in result
 
@@ -61,16 +47,12 @@ class TestGrepFilesWithMatches:
 
 
 class TestGrepContent:
-    """output_mode = 'content' returns matching lines with line numbers."""
-
     def test_content_mode(self, mw: SearchService, workspace: Path):
         result = _grep(mw, pattern="hello", output_mode="content")
-        # Python implementation format: <filepath>:<lineno>:<line>
         assert ":2:" in result or ":5:" in result  # line2 or line5 in data.txt
         assert "hello" in result
 
     def test_content_line_numbers(self, mw: SearchService, workspace: Path):
-        # data.txt has "hello" on lines 2 and 4
         data_path = str(workspace / "data.txt")
         result = _grep(mw, pattern="hello", path=data_path, output_mode="content")
         assert f"{data_path}:2:" in result
@@ -78,12 +60,9 @@ class TestGrepContent:
 
 
 class TestGrepCount:
-    """output_mode = 'count' returns match counts per file."""
-
     def test_count_mode(self, mw: SearchService, workspace: Path):
         data_path = str(workspace / "data.txt")
         result = _grep(mw, pattern="hello", path=data_path, output_mode="count")
-        # data.txt has 2 lines matching "hello"
         assert f"{data_path}:2" in result
 
     def test_count_multiple_files(self, mw: SearchService):
@@ -384,8 +363,6 @@ class TestGlobPathParameter:
 
 
 class TestPaginate:
-    """Unit tests for _paginate static method."""
-
     @pytest.mark.parametrize(
         ("text", "head_limit", "offset", "expected"),
         [
@@ -401,8 +378,6 @@ class TestPaginate:
 
 
 class TestIsExcluded:
-    """Unit tests for _is_excluded."""
-
     @pytest.mark.parametrize(
         ("path", "expected"),
         [

--- a/tests/Unit/sandbox/test_daytona_provider.py
+++ b/tests/Unit/sandbox/test_daytona_provider.py
@@ -1,5 +1,3 @@
-"""Tests for Daytona sandbox provider."""
-
 import os
 from types import SimpleNamespace
 
@@ -29,21 +27,17 @@ class _FakeVolumeClient:
 
 
 class TestDaytonaProvider:
-    """Test Daytona provider basic functionality."""
-
     pytestmark = pytest.mark.skipif(
         not os.getenv("DAYTONA_API_KEY"),
         reason="DAYTONA_API_KEY not set",
     )
 
     def test_import(self):
-        """Test that Daytona provider can be imported."""
         from sandbox.providers.daytona import DaytonaProvider
 
         assert DaytonaProvider.name == "daytona"
 
     def test_create_provider(self):
-        """Test creating a Daytona provider instance."""
         from sandbox.providers.daytona import DaytonaProvider
 
         api_key = os.getenv("DAYTONA_API_KEY")

--- a/tests/Unit/sandbox/test_daytona_provider_proxy.py
+++ b/tests/Unit/sandbox/test_daytona_provider_proxy.py
@@ -1,5 +1,3 @@
-"""Unit tests for Daytona local toolbox URL normalization."""
-
 import sys
 from types import ModuleType
 from typing import Any, cast


### PR DESCRIPTION
## Summary
- Delete redundant test module/class/function docstrings and step comments
- Keep behavior and assertions unchanged

## Line count
- 17 files changed, 1 insertion, 108 deletions
- Net -107 lines

## Verification
- uv run python -m pytest -q <changed test files>: 461 passed, 4 skipped
- uv run ruff check <changed test files>
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q: 1603 passed, 8 skipped
