### PR TITLE
chore: delete redundant run docs

### DIFF
--- a/backend/threads/run/activity_bridge.py
+++ b/backend/threads/run/activity_bridge.py
@@ -1,5 +1,3 @@
-"""Runtime activity-event bridge helpers for thread runs."""
-
 from __future__ import annotations
 
 import asyncio
@@ -16,7 +14,6 @@ def build_activity_bridge(
     emit: Callable[[dict[str, Any]], Awaitable[None]],
     maxsize: int = 1000,
 ) -> tuple[Callable[[], Awaitable[None]], Callable[[], None], Callable[[], None]]:
-    """Build queue-backed runtime event attach/drain/detach helpers."""
     activity_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
 
     def on_activity_event(event: dict[str, Any]) -> None:

--- a/backend/threads/run/buffer_wiring.py
+++ b/backend/threads/run/buffer_wiring.py
@@ -1,5 +1,3 @@
-"""Thread buffer lifecycle and runtime handler wiring helpers."""
-
 from __future__ import annotations
 
 import json
@@ -17,7 +15,6 @@ _append_event: Callable[[str, str, dict[str, Any]], Awaitable[int]] | None = Non
 
 
 def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
-    """Get existing or create new ThreadEventBuffer for a thread."""
     buf = app.state.thread_event_buffers.get(thread_id)
     if isinstance(buf, ThreadEventBuffer):
         return buf
@@ -27,7 +24,6 @@ def get_or_create_thread_buffer(app: Any, thread_id: str) -> ThreadEventBuffer:
 
 
 def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
-    """Bind per-thread handlers (activity_sink, wake_handler) if not already set."""
     runtime = getattr(agent, "runtime", None)
     if not runtime:
         return
@@ -74,7 +70,6 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
     loop = getattr(runtime_state, "event_loop", None)
 
     def wake_handler(item: Any) -> None:
-        """Called by enqueue() with the newly-enqueued QueueItem — may run in any thread."""
         if not (hasattr(agent, "runtime") and agent.runtime.transition(AgentState.ACTIVE)):
             source = getattr(item, "source", None)
             if loop and not loop.is_closed():

--- a/backend/threads/run/entrypoints.py
+++ b/backend/threads/run/entrypoints.py
@@ -1,5 +1,3 @@
-"""Run entrypoint helpers for thread runtime streaming."""
-
 from __future__ import annotations
 
 import asyncio
@@ -29,7 +27,6 @@ def start_agent_run(
     message_metadata: dict[str, Any] | None = None,
     input_messages: list[Any] | None = None,
 ) -> str:
-    """Launch agent producer on the persistent ThreadEventBuffer. Returns run_id."""
     thread_buf = _get_or_create_thread_buffer(app, thread_id)
     run_id = str(_uuid.uuid4())
     if _run_agent_to_buffer is None:
@@ -62,7 +59,6 @@ async def run_child_thread_live(
     *,
     input_messages: list[Any],
 ) -> str:
-    """Run a spawned child agent through the normal web thread path."""
     sandbox_type = _resolve_thread_sandbox(app, thread_id)
     pool_key = f"{thread_id}:{sandbox_type}"
     app.state.agent_pool[pool_key] = agent

--- a/backend/threads/run/epilogue.py
+++ b/backend/threads/run/epilogue.py
@@ -1,5 +1,3 @@
-"""Run epilogue helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import json

--- a/backend/threads/run/lifecycle.py
+++ b/backend/threads/run/lifecycle.py
@@ -1,5 +1,3 @@
-"""Run lifecycle helpers for thread runtime streaming."""
-
 from __future__ import annotations
 
 import asyncio
@@ -10,8 +8,6 @@ logger = logging.getLogger(__name__)
 
 
 async def prime_sandbox(agent: Any, thread_id: str) -> None:
-    """Prime sandbox runtime before tool calls to avoid race conditions."""
-
     def _prime_sandbox() -> None:
         mgr = agent._sandbox.manager
         mgr.enforce_idle_timeouts()
@@ -30,7 +26,6 @@ async def write_cancellation_markers(
     config: dict[str, Any],
     pending_tool_calls: dict[str, dict],
 ) -> list[str]:
-    """Write cancellation markers to checkpoint for pending tool calls."""
     cancelled_tool_call_ids = []
     if not pending_tool_calls or not agent:
         return cancelled_tool_call_ids
@@ -98,7 +93,6 @@ async def write_cancellation_markers(
 
 
 async def repair_incomplete_tool_calls(agent: Any, config: dict[str, Any]) -> None:
-    """Detect and repair incomplete tool_call history in checkpoint."""
     try:
         from langchain_core.messages import RemoveMessage, ToolMessage
 

--- a/backend/threads/run/observation.py
+++ b/backend/threads/run/observation.py
@@ -1,5 +1,3 @@
-"""Observation provider setup/flush helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import logging
@@ -10,7 +8,6 @@ logger = logging.getLogger(__name__)
 
 
 def build_observation(app: Any, thread_id: str, config: dict[str, Any]) -> Callable[[], None]:
-    """Build an observation handler and its flush callback."""
     obs_handler = None
     obs_active = None
     obs_provider = None

--- a/backend/threads/run/prologue.py
+++ b/backend/threads/run/prologue.py
@@ -1,5 +1,3 @@
-"""Run prologue helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import json

--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -1,5 +1,3 @@
-"""General helper utilities."""
-
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +11,6 @@ _cached_thread_repo = None
 
 
 def load_thread_row(thread_id: str, thread_repo=None) -> dict[str, Any] | None:
-    """Load the current thread row. Returns dict or None."""
     if thread_repo is None:
         global _cached_thread_repo
         if _cached_thread_repo is None:
@@ -28,7 +25,6 @@ def resolve_local_workspace_path(
     thread_cwd_map: dict[str, str] | None = None,
     local_workspace_root: Path | None = None,
 ) -> Path:
-    """Resolve a workspace path relative to thread-specific or global workspace root."""
     from backend.web.core.config import LOCAL_WORKSPACE_ROOT
 
     if local_workspace_root is None:


### PR DESCRIPTION
## Summary
- delete redundant thread run helper docstrings
- keep this as a pure line-reduction cleanup

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q