### PR TITLE
chore: trim filesystem reader docs

### DIFF
--- a/core/tools/filesystem/read/dispatcher.py
+++ b/core/tools/filesystem/read/dispatcher.py
@@ -22,26 +22,6 @@ def read_file(
     limit: int | None = None,
     pages: str | None = None,
 ) -> ReadResult:
-    """
-    Read file with type-specific handling.
-
-    Dispatches to appropriate reader based on file type:
-    - TEXT: read_text with triple limits
-    - BINARY: read_binary (metadata only)
-    - DOCUMENT: PDF/PPTX readers, unsupported summary for other documents
-    - NOTEBOOK: notebook reader
-    - ARCHIVE: unsupported summary
-
-    Args:
-        path: Absolute path to file
-        limits: ReadLimits configuration (uses defaults if None)
-        offset: Start line for text files (1-indexed)
-        limit: Number of lines for text files
-        pages: Optional page range for document files, e.g. "1" or "3-5"
-
-    Returns:
-        ReadResult with content and metadata
-    """
     if limits is None:
         limits = ReadLimits()
 
@@ -125,7 +105,6 @@ def _read_document(
     start_page: int | None = None,
     limit_pages: int | None = None,
 ) -> ReadResult:
-    """Dispatch document reading based on extension."""
     ext = path.suffix.lstrip(".").lower()
 
     if ext == "pdf":

--- a/core/tools/filesystem/read/readers/binary.py
+++ b/core/tools/filesystem/read/readers/binary.py
@@ -23,18 +23,6 @@ MAX_IMAGE_SIZE: int = 20 * 1024 * 1024  # 20MB
 
 
 def read_binary(path: Path) -> ReadResult:
-    """
-    Read binary file.
-
-    For image files, returns content_blocks with base64-encoded image data.
-    For other binary files, returns metadata only.
-
-    Args:
-        path: Absolute path to file
-
-    Returns:
-        ReadResult with content_blocks for images, or metadata text for other binaries
-    """
     stat = path.stat()
     mime_type, _ = mimetypes.guess_type(str(path))
     ext = path.suffix.lstrip(".").lower()
@@ -60,7 +48,6 @@ def read_binary(path: Path) -> ReadResult:
 
 
 def _read_image(path: Path, size: int, mime_type: str) -> ReadResult:
-    """Read image file and return as content block."""
     if size > MAX_IMAGE_SIZE:
         return ReadResult(
             file_path=str(path),

--- a/core/tools/filesystem/read/readers/notebook.py
+++ b/core/tools/filesystem/read/readers/notebook.py
@@ -12,18 +12,6 @@ def read_notebook(
     start_cell: int | None = None,
     limit_cells: int | None = None,
 ) -> ReadResult:
-    """
-    Read Jupyter Notebook with cell-based pagination.
-
-    Args:
-        path: Absolute path to .ipynb file
-        limits: ReadLimits configuration (max_chars applies to total output)
-        start_cell: Start cell (0-indexed, None = start from cell 0)
-        limit_cells: Number of cells to read (None = default 50 cells)
-
-    Returns:
-        ReadResult with formatted cells and metadata
-    """
     stat = path.stat()
     result = ReadResult(
         file_path=str(path),

--- a/core/tools/filesystem/read/readers/pdf.py
+++ b/core/tools/filesystem/read/readers/pdf.py
@@ -21,18 +21,6 @@ def read_pdf(
     start_page: int | None = None,
     limit_pages: int | None = None,
 ) -> ReadResult:
-    """
-    Read PDF file with page-based pagination.
-
-    Args:
-        path: Absolute path to PDF file
-        limits: ReadLimits configuration (max_chars applies to total output)
-        start_page: Start page (1-indexed, None = start from page 1)
-        limit_pages: Number of pages to read (None = default 10 pages)
-
-    Returns:
-        ReadResult with extracted text and metadata
-    """
     if not HAS_PYMUPDF:
         return _no_pymupdf_result(path)
     if _pymupdf is None:

--- a/core/tools/filesystem/read/readers/pptx.py
+++ b/core/tools/filesystem/read/readers/pptx.py
@@ -19,18 +19,6 @@ def read_pptx(
     start_slide: int | None = None,
     limit_slides: int | None = None,
 ) -> ReadResult:
-    """
-    Read PowerPoint file with slide-based pagination.
-
-    Args:
-        path: Absolute path to PPTX file
-        limits: ReadLimits configuration (max_chars applies to total output)
-        start_slide: Start slide (1-indexed, None = start from slide 1)
-        limit_slides: Number of slides to read (None = default 20 slides)
-
-    Returns:
-        ReadResult with extracted text and metadata
-    """
     if not HAS_PPTX:
         return _no_pptx_result(path)
 

--- a/core/tools/filesystem/read/readers/text.py
+++ b/core/tools/filesystem/read/readers/text.py
@@ -11,23 +11,6 @@ def read_text(
     offset: int | None = None,
     limit: int | None = None,
 ) -> ReadResult:
-    """
-    Read text file with triple limits.
-
-    Limits applied (first reached wins):
-    1. max_lines: Maximum number of lines to return
-    2. max_chars: Maximum total characters to return
-    3. max_line_length: Truncate individual lines exceeding this
-
-    Args:
-        path: Absolute path to file
-        limits: ReadLimits configuration
-        offset: Start line (1-indexed, None = start from beginning)
-        limit: Number of lines to read (None = use limits.max_lines)
-
-    Returns:
-        ReadResult with content and metadata
-    """
     result = ReadResult(
         file_path=str(path),
         file_type=FileType.TEXT,

--- a/core/tools/filesystem/read/types.py
+++ b/core/tools/filesystem/read/types.py
@@ -15,13 +15,6 @@ class FileType(Enum):
 
 @dataclass
 class ReadLimits:
-    """Limits for file reading to prevent excessive token usage.
-
-    Two layers of limits:
-    - max_size_bytes / max_tokens: Hard-reject when no offset/limit specified (bypassed with offset/limit)
-    - max_lines / max_chars: Per-read limits (always enforced)
-    """
-
     max_lines: int = 2000
     max_chars: int = 200_000
     max_line_length: int = 2000


### PR DESCRIPTION
## Summary
- remove repeated filesystem reader docstrings
- keep runtime behavior and @@@ seam comments unchanged

## Verification
- uv run ruff check core/tools/filesystem/read
- uv run ruff format --check core/tools/filesystem/read
- uv run python -m pytest -q tests/Unit/filesystem/test_filesystem_service.py tests/Unit/core/test_tool_registry_runner.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check