### PR TITLE
chore: delete redundant backend domain docstrings

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -1,5 +1,3 @@
-"""HTTP client for Mycel Hub marketplace API."""
-
 import copy
 import json
 import logging

--- a/backend/hub/snapshot_install.py
+++ b/backend/hub/snapshot_install.py
@@ -1,5 +1,3 @@
-"""Neutral owner for marketplace agent-user snapshot installs."""
-
 from __future__ import annotations
 
 import re

--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -1,5 +1,3 @@
-"""Authentication service — Supabase Auth backed register, login, JWT verify."""
-
 from __future__ import annotations
 
 import logging

--- a/backend/identity/auth/supabase_runtime.py
+++ b/backend/identity/auth/supabase_runtime.py
@@ -1,5 +1,3 @@
-"""Neutral Supabase runtime client factories for storage and auth wiring."""
-
 from __future__ import annotations
 
 import os

--- a/backend/identity/profile.py
+++ b/backend/identity/profile.py
@@ -1,5 +1,3 @@
-"""Profile CRUD — config.json based, with auth-user override for signed-in shell."""
-
 import json
 from pathlib import Path
 from typing import Any

--- a/backend/library/paths.py
+++ b/backend/library/paths.py
@@ -1,5 +1,3 @@
-"""Shared library path owner."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -1,5 +1,3 @@
-"""Library CRUD for file-backed assets and DB-backed sandbox templates."""
-
 import json
 import shutil
 import time

--- a/backend/sandboxes/account.py
+++ b/backend/sandboxes/account.py
@@ -1,5 +1,3 @@
-"""User account resource limits."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/sandboxes/local_workspace.py
+++ b/backend/sandboxes/local_workspace.py
@@ -1,5 +1,3 @@
-"""Shared local workspace root helper."""
-
 from __future__ import annotations
 
 import os

--- a/backend/sandboxes/resources/common.py
+++ b/backend/sandboxes/resources/common.py
@@ -1,5 +1,3 @@
-"""Shared resource helper functions for monitor and product projections."""
-
 from __future__ import annotations
 
 import json

--- a/backend/sandboxes/resources/projection.py
+++ b/backend/sandboxes/resources/projection.py
@@ -1,5 +1,3 @@
-"""User-visible resource projection over shared resource facts."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/backend/sandboxes/resources/provider_boundary.py
+++ b/backend/sandboxes/resources/provider_boundary.py
@@ -1,5 +1,3 @@
-"""Product resource boundary for user-visible resource projections."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/sandboxes/resources/provider_contracts.py
+++ b/backend/sandboxes/resources/provider_contracts.py
@@ -1,5 +1,3 @@
-"""Shared provider display and row payload contracts."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/backend/sandboxes/service.py
+++ b/backend/sandboxes/service.py
@@ -1,5 +1,3 @@
-"""Sandbox management service."""
-
 import logging
 from typing import Any
 


### PR DESCRIPTION
## Summary
- delete redundant one-line module docstrings from backend hub, identity, library, and sandbox domain modules
- keep the slice behavior-free and deletion-only

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check