### PR TITLE
chore: trim service helper docs

### DIFF
--- a/backend/hub/snapshot_install.py
+++ b/backend/hub/snapshot_install.py
@@ -87,7 +87,6 @@ def install_from_snapshot(
     user_repo: Any = None,
     agent_config_repo: Any = None,
 ) -> str:
-    """Create or update a marketplace-backed agent user via repos only."""
     from storage.contracts import UserRow, UserType
     from storage.utils import generate_agent_config_id, generate_agent_user_id
 

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -350,7 +350,6 @@ def list_library_names(
     owner_user_id: str | None = None,
     recipe_repo: RecipeRepo | None = None,
 ) -> list[dict[str, str]]:
-    """Lightweight name+desc list for Picker UI."""
     return [
         {"name": item["name"], "desc": item["desc"]}
         for item in list_library(resource_type, owner_user_id=owner_user_id, recipe_repo=recipe_repo)
@@ -405,7 +404,6 @@ def get_resource_content(
     owner_user_id: str | None = None,
     recipe_repo: RecipeRepo | None = None,
 ) -> str | None:
-    """Read the .md content file for a skill or agent resource."""
     if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         for item in list_library("sandbox-template", owner_user_id=owner_user_id, recipe_repo=recipe_repo):
@@ -428,7 +426,6 @@ def get_resource_content(
 
 
 def update_resource_content(resource_type: str, resource_id: str, content: str) -> bool:
-    """Write the .md content file for a skill or agent resource."""
     now = int(time.time() * 1000)
     if resource_type == "sandbox-template":
         return False

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -306,8 +306,6 @@ ASK_USER_QUESTION_SCHEMA = make_tool_schema(
 
 
 class _RunningTask:
-    """Tracks a background asyncio.Task (agent run) with its metadata."""
-
     def __init__(self, task: asyncio.Task, agent_id: str, thread_id: str, description: str = ""):
         self.task = task
         self.agent_id = agent_id
@@ -328,8 +326,6 @@ class _RunningTask:
 
 
 class _BashBackgroundRun:
-    """Wraps AsyncCommand to provide the same is_done/get_result interface as _RunningTask."""
-
     def __init__(self, async_cmd: Any, command: str, description: str = ""):
         self._cmd = async_cmd
         self.command = command
@@ -364,7 +360,6 @@ def _background_run_cancelled(running: BackgroundRun) -> bool:
 
 
 async def request_background_run_stop(running: BackgroundRun) -> None:
-    """Stop a background run and mark bash runs with authoritative cancellation state."""
     if isinstance(running, _RunningTask):
         running.task.cancel()
         return
@@ -632,7 +627,6 @@ class AgentService:
         fork_context: bool = False,
         tool_context: ToolUseContext | None = None,
     ) -> Any:
-        """Spawn an independent LeonAgent and run it with the given prompt."""
         from sandbox.thread_context import get_current_thread_id
 
         task_id = uuid.uuid4().hex[:8]
@@ -728,7 +722,6 @@ class AgentService:
         fork_context: bool = False,
         parent_tool_context: ToolUseContext | None = None,
     ) -> str:
-        """Create and run an independent LeonAgent, collect its text output."""
         # Isolate this sub-agent from the parent's LangChain callback chain.
         # asyncio.create_task() copies the current context, so this task inherits
         # var_child_runnable_config which carries the parent graph's inheritable
@@ -1161,7 +1154,6 @@ class AgentService:
             )
 
     async def _handle_task_output(self, task_id: str, block: bool = True, timeout: int = 30_000) -> str:
-        """Get output of a background agent task."""
         running = self._tasks.get(task_id)
         if not running:
             return f"Error: task '{task_id}' not found"
@@ -1306,7 +1298,6 @@ class AgentService:
             await self._stop_background_run(task_id, running)
 
     async def _handle_task_stop(self, task_id: str) -> str:
-        """Stop a running background agent task."""
         running = self._tasks.get(task_id)
         if not running:
             return f"Error: task '{task_id}' not found"

--- a/core/tools/filesystem/read/types.py
+++ b/core/tools/filesystem/read/types.py
@@ -240,7 +240,6 @@ ARCHIVE_EXTENSIONS: set[str] = {
 
 
 def detect_file_type(path: Path) -> FileType:
-    """Detect file type based on extension."""
     ext = path.suffix.lstrip(".").lower()
 
     if not ext:

--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -74,7 +74,6 @@ def schema_rpc(client: Any, schema: str, function_name: str, params: dict[str, A
 
 
 def rows(response: Any, repo: str, operation: str) -> list[dict[str, Any]]:
-    """Extract and validate the `.data` list from a supabase-py response."""
     if isinstance(response, dict):
         payload = response.get("data")
     else:


### PR DESCRIPTION
## Summary
- remove redundant helper docstrings in agent, library, hub, filesystem, and Supabase query code
- preserve behavioral comments, @@@ notes, and schema descriptions
- keep the slice deletion-only

## Verification
- uv run ruff check backend/library/service.py backend/hub/snapshot_install.py storage/providers/supabase/_query.py core/tools/filesystem/read/types.py core/agents/service.py tests/Unit
- uv run ruff format --check backend/library/service.py backend/hub/snapshot_install.py storage/providers/supabase/_query.py core/tools/filesystem/read/types.py core/agents/service.py
- uv run python -m compileall -q backend/library/service.py backend/hub/snapshot_install.py storage/providers/supabase/_query.py core/tools/filesystem/read/types.py core/agents/service.py
- uv run python -m pytest -q tests/Unit/backend tests/Unit/storage tests/Unit/core
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check