### PR TITLE
chore: delete redundant reader docs

### DIFF
--- a/core/runtime/middleware/memory/compactor.py
+++ b/core/runtime/middleware/memory/compactor.py
@@ -204,19 +204,16 @@ class ContextCompactor:
         if len(to_keep) <= 1:
             return False, []
 
-        # Calculate token budgets
         new_content_tokens = sum(self._estimate_msg_tokens(msg) for msg in to_keep)
         max_history_tokens = int(context_limit * 0.5 * 1.2)  # 50% + 20% safety margin
 
         if new_content_tokens <= max_history_tokens:
             return False, []
 
-        # Need to split: extract prefix from to_keep
         turn_prefix = self._extract_turn_prefix(to_keep, max_history_tokens)
         return True, turn_prefix
 
     def _extract_turn_prefix(self, to_keep: list[Any], max_tokens: int) -> list[Any]:
-        """Extract prefix messages from to_keep up to max_tokens."""
         accumulated = 0
         prefix_end_idx = 0
 
@@ -256,7 +253,6 @@ class ContextCompactor:
         return combined, prefix_summary
 
     def _format_messages_for_summary(self, messages: list[Any]) -> str:
-        """Format messages into a readable string for the summarization LLM."""
         parts = []
         for msg in messages:
             role = msg.__class__.__name__.replace("Message", "")

--- a/core/tools/filesystem/read/readers/binary.py
+++ b/core/tools/filesystem/read/readers/binary.py
@@ -91,7 +91,6 @@ def _read_image(path: Path, size: int, mime_type: str) -> ReadResult:
 
 
 def _format_size(size: int) -> str:
-    """Format file size in human-readable form."""
     for unit in ("B", "KB", "MB", "GB"):
         if size < 1024:
             return f"{size:.1f} {unit}" if unit != "B" else f"{size} {unit}"

--- a/core/tools/filesystem/read/readers/notebook.py
+++ b/core/tools/filesystem/read/readers/notebook.py
@@ -96,7 +96,6 @@ def read_notebook(
 
 
 def _format_cell(cell: dict, cell_num: int, total_cells: int) -> str:
-    """Format a single notebook cell."""
     cell_type = cell.get("cell_type", "unknown")
     source = cell.get("source", [])
 
@@ -134,7 +133,6 @@ def _format_cell(cell: dict, cell_num: int, total_cells: int) -> str:
 
 
 def _format_output(output: dict) -> str:
-    """Format a cell output."""
     output_type = output.get("output_type", "")
 
     if output_type == "stream":

--- a/core/tools/filesystem/read/readers/pdf.py
+++ b/core/tools/filesystem/read/readers/pdf.py
@@ -108,7 +108,6 @@ def read_pdf(
 
 
 def _no_pymupdf_result(path: Path) -> ReadResult:
-    """Return result when pymupdf is not installed."""
     stat = path.stat()
     content = (
         f"PDF file: {path.name}\n  Size: {stat.st_size:,} bytes\n\npymupdf is not installed. To read PDF files:\n  uv pip install pymupdf"

--- a/core/tools/filesystem/read/readers/pptx.py
+++ b/core/tools/filesystem/read/readers/pptx.py
@@ -100,7 +100,6 @@ def read_pptx(
 
 
 def _extract_slide_text(slide, slide_num: int, total_slides: int) -> str:
-    """Extract text content from a slide."""
     parts = [f"\n{'=' * 60}", f"Slide {slide_num}/{total_slides}", "=" * 60]
 
     for shape in slide.shapes:
@@ -116,7 +115,6 @@ def _extract_slide_text(slide, slide_num: int, total_slides: int) -> str:
 
 
 def _no_pptx_result(path: Path) -> ReadResult:
-    """Return result when python-pptx is not installed."""
     stat = path.stat()
     content = (
         f"PowerPoint file: {path.name}\n"

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -565,7 +565,6 @@ class LSPService:
 
     @staticmethod
     def _check_file(file_path: str) -> str | None:
-        """Return error string if file exceeds 10 MB limit, else None."""
         try:
             size = Path(file_path).stat().st_size
         except OSError:
@@ -576,7 +575,6 @@ class LSPService:
         return None
 
     def _filter_gitignored(self, locations: list) -> list:
-        """Filter out locations inside gitignored paths (batches of 50, like CC)."""
         if not locations:
             return locations
         abs_paths = [loc.get("absolutePath") or loc.get("uri", "").replace("file://", "") for loc in locations]
@@ -596,7 +594,6 @@ class LSPService:
         return [loc for loc, p in zip(locations, abs_paths) if p not in ignored]
 
     def _filter_gitignored_batched(self, locations: list) -> list:
-        """Run _filter_gitignored in batches of 50 (matches CC batch size)."""
         out = []
         for i in range(0, len(locations), 50):
             out.extend(self._filter_gitignored(locations[i : i + 50]))

--- a/core/tools/web/fetchers/markdownify.py
+++ b/core/tools/web/fetchers/markdownify.py
@@ -106,7 +106,6 @@ class MarkdownifyFetcher(BaseFetcher):
         return result
 
     def _process_html(self, html: str, result: FetchResult) -> str:
-        """Process HTML content to Markdown or plain text."""
         if self.has_markdownify:
             return self._markdownify_html(html, result)
         if self.has_bs4:
@@ -114,7 +113,6 @@ class MarkdownifyFetcher(BaseFetcher):
         return self._basic_extract(html, result)
 
     def _markdownify_html(self, html: str, result: FetchResult) -> str:
-        """Convert HTML to Markdown using markdownify."""
         if md is None:
             raise RuntimeError("markdownify import unexpectedly unavailable")
         if self.has_bs4:
@@ -149,7 +147,6 @@ class MarkdownifyFetcher(BaseFetcher):
         return content.strip()
 
     def _bs4_extract(self, html: str, result: FetchResult) -> str:
-        """Extract text using BeautifulSoup."""
         if BeautifulSoup is None:
             raise RuntimeError("BeautifulSoup import unexpectedly unavailable")
         soup = BeautifulSoup(html, "html.parser")


### PR DESCRIPTION
Pure deletion cleanup: removes redundant private reader/formatter helper docstrings and comments without behavior changes.\n\nLocal verification:\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- git diff --check\n- uv run python -m pytest -q (1613 passed, 8 skipped)