### PR TITLE
chore: delete redundant helper docs

### DIFF
--- a/core/operations.py
+++ b/core/operations.py
@@ -1,9 +1,4 @@
-"""File operation recorder."""
-
-
 class FileOperationRecorder:
-    """Records file operations."""
-
     def __init__(self, repo=None):
         self._repo = repo
 
@@ -17,7 +12,6 @@ class FileOperationRecorder:
         after_content: str,
         changes: list[dict] | None = None,
     ) -> str:
-        """Record a file operation. Noop if no repo configured."""
         if self._repo is None:
             return ""
         return self._repo.record(
@@ -31,12 +25,10 @@ class FileOperationRecorder:
         )
 
 
-# Global recorder instance (initialized lazily)
 _recorder: FileOperationRecorder | None = None
 
 
 def get_recorder() -> FileOperationRecorder:
-    """Get or create the global recorder instance"""
     global _recorder
     if _recorder is None:
         _recorder = FileOperationRecorder()
@@ -44,6 +36,5 @@ def get_recorder() -> FileOperationRecorder:
 
 
 def set_recorder(recorder: FileOperationRecorder) -> None:
-    """Set the global recorder instance"""
     global _recorder
     _recorder = recorder

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1163,7 +1163,6 @@ class LeonAgent:
         # Skills tools
         bundle_skills = self._agent_bundle.skills if hasattr(self, "_agent_bundle") and self._agent_bundle else []
         if self.config.skills.enabled and (self.config.skills.paths or bundle_skills):
-            # Use the agent bundle's skills enabled/disabled state if available.
             enabled_skills = self.config.skills.skills
             if hasattr(self, "_agent_bundle") and self._agent_bundle:
                 bundle_skill_entries = {k.split(":", 1)[1]: v for k, v in self._agent_bundle.runtime.items() if k.startswith("skills:")}

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -625,7 +625,6 @@ class SandboxManager:
           2) close chat session runtime + mark session closed
         - Local sandbox is exempt from idle timeout (no cost to keep running)
         """
-        # Skip idle timeout for local sandbox
         if self.provider.name == "local":
             return 0
 

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -1,5 +1,3 @@
-"""Runtime wiring helpers for storage (Supabase-only)."""
-
 from __future__ import annotations
 
 import importlib
@@ -28,7 +26,6 @@ def build_storage_container(
     supabase_client: Any | None = None,
     supabase_client_factory: str | None = None,
 ) -> StorageContainer:
-    """Build a runtime storage container (Supabase-only)."""
     client = _resolve_supabase_client(supabase_client, supabase_client_factory)
     return StorageContainer(supabase_client=client)
 


### PR DESCRIPTION
## Summary
- delete redundant helper docstrings and comments
- keep behavior unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
