### PR TITLE
chore: trim unused verbose plumbing

### DIFF
--- a/backend/threads/pool/idle_reaper.py
+++ b/backend/threads/pool/idle_reaper.py
@@ -35,9 +35,7 @@ def run_idle_reaper_once(app_obj: Any) -> int:
 async def idle_reaper_loop(app_obj: Any) -> None:
     while True:
         try:
-            count = await asyncio.to_thread(run_idle_reaper_once, app_obj)
-            if count > 0:
-                print(f"[idle-reaper] reclaimed+closed {count} expired chat session(s)")
+            await asyncio.to_thread(run_idle_reaper_once, app_obj)
         except Exception as e:
             print(f"[idle-reaper] error: {e}")
         await asyncio.sleep(IDLE_REAPER_INTERVAL_SEC)

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -803,7 +803,6 @@ class AgentService:
                         child_thread_live_runner=self._child_thread_live_runner,
                         extra_blocked_tools=extra_blocked,
                         allowed_tools=allowed,
-                        verbose=False,
                     )
                 else:
                     raise AttributeError("no parent bootstrap")
@@ -831,7 +830,6 @@ class AgentService:
                         child_thread_live_runner=self._child_thread_live_runner,
                         extra_blocked_tools=extra_blocked,
                         allowed_tools=allowed,
-                        verbose=False,
                     )
                 # @@@sa-04-child-bootstrap-wiring
                 # Keep the forked bootstrap/context handoff behind an explicit
@@ -863,7 +861,6 @@ class AgentService:
                     child_thread_live_runner=self._child_thread_live_runner,
                     extra_blocked_tools=extra_blocked,
                     allowed_tools=allowed,
-                    verbose=False,
                 )
             # In async context LeonAgent defers checkpointer init; call ainit() to
             # ensure state is persisted (and loadable via GET /api/threads/{thread_id}).

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -319,10 +319,6 @@ class LeonAgent:
             self._steering_middleware._agent_runtime = self.runtime
             self._memory_middleware.set_model(self.model, self._current_model_config)
 
-        if self.verbose:
-            if self.checkpointer is None:
-                print("[LeonAgent] Note: Async components need initialization via ainit()")
-
         # Wire CleanupRegistry for priority-ordered resource teardown
         self._cleanup_registry = CleanupRegistry()
         self._cleanup_registry.register(self._cleanup_model_clients, priority=1)
@@ -992,7 +988,6 @@ class LeonAgent:
             summary_repo=summary_repo,
             checkpointer=self.checkpointer,
             compaction_threshold=0.7,
-            verbose=self.verbose,
         )
         # Cap keep_recent_tokens for small context windows
         self._memory_middleware.set_context_limit(context_limit)
@@ -1072,7 +1067,6 @@ class LeonAgent:
                         DangerousCommandsHook(
                             workspace_root=self.workspace_root,
                             block_network=self.block_network_commands,
-                            verbose=self.verbose,
                         )
                     )
             self._command_service = CommandService(

--- a/core/runtime/middleware/memory/middleware.py
+++ b/core/runtime/middleware/memory/middleware.py
@@ -38,7 +38,6 @@ class MemoryMiddleware(AgentMiddleware):
         summary_repo: SummaryRepo | None = None,
         checkpointer: Any = None,
         compaction_threshold: float = 0.7,
-        verbose: bool = False,
     ):
         self._context_limit = context_limit
         self._compaction_threshold = compaction_threshold

--- a/core/tools/command/hooks/dangerous_commands.py
+++ b/core/tools/command/hooks/dangerous_commands.py
@@ -68,7 +68,6 @@ class DangerousCommandsHook(BashHook):
         workspace_root: Path | str | None = None,
         block_network: bool = False,
         custom_blocked: list[str] | None = None,
-        verbose: bool = True,
     ):
         super().__init__(workspace_root)
 

--- a/sandbox/providers/agentbay.py
+++ b/sandbox/providers/agentbay.py
@@ -181,12 +181,6 @@ class AgentBayProvider(SandboxProvider):
             # @@@agentbay-shell-link-route - shared provider runs proved shell can degrade into the API path
             # despite hydrated direct-call metadata; take the explicit LinkUrl route when shell server is known.
             result = self._call_link_url_tool(session, "shell", exec_args, shell_server)
-            print(
-                "[AgentBay.execute] "
-                f"session_id={session_id} path=link_url exit_code={result.exit_code} "
-                f"error={result.error!r} output_len={len(result.output or '')}",
-                flush=True,
-            )
             return result
 
         try:

--- a/tests/Integration/test_e2e_summary_persistence.py
+++ b/tests/Integration/test_e2e_summary_persistence.py
@@ -40,7 +40,6 @@ class TestFullAgentSummaryPersistence:
         agent = create_leon_agent(
             workspace_root=temp_workspace,
             sandbox="local",
-            verbose=True,
         )
 
         try:
@@ -83,7 +82,6 @@ class TestFullAgentSummaryPersistence:
         agent2 = create_leon_agent(
             workspace_root=temp_workspace,
             sandbox="local",
-            verbose=True,
         )
 
         try:
@@ -113,7 +111,6 @@ class TestAgentSplitTurnE2E:
         agent = create_leon_agent(
             workspace_root=temp_workspace,
             sandbox="local",
-            verbose=True,
         )
 
         try:
@@ -148,7 +145,6 @@ class TestAgentConcurrentThreads:
             agent = create_leon_agent(
                 workspace_root=temp_workspace,
                 sandbox="local",
-                verbose=True,
             )
 
             try:
@@ -193,7 +189,6 @@ class TestAgentConcurrentThreads:
             agent = create_leon_agent(
                 workspace_root=temp_workspace,
                 sandbox="local",
-                verbose=True,
             )
 
             try:

--- a/tests/Unit/core/test_command_service.py
+++ b/tests/Unit/core/test_command_service.py
@@ -102,32 +102,32 @@ class TestDangerousCommandsHook:
         assert "SECURITY" in result.error_message
 
     def test_allow_dangerous_text_inside_quotes(self):
-        hook = DangerousCommandsHook(verbose=False)
+        hook = DangerousCommandsHook()
         result = hook.check_command('echo "rm -rf /"', {})
         assert result.allow
 
     def test_allow_dangerous_text_inside_comment(self):
-        hook = DangerousCommandsHook(verbose=False)
+        hook = DangerousCommandsHook()
         result = hook.check_command("echo hi # rm -rf /", {})
         assert result.allow
 
     def test_block_obfuscated_dangerous_command_name_with_inline_quotes(self):
-        hook = DangerousCommandsHook(verbose=False)
+        hook = DangerousCommandsHook()
         result = hook.check_command('s"u"do echo hi', {})
         assert not result.allow
 
     def test_block_obfuscated_file_mutation_command_name_with_inline_quotes(self):
-        hook = DangerousCommandsHook(verbose=False)
+        hook = DangerousCommandsHook()
         result = hook.check_command('ch"mo"d 777 /tmp/x', {})
         assert not result.allow
 
     def test_block_ansi_c_quoted_obfuscation(self):
-        hook = DangerousCommandsHook(verbose=False)
+        hook = DangerousCommandsHook()
         result = hook.check_command("s$'udo' echo hi", {})
         assert not result.allow
 
     def test_block_locale_quoted_obfuscation(self):
-        hook = DangerousCommandsHook(verbose=False)
+        hook = DangerousCommandsHook()
         result = hook.check_command('$"chmod" 777 /tmp/x', {})
         assert not result.allow
 

--- a/tests/Unit/core/test_tool_registry_runner.py
+++ b/tests/Unit/core/test_tool_registry_runner.py
@@ -939,7 +939,7 @@ class TestToolRunnerErrorNormalization:
         CommandService(
             registry=registry,
             workspace_root=tmp_path,
-            hooks=[DangerousCommandsHook(verbose=False)],
+            hooks=[DangerousCommandsHook()],
         )
         runner = ToolRunner(registry=registry)
         req = _make_tool_call_request("Bash", {"command": 'echo "rm -rf /"'})
@@ -956,7 +956,7 @@ class TestToolRunnerErrorNormalization:
         CommandService(
             registry=registry,
             workspace_root=tmp_path,
-            hooks=[DangerousCommandsHook(verbose=False)],
+            hooks=[DangerousCommandsHook()],
         )
         runner = ToolRunner(registry=registry)
         req = _make_tool_call_request("Bash", {"command": "echo hi # rm -rf /"})
@@ -973,7 +973,7 @@ class TestToolRunnerErrorNormalization:
         CommandService(
             registry=registry,
             workspace_root=tmp_path,
-            hooks=[DangerousCommandsHook(verbose=False)],
+            hooks=[DangerousCommandsHook()],
         )
         runner = ToolRunner(registry=registry)
         req = _make_tool_call_request("Bash", {"command": 's"u"do echo hi'})
@@ -990,7 +990,7 @@ class TestToolRunnerErrorNormalization:
         CommandService(
             registry=registry,
             workspace_root=tmp_path,
-            hooks=[DangerousCommandsHook(verbose=False)],
+            hooks=[DangerousCommandsHook()],
         )
         runner = ToolRunner(registry=registry)
         req = _make_tool_call_request("Bash", {"command": "s$'udo' echo hi"})

--- a/tests/Unit/integration_contracts/test_memory_middleware_integration.py
+++ b/tests/Unit/integration_contracts/test_memory_middleware_integration.py
@@ -92,7 +92,6 @@ class TestSummarySaveOnCompaction:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware.set_model(mock_model)
 
@@ -123,7 +122,6 @@ class TestSummaryRestoreOnStartup:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware1.set_model(mock_model)
 
@@ -143,7 +141,6 @@ class TestSummaryRestoreOnStartup:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware2.set_model(mock_model)
 
@@ -162,7 +159,6 @@ class TestSummaryRestoreOnStartup:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware.set_model(mock_model)
 
@@ -221,7 +217,6 @@ class TestRebuildFromCheckpointer:
             compaction_threshold=0.5,
             db_path=temp_db,
             checkpointer=None,
-            verbose=True,
         )
         middleware.set_model(mock_model)
 
@@ -248,7 +243,6 @@ class TestRebuildFromCheckpointer:
             compaction_threshold=0.5,
             db_path=temp_db,
             checkpointer=mock_checkpointer,
-            verbose=True,
         )
         middleware.set_model(mock_model)
 
@@ -281,7 +275,6 @@ class TestMultipleThreadsIsolated:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware.set_model(mock_model)
 
@@ -341,7 +334,6 @@ class TestCompactionBreakerScope:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware.set_model(model)
 
@@ -390,7 +382,6 @@ class TestSummaryUpdateOnSecondCompaction:
             context_limit=10000,
             compaction_threshold=0.5,
             db_path=temp_db,
-            verbose=True,
         )
         middleware.set_model(mock_model)
 


### PR DESCRIPTION
## Summary
- remove unused verbose compatibility args from MemoryMiddleware and DangerousCommandsHook
- drop explicit default verbose wiring in agent/subagent/test setup
- remove success-path stdout noise from idle reaper and AgentBay link-url execution

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q tests/Unit/core/test_command_service.py tests/Unit/core/test_tool_registry_runner.py tests/Unit/integration_contracts/test_memory_middleware_integration.py tests/Integration/test_e2e_summary_persistence.py
- uv run python -m pytest -q
- git diff --check