### PR TITLE
chore: trim sandbox provider docs

### DIFF
--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -16,13 +16,6 @@ def create_sandbox(
     workspace_root: str | None = None,
     db_path: Path | None = None,
 ) -> Sandbox:
-    """Factory: create a Sandbox from config.
-
-    Args:
-        config: SandboxConfig (from SandboxConfig.load() or inline)
-        workspace_root: Default working dir for LocalSandbox
-        db_path: SQLite path for session tracking
-    """
     p = config.provider
 
     if p == "local":

--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -111,8 +111,6 @@ def _run_coroutine_blocking[T](coro: Coroutine[Any, Any, T], *, timeout: float |
 
 
 class RemoteSandbox(Sandbox):
-    """Concrete sandbox for all provider-backed environments (AgentBay, Docker, E2B, Daytona)."""
-
     def __init__(
         self,
         provider: SandboxProvider,
@@ -240,8 +238,6 @@ class _LazyLocalExecutor:
 
 
 class LocalSandbox(Sandbox):
-    """Concrete sandbox for the local host environment."""
-
     def __init__(self, workspace_root: str, db_path: Path | None = None) -> None:
         from sandbox.manager import SandboxManager
         from sandbox.providers.local import LocalSessionProvider

--- a/sandbox/provider.py
+++ b/sandbox/provider.py
@@ -118,14 +118,12 @@ class Metrics:
 
 
 class SandboxProvider(ABC):
-    """Abstract interface for sandbox providers."""
-
     name: str  # Provider identifier: 'agentbay', 'e2b', 'docker', 'local'
     WORKSPACE_ROOT: str = "/workspace"  # Override in subclasses with non-standard workspace paths
 
     @abstractmethod
     def get_capability(self) -> ProviderCapability:
-        """Return lifecycle capability contract for this provider."""
+        pass
 
     @abstractmethod
     def create_session(self, context_id: str | None = None, thread_id: str | None = None) -> SessionInfo:
@@ -181,7 +179,7 @@ class SandboxProvider(ABC):
 
     @abstractmethod
     def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:
-        """Create the appropriate PhysicalTerminalRuntime for this provider."""
+        pass
 
     def get_metrics_via_commands(self, session_id: str) -> Metrics | None:
         try:
@@ -228,25 +226,19 @@ class SandboxProvider(ABC):
         return None
 
     def create_managed_volume(self, managed_ref: str, mount_path: str) -> str:
-        """Create provider-managed persistent volume. Returns backend_ref (volume name).
-        Override in providers with managed volume support (Daytona, Docker).
-        """
         raise NotImplementedError(f"{self.name} does not support managed volumes")
 
     def set_managed_volume_mount(self, thread_id: str, backend_ref: str, mount_path: str) -> None:
-        """Configure managed volume mount for next create_session().
-        Called before create_session(). Provider stores this internally.
-        """
         raise NotImplementedError(f"{self.name} does not support managed volumes")
 
     def delete_managed_volume(self, backend_ref: str) -> None:
         raise NotImplementedError(f"{self.name} does not support managed volumes")
 
     def wait_managed_volume_ready(self, backend_ref: str) -> None:
-        """Block until a previously created managed volume is reusable."""
+        pass
 
     def set_thread_bind_mounts(self, thread_id: str, mounts: list) -> None:
-        """Set per-thread bind mounts for next create_session(). No-op for providers without mount support."""
+        pass
 
     def list_provider_runtimes(self) -> list[SessionInfo]:
         return []

--- a/sandbox/volume_source.py
+++ b/sandbox/volume_source.py
@@ -92,7 +92,6 @@ class HostVolume:
 
 
 def deserialize_volume_source(data: dict[str, Any]) -> VolumeSource:
-    """Reconstruct VolumeSource from serialized JSON."""
     match data["type"]:
         case "host":
             return HostVolume(Path(data["path"]))


### PR DESCRIPTION
## Summary
- remove redundant internal sandbox/provider docstrings
- keep behavior and @@@ anchors unchanged

## Verification
- uv run ruff check sandbox tests/Unit/sandbox tests/Unit/backend/thread_runtime tests/Unit/integration_contracts
- uv run ruff format --check sandbox
- uv run python -m compileall -q sandbox
- uv run python -m pytest -q tests/Unit/sandbox tests/Unit/backend/thread_runtime tests/Unit/integration_contracts
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- git diff --check
- uv run python -m pytest -q