### PR TITLE
fix: return conflict for stale internal chat sends

### DIFF
--- a/backend/chat/api/http/internal_messaging_router.py
+++ b/backend/chat/api/http/internal_messaging_router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 
 from backend.chat.api.http.dependencies import get_messaging_service
+from messaging.errors import ChatNotCaughtUpError
 
 router = APIRouter(prefix="/api/internal/messaging", tags=["chat-internal"])
 
@@ -124,18 +125,21 @@ def send_message(
     body: InternalSendMessageBody,
     messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ) -> dict[str, Any]:
-    return messaging_service.send(
-        chat_id,
-        body.sender_id,
-        body.content,
-        message_type=body.message_type,
-        content_type=body.content_type,
-        mentions=body.mentions,
-        signal=body.signal,
-        reply_to=body.reply_to,
-        ai_metadata=body.ai_metadata,
-        enforce_caught_up=body.enforce_caught_up,
-    )
+    try:
+        return messaging_service.send(
+            chat_id,
+            body.sender_id,
+            body.content,
+            message_type=body.message_type,
+            content_type=body.content_type,
+            mentions=body.mentions,
+            signal=body.signal,
+            reply_to=body.reply_to,
+            ai_metadata=body.ai_metadata,
+            enforce_caught_up=body.enforce_caught_up,
+        )
+    except ChatNotCaughtUpError as exc:
+        raise HTTPException(409, str(exc)) from exc
 
 
 @router.post("/chats/{chat_id}/read")

--- a/messaging/errors.py
+++ b/messaging/errors.py
@@ -1,0 +1,7 @@
+"""Messaging domain errors that HTTP/tool surfaces can map explicitly."""
+
+from __future__ import annotations
+
+
+class ChatNotCaughtUpError(RuntimeError):
+    """Raised when a sender must read newer chat messages before replying."""

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -20,6 +20,8 @@ from messaging.avatars import AvatarUrlBuilder
 from messaging.contracts import ContentType, MessageType
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
 from messaging.display_user import resolve_messaging_display_user
+from messaging.errors import ChatNotCaughtUpError
+from storage.errors import StorageConflictError
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +214,10 @@ class MessagingService:
             last_read_seq = getattr(self._chat_members_repo, "last_read_seq", None)
             if last_read_seq is None:
                 raise RuntimeError("chat_member_repo must expose last_read_seq for caught-up sends")
-            created_row = self._messages.create(row, expected_read_seq=int(last_read_seq(chat_id, sender_id)))
+            try:
+                created_row = self._messages.create(row, expected_read_seq=int(last_read_seq(chat_id, sender_id)))
+            except StorageConflictError as exc:
+                raise ChatNotCaughtUpError(str(exc)) from exc
         else:
             created_row = self._messages.create(row)
         created = self._normalize_message_row(created_row)

--- a/storage/errors.py
+++ b/storage/errors.py
@@ -1,0 +1,7 @@
+"""Storage-layer errors shared by provider implementations."""
+
+from __future__ import annotations
+
+
+class StorageConflictError(RuntimeError):
+    """Raised when a conditional storage write loses a concurrency race."""

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from messaging._utils import now_iso
 from messaging.contracts import RelationshipState
+from storage.errors import StorageConflictError
 from storage.providers.supabase import _query as q
 
 logger = logging.getLogger(__name__)
@@ -123,7 +124,7 @@ class SupabaseMessagesRepo:
                 .execute()
             )
             if not update_res.data:
-                raise RuntimeError(f"Chat advanced after your last read. Call read_messages(chat_id='{row['chat_id']}') first.")
+                raise StorageConflictError(f"Chat advanced after your last read. Call read_messages(chat_id='{row['chat_id']}') first.")
             seq = next_seq
         payload = {**row, "seq": int(seq)}
         res = self._t().insert(payload).execute()

--- a/tests/Integration/test_chat_internal_messaging_router.py
+++ b/tests/Integration/test_chat_internal_messaging_router.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.chat.api.http import internal_messaging_router
+from messaging.errors import ChatNotCaughtUpError
 
 
 def test_internal_messaging_router_dispatches_display_user_and_send_message() -> None:
@@ -120,3 +121,26 @@ def test_internal_messaging_router_dispatches_display_user_and_send_message() ->
         ),
         ("mark_read", {"chat_id": "chat-1", "user_id": "agent-1"}),
     ]
+
+
+def test_internal_messaging_router_returns_conflict_when_sender_is_not_caught_up() -> None:
+    class _MessagingService:
+        def send(self, *_args, **_kwargs):
+            raise ChatNotCaughtUpError("Call read_messages(chat_id='chat-1') first.")
+
+    app = FastAPI()
+    app.state.chat_runtime_state = SimpleNamespace(messaging_service=_MessagingService())
+    app.include_router(internal_messaging_router.router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/internal/messaging/chats/chat-1/messages/send",
+            json={
+                "sender_id": "agent-1",
+                "content": "hello",
+                "enforce_caught_up": True,
+            },
+        )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Call read_messages(chat_id='chat-1') first."}

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -867,6 +867,38 @@ def test_messaging_service_agent_send_passes_expected_read_seq_to_messages_repo(
     assert expected_read_seq == 7
 
 
+def test_messaging_service_agent_send_maps_storage_conflict_to_not_caught_up_error() -> None:
+    from messaging.errors import ChatNotCaughtUpError
+    from storage.errors import StorageConflictError
+
+    class _StatefulChatMemberRepo:
+        def list_members(self, _chat_id: str) -> list[dict[str, Any]]:
+            return []
+
+        def last_read_seq(self, chat_id: str, user_id: str) -> int:
+            assert chat_id == "chat-1"
+            assert user_id == "agent-user-1"
+            return 7
+
+    class _MessagesRepo:
+        def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
+            raise StorageConflictError("Chat advanced after your last read.")
+
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=_StatefulChatMemberRepo(),
+        messages_repo=_MessagesRepo(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None) if uid == "agent-user-1" else None
+        ),
+    )
+
+    with pytest.raises(ChatNotCaughtUpError) as excinfo:
+        service.send("chat-1", "agent-user-1", "hello", enforce_caught_up=True)
+
+    assert str(excinfo.value) == "Chat advanced after your last read."
+
+
 def test_messaging_service_list_chats_exposes_agent_user_participant_id() -> None:
     service = MessagingService(
         chat_repo=SimpleNamespace(

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from storage.contracts import ChatRow, ContactEdgeRow
+from storage.errors import StorageConflictError
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
 from storage.providers.supabase.contact_repo import SupabaseContactRepo
 from storage.providers.supabase.messaging_repo import (
@@ -398,7 +399,7 @@ def test_supabase_messages_repo_create_with_stale_expected_read_seq_fails_loudly
     client.schema("chat").table("chats").rows = []
     repo = SupabaseMessagesRepo(client)
 
-    with pytest.raises(RuntimeError, match="Chat advanced after your last read. Call read_messages\\(chat_id='chat-1'\\) first\\."):
+    with pytest.raises(StorageConflictError, match="Chat advanced after your last read. Call read_messages\\(chat_id='chat-1'\\) first\\."):
         repo.create(
             {
                 "id": "msg-7",


### PR DESCRIPTION
## Summary
- add explicit storage and messaging domain errors for stale caught-up sends
- map internal messaging not-caught-up failures to HTTP 409 instead of leaking 500
- cover the storage -> messaging -> HTTP error path with regression tests

## Verification
- uv run pytest tests/Integration/test_chat_internal_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q
- uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright --pythonversion 3.12 backend/chat/api/http/internal_messaging_router.py messaging/service.py storage/providers/supabase/messaging_repo.py messaging/errors.py storage/errors.py
- git diff --check

## Live backend note
- Current 8018 live backend reproduced the bug before this fix: unread-guarded send failed as HTTP 500.
- Branch-local backend startup on 8022 is currently blocked by pgl SSH banner timeout / missing 15433 Postgres tunnel, so no branch-local live YATU was claimed.