### PR TITLE
chore: trim sandbox runtime docs

### DIFF
--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -263,23 +263,19 @@ class SandboxManager:
         )
 
     def _get_sandbox_runtime(self, sandbox_runtime_id: str):
-        """Get sandbox runtime as domain object, or None."""
         row = self.sandbox_runtime_store.get(sandbox_runtime_id)
         if row is None:
             return None
         return sandbox_runtime_from_row(row, self.db_path)
 
     def _create_sandbox_runtime(self, sandbox_runtime_id: str, provider_name: str):
-        """Create sandbox runtime and return as domain object."""
         row = self.sandbox_runtime_store.create(sandbox_runtime_id, provider_name)
         return sandbox_runtime_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
-        """Public API: get active terminal as domain object."""
         return self._get_active_terminal(thread_id)
 
     def get_sandbox_runtime(self, sandbox_runtime_id: str):
-        """Public API: get sandbox runtime as domain object."""
         return self._get_sandbox_runtime(sandbox_runtime_id)
 
     def _default_terminal_cwd(self) -> str:
@@ -295,7 +291,6 @@ class SandboxManager:
         self.provider.delete_managed_volume(f"leon-volume-{sandbox_runtime_id}")
 
     def _setup_mounts(self, thread_id: str) -> dict:
-        """Mount the workspace file channel into the sandbox."""
         terminal = self._get_active_terminal(thread_id)
         if not terminal:
             raise ValueError(f"No active terminal for thread {thread_id}")
@@ -320,8 +315,6 @@ class SandboxManager:
         return {"source_path": source_path, "remote_path": remote_path}
 
     def _upgrade_to_daytona_volume(self, thread_id: str, sandbox_runtime_id: str, remote_path: str):
-        """Ensure Daytona managed volume exists and return provider backend ref."""
-
         try:
             volume_name = self.provider.create_managed_volume(sandbox_runtime_id, remote_path)
         except Exception as e:
@@ -426,7 +419,6 @@ class SandboxManager:
         self.volume.sync_download(thread_id, instance_id, source, self.volume.resolve_mount_path())
 
     def sync_uploads(self, thread_id: str, files: list[str] | None = None) -> bool:
-        """Upload files to the active sandbox. Returns False if no active session."""
         terminal = self._get_active_terminal(thread_id)
         if not terminal:
             return False
@@ -714,7 +706,6 @@ class SandboxManager:
         return capability.resolve_session_info(self.provider.name)
 
     def pause_session(self, thread_id: str) -> bool:
-        """Pause session for thread."""
         terminals = self._get_thread_terminals(thread_id)
         if not terminals:
             return False
@@ -813,7 +804,6 @@ class SandboxManager:
         return self.destroy_thread_resources(thread_id)
 
     def destroy_thread_resources(self, thread_id: str) -> bool:
-        """Destroy physical resources and detach thread from terminal/runtime records."""
         terminal_rows = self.terminal_store.list_by_thread(thread_id)
         terminals = [terminal_from_row(r, self.db_path) for r in terminal_rows]
         if not terminals:

--- a/sandbox/providers/agentbay.py
+++ b/sandbox/providers/agentbay.py
@@ -24,16 +24,6 @@ if TYPE_CHECKING:
 
 
 class AgentBayProvider(SandboxProvider):
-    """
-    AgentBay (Alibaba Cloud) sandbox provider.
-
-    Features:
-    - Cloud-based Linux/Windows/Browser environments
-    - Context sync for data persistence
-    - Pause/resume for cost optimization
-    - Rich inspection APIs (metrics, screenshot, processes)
-    """
-
     CATALOG_ENTRY = {"vendor": "Alibaba Cloud", "description": "Remote Linux sandbox", "provider_type": "cloud"}
 
     name = "agentbay"
@@ -302,12 +292,10 @@ class AgentBayProvider(SandboxProvider):
         return []
 
     def get_web_url(self, session_id: str) -> str | None:
-        """Get AgentBay web UI URL for the session."""
         session = self._get_session(session_id)
         return getattr(session, "resource_url", None)
 
     def _get_session(self, session_id: str) -> Any:
-        """Get session object, fetching from API if not cached."""
         if session_id not in self._sessions:
             result = self.client.get(session_id)
             if not result.success:
@@ -319,7 +307,6 @@ class AgentBayProvider(SandboxProvider):
         return hydrated
 
     def _hydrate_direct_call_session(self, session: Any) -> Any:
-        """Ensure cached session carries LinkUrl/token/tool metadata for direct shell calls."""
         if not self._session_needs_direct_call_refresh(session):
             return session
         session_id = str(getattr(session, "session_id", "") or "")

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -40,15 +40,6 @@ logger = logging.getLogger(__name__)
 
 
 class DockerProvider(SandboxProvider):
-    """
-    Local Docker sandbox provider.
-
-    Notes:
-    - Requires Docker CLI available on host.
-    - Uses one container per session.
-    - If context_id is provided, uses a named Docker volume for persistence.
-    """
-
     CATALOG_ENTRY = {"vendor": None, "description": "Isolated container sandbox", "provider_type": "container"}
 
     name = "docker"
@@ -102,7 +93,6 @@ class DockerProvider(SandboxProvider):
         self._thread_bind_mounts: dict[str, list[MountSpec]] = {}  # thread_id -> bind_mounts
 
     def set_thread_bind_mounts(self, thread_id: str, mounts: list[MountSpec | dict]) -> None:
-        """Set thread-specific bind mounts that will be applied when creating sessions."""
         self._thread_bind_mounts[thread_id] = [MountSpec.model_validate(m) if isinstance(m, dict) else m for m in mounts]
 
     def create_session(self, context_id: str | None = None, thread_id: str | None = None) -> SessionInfo:
@@ -349,7 +339,6 @@ class DockerProvider(SandboxProvider):
         )
 
     def _disk_usage_from_ps(self, container_id: str) -> float | None:
-        """Read writable-layer size for any container state via docker ps --size."""
         result = self._run(
             ["docker", "ps", "-a", "--filter", f"id={container_id}", "--format", "{{.Size}}"],
             timeout=self.command_timeout_sec,
@@ -512,8 +501,6 @@ class DockerProvider(SandboxProvider):
 
 
 class DockerPtyRuntime(_RemoteRuntimeBase):
-    """Docker runtime using a persistent PTY shell inside container."""
-
     def __init__(self, terminal, sandbox_runtime, provider):
         super().__init__(terminal, sandbox_runtime, provider)
         self._session_lock = asyncio.Lock()
@@ -597,7 +584,6 @@ class DockerPtyRuntime(_RemoteRuntimeBase):
                 return ExecuteResult(exit_code=1, stdout="", stderr=f"Error: {exc}")
 
     async def _recover_after_timeout(self) -> None:
-        """Recover PTY session after a command timeout."""
         if self._pty_session is None:
             return
         recovered = await asyncio.to_thread(self._pty_session.interrupt_and_recover)

--- a/sandbox/providers/local.py
+++ b/sandbox/providers/local.py
@@ -28,8 +28,6 @@ if TYPE_CHECKING:
 
 @dataclass
 class LocalSessionProvider(SandboxProvider):
-    """Local session provider with direct host access."""
-
     CATALOG_ENTRY = {"vendor": None, "description": "Direct host access", "provider_type": "local"}
     name: str = "local"
     CAPABILITY = ProviderCapability(
@@ -338,11 +336,6 @@ def _build_windows_shell_script(
 
 
 class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
-    """Local persistent shell runtime (for local provider).
-
-    Uses a persistent PTY-backed shell session.
-    """
-
     def __init__(
         self,
         terminal,
@@ -477,7 +470,6 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
                 )
 
     async def _recover_after_timeout(self) -> None:
-        """Recover PTY session after a command timeout."""
         if self._use_windows_shell:
             return
         if self._pty_session is None:
@@ -495,11 +487,9 @@ class LocalPersistentShellRuntime(PhysicalTerminalRuntime):
         return True
 
     async def execute(self, command: str, timeout: float | None = None) -> ExecuteResult:
-        """Execute command in local shell."""
         return await self._execute_background_command(command, timeout=timeout)
 
     async def close(self) -> None:
-        """Close the shell session."""
         if self._use_windows_shell:
             return
         if self._pty_session:

--- a/sandbox/runtime_handle.py
+++ b/sandbox/runtime_handle.py
@@ -92,8 +92,6 @@ def _make_sandbox_repo():
 
 @dataclass
 class SandboxInstance:
-    """Ephemeral sandbox compute instance."""
-
     instance_id: str
     provider_name: str
     status: str
@@ -101,8 +99,6 @@ class SandboxInstance:
 
 
 class SandboxRuntimeHandle(ABC):
-    """Durable shared compute handle."""
-
     def __init__(
         self,
         sandbox_runtime_id: str,
@@ -177,8 +173,6 @@ class SandboxRuntimeHandle(ABC):
 
 
 class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
-    """SQLite-backed sandbox runtime handle implementation."""
-
     _lock_guard = threading.Lock()
     _runtime_locks: dict[str, threading.RLock] = {}
 
@@ -1098,7 +1092,6 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
 
 
 def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteSandboxRuntimeHandle:
-    """Construct SQLiteSandboxRuntimeHandle from a dict returned by the repo."""
     instance = None
     inst_data = row.get("_instance")
     if inst_data:


### PR DESCRIPTION
## Summary
- Remove redundant internal sandbox runtime/provider docstrings
- Keep behavior and @@@ anchors unchanged

## Verification
- uv run ruff check sandbox tests/Unit/sandbox tests/Unit/platform/test_agentbay_capability_override.py
- uv run ruff format --check sandbox
- uv run python -m compileall -q sandbox
- uv run python -m pytest -q tests/Unit/sandbox tests/Unit/platform/test_agentbay_capability_override.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check