### PR TITLE
chore: delete middleware passthrough wrappers

### DIFF
--- a/core/runtime/middleware/queue/middleware.py
+++ b/core/runtime/middleware/queue/middleware.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 
 from core.runtime.middleware import (
@@ -11,7 +11,6 @@ from core.runtime.middleware import (
     ModelCallResult,
     ModelRequest,
     ModelResponse,
-    ToolCallRequest,
 )
 from core.runtime.notifications import is_terminal_background_notification
 
@@ -69,22 +68,6 @@ class SteeringMiddleware(AgentMiddleware):
         self._queue_manager = queue_manager
         self._agent_runtime = agent_runtime  # our AgentRuntime, not LangGraph's Runtime
 
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage],
-    ) -> ToolMessage:
-        """Pure passthrough — never skip tool calls."""
-        return handler(request)
-
-    async def awrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage]],
-    ) -> ToolMessage:
-        """Async pure passthrough — never skip tool calls."""
-        return await handler(request)
-
     def wrap_model_call(
         self,
         request: ModelRequest,
@@ -105,7 +88,6 @@ class SteeringMiddleware(AgentMiddleware):
         runtime: Any,
         config: RunnableConfig | None = None,
     ) -> dict[str, Any] | None:
-        """Drain all pending messages from unified queue and inject before model call."""
         thread_id = (config or {}).get("configurable", {}).get("thread_id")
         if not thread_id:
             logger.debug("SteeringMiddleware: no thread_id in config, skipping steer injection")
@@ -185,5 +167,4 @@ class SteeringMiddleware(AgentMiddleware):
         runtime: Any,
         config: RunnableConfig | None = None,
     ) -> dict[str, Any] | None:
-        """Async version of before_model."""
         return self.before_model(state, runtime, config)

--- a/core/runtime/middleware/spill_buffer/middleware.py
+++ b/core/runtime/middleware/spill_buffer/middleware.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from langchain_core.messages import ToolMessage
 
-from core.runtime.middleware import AgentMiddleware, ModelRequest, ModelResponse, ToolCallRequest
+from core.runtime.middleware import AgentMiddleware, ToolCallRequest
 from sandbox.interfaces.filesystem import FileSystemBackend
 
 from .spill import spill_if_needed
@@ -90,26 +90,7 @@ class SpillBufferMiddleware(AgentMiddleware):
             return text_only or content
         return "\n".join(line for line in lines if line)
 
-    # -- model call: pass-through ------------------------------------------
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelResponse:
-        return handler(request)
-
-    async def awrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
-    ) -> ModelResponse:
-        return await handler(request)
-
-    # -- tool call: spill if needed ----------------------------------------
-
     def _maybe_spill(self, request: ToolCallRequest, result: ToolMessage) -> ToolMessage:
-        """Shared logic for sync/async tool-call wrappers."""
         tool_name = request.tool_call.get("name", "")
         if tool_name in SKIP_TOOLS:
             return result


### PR DESCRIPTION
## Summary
- remove no-op tool-call wrappers from steering middleware
- remove no-op model-call wrappers from spill-buffer middleware
- keep middleware chains limited to middleware that actually changes that surface

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check