### PR TITLE
chore: trim middleware helper docs

### DIFF
--- a/core/runtime/middleware/memory/compactor.py
+++ b/core/runtime/middleware/memory/compactor.py
@@ -38,16 +38,6 @@ class ContextCompactor:
         self.keep_recent_tokens = keep_recent_tokens
 
     def should_compact(self, estimated_tokens: int, context_limit: int, threshold: float = 0.7) -> bool:
-        """Whether current context exceeds the compaction threshold.
-
-        Args:
-            estimated_tokens: Current estimated token count
-            context_limit: Maximum context window size
-            threshold: Fraction of context_limit to trigger compaction (default 0.7)
-
-        Returns:
-            True if compaction should be triggered
-        """
         threshold_tokens = int(context_limit * threshold)
         return estimated_tokens > threshold_tokens
 
@@ -146,7 +136,6 @@ class ContextCompactor:
         return summary
 
     def _estimate_msg_tokens(self, msg: Any) -> int:
-        """Estimate tokens for a single message (chars // 2)."""
         content = getattr(msg, "content", "")
         if isinstance(content, str):
             return len(content) // 2

--- a/core/runtime/middleware/memory/pruner.py
+++ b/core/runtime/middleware/memory/pruner.py
@@ -16,10 +16,6 @@ class SessionPruner:
         self.protect_recent = protect_recent
 
     def prune(self, messages: list[Any]) -> list[Any]:
-        """Return new message list with old ToolMessage content trimmed/cleared.
-
-        Does NOT modify original messages — returns shallow copies with replaced content.
-        """
         protected_ids = self._get_protected_tool_call_ids(messages)
         result = []
         for msg in messages:
@@ -30,7 +26,6 @@ class SessionPruner:
         return result
 
     def _get_protected_tool_call_ids(self, messages: list[Any]) -> set[str]:
-        """Collect tool_call_ids from the most recent N AIMessages with tool_calls."""
         ids: set[str] = set()
         count = 0
         for msg in reversed(messages):
@@ -69,7 +64,6 @@ class SessionPruner:
         if n <= self.soft_trim_chars:
             return msg
 
-        # Determine new content based on size
         if n > self.hard_clear_threshold:
             new_content = f"[Tool output cleared — {n} chars]"
         else:

--- a/core/runtime/middleware/monitor/usage_patches.py
+++ b/core/runtime/middleware/monitor/usage_patches.py
@@ -13,7 +13,6 @@ _anthropic_patched = False
 
 
 def patch_anthropic_streaming_usage() -> None:
-    """Restore input-token extraction from message_start in streaming."""
     global _anthropic_patched
     if _anthropic_patched:
         return
@@ -54,5 +53,4 @@ def patch_anthropic_streaming_usage() -> None:
 
 
 def apply_all() -> None:
-    """Apply all provider-specific streaming usage patches."""
     patch_anthropic_streaming_usage()


### PR DESCRIPTION
## Summary
- Remove redundant helper docstrings in memory pruning/compaction and usage patch helpers
- Preserve behavioral comments and @@@ anchors

## Verification
- uv run ruff check core/runtime/middleware/memory core/runtime/middleware/monitor tests/Unit/core tests/Unit/integration_contracts/test_memory_middleware_integration.py
- uv run ruff format --check core/runtime/middleware/memory core/runtime/middleware/monitor
- uv run python -m compileall -q core/runtime/middleware/memory core/runtime/middleware/monitor
- uv run python -m pytest -q tests/Unit/core tests/Unit/integration_contracts/test_memory_middleware_integration.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check