### PR TITLE
chore: trim sqlite repo docs

### DIFF
--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -11,12 +11,6 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolv
 
 
 class SQLiteChatSessionRepo:
-    """Chat session CRUD backed by SQLite.
-
-    Thread-safe: all connection access is serialized via a lock.
-    Returns raw dicts — domain object construction is the consumer's job.
-    """
-
     def __init__(self, db_path: str | Path | None = None, conn: sqlite3.Connection | None = None) -> None:
         self._own_conn = conn is None
         self._lock = threading.Lock()

--- a/storage/providers/sqlite/queue_repo.py
+++ b/storage/providers/sqlite/queue_repo.py
@@ -10,11 +10,6 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolv
 
 
 class SQLiteQueueRepo:
-    """Message queue backed by SQLite.
-
-    Thread-safe: all connection access is serialized via a lock.
-    """
-
     def __init__(self, db_path: str | Path | None = None, conn: sqlite3.Connection | None = None) -> None:
         self._own_conn = conn is None
         self._lock = threading.Lock()

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -13,12 +13,6 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolv
 
 
 class SQLiteSandboxRuntimeRepo:
-    """Sandbox runtime persistence backed by SQLite.
-
-    Thread-safe: all connection access is serialized via a lock.
-    Returns raw dicts — domain object construction is the consumer's job.
-    """
-
     def __init__(self, db_path: str | Path | None = None, conn: sqlite3.Connection | None = None) -> None:
         self._own_conn = conn is None
         self._lock = threading.Lock()

--- a/storage/providers/sqlite/summary_repo.py
+++ b/storage/providers/sqlite/summary_repo.py
@@ -9,8 +9,6 @@ from storage.providers.sqlite.kernel import connect_sqlite
 
 
 class SQLiteSummaryRepo:
-    """Repository boundary for summaries table operations."""
-
     def __init__(
         self,
         db_path: Path | str,

--- a/storage/providers/sqlite/terminal_repo.py
+++ b/storage/providers/sqlite/terminal_repo.py
@@ -14,12 +14,6 @@ from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolv
 
 
 class SQLiteTerminalRepo:
-    """Abstract terminal CRUD backed by SQLite.
-
-    Thread-safe: all connection access is serialized via a lock.
-    Returns raw dicts — domain object construction is the consumer's job.
-    """
-
     def __init__(self, db_path: str | Path | None = None, conn: sqlite3.Connection | None = None) -> None:
         self._own_conn = conn is None
         self._lock = threading.Lock()


### PR DESCRIPTION
## Summary
- remove redundant SQLite storage repo class docstrings
- leave SQL strings, @@@ comments, and behavior untouched

## Verification
- uv run ruff check storage/providers/sqlite tests/Unit/storage tests/Unit/sandbox
- uv run ruff format --check storage/providers/sqlite
- uv run python -m compileall -q storage/providers/sqlite
- uv run python -m pytest -q tests/Unit/storage tests/Unit/sandbox
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check