### PR TITLE
chore: delete redundant monitor read model docstrings

### DIFF
--- a/backend/monitor/infrastructure/read_models/resource_read_service.py
+++ b/backend/monitor/infrastructure/read_models/resource_read_service.py
@@ -1,5 +1,3 @@
-"""Monitor resource storage read-source boundary."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/backend/monitor/infrastructure/read_models/sandbox_read_service.py
+++ b/backend/monitor/infrastructure/read_models/sandbox_read_service.py
@@ -1,5 +1,3 @@
-"""Sandbox runtime read-source boundary for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/infrastructure/read_models/thread_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_read_service.py
@@ -1,5 +1,3 @@
-"""Thread read-source boundary for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
+++ b/backend/monitor/infrastructure/read_models/thread_workbench_read_service.py
@@ -1,5 +1,3 @@
-"""Owner thread workbench app-state read boundary."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/backend/monitor/infrastructure/read_models/trace_read_service.py
+++ b/backend/monitor/infrastructure/read_models/trace_read_service.py
@@ -1,5 +1,3 @@
-"""Monitor trace read-source boundary."""
-
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from monitor read-model services
- keep read-model logic unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check