### PR TITLE
chore: trim sandbox provider docs

### DIFF
--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -52,8 +52,6 @@ if TYPE_CHECKING:
 
 
 class DaytonaProvider(SandboxProvider):
-    """Daytona cloud sandbox provider."""
-
     CATALOG_ENTRY = {
         "vendor": "Daytona",
         "description": "Managed cloud or self-host Daytona sandboxes",
@@ -412,7 +410,6 @@ class DaytonaProvider(SandboxProvider):
         return urlunparse(parsed._replace(netloc=f"127.0.0.1:{parsed.port or 4000}"))
 
     def get_runtime_sandbox(self, session_id: str):
-        """Expose native SDK sandbox for runtime-level persistent terminal handling."""
         return self._get_sandbox(session_id)
 
     def _api_auth_headers(self) -> dict[str, str]:
@@ -513,8 +510,6 @@ from sandbox.runtime import (  # noqa: E402
 
 
 class DaytonaSessionRuntime(_RemoteRuntimeBase):
-    """Daytona runtime using native PTY session API (persistent terminal semantics)."""
-
     def __init__(self, terminal, sandbox_runtime, provider):
         super().__init__(terminal, sandbox_runtime, provider)
         self._session_lock = asyncio.Lock()

--- a/sandbox/providers/e2b.py
+++ b/sandbox/providers/e2b.py
@@ -103,8 +103,6 @@ def _require_e2b_bytes(
 
 
 class E2BProvider(SandboxProvider):
-    """E2B cloud sandbox provider."""
-
     CATALOG_ENTRY = {"vendor": "E2B", "description": "Cloud sandbox with runtime metrics", "provider_type": "cloud"}
 
     name = "e2b"
@@ -316,7 +314,6 @@ class E2BProvider(SandboxProvider):
         return self.get_metrics_via_commands(session_id)
 
     def snapshot_workspace(self, session_id: str) -> list[dict]:
-        """Download all files from /home/user/workspace."""
         sandbox = self._get_sandbox(session_id)
         stack = [self.WORKSPACE_ROOT]
         files = []
@@ -386,8 +383,6 @@ from sandbox.runtime import (  # noqa: E402
 
 
 class E2BPtyRuntime(_RemoteRuntimeBase):
-    """E2B runtime using native SDK PTY handle for persistent shell."""
-
     def __init__(self, terminal, sandbox_runtime, provider):
         super().__init__(terminal, sandbox_runtime, provider)
         self._session_lock = asyncio.Lock()

--- a/sandbox/sync/retry.py
+++ b/sandbox/sync/retry.py
@@ -6,8 +6,6 @@ logger = logging.getLogger(__name__)
 
 
 class RetryWithBackoff:
-    """Decorator: retry on transient errors with exponential backoff."""
-
     TRANSIENT = (OSError, ConnectionError, TimeoutError)
 
     def __init__(self, max_retries: int = 3, backoff_factor: int = 2):


### PR DESCRIPTION
Summary:
- remove redundant one-line docstrings from sandbox provider/runtime helpers
- preserve behavioral @@@ notes and interface docstrings
- keep the slice deletion-only

Verification:
- uv run ruff check sandbox/providers/daytona.py sandbox/providers/e2b.py sandbox/sync/retry.py tests/Unit/sandbox
- uv run ruff format --check sandbox/providers/daytona.py sandbox/providers/e2b.py sandbox/sync/retry.py
- uv run python -m compileall -q sandbox/providers/daytona.py sandbox/providers/e2b.py sandbox/sync/retry.py
- uv run python -m pytest -q tests/Unit/sandbox (109 passed, 2 skipped)
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check