### PR TITLE
chore: delete redundant sqlite provider docstrings

### DIFF
--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -1,5 +1,3 @@
-"""SQLite repository for chat session persistence."""
-
 from __future__ import annotations
 
 import sqlite3

--- a/storage/providers/sqlite/kernel.py
+++ b/storage/providers/sqlite/kernel.py
@@ -1,5 +1,3 @@
-"""Unified SQLite kernel for role-based connections and consistent PRAGMA setup."""
-
 from __future__ import annotations
 
 import os

--- a/storage/providers/sqlite/queue_repo.py
+++ b/storage/providers/sqlite/queue_repo.py
@@ -1,5 +1,3 @@
-"""SQLite repository for message queue persistence."""
-
 from __future__ import annotations
 
 import sqlite3

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -1,5 +1,3 @@
-"""SQLite repository for sandbox runtime persistence."""
-
 from __future__ import annotations
 
 import json

--- a/storage/providers/sqlite/summary_repo.py
+++ b/storage/providers/sqlite/summary_repo.py
@@ -1,5 +1,3 @@
-"""SQLite repository for summaries persistence."""
-
 from __future__ import annotations
 
 import sqlite3

--- a/storage/providers/sqlite/terminal_repo.py
+++ b/storage/providers/sqlite/terminal_repo.py
@@ -1,5 +1,3 @@
-"""SQLite repository for abstract terminal persistence."""
-
 from __future__ import annotations
 
 import sqlite3


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from SQLite provider modules
- keep repository/class docstrings and behavior unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check