### PR TITLE
chore: trim chat adapter docs

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -203,7 +203,6 @@ def _agent_user_summary_from_repos(user: Any, agent_config_repo: Any) -> dict[st
 
 
 def _leon_builtin() -> dict[str, Any]:
-    """Build Leon builtin agent-user dict with full tool catalog."""
     tools = [{"name": k, "enabled": v.default, "desc": v.desc, "group": v.group} for k, v in TOOLS_BY_NAME.items()]
     builtin_agents = _load_builtin_agents(TOOLS_BY_NAME)
 
@@ -221,7 +220,6 @@ def _leon_builtin() -> dict[str, Any]:
 
 
 def _load_builtin_agents(catalog: dict[str, ToolDef]) -> list[dict[str, Any]]:
-    """Load system built-in agents for display (read-only)."""
     loader = AgentLoader()
     agents = []
     if _SYSTEM_AGENTS_DIR.is_dir():

--- a/backend/threads/chat_adapters/activity_reader.py
+++ b/backend/threads/chat_adapters/activity_reader.py
@@ -21,8 +21,6 @@ def _normalize_state(state: AgentState) -> Literal["initializing", "ready", "act
 
 
 class AppRuntimeThreadActivityReader:
-    """Read live runtime thread activity from app-backed state."""
-
     def __init__(self, *, thread_repo: Any, agent_pool: dict[str, Any]) -> None:
         self._thread_repo = thread_repo
         self._agent_pool = agent_pool

--- a/backend/threads/chat_adapters/chat_handler.py
+++ b/backend/threads/chat_adapters/chat_handler.py
@@ -9,8 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 class NativeAgentChatDeliveryHandler:
-    """Routes Chat messages into native Mycel Agent threads."""
-
     def __init__(
         self,
         *,

--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
-    """Create a delivery callback for MessagingService."""
     import asyncio
 
     if activity_reader is None:

--- a/backend/threads/chat_adapters/chat_runtime_services.py
+++ b/backend/threads/chat_adapters/chat_runtime_services.py
@@ -20,8 +20,6 @@ class AgentChatRuntimeServices(Protocol):
 
 
 class AppAgentChatRuntimeServices:
-    """Runtime-owned adapter around app-backed chat delivery dependencies."""
-
     def __init__(
         self,
         app: Any,

--- a/backend/threads/chat_adapters/gateway.py
+++ b/backend/threads/chat_adapters/gateway.py
@@ -19,8 +19,6 @@ class AgentThreadInputRuntimeHandler(Protocol):
 
 
 class NativeAgentRuntimeGateway:
-    """In-process Agent-side gateway for native Mycel runtime dispatch."""
-
     def __init__(
         self,
         *,
@@ -41,7 +39,6 @@ class NativeAgentRuntimeGateway:
     async def dispatch_thread_input(
         self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope
     ) -> agent_runtime_protocol.AgentThreadInputResult:
-        """Route direct thread input through the Agent-side gateway."""
         if self._thread_input_handler is None:
             raise ValueError("No Agent thread input runtime handler configured")
         return await self._thread_input_handler.dispatch(envelope)

--- a/backend/threads/chat_adapters/thread_handler.py
+++ b/backend/threads/chat_adapters/thread_handler.py
@@ -11,8 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class NativeAgentThreadInputHandler:
-    """Routes direct thread input into native Mycel Agent runs."""
-
     def __init__(
         self,
         app: Any,

--- a/backend/threads/streaming.py
+++ b/backend/threads/streaming.py
@@ -95,7 +95,6 @@ async def _run_agent_to_buffer(  # pyright: ignore[reportGeneralTypeIssues]  # @
     message_metadata: dict[str, Any] | None = None,
     input_messages: list[Any] | None = None,
 ) -> str:
-    """Run agent execution and write all SSE events into *thread_buf*."""
     _run_execution.ensure_thread_handlers = _ensure_thread_handlers
     _run_execution.prime_sandbox = _run_lifecycle.prime_sandbox
     _run_execution.repair_incomplete_tool_calls = _run_lifecycle.repair_incomplete_tool_calls

--- a/storage/providers/supabase/chat_repo.py
+++ b/storage/providers/supabase/chat_repo.py
@@ -10,8 +10,6 @@ _TABLE_CHATS = "chats"
 
 
 class SupabaseChatRepo:
-    """Chat CRUD backed by Supabase."""
-
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO_CHAT)
 

--- a/storage/providers/supabase/invite_code_repo.py
+++ b/storage/providers/supabase/invite_code_repo.py
@@ -104,6 +104,5 @@ class SupabaseInviteCodeRepo:
         return not _is_expired(existing)
 
     def revoke(self, code: str) -> bool:
-        """Delete (revoke) a code. Returns True if it existed."""
         resp = self._table().delete().eq("code", code).execute()
         return bool(resp.data)

--- a/storage/providers/supabase/summary_repo.py
+++ b/storage/providers/supabase/summary_repo.py
@@ -9,8 +9,6 @@ _TABLE = "summaries"
 
 
 class SupabaseSummaryRepo:
-    """Minimal summary repository backed by a Supabase client."""
-
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
 


### PR DESCRIPTION
## Summary
- remove redundant docstrings from chat/runtime adapters and small Supabase repos
- preserve behavioral comments and @@@ notes
- keep the slice deletion-only

## Verification
- uv run ruff check backend/threads/agent_user_service.py backend/threads/chat_adapters backend/threads/streaming.py storage/providers/supabase/chat_repo.py storage/providers/supabase/invite_code_repo.py storage/providers/supabase/summary_repo.py tests/Unit
- uv run ruff format --check backend/threads/agent_user_service.py backend/threads/chat_adapters backend/threads/streaming.py storage/providers/supabase/chat_repo.py storage/providers/supabase/invite_code_repo.py storage/providers/supabase/summary_repo.py
- uv run python -m compileall -q backend/threads/agent_user_service.py backend/threads/chat_adapters backend/threads/streaming.py storage/providers/supabase/chat_repo.py storage/providers/supabase/invite_code_repo.py storage/providers/supabase/summary_repo.py
- uv run python -m pytest -q tests/Unit/backend tests/Unit/storage tests/Unit/integration_contracts/test_query_loop_backend_contracts.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check