### PR TITLE
chore: trim sandbox sync scaffolding docs

### DIFF
--- a/core/runtime/cleanup.py
+++ b/core/runtime/cleanup.py
@@ -9,15 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 class CleanupRegistry:
-    """Registry of async cleanup functions executed in priority order on shutdown.
-
-    Usage:
-        registry = CleanupRegistry()
-        registry.register(close_db, priority=1)
-        registry.register(close_sandbox, priority=2)
-        await registry.run_cleanup()
-    """
-
     def __init__(self):
         self._entries: list[tuple[int, Callable[[], Awaitable[None] | None]]] = []
         self._timeout_s = 2.0
@@ -25,12 +16,6 @@ class CleanupRegistry:
         self._shutdown_in_progress = False
 
     def register(self, fn: Callable[[], Awaitable[None] | None], priority: int = 5) -> Callable[[], None]:
-        """Register a cleanup function.
-
-        Args:
-            fn: Sync or async callable that releases resources.
-            priority: Execution order — lower number runs first (1 before 2).
-        """
         entry = (priority, fn)
         self._entries.append(entry)
 
@@ -43,11 +28,6 @@ class CleanupRegistry:
         return unregister
 
     async def run_cleanup(self) -> None:
-        """Execute all registered cleanup functions in priority order.
-
-        Different priority tiers run in order. Entries inside the same priority
-        tier run concurrently so one slow cleanup does not serialize its peers.
-        """
         if self._cleanup_task is not None:
             await asyncio.shield(self._cleanup_task)
             return

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -38,7 +38,6 @@ class MessageQueueManager:
         sender_avatar_url: str | None = None,
         is_steer: bool = False,
     ) -> None:
-        """Persist a message. Fires wake handler after INSERT."""
         self._repo.enqueue(
             thread_id,
             content,
@@ -66,11 +65,9 @@ class MessageQueueManager:
                 logger.exception("Wake handler raised for thread %s", thread_id)
 
     def dequeue(self, thread_id: str) -> QueueItem | None:
-        """Atomically pop the oldest message."""
         return self._repo.dequeue(thread_id)
 
     def drain_all(self, thread_id: str) -> list[QueueItem]:
-        """Atomically pop all pending messages, return FIFO-ordered list."""
         return self._repo.drain_all(thread_id)
 
     def peek(self, thread_id: str) -> bool:
@@ -80,11 +77,6 @@ class MessageQueueManager:
         return self._repo.list_queue(thread_id)
 
     def register_wake(self, thread_id: str, handler: Callable[[QueueItem], None]) -> None:
-        """Register a wake handler for a thread.
-
-        The handler receives the newly-enqueued QueueItem.
-        Called by enqueue() after INSERT.
-        """
         with self._wake_lock:
             self._wake_handlers[thread_id] = handler
 
@@ -93,11 +85,9 @@ class MessageQueueManager:
             self._wake_handlers.pop(thread_id, None)
 
     def clear_queue(self, thread_id: str) -> None:
-        """Clear persisted queue for a thread."""
         self._repo.clear_queue(thread_id)
 
     def clear_all(self, thread_id: str) -> None:
-        """Clear queue and unregister wake handler for a thread."""
         self.clear_queue(thread_id)
         self.unregister_wake(thread_id)
 

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -16,18 +16,6 @@ if TYPE_CHECKING:
 
 
 class SandboxCapability:
-    """Agent-facing capability object.
-
-    Wraps ChatSession and provides access to command execution and filesystem.
-    Agents interact through command and filesystem handles; sandbox runtime
-    binding details stay behind this capability object.
-
-    Usage:
-        sandbox = sandbox_manager.get_sandbox(thread_id)
-        result = await sandbox.command.execute("ls")
-        content = sandbox.fs.read_file("/path/to/file")
-    """
-
     def __init__(self, session: ChatSession, manager: SandboxManager | None = None):
         self._session = session
         self._command_wrapper = _CommandWrapper(session, manager=manager)
@@ -59,8 +47,6 @@ class SandboxCapability:
 
 
 class _CommandWrapper(BaseExecutor):
-    """Wrapper that delegates to runtime's execute method."""
-
     runtime_owns_cwd = True
 
     def __init__(self, session: ChatSession, manager: SandboxManager | None = None):
@@ -82,7 +68,6 @@ class _CommandWrapper(BaseExecutor):
         return wrapped, work_dir
 
     async def execute(self, command: str, cwd: str | None = None, timeout: float | None = None, env: dict[str, str] | None = None):
-        """Execute command via runtime."""
         self._session.touch()
         # @@@command-context - CommandService passes env; preserve that context for remote runtimes.
         wrapped, _ = self._wrap_command(command, cwd, env)
@@ -97,7 +82,6 @@ class _CommandWrapper(BaseExecutor):
         return await self._session.runtime.execute(wrapped, timeout)
 
     async def execute_async(self, command: str, cwd: str | None = None, env: dict[str, str] | None = None):
-        """Execute command asynchronously via runtime and return command handle."""
         self._session.touch()
         wrapped, work_dir = self._wrap_command(command, cwd, env)
         if self._manager is None:
@@ -173,14 +157,11 @@ class _CommandWrapper(BaseExecutor):
         return await session.runtime.get_command(command_id)
 
     async def wait_for(self, command_id: str, timeout: float | None = None):
-        """Wait for async command completion."""
         session = self._resolve_session_for_command(command_id)
         return await session.runtime.wait_for_command(command_id, timeout=timeout)
 
 
 class _FileSystemWrapper(FileSystemBackend):
-    """Wrapper that delegates to provider via sandbox runtime."""
-
     is_remote = True
 
     def __init__(self, session: ChatSession, manager: SandboxManager | None = None):

--- a/sandbox/sync/state.py
+++ b/sandbox/sync/state.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 
 def _calculate_checksum(file_path: Path) -> str:
-    """Calculate SHA256 checksum of file."""
     sha256 = hashlib.sha256()
     with open(file_path, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
@@ -19,21 +18,15 @@ class SyncState:
         self._repo.close()
 
     def track_files_batch(self, thread_id: str, file_records: list[tuple[str, str, int]]):
-        """Batch insert/update multiple files in a single transaction.
-        file_records: list of (relative_path, checksum, timestamp)
-        """
         self._repo.track_files_batch(thread_id, file_records)
 
     def get_all_files(self, thread_id: str) -> dict[str, str]:
-        """Batch fetch all tracked files for a thread. Returns {relative_path: checksum}."""
         return self._repo.get_all_files(thread_id)
 
     def clear_thread(self, thread_id: str) -> int:
-        """Delete all sync records for a thread."""
         return self._repo.clear_thread(thread_id)
 
     def detect_changes(self, thread_id: str, workspace_path: Path) -> list[str]:
-        """Detect files that changed since last sync. Uses batch DB query + mtime heuristic."""
         known = self.get_all_files(thread_id)
         changed = []
         for file_path in workspace_path.rglob("*"):

--- a/sandbox/sync/strategy.py
+++ b/sandbox/sync/strategy.py
@@ -12,11 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 def _native_upload(session_id: str, provider, workspace: Path, workspace_root: str, files: list[str]):
-    """Upload files using provider's native file API (upload_bytes).
-
-    Each file is uploaded individually via the SDK's binary upload endpoint.
-    No shell commands, no base64, no size limits from execute().
-    """
     t0 = time.time()
     total_bytes = 0
     # @@@mkdir-batch - collect all needed dirs, create in one command
@@ -42,10 +37,6 @@ def _native_upload(session_id: str, provider, workspace: Path, workspace_root: s
 
 
 def _native_download(session_id: str, provider, workspace: Path, workspace_root: str):
-    """Download files from sandbox using provider's native file API.
-
-    Lists remote dir, downloads each file individually.
-    """
     t0 = time.time()
     try:
         entries = provider.list_dir(session_id, workspace_root)
@@ -82,7 +73,6 @@ def _native_download(session_id: str, provider, workspace: Path, workspace_root:
 
 
 def _pack_tar(workspace: Path, files: list[str]) -> bytes:
-    """Pack files into an in-memory tar.gz archive."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         for rel_path in files:
@@ -95,7 +85,6 @@ def _pack_tar(workspace: Path, files: list[str]) -> bytes:
 
 
 def _batch_upload_tar(session_id: str, provider, workspace: Path, workspace_root: str, files: list[str]):
-    """Tar upload path for providers without native file API."""
     t0 = time.time()
     tar_bytes = _pack_tar(workspace, files)
     if not tar_bytes or len(tar_bytes) < 10:
@@ -117,7 +106,6 @@ def _batch_upload_tar(session_id: str, provider, workspace: Path, workspace_root
 
 
 def _batch_download_tar(session_id: str, provider, workspace: Path, workspace_root: str):
-    """Tar download path for providers without native file API."""
     t0 = time.time()
     check = provider.execute(session_id, f"test -d {workspace_root} && echo EXISTS", timeout_ms=10000)
     check_out = (getattr(check, "output", "") or "").strip()
@@ -164,7 +152,7 @@ class SyncStrategy(ABC):
         pass
 
     def clear_state(self, state_key: str):
-        """Remove all sync state for a key. Default no-op."""
+        pass
 
 
 class NoOpStrategy(SyncStrategy):
@@ -237,7 +225,6 @@ class IncrementalSyncStrategy(SyncStrategy):
         self.state.clear_thread(state_key)
 
     def _update_checksums_after_download(self, state_key: str | None, source_path: Path):
-        """Update checksum DB to match downloaded files, preventing redundant re-uploads on resume."""
         if not state_key:
             return
         if not source_path.exists():


### PR DESCRIPTION
## Summary
- remove redundant sandbox capability and sync docstrings already expressed by names/signatures
- trim queue and cleanup registry scaffolding comments without changing behavior
- preserve @@@ invariant comments

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check