### PR TITLE
chore: delete stale runtime module docstrings

### DIFF
--- a/core/runtime/loop.py
+++ b/core/runtime/loop.py
@@ -1,16 +1,3 @@
-"""QueryLoop — self-managing agentic tool loop replacing LangGraph create_agent.
-
-Implements CC Pattern 1: Agentic Tool Loop (queryLoop).
-
-Design:
-- AsyncGenerator that alternates LLM sampling and tool execution.
-- Exposes the same .astream(input, config, stream_mode) interface as CompiledStateGraph.
-- Middleware chain (SpillBuffer/Monitor/PromptCaching/Memory/Steering/ToolRunner) is
-  preserved exactly — awrap_model_call and awrap_tool_call pass through in order.
-- is_concurrency_safe tools execute in parallel; others execute serially.
-- Checkpointer (AsyncSqliteSaver) stores/restores message history across calls.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/core/runtime/state.py
+++ b/core/runtime/state.py
@@ -1,10 +1,3 @@
-"""Three-layer state models aligned with CC architecture.
-
-Layer 1: BootstrapConfig — survives /clear, process-level constants
-Layer 2: AppState — per-session mutable state (Zustand-style store)
-Layer 3: ToolUseContext — per-turn, holds live closures to AppState
-"""
-
 from __future__ import annotations
 
 import uuid

--- a/core/runtime/visibility.py
+++ b/core/runtime/visibility.py
@@ -1,10 +1,3 @@
-"""Owner visibility helpers.
-
-v3 default is "visible unless explicitly hidden". Some backend paths still emit
-durable hidden owner messages (for example AskUserQuestion answer anchors), so
-this layer must preserve an already-declared display contract.
-"""
-
 from __future__ import annotations
 
 from typing import Any

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -1,8 +1,3 @@
-"""Sandbox session manager.
-
-Orchestrates: Thread → ChatSession → Runtime with sandbox runtime bindings.
-"""
-
 import logging
 import uuid
 from collections.abc import Callable

--- a/sandbox/providers/agentbay.py
+++ b/sandbox/providers/agentbay.py
@@ -1,9 +1,3 @@
-"""
-AgentBay sandbox provider.
-
-Implements SandboxProvider using Alibaba Cloud's AgentBay SDK.
-"""
-
 from __future__ import annotations
 
 import json

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -1,13 +1,3 @@
-"""AbstractTerminal - Durable terminal identity + state snapshot.
-
-This module implements the terminal abstraction layer that separates
-durable terminal state (cwd, env_delta) from ephemeral runtime processes.
-
-Architecture:
-    Thread → AbstractTerminal (durable state) → SandboxRuntimeHandle → Instance
-    Thread → ChatSession → PhysicalTerminalRuntime (ephemeral process)
-"""
-
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- delete stale module-level architecture docstrings from runtime state, loop, visibility, sandbox manager, terminal, and AgentBay provider modules
- keep the slice deletion-only with no runtime behavior changes

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check