### PR TITLE
chore: delete redundant monitor infrastructure docstrings

### DIFF
--- a/backend/monitor/infrastructure/config/app_config_service.py
+++ b/backend/monitor/infrastructure/config/app_config_service.py
@@ -1,5 +1,3 @@
-"""Monitor-local access to app config values."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/backend/monitor/infrastructure/io/resource_io_service.py
+++ b/backend/monitor/infrastructure/io/resource_io_service.py
@@ -1,5 +1,3 @@
-"""Resource refresh and file IO port for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/infrastructure/persistence/operation_repo.py
+++ b/backend/monitor/infrastructure/persistence/operation_repo.py
@@ -1,5 +1,3 @@
-"""Monitor operation storage boundary."""
-
 from __future__ import annotations
 
 import copy

--- a/backend/monitor/infrastructure/providers/provider_runtime_inventory_service.py
+++ b/backend/monitor/infrastructure/providers/provider_runtime_inventory_service.py
@@ -1,5 +1,3 @@
-"""Provider runtime inventory read port for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/infrastructure/providers/sandbox_config_provider_service.py
+++ b/backend/monitor/infrastructure/providers/sandbox_config_provider_service.py
@@ -1,5 +1,3 @@
-"""Sandbox provider inventory port for Monitor config projection."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/infrastructure/resources/resource_overview_cache.py
+++ b/backend/monitor/infrastructure/resources/resource_overview_cache.py
@@ -1,5 +1,3 @@
-"""Cached monitor resource overview snapshot."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/monitor/infrastructure/resources/resource_projection_service.py
+++ b/backend/monitor/infrastructure/resources/resource_projection_service.py
@@ -1,5 +1,3 @@
-"""Monitor-local access to product resource projections."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/infrastructure/web/gateway.py
+++ b/backend/monitor/infrastructure/web/gateway.py
@@ -1,5 +1,3 @@
-"""Monitor backend boundary for routers and future service extraction."""
-
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from monitor infrastructure services
- keep implementation logic unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check