### PR TITLE
chore: delete monitor scaffolding comments

### DIFF
--- a/core/runtime/middleware/monitor/base.py
+++ b/core/runtime/middleware/monitor/base.py
@@ -3,22 +3,14 @@ from typing import Any
 
 
 class BaseMonitor(ABC):
-    """Monitor 接口
-
-    所有 Monitor 实现此接口，由 MonitorMiddleware 统一调度。
-    """
+    @abstractmethod
+    def on_request(self, request: dict[str, Any]) -> None: ...
 
     @abstractmethod
-    def on_request(self, request: dict[str, Any]) -> None:
-        """LLM 请求前调用"""
-
-    @abstractmethod
-    def on_response(self, request: dict[str, Any], response: dict[str, Any]) -> None:
-        """LLM 响应后调用"""
+    def on_response(self, request: dict[str, Any], response: dict[str, Any]) -> None: ...
 
     def get_metrics(self) -> dict[str, Any]:
-        """返回当前指标，供 runtime 聚合"""
         return {}
 
     def reset(self) -> None:
-        """重置指标"""
+        pass

--- a/core/runtime/middleware/monitor/context_monitor.py
+++ b/core/runtime/middleware/monitor/context_monitor.py
@@ -4,12 +4,6 @@ from .base import BaseMonitor
 
 
 class ContextMonitor(BaseMonitor):
-    """追踪上下文大小
-
-    统计 messages 数量和估算 token 数。
-    为后续的上下文压缩功能提供数据支持。
-    """
-
     def __init__(self, context_limit: int = 100000):
         self.context_limit = context_limit
         self.message_count = 0
@@ -17,7 +11,6 @@ class ContextMonitor(BaseMonitor):
         self._last_request_messages = 0
 
     def on_request(self, request: dict[str, Any]) -> None:
-        """请求前：统计当前上下文大小"""
         messages = request.get("messages", [])
         if not isinstance(messages, list):
             messages = [messages]
@@ -25,20 +18,14 @@ class ContextMonitor(BaseMonitor):
         self.message_count = len(messages)
         self._last_request_messages = self.message_count
 
-        # 估算 token 数（粗略：每条消息平均 100 tokens）
-        # 后续可以用 tiktoken 精确计算
         self.estimated_tokens = self._estimate_tokens(messages)
 
     def on_response(self, request: dict[str, Any], response: dict[str, Any]) -> None:
-        """响应后：用 API 返回的真实 input_tokens 更新上下文大小"""
         messages = response.get("messages", [])
         if isinstance(messages, list):
             new_messages = len(messages)
             self.message_count = self._last_request_messages + new_messages
 
-            # 从 usage_metadata 取真实 input_tokens（含 system + tools + messages）
-            # input_tokens 在 LangChain 中对所有 provider 都是总量（含缓存），
-            # 不需要额外加 cache_read / cache_write（否则会双重计算）
             for msg in reversed(messages):
                 usage = getattr(msg, "usage_metadata", None)
                 if usage:
@@ -48,16 +35,10 @@ class ContextMonitor(BaseMonitor):
                         return
 
     def _estimate_tokens(self, messages: list) -> int:
-        """估算消息的 token 数
-
-        简单估算：每 4 个字符约 1 个 token（英文）
-        中文每个字符约 1-2 个 token
-        """
         total_chars = sum(self._extract_content_length(msg) for msg in messages)
         return total_chars // 2
 
     def _extract_content_length(self, msg) -> int:
-        """提取消息内容长度"""
         content = msg.content if hasattr(msg, "content") else msg.get("content", "") if isinstance(msg, dict) else ""
 
         if isinstance(content, str):
@@ -71,7 +52,6 @@ class ContextMonitor(BaseMonitor):
         return 0
 
     def is_near_limit(self, threshold: float = 0.8) -> bool:
-        """是否接近上下文限制"""
         return self.estimated_tokens >= self.context_limit * threshold
 
     def get_metrics(self) -> dict[str, Any]:

--- a/core/runtime/middleware/monitor/middleware.py
+++ b/core/runtime/middleware/monitor/middleware.py
@@ -17,22 +17,14 @@ from .token_monitor import TokenMonitor
 
 
 class MonitorMiddleware(AgentMiddleware):
-    """监控中间件
-
-    作为容器组合多个 Monitor，在 LLM 调用前后统一调度。
-    提供 AgentRuntime 聚合所有监控数据。
-    """
-
-    tools = ()  # 不注入工具
+    tools = ()
 
     def __init__(self, context_limit: int = 0, model_name: str = "", verbose: bool = False):
         self.verbose = verbose
 
-        # 内置 monitors
         self._token_monitor = TokenMonitor()
         self._state_monitor = StateMonitor()
 
-        # 注入成本计算器 + 从模型推导 context_limit（先拉取 OpenRouter 定价）
         if model_name:
             fetch_openrouter_pricing()
             self._token_monitor.cost_calculator = CostCalculator(model_name)
@@ -44,14 +36,12 @@ class MonitorMiddleware(AgentMiddleware):
 
         self._context_monitor = ContextMonitor(context_limit=context_limit)
 
-        # 可扩展的 monitors 列表
         self._monitors: list[BaseMonitor] = [
             self._token_monitor,
             self._context_monitor,
             self._state_monitor,
         ]
 
-        # 聚合运行时
         self.runtime = AgentRuntime(
             token_monitor=self._token_monitor,
             context_monitor=self._context_monitor,
@@ -62,45 +52,32 @@ class MonitorMiddleware(AgentMiddleware):
             print("[MonitorMiddleware] Initialized")
 
     def add_monitor(self, monitor: BaseMonitor) -> None:
-        """添加自定义 Monitor"""
         self._monitors.append(monitor)
 
     def update_model(self, model_name: str, overrides: dict | None = None) -> None:
-        """更新 cost calculator 和 context_limit（不重建 middleware）"""
         overrides = overrides or {}
         lookup_name = overrides.get("based_on") or model_name
         self._token_monitor.cost_calculator = CostCalculator(lookup_name)
         self._context_monitor.context_limit = overrides.get("context_limit") or get_model_context_limit(lookup_name)
 
     def mark_ready(self) -> None:
-        """标记 Agent 就绪（初始化完成后调用）"""
         self._state_monitor.mark_ready()
 
     def mark_terminated(self) -> None:
-        """标记 Agent 终止"""
         self._state_monitor.mark_terminated()
 
     def mark_error(self, error: Exception | None = None) -> None:
-        """标记错误状态"""
         self._state_monitor.mark_error(error)
 
     def _dispatch_monitors(self, method_name: str, *args) -> None:
-        """统一调度 monitors 方法"""
         for monitor in self._monitors:
-            try:
-                getattr(monitor, method_name)(*args)
-            except Exception as e:
-                if self.verbose:
-                    print(f"[MonitorMiddleware] {method_name} error: {e}")
-
-    # ========== AgentMiddleware 接口 ==========
+            getattr(monitor, method_name)(*args)
 
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
-        """异步包装 LLM 调用，在前后调度所有 monitors"""
         req_dict = {"messages": request.messages}
 
         self._dispatch_monitors("on_request", req_dict)
@@ -121,18 +98,7 @@ class MonitorMiddleware(AgentMiddleware):
 
         return response
 
-    def wrap_tool_call(self, request, handler):
-        """包装工具调用（透传，不做处理）"""
-        return handler(request)
-
-    async def awrap_tool_call(self, request, handler):
-        """异步包装工具调用（透传，不做处理）"""
-        return await handler(request)
-
-    # ========== 指标访问 ==========
-
     def get_all_metrics(self) -> dict[str, Any]:
-        """获取所有 monitors 的指标"""
         metrics = {}
         for monitor in self._monitors:
             name = monitor.__class__.__name__
@@ -140,6 +106,5 @@ class MonitorMiddleware(AgentMiddleware):
         return metrics
 
     def reset_all(self) -> None:
-        """重置所有 monitors"""
         for monitor in self._monitors:
             monitor.reset()

--- a/core/runtime/middleware/monitor/state_monitor.py
+++ b/core/runtime/middleware/monitor/state_monitor.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 class AgentState(Enum):
-    """Agent 运行时状态"""
-
     INITIALIZING = "initializing"
     READY = "ready"
     ACTIVE = "active"
@@ -26,8 +24,6 @@ class AgentState(Enum):
 
 @dataclass
 class AgentFlags:
-    """Agent 状态标志位"""
-
     is_streaming: bool = False
     is_compacting: bool = False
     is_waiting: bool = False
@@ -37,7 +33,6 @@ class AgentFlags:
     needs_recovery: bool = False
 
 
-# 状态转移规则
 VALID_TRANSITIONS = {
     AgentState.INITIALIZING: [AgentState.READY, AgentState.ERROR],
     AgentState.READY: [AgentState.ACTIVE, AgentState.TERMINATED],
@@ -51,11 +46,6 @@ VALID_TRANSITIONS = {
 
 
 class StateMonitor(BaseMonitor):
-    """追踪执行状态
-
-    管理 Agent 的状态机和标志位。
-    """
-
     def __init__(self):
         self.state = AgentState.INITIALIZING
         self.flags = AgentFlags()
@@ -68,15 +58,12 @@ class StateMonitor(BaseMonitor):
         self._transition_lock = threading.Lock()
 
     def on_request(self, request: dict[str, Any]) -> None:
-        """请求前：记录活动时间（不做状态转移，由外部控制）"""
         self.last_activity = datetime.now()
 
     def on_response(self, request: dict[str, Any], response: dict[str, Any]) -> None:
-        """响应后：记录活动时间（不做状态转移，由外部控制）"""
         self.last_activity = datetime.now()
 
     def transition(self, new_state: AgentState) -> bool:
-        """状态转移（线程安全）"""
         with self._transition_lock:
             if new_state in VALID_TRANSITIONS.get(self.state, []):
                 old_state = self.state
@@ -88,16 +75,13 @@ class StateMonitor(BaseMonitor):
         return True
 
     def set_flag(self, name: str, value: bool) -> None:
-        """设置标志位"""
         if hasattr(self.flags, name):
             setattr(self.flags, name, value)
 
     def on_state_changed(self, callback: Callable[[AgentState, AgentState], None]) -> None:
-        """注册状态变化回调"""
         self._callbacks.append(callback)
 
     def _emit_state_changed(self, old: AgentState, new: AgentState) -> None:
-        """触发状态变化回调"""
         for cb in self._callbacks:
             try:
                 cb(old, new)
@@ -105,11 +89,9 @@ class StateMonitor(BaseMonitor):
                 logger.exception("State transition callback failed: %s -> %s", old.value, new.value)
 
     def mark_ready(self) -> bool:
-        """标记为就绪（初始化完成后调用）"""
         return self.transition(AgentState.READY)
 
     def mark_error(self, error: Exception | None = None) -> bool:
-        """标记为错误状态"""
         self.flags.has_error = True
         if error is not None:
             # @@@error-snapshot - Capture a small, inspectable error snapshot for debugging.
@@ -127,7 +109,6 @@ class StateMonitor(BaseMonitor):
         return self.transition(AgentState.ERROR)
 
     def mark_terminated(self) -> bool:
-        """标记为终止"""
         if self.state == AgentState.ACTIVE:
             self.transition(AgentState.IDLE)
 
@@ -137,11 +118,9 @@ class StateMonitor(BaseMonitor):
         return False
 
     def can_accept_task(self) -> bool:
-        """是否可以接受新任务"""
         return self.state in (AgentState.READY, AgentState.IDLE)
 
     def is_running(self) -> bool:
-        """是否正在运行"""
         return self.state == AgentState.ACTIVE
 
     def get_metrics(self) -> dict[str, Any]:

--- a/core/runtime/middleware/monitor/token_monitor.py
+++ b/core/runtime/middleware/monitor/token_monitor.py
@@ -7,50 +7,36 @@ from .cost import CostCalculator
 
 
 class TokenMonitor(BaseMonitor):
-    """追踪 Token 使用量
-
-    从 AIMessage 的 usage_metadata 中提取 token 统计（LangChain 统一格式），
-    支持 6 项分项追踪：input / output / reasoning / cache_read / cache_write / total。
-    当 usage_metadata 不可用时，回退到 response_metadata。
-    """
-
     def __init__(self):
         self.call_count = 0
-        # 6 项分项追踪
-        self.input_tokens = 0  # 输入（排除缓存）
-        self.output_tokens = 0  # 输出（排除推理）
-        self.reasoning_tokens = 0  # 推理 token（o1/o3）
-        self.cache_read_tokens = 0  # 缓存命中
-        self.cache_write_tokens = 0  # 缓存写入
-        self.total_tokens = 0  # 总计
-
-        # 成本计算器（由 MonitorMiddleware 注入）
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.reasoning_tokens = 0
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+        self.total_tokens = 0
         self.cost_calculator: CostCalculator | None = None
 
     def on_request(self, request: dict[str, Any]) -> None:
-        """请求前：无操作（call_count 在 on_response 中计数）"""
+        pass
 
     def on_response(self, request: dict[str, Any], response: dict[str, Any]) -> None:
-        """响应后：从 usage_metadata 提取 token 统计，回退到 response_metadata"""
         messages = response.get("messages", [])
         if not isinstance(messages, list):
             messages = [messages]
 
         for msg in reversed(messages):
-            # 优先使用 usage_metadata（LangChain 统一格式）
             usage = getattr(msg, "usage_metadata", None)
             if usage:
                 self._extract_from_usage_metadata(usage)
                 return
 
-            # 回退到 response_metadata
             metadata = getattr(msg, "response_metadata", None)
             if metadata:
                 self._extract_from_response_metadata(metadata)
                 return
 
     def _extract_from_usage_metadata(self, usage: dict) -> None:
-        """从 LangChain usage_metadata 提取分项数据"""
         input_total = usage.get("input_tokens", 0) or 0
         output_total = usage.get("output_tokens", 0) or 0
         total = usage.get("total_tokens", input_total + output_total) or 0
@@ -71,7 +57,6 @@ class TokenMonitor(BaseMonitor):
         self.call_count += 1
 
     def _extract_from_response_metadata(self, metadata: dict) -> None:
-        """回退：从 response_metadata 提取（仅 input/output/total）"""
         usage = metadata.get("token_usage") or metadata.get("usage")
         if not usage:
             return
@@ -86,13 +71,11 @@ class TokenMonitor(BaseMonitor):
         self.call_count += 1
 
     def get_cost(self) -> dict:
-        """计算当前累计成本"""
         if not self.cost_calculator:
             return {"total": 0, "breakdown": {}}
         return self.cost_calculator.calculate(self.get_token_dict())
 
     def get_token_dict(self) -> dict:
-        """返回 token 字典（供 CostCalculator 使用）"""
         return {
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,

--- a/core/tools/web/fetchers/base.py
+++ b/core/tools/web/fetchers/base.py
@@ -6,36 +6,14 @@ from core.tools.web.types import FetchLimits, FetchResult
 
 
 class BaseFetcher(ABC):
-    """Abstract base class for URL fetchers."""
-
     def __init__(self, limits: FetchLimits | None = None, timeout: int = 10):
         self.limits = limits or FetchLimits()
         self.timeout = timeout
 
     @abstractmethod
-    async def fetch(self, url: str) -> FetchResult:
-        """
-        Fetch content from URL asynchronously.
-
-        Args:
-            url: URL to fetch
-
-        Returns:
-            FetchResult with content and metadata
-        """
-        ...
+    async def fetch(self, url: str) -> FetchResult: ...
 
     def _split_into_chunks(self, content: str, headings: list[str] | None = None) -> list[tuple[int, str, str | None]]:
-        """
-        Split content into chunks.
-
-        Args:
-            content: Full content string
-            headings: Optional list of heading markers to use for chunk boundaries
-
-        Returns:
-            List of (position, content, heading) tuples
-        """
         chunks: list[tuple[int, str, str | None]] = []
         chunk_size = self.limits.chunk_size
 

--- a/core/tools/web/searchers/base.py
+++ b/core/tools/web/searchers/base.py
@@ -6,8 +6,6 @@ from core.tools.web.types import SearchResult
 
 
 class BaseSearcher(ABC):
-    """Abstract base class for web searchers."""
-
     def __init__(self, max_results: int = 5, timeout: int = 10):
         self.max_results = max_results
         self.timeout = timeout
@@ -19,17 +17,4 @@ class BaseSearcher(ABC):
         max_results: int | None = None,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
-    ) -> SearchResult:
-        """
-        Search the web asynchronously.
-
-        Args:
-            query: Search query
-            max_results: Maximum number of results (overrides default)
-            include_domains: Only include results from these domains
-            exclude_domains: Exclude results from these domains
-
-        Returns:
-            SearchResult with results and metadata
-        """
-        ...
+    ) -> SearchResult: ...


### PR DESCRIPTION
## Summary
- delete redundant monitor and web interface docstrings/comments
- remove no-op monitor tool-call wrappers so the middleware chain only includes real tool middleware
- let monitor dispatch failures surface instead of silently swallowing them

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check