### PR TITLE
chore: delete redundant infrastructure docs

### DIFF
--- a/backend/threads/state.py
+++ b/backend/threads/state.py
@@ -22,7 +22,6 @@ def _runtime_row_from_binding(runtime_repo: Any, binding: Any) -> dict[str, Any]
 
 
 def get_sandbox_info(app: Any, thread_id: str, sandbox_type: str) -> dict[str, Any]:
-    """Get sandbox info for a thread from the target runtime binding."""
     sandbox_info: dict[str, Any] = {"type": sandbox_type, "status": None}
 
     try:
@@ -70,7 +69,6 @@ async def get_sandbox_status_from_repos(
     sandbox_runtime_repo: Any,
     thread_id: str,
 ) -> dict[str, Any] | None:
-    """Get thread sandbox status from storage repos without bootstrapping an agent."""
     binding = await asyncio.to_thread(
         resolve_thread_runtime_binding,
         thread_repo=thread_repo,

--- a/core/tools/task/types.py
+++ b/core/tools/task/types.py
@@ -7,16 +7,12 @@ from pydantic import BaseModel, Field
 
 
 class TaskStatus(StrEnum):
-    """Task status enum."""
-
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
 
 
 class Task(BaseModel):
-    """Task model for tracking work items."""
-
     id: str
     subject: str
     description: str
@@ -28,7 +24,6 @@ class Task(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def is_blocked(self, all_tasks: dict[str, "Task"]) -> bool:
-        """Check if this task is blocked by any incomplete tasks."""
         for task_id in self.blocked_by:
             if task_id in all_tasks:
                 blocker = all_tasks[task_id]
@@ -37,7 +32,6 @@ class Task(BaseModel):
         return False
 
     def to_summary(self) -> dict:
-        """Return summary for TaskList."""
         return {
             "id": self.id,
             "subject": self.subject,
@@ -47,7 +41,6 @@ class Task(BaseModel):
         }
 
     def to_detail(self) -> dict:
-        """Return full details for TaskGet."""
         return {
             "id": self.id,
             "subject": self.subject,

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -42,20 +42,16 @@ class SandboxCapability:
 
     @property
     def command(self) -> BaseExecutor:
-        """Get command executor."""
         return self._command_wrapper
 
     @property
     def fs(self) -> FileSystemBackend:
-        """Get filesystem backend."""
         return self._fs_wrapper
 
     def touch(self) -> None:
-        """Update session activity timestamp."""
         self._session.touch()
 
     def resolve_session_info(self, provider_name: str):
-        """Resolve current session info without exposing internal session object."""
         from sandbox.provider import SessionInfo
 
         instance = self._session.sandbox_runtime.get_instance()

--- a/sandbox/interfaces/filesystem.py
+++ b/sandbox/interfaces/filesystem.py
@@ -11,24 +11,18 @@ from dataclasses import dataclass, field
 
 @dataclass
 class FileReadResult:
-    """Raw file content from backend."""
-
     content: str
     size: int = 0
 
 
 @dataclass
 class FileWriteResult:
-    """Result of a write operation."""
-
     success: bool
     error: str | None = None
 
 
 @dataclass
 class DirEntry:
-    """Single directory entry."""
-
     name: str
     is_dir: bool
     size: int = 0
@@ -37,8 +31,6 @@ class DirEntry:
 
 @dataclass
 class DirListResult:
-    """Result of listing a directory."""
-
     entries: list[DirEntry] = field(default_factory=list)
     error: str | None = None
 

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_provider_cwd(provider) -> str:
-    """Get the default working directory for a provider."""
     for attr in ("default_cwd", "default_context_path", "mount_path"):
         val = getattr(provider, attr, None)
         if isinstance(val, str) and val:
@@ -588,7 +587,6 @@ class SandboxManager:
         )
 
     def _terminal_is_busy(self, terminal_id: str) -> bool:
-        """Return True if this terminal has a running command."""
         if not terminal_id:
             return False
         if not self.db_path.exists():
@@ -596,7 +594,6 @@ class SandboxManager:
         return self.session_manager._repo.terminal_has_running_command(terminal_id)
 
     def _sandbox_runtime_is_busy(self, sandbox_runtime_id: str) -> bool:
-        """Return True if any terminal under this sandbox runtime has a running command."""
         if not sandbox_runtime_id:
             return False
         if not self.db_path.exists():

--- a/sandbox/provider.py
+++ b/sandbox/provider.py
@@ -60,8 +60,6 @@ def build_resource_capabilities(
 
 @dataclass(frozen=True)
 class MountCapability:
-    """Mount behavior capability shared across providers."""
-
     supports_mount: bool = False
     supports_copy: bool = False
     supports_read_only: bool = False
@@ -80,8 +78,6 @@ class MountCapability:
 
 @dataclass(frozen=True)
 class ProviderCapability:
-    """Declared lifecycle capability of a provider implementation."""
-
     can_pause: bool
     can_resume: bool
     can_destroy: bool
@@ -172,17 +168,9 @@ class SandboxProvider(ABC):
         pass
 
     def upload_bytes(self, session_id: str, remote_path: str, data: bytes) -> None:
-        """Upload raw bytes to remote path. Uses native SDK file API when available.
-        Default: falls back to write_file with utf-8 decode (lossy for binary).
-        Override in providers with native binary upload support.
-        """
         self.write_file(session_id, remote_path, data.decode("utf-8", errors="replace"))
 
     def download_bytes(self, session_id: str, remote_path: str) -> bytes:
-        """Download raw bytes from remote path. Uses native SDK file API when available.
-        Default: falls back to read_file with utf-8 encode.
-        Override in providers with native binary download support.
-        """
         return self.read_file(session_id, remote_path).encode("utf-8")
 
     @abstractmethod
@@ -198,7 +186,6 @@ class SandboxProvider(ABC):
         """Create the appropriate PhysicalTerminalRuntime for this provider."""
 
     def get_metrics_via_commands(self, session_id: str) -> Metrics | None:
-        """Get metrics by running Linux shell commands inside the sandbox."""
         try:
             cpu_result = self.execute(
                 session_id,
@@ -255,7 +242,6 @@ class SandboxProvider(ABC):
         raise NotImplementedError(f"{self.name} does not support managed volumes")
 
     def delete_managed_volume(self, backend_ref: str) -> None:
-        """Delete provider-managed persistent volume."""
         raise NotImplementedError(f"{self.name} does not support managed volumes")
 
     def wait_managed_volume_ready(self, backend_ref: str) -> None:
@@ -265,5 +251,4 @@ class SandboxProvider(ABC):
         """Set per-thread bind mounts for next create_session(). No-op for providers without mount support."""
 
     def list_provider_runtimes(self) -> list[SessionInfo]:
-        """List raw provider runtimes for monitor/orphan visibility. Empty by default."""
         return []

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -56,7 +56,6 @@ class TerminalState:
     state_version: int = 0
 
     def to_json(self) -> str:
-        """Serialize to JSON for DB storage."""
         return json.dumps(
             {
                 "cwd": self.cwd,
@@ -67,7 +66,6 @@ class TerminalState:
 
     @classmethod
     def from_json(cls, data: str) -> TerminalState:
-        """Deserialize from JSON."""
         obj = json.loads(data)
         return cls(
             cwd=obj["cwd"],
@@ -107,7 +105,6 @@ class AbstractTerminal(ABC):
         self._state = state
 
     def get_state(self) -> TerminalState:
-        """Get current terminal state snapshot."""
         return self._state
 
     def update_state(self, state: TerminalState) -> None:

--- a/storage/providers/sqlite/kernel.py
+++ b/storage/providers/sqlite/kernel.py
@@ -14,15 +14,12 @@ SYNCHRONOUS = "NORMAL"
 
 
 class SQLiteDBRole(StrEnum):
-    """Logical database roles used by SQLite callers."""
-
     MAIN = "main"
     SANDBOX = "sandbox"
     QUEUE = "queue"
 
 
 def _env_path(env_var: str, default_path: Path) -> Path:
-    """Return Path from environment variable if set, otherwise the default path."""
     raw = os.getenv(env_var)
     return Path(raw) if raw else default_path
 
@@ -58,7 +55,6 @@ def connect_sqlite(
     check_same_thread: bool = True,
     timeout_ms: int = BUSY_TIMEOUT_MS,
 ) -> sqlite3.Connection:
-    """Create a SQLite connection with unified settings."""
     path = Path(db_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(
@@ -78,7 +74,6 @@ async def connect_sqlite_async(
     row_factory: Any | None = None,
     timeout_ms: int = BUSY_TIMEOUT_MS,
 ):
-    """Create async SQLite connection with unified settings."""
     import aiosqlite
 
     path = Path(db_path)

--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -9,7 +9,6 @@ IN_FILTER_CHUNK_SIZE = 80
 
 
 def validate_client(client: Any, repo: str) -> Any:
-    """Validate and return a Supabase client, raising on None or missing table()."""
     if client is None:
         raise RuntimeError(f"Supabase {repo} requires a client. Pass supabase_client=... into StorageContainer.")
     if not hasattr(client, "table"):
@@ -49,7 +48,6 @@ def _preserve_postgrest_session(client: Any, schema: str) -> Any | None:
 
 
 def schema_table(client: Any, schema: str, table: str, repo: str) -> Any:
-    """Return a schema-qualified table query root, failing loudly if unsupported."""
     scoped = _preserve_postgrest_session(client, schema)
     schema_method = getattr(client, "schema", None)
     if scoped is None and not callable(schema_method):
@@ -64,7 +62,6 @@ def schema_table(client: Any, schema: str, table: str, repo: str) -> Any:
 
 
 def schema_rpc(client: Any, schema: str, function_name: str, params: dict[str, Any], repo: str) -> Any:
-    """Return a schema-qualified RPC query, failing loudly if unsupported."""
     scoped = _preserve_postgrest_session(client, schema)
     schema_method = getattr(client, "schema", None)
     if scoped is None and not callable(schema_method):


### PR DESCRIPTION
Pure deletion cleanup: removes redundant helper docstrings/comments from infrastructure modules without changing behavior.\n\nLocal verification:\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- git diff --check\n- uv run python -m pytest -q (1613 passed, 8 skipped)