### PR TITLE
chore: delete redundant middleware docstrings

### DIFF
--- a/core/runtime/middleware/memory/compactor.py
+++ b/core/runtime/middleware/memory/compactor.py
@@ -1,9 +1,3 @@
-"""ContextCompactor — Layer 2: LLM-based conversation summarization.
-
-Generates summaries of old messages, caches them in memory.
-Does NOT modify LangGraph state.
-"""
-
 from __future__ import annotations
 
 from typing import Any
@@ -35,8 +29,6 @@ Provide a concise summary that captures the essential context."""
 
 
 class ContextCompactor:
-    """Summarize old messages via LLM call. Stateless — caller manages cache."""
-
     def __init__(
         self,
         reserve_tokens: int = 16384,

--- a/core/runtime/middleware/memory/middleware.py
+++ b/core/runtime/middleware/memory/middleware.py
@@ -1,10 +1,3 @@
-"""MemoryMiddleware — Context pruning + compaction.
-
-Combines SessionPruner (Layer 1) and ContextCompactor (Layer 2).
-All operations happen in awrap_model_call — modifies the request sent to LLM,
-does NOT modify LangGraph state. TUI sees full history, agent sees compressed.
-"""
-
 from __future__ import annotations
 
 import json
@@ -34,12 +27,6 @@ _COMPACTION_BREAKER_THRESHOLD = 3
 
 
 class MemoryMiddleware(AgentMiddleware):
-    """Context memory management middleware.
-
-    Layer 1 (Pruning): trim/clear old ToolMessage content
-    Layer 2 (Compaction): LLM summarization when context exceeds threshold
-    """
-
     tools = ()  # no tools injected
 
     def __init__(

--- a/core/runtime/middleware/memory/pruner.py
+++ b/core/runtime/middleware/memory/pruner.py
@@ -1,8 +1,3 @@
-"""SessionPruner — Layer 1: trim/clear old ToolMessage content.
-
-Pure string operations, no LLM calls. Protects recent tool results.
-"""
-
 from __future__ import annotations
 
 import copy
@@ -10,13 +5,6 @@ from typing import Any
 
 
 class SessionPruner:
-    """Prune old ToolMessage content to reduce context size.
-
-    Two levels:
-    - soft-trim: keep head + tail, replace middle with [...trimmed...]
-    - hard-clear: replace entire content with placeholder
-    """
-
     def __init__(
         self,
         soft_trim_chars: int = 3000,

--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -1,15 +1,3 @@
-"""SummaryStore - Persistent storage for conversation summaries.
-
-This module implements persistent storage for MemoryMiddleware summaries,
-preventing loss of cached summaries across restarts.
-
-Architecture:
-    MemoryMiddleware → SummaryStore → SQLite
-    - Summaries stored with thread_id as key
-    - Only latest summary per thread is active
-    - Historical summaries retained for audit
-"""
-
 from __future__ import annotations
 
 import logging
@@ -47,12 +35,6 @@ class SummaryData:
 
 
 class SummaryStore:
-    """Store for managing conversation summary persistence.
-
-    Handles CRUD operations for summaries in the database.
-    Follows the same pattern as TerminalStore for consistency.
-    """
-
     def __init__(self, db_path: Path | None = None, summary_repo: SummaryRepo | None = None):
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
         self._repo: SummaryRepo

--- a/core/runtime/middleware/queue/formatters.py
+++ b/core/runtime/middleware/queue/formatters.py
@@ -1,10 +1,3 @@
-"""XML formatters for steer messages and task notifications.
-
-Matches Claude Code's system-reminder convention so the LLM treats
-injected content as authoritative system instructions.
-Frontend strips <system-reminder> tags — agent sees full XML, user sees clean text.
-"""
-
 import json
 from html import escape
 from typing import Literal

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -1,9 +1,3 @@
-"""Message Queue Manager — facade over QueueRepo with wake-on-enqueue.
-
-Delegates all persistence to a QueueRepo (storage layer).
-Wake handlers notify the host when messages arrive for idle agents.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -18,8 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 class MessageQueueManager:
-    """Facade: QueueRepo persistence + wake handler orchestration."""
-
     def __init__(self, repo: QueueRepo | None = None, *, db_path: str | None = None) -> None:
         if repo is not None:
             self._repo = repo

--- a/core/runtime/middleware/queue/middleware.py
+++ b/core/runtime/middleware/queue/middleware.py
@@ -1,10 +1,3 @@
-"""Steering Middleware - injects queued messages before model calls (non-preemptive)
-
-Tool calls are never skipped. All pending messages are drained from the unified
-SQLite queue and injected as HumanMessage(metadata={"source": "system"}) before
-the next LLM call.
-"""
-
 import json
 import logging
 from collections.abc import Awaitable, Callable
@@ -72,15 +65,6 @@ def _apply_steer_contract(request: ModelRequest) -> ModelRequest:
 
 
 class SteeringMiddleware(AgentMiddleware):
-    """Non-preemptive steering: let all tool calls finish, inject before next LLM call.
-
-    Flow:
-    1. Tool calls execute normally (no skipping)
-    2. Before next model call, drain ALL pending messages from SQLite queue
-    3. Inject as HumanMessage with metadata source="system"
-    4. Update runtime.visibility_context so streaming tags events correctly
-    """
-
     def __init__(self, queue_manager: MessageQueueManager, agent_runtime: Any = None) -> None:
         self._queue_manager = queue_manager
         self._agent_runtime = agent_runtime  # our AgentRuntime, not LangGraph's Runtime


### PR DESCRIPTION
## Summary
- delete redundant module and class docstrings from runtime memory and queue middleware modules
- preserve @@@ invariant comments and method-level behavior notes

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check