### PR TITLE
chore: delete redundant runtime comments

### DIFF
--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -40,7 +40,6 @@ class AuthService:
         self._recipe_repo = recipe_repo
 
     def send_otp(self, email: str, password: str, invite_code: str) -> None:
-        """Validate invite code, create user via signUp (sends confirmation OTP to email)."""
         auth_client = self._auth_api(self._require_auth_client())
         if self._sb is None:
             raise RuntimeError("Supabase client required.")
@@ -57,7 +56,6 @@ class AuthService:
             raise ValueError("发送验证码失败，请稍后重试") from e
 
     def verify_register_otp(self, email: str, token: str) -> dict:
-        """Verify signup OTP. Returns temp_token to be used in complete_register."""
         auth_client = self._auth_api(self._require_auth_client())
         if self._sb is None:
             raise RuntimeError("Supabase client required.")
@@ -72,11 +70,9 @@ class AuthService:
         return {"temp_token": resp.session.access_token}
 
     def complete_register(self, temp_token: str, invite_code: str) -> dict:
-        """Complete registration: validate invite code, create unified user records."""
         if self._sb is None:
             raise RuntimeError("Supabase client required.")
 
-        # 1. Decode temp_token to get user_id
         jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
         if not jwt_secret:
             raise RuntimeError("SUPABASE_JWT_SECRET not set.")
@@ -86,11 +82,9 @@ class AuthService:
             raise ValueError("会话已过期，请重新验证邮箱") from e
         auth_user_id = payload["sub"]
 
-        # 2. Validate invite code (re-check; repo handles expired/used)
         if self._invite_codes is None or not self._invite_codes.is_valid(invite_code):
             raise ValueError("邀请码无效或已过期")
 
-        # 3. Create unified user records (idempotent guard)
         email_from_payload = payload.get("email", "")
         existing = self._users.get_by_id(auth_user_id)
         if existing is None:
@@ -109,7 +103,6 @@ class AuthService:
                 )
             )
 
-            # Initial agents
             first_agent_info = self._create_initial_agents(auth_user_id, now)
             self._seed_default_recipes(auth_user_id)
         else:
@@ -122,7 +115,6 @@ class AuthService:
                 agent = owned_agents[0]
                 first_agent_info = {"id": agent.id, "name": agent.display_name, "type": agent.type.value, "avatar": agent.avatar}
 
-        # 4. Mark invite code used (atomic via repo)
         if self._invite_codes is not None:
             self._invite_codes.use(invite_code, auth_user_id)
 
@@ -134,14 +126,12 @@ class AuthService:
         }
 
     def login(self, identifier: str, password: str) -> dict:
-        """Login with email or mycel_id + password."""
         auth_client = self._auth_api(self._require_auth_client())
 
         email = self._resolve_email(identifier)
 
         from supabase_auth.errors import AuthApiError
 
-        # Sign in via Supabase
         try:
             resp = auth_client.sign_in_with_password({"email": email, "password": password})
         except AuthApiError:
@@ -178,7 +168,6 @@ class AuthService:
         }
 
     def verify_token(self, token: str) -> dict:
-        """Verify Supabase JWT. Returns {user_id}."""
         jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
         if not jwt_secret:
             raise RuntimeError("SUPABASE_JWT_SECRET env var required for token verification.")
@@ -196,10 +185,7 @@ class AuthService:
         except jwt.InvalidTokenError as e:
             raise ValueError(f"Token 无效: {e}")
 
-    # Internal helpers
-
     def _resolve_email(self, identifier: str) -> str:
-        """Turn mycel_id (numeric string) or email into email address."""
         if identifier.strip().lstrip("0123456789") == "" and identifier.strip().isdigit():
             user = self._users.get_by_mycel_id(int(identifier.strip()))
             if user is None or user.email is None:
@@ -223,7 +209,6 @@ class AuthService:
         seed_default_recipes(owner_user_id, recipe_repo=self._recipe_repo)
 
     def _create_initial_agents(self, owner_user_id: str, now: float) -> dict | None:
-        """Create Toad and Morel agents for a new user. Returns first agent info."""
         if self._agent_configs is None:
             raise RuntimeError("Agent config repo required for initial agent creation during schema cutover.")
         from pathlib import Path

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -19,7 +19,6 @@ def _unbound_get_file_channel_binding(*_args, **_kwargs):
 
 get_file_channel_binding = _unbound_get_file_channel_binding
 
-# Thread lock for config updates
 _config_update_locks: dict[str, asyncio.Lock] = {}
 _agent_create_locks: dict[str, asyncio.Lock] = {}
 
@@ -32,12 +31,9 @@ async def get_or_create_agent(
     *,
     messaging_service: Any | None = None,
 ) -> Any:
-    """Lazy agent pool — one agent per thread, created on demand."""
     if thread_id:
         set_current_thread_id(thread_id)
 
-    # Per-thread Agent instance: pool key = thread_id:sandbox_type
-    # This ensures complete isolation of middleware state (memory, todo, runtime, filesystem, etc.)
     if not thread_id:
         raise ValueError("thread_id is required for agent creation")
 

--- a/backend/web/routers/auth.py
+++ b/backend/web/routers/auth.py
@@ -19,9 +19,6 @@ async def _call_auth_service(app: Any, status_code: int, call: Callable[[Any], A
         raise HTTPException(status_code, str(e))
 
 
-# ── Registration step 1: send OTP ──────────────────────────────────────────
-
-
 class SendOtpRequest(BaseModel):
     email: str
     password: str
@@ -38,9 +35,6 @@ async def send_otp(payload: SendOtpRequest, app: Annotated[Any, Depends(get_app)
     return {"ok": True}
 
 
-# ── Registration step 2: verify OTP ────────────────────────────────────────
-
-
 class VerifyOtpRequest(BaseModel):
     email: str
     token: str
@@ -55,9 +49,6 @@ async def verify_otp(payload: VerifyOtpRequest, app: Annotated[Any, Depends(get_
     )
 
 
-# ── Registration step 3: set password + invite code ────────────────────────
-
-
 class CompleteRegisterRequest(BaseModel):
     temp_token: str
     invite_code: str
@@ -70,9 +61,6 @@ async def complete_register(payload: CompleteRegisterRequest, app: Annotated[Any
         400,
         lambda service: service.complete_register(payload.temp_token, payload.invite_code),
     )
-
-
-# ── Login ───────────────────────────────────────────────────────────────────
 
 
 class LoginRequest(BaseModel):

--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -37,9 +37,6 @@ async def _call_invite_code_repo(error_prefix: str, call: Callable[[], Any]) -> 
         raise HTTPException(500, f"{error_prefix}{e}") from e
 
 
-# ── List all invite codes ────────────────────────────────────────────────────
-
-
 @router.get("")
 async def list_invite_codes(
     request: Request,
@@ -48,9 +45,6 @@ async def list_invite_codes(
     repo = _invite_code_repo(request)
     codes = await _call_invite_code_repo("获取邀请码列表失败：", repo.list_all)
     return {"codes": [_invite_code_payload(code) for code in codes]}
-
-
-# ── Generate a new invite code ───────────────────────────────────────────────
 
 
 class GenerateInviteCodeRequest(BaseModel):
@@ -71,9 +65,6 @@ async def generate_invite_code(
     return _invite_code_payload(code)
 
 
-# ── Revoke (delete) an invite code ──────────────────────────────────────────
-
-
 @router.delete("/{code}")
 async def revoke_invite_code(
     code: str,
@@ -85,9 +76,6 @@ async def revoke_invite_code(
     if not ok:
         raise HTTPException(404, "邀请码不存在")
     return {"ok": True}
-
-
-# ── Validate an invite code (no auth required) ───────────────────────────────
 
 
 @router.get("/validate/{code}")

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -24,15 +24,9 @@ from config.models_loader import ModelsLoader  # noqa: E402
 from config.models_schema import ModelsConfig  # noqa: E402
 from config.observation_loader import ObservationLoader  # noqa: E402
 from config.observation_schema import ObservationConfig  # noqa: E402
-
-# Multi-agent services
 from core.agents.service import AgentService  # noqa: E402
 from core.model_params import normalize_model_kwargs  # noqa: E402
-
-# Import file operation recorder for time travel
 from core.operations import get_recorder  # noqa: E402
-
-# New architecture: ToolRegistry + ToolRunner + Services
 from core.runtime.cleanup import CleanupRegistry  # noqa: E402
 from core.runtime.loop import QueryLoop  # noqa: E402
 from core.runtime.middleware.mcp_instructions import McpInstructionsDeltaMiddleware  # noqa: E402
@@ -40,15 +34,11 @@ from core.runtime.middleware.memory import MemoryMiddleware  # noqa: E402
 from core.runtime.middleware.monitor import MonitorMiddleware, apply_usage_patches  # noqa: E402
 from core.runtime.middleware.prompt_caching import PromptCachingMiddleware  # noqa: E402
 from core.runtime.middleware.queue import MessageQueueManager, SteeringMiddleware  # noqa: E402
-
-# Middleware imports (migrated paths)
 from core.runtime.middleware.spill_buffer import SpillBufferMiddleware  # noqa: E402
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema  # noqa: E402
 from core.runtime.runner import ToolRunner  # noqa: E402
 from core.runtime.state import AppState, BootstrapConfig  # noqa: E402
 from core.runtime.validator import ToolValidator  # noqa: E402
-
-# Hooks (used by Services)
 from core.tools.command.hooks.dangerous_commands import DangerousCommandsHook  # noqa: E402
 from core.tools.command.hooks.file_access_logger import FileAccessLoggerHook  # noqa: E402
 from core.tools.command.hooks.file_permission import FilePermissionHook  # noqa: E402
@@ -1671,21 +1661,10 @@ class LeonAgent:
         return True
 
     def get_response(self, message: str, thread_id: str = "default", **kwargs) -> str:
-        """Get agent's text response.
-
-        Args:
-            message: User message
-            thread_id: Thread ID
-            **kwargs: Additional state parameters
-
-        Returns:
-            Agent's text response
-        """
         result = self.invoke(message, thread_id, **kwargs)
         return result["messages"][-1].content
 
     def cleanup(self):
-        """Clean up temporary workspace directory."""
         if self.workspace_root.exists() and "tmp" in str(self.workspace_root):
             import shutil
 
@@ -1700,30 +1679,6 @@ def create_leon_agent(
     storage_container: StorageContainer | None = None,
     **kwargs,
 ) -> LeonAgent:
-    """Create Leon Agent.
-
-    Args:
-        model_name: Model name. None means "let LeonAgent resolve defaults".
-        api_key: API key
-        workspace_root: Workspace directory
-        sandbox: Sandbox instance, name string, or None for local
-        storage_container: Optional pre-built storage container (runtime wiring injection)
-        **kwargs: Additional configuration parameters
-
-    Returns:
-        Configured LeonAgent instance
-
-    Examples:
-        # Basic usage
-        agent = create_leon_agent()
-
-        # With sandbox
-        agent = create_leon_agent(sandbox="agentbay")
-
-        # Custom workspace
-        agent = create_leon_agent(workspace_root="/path/to/workspace")
-    """
-    # Filter out kwargs that LeonAgent.__init__ doesn't accept (e.g. profile from CLI)
     import inspect as _inspect
 
     from storage.runtime import build_storage_container, uses_supabase_storage
@@ -1741,29 +1696,3 @@ def create_leon_agent(
         storage_container=storage_container,
         **kwargs,
     )
-
-
-if __name__ == "__main__":
-    # Example usage
-    leon_agent = create_leon_agent()
-
-    try:
-        print("=== Example 1: File Operations ===")
-        response = leon_agent.get_response(
-            f"Create a Python file at {leon_agent.workspace_root}/hello.py that prints 'Hello, Mycel!'",
-            thread_id="demo",
-        )
-        print(response)
-        print()
-
-        print("=== Example 2: Read File ===")
-        response = leon_agent.get_response(f"Read the file {leon_agent.workspace_root}/hello.py", thread_id="demo")
-        print(response)
-        print()
-
-        print("=== Example 3: Search ===")
-        response = leon_agent.get_response(f"Search for 'Hello' in {leon_agent.workspace_root}", thread_id="demo")
-        print(response)
-
-    finally:
-        leon_agent.cleanup()

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -150,7 +150,6 @@ class DaytonaProvider(SandboxProvider):
         self._managed_mounts[thread_id] = (backend_ref, mount_path)
 
     def delete_managed_volume(self, backend_ref: str) -> None:
-        """Delete provider-managed volume. backend_ref is the volume name."""
         logger.info("Deleting managed volume: %s", backend_ref)
         try:
             vol = self.client.volume.get(backend_ref)


### PR DESCRIPTION
## Summary
- delete stale route section banners and obvious auth/runtime docstrings
- remove the manual core runtime demo entry point
- keep behavior and @@@ invariant comments unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check