### PR TITLE
chore: trim sandbox domain docs

### DIFF
--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -48,15 +48,11 @@ def _require_row_text(row: dict[str, object], key: str) -> str:
 
 @dataclass
 class ChatSessionPolicy:
-    """Policy configuration for ChatSession lifecycle."""
-
     idle_ttl_sec: int = 600
     max_duration_sec: int = 86400
 
 
 class ChatSession:
-    """Policy/lifecycle window for PhysicalTerminalRuntime."""
-
     def __init__(
         self,
         session_id: str,
@@ -125,8 +121,6 @@ class ChatSession:
 
 
 class ChatSessionManager:
-    """Manager for ChatSession lifecycle."""
-
     def __init__(
         self,
         provider: SandboxProvider,

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -34,13 +34,6 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 @dataclass
 class TerminalState:
-    """Terminal state snapshot.
-
-    Represents the current state of a terminal that needs to persist
-    across session boundaries. This is the "continuity" layer that
-    makes terminals feel persistent even when physical processes die.
-    """
-
     cwd: str
     env_delta: dict[str, str] = field(default_factory=dict)
     state_version: int = 0
@@ -65,23 +58,6 @@ class TerminalState:
 
 
 class AbstractTerminal(ABC):
-    """Durable terminal identity + state snapshot.
-
-    This is the logical terminal that persists across ChatSession boundaries.
-    It does NOT own the physical process - that's owned by PhysicalTerminalRuntime.
-
-    Responsibilities:
-    - Store terminal identity (terminal_id, thread_id, sandbox_runtime_id)
-    - Maintain state snapshot (cwd, env_delta, state_version)
-    - Persist state to database
-    - Provide state to PhysicalTerminalRuntime for hydration
-
-    Does NOT:
-    - Own physical shell/pty process
-    - Execute commands directly
-    - Manage process lifecycle
-    """
-
     def __init__(
         self,
         terminal_id: str,
@@ -98,24 +74,15 @@ class AbstractTerminal(ABC):
         return self._state
 
     def update_state(self, state: TerminalState) -> None:
-        """Update terminal state snapshot.
-
-        This should be called after each command execution to persist
-        the new cwd/env state.
-        """
         state.state_version = self._state.state_version + 1
         self._state = state
         self._persist_state()
 
     @abstractmethod
-    def _persist_state(self) -> None:
-        """Persist state to storage backend."""
-        ...
+    def _persist_state(self) -> None: ...
 
 
 class SQLiteTerminal(AbstractTerminal):
-    """SQLite-backed terminal implementation."""
-
     def __init__(
         self,
         terminal_id: str,
@@ -128,7 +95,6 @@ class SQLiteTerminal(AbstractTerminal):
         self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
     def _persist_state(self) -> None:
-        """Persist state to SQLite."""
         with _connect(self.db_path) as conn:
             conn.execute(
                 """
@@ -148,7 +114,6 @@ class SQLiteTerminal(AbstractTerminal):
 
 
 def terminal_from_row(row: dict, db_path: Path) -> AbstractTerminal:
-    """Construct a terminal domain object from a repo dict."""
     state = TerminalState(
         cwd=row.get("cwd", "/root"),
         env_delta=json.loads(row.get("env_delta_json", "{}")),

--- a/storage/models.py
+++ b/storage/models.py
@@ -4,30 +4,18 @@ from enum import Enum
 
 
 class SandboxObservedState(Enum):
-    """Sandbox actual state reported by the provider.
-
-    These are the actual states reported by sandbox providers.
-    """
-
     RUNNING = "running"
     DETACHED = "detached"
     PAUSED = "paused"
 
 
 class SandboxDesiredState(Enum):
-    """Sandbox desired state set by user or system."""
-
     RUNNING = "running"
     PAUSED = "paused"
     DESTROYED = "destroyed"
 
 
 class SandboxDisplayStatus(Enum):
-    """Frontend sandbox display status.
-
-    These are the status values that frontend expects and displays.
-    """
-
     RUNNING = "running"
     PAUSED = "paused"
     STOPPED = "stopped"
@@ -35,24 +23,6 @@ class SandboxDisplayStatus(Enum):
 
 
 def map_sandbox_state_to_display_status(observed_state: str | None, desired_state: str | None) -> str:
-    """Map sandbox state to frontend display status.
-
-    Mapping rules:
-    - observed="detached" + desired="running" → "running"
-    - observed="detached" + desired="paused" → "paused"
-    - observed="detached" + desired missing/other → "stopped"
-    - observed="running" → "running"
-    - observed="paused" → "paused"
-    - observed=None → "stopped"
-    - desired="destroyed" → "destroying"
-
-    Args:
-        observed_state: Actual state from provider ("running", "detached", "paused", or None)
-        desired_state: Desired state ("running", "paused", "destroyed", or None)
-
-    Returns:
-        Display status string ("running", "paused", "stopped", or "destroying")
-    """
     if not observed_state:
         return SandboxDisplayStatus.STOPPED.value
 


### PR DESCRIPTION
## Summary
- remove repeated docstrings from sandbox state and terminal/session domain helpers
- preserve @@@ detached-state invariant and runtime behavior

## Verification
- uv run ruff check storage/models.py sandbox/terminal.py sandbox/chat_session.py tests/Unit/sandbox/test_sandbox_state.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
- uv run ruff format --check storage/models.py sandbox/terminal.py sandbox/chat_session.py
- uv run python -m compileall -q storage/models.py sandbox/terminal.py sandbox/chat_session.py
- uv run python -m pytest -q tests/Unit/sandbox/test_sandbox_state.py tests/Unit/core/test_runtime.py tests/Unit/sandbox/test_sandbox_runtime_attribute_naming.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check