### PR TITLE
chore: delete redundant monitor boundary docstrings

### DIFF
--- a/backend/monitor/api/http/execution_target.py
+++ b/backend/monitor/api/http/execution_target.py
@@ -1,5 +1,3 @@
-"""Execution target resolution for monitor-triggered evaluation runs."""
-
 from __future__ import annotations
 
 import os

--- a/backend/monitor/api/http/global_router.py
+++ b/backend/monitor/api/http/global_router.py
@@ -1,5 +1,3 @@
-"""Global monitor routes eligible for future monitor_app mounting."""
-
 import asyncio
 from typing import Annotated
 

--- a/backend/monitor/app/lifespan.py
+++ b/backend/monitor/app/lifespan.py
@@ -1,5 +1,3 @@
-"""Minimal lifespan for the separate Monitor app shell."""
-
 import asyncio
 from contextlib import asynccontextmanager
 

--- a/backend/monitor/app/main.py
+++ b/backend/monitor/app/main.py
@@ -1,5 +1,3 @@
-"""Separate-process Monitor app shell."""
-
 from fastapi import FastAPI
 
 from backend.bootstrap.app_entrypoint import add_permissive_cors, load_env_file_from_env, resolve_app_port, run_reloadable_app

--- a/backend/monitor/application/use_cases/evaluation.py
+++ b/backend/monitor/application/use_cases/evaluation.py
@@ -1,5 +1,3 @@
-"""Evaluation read and batch control boundary for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/application/use_cases/operations.py
+++ b/backend/monitor/application/use_cases/operations.py
@@ -1,5 +1,3 @@
-"""Monitor cleanup operation truth."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/backend/monitor/application/use_cases/provider_runtimes.py
+++ b/backend/monitor/application/use_cases/provider_runtimes.py
@@ -1,5 +1,3 @@
-"""Provider/runtime read and cleanup boundary for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/application/use_cases/resources.py
+++ b/backend/monitor/application/use_cases/resources.py
@@ -1,5 +1,3 @@
-"""Monitor resource boundary for overview and sandbox file reads."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/application/use_cases/sandbox_configs.py
+++ b/backend/monitor/application/use_cases/sandbox_configs.py
@@ -1,5 +1,3 @@
-"""Sandbox provider inventory boundary for Monitor."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/application/use_cases/sandbox_detail.py
+++ b/backend/monitor/application/use_cases/sandbox_detail.py
@@ -1,5 +1,3 @@
-"""Sandbox detail and cleanup boundary for Monitor."""
-
 from __future__ import annotations
 
 from backend.monitor.application.use_cases import operations, sandbox_projection

--- a/backend/monitor/application/use_cases/sandbox_projection.py
+++ b/backend/monitor/application/use_cases/sandbox_projection.py
@@ -1,5 +1,3 @@
-"""Sandbox projection read surface for Monitor and resource triage."""
-
 from __future__ import annotations
 
 from datetime import datetime

--- a/backend/monitor/application/use_cases/thread_workbench.py
+++ b/backend/monitor/application/use_cases/thread_workbench.py
@@ -1,5 +1,3 @@
-"""Owner thread workbench projection."""
-
 from __future__ import annotations
 
 from backend.monitor.infrastructure.read_models.thread_workbench_read_service import OwnerThreadWorkbenchReader

--- a/backend/monitor/application/use_cases/threads.py
+++ b/backend/monitor/application/use_cases/threads.py
@@ -1,5 +1,3 @@
-"""Thread read boundary for Monitor."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/backend/monitor/application/use_cases/trace.py
+++ b/backend/monitor/application/use_cases/trace.py
@@ -1,5 +1,3 @@
-"""Monitor thread trajectory surface."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/monitor/mutations/contracts.py
+++ b/backend/monitor/mutations/contracts.py
@@ -1,5 +1,3 @@
-"""Monitor cleanup mutation contracts."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/monitor/mutations/sandbox_mutations.py
+++ b/backend/monitor/mutations/sandbox_mutations.py
@@ -1,5 +1,3 @@
-"""Monitor sandbox mutation port."""
-
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
## Summary
- Delete redundant single-line module docstrings from monitor app/api/mutations/use-case boundaries

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check