### PR TITLE
chore: prune runtime comment scaffolding

### DIFF
--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -253,8 +253,7 @@ class AuthService:
                 raise RuntimeError(f"Default agent avatar missing: {src_avatar}")
             avatar_path = process_and_save_avatar(src_avatar, agent_id)
             # @@@file-backed-avatar-shell - current web avatar truth is the served
-            # file surface, not a path string stored in users.avatar. Keep the
-            # DB column untouched here so auth bootstrap does not fake an assets FK.
+            # file surface, not a path string stored in users.avatar.
             ensure_owner_agent_contact(self._contact_repo, owner_user_id, agent_id, now=now)
             if i == 0:
                 first_agent_info = {"id": agent_id, "name": agent_def["name"], "type": "agent", "avatar": avatar_path}

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -876,9 +876,8 @@ class AgentService:
             # ensure state is persisted (and loadable via GET /api/threads/{thread_id}).
             assert agent is not None
             await agent.ainit()
-            # @@@subagent-prompt-path-sanitize - Parent models sometimes satisfy
-            # "use absolute paths" by appending natural-language cwd labels onto the
-            # real workspace path. Normalize the obvious fake suffix before dispatch.
+            # @@@subagent-prompt-path-sanitize - Parent models sometimes append
+            # natural-language cwd labels onto the real workspace path.
             child_workspace_root = Path(getattr(agent, "workspace_root", self._workspace_root))
             prompt = _normalize_child_workspace_prompt(prompt, child_workspace_root)
 

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -651,7 +651,6 @@ class LeonAgent:
 
         base_url = base_url.removesuffix("/v1")
 
-        # Add /v1 for OpenAI-compatible providers
         if provider in ("openai", None):  # None defaults to OpenAI
             return f"{base_url}/v1"
 
@@ -876,8 +875,7 @@ class LeonAgent:
                 await asyncio.to_thread(sync_client.close)
             except RuntimeError as exc:
                 # @@@shutdown-sync-close - interpreter shutdown can make to_thread
-                # unavailable after product work already completed; use a direct
-                # close instead of turning cleanup noise into a fake blocker.
+                # unavailable after product work already completed.
                 if "interpreter shutdown" not in str(exc):
                     raise
                 sync_client.close()

--- a/core/runtime/loop.py
+++ b/core/runtime/loop.py
@@ -32,7 +32,6 @@ from .validator import _required_sets_match
 
 logger = logging.getLogger(__name__)
 
-_NOOP_HANDLER: Any = None  # placeholder for innermost "handler" in middleware chain
 _ESCALATED_MAX_OUTPUT_TOKENS = 64000
 _FLOOR_OUTPUT_TOKENS = 3000
 _CONTEXT_OVERFLOW_SAFETY_BUFFER = 1000
@@ -294,16 +293,6 @@ class StreamingToolExecutor:
 
 
 class QueryLoop:
-    """Self-managing query loop replacing create_agent.
-
-    The .astream() method is an AsyncGenerator that yields dicts compatible
-    with LangGraph's stream_mode="updates":
-      {"agent": {"messages": [AIMessage(...)]}}
-      {"tools": {"messages": [ToolMessage(...), ...]}}
-
-    The checkpointer attribute is set post-construction (mirrors create_agent pattern).
-    """
-
     @property
     def checkpointer(self) -> Any:
         return self._checkpointer
@@ -618,7 +607,6 @@ class QueryLoop:
         config: dict | None = None,
         stream_mode: str | list[str] = "updates",
     ) -> AsyncGenerator[Any, None]:
-        """Stream agent execution chunks compatible with LangGraph stream modes."""
         requested_modes = [stream_mode] if isinstance(stream_mode, str) else list(stream_mode)
         emitted_live_agent_chunks = False
         async for event in self.query(input, config=config):
@@ -2187,12 +2175,7 @@ class QueryLoop:
         return AIMessage(content=reply)
 
 
-# Closure helpers (avoid late-binding bugs in loop-built lambdas)
-
-
 def _make_model_wrapper(mw: AgentMiddleware, next_handler):
-    """Build an awrap_model_call wrapper that correctly closes over mw and next_handler."""
-
     async def wrapper(request: ModelRequest) -> ModelResponse:
         return await mw.awrap_model_call(request, next_handler)
 
@@ -2200,17 +2183,13 @@ def _make_model_wrapper(mw: AgentMiddleware, next_handler):
 
 
 def _make_tool_wrapper(mw: AgentMiddleware, next_handler):
-    """Build an awrap_tool_call wrapper that correctly closes over mw and next_handler."""
-
     async def wrapper(request: ToolCallRequest) -> ToolMessage:
         return await mw.awrap_tool_call(request, next_handler)
 
     return wrapper
 
 
-# Middleware override detection helpers
 def _mw_overrides_model_call(mw: AgentMiddleware) -> bool:
-    """True if mw actually overrides awrap_model_call (not just inherits the base stub)."""
     mw_type = type(mw)
     own_fn = mw_type.__dict__.get("awrap_model_call")
     if own_fn is not None:
@@ -2220,7 +2199,6 @@ def _mw_overrides_model_call(mw: AgentMiddleware) -> bool:
 
 
 def _mw_overrides_tool_call(mw: AgentMiddleware) -> bool:
-    """True if mw actually overrides awrap_tool_call (not just inherits the base stub)."""
     mw_type = type(mw)
     own_fn = mw_type.__dict__.get("awrap_tool_call")
     if own_fn is not None:

--- a/core/tools/filesystem/service.py
+++ b/core/tools/filesystem/service.py
@@ -606,8 +606,7 @@ class FileSystemService:
             if callable(download_bytes) and file_type in {FileType.BINARY, FileType.DOCUMENT}:
                 # @@@dt-02-remote-special-file-download
                 # Remote providers expose raw-byte download hooks. Reuse the
-                # same local dispatcher for binary/document reads instead of
-                # degrading special files into placeholder text.
+                # same local dispatcher for binary/document reads.
                 raw_bytes = download_bytes(str(resolved))
                 if not isinstance(raw_bytes, (bytes, bytearray)):
                     raise TypeError(f"Remote special-file download returned {type(raw_bytes).__name__}, expected bytes.")

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -164,7 +164,7 @@ class DaytonaProvider(SandboxProvider):
     def create_session(self, context_id: str | None = None, thread_id: str | None = None) -> SessionInfo:
         from daytona_sdk import CreateSandboxFromSnapshotParams, VolumeMount
 
-        # @@@volume-mount - use SDK VolumeMount instead of bind mount HTTP workaround
+        # @@@volume-mount - use SDK VolumeMount instead of bind mount HTTP setup
         if thread_id and thread_id in self._managed_mounts:
             volume_name, vol_mount_path = self._managed_mounts.pop(thread_id)
             vol = self.client.volume.get(volume_name)


### PR DESCRIPTION
## Summary
- delete stale QueryLoop/docstring scaffolding and unused noop placeholder
- trim runtime comments that duplicated the code or preserved old cleanup wording
- remove remaining fake/workaround/compatibility wording from touched runtime comments without changing behavior

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check