### PR TITLE
chore: delete redundant module docstrings

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -1,5 +1,3 @@
-"""Chat runtime bootstrap owned by the chat backend."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/backend/web/core/config.py
+++ b/backend/web/core/config.py
@@ -1,5 +1,3 @@
-"""Configuration constants for Mycel web backend."""
-
 from backend.sandboxes.local_workspace import local_workspace_root
 from config.user_paths import user_home_path
 

--- a/backend/web/core/dependencies.py
+++ b/backend/web/core/dependencies.py
@@ -1,5 +1,3 @@
-"""FastAPI dependency injection functions."""
-
 import asyncio
 from typing import Annotated, Any
 

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -1,5 +1,3 @@
-"""Application lifespan management."""
-
 import asyncio
 import os
 from contextlib import asynccontextmanager

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -1,5 +1,3 @@
-"""Mycel Web Backend - FastAPI Application."""
-
 from backend.bootstrap.app_entrypoint import add_permissive_cors, load_env_file_from_env, resolve_app_port, run_reloadable_app
 
 load_env_file_from_env()

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -1,5 +1,3 @@
-"""Agent registry shared row types."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/core/runtime/abort.py
+++ b/core/runtime/abort.py
@@ -1,5 +1,3 @@
-"""Minimal abort controller tree for runtime lifecycle wiring."""
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/core/runtime/middleware/monitor/base.py
+++ b/core/runtime/middleware/monitor/base.py
@@ -1,5 +1,3 @@
-"""Monitor 基类"""
-
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/core/runtime/middleware/monitor/context_monitor.py
+++ b/core/runtime/middleware/monitor/context_monitor.py
@@ -1,5 +1,3 @@
-"""上下文大小监控"""
-
 from typing import Any
 
 from .base import BaseMonitor

--- a/core/runtime/middleware/monitor/middleware.py
+++ b/core/runtime/middleware/monitor/middleware.py
@@ -1,5 +1,3 @@
-"""Monitor Middleware - 监控容器"""
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/core/runtime/middleware/monitor/runtime.py
+++ b/core/runtime/middleware/monitor/runtime.py
@@ -1,5 +1,3 @@
-"""Agent 运行时状态聚合"""
-
 import asyncio
 import json
 import logging

--- a/core/runtime/middleware/monitor/state_monitor.py
+++ b/core/runtime/middleware/monitor/state_monitor.py
@@ -1,5 +1,3 @@
-"""执行状态监控"""
-
 import logging
 import threading
 from collections.abc import Callable

--- a/core/runtime/middleware/monitor/token_monitor.py
+++ b/core/runtime/middleware/monitor/token_monitor.py
@@ -1,5 +1,3 @@
-"""Token 使用量监控（6 项分项追踪）"""
-
 from __future__ import annotations
 
 from typing import Any

--- a/core/runtime/middleware/spill_buffer/middleware.py
+++ b/core/runtime/middleware/spill_buffer/middleware.py
@@ -1,5 +1,3 @@
-"""SpillBuffer middleware - intercepts oversized tool outputs."""
-
 from __future__ import annotations
 
 import json

--- a/core/runtime/middleware/spill_buffer/spill.py
+++ b/core/runtime/middleware/spill_buffer/spill.py
@@ -1,5 +1,3 @@
-"""Core spill logic: detect oversized content, write to disk, return preview."""
-
 from __future__ import annotations
 
 import posixpath

--- a/storage/container.py
+++ b/storage/container.py
@@ -1,5 +1,3 @@
-"""Storage container — Supabase-only repo composition root."""
-
 from __future__ import annotations
 
 import importlib

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -1,5 +1,3 @@
-"""Structural storage contracts for repo-level provider parity."""
-
 from __future__ import annotations
 
 from enum import StrEnum

--- a/storage/errors.py
+++ b/storage/errors.py
@@ -1,5 +1,3 @@
-"""Storage-layer errors shared by provider implementations."""
-
 from __future__ import annotations
 
 

--- a/storage/models.py
+++ b/storage/models.py
@@ -1,5 +1,3 @@
-"""Shared storage domain models — provider-neutral data types."""
-
 from __future__ import annotations
 
 from enum import Enum

--- a/storage/utils.py
+++ b/storage/utils.py
@@ -1,5 +1,3 @@
-"""Storage utility functions."""
-
 import secrets
 import string
 

--- a/tests/Config/conftest.py
+++ b/tests/Config/conftest.py
@@ -1,5 +1,3 @@
-"""Pytest configuration for config tests."""
-
 import sys
 from pathlib import Path
 

--- a/tests/Unit/core/test_runtime_support.py
+++ b/tests/Unit/core/test_runtime_support.py
@@ -1,5 +1,3 @@
-"""Focused runtime support tests for cleanup, fork, and state helpers."""
-
 import asyncio
 from pathlib import Path
 from typing import Any, get_type_hints

--- a/tests/Unit/integration_contracts/test_child_thread_live_contract.py
+++ b/tests/Unit/integration_contracts/test_child_thread_live_contract.py
@@ -1,5 +1,3 @@
-"""Integration coverage for live child-thread execution contracts."""
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/Unit/integration_contracts/test_query_loop_backend_contracts.py
+++ b/tests/Unit/integration_contracts/test_query_loop_backend_contracts.py
@@ -1,5 +1,3 @@
-"""Backend-facing regression tests for QueryLoop web caller contracts."""
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/Unit/sandbox/test_e2b_provider.py
+++ b/tests/Unit/sandbox/test_e2b_provider.py
@@ -1,5 +1,3 @@
-"""Smoke test for E2B provider and sandbox."""
-
 import builtins
 import os
 import sys


### PR DESCRIPTION
## Summary
- delete redundant one-line module docstrings from storage, runtime middleware, backend web, chat bootstrap, and focused tests
- keep the slice deletion-only with no runtime behavior changes

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check