### PR TITLE
chore: delete redundant utility comments

### DIFF
--- a/backend/identity/avatar/files.py
+++ b/backend/identity/avatar/files.py
@@ -10,7 +10,6 @@ AVATARS_DIR = avatars_dir()
 
 
 def process_and_save_avatar(source: Path | bytes, user_id: str) -> str:
-    """Process image through PIL pipeline and save as 256x256 PNG."""
     from PIL import Image, ImageOps
 
     if isinstance(source, (bytes, bytearray)):

--- a/backend/threads/pool/factory.py
+++ b/backend/threads/pool/factory.py
@@ -24,7 +24,6 @@ def create_agent_sync(
     models_config_override: dict[str, Any] | None = None,
     memory_config_override: dict[str, Any] | None = None,
 ) -> Any:
-    """Create a LeonAgent with the given sandbox. Runs in a thread."""
     storage_container = build_storage_container()
     # @@@web-file-ops-repo - inject storage-backed repo so file_operations route to correct provider.
     from core.operations import FileOperationRecorder, set_recorder

--- a/backend/threads/pool/idle_reaper.py
+++ b/backend/threads/pool/idle_reaper.py
@@ -7,11 +7,9 @@ init_providers_and_managers: Callable[[], tuple[Any, dict[str, Any]]] | None = N
 
 
 def run_idle_reaper_once(app_obj: Any) -> int:
-    """External idle manager: enforce idle timeout across providers."""
     total = 0
     managed_providers: set[str] = set()
 
-    # First use live managers from resident agents (can close live runtimes safely).
     # @@@idle-reaper-pool-snapshot - reaping a live manager can evict sibling agents from the pool.
     # Iterate a stable snapshot so cleanup never mutates the dict view we're walking.
     for agent in list(app_obj.state.agent_pool.values()):
@@ -23,7 +21,6 @@ def run_idle_reaper_once(app_obj: Any) -> int:
         managed_providers.add(provider_name)
         total += manager.enforce_idle_timeouts()
 
-    # Then cover providers without resident agent (DB-only cleanup).
     if init_providers_and_managers is None:
         raise RuntimeError("thread_runtime.pool.idle_reaper requires init_providers_and_managers binding")
     _, managers = init_providers_and_managers()
@@ -36,7 +33,6 @@ def run_idle_reaper_once(app_obj: Any) -> int:
 
 
 async def idle_reaper_loop(app_obj: Any) -> None:
-    """Background task that periodically enforces idle timeouts."""
     while True:
         try:
             count = await asyncio.to_thread(run_idle_reaper_once, app_obj)

--- a/backend/threads/sandbox_resolution.py
+++ b/backend/threads/sandbox_resolution.py
@@ -6,7 +6,6 @@ from sandbox.manager import lookup_sandbox_for_thread
 
 
 def resolve_thread_sandbox(app_obj: Any, thread_id: str) -> str:
-    """Look up sandbox type for a thread: memory cache -> repo -> sandbox DB -> default local."""
     mapping = app_obj.state.thread_sandbox
     if thread_id in mapping:
         return mapping[thread_id]

--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -2,8 +2,6 @@ from pydantic import BaseModel, Field
 
 from backend.hub.versioning import BumpType
 
-# ── Agents ──
-
 
 class CompactConfigPayload(BaseModel):
     trigger_tokens: int | None = Field(default=None, gt=0)
@@ -35,9 +33,6 @@ class PublishAgentRequest(BaseModel):
     notes: str = ""
 
 
-# ── Library ──
-
-
 class CreateResourceRequest(BaseModel):
     name: str
     desc: str = ""
@@ -54,9 +49,6 @@ class UpdateResourceRequest(BaseModel):
 
 class UpdateResourceContentRequest(BaseModel):
     content: str
-
-
-# ── Profile ──
 
 
 class UpdateProfileRequest(BaseModel):

--- a/core/tools/command/dispatcher.py
+++ b/core/tools/command/dispatcher.py
@@ -10,19 +10,6 @@ from .zsh import ZshExecutor
 
 
 def get_executor(default_cwd: str | None = None) -> BaseExecutor:
-    """
-    Get the appropriate executor for the current OS.
-
-    - macOS → ZshExecutor
-    - Windows → PowerShellExecutor
-    - Linux/other → BashExecutor
-
-    Args:
-        default_cwd: Default working directory for commands
-
-    Returns:
-        Appropriate executor instance
-    """
     system = platform.system()
 
     if system == "Darwin":

--- a/core/tools/command/powershell/executor.py
+++ b/core/tools/command/powershell/executor.py
@@ -10,8 +10,6 @@ _RUNNING_COMMANDS: dict[str, AsyncCommand] = {}
 
 
 class PowerShellExecutor(BaseExecutor):
-    """Executor for PowerShell (Windows default)."""
-
     shell_name = "powershell"
     shell_command = ("powershell.exe", "-Command")
 
@@ -115,7 +113,6 @@ class PowerShellExecutor(BaseExecutor):
         return async_cmd
 
     async def _monitor_process(self, async_cmd: AsyncCommand) -> None:
-        """Background task to monitor process and collect output."""
         proc = async_cmd.process
         if proc is None:
             return

--- a/storage/utils.py
+++ b/storage/utils.py
@@ -5,10 +5,8 @@ _ID_ALPHABET = string.ascii_letters + string.digits
 
 
 def generate_agent_user_id() -> str:
-    """Generate agent user ID: m_{12 random alphanumeric chars}."""
     return "m_" + "".join(secrets.choice(_ID_ALPHABET) for _ in range(12))
 
 
 def generate_agent_config_id() -> str:
-    """Generate agent config ID: cfg_{12 random alphanumeric chars}."""
     return "cfg_" + "".join(secrets.choice(_ID_ALPHABET) for _ in range(12))


### PR DESCRIPTION
## Summary
- delete obvious utility and dispatcher docstrings
- remove DTO section banners and non-invariant idle reaper comments
- keep @@@ invariant comments unchanged

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check