### PR TITLE
chore: trim resource helper docs

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -27,7 +27,6 @@ _hub_client = httpx.Client(timeout=30.0, trust_env=False)
 
 
 def _hub_api(method: str, path: str, **kwargs: Any) -> dict:
-    """Call Hub API."""
     url = f"{HUB_URL}/api/v1{path}"
     try:
         resp = _hub_client.request(method, url, **kwargs)
@@ -170,7 +169,6 @@ def publish(
     user_repo: Any = None,
     agent_config_repo: Any = None,
 ) -> dict:
-    """Publish a local agent user bundle to the Hub."""
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required for publish()")
 
@@ -253,7 +251,6 @@ def download(
     agent_config_repo: Any = None,
     agent_user_id: str | None = None,
 ) -> dict:
-    """Download a marketplace item to local library or install an agent user."""
     result = _hub_api("POST", f"/items/{item_id}/download")
     snapshot = result["snapshot"]
     item = result["item"]

--- a/backend/sandboxes/resources/io.py
+++ b/backend/sandboxes/resources/io.py
@@ -47,7 +47,6 @@ def browse_sandbox(
     make_sandbox_monitor_repo_fn=make_sandbox_monitor_repo,
     build_provider_from_config_name_fn=build_provider_from_config_name,
 ) -> dict[str, Any]:
-    """Browse the filesystem of a sandbox via its provider."""
     from pathlib import PurePosixPath
 
     provider, instance_id = _resolve_sandbox_provider(
@@ -113,7 +112,6 @@ def refresh_resource_snapshots(
     probe_and_upsert_for_instance_fn=probe_and_upsert_for_instance,
     upsert_resource_snapshot_for_sandbox_fn=upsert_resource_snapshot_for_sandbox,
 ) -> dict[str, Any]:
-    """Probe active sandbox runtimes and upsert resource snapshots."""
     repo = make_sandbox_monitor_repo_fn()
     try:
         probe_targets = repo.list_probe_targets()

--- a/backend/sandboxes/resources/projection.py
+++ b/backend/sandboxes/resources/projection.py
@@ -84,7 +84,6 @@ def _resource_display_status(
 
 
 def _project_user_visible_resource_rows(repo: Any, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Project raw monitor rows into the user-visible resource surface."""
     grouped: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
         sandbox_id = str(row.get("sandbox_id") or "").strip()

--- a/backend/web/core/dependencies.py
+++ b/backend/web/core/dependencies.py
@@ -33,7 +33,6 @@ async def verify_thread_owner(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[FastAPI, Depends(get_app)],
 ) -> str:
-    """Verify that user_id owns the thread. Returns user_id."""
     runtime_state = thread_runtime_convergence.inspect_owner_thread_runtime(app, thread_id)
     if runtime_state == "missing":
         raise HTTPException(404, "Thread not found")

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -34,7 +34,6 @@ async def _validate_web_checkpointer_contract() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """FastAPI lifespan context manager for startup and shutdown."""
     _require_web_runtime_contract()
     await _validate_web_checkpointer_contract()
 

--- a/storage/providers/supabase/invite_code_repo.py
+++ b/storage/providers/supabase/invite_code_repo.py
@@ -77,7 +77,6 @@ class SupabaseInviteCodeRepo:
         return [dict(r) for r in rows]
 
     def use(self, code: str, user_id: str) -> dict[str, Any] | None:
-        """Atomically mark a code as used. Returns the row if successful, None if not valid."""
         now = datetime.now(UTC).isoformat()
         resp = (
             self._table()

--- a/storage/providers/supabase/thread_repo.py
+++ b/storage/providers/supabase/thread_repo.py
@@ -192,7 +192,6 @@ class SupabaseThreadRepo:
         return [_to_dict(r) for r in rows]
 
     def list_by_owner_user_id(self, owner_user_id: str) -> list[dict[str, Any]]:
-        """Return all threads owned by this user via a two-step query (users JOIN threads)."""
         user_response = (
             q.schema_table(self._client, "identity", "users", _REPO)
             .select("id, display_name, avatar")


### PR DESCRIPTION
Summary:
- remove redundant helper docstrings from hub, web runtime, sandbox resource, and Supabase repo helpers
- preserve behavioral comments, route docs, and @@@ notes
- keep the slice deletion-only

Verification:
- uv run ruff check backend/hub/client.py backend/web/core/dependencies.py backend/web/core/lifespan.py backend/sandboxes/resources/io.py backend/sandboxes/resources/projection.py storage/providers/supabase/invite_code_repo.py storage/providers/supabase/thread_repo.py tests/Unit
- uv run ruff format --check backend/hub/client.py backend/web/core/dependencies.py backend/web/core/lifespan.py backend/sandboxes/resources/io.py backend/sandboxes/resources/projection.py storage/providers/supabase/invite_code_repo.py storage/providers/supabase/thread_repo.py
- uv run python -m compileall -q backend/hub/client.py backend/web/core/dependencies.py backend/web/core/lifespan.py backend/sandboxes/resources/io.py backend/sandboxes/resources/projection.py storage/providers/supabase/invite_code_repo.py storage/providers/supabase/thread_repo.py
- uv run python -m pytest -q tests/Unit/backend tests/Unit/storage tests/Unit/monitor (381 passed)
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check