### PR TITLE
chore: trim runtime init stdout noise

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -320,9 +320,6 @@ class LeonAgent:
             self._memory_middleware.set_model(self.model, self._current_model_config)
 
         if self.verbose:
-            print("[LeonAgent] Initialized successfully")
-            print(f"[LeonAgent] Workspace: {self.workspace_root}")
-            print(f"[LeonAgent] Audit log: {self.enable_audit_log}")
             if self.checkpointer is None:
                 print("[LeonAgent] Note: Async components need initialization via ainit()")
 
@@ -1172,12 +1169,6 @@ class LeonAgent:
             )
         except Exception as e:
             logger.debug("[LeonAgent] LSPService init skipped: %s", e)
-
-        if self.verbose:
-            all_tools = self._tool_registry.list_all()
-            inline = [t for t in all_tools if t.mode.value == "inline"]
-            deferred = [t for t in all_tools if t.mode.value == "deferred"]
-            print(f"[LeonAgent] ToolRegistry: {len(inline)} inline, {len(deferred)} deferred tools")
 
     async def _init_mcp_tools(self) -> list:
         mcp_enabled = self.config.mcp.enabled

--- a/core/runtime/middleware/memory/middleware.py
+++ b/core/runtime/middleware/memory/middleware.py
@@ -86,11 +86,6 @@ class MemoryMiddleware(AgentMiddleware):
         self._compaction_failure_counts_by_thread: dict[str, int] = {}
         self._compaction_breaker_open_by_thread: dict[str, bool] = {}
 
-        if verbose:
-            print("[MemoryMiddleware] Initialized")
-            if self.summary_store:
-                print(f"[MemoryMiddleware] SummaryStore enabled at {db_path}")
-
     def set_model(self, model: Any, model_config: dict[str, Any] | None = None) -> None:
         self._model = model
         self._model_config = model_config

--- a/core/runtime/middleware/monitor/middleware.py
+++ b/core/runtime/middleware/monitor/middleware.py
@@ -48,9 +48,6 @@ class MonitorMiddleware(AgentMiddleware):
             state_monitor=self._state_monitor,
         )
 
-        if verbose:
-            print("[MonitorMiddleware] Initialized")
-
     def add_monitor(self, monitor: BaseMonitor) -> None:
         self._monitors.append(monitor)
 


### PR DESCRIPTION
Summary:
- remove verbose initialization success prints from runtime agent and middleware setup
- preserve failure/cleanup diagnostics and memory compaction runtime traces
- keep the slice deletion-only

Verification:
- uv run ruff check core/runtime/agent.py core/runtime/middleware/monitor/middleware.py core/runtime/middleware/memory/middleware.py tests/Unit/core
- uv run ruff format --check core/runtime/agent.py core/runtime/middleware/monitor/middleware.py core/runtime/middleware/memory/middleware.py
- uv run python -m compileall -q core/runtime/agent.py core/runtime/middleware/monitor/middleware.py core/runtime/middleware/memory/middleware.py
- uv run python -m pytest -q tests/Unit/core (414 passed, 1 skipped)
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1615 passed, 8 skipped)
- git diff --check