### PR TITLE
chore: delete redundant helper docstrings

### DIFF
--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -1,5 +1,3 @@
-"""Chat HTTP dependency helpers."""
-
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 

--- a/backend/monitor/mutations/__init__.py
+++ b/backend/monitor/mutations/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor mutation helpers."""

--- a/backend/web/utils/serializers.py
+++ b/backend/web/utils/serializers.py
@@ -1,5 +1,3 @@
-"""Message serialization utilities."""
-
 from typing import Any
 
 from backend.threads.message_content import extract_text_content, strip_system_tags
@@ -8,7 +6,6 @@ __all__ = ["strip_system_tags", "extract_text_content", "serialize_message"]
 
 
 def serialize_message(msg: Any) -> dict[str, Any]:
-    """Serialize a LangChain message to a JSON-serializable dict."""
     content = getattr(msg, "content", "")
     metadata = dict(getattr(msg, "metadata", None) or {})
     additional_kwargs = getattr(msg, "additional_kwargs", None) or {}

--- a/sandbox/resource_snapshot.py
+++ b/sandbox/resource_snapshot.py
@@ -1,5 +1,3 @@
-"""Sandbox resource probing helpers."""
-
 from __future__ import annotations
 
 from typing import Any
@@ -76,7 +74,6 @@ def probe_and_upsert_for_instance(
     instance_id: str,
     repo: Any | None = None,
 ) -> dict[str, Any]:
-    """Probe provider metrics and persist to storage."""
     if not sandbox_id:
         return {"ok": False, "error": "sandbox-shaped snapshot helper requires sandbox_id"}
 

--- a/sandbox/shell_output.py
+++ b/sandbox/shell_output.py
@@ -1,5 +1,3 @@
-"""Shared shell/PTY output normalization helpers."""
-
 from __future__ import annotations
 
 import re

--- a/storage/container_cache.py
+++ b/storage/container_cache.py
@@ -1,5 +1,3 @@
-"""Process-local storage container cache."""
-
 from __future__ import annotations
 
 from storage.container import StorageContainer

--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -1,5 +1,3 @@
-"""Shared PostgREST query helpers for all Supabase repos."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/storage/providers/supabase/sandbox_monitor_repo.py
+++ b/storage/providers/supabase/sandbox_monitor_repo.py
@@ -1,5 +1,3 @@
-"""Supabase read-only queries against the sandbox tables for monitoring."""
-
 from __future__ import annotations
 
 from typing import Any
@@ -14,8 +12,6 @@ _SANDBOX_SELECT = (
 
 
 class SupabaseSandboxMonitorRepo:
-    """Read-only monitor queries backed by Supabase tables."""
-
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
 


### PR DESCRIPTION
## Summary
- delete redundant helper/module docstrings from small backend, sandbox, and storage helpers
- keep behavior unchanged; pure deletion slice

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check