### PR TITLE
chore: delete redundant monitor evaluation docstrings

### DIFF
--- a/backend/monitor/infrastructure/evaluation/background_task_scheduler.py
+++ b/backend/monitor/infrastructure/evaluation/background_task_scheduler.py
@@ -1,5 +1,3 @@
-"""BackgroundTasks-backed evaluation scheduler."""
-
 from __future__ import annotations
 
 from backend.monitor.infrastructure.evaluation.evaluation_execution_service import run_monitor_evaluation_batch

--- a/backend/monitor/infrastructure/evaluation/evaluation_execution_service.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_execution_service.py
@@ -1,5 +1,3 @@
-"""Evaluation scenario and runner port for Monitor."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/backend/monitor/infrastructure/evaluation/evaluation_scheduler.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_scheduler.py
@@ -1,5 +1,3 @@
-"""Evaluation job scheduling contract."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/monitor/infrastructure/evaluation/evaluation_storage_service.py
+++ b/backend/monitor/infrastructure/evaluation/evaluation_storage_service.py
@@ -1,5 +1,3 @@
-"""Monitor evaluation storage construction boundary."""
-
 from __future__ import annotations
 
 from eval.batch_service import EvaluationBatchService


### PR DESCRIPTION
## Summary
- delete redundant single-line module docstrings from monitor evaluation infrastructure
- keep evaluation logic unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check