### PR TITLE
chore: delete test script entrypoints

### DIFF
--- a/tests/Integration/test_e2e_summary_persistence.py
+++ b/tests/Integration/test_e2e_summary_persistence.py
@@ -231,7 +231,3 @@ class TestAgentConcurrentThreads:
 
             finally:
                 agent.close()
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s"])

--- a/tests/Unit/integration_contracts/test_memory_middleware_integration.py
+++ b/tests/Unit/integration_contracts/test_memory_middleware_integration.py
@@ -425,7 +425,3 @@ class TestSummaryUpdateOnSecondCompaction:
         active_summaries = [s for s in all_summaries if s["is_active"]]
         assert len(active_summaries) == 1
         assert active_summaries[0]["summary_id"] == summary2.summary_id
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/tests/Unit/sandbox/test_e2b_provider.py
+++ b/tests/Unit/sandbox/test_e2b_provider.py
@@ -53,59 +53,36 @@ def test_e2b_create_session_bootstraps_workspace_files_dir(monkeypatch):
 def test_e2b_provider():
     api_key = os.getenv("E2B_API_KEY")
     if not api_key or not api_key.startswith("e2b_"):
-        print("E2B_API_KEY not set, skipping")
         return
 
     provider = E2BProvider(api_key=api_key, timeout=60)
 
-    print("Creating session...")
     info = provider.create_session()
-    print(f"  session_id: {info.session_id}")
     sid = info.session_id
 
-    print("\nExecuting command...")
     result = provider.execute(sid, "echo hello && uname -a")
-    print(f"  output: {result.output}")
     assert result.exit_code == 0
 
-    print("\nWriting file...")
     provider.write_file(sid, "/home/user/test.txt", "hello from leon")
 
-    print("\nReading file...")
     content = provider.read_file(sid, "/home/user/test.txt")
-    print(f"  content: {content}")
     assert content == "hello from leon"
 
-    print("\nListing /home/user...")
     items = provider.list_dir(sid, "/home/user")
     names = [i["name"] for i in items]
-    print(f"  entries: {names}")
     assert "test.txt" in names
 
-    print("\nChecking status...")
     status = provider.get_session_status(sid)
-    print(f"  status: {status}")
     assert status == "running"
 
-    print("\nPausing...")
     assert provider.pause_session(sid)
 
     status = provider.get_session_status(sid)
-    print(f"  status after pause: {status}")
     assert status == "paused"
 
-    print("\nResuming...")
     assert provider.resume_session(sid)
 
     content = provider.read_file(sid, "/home/user/test.txt")
-    print(f"  content after resume: {content}")
     assert content == "hello from leon"
 
-    print("\nDestroying...")
     assert provider.destroy_session(sid)
-
-    print("\nAll tests passed!")
-
-
-if __name__ == "__main__":
-    test_e2b_provider()

--- a/tests/Unit/scripts/test_check_dev_validity.py
+++ b/tests/Unit/scripts/test_check_dev_validity.py
@@ -180,7 +180,3 @@ class CheckDevValidityScriptTests(unittest.TestCase):
         requested_extras = set(re.findall(r"--extra\s+([A-Za-z0-9_-]+)", dockerfile))
 
         self.assertLessEqual(requested_extras, set(optional_dependencies))
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## Summary
- delete direct-run __main__ blocks from pytest/unittest files
- remove manual progress prints from the E2B provider test

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check