### PR TITLE
chore: delete redundant core tool docstrings

### DIFF
--- a/core/tools/command/base.py
+++ b/core/tools/command/base.py
@@ -1,5 +1,3 @@
-"""Command helper functions."""
-
 from __future__ import annotations
 
 

--- a/core/tools/command/bash/executor.py
+++ b/core/tools/command/bash/executor.py
@@ -1,5 +1,3 @@
-"""Bash executor for Linux systems."""
-
 from __future__ import annotations
 
 from typing import ClassVar

--- a/core/tools/command/dispatcher.py
+++ b/core/tools/command/dispatcher.py
@@ -1,5 +1,3 @@
-"""Dispatcher to select appropriate executor based on OS."""
-
 from __future__ import annotations
 
 import platform

--- a/core/tools/command/hooks/base.py
+++ b/core/tools/command/hooks/base.py
@@ -1,5 +1,3 @@
-"""Base class definition for bash hooks."""
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path

--- a/core/tools/command/posix_executor.py
+++ b/core/tools/command/posix_executor.py
@@ -1,5 +1,3 @@
-"""Shared persistent-shell executor for POSIX shells."""
-
 from __future__ import annotations
 
 import asyncio

--- a/core/tools/command/powershell/executor.py
+++ b/core/tools/command/powershell/executor.py
@@ -1,5 +1,3 @@
-"""PowerShell executor implementation for Windows."""
-
 from __future__ import annotations
 
 import asyncio

--- a/core/tools/command/service.py
+++ b/core/tools/command/service.py
@@ -1,5 +1,3 @@
-"""Command Service - registers the Bash tool with ToolRegistry."""
-
 from __future__ import annotations
 
 import asyncio

--- a/core/tools/command/zsh/executor.py
+++ b/core/tools/command/zsh/executor.py
@@ -1,5 +1,3 @@
-"""Zsh executor for macOS systems."""
-
 from __future__ import annotations
 
 from typing import ClassVar

--- a/core/tools/filesystem/read/dispatcher.py
+++ b/core/tools/filesystem/read/dispatcher.py
@@ -1,5 +1,3 @@
-"""Dispatcher for file reading based on file type."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/core/tools/filesystem/read/readers/binary.py
+++ b/core/tools/filesystem/read/readers/binary.py
@@ -1,5 +1,3 @@
-"""Binary file reader - returns metadata or image content blocks."""
-
 from __future__ import annotations
 
 import base64

--- a/core/tools/filesystem/read/readers/notebook.py
+++ b/core/tools/filesystem/read/readers/notebook.py
@@ -1,5 +1,3 @@
-"""Jupyter Notebook reader - parses .ipynb cell by cell."""
-
 from __future__ import annotations
 
 import json

--- a/core/tools/filesystem/read/readers/pdf.py
+++ b/core/tools/filesystem/read/readers/pdf.py
@@ -1,5 +1,3 @@
-"""PDF file reader using pymupdf (optional dependency)."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/core/tools/filesystem/read/readers/pptx.py
+++ b/core/tools/filesystem/read/readers/pptx.py
@@ -1,5 +1,3 @@
-"""PowerPoint file reader using python-pptx (optional dependency)."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/core/tools/filesystem/read/readers/text.py
+++ b/core/tools/filesystem/read/readers/text.py
@@ -1,5 +1,3 @@
-"""Text file reader with triple limits: lines, chars, line length."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/core/tools/filesystem/read/types.py
+++ b/core/tools/filesystem/read/types.py
@@ -1,5 +1,3 @@
-"""Types for file reading operations."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/core/tools/web/fetchers/base.py
+++ b/core/tools/web/fetchers/base.py
@@ -1,5 +1,3 @@
-"""Base fetcher interface."""
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/core/tools/web/fetchers/jina.py
+++ b/core/tools/web/fetchers/jina.py
@@ -1,5 +1,3 @@
-"""Jina Reader fetcher - best quality content extraction."""
-
 from __future__ import annotations
 
 import httpx

--- a/core/tools/web/fetchers/markdownify.py
+++ b/core/tools/web/fetchers/markdownify.py
@@ -1,5 +1,3 @@
-"""Markdownify fetcher - local HTML to Markdown conversion."""
-
 from __future__ import annotations
 
 import re

--- a/core/tools/web/searchers/base.py
+++ b/core/tools/web/searchers/base.py
@@ -1,5 +1,3 @@
-"""Base searcher interface."""
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/core/tools/web/searchers/exa.py
+++ b/core/tools/web/searchers/exa.py
@@ -1,5 +1,3 @@
-"""Exa searcher - semantic AI search."""
-
 from __future__ import annotations
 
 import httpx

--- a/core/tools/web/searchers/firecrawl.py
+++ b/core/tools/web/searchers/firecrawl.py
@@ -1,5 +1,3 @@
-"""Firecrawl searcher - web crawling and search."""
-
 from __future__ import annotations
 
 import httpx

--- a/core/tools/web/searchers/tavily.py
+++ b/core/tools/web/searchers/tavily.py
@@ -1,5 +1,3 @@
-"""Tavily searcher - AI-optimized search."""
-
 from __future__ import annotations
 
 import httpx

--- a/core/tools/web/types.py
+++ b/core/tools/web/types.py
@@ -1,5 +1,3 @@
-"""Types for web operations."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from core tool command/filesystem/web modules
- keep behavior unchanged; pure deletion slice

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check