### PR TITLE
chore: delete redundant formatter docs

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1274,9 +1274,7 @@ class LeonAgent:
             self._mcp_client = client  # Save reference for cleanup
             tools = await client.get_tools()
 
-            # Apply mcp__ prefix to match Claude Code naming convention
             for tool in tools:
-                # Extract server name from tool metadata or connection
                 server_name = None
                 for name in configs:
                     if hasattr(tool, "metadata") and tool.metadata:
@@ -1314,7 +1312,6 @@ class LeonAgent:
         await self.checkpointer.setup()
 
     def _is_tool_allowed(self, tool) -> bool:
-        # Extract original tool name without mcp__ prefix
         tool_name = tool.name
         if tool_name.startswith("mcp__"):
             parts = tool_name.split("__", 2)

--- a/core/runtime/middleware/queue/formatters.py
+++ b/core/runtime/middleware/queue/formatters.py
@@ -11,7 +11,6 @@ from typing import Literal
 
 
 def format_agent_message(sender_name: str, message: str) -> str:
-    """Format inter-agent delivery for steering injection on the next turn."""
     return (
         "<system-reminder>\n"
         "<agent-message>\n"
@@ -28,7 +27,6 @@ def format_progress_notification(
     *,
     step: str = "running",
 ) -> str:
-    """Format background worker progress for coordinator-style prompt injection."""
     return (
         "<system-reminder>\n"
         "<worker-progress>\n"
@@ -48,7 +46,6 @@ def format_background_notification(
     usage: dict | None = None,
     description: str | None = None,
 ) -> str:
-    """Format background task completion as system-reminder XML."""
     parts = [
         "<system-reminder>",
         "<task-notification>",
@@ -77,11 +74,8 @@ def format_command_notification(
     output: str,
     description: str | None = None,
 ) -> str:
-    """Format Bash command completion as system-reminder XML."""
-    # Truncate output to 1000 characters
     truncated_output = output[:1000] if output else ""
 
-    # Escape XML special characters
     escaped_command = escape(command_line)
     escaped_output = escape(truncated_output)
 

--- a/core/tools/filesystem/read/types.py
+++ b/core/tools/filesystem/read/types.py
@@ -8,8 +8,6 @@ from pathlib import Path
 
 
 class FileType(Enum):
-    """Supported file types."""
-
     TEXT = "text"
     BINARY = "binary"
     DOCUMENT = "document"
@@ -47,8 +45,6 @@ class ReadLimits:
 
 @dataclass
 class ReadResult:
-    """Result of a file read operation."""
-
     file_path: str
     file_type: FileType
 
@@ -71,7 +67,6 @@ class ReadResult:
     error: str | None = None
 
     def format_output(self) -> str:
-        """Format result as string output for the agent."""
         if self.error:
             return self.error
 

--- a/core/tools/web/types.py
+++ b/core/tools/web/types.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass, field
 
 @dataclass
 class FetchLimits:
-    """Limits for URL fetching to prevent excessive token usage."""
-
     max_chars: int = 100_000
     chunk_size: int = 4000
     max_chunks: int = 50
@@ -24,8 +22,6 @@ class FetchLimits:
 
 @dataclass
 class ContentChunk:
-    """A chunk of fetched content."""
-
     position: int
     content: str
     heading: str | None = None
@@ -33,8 +29,6 @@ class ContentChunk:
 
 @dataclass
 class FetchResult:
-    """Result of a URL fetch operation."""
-
     url: str
     title: str | None = None
     description: str | None = None
@@ -51,7 +45,6 @@ class FetchResult:
     error: str | None = None
 
     def format_output(self) -> str:
-        """Format result as string output for the agent."""
         if self.error:
             return self.error
 
@@ -86,7 +79,6 @@ class FetchResult:
         return "\n".join(parts)
 
     def get_chunk(self, position: int) -> str | None:
-        """Get content of a specific chunk by position."""
         for chunk in self.chunks:
             if chunk.position == position:
                 return chunk.content
@@ -95,15 +87,12 @@ class FetchResult:
 
 @dataclass
 class SearchResult:
-    """Result of a web search operation."""
-
     query: str
     results: list[SearchItem] = field(default_factory=list)
     total_results: int = 0
     error: str | None = None
 
     def format_output(self) -> str:
-        """Format result as string output for the agent."""
         if self.error:
             return self.error
 
@@ -127,8 +116,6 @@ class SearchResult:
 
 @dataclass
 class SearchItem:
-    """A single search result item."""
-
     title: str
     url: str
     snippet: str | None = None

--- a/storage/providers/supabase/queue_repo.py
+++ b/storage/providers/supabase/queue_repo.py
@@ -54,7 +54,6 @@ class SupabaseQueueRepo:
         ).execute()
 
     def dequeue(self, thread_id: str) -> QueueItem | None:
-        # Find the minimum id for this thread
         head = q.rows(
             q.limit(
                 q.order(
@@ -77,7 +76,6 @@ class SupabaseQueueRepo:
         row_id = row.get("id")
         if row_id is None:
             raise RuntimeError("Supabase queue repo expected non-null id in dequeue row. Check message_queue table schema.")
-        # Delete the row we just selected
         self._t().delete().eq("id", row_id).execute()
         return self._hydrate_item(row)
 


### PR DESCRIPTION
Pure deletion cleanup: removes redundant formatter/type docstrings and restating comments without behavior changes.\n\nLocal verification:\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- git diff --check\n- uv run python -m pytest -q (1613 passed, 8 skipped)