### PR TITLE
chore: delete redundant inline comments

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -730,7 +730,6 @@ class LeonAgent:
         if hasattr(self, "_model_overrides"):
             kwargs.update({k: v for k, v in self._model_overrides.items() if k not in ("context_limit", "based_on")})
 
-        # Use provider from model overrides (mapping) first, then infer
         provider = self._resolve_provider_name(self.model_name, kwargs or None)
         if provider:
             kwargs["model_provider"] = provider
@@ -1483,7 +1482,6 @@ class LeonAgent:
             # Reuse the event loop created during initialization
             if hasattr(self, "_event_loop") and self._event_loop:
                 return self._event_loop.run_until_complete(_ainvoke())
-            # Use asyncio.run() if no loop exists
             return asyncio.run(_ainvoke())
         except Exception as e:
             self._monitor_middleware.mark_error(e)

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -167,7 +167,6 @@ class _PyrightSession:
         try:
             while True:
                 assert self._proc and self._proc.stdout
-                # Read headers until blank line
                 content_length = 0
                 while True:
                     raw = await self._proc.stdout.readline()

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -254,7 +254,6 @@ class TaskService:
         if "owner" in args:
             task.owner = args["owner"]
 
-        # Add dependency edges (bidirectional)
         if "add_blocks" in args:
             for blocked_id in args["add_blocks"]:
                 if blocked_id not in task.blocks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,3 @@
-"""Pytest configuration for Leon tests.
-
-Ensures the project root is in sys.path so imports work correctly.
-"""
-
 import gc
 import sys
 import time
@@ -12,7 +7,6 @@ import pytest
 
 from sandbox.thread_context import set_current_messages, set_current_run_id, set_current_thread_id
 
-# Add project root to sys.path
 project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))


### PR DESCRIPTION
## Summary
- delete redundant inline comments and test conftest narrative
- keep behavior unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
