### PR TITLE
chore: delete redundant sandbox docs

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -1,5 +1,3 @@
-"""Shared sandbox inventory helpers."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/sandboxes/paths.py
+++ b/backend/sandboxes/paths.py
@@ -1,5 +1,3 @@
-"""Neutral sandbox path helpers."""
-
 from config.user_paths import user_home_path
 
 SANDBOXES_DIR = user_home_path("sandboxes")

--- a/backend/sandboxes/provider_availability.py
+++ b/backend/sandboxes/provider_availability.py
@@ -1,5 +1,3 @@
-"""Shared sandbox provider availability helpers."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/sandboxes/recipe_bootstrap.py
+++ b/backend/sandboxes/recipe_bootstrap.py
@@ -1,5 +1,3 @@
-"""Neutral recipe bootstrap helpers used by auth/bootstrap flows."""
-
 from __future__ import annotations
 
 import time

--- a/backend/sandboxes/recipe_catalog.py
+++ b/backend/sandboxes/recipe_catalog.py
@@ -1,5 +1,3 @@
-"""Shared sandbox recipe catalog helpers."""
-
 from __future__ import annotations
 
 from backend.sandboxes.inventory import available_sandbox_types

--- a/backend/sandboxes/resources/io.py
+++ b/backend/sandboxes/resources/io.py
@@ -1,5 +1,3 @@
-"""Shared resource refresh and sandbox file IO helpers."""
-
 from __future__ import annotations
 
 from typing import Any
@@ -89,7 +87,6 @@ def read_sandbox(
     make_sandbox_monitor_repo_fn=make_sandbox_monitor_repo,
     build_provider_from_config_name_fn=build_provider_from_config_name,
 ) -> dict[str, Any]:
-    """Read a file from a sandbox via its provider."""
     provider, instance_id = _resolve_sandbox_provider(
         sandbox_id,
         make_sandbox_monitor_repo_fn=make_sandbox_monitor_repo_fn,

--- a/backend/sandboxes/resources/runtime_service.py
+++ b/backend/sandboxes/resources/runtime_service.py
@@ -1,5 +1,3 @@
-"""Shared runtime read helpers for sandbox resource projections."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/backend/sandboxes/resources/user_projection.py
+++ b/backend/sandboxes/resources/user_projection.py
@@ -1,5 +1,3 @@
-"""Shared user-scoped resource projection helpers."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/backend/sandboxes/runtime/metrics.py
+++ b/backend/sandboxes/runtime/metrics.py
@@ -1,5 +1,3 @@
-"""Shared sandbox runtime metrics helpers."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/sandboxes/runtime/mutations.py
+++ b/backend/sandboxes/runtime/mutations.py
@@ -1,5 +1,3 @@
-"""Shared sandbox runtime mutation helpers."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/sandboxes/runtime/reads.py
+++ b/backend/sandboxes/runtime/reads.py
@@ -1,5 +1,3 @@
-"""Shared sandbox runtime read helpers."""
-
 from __future__ import annotations
 
 from datetime import datetime
@@ -53,7 +51,6 @@ def _to_ts(value: Any) -> float:
 
 
 def load_all_sandbox_runtimes(managers: dict) -> list[dict]:
-    """Load sandbox runtime rows from all managers in parallel."""
     runtimes: list[dict] = []
     if not managers:
         return runtimes
@@ -97,7 +94,6 @@ def find_runtime_and_manager(
     runtime_id: str,
     provider_name: str | None = None,
 ) -> tuple[dict | None, Any | None]:
-    """Find sandbox runtime by external ID/prefix (+optional provider), return (runtime, manager)."""
     candidates: list[dict] = []
     for runtime in runtimes:
         if provider_name and runtime.get("provider") != provider_name:

--- a/backend/sandboxes/thread_resources.py
+++ b/backend/sandboxes/thread_resources.py
@@ -1,5 +1,3 @@
-"""Shared sandbox thread resource cleanup helpers."""
-
 from __future__ import annotations
 
 from backend.sandboxes.inventory import init_providers_and_managers

--- a/backend/sandboxes/user_reads.py
+++ b/backend/sandboxes/user_reads.py
@@ -1,5 +1,3 @@
-"""Shared user-scoped sandbox read helpers."""
-
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- delete redundant sandbox helper docstrings
- keep this as a pure line-reduction cleanup

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q