### PR TITLE
chore: delete redundant core sandbox docstrings

### DIFF
--- a/core/tools/command/hooks/dangerous_commands.py
+++ b/core/tools/command/hooks/dangerous_commands.py
@@ -1,5 +1,3 @@
-"""Dangerous commands hook - blocks commands that may harm the system."""
-
 import re
 import shlex
 from pathlib import Path

--- a/core/tools/command/hooks/file_access_logger.py
+++ b/core/tools/command/hooks/file_access_logger.py
@@ -1,5 +1,3 @@
-"""File access logger hook - logs all file operations for audit purposes."""
-
 from datetime import datetime
 from pathlib import Path
 

--- a/core/tools/command/hooks/file_permission.py
+++ b/core/tools/command/hooks/file_permission.py
@@ -1,5 +1,3 @@
-"""File permission control hook - supports file type restrictions and path blacklists."""
-
 from pathlib import Path
 
 from .base import HookResult

--- a/core/tools/filesystem/local_backend.py
+++ b/core/tools/filesystem/local_backend.py
@@ -1,5 +1,3 @@
-"""Local filesystem backend - direct local I/O."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/core/tools/mcp_resources/service.py
+++ b/core/tools/mcp_resources/service.py
@@ -1,5 +1,3 @@
-"""Expose MCP resource discovery and reading as agent-callable deferred tools."""
-
 from __future__ import annotations
 
 import base64

--- a/core/tools/task/types.py
+++ b/core/tools/task/types.py
@@ -1,5 +1,3 @@
-"""Type definitions for Todo middleware."""
-
 from enum import StrEnum
 from typing import Any
 

--- a/sandbox/interfaces/executor.py
+++ b/sandbox/interfaces/executor.py
@@ -1,5 +1,3 @@
-"""Base executor class and result types for command execution."""
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any

--- a/sandbox/provider.py
+++ b/sandbox/provider.py
@@ -1,5 +1,3 @@
-"""Abstract sandbox provider interface."""
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -1,5 +1,3 @@
-"""LocalSessionProvider — in-process session provider for local sandbox."""
-
 from __future__ import annotations
 
 import os

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -1,5 +1,3 @@
-"""PhysicalTerminalRuntime ABC, helpers, and remote runtime base classes."""
-
 from __future__ import annotations
 
 import asyncio

--- a/sandbox/thread_context.py
+++ b/sandbox/thread_context.py
@@ -1,5 +1,3 @@
-"""Thread context tracking via ContextVar."""
-
 from __future__ import annotations
 
 from contextvars import ContextVar


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from core tools and sandbox modules
- keep runtime logic and useful inline comments unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check