### PR TITLE
chore: delete remaining runtime module docstrings

### DIFF
--- a/core/runtime/fork.py
+++ b/core/runtime/fork.py
@@ -1,11 +1,3 @@
-"""Context fork for sub-agent spawning.
-
-When a sub-agent is spawned, it inherits workspace/model/permission configuration
-from the parent but gets its own isolated messages and session identity.
-
-Aligned with CC createSubagentContext() field-by-field fork table.
-"""
-
 from __future__ import annotations
 
 import copy

--- a/core/runtime/middleware/__init__.py
+++ b/core/runtime/middleware/__init__.py
@@ -1,9 +1,3 @@
-"""Local runtime middleware protocol and request/response types.
-
-This replaces the phantom `langchain.agents.middleware.types` dependency for
-the current runtime stack.
-"""
-
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
@@ -46,8 +40,6 @@ class ToolCallRequest:
 
 
 class AgentMiddleware:
-    """Minimal chain-of-responsibility middleware base for the runtime stack."""
-
     tools: ClassVar[tuple[Any, ...]] = ()
 
     def wrap_model_call(

--- a/core/runtime/middleware/mcp_instructions.py
+++ b/core/runtime/middleware/mcp_instructions.py
@@ -1,11 +1,3 @@
-"""Thread-scoped MCP instruction delta injection.
-
-Mycel does not have CC's attachment plane. Keep this contract smaller:
-- MCP server configs may carry `instructions`
-- the loop stores which server names have already been announced per thread
-- on the next turn after a change, inject one delta SystemMessage
-"""
-
 from __future__ import annotations
 
 import json
@@ -45,8 +37,6 @@ def _render_delta_message(*, added: dict[str, str], removed: list[str]) -> Syste
 
 
 class McpInstructionsDeltaMiddleware(AgentMiddleware):
-    """Injects MCP instruction deltas once per thread when the connected set changes."""
-
     def __init__(
         self,
         *,

--- a/core/runtime/middleware/monitor/cost.py
+++ b/core/runtime/middleware/monitor/cost.py
@@ -1,10 +1,3 @@
-"""模型成本计算
-
-定价来源优先级：
-1. OpenRouter API（启动时拉取，缓存到 ~/.leon/pricing_cache.json，24h TTL）
-2. 本地 models.json（OpenRouter /models 原始快照，随代码发布，离线兜底）
-"""
-
 from __future__ import annotations
 
 import json

--- a/core/runtime/middleware/monitor/usage_patches.py
+++ b/core/runtime/middleware/monitor/usage_patches.py
@@ -1,12 +1,3 @@
-"""Provider-specific streaming usage patches.
-
-Centralizes workarounds for upstream bugs where streaming responses
-return incomplete token usage data. Each patch is idempotent and
-guarded by a flag so it can be called multiple times safely.
-
-Remove individual patches once the upstream library is fixed.
-"""
-
 from __future__ import annotations
 
 from typing import Any

--- a/core/runtime/middleware/prompt_caching/__init__.py
+++ b/core/runtime/middleware/prompt_caching/__init__.py
@@ -1,10 +1,3 @@
-"""Anthropic prompt caching middleware.
-
-Requires:
-    - local `core.runtime.middleware` protocol types
-    - `langchain-anthropic`: For `ChatAnthropic` model
-"""
-
 from collections.abc import Awaitable, Callable
 from typing import Literal
 from warnings import warn
@@ -29,16 +22,6 @@ except ImportError as e:
 
 
 class PromptCachingMiddleware(AgentMiddleware):
-    """Prompt Caching Middleware.
-
-    Optimizes API usage by caching conversation prefixes for Anthropic models.
-
-    Requires the local runtime middleware protocol plus `langchain-anthropic`.
-
-    Learn more about Anthropic prompt caching
-    [here](https://platform.claude.com/docs/en/build-with-claude/prompt-caching).
-    """
-
     def __init__(
         self,
         type: Literal["ephemeral"] = "ephemeral",  # noqa: A002

--- a/core/runtime/prompts.py
+++ b/core/runtime/prompts.py
@@ -1,15 +1,3 @@
-"""System prompt builders — pure functions, no agent state.
-
-Extracted from LeonAgent so agent.py stays lean.
-
-Middleware Stack
-- MemoryMiddleware: trims/compacts conversation context before model calls.
-- MonitorMiddleware: aggregates runtime metrics and observes model execution.
-- PromptCachingMiddleware: enables Anthropic prompt caching for eligible requests.
-- SteeringMiddleware: drains queued messages and injects them before the next model call.
-- SpillBufferMiddleware: spills oversized tool outputs to disk and replaces them with previews.
-"""
-
 from __future__ import annotations
 
 from typing import NamedTuple

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -1,17 +1,3 @@
-"""LSP Service - Language Server Protocol code intelligence via multilspy.
-
-Registers a single DEFERRED `LSP` tool with 9 operations:
-  goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol,
-  goToImplementation, prepareCallHierarchy, incomingCalls, outgoingCalls
-
-Sessions are managed by the process-level _LSPSessionPool singleton — they
-start lazily on first use and persist for the lifetime of the process,
-surviving agent restarts. Call `await lsp_pool.close_all()` on process exit.
-
-Supported languages (via multilspy):
-  python, typescript, javascript, go, rust, java, ruby, kotlin, csharp
-"""
-
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary
- delete remaining redundant runtime and LSP module docstrings
- leave executable prompt string constants and @@@ invariant comments intact

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check