### PR TITLE
chore: trim sandbox interface docs

### DIFF
--- a/sandbox/interfaces/executor.py
+++ b/sandbox/interfaces/executor.py
@@ -17,7 +17,6 @@ class ExecuteResult:
 
     @property
     def output(self) -> str:
-        """Combined output (stdout + stderr if present)."""
         if self.stderr:
             return f"{self.stdout}\n[stderr]\n{self.stderr}".strip()
         return self.stdout.strip()
@@ -44,8 +43,6 @@ class AsyncCommand:
 
 
 class BaseExecutor(ABC):
-    """Base class for shell executors."""
-
     shell_name: str = "unknown"
     shell_command: tuple[str, ...] = ()
     is_remote: bool = False
@@ -61,20 +58,7 @@ class BaseExecutor(ABC):
         cwd: str | None = None,
         timeout: float | None = None,
         env: dict[str, str] | None = None,
-    ) -> ExecuteResult:
-        """
-        Execute a command and wait for completion.
-
-        Args:
-            command: Command to execute
-            cwd: Working directory (uses default if not specified)
-            timeout: Timeout in seconds (None = no timeout)
-            env: Environment variables to set
-
-        Returns:
-            ExecuteResult with exit code, stdout, stderr
-        """
-        ...
+    ) -> ExecuteResult: ...
 
     @abstractmethod
     async def execute_async(
@@ -82,47 +66,14 @@ class BaseExecutor(ABC):
         command: str,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
-    ) -> AsyncCommand:
-        """
-        Start a command without waiting for completion.
-
-        Args:
-            command: Command to execute
-            cwd: Working directory
-            env: Environment variables
-
-        Returns:
-            AsyncCommand with command_id for status queries
-        """
-        ...
+    ) -> AsyncCommand: ...
 
     @abstractmethod
-    async def get_status(self, command_id: str) -> AsyncCommand | None:
-        """
-        Get status of an async command.
-
-        Args:
-            command_id: ID returned by execute_async
-
-        Returns:
-            AsyncCommand with current status, or None if not found
-        """
-        ...
+    async def get_status(self, command_id: str) -> AsyncCommand | None: ...
 
     @abstractmethod
     async def wait_for(
         self,
         command_id: str,
         timeout: float | None = None,
-    ) -> ExecuteResult | None:
-        """
-        Wait for an async command to complete.
-
-        Args:
-            command_id: ID returned by execute_async
-            timeout: Max seconds to wait
-
-        Returns:
-            ExecuteResult if command finished, None if not found
-        """
-        ...
+    ) -> ExecuteResult | None: ...

--- a/sandbox/interfaces/filesystem.py
+++ b/sandbox/interfaces/filesystem.py
@@ -31,79 +31,25 @@ class DirListResult:
 
 
 class FileSystemBackend(ABC):
-    """Abstract backend for filesystem I/O.
-
-    Implementations:
-    - LocalBackend: direct local filesystem access
-    - Remote capability wrapper: delegates to SandboxProvider via sandbox provider/runtime
-    """
-
     is_remote: bool = False
 
     @abstractmethod
-    def read_file(self, path: str) -> FileReadResult:
-        """Read raw file content.
-
-        Args:
-            path: Absolute file path
-
-        Returns:
-            FileReadResult with content string
-
-        Raises:
-            IOError: If file cannot be read
-        """
-        ...
+    def read_file(self, path: str) -> FileReadResult: ...
 
     @abstractmethod
-    def write_file(self, path: str, content: str) -> FileWriteResult:
-        """Write content to file, creating parent dirs as needed.
-
-        Args:
-            path: Absolute file path
-            content: File content
-
-        Returns:
-            FileWriteResult indicating success/failure
-        """
-        ...
+    def write_file(self, path: str, content: str) -> FileWriteResult: ...
 
     @abstractmethod
-    def file_exists(self, path: str) -> bool:
-        """Check if file exists."""
-        ...
+    def file_exists(self, path: str) -> bool: ...
 
     @abstractmethod
-    def file_mtime(self, path: str) -> float | None:
-        """Get file modification time.
-
-        Returns:
-            mtime as float, or None if not available (e.g. sandbox)
-        """
-        ...
+    def file_mtime(self, path: str) -> float | None: ...
 
     @abstractmethod
-    def file_size(self, path: str) -> int | None:
-        """Get file size in bytes.
-
-        Returns:
-            Size in bytes, or None if not available
-        """
-        ...
+    def file_size(self, path: str) -> int | None: ...
 
     @abstractmethod
-    def is_dir(self, path: str) -> bool:
-        """Check if path is a directory."""
-        ...
+    def is_dir(self, path: str) -> bool: ...
 
     @abstractmethod
-    def list_dir(self, path: str) -> DirListResult:
-        """List directory contents.
-
-        Args:
-            path: Absolute directory path
-
-        Returns:
-            DirListResult with entries
-        """
-        ...
+    def list_dir(self, path: str) -> DirListResult: ...

--- a/sandbox/volume.py
+++ b/sandbox/volume.py
@@ -7,12 +7,6 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxVolume:
-    """Provider-agnostic volume engine.
-
-    Created once per SandboxManager (per provider).
-    Source paths are resolved by SandboxManager and passed to operations.
-    """
-
     def __init__(self, provider, provider_capability):
         self.provider = provider
         self.capability = provider_capability
@@ -21,10 +15,6 @@ class SandboxVolume:
         self._sync = SyncManager(provider_capability=provider_capability)
 
     def mount(self, thread_id: str, source_path: Path | None, target_path: str) -> None:
-        """Make source_path visible at target_path inside sandbox.
-        local: no-op. providers without mount support: no-op (sync handles it).
-        docker/daytona with mount: bind mount.
-        """
         if self.capability.runtime_kind == "local":
             return
         if source_path is None or not self.capability.mount.supports_mount:
@@ -37,21 +27,16 @@ class SandboxVolume:
         )
 
     def mount_managed_volume(self, thread_id: str, backend_ref: str, target_path: str) -> None:
-        """Mount provider-managed persistent volume."""
         self.provider.set_managed_volume_mount(thread_id, backend_ref, target_path)
 
     def resolve_mount_path(self) -> str:
-        """Container-side path where volumes are mounted."""
         return getattr(self.provider, "WORKSPACE_ROOT", "/workspace") + "/files"
 
     def sync_upload(self, thread_id: str, session_id: str, source_path: Path, remote_path: str, files: list[str] | None = None) -> None:
-        """Sync files from the local file root to sandbox."""
         self._sync.upload(source_path, remote_path, session_id, self.provider, files=files, state_key=thread_id)
 
     def sync_download(self, thread_id: str, session_id: str, source_path: Path, remote_path: str) -> None:
-        """Sync files from sandbox back to the local file root."""
         self._sync.download(source_path, remote_path, session_id, self.provider, state_key=thread_id)
 
     def clear_sync_state(self, thread_id: str) -> None:
-        """Remove all sync tracking state for a thread."""
         self._sync.clear_state(thread_id)

--- a/sandbox/volume_source.py
+++ b/sandbox/volume_source.py
@@ -12,24 +12,19 @@ logger = logging.getLogger(__name__)
 
 @runtime_checkable
 class VolumeSource(Protocol):
-    """Abstract persistent storage backend."""
-
     def save_file(self, relative_path: str, content: bytes) -> dict[str, Any]: ...
     def list_files(self) -> list[dict[str, Any]]: ...
     def resolve_file(self, relative_path: str) -> Path: ...
     def delete_file(self, relative_path: str) -> None: ...
 
     @property
-    def host_path(self) -> Path | None:
-        """Host filesystem path for sync. None if no host backing."""
-        ...
+    def host_path(self) -> Path | None: ...
 
     def cleanup(self) -> None: ...
     def serialize(self) -> dict[str, Any]: ...
 
 
 def _resolve_safe_path(base: Path, relative_path: str) -> Path:
-    """Resolve relative path with traversal protection."""
     # @@@path-boundary - Reject traversal so callers cannot escape the volume root
     requested = Path(relative_path)
     if requested.is_absolute():
@@ -40,8 +35,6 @@ def _resolve_safe_path(base: Path, relative_path: str) -> Path:
 
 
 class HostVolume:
-    """Host filesystem volume used by host-backed providers and Daytona file roots."""
-
     def __init__(self, base_path: Path):
         self.base_path = base_path.expanduser().resolve()
         self.base_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- remove redundant sandbox interface docstrings already expressed by signatures
- trim volume abstraction comments without changing behavior
- keep @@@ path-boundary invariant comment intact

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check