### PR TITLE
chore: delete redundant supabase repo docstrings

### DIFF
--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for agent configuration (config, rules, skills, sub-agents)."""
-
 from __future__ import annotations
 
 import uuid

--- a/storage/providers/supabase/chat_repo.py
+++ b/storage/providers/supabase/chat_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for chats."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/checkpoint_repo.py
+++ b/storage/providers/supabase/checkpoint_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for checkpoint/writes persistence operations."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/contact_repo.py
+++ b/storage/providers/supabase/contact_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for directional contact relationships."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/eval_repo.py
+++ b/storage/providers/supabase/eval_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for eval trajectory persistence operations."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/file_operation_repo.py
+++ b/storage/providers/supabase/file_operation_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for file operation persistence operations."""
-
 from __future__ import annotations
 
 import time

--- a/storage/providers/supabase/invite_code_repo.py
+++ b/storage/providers/supabase/invite_code_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for invite codes."""
-
 from __future__ import annotations
 
 import secrets

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -1,5 +1,3 @@
-"""Supabase implementations for messaging v2 repos."""
-
 from __future__ import annotations
 
 import logging

--- a/storage/providers/supabase/monitor_operation_repo.py
+++ b/storage/providers/supabase/monitor_operation_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for monitor operation persistence."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/supabase/provider_event_repo.py
+++ b/storage/providers/supabase/provider_event_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for sandbox provider webhook events."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/supabase/queue_repo.py
+++ b/storage/providers/supabase/queue_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for message queue persistence."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/recipe_repo.py
+++ b/storage/providers/supabase/recipe_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for user-scoped recipe overrides and custom recipes."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/supabase/resource_snapshot_repo.py
+++ b/storage/providers/supabase/resource_snapshot_repo.py
@@ -1,5 +1,3 @@
-"""Supabase resource snapshot repo."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/storage/providers/supabase/run_event_repo.py
+++ b/storage/providers/supabase/run_event_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for run event persistence operations."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/supabase/sandbox_repo.py
+++ b/storage/providers/supabase/sandbox_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for container sandboxes."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/storage/providers/supabase/sandbox_runtime_repo.py
+++ b/storage/providers/supabase/sandbox_runtime_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for sandbox runtime persistence."""
-
 from __future__ import annotations
 
 import uuid

--- a/storage/providers/supabase/schedule_repo.py
+++ b/storage/providers/supabase/schedule_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for agent schedule records."""
-
 from __future__ import annotations
 
 import uuid

--- a/storage/providers/supabase/summary_repo.py
+++ b/storage/providers/supabase/summary_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for summaries persistence operations."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for threads."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/storage/providers/supabase/tool_task_repo.py
+++ b/storage/providers/supabase/tool_task_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for thread-scoped tool tasks."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for unified users."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/storage/providers/supabase/user_settings_repo.py
+++ b/storage/providers/supabase/user_settings_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for per-user workspace preferences."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/supabase/workspace_repo.py
+++ b/storage/providers/supabase/workspace_repo.py
@@ -1,5 +1,3 @@
-"""Supabase repository for container workspaces."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from Supabase repo implementation files
- keep storage contracts/models untouched
- pure deletion slice: 46 deletions, 0 insertions

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check