### PR TITLE
chore: delete redundant thread module docstrings

### DIFF
--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -1,5 +1,3 @@
-"""Agent pool management service."""
-
 from backend.threads.file_channel import get_file_channel_binding
 from backend.threads.pool import registry as _registry
 from backend.threads.pool.factory import create_agent_sync

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -1,5 +1,3 @@
-"""Agent-user CRUD over repo-backed users/configs."""
-
 import time
 from pathlib import Path
 from typing import Any

--- a/backend/threads/binding.py
+++ b/backend/threads/binding.py
@@ -1,5 +1,3 @@
-"""Target-style thread runtime binding read model."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -1,5 +1,3 @@
-"""Threads runtime bootstrap owned by the threads backend."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/threads/chat_adapters/activity_reader.py
+++ b/backend/threads/chat_adapters/activity_reader.py
@@ -1,5 +1,3 @@
-"""App-backed runtime thread activity reader."""
-
 from __future__ import annotations
 
 from typing import Any, Literal

--- a/backend/threads/chat_adapters/chat_handler.py
+++ b/backend/threads/chat_adapters/chat_handler.py
@@ -1,5 +1,3 @@
-"""Native Chat delivery handler for the Agent runtime."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -1,5 +1,3 @@
-"""Chat delivery inlet from messaging into Agent Runtime."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/threads/chat_adapters/chat_notification_format.py
+++ b/backend/threads/chat_adapters/chat_notification_format.py
@@ -1,5 +1,3 @@
-"""Native runtime formatting for Chat delivery notifications."""
-
 from __future__ import annotations
 
 

--- a/backend/threads/chat_adapters/chat_runtime_services.py
+++ b/backend/threads/chat_adapters/chat_runtime_services.py
@@ -1,5 +1,3 @@
-"""App-backed services for native Agent Runtime chat delivery."""
-
 from __future__ import annotations
 
 from typing import Any, Protocol

--- a/backend/threads/chat_adapters/gateway.py
+++ b/backend/threads/chat_adapters/gateway.py
@@ -1,5 +1,3 @@
-"""Agent Runtime Gateway facade for service-to-service dispatch."""
-
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/backend/threads/chat_adapters/port.py
+++ b/backend/threads/chat_adapters/port.py
@@ -1,5 +1,3 @@
-"""Agent runtime port used by web routes and chat delivery."""
-
 from __future__ import annotations
 
 from typing import Any, Protocol

--- a/backend/threads/chat_adapters/thread_handler.py
+++ b/backend/threads/chat_adapters/thread_handler.py
@@ -1,5 +1,3 @@
-"""Native direct Thread input handler for the Agent runtime."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/threads/event_bus.py
+++ b/backend/threads/event_bus.py
@@ -1,5 +1,3 @@
-"""Process-level EventBus for multi-agent event routing."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/threads/events/buffer.py
+++ b/backend/threads/events/buffer.py
@@ -1,5 +1,3 @@
-"""In-memory event buffer for decoupling agent execution from SSE consumers."""
-
 import asyncio
 from collections import deque
 from dataclasses import dataclass, field

--- a/backend/threads/events/store.py
+++ b/backend/threads/events/store.py
@@ -1,5 +1,3 @@
-"""Persistent run-event write service via storage repository boundary."""
-
 import asyncio
 import json
 from typing import Any

--- a/backend/threads/file_channel.py
+++ b/backend/threads/file_channel.py
@@ -1,5 +1,3 @@
-"""File channel service for workspace-owned user↔agent file transfer."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -1,5 +1,3 @@
-"""Shared thread history read surface."""
-
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable

--- a/backend/threads/interruption.py
+++ b/backend/threads/interruption.py
@@ -1,5 +1,3 @@
-"""Shared message-level interruption repair for cold thread reads."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/threads/launch_config.py
+++ b/backend/threads/launch_config.py
@@ -1,5 +1,3 @@
-"""Resolve + persist per-agent new-thread config defaults."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/threads/owner_reads.py
+++ b/backend/threads/owner_reads.py
@@ -1,5 +1,3 @@
-"""Shared owner-thread reads for bursty authenticated surfaces."""
-
 from __future__ import annotations
 
 import asyncio

--- a/backend/threads/pool/factory.py
+++ b/backend/threads/pool/factory.py
@@ -1,5 +1,3 @@
-"""Thread runtime instance factory."""
-
 from pathlib import Path
 from typing import Any
 

--- a/backend/threads/pool/idle_reaper.py
+++ b/backend/threads/pool/idle_reaper.py
@@ -1,5 +1,3 @@
-"""Idle session reaper service."""
-
 import asyncio
 from collections.abc import Callable
 from typing import Any

--- a/backend/threads/run/trajectory.py
+++ b/backend/threads/run/trajectory.py
@@ -1,5 +1,3 @@
-"""Trajectory tracing scope for thread runtime runs."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/threads/state.py
+++ b/backend/threads/state.py
@@ -1,5 +1,3 @@
-"""Thread state query service for sandbox status."""
-
 import asyncio
 from typing import Any
 

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -1,5 +1,3 @@
-"""SSE streaming service for agent execution."""
-
 import logging
 from typing import Any
 

--- a/backend/threads/virtual_threads.py
+++ b/backend/threads/virtual_threads.py
@@ -1,5 +1,2 @@
-"""Neutral virtual-thread helper."""
-
-
 def is_virtual_thread_id(thread_id: str | None) -> bool:
     return bool(thread_id) and thread_id.startswith("(") and thread_id.endswith(")")


### PR DESCRIPTION
## Summary
- Delete redundant single-line module docstrings from backend thread modules

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check