### PR TITLE
chore: trim runtime state docs

### DIFF
--- a/core/runtime/fork.py
+++ b/core/runtime/fork.py
@@ -8,12 +8,6 @@ from .state import BootstrapConfig, ToolUseContext
 
 
 def fork_context(parent: BootstrapConfig) -> BootstrapConfig:
-    """Create a child BootstrapConfig for a sub-agent.
-
-    Inherits all workspace identity, model settings, and security flags
-    from parent. Generates a fresh session_id and sets parent_session_id.
-    Messages, cost, and turn_count live in AppState — not here.
-    """
     return BootstrapConfig(
         workspace_root=parent.workspace_root,
         original_cwd=parent.original_cwd,
@@ -46,15 +40,6 @@ def create_subagent_context(
     *,
     share_set_app_state: bool = False,
 ) -> ToolUseContext:
-    """Create a minimally isolated ToolUseContext for sub-agents.
-
-    Default contract:
-    - bootstrap: fresh fork
-    - set_app_state: NO-OP
-    - set_app_state_for_tasks: always reaches the root/session store
-    - turn-local refs: fresh
-    - file cache/messages: cloned snapshots
-    """
     read_file_state = parent.read_file_state
     if hasattr(read_file_state, "clone") and callable(read_file_state.clone):
         cloned_read_file_state = read_file_state.clone()

--- a/core/runtime/middleware/spill_buffer/middleware.py
+++ b/core/runtime/middleware/spill_buffer/middleware.py
@@ -19,14 +19,6 @@ SKIP_TOOLS: set[str] = {"Read"}
 
 
 class SpillBufferMiddleware(AgentMiddleware):
-    """Catches tool outputs that exceed a byte threshold.
-
-    Oversized content is written to disk under
-    ``{workspace_root}/.leon/tool-results/{tool_call_id}.txt``
-    and replaced with a preview + file path so the model can
-    use ``Read`` to inspect specific sections.
-    """
-
     def __init__(
         self,
         fs_backend: FileSystemBackend | None = None,

--- a/core/runtime/middleware/spill_buffer/spill.py
+++ b/core/runtime/middleware/spill_buffer/spill.py
@@ -23,18 +23,6 @@ def spill_if_needed(
     fs_backend: FileSystemBackend,
     workspace_root: str,
 ) -> Any:
-    """Replace oversized string content with a preview + on-disk path.
-
-    Args:
-        content: Tool output (only strings are checked).
-        threshold_bytes: Max byte size before spilling.
-        tool_call_id: Used to derive the spill filename.
-        fs_backend: Backend for writing the full output to disk.
-        workspace_root: Root directory for the .leon/tool-results/ folder.
-
-    Returns:
-        Original content if within threshold, otherwise a preview string.
-    """
     if not isinstance(content, str):
         return content
 

--- a/core/runtime/state.py
+++ b/core/runtime/state.py
@@ -20,12 +20,6 @@ class ToolPermissionState(BaseModel):
 
 
 class BootstrapConfig(BaseModel):
-    """Process-level configuration that survives /clear.
-
-    Analogous to CC Bootstrap State (~85 fields). Contains workspace
-    identity, model config, security flags, and API credentials.
-    """
-
     workspace_root: Path
     original_cwd: Path | None = None
     project_root: Path | None = None
@@ -71,12 +65,6 @@ class BootstrapConfig(BaseModel):
 
 
 class AppState(BaseModel):
-    """Per-session mutable state. Analogous to CC AppState store.
-
-    Implements a minimal Zustand-style store with getState/setState.
-    Not reactive — no subscriptions needed for Python backend.
-    """
-
     messages: list = Field(default_factory=list)
     turn_count: int = 0
     total_cost: float = 0.0
@@ -138,12 +126,6 @@ PermissionResolutionConsumer = Callable[
 
 
 class ToolUseContext(BaseModel):
-    """Per-turn context bag. Analogous to CC ToolUseContext.
-
-    Carries live closures to AppState so tools can read/mutate session state.
-    Sub-agents receive a NO-OP set_app_state to prevent write-through.
-    """
-
     bootstrap: BootstrapConfig
     get_app_state: AppStateGetter = Field(exclude=True)
     set_app_state: AppStateSetter = Field(exclude=True)

--- a/core/runtime/visibility.py
+++ b/core/runtime/visibility.py
@@ -6,7 +6,6 @@ _ALWAYS_SHOWING = {"showing": True}
 
 
 def annotate_owner_visibility(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str]:
-    """Annotate messages as visible unless they already carry display metadata."""
     for msg in messages:
         msg.setdefault("display", _ALWAYS_SHOWING)
     return messages, "owner"


### PR DESCRIPTION
## Summary
- remove redundant internal runtime state/fork/spill docstrings
- keep behavior, @@@ anchors, and tool output contracts unchanged

## Verification
- uv run ruff check core/runtime tests/Unit/core tests/Unit/backend/thread_runtime tests/Unit/integration_contracts
- uv run ruff format --check core/runtime
- uv run python -m compileall -q core/runtime
- uv run python -m pytest -q tests/Unit/core tests/Unit/backend/thread_runtime tests/Unit/integration_contracts
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q