### PR TITLE
chore: delete redundant helper docstrings

### DIFF
--- a/backend/identity/avatar/urls.py
+++ b/backend/identity/avatar/urls.py
@@ -1,12 +1,9 @@
-"""Shared avatar URL helpers."""
-
 from __future__ import annotations
 
 from backend.identity.avatar.paths import avatars_dir
 
 
 def avatar_url(user_id: str | None, has_avatar: bool) -> str | None:
-    """Build avatar URL. Returns None if no avatar uploaded."""
     # @@@avatar-truth-seam - current web avatar serving is file-backed; DB avatar
     # rows may legitimately stay null on the Supabase path, so visibility truth
     # must follow the actual served file surface instead of trusting the column alone.

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -360,7 +360,6 @@ def list_library_names(
 
 
 def get_library_skill_desc(name: str) -> str:
-    """Get skill description from Library by name."""
     return next((item["desc"] for item in list_library("skill") if item["name"] == name), "")
 
 
@@ -389,7 +388,6 @@ def get_resource_used_by(
     user_repo: Any = None,
     agent_config_repo: Any = None,
 ) -> list[str]:
-    """Return agent user names under the owner that use a given resource."""
     from backend.threads.agent_user_service import list_agent_users
 
     config_key = {"skill": "skills", "mcp": "mcps", "agent": "subAgents"}.get(resource_type, "")

--- a/backend/sandboxes/provider_factory.py
+++ b/backend/sandboxes/provider_factory.py
@@ -1,12 +1,9 @@
-"""Neutral sandbox provider factory helpers."""
-
 from __future__ import annotations
 
 from typing import Any
 
 
 def build_provider_from_config_name(name: str, *, sandboxes_dir=None) -> Any | None:
-    """Build one provider instance from sandbox config name."""
     from backend.sandboxes.inventory import init_providers_and_managers
 
     providers, _ = init_providers_and_managers()

--- a/backend/threads/display/builder.py
+++ b/backend/threads/display/builder.py
@@ -192,12 +192,10 @@ class DisplayBuilder:
         self._threads: dict[str, ThreadDisplay] = {}
 
     def get_entries(self, thread_id: str) -> list[dict] | None:
-        """Return in-memory entries, or None if not cached (cold start)."""
         td = self._threads.get(thread_id)
         return td.entries if td else None
 
     def get_display_seq(self, thread_id: str) -> int:
-        """Return current display_seq for dedup on SSE reconnect."""
         td = self._threads.get(thread_id)
         return td.display_seq if td else 0
 
@@ -417,7 +415,6 @@ class DisplayBuilder:
 
 
 def _get_current_turn(td: ThreadDisplay) -> dict | None:
-    """Get the current open assistant turn, or None."""
     if not td.current_turn_id:
         return None
     for entry in reversed(td.entries):

--- a/backend/threads/file_channel.py
+++ b/backend/threads/file_channel.py
@@ -22,7 +22,6 @@ class FileChannelBinding:
 
 
 def get_file_channel_source(thread_id: str):
-    """Get the local file-channel source for a thread."""
     from sandbox.volume_source import HostVolume
 
     binding = get_file_channel_binding(thread_id)

--- a/backend/web/core/paths.py
+++ b/backend/web/core/paths.py
@@ -1,5 +1,3 @@
-"""Web runtime path helpers."""
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,7 +7,6 @@ from config.user_paths import preferred_user_home_dir
 
 
 def leon_home_dir() -> Path:
-    """Return the filesystem root for Mycel web runtime assets."""
     return preferred_user_home_dir()
 
 

--- a/core/identity/agent_registry.py
+++ b/core/identity/agent_registry.py
@@ -42,7 +42,6 @@ def get_or_create_agent_id(
     sandbox_type: str,
     user_path: str | None = None,
 ) -> str:
-    """Get existing agent_id for this user+thread combo, or create a new one."""
     instances = _load()
 
     for aid, info in instances.items():

--- a/core/model_params.py
+++ b/core/model_params.py
@@ -1,12 +1,9 @@
-"""Model parameter normalization for provider/model-specific request shapes."""
-
 from __future__ import annotations
 
 from typing import Any
 
 
 def normalize_model_kwargs(model_name: str, model_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Return model kwargs normalized for the target model/provider behavior."""
     kwargs = dict(model_kwargs)
     provider = str(kwargs.get("model_provider") or "").strip().lower()
     name = (model_name or "").strip().lower()


### PR DESCRIPTION
## Summary
- delete redundant internal helper docstrings
- keep behavior unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q
