### PR TITLE
chore: delete redundant run helper docs

### DIFF
--- a/backend/threads/run/__init__.py
+++ b/backend/threads/run/__init__.py
@@ -1,1 +1,0 @@
-"""Thread runtime run lifecycle helpers."""

--- a/backend/threads/run/cancellation.py
+++ b/backend/threads/run/cancellation.py
@@ -1,5 +1,3 @@
-"""Cancellation and terminal follow-up helpers for thread runtime runs."""
-
 import asyncio
 import json
 from typing import Any

--- a/backend/threads/run/emit.py
+++ b/backend/threads/run/emit.py
@@ -1,5 +1,3 @@
-"""Event emission helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import json

--- a/backend/threads/run/execution.py
+++ b/backend/threads/run/execution.py
@@ -1,5 +1,3 @@
-"""Execution orchestration helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/threads/run/followups.py
+++ b/backend/threads/run/followups.py
@@ -1,5 +1,3 @@
-"""Follow-up queue consumption helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import logging
@@ -13,7 +11,6 @@ _start_agent_run = None
 
 
 async def consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
-    """Dequeue a pending followup message and start a new run."""
     item = None
     try:
         qm = app.state.queue_manager

--- a/backend/threads/run/input_construction.py
+++ b/backend/threads/run/input_construction.py
@@ -1,5 +1,3 @@
-"""Input construction helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable

--- a/backend/threads/run/observer.py
+++ b/backend/threads/run/observer.py
@@ -1,5 +1,3 @@
-"""SSE observer helpers for thread runtime event buffers."""
-
 from __future__ import annotations
 
 import json
@@ -14,7 +12,6 @@ async def observe_thread_events(
     thread_buf: ThreadEventBuffer,
     after: int = 0,
 ) -> AsyncGenerator[SSEEvent, None]:
-    """Consume events from a persistent ThreadEventBuffer."""
     async for event in observe_sse_buffer(thread_buf, after=after, stop_on_finish=False):
         yield event
 
@@ -23,7 +20,6 @@ async def observe_run_events(
     buf: RunEventBuffer,
     after: int = 0,
 ) -> AsyncGenerator[SSEEvent, None]:
-    """Consume events from a RunEventBuffer (subagent streams only)."""
     async for event in observe_sse_buffer(buf, after=after, stop_on_finish=True):
         yield event
 
@@ -34,7 +30,6 @@ async def observe_sse_buffer(
     after: int,
     stop_on_finish: bool,
 ) -> AsyncGenerator[SSEEvent, None]:
-    """Shared SSE observer loop for thread and run buffers."""
     yield {"retry": 5000}
 
     cursor = 0

--- a/backend/threads/run/stream_loop.py
+++ b/backend/threads/run/stream_loop.py
@@ -1,5 +1,3 @@
-"""Streaming loop helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/threads/run/tool_call_dedup.py
+++ b/backend/threads/run/tool_call_dedup.py
@@ -1,5 +1,3 @@
-"""Tool-call dedup helpers for thread runtime runs."""
-
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
## Summary
- delete redundant thread run helper docstrings
- keep this as a pure line-reduction cleanup

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q