### PR TITLE
chore: delete stale sandbox module docstrings

### DIFF
--- a/core/identity/agent_registry.py
+++ b/core/identity/agent_registry.py
@@ -1,9 +1,3 @@
-"""Agent instance identity persistence.
-
-Stores agent identity mappings in ~/.leon/agent_instances.json.
-Backend-internal only — agent_id does not leak to SSE events.
-"""
-
 from __future__ import annotations
 
 import json

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -1,10 +1,3 @@
-"""SandboxCapability - Agent-facing sandbox binding surface.
-
-This module provides the capability object that agents interact with.
-It wraps the agent-facing thread/runtime/sandbox binding surface while
-keeping sandbox runtime identity details behind the capability interface.
-"""
-
 from __future__ import annotations
 
 import shlex

--- a/sandbox/lifecycle.py
+++ b/sandbox/lifecycle.py
@@ -1,10 +1,3 @@
-"""Lifecycle state machine contracts for chat sessions and sandbox runtime instances.
-
-Fail-loud policy:
-- Invalid state strings raise immediately.
-- Illegal transitions raise immediately.
-"""
-
 from __future__ import annotations
 
 from enum import StrEnum

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -1,11 +1,3 @@
-"""
-Daytona sandbox provider.
-
-Uses Daytona's Python SDK for sandbox lifecycle, filesystem, and process execution.
-
-Important: runtime semantics remain PTY-backed (`daytona_pty`) for both SaaS and self-hosted.
-"""
-
 from __future__ import annotations
 
 import logging

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -1,9 +1,3 @@
-"""
-Docker sandbox provider.
-
-Implements SandboxProvider using local Docker containers.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/sandbox/providers/e2b.py
+++ b/sandbox/providers/e2b.py
@@ -1,14 +1,3 @@
-"""
-E2B sandbox provider.
-
-Implements SandboxProvider using E2B's cloud sandbox SDK.
-
-Key differences from AgentBay:
-- No persistent storage (context_id ignored) -- pause is the only way to preserve state
-- Pause/resume via beta API: beta_pause() / Sandbox.connect()
-- Uses beta_create(auto_pause=True) so sandboxes pause on timeout instead of dying
-"""
-
 from __future__ import annotations
 
 import logging

--- a/sandbox/runtime_handle.py
+++ b/sandbox/runtime_handle.py
@@ -1,13 +1,3 @@
-"""SandboxRuntimeHandle - durable compute handle with sandbox-runtime state machine.
-
-Architecture:
-    SandboxRuntimeHandle (durable) -> SandboxInstance (ephemeral)
-
-State machine contract:
-- Physical lifecycle writes must go through SQLiteSandboxRuntimeHandle.apply(event).
-- Sandbox runtime snapshot stores desired_state + observed_state + version.
-"""
-
 from __future__ import annotations
 
 import json

--- a/sandbox/volume.py
+++ b/sandbox/volume.py
@@ -1,13 +1,3 @@
-"""SandboxVolume — provider-agnostic mount/sync engine.
-
-"Mount" is abstract: make a manager-supplied source path visible inside the sandbox.
-Docker uses bind mount, E2B uses tar sync, Daytona uses managed volume.
-SandboxVolume smooths over these differences.
-
-This is sandbox infrastructure. It doesn't know what's being mounted
-(files, code, data) — that's decided by the application layer.
-"""
-
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- delete stale module-level architecture docstrings from sandbox capability, volume, runtime handle, lifecycle, and provider modules
- delete stale agent identity module docstring
- keep the slice deletion-only with no runtime behavior changes

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check