### PR TITLE
chore: trim runtime loop docs

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -577,13 +577,11 @@ class LeonAgent:
         return config.model_copy(update={"memory": type(config.memory)(**memory_data)})
 
     def _resolve_workspace_root(self) -> Path:
-        """Resolve workspace root from config or current directory."""
         if self.config.workspace_root:
             return Path(self.config.workspace_root).expanduser().resolve()
         return Path.cwd()
 
     def _init_config_attributes(self) -> None:
-        """Initialize configuration attributes from config."""
         self.allowed_file_extensions = self.config.runtime.allowed_extensions
         self.block_dangerous_commands = self.config.runtime.block_dangerous_commands
         self.block_network_commands = self.config.runtime.block_network_commands
@@ -599,7 +597,6 @@ class LeonAgent:
         self.sandbox_db_path.parent.mkdir(parents=True, exist_ok=True)
 
     def _init_sandbox(self, sandbox: Any) -> Any:
-        """Initialize sandbox infrastructure layer."""
         from sandbox import Sandbox as SandboxBase
         from sandbox import SandboxConfig, create_sandbox, resolve_sandbox_name
 
@@ -618,7 +615,6 @@ class LeonAgent:
         raise TypeError(f"sandbox must be Sandbox, str, or None, got {type(sandbox)}")
 
     def _resolve_provider_name(self, model_name: str, overrides: dict | None = None) -> str | None:
-        """Resolve provider: overrides → active config → infer from model name → configured default."""
         if overrides and overrides.get("model_provider"):
             return overrides["model_provider"]
         if self.models_config.active and self.models_config.active.provider:
@@ -694,7 +690,6 @@ class LeonAgent:
         }
 
     def _create_extraction_model(self):
-        """Create a small model for WebFetch AI extraction (leon:mini)."""
         model_name, overrides = self.models_config.resolve_model("leon:mini")
         provider = self._resolve_provider_name(model_name, overrides)
         kwargs: dict = {}
@@ -713,7 +708,6 @@ class LeonAgent:
         return init_chat_model(model_name, **kwargs)
 
     def _build_model_kwargs(self) -> dict:
-        """Build model parameters for model initialization and sub-agents."""
         kwargs = {}
 
         if hasattr(self, "_model_overrides"):
@@ -803,7 +797,6 @@ class LeonAgent:
 
     @property
     def observation_config(self) -> ObservationConfig:
-        """Current observation provider configuration."""
         return self._observation_config
 
     def update_observation(self, **overrides) -> None:
@@ -901,7 +894,6 @@ class LeonAgent:
                 await result
 
     def _cleanup_sandbox(self) -> None:
-        """Clean up sandbox resources."""
         if hasattr(self, "_sandbox") and self._sandbox:
             try:
                 self._sandbox.close()
@@ -909,7 +901,6 @@ class LeonAgent:
                 print(f"[LeonAgent] Sandbox cleanup error: {e}")
 
     def _mark_terminated(self) -> None:
-        """Mark agent as terminated."""
         if hasattr(self, "_monitor_middleware"):
             self._monitor_middleware.mark_terminated()
 
@@ -938,7 +929,6 @@ class LeonAgent:
                 raise RuntimeError(f"{label} cleanup failed: {exc}") from exc
 
     def _cleanup_mcp_client(self) -> None:
-        """Clean up MCP client."""
         if not hasattr(self, "_mcp_client") or not self._mcp_client:
             return
 
@@ -1032,7 +1022,6 @@ class LeonAgent:
         return middleware
 
     def _add_memory_middleware(self, middleware: list) -> None:
-        """Add memory middleware to stack."""
         # @@@context-limit-default - prefer mapping override (e.g. leon:tiny -> 8000),
         # then Monitor's resolved value (model API or its 128000 default).
         context_limit = self._model_overrides.get("context_limit") or self._monitor_middleware._context_monitor.context_limit
@@ -1314,7 +1303,6 @@ class LeonAgent:
         return True
 
     def _build_system_prompt(self) -> str:
-        """Build system prompt based on sandbox mode."""
         # If agent override is set, use its system_prompt + rules.
         if hasattr(self, "_agent_override") and self._agent_override:
             prompt = self._agent_override.system_prompt
@@ -1497,7 +1485,6 @@ class LeonAgent:
         stream_mode: str | list[str] = "updates",
         max_budget_usd: float | None = None,
     ):
-        """Stream agent output through a caller-owned LeonAgent surface."""
         try:
             async for chunk in self.agent.astream(
                 {"messages": [{"role": "user", "content": message}]},
@@ -1512,7 +1499,6 @@ class LeonAgent:
             raise
 
     async def aclear_thread(self, thread_id: str = "default") -> None:
-        """Clear turn-scoped state for a thread while preserving session accumulators."""
         try:
             await self.agent.aclear(thread_id)
             self._invalidate_system_prompt_cache()
@@ -1523,7 +1509,6 @@ class LeonAgent:
             raise
 
     def clear_thread(self, thread_id: str = "default") -> None:
-        """Sync wrapper for aclear_thread()."""
         import asyncio
 
         async def _aclear():

--- a/core/runtime/loop.py
+++ b/core/runtime/loop.py
@@ -346,7 +346,6 @@ class QueryLoop:
         input: dict,
         config: dict | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
-        """Raw loop generator with an explicit final terminal event."""
         config = config or {}
         thread_id = config.get("configurable", {}).get("thread_id", "default")
 
@@ -660,7 +659,6 @@ class QueryLoop:
         config: dict | None = None,
         stream_mode: str = "updates",
     ) -> dict[str, Any]:
-        """Drain query and return messages plus explicit terminal state."""
         drained_messages: list[Any] = []
         terminal: TerminalState | None = None
         transition: ContinueState | None = None
@@ -684,7 +682,6 @@ class QueryLoop:
         }
 
     async def aget_state(self, config: dict | None = None) -> Any:
-        """Minimal graph-state view for backend/web callers."""
         config = config or {}
         thread_id = config.get("configurable", {}).get("thread_id", "default")
         if self._is_runtime_active():
@@ -702,7 +699,6 @@ class QueryLoop:
         input_data: dict[str, Any] | None,
         as_node: str | None = None,
     ) -> Any:
-        """Minimal graph-state update path for resumed-thread callers."""
         config = config or {}
         input_data = input_data or {}
         thread_id = config.get("configurable", {}).get("thread_id", "default")
@@ -729,7 +725,6 @@ class QueryLoop:
         return await self.aget_state(config)
 
     async def apersist_state(self, thread_id: str) -> None:
-        """Persist the current thread-scoped loop/app state to the checkpointer."""
         messages = list(self._app_state.messages) if self._app_state is not None else await self._load_messages(thread_id)
         await self._save_messages(thread_id, messages)
 
@@ -743,10 +738,7 @@ class QueryLoop:
         thread_id: str = "default",
         max_output_tokens_override: int | None = None,
     ) -> ModelResponse:
-        """Call model through the full middleware chain (awrap_model_call)."""
-
         async def innermost_handler(request: ModelRequest) -> ModelResponse:
-            """Actual model call — innermost of the chain."""
             tools = request.tools or []
             model = request.model
             bound = self._bind_model(model, tools, max_output_tokens_override=max_output_tokens_override)
@@ -935,7 +927,6 @@ class QueryLoop:
         return await self._apply_before_model(list(messages), config)
 
     async def _apply_before_model(self, messages: list, config: dict) -> tuple[list, list]:
-        """Run middleware before_model/abefore_model hooks on the live path."""
         current_messages = list(messages)
         injected_messages: list[Any] = []
         state = {"messages": current_messages}
@@ -968,7 +959,6 @@ class QueryLoop:
         return current_messages, injected_messages
 
     def _sync_app_state(self, messages: list, turn_count: int) -> None:
-        """Keep runtime AppState aligned with the loop's live state."""
         if self._app_state is None:
             return
 
@@ -1534,7 +1524,6 @@ class QueryLoop:
         model_response: ModelResponse,
         tool_context: ToolUseContext | None,
     ) -> list[ToolMessage]:
-        """Execute tool calls respecting concurrency safety, via middleware chain."""
         results: dict[int, ToolMessage] = {}
 
         async def execute_batch(batch: list[tuple[int, dict]]) -> None:
@@ -1736,7 +1725,6 @@ class QueryLoop:
     # Checkpointer persistence
 
     async def _load_messages(self, thread_id: str) -> list:
-        """Load message history from checkpointer (if available)."""
         state = await self._load_thread_checkpoint_state(thread_id)
         return list(state.messages) if state is not None else []
 
@@ -1750,7 +1738,6 @@ class QueryLoop:
             return None
 
     async def _load_checkpoint_channel_values(self, thread_id: str) -> dict[str, Any]:
-        """State snapshot helper for tests and state callers that inspect channel_values."""
         state = await self._load_thread_checkpoint_state(thread_id)
         if state is None:
             return {}
@@ -1908,7 +1895,6 @@ class QueryLoop:
         }
 
     async def _save_messages(self, thread_id: str, messages: list) -> None:
-        """Persist message history to checkpointer."""
         if self._checkpoint_store is None:
             return
         try:
@@ -1997,7 +1983,6 @@ class QueryLoop:
         return AIMessage(content=f"Error: {error_text}")
 
     async def aclear(self, thread_id: str) -> None:
-        """Clear turn-scoped state for a thread while preserving session accumulators."""
         await self._save_messages(thread_id, [])
 
         self._tool_read_file_state.clear()
@@ -2059,7 +2044,6 @@ class QueryLoop:
 
     @staticmethod
     def _parse_input(input: dict | None) -> list:
-        """Convert input dict to list of LangChain message objects."""
         if input is None:
             return []
         raw_messages = input.get("messages", [])


### PR DESCRIPTION
## Summary
- Remove redundant internal runtime loop/agent docstrings
- Preserve behavior and @@@ anchors

## Verification
- uv run ruff check core/runtime tests/Unit/core tests/Unit/integration_contracts/test_leon_agent.py
- uv run ruff format --check core/runtime
- uv run python -m compileall -q core/runtime
- uv run python -m pytest -q tests/Unit/core tests/Unit/integration_contracts/test_leon_agent.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check