### PR TITLE
chore: delete redundant backend helper docs

### DIFF
--- a/backend/bootstrap/app_entrypoint.py
+++ b/backend/bootstrap/app_entrypoint.py
@@ -1,5 +1,3 @@
-"""Shared helpers for Python app entrypoints."""
-
 from __future__ import annotations
 
 import os

--- a/backend/bootstrap/storage.py
+++ b/backend/bootstrap/storage.py
@@ -1,5 +1,3 @@
-"""Shared storage bootstrap helpers for backend app entrypoints."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/identity/auth/dependencies.py
+++ b/backend/identity/auth/dependencies.py
@@ -1,5 +1,3 @@
-"""Neutral auth dependency helpers."""
-
 from fastapi import FastAPI, HTTPException
 
 

--- a/backend/identity/auth/runtime_bootstrap.py
+++ b/backend/identity/auth/runtime_bootstrap.py
@@ -1,5 +1,3 @@
-"""Shared auth bootstrap helpers for backend app lifecycles."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/backend/identity/auth/user_resolution.py
+++ b/backend/identity/auth/user_resolution.py
@@ -1,5 +1,3 @@
-"""Neutral current-user resolution helpers."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/identity/avatar/files.py
+++ b/backend/identity/avatar/files.py
@@ -1,5 +1,3 @@
-"""Neutral avatar file processing helpers."""
-
 from __future__ import annotations
 
 import io

--- a/backend/identity/avatar/paths.py
+++ b/backend/identity/avatar/paths.py
@@ -1,5 +1,3 @@
-"""Neutral avatar path helpers."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/backend/identity/contact_bootstrap.py
+++ b/backend/identity/contact_bootstrap.py
@@ -1,5 +1,3 @@
-"""Neutral contact bootstrap helpers."""
-
 from __future__ import annotations
 
 import time

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -1,5 +1,3 @@
-"""Bootstrap helpers for binding the Agent Runtime Gateway to app-backed handlers."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/threads/convergence.py
+++ b/backend/threads/convergence.py
@@ -1,5 +1,3 @@
-"""Shared owner-thread runtime convergence helpers."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/threads/events/__init__.py
+++ b/backend/threads/events/__init__.py
@@ -1,1 +1,0 @@
-"""Thread runtime event helpers."""

--- a/backend/threads/events/reads.py
+++ b/backend/threads/events/reads.py
@@ -1,5 +1,3 @@
-"""Shared run-event read transport helpers."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/threads/message_content.py
+++ b/backend/threads/message_content.py
@@ -1,5 +1,3 @@
-"""Neutral message-content helpers shared across backend owners."""
-
 import re
 from typing import Any
 

--- a/backend/threads/pool/__init__.py
+++ b/backend/threads/pool/__init__.py
@@ -1,1 +1,0 @@
-"""Thread runtime pool helpers."""

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -1,5 +1,3 @@
-"""Thread runtime pool lifecycle helpers."""
-
 import asyncio
 import logging
 from pathlib import Path

--- a/backend/threads/projection.py
+++ b/backend/threads/projection.py
@@ -1,5 +1,3 @@
-"""Shared thread projection helpers."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/threads/sandbox_resolution.py
+++ b/backend/threads/sandbox_resolution.py
@@ -1,5 +1,3 @@
-"""Shared thread sandbox lookup helpers."""
-
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
## Summary
- delete redundant backend helper module docstrings
- keep this as a pure line-reduction cleanup

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q