### PR TITLE
chore: trim tool infrastructure docs

### DIFF
--- a/core/tools/command/hooks/base.py
+++ b/core/tools/command/hooks/base.py
@@ -6,8 +6,6 @@ from typing import Any
 
 @dataclass
 class HookResult:
-    """Hook execution result."""
-
     allow: bool
     error_message: str = ""
     continue_chain: bool = True
@@ -28,8 +26,6 @@ class HookResult:
 
 
 class BashHook(ABC):
-    """Base class for bash hook plugins. Hooks are executed by priority (lower numbers first)."""
-
     priority: int = 100
     name: str = "UnnamedHook"
     description: str = ""
@@ -40,13 +36,13 @@ class BashHook(ABC):
 
     @abstractmethod
     def check_command(self, command: str, context: dict[str, Any]) -> HookResult:
-        """Check if command is allowed to execute."""
+        pass
 
     def on_command_success(self, command: str, output: str, context: dict[str, Any]) -> None:
-        """Optional callback after successful command execution."""
+        pass
 
     def on_command_error(self, command: str, error: str, context: dict[str, Any]) -> None:
-        """Optional callback after failed command execution."""
+        pass
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}(name={self.name}, priority={self.priority}, enabled={self.enabled})>"

--- a/core/tools/command/hooks/dangerous_commands.py
+++ b/core/tools/command/hooks/dangerous_commands.py
@@ -7,8 +7,6 @@ from .base import BashHook, HookResult
 
 
 class DangerousCommandsHook(BashHook):
-    """Dangerous commands hook - blocks destructive system commands."""
-
     priority = 5
     name = "DangerousCommands"
     description = "Block dangerous commands that may harm the system"

--- a/core/tools/command/hooks/file_access_logger.py
+++ b/core/tools/command/hooks/file_access_logger.py
@@ -5,8 +5,6 @@ from .base import HookResult
 
 
 class FileAccessLoggerHook:
-    """File access logger hook - logs all file operations with timestamps."""
-
     def __init__(self, workspace_root: Path | str | None = None, log_file: str = "file_access.log"):
         self.workspace_root = Path(workspace_root) if workspace_root else None
         self.log_path = (Path(workspace_root) / log_file) if workspace_root else Path(log_file)

--- a/core/tools/command/hooks/file_permission.py
+++ b/core/tools/command/hooks/file_permission.py
@@ -4,8 +4,6 @@ from .base import HookResult
 
 
 class FilePermissionHook:
-    """File permission control hook with extension whitelist and path blacklist."""
-
     def __init__(
         self,
         workspace_root: Path | str | None = None,

--- a/core/tools/command/posix_executor.py
+++ b/core/tools/command/posix_executor.py
@@ -11,8 +11,6 @@ from .base import require_subprocess_pipe
 
 
 class PosixShellExecutor(BaseExecutor):
-    """Executor for bash/zsh-style shells with a persistent blocking session."""
-
     shell_command: tuple[str, ...]
     _running_commands: ClassVar[dict[str, AsyncCommand]] = {}
 

--- a/core/tools/command/service.py
+++ b/core/tools/command/service.py
@@ -20,8 +20,6 @@ DEFAULT_TIMEOUT_MS = 120_000
 
 
 class CommandService:
-    """Registers Bash tool into ToolRegistry."""
-
     def __init__(
         self,
         registry: ToolRegistry,
@@ -205,7 +203,6 @@ class CommandService:
         emit_fn: Callable[[dict[str, Any]], Awaitable[None] | None] | None = None,
         description: str = "",
     ) -> None:
-        """Poll until async command finishes, then enqueue CommandNotification."""
         while not async_cmd.done:
             await asyncio.sleep(1)
 

--- a/core/tools/filesystem/local_backend.py
+++ b/core/tools/filesystem/local_backend.py
@@ -12,8 +12,6 @@ from sandbox.interfaces.filesystem import (
 
 
 class LocalBackend(FileSystemBackend):
-    """Backend that operates directly on the local filesystem."""
-
     def read_file(self, path: str) -> FileReadResult:
         p = Path(path)
         with p.open("r", encoding="utf-8", newline="") as f:

--- a/core/tools/filesystem/service.py
+++ b/core/tools/filesystem/service.py
@@ -88,8 +88,6 @@ class _ReadFileStateCache:
 
 
 class FileSystemService:
-    """Registers filesystem tools (Read/Write/Edit/list_dir) into ToolRegistry."""
-
     def __init__(
         self,
         registry: ToolRegistry,


### PR DESCRIPTION
## Summary
- remove redundant internal docstrings from command hook/tool infrastructure
- keep behavior, tool schemas, and @@@ anchors unchanged

## Verification
- uv run ruff check core/tools/command core/tools/filesystem tests/Unit
- uv run ruff format --check core/tools/command core/tools/filesystem
- uv run python -m compileall -q core/tools/command core/tools/filesystem
- uv run python -m pytest -q tests/Unit/core/test_command_service.py tests/Unit/core/test_tool_registry_runner.py tests/Unit/filesystem/test_filesystem_service.py tests/Unit/sandbox tests/Unit/storage
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q