### PR TITLE
chore: delete obvious cleanup comments

### DIFF
--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -796,7 +796,6 @@ def _create_owned_thread(
         current_workspace_id=current_workspace_id,
     )
 
-    # Set thread state
     app.state.thread_sandbox[new_thread_id] = sandbox_type
     if payload.cwd:
         app.state.thread_cwd[new_thread_id] = payload.cwd
@@ -826,7 +825,6 @@ async def create_thread(
     provider_error = _validate_sandbox_provider_gate(app, user_id, payload)
     if provider_error is not None:
         return provider_error
-    # Validate bind_mounts capability before creating thread
     sandbox_type = payload.sandbox or "local"
     requested_mounts = payload.bind_mounts or []
     capability_error = await _validate_mount_capability_gate(sandbox_type, requested_mounts)
@@ -962,13 +960,11 @@ async def delete_thread(
         # Also delete from threads table.
         app.state.thread_repo.delete(thread_id)
 
-    # Clean up thread-specific state
     app.state.thread_sandbox.pop(thread_id, None)
     app.state.thread_cwd.pop(thread_id, None)
     app.state.thread_event_buffers.pop(thread_id, None)
     app.state.queue_manager.clear_all(thread_id)
 
-    # Remove per-thread Agent from pool
     app.state.agent_pool.pop(pool_key, None)
     _invalidate_resource_overview_cache()
 

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -664,7 +664,6 @@ class AgentService:
             model_name=model or self._model_name,
         )
 
-        # Create async task (independent LeonAgent runs inside)
         task = asyncio.create_task(
             self._run_agent(
                 task_id,
@@ -702,7 +701,6 @@ class AgentService:
                 },
             )
 
-        # Default: parent blocks until sub-agent completes (does not block frontend event loop)
         try:
             result = await task
             return tool_success(
@@ -946,7 +944,6 @@ class AgentService:
                     )
                 )
 
-            # Build initial input — with or without forked parent context
             if fork_context:
                 from sandbox.thread_context import get_current_messages
 

--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -155,7 +155,6 @@ class SummaryStore:
                 if not row:
                     return None
 
-                # Validate data integrity
                 try:
                     return SummaryData(
                         summary_id=row["summary_id"],

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -515,7 +515,6 @@ class _LSPSessionPool:
         self._pyright.clear()
 
 
-# Process-level singleton — import and use directly
 lsp_pool = _LSPSessionPool()
 
 

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -223,7 +223,6 @@ class TaskService:
 
         status = args.get("status")
 
-        # Handle deletion — clean up dependency refs
         if status == "deleted":
             all_tasks = self._repo.list_all(thread_id)
             for other in all_tasks:

--- a/tests/Config/conftest.py
+++ b/tests/Config/conftest.py
@@ -3,7 +3,6 @@
 import sys
 from pathlib import Path
 
-# Ensure project root is in sys.path
 project_root = Path(__file__).parent.parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))

--- a/tests/Unit/core/test_spill_buffer.py
+++ b/tests/Unit/core/test_spill_buffer.py
@@ -12,7 +12,6 @@ from core.runtime.middleware.spill_buffer.spill import PREVIEW_BYTES, spill_if_n
 
 
 def _make_fs_backend():
-    """Return a mock FileSystemBackend with write_file as a MagicMock."""
     backend = MagicMock()
     backend.write_file = MagicMock(return_value=None)
     return backend
@@ -29,7 +28,6 @@ class _ModelRequestHarness:
 
 
 def _make_request(tool_name: str, tool_call_id: str = "call_abc123"):
-    """Build a minimal request harness matching the middleware surface."""
     return cast(Any, _ToolCallRequestHarness(tool_call={"name": tool_name, "id": tool_call_id}))
 
 
@@ -330,7 +328,6 @@ class TestSpillBufferMiddleware:
         fs.write_file.assert_called_once()
 
     def test_spill_path_uses_tool_call_id(self):
-        """Verify the spill file name is derived from tool_call_id."""
         mw, fs = self._make_middleware(default_threshold=10)
         unique_id = "call_unique_xyz_789"
         request = _make_request("Bash", unique_id)

--- a/tests/Unit/core/test_tool_registry_runner.py
+++ b/tests/Unit/core/test_tool_registry_runner.py
@@ -2164,8 +2164,6 @@ class TestToolRunnerInlineInjection:
 
 
 class TestServiceDeclaredToolModes:
-    """Verify services declare the runtime tool modes they own."""
-
     def test_task_service_registers_deferred(self):
         reg = ToolRegistry()
         from core.tools.task.service import TaskService

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -70,7 +70,6 @@ def test_hub_api_preserves_hub_bad_request_detail(monkeypatch):
 
 
 def _make_hub_response(item_type: str, slug: str, content: str = "# Hello", version: str = "1.0.0", publisher: str = "tester") -> dict:
-    """Build a fake Hub /download response."""
     return {
         "item": {
             "name": slug.replace("-", " ").title(),

--- a/tests/Unit/platform/test_search_tools.py
+++ b/tests/Unit/platform/test_search_tools.py
@@ -392,8 +392,6 @@ class TestIsExcluded:
 
 
 class TestDefaultExcludes:
-    """Verify the DEFAULT_EXCLUDES list contains essential entries."""
-
     def test_essential_entries(self):
         for entry in ["node_modules", ".git", "__pycache__", ".venv", "dist", "build"]:
             assert entry in DEFAULT_EXCLUDES


### PR DESCRIPTION
## Summary
- delete redundant source/test comments that restated nearby code
- keep runtime behavior unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
