### PR TITLE
chore: trim remote sandbox stdout noise

### DIFF
--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -141,25 +141,15 @@ class RemoteSandbox(Sandbox):
         thread_id = get_current_thread_id()
         if not thread_id:
             raise RuntimeError("No thread_id set. Call set_current_thread_id first.")
-        print(f"[RemoteSandbox._get_capability] provider={self._provider.name} thread_id={thread_id}", flush=True)
         cached = self._capability_cache.get(thread_id)
         if cached is not None and _cached_capability_is_stale(self._manager, thread_id, cached):
             self._capability_cache.pop(thread_id, None)
         if thread_id not in self._capability_cache:
-            print(
-                f"[RemoteSandbox._get_capability] provider={self._provider.name} thread_id={thread_id} cache=miss",
-                flush=True,
-            )
             capability = self._manager.get_sandbox(thread_id)
             if self._config.init_commands and thread_id not in self._init_commands_run:
                 self._run_init_commands(capability)
                 self._init_commands_run.add(thread_id)
             self._capability_cache[thread_id] = capability
-        else:
-            print(
-                f"[RemoteSandbox._get_capability] provider={self._provider.name} thread_id={thread_id} cache=hit",
-                flush=True,
-            )
         return self._capability_cache[thread_id]
 
     def _run_init_commands(self, capability: SandboxCapability) -> None:

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -71,14 +71,6 @@ class _CommandWrapper(BaseExecutor):
         self._session.touch()
         # @@@command-context - CommandService passes env; preserve that context for remote runtimes.
         wrapped, _ = self._wrap_command(command, cwd, env)
-        print(
-            "[_CommandWrapper.execute] "
-            f"thread_id={self._session.thread_id} "
-            f"terminal_id={self._session.terminal.terminal_id} "
-            f"command={command[:200]!r} "
-            f"cwd={cwd!r} timeout={timeout}",
-            flush=True,
-        )
         return await self._session.runtime.execute(wrapped, timeout)
 
     async def execute_async(self, command: str, cwd: str | None = None, env: dict[str, str] | None = None):

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -910,17 +910,6 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
         instance = self.sandbox_runtime.ensure_active_instance(self.provider)
         state = self.terminal.get_state()
         timeout_ms = int(timeout * 1000) if timeout else 30000
-        print(
-            "[RemoteWrappedRuntime._execute_once] "
-            f"thread_id={self.terminal.thread_id} "
-            f"sandbox_runtime_id={self.sandbox_runtime.sandbox_runtime_id} "
-            f"instance_id={instance.instance_id} "
-            f"provider={getattr(self.provider, 'name', '?')} "
-            f"cwd={state.cwd!r} "
-            f"timeout_ms={timeout_ms} "
-            f"command={command[:200]!r}",
-            flush=True,
-        )
         start_marker, end_marker = _build_state_markers()
         exports = _build_export_block(state.env_delta)
         wrapped = "\n".join(
@@ -945,14 +934,6 @@ class RemoteWrappedRuntime(_RemoteRuntimeBase):
             cwd=state.cwd,
         )
         raw_output = result.output or ""
-        print(
-            "[RemoteWrappedRuntime._execute_once] "
-            f"thread_id={self.terminal.thread_id} "
-            f"provider_exit={result.exit_code} "
-            f"provider_error={result.error!r} "
-            f"output_len={len(raw_output)}",
-            flush=True,
-        )
 
         try:
             new_cwd, env_map, raw_output = _extract_state_from_output(


### PR DESCRIPTION
Summary:
- remove unconditional success-path stdout prints from remote sandbox capability lookup and command execution
- keep failure-path diagnostic prints intact
- keep the slice deletion-only

Verification:
- uv run ruff check sandbox/base.py sandbox/capability.py sandbox/runtime.py tests/Unit/sandbox tests/Unit/core
- uv run ruff format --check sandbox/base.py sandbox/capability.py sandbox/runtime.py
- uv run python -m compileall -q sandbox/base.py sandbox/capability.py sandbox/runtime.py
- uv run python -m pytest -q tests/Unit/sandbox tests/Unit/core (523 passed, 3 skipped)
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check