### PR TITLE
chore: trim thread state docs

### DIFF
--- a/backend/threads/display/builder.py
+++ b/backend/threads/display/builder.py
@@ -176,8 +176,6 @@ class ThreadDisplay:
 
 
 class DisplayBuilder:
-    """Single source of truth for per-thread ChatEntry[] display state."""
-
     def __init__(self) -> None:
         self._threads: dict[str, ThreadDisplay] = {}
 
@@ -190,14 +188,9 @@ class DisplayBuilder:
         return td.display_seq if td else 0
 
     def set_entries(self, thread_id: str, entries: list[dict]) -> None:
-        """Set entries for a thread (after build_from_checkpoint)."""
         self._threads[thread_id] = ThreadDisplay(entries=entries)
 
     def build_from_checkpoint(self, thread_id: str, messages: list[dict]) -> list[dict]:
-        """Convert serialized checkpoint messages → ChatEntry[].
-
-        Port of frontend mapBackendEntries.
-        """
         now = int(time.time() * 1000)
         current_turn: dict | None = None
         current_run_id: str | None = None
@@ -233,11 +226,6 @@ class DisplayBuilder:
         return entries
 
     def apply_event(self, thread_id: str, event_type: str, data: dict) -> dict | None:
-        """Apply a streaming event → mutate entries → return delta dict or None.
-
-        Called after emit() in streaming_service.  The delta is sent as
-        SSE event: display_delta.
-        """
         td = self._threads.get(thread_id)
         if td is None:
             td = ThreadDisplay()
@@ -253,14 +241,12 @@ class DisplayBuilder:
         return None
 
     def finalize_turn(self, thread_id: str) -> dict | None:
-        """Close the current turn.  Returns finalize_turn delta."""
         td = self._threads.get(thread_id)
         if not td or not td.current_turn_id:
             return None
         return _handle_finalize(td)
 
     def open_turn(self, thread_id: str, turn_id: str | None = None, timestamp: int | None = None) -> dict:
-        """Open a new assistant turn.  Returns append_entry delta."""
         td = self._threads.get(thread_id)
         if td is None:
             td = ThreadDisplay()
@@ -273,7 +259,6 @@ class DisplayBuilder:
         return {"type": "append_entry", "entry": turn}
 
     def clear(self, thread_id: str) -> None:
-        """Remove cached display state for a thread."""
         self._threads.pop(thread_id, None)
 
     def _handle_human(

--- a/backend/threads/event_bus.py
+++ b/backend/threads/event_bus.py
@@ -12,8 +12,6 @@ Unsubscribe = Callable[[], None]
 
 
 class EventBus:
-    """Thread-scoped publish/subscribe bus for agent activity events."""
-
     def __init__(self) -> None:
         self._subs: dict[str, list[EventCallback]] = {}
 

--- a/backend/threads/events/buffer.py
+++ b/backend/threads/events/buffer.py
@@ -5,12 +5,6 @@ from dataclasses import dataclass, field
 
 @dataclass
 class RunEventBuffer:
-    """Short-lived event buffer for per-subagent SSE streams.
-
-    Append-only list with cursor-based reading and completion signal.
-    Used exclusively for subagent detail streams that have bounded lifetime.
-    """
-
     events: list[dict] = field(default_factory=list)
     finished: asyncio.Event = field(default_factory=asyncio.Event)
     _notify: asyncio.Condition = field(default_factory=asyncio.Condition)
@@ -27,7 +21,6 @@ class RunEventBuffer:
             self._notify.notify_all()
 
     async def read(self, cursor: int) -> tuple[list[dict], int]:
-        """Return (new_events, new_cursor). Waits if no new events and not finished."""
         while True:
             if cursor < len(self.events):
                 new = self.events[cursor:]
@@ -38,7 +31,6 @@ class RunEventBuffer:
                 await self._notify.wait()
 
     async def read_with_timeout(self, cursor: int, timeout: float = 30) -> tuple[list[dict] | None, int]:
-        """Same as read() but returns (None, cursor) on timeout instead of blocking forever."""
         if cursor < len(self.events):
             return self.events[cursor:], len(self.events)
         if self.finished.is_set():
@@ -58,13 +50,6 @@ class RunEventBuffer:
 
 @dataclass
 class ThreadEventBuffer:
-    """Per-thread persistent event buffer — survives across runs.
-
-    Ring buffer mode: keeps the most recent `maxlen` events in memory.
-    Older events are available via the persistent event_store.
-    Never calls mark_done() — the connection lifecycle is managed by client disconnect.
-    """
-
     _ring: deque[dict] = field(default_factory=lambda: deque(maxlen=2000))
     _notify: asyncio.Condition = field(default_factory=asyncio.Condition)
     _total_count: int = 0  # monotonic counter (total events ever put)
@@ -79,11 +64,6 @@ class ThreadEventBuffer:
             self._notify.notify_all()
 
     async def read_with_timeout(self, cursor: int, timeout: float = 30) -> tuple[list[dict] | None, int]:
-        """Return events after cursor position. cursor is an absolute index into _total_count.
-
-        Returns:
-            (events, new_cursor) — events is None on timeout, [] never happens (no mark_done).
-        """
         avail_start = self._total_count - len(self._ring)
         if cursor < avail_start:
             events = list(self._ring)

--- a/backend/threads/file_channel.py
+++ b/backend/threads/file_channel.py
@@ -29,11 +29,6 @@ def get_file_channel_source(thread_id: str):
 
 
 def get_file_channel_binding(thread_id: str) -> FileChannelBinding:
-    """Resolve split file-channel truth for a thread.
-
-    Ownership/binding lives on the thread -> workspace edge.
-    Host file storage remains whatever local root the current runtime uses.
-    """
     container = _get_container()
     thread_repo = container.thread_repo()
     try:
@@ -67,7 +62,6 @@ def get_file_channel_binding(thread_id: str) -> FileChannelBinding:
 
 
 def save_file(*, thread_id: str, relative_path: str, content: bytes) -> dict:
-    """Save file to the thread's file channel."""
     source = get_file_channel_source(thread_id)
     result = source.save_file(relative_path, content)
     result["thread_id"] = thread_id

--- a/backend/threads/owner_reads.py
+++ b/backend/threads/owner_reads.py
@@ -8,8 +8,6 @@ _INFLIGHT_ATTR = "_owner_thread_read_inflight"
 
 
 async def list_owner_thread_rows_for_auth_burst(app: Any, user_id: str) -> list[dict]:
-    """Reuse only currently in-flight owner thread reads for the same user."""
-
     state = app.state
     lock = getattr(state, _LOCK_ATTR, None)
     if lock is None:


### PR DESCRIPTION
## Summary
- remove repeated internal docstrings from thread event/display state helpers
- preserve @@@ state-machine comments and runtime behavior

## Verification
- uv run ruff check backend/threads/events/buffer.py backend/threads/display/builder.py backend/threads/file_channel.py backend/threads/owner_reads.py backend/threads/event_bus.py tests/Unit/core/test_event_bus.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Unit/integration_contracts/test_query_loop_backend_contracts.py tests/Unit/integration_contracts/test_child_thread_live_contract.py
- uv run ruff format --check backend/threads/events/buffer.py backend/threads/display/builder.py backend/threads/file_channel.py backend/threads/owner_reads.py backend/threads/event_bus.py
- uv run python -m compileall -q backend/threads/events/buffer.py backend/threads/display/builder.py backend/threads/file_channel.py backend/threads/owner_reads.py backend/threads/event_bus.py
- uv run python -m pytest -q tests/Unit/core/test_event_bus.py tests/Unit/backend/web/services/test_file_channel_service.py tests/Unit/integration_contracts/test_child_thread_live_contract.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check