### PR TITLE
chore: trim runtime tool docs

### DIFF
--- a/core/runtime/errors.py
+++ b/core/runtime/errors.py
@@ -1,6 +1,4 @@
 class InputValidationError(Exception):
-    """Tool parameter validation failed."""
-
     def __init__(
         self,
         message: str,

--- a/core/runtime/registry.py
+++ b/core/runtime/registry.py
@@ -100,12 +100,6 @@ def make_tool_schema(
 
 
 class ToolRegistry:
-    """Central registry for all tools.
-
-    Tools with INLINE mode are injected into every model call.
-    Tools with DEFERRED mode are only discoverable via tool_search.
-    """
-
     def __init__(
         self,
         allowed_tools: set[str] | None = None,

--- a/core/runtime/runner.py
+++ b/core/runtime/runner.py
@@ -42,12 +42,6 @@ class _ToolSpecificValidationError(Exception):
 
 
 class ToolRunner(AgentMiddleware):
-    """Innermost middleware: routes all registered tool calls.
-
-    - wrap_model_call: injects inline tool schemas
-    - wrap_tool_call: validates, dispatches, normalizes errors
-    """
-
     def __init__(self, registry: ToolRegistry, validator: ToolValidator | None = None):
         self._registry = registry
         self._validator = validator or ToolValidator()

--- a/core/runtime/validator.py
+++ b/core/runtime/validator.py
@@ -58,8 +58,6 @@ class ValidationResult:
 
 
 class ToolValidator:
-    """Three-phase tool argument validation."""
-
     def validate(self, schema: dict, args: dict) -> ValidationResult:
         parameters = schema.get("parameters", {})
         properties = parameters.get("properties", {})

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -109,15 +109,6 @@ TASK_UPDATE_SCHEMA = make_tool_schema(
 
 
 class TaskService:
-    """Task management service providing DEFERRED tools.
-
-    Tasks are stored in SQLite and partitioned by thread_id so all agents
-    in the same thread/team share the same task list.
-
-    thread_id is resolved at call time from sandbox.thread_context;
-    falls back to a fixed thread_id if provided at construction (for tests).
-    """
-
     def __init__(
         self,
         registry: ToolRegistry,

--- a/storage/errors.py
+++ b/storage/errors.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 
 class StorageConflictError(RuntimeError):
-    """Raised when a conditional storage write loses a concurrency race."""
+    pass


### PR DESCRIPTION
## Summary
- remove redundant internal runtime/tool docstrings
- keep tool schemas, @@@ anchors, and behavior unchanged

## Verification
- uv run ruff check core/runtime core/tools/task storage tests/Unit/core tests/Unit/storage
- uv run ruff format --check core/runtime core/tools/task storage/errors.py
- uv run python -m compileall -q core/tools/task core/runtime storage/errors.py
- uv run python -m pytest -q tests/Unit/core tests/Unit/storage tests/Unit/integration_contracts/test_thread_files_channel_shell.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q