### PR TITLE
chore: delete redundant package docstrings

### DIFF
--- a/backend/bootstrap/__init__.py
+++ b/backend/bootstrap/__init__.py
@@ -1,1 +1,0 @@
-"""Shared code for FastAPI app shells."""

--- a/backend/chat/__init__.py
+++ b/backend/chat/__init__.py
@@ -1,1 +1,0 @@
-"""Chat backend module root."""

--- a/backend/chat/api/__init__.py
+++ b/backend/chat/api/__init__.py
@@ -1,1 +1,0 @@
-"""Chat API package."""

--- a/backend/chat/api/http/__init__.py
+++ b/backend/chat/api/http/__init__.py
@@ -1,5 +1,3 @@
-"""HTTP routers for the chat backend."""
-
 from backend.chat.api.http import (
     app_router,
     chats_router,

--- a/backend/identity/auth/__init__.py
+++ b/backend/identity/auth/__init__.py
@@ -1,1 +1,0 @@
-"""Authentication — Supabase Auth register/login/OTP/verify_token."""

--- a/backend/identity/avatar/__init__.py
+++ b/backend/identity/avatar/__init__.py
@@ -1,1 +1,0 @@
-"""Avatar — upload processing, path resolution, URL construction."""

--- a/backend/monitor/__init__.py
+++ b/backend/monitor/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor module root."""

--- a/backend/monitor/api/__init__.py
+++ b/backend/monitor/api/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor API surfaces."""

--- a/backend/monitor/api/http/__init__.py
+++ b/backend/monitor/api/http/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor HTTP API."""

--- a/backend/monitor/app/__init__.py
+++ b/backend/monitor/app/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor separate-process app package."""

--- a/backend/monitor/application/__init__.py
+++ b/backend/monitor/application/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor application layer."""

--- a/backend/monitor/application/use_cases/__init__.py
+++ b/backend/monitor/application/use_cases/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor use cases."""

--- a/backend/monitor/infrastructure/__init__.py
+++ b/backend/monitor/infrastructure/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor infrastructure implementations."""

--- a/backend/monitor/infrastructure/config/__init__.py
+++ b/backend/monitor/infrastructure/config/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor config adapters."""

--- a/backend/monitor/infrastructure/evaluation/__init__.py
+++ b/backend/monitor/infrastructure/evaluation/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor evaluation adapters."""

--- a/backend/monitor/infrastructure/io/__init__.py
+++ b/backend/monitor/infrastructure/io/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor IO adapters."""

--- a/backend/monitor/infrastructure/persistence/__init__.py
+++ b/backend/monitor/infrastructure/persistence/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor persistence adapters."""

--- a/backend/monitor/infrastructure/providers/__init__.py
+++ b/backend/monitor/infrastructure/providers/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor provider/inventory adapters."""

--- a/backend/monitor/infrastructure/read_models/__init__.py
+++ b/backend/monitor/infrastructure/read_models/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor read-model adapters."""

--- a/backend/monitor/infrastructure/resources/__init__.py
+++ b/backend/monitor/infrastructure/resources/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor resource projection adapters."""

--- a/backend/monitor/infrastructure/web/__init__.py
+++ b/backend/monitor/infrastructure/web/__init__.py
@@ -1,1 +1,0 @@
-"""Monitor web-facing integration layer."""

--- a/backend/sandboxes/resources/__init__.py
+++ b/backend/sandboxes/resources/__init__.py
@@ -1,1 +1,0 @@
-"""Resource projections — user-visible view of sandbox resources."""

--- a/backend/sandboxes/runtime/__init__.py
+++ b/backend/sandboxes/runtime/__init__.py
@@ -1,1 +1,0 @@
-"""Sandbox runtime mutations, reads, and metrics (HTTP service layer)."""

--- a/backend/web/__init__.py
+++ b/backend/web/__init__.py
@@ -1,1 +1,0 @@
-"""Web edge — FastAPI app composition for the main backend process."""

--- a/backend/web/core/__init__.py
+++ b/backend/web/core/__init__.py
@@ -1,1 +1,0 @@
-"""Core module for Mycel web backend."""

--- a/backend/web/models/__init__.py
+++ b/backend/web/models/__init__.py
@@ -1,1 +1,0 @@
-"""Models module for Mycel web backend."""

--- a/backend/web/routers/__init__.py
+++ b/backend/web/routers/__init__.py
@@ -1,1 +1,0 @@
-"""Routers module for Mycel web backend."""

--- a/backend/web/utils/__init__.py
+++ b/backend/web/utils/__init__.py
@@ -1,1 +1,0 @@
-"""Utils module for Mycel web backend."""

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,0 @@
-"""Mycel Core - Runtime, Tools, and Agent coordination."""

--- a/core/identity/__init__.py
+++ b/core/identity/__init__.py
@@ -1,1 +1,0 @@
-"""Agent identity management."""

--- a/core/runtime/middleware/queue/__init__.py
+++ b/core/runtime/middleware/queue/__init__.py
@@ -1,5 +1,3 @@
-"""Queue middleware for message routing during agent execution."""
-
 from storage.contracts import QueueItem
 
 from .formatters import (

--- a/core/runtime/middleware/spill_buffer/__init__.py
+++ b/core/runtime/middleware/spill_buffer/__init__.py
@@ -1,5 +1,3 @@
-"""SpillBuffer - catches oversized tool outputs, writes to disk, returns preview."""
-
 from .middleware import SpillBufferMiddleware
 from .spill import spill_if_needed
 

--- a/core/tools/command/bash/__init__.py
+++ b/core/tools/command/bash/__init__.py
@@ -1,5 +1,3 @@
-"""Bash executor for Linux systems."""
-
 from .executor import BashExecutor
 
 __all__ = ["BashExecutor"]

--- a/core/tools/command/powershell/__init__.py
+++ b/core/tools/command/powershell/__init__.py
@@ -1,5 +1,3 @@
-"""PowerShell executor for Windows systems."""
-
 from .executor import PowerShellExecutor
 
 __all__ = ["PowerShellExecutor"]

--- a/core/tools/command/zsh/__init__.py
+++ b/core/tools/command/zsh/__init__.py
@@ -1,5 +1,3 @@
-"""Zsh executor for macOS systems."""
-
 from .executor import ZshExecutor
 
 __all__ = ["ZshExecutor"]

--- a/core/tools/filesystem/read/__init__.py
+++ b/core/tools/filesystem/read/__init__.py
@@ -1,5 +1,3 @@
-"""Read subpackage - handles file reading with type-specific strategies."""
-
 from core.tools.filesystem.read.dispatcher import read_file
 from core.tools.filesystem.read.types import FileType, ReadLimits, ReadResult
 

--- a/core/tools/filesystem/read/readers/__init__.py
+++ b/core/tools/filesystem/read/readers/__init__.py
@@ -1,5 +1,3 @@
-"""File readers for different file types."""
-
 from core.tools.filesystem.read.readers.binary import read_binary
 from core.tools.filesystem.read.readers.notebook import read_notebook
 from core.tools.filesystem.read.readers.pdf import read_pdf

--- a/core/tools/web/fetchers/__init__.py
+++ b/core/tools/web/fetchers/__init__.py
@@ -1,5 +1,3 @@
-"""Fetchers subpackage - handles URL content fetching with multiple strategies."""
-
 from core.tools.web.fetchers.base import BaseFetcher
 from core.tools.web.fetchers.jina import JinaFetcher
 from core.tools.web.fetchers.markdownify import MarkdownifyFetcher

--- a/core/tools/web/searchers/__init__.py
+++ b/core/tools/web/searchers/__init__.py
@@ -1,5 +1,3 @@
-"""Searchers subpackage - handles web search with multiple providers."""
-
 from core.tools.web.searchers.base import BaseSearcher
 from core.tools.web.searchers.exa import ExaSearcher
 from core.tools.web.searchers.firecrawl import FirecrawlSearcher

--- a/sandbox/providers/__init__.py
+++ b/sandbox/providers/__init__.py
@@ -1,3 +1,1 @@
-"""Sandbox provider implementations."""
-
 __all__: list[str] = []

--- a/storage/providers/__init__.py
+++ b/storage/providers/__init__.py
@@ -1,1 +1,0 @@
-"""Storage providers package."""

--- a/storage/providers/sqlite/__init__.py
+++ b/storage/providers/sqlite/__init__.py
@@ -1,5 +1,3 @@
-"""SQLite storage provider — only sandbox/runtime repos remain."""
-
 from .kernel import SQLiteDBRole, connect_sqlite, connect_sqlite_async
 from .queue_repo import SQLiteQueueRepo
 from .summary_repo import SQLiteSummaryRepo

--- a/storage/providers/supabase/__init__.py
+++ b/storage/providers/supabase/__init__.py
@@ -1,5 +1,3 @@
-"""Supabase storage provider implementations."""
-
 from .agent_config_repo import SupabaseAgentConfigRepo
 from .chat_repo import SupabaseChatRepo
 from .checkpoint_repo import SupabaseCheckpointRepo


### PR DESCRIPTION
## Summary
- delete redundant one-line package docstrings from empty/lightweight __init__.py files
- keep multi-line architecture boundary docs in place
- pure deletion slice: 56 deletions, 0 insertions

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check