### PR TITLE
chore: delete redundant tool service docstrings

### DIFF
--- a/core/tools/filesystem/service.py
+++ b/core/tools/filesystem/service.py
@@ -1,12 +1,3 @@
-"""FileSystem Service - registers file operation tools with ToolRegistry.
-
-Tools:
-- Read: Read file content (with chunking support)
-- Write: Create new file
-- Edit: Edit file (str_replace mode, supports replace_all)
-- list_dir: List directory
-"""
-
 from __future__ import annotations
 
 import logging

--- a/core/tools/search/service.py
+++ b/core/tools/search/service.py
@@ -1,10 +1,3 @@
-"""Search Service - registers Grep and Glob tools with ToolRegistry.
-
-Tools:
-- Grep: Content search using regex (ripgrep when available, Python implementation otherwise)
-- Glob: File pattern matching sorted by modification time
-"""
-
 from __future__ import annotations
 
 import re
@@ -36,8 +29,6 @@ DEFAULT_EXCLUDES: list[str] = [
 
 
 class SearchService:
-    """Registers Grep and Glob tools into ToolRegistry."""
-
     def __init__(
         self,
         registry: ToolRegistry,

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -1,11 +1,3 @@
-"""Skills Service - registers load_skill tool with ToolRegistry.
-
-Tools:
-- load_skill: Progressive disclosure of specialized capabilities
-
-Uses dynamic schema (callable) to reflect current skill index on each call.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -19,8 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class SkillsService:
-    """Registers load_skill tool into ToolRegistry with dynamic schema."""
-
     def __init__(
         self,
         registry: ToolRegistry,

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -1,10 +1,3 @@
-"""TaskService - repository-backed task management tools.
-
-Provides TaskCreate/TaskGet/TaskList/TaskUpdate as DEFERRED tools.
-Tasks are partitioned by thread_id so all agents in the same thread share
-the same task list. Thread ID is read from sandbox.thread_context at runtime.
-"""
-
 from __future__ import annotations
 
 import json

--- a/core/tools/tool_search/service.py
+++ b/core/tools/tool_search/service.py
@@ -1,9 +1,3 @@
-"""ToolSearchService - Discover available tools via search.
-
-Registers a single INLINE tool (tool_search) that queries ToolRegistry
-to find matching tools by name or description.
-"""
-
 from __future__ import annotations
 
 import json
@@ -32,8 +26,6 @@ TOOL_SEARCH_SCHEMA = make_tool_schema(
 
 
 class ToolSearchService:
-    """Provides tool_search as an INLINE tool for discovering DEFERRED tools."""
-
     def __init__(self, registry: ToolRegistry):
         self._registry = registry
         registry.register(

--- a/core/tools/web/service.py
+++ b/core/tools/web/service.py
@@ -1,10 +1,3 @@
-"""Web Service - registers WebSearch and WebFetch tools with ToolRegistry.
-
-Tools:
-- WebSearch: Web search provider chain (Tavily -> Exa -> Firecrawl)
-- WebFetch: Fetch web content and extract information using AI
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -20,8 +13,6 @@ from core.tools.web.types import FetchLimits, FetchResult, SearchResult
 
 
 class WebService:
-    """Registers WebSearch and WebFetch tools into ToolRegistry."""
-
     def __init__(
         self,
         registry: ToolRegistry,


### PR DESCRIPTION
## Summary
- delete redundant module and service class docstrings from tool service modules
- keep runtime invariant comments such as @@@remote-posix-path-contract intact

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check