### PR TITLE
chore: delete redundant http module docstrings

### DIFF
--- a/backend/chat/api/http/app_router.py
+++ b/backend/chat/api/http/app_router.py
@@ -1,5 +1,3 @@
-"""Aggregate HTTP router for the chat backend."""
-
 from fastapi import APIRouter
 
 from backend.chat.api.http import (

--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -1,5 +1,3 @@
-"""Chats API router — chat/backend owner module."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/chat/api/http/conversations_router.py
+++ b/backend/chat/api/http/conversations_router.py
@@ -1,5 +1,3 @@
-"""Unified conversation list API — chat/backend owner module."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/chat/api/http/internal_identity_router.py
+++ b/backend/chat/api/http/internal_identity_router.py
@@ -1,5 +1,3 @@
-"""Internal identity routes for thin external-agent tooling."""
-
 from __future__ import annotations
 
 import time

--- a/backend/chat/api/http/internal_messaging_router.py
+++ b/backend/chat/api/http/internal_messaging_router.py
@@ -1,5 +1,3 @@
-"""Internal messaging routes for cross-backend agent chat access."""
-
 from __future__ import annotations
 
 from typing import Annotated, Any

--- a/backend/chat/api/http/relationships_router.py
+++ b/backend/chat/api/http/relationships_router.py
@@ -1,5 +1,3 @@
-"""Relationship API router — chat/backend owner module."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/web/models/marketplace.py
+++ b/backend/web/models/marketplace.py
@@ -1,5 +1,3 @@
-"""Marketplace request/response models (Mycel client side)."""
-
 from typing import Literal
 
 from pydantic import BaseModel, Field

--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -1,5 +1,3 @@
-"""Pydantic models for panel API."""
-
 from pydantic import BaseModel, Field
 
 from backend.hub.versioning import BumpType

--- a/backend/web/models/requests.py
+++ b/backend/web/models/requests.py
@@ -1,5 +1,3 @@
-"""Pydantic request models for Mycel web API."""
-
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/backend/web/routers/auth.py
+++ b/backend/web/routers/auth.py
@@ -1,5 +1,3 @@
-"""Authentication endpoints — 3-step registration + login."""
-
 import asyncio
 from collections.abc import Callable
 from typing import Annotated, Any

--- a/backend/web/routers/contacts.py
+++ b/backend/web/routers/contacts.py
@@ -1,5 +1,3 @@
-"""Contacts API router — /api/contacts endpoints."""
-
 from __future__ import annotations
 
 import time

--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -1,5 +1,3 @@
-"""Invite code management endpoints."""
-
 import asyncio
 from collections.abc import Callable
 from typing import Annotated, Any

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -1,5 +1,3 @@
-"""Marketplace API router — publish, install, upgrade, check updates."""
-
 import asyncio
 from typing import Annotated, Any
 

--- a/backend/web/routers/monitor_threads.py
+++ b/backend/web/routers/monitor_threads.py
@@ -1,5 +1,3 @@
-"""Web-owned monitor-local thread routes."""
-
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -1,5 +1,3 @@
-"""Panel API router — Agents, Library, Profile."""
-
 import asyncio
 from typing import Annotated, Any
 

--- a/backend/web/routers/resources.py
+++ b/backend/web/routers/resources.py
@@ -1,5 +1,3 @@
-"""User-scoped resource endpoints."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -1,5 +1,3 @@
-"""Sandbox management endpoints."""
-
 import asyncio
 from typing import Annotated, Any
 

--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -1,5 +1,3 @@
-"""User settings management endpoints."""
-
 import asyncio
 import copy
 import json

--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -1,5 +1,3 @@
-"""Thread file browsing endpoints."""
-
 import asyncio
 from typing import Annotated, Any
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1,5 +1,3 @@
-"""Thread management and execution endpoints."""
-
 import asyncio
 import json
 import logging

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -1,5 +1,3 @@
-"""User-backed identity endpoints for discovery, avatars, and agent thread lookup."""
-
 import logging
 import time
 from pathlib import Path

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -1,5 +1,3 @@
-"""Webhook endpoints for provider events."""
-
 import asyncio
 from typing import Any
 


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from web/chat HTTP models and routers
- keep runtime logic unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check