### PR TITLE
chore: trim runtime helper docs

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -367,7 +367,6 @@ def download(
 
 
 def upgrade(user_id: str, item_id: str, owner_user_id: str, user_repo: Any = None, agent_config_repo: Any = None) -> dict:
-    """Upgrade a locally installed marketplace item."""
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required to upgrade marketplace user snapshot")
 
@@ -391,5 +390,4 @@ def upgrade(user_id: str, item_id: str, owner_user_id: str, user_repo: Any = Non
 
 
 def check_updates(items: list[dict]) -> dict:
-    """Check for updates for installed marketplace items."""
     return _hub_api("POST", "/check-updates", json={"installed": items})

--- a/backend/threads/convergence.py
+++ b/backend/threads/convergence.py
@@ -10,7 +10,6 @@ from storage.runtime import uses_supabase_runtime_defaults
 
 
 def delete_thread_in_db(thread_id: str) -> None:
-    """Delete all records for a thread via storage repos + sandbox db."""
     _get_container().purge_thread(thread_id)
 
     sandbox_db = resolve_sandbox_db_path()
@@ -52,7 +51,6 @@ def purge_incomplete_owner_thread(app: Any, thread_id: str) -> None:
 
 
 def inspect_owner_thread_runtime(app: Any, thread_id: str) -> str:
-    """Check an owner-visible thread against the runtime contract without mutating thread rows."""
     thread = app.state.thread_repo.get_by_id(thread_id)
     if thread is None:
         return "missing"

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -209,7 +209,6 @@ async def get_or_create_agent(
 
 
 async def update_agent_config(app_obj: FastAPI, model: str, thread_id: str | None = None) -> dict[str, Any]:
-    """Update agent configuration with hot-reload."""
     lock_key = thread_id or "global"
     lock = _config_update_locks.setdefault(lock_key, asyncio.Lock())
 

--- a/backend/web/core/dependencies.py
+++ b/backend/web/core/dependencies.py
@@ -53,7 +53,6 @@ async def verify_thread_row_owner(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[FastAPI, Depends(get_app)],
 ) -> str:
-    """Verify ownership without mutating or converging thread runtime state."""
     thread = app.state.thread_repo.get_by_id(thread_id)
     if not thread:
         raise HTTPException(404, "Thread not found")
@@ -64,7 +63,6 @@ async def verify_thread_row_owner(
 
 
 async def get_thread_lock(app: Annotated[FastAPI, Depends(get_app)], thread_id: str) -> asyncio.Lock:
-    """Get or create a lock for a specific thread."""
     async with app.state.thread_locks_guard:
         lock = app.state.thread_locks.get(thread_id)
         if lock is None:
@@ -78,7 +76,6 @@ async def get_thread_agent(
     thread_id: str,
     require_remote: bool = False,
 ) -> Any:
-    """Get or create agent for a thread, with optional remote sandbox requirement."""
     sandbox_type = resolve_thread_sandbox(app, thread_id)
     if require_remote and sandbox_type == "local":
         raise HTTPException(400, "Local threads have no remote sandbox")

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -125,11 +125,9 @@ class DaytonaProvider(SandboxProvider):
         self._managed_mounts: dict[str, tuple[str, str]] = {}  # thread_id -> (backend_ref, mount_path)
 
     def set_thread_bind_mounts(self, thread_id: str, mounts: list[MountSpec | dict]) -> None:
-        """Set thread-specific bind mounts that will be applied when creating sessions."""
         self._thread_bind_mounts[thread_id] = [MountSpec.model_validate(m) if isinstance(m, dict) else m for m in mounts]
 
     def create_managed_volume(self, managed_ref: str, mount_path: str) -> str:
-        """Create a Daytona managed volume. Returns volume name as backend_ref."""
         volume_name = f"leon-volume-{managed_ref}"
         logger.info("Creating managed volume: %s", volume_name)
         # @@@volume-ready - volume transitions pending_create → ready (~6s)

--- a/sandbox/providers/e2b.py
+++ b/sandbox/providers/e2b.py
@@ -341,14 +341,12 @@ class E2BProvider(SandboxProvider):
         return files
 
     def restore_workspace(self, session_id: str, files: list[dict]) -> None:
-        """Upload files back into /home/user/workspace."""
         sandbox = self._get_sandbox(session_id)
         for f in files:
             abs_path = f"{self.WORKSPACE_ROOT}/{f['file_path']}"
             sandbox.files.write(abs_path, f["content"])
 
     def _get_sandbox(self, session_id: str) -> _E2BSandboxHandle:
-        """Get sandbox object, reconnecting if not cached."""
         if session_id not in self._sandboxes:
             from e2b import Sandbox
 
@@ -361,7 +359,6 @@ class E2BProvider(SandboxProvider):
         return cast(_E2BSandboxHandle, self._sandboxes[session_id])
 
     def get_runtime_sandbox(self, session_id: str) -> _E2BSandboxHandle:
-        """Expose native SDK sandbox for runtime-level persistent terminal handling."""
         return self._get_sandbox(session_id)
 
     def create_runtime(self, terminal: AbstractTerminal, sandbox_runtime: SandboxRuntimeHandle) -> PhysicalTerminalRuntime:


### PR DESCRIPTION
## Summary
- remove redundant internal helper docstrings from hub/runtime/sandbox support code
- preserve @@@ comments and externally visible route/schema documentation
- keep the slice deletion-only

## Verification
- uv run ruff check backend/hub/client.py backend/threads/convergence.py backend/threads/pool/registry.py backend/web/core/dependencies.py sandbox/providers/daytona.py sandbox/providers/e2b.py tests/Unit
- uv run ruff format --check backend/hub/client.py backend/threads/convergence.py backend/threads/pool/registry.py backend/web/core/dependencies.py sandbox/providers/daytona.py sandbox/providers/e2b.py
- uv run python -m compileall -q backend/hub/client.py backend/threads/convergence.py backend/threads/pool/registry.py backend/web/core/dependencies.py sandbox/providers/daytona.py sandbox/providers/e2b.py
- uv run python -m pytest -q tests/Unit/backend tests/Unit/sandbox
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check