### PR TITLE
chore: remove web tool fallback paths

### DIFF
--- a/core/tools/web/fetchers/jina.py
+++ b/core/tools/web/fetchers/jina.py
@@ -7,15 +7,6 @@ from core.tools.web.types import ContentChunk, FetchLimits, FetchResult
 
 
 class JinaFetcher(BaseFetcher):
-    """
-    Fetcher using Jina Reader API.
-
-    Features:
-    - Returns clean Markdown directly
-    - Automatically removes ads, navigation, etc.
-    - Supports PDF extraction
-    """
-
     READER_BASE_URL = "https://r.jina.ai/"
 
     def __init__(
@@ -28,7 +19,6 @@ class JinaFetcher(BaseFetcher):
         self.api_key = api_key
 
     async def fetch(self, url: str) -> FetchResult:
-        """Fetch URL content using Jina Reader API."""
         result = FetchResult(url=url)
 
         try:

--- a/core/tools/web/fetchers/markdownify.py
+++ b/core/tools/web/fetchers/markdownify.py
@@ -30,12 +30,6 @@ _BROWSER_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.3
 
 
 class MarkdownifyFetcher(BaseFetcher):
-    """
-    Fetcher using markdownify for HTML to Markdown conversion.
-
-    Falls back to BeautifulSoup text extraction if markdownify unavailable.
-    """
-
     def __init__(
         self,
         limits: FetchLimits | None = None,
@@ -47,33 +41,21 @@ class MarkdownifyFetcher(BaseFetcher):
         self.has_markdownify = HAS_MARKDOWNIFY
         self.has_bs4 = HAS_BS4
 
-    async def _do_fetch(self, url: str, verify: bool = True) -> httpx.Response:
-        """Fetch URL with explicit timeout and redirect following."""
+    async def _do_fetch(self, url: str) -> httpx.Response:
         timeout = httpx.Timeout(self.timeout, connect=5.0)
         async with httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
-            verify=verify,
         ) as client:
             response = await client.get(url, headers={"User-Agent": self.user_agent})
             response.raise_for_status()
             return response
 
     async def fetch(self, url: str) -> FetchResult:
-        """Fetch URL content and convert to Markdown."""
         result = FetchResult(url=url)
 
         try:
-            try:
-                response = await self._do_fetch(url, verify=True)
-            except httpx.ConnectError as e:
-                # Only retry without SSL verify for certificate-related errors
-                cause = str(e.__cause__) if e.__cause__ else str(e)
-                if "ssl" in cause.lower() or "certificate" in cause.lower():
-                    response = await self._do_fetch(url, verify=False)
-                else:
-                    raise
-
+            response = await self._do_fetch(url)
             content_type = response.headers.get("Content-Type", "")
 
             if "text/html" in content_type:
@@ -170,7 +152,6 @@ class MarkdownifyFetcher(BaseFetcher):
         return re.sub(r"\n{3,}", "\n\n", text)
 
     def _basic_extract(self, html: str, result: FetchResult) -> str:
-        """Basic HTML extraction without external libraries."""
         title_match = re.search(r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
         if title_match:
             result.title = title_match.group(1).strip()

--- a/core/tools/web/searchers/exa.py
+++ b/core/tools/web/searchers/exa.py
@@ -7,15 +7,6 @@ from core.tools.web.types import SearchItem, SearchResult
 
 
 class ExaSearcher(BaseSearcher):
-    """
-    Searcher using Exa API.
-
-    Features:
-    - Semantic AI-powered search
-    - Good for academic/deep content
-    - Neural search capabilities
-    """
-
     API_URL = "https://api.exa.ai/search"
 
     def __init__(
@@ -34,7 +25,6 @@ class ExaSearcher(BaseSearcher):
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
     ) -> SearchResult:
-        """Search using Exa API."""
         result = SearchResult(query=query)
 
         try:
@@ -83,7 +73,5 @@ class ExaSearcher(BaseSearcher):
             result.error = f"Exa API error {e.response.status_code}"
         except httpx.RequestError as e:
             result.error = f"Search error: {e}"
-        except Exception as e:
-            result.error = f"Unexpected error: {e}"
 
         return result

--- a/core/tools/web/searchers/firecrawl.py
+++ b/core/tools/web/searchers/firecrawl.py
@@ -7,15 +7,6 @@ from core.tools.web.types import SearchItem, SearchResult
 
 
 class FirecrawlSearcher(BaseSearcher):
-    """
-    Searcher using Firecrawl API.
-
-    Features:
-    - Web crawling capabilities
-    - Can search and extract content
-    - Crawler-backed secondary provider
-    """
-
     API_URL = "https://api.firecrawl.dev/v1/search"
 
     def __init__(
@@ -34,7 +25,6 @@ class FirecrawlSearcher(BaseSearcher):
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
     ) -> SearchResult:
-        """Search using Firecrawl API."""
         result = SearchResult(query=query)
 
         try:
@@ -81,7 +71,5 @@ class FirecrawlSearcher(BaseSearcher):
             result.error = f"Firecrawl API error {e.response.status_code}"
         except httpx.RequestError as e:
             result.error = f"Search error: {e}"
-        except Exception as e:
-            result.error = f"Unexpected error: {e}"
 
         return result

--- a/core/tools/web/searchers/tavily.py
+++ b/core/tools/web/searchers/tavily.py
@@ -7,15 +7,6 @@ from core.tools.web.types import SearchItem, SearchResult
 
 
 class TavilySearcher(BaseSearcher):
-    """
-    Searcher using Tavily API.
-
-    Features:
-    - AI-optimized search results
-    - Returns relevant snippets
-    - Supports domain filtering
-    """
-
     API_URL = "https://api.tavily.com/search"
 
     def __init__(
@@ -34,7 +25,6 @@ class TavilySearcher(BaseSearcher):
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
     ) -> SearchResult:
-        """Search using Tavily API."""
         result = SearchResult(query=query)
 
         try:
@@ -75,7 +65,5 @@ class TavilySearcher(BaseSearcher):
             result.error = f"Tavily API error {e.response.status_code}"
         except httpx.RequestError as e:
             result.error = f"Search error: {e}"
-        except Exception as e:
-            result.error = f"Unexpected error: {e}"
 
         return result

--- a/core/tools/web/service.py
+++ b/core/tools/web/service.py
@@ -129,45 +129,34 @@ class WebService:
         blocked_domains: list[str] | None = None,
     ) -> str:
         if not self._searchers:
-            return "No search providers configured"
+            raise RuntimeError("No search providers configured")
 
         effective_max = max_results or self.max_search_results
 
-        for name, searcher in self._searchers:
-            try:
-                result: SearchResult = await searcher.search(
-                    query=query,
-                    max_results=effective_max,
-                    include_domains=allowed_domains,
-                    exclude_domains=blocked_domains,
-                )
-                if not result.error:
-                    return result.format_output()
-            except Exception:
-                continue
+        searcher = self._searchers[0][1]
+        result: SearchResult = await searcher.search(
+            query=query,
+            max_results=effective_max,
+            include_domains=allowed_domains,
+            exclude_domains=blocked_domains,
+        )
+        if result.error:
+            raise RuntimeError(result.error)
 
-        return "All search providers failed"
+        return result.format_output()
 
     async def _web_fetch(self, url: str, prompt: str) -> str:
         if not self._fetchers:
-            return "Error: No fetch providers configured"
+            raise RuntimeError("No fetch providers configured")
 
-        fetch_result: FetchResult | None = None
-        for name, fetcher in self._fetchers:
-            try:
-                result = await fetcher.fetch(url)
-                if not result.error:
-                    fetch_result = result
-                    break
-            except Exception:
-                continue
-
-        if fetch_result is None:
-            return f"Error: Failed to fetch URL: {url}"
+        fetcher = self._fetchers[0][1]
+        fetch_result: FetchResult = await fetcher.fetch(url)
+        if fetch_result.error:
+            raise RuntimeError(fetch_result.error)
 
         content = fetch_result.content or ""
         if not content:
-            return f"Error: No content retrieved from URL: {url}"
+            raise RuntimeError(f"No content retrieved from URL: {url}")
 
         max_chars = 100_000
         if len(content) > max_chars:
@@ -176,28 +165,20 @@ class WebService:
         return await self._ai_extract(content, prompt, url)
 
     async def _ai_extract(self, content: str, prompt: str, url: str) -> str:
-        try:
-            model = self._extraction_model
-            if model is None:
-                preview = content[:5000] if len(content) > 5000 else content
-                return f"AI extraction unavailable. Configure an extraction model. Raw content:\n\n{preview}"
+        model = self._extraction_model
+        if model is None:
+            raise RuntimeError("AI extraction model is not configured")
 
-            extraction_prompt = (
-                f"You are extracting information from a web page.\n"
-                f"URL: {url}\n\n"
-                f"Web page content:\n{content}\n\n"
-                f"User's request: {prompt}\n\n"
-                f"Provide a concise, relevant answer based on the web page content."
-            )
+        extraction_prompt = (
+            f"You are extracting information from a web page.\n"
+            f"URL: {url}\n\n"
+            f"Web page content:\n{content}\n\n"
+            f"User's request: {prompt}\n\n"
+            f"Provide a concise, relevant answer based on the web page content."
+        )
 
-            response = await asyncio.wait_for(
-                model.ainvoke(extraction_prompt, config={"callbacks": []}),
-                timeout=30,
-            )
-            return response.content
-        except TimeoutError:
-            preview = content[:5000] if len(content) > 5000 else content
-            return f"AI extraction timed out (30s). Raw content preview:\n\n{preview}"
-        except Exception as e:
-            preview = content[:5000] if len(content) > 5000 else content
-            return f"AI extraction failed ({e}). Raw content preview:\n\n{preview}"
+        response = await asyncio.wait_for(
+            model.ainvoke(extraction_prompt, config={"callbacks": []}),
+            timeout=30,
+        )
+        return response.content


### PR DESCRIPTION
## Summary
- remove web search/fetch provider fallback loops so the selected provider fails loudly
- remove WebFetch raw-content fallback when extraction is unavailable or fails
- remove insecure SSL verification downgrade and redundant web provider docstrings

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check