### PR TITLE
chore: trim unused monitor verbose wiring

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -917,7 +917,6 @@ class LeonAgent:
         self._monitor_middleware = MonitorMiddleware(
             context_limit=context_limit,
             model_name=self.model_name,
-            verbose=self.verbose,
         )
         middleware.append(self._monitor_middleware)
 

--- a/core/runtime/middleware/monitor/middleware.py
+++ b/core/runtime/middleware/monitor/middleware.py
@@ -19,9 +19,7 @@ from .token_monitor import TokenMonitor
 class MonitorMiddleware(AgentMiddleware):
     tools = ()
 
-    def __init__(self, context_limit: int = 0, model_name: str = "", verbose: bool = False):
-        self.verbose = verbose
-
+    def __init__(self, context_limit: int = 0, model_name: str = ""):
         self._token_monitor = TokenMonitor()
         self._state_monitor = StateMonitor()
 

--- a/tests/Unit/core/test_agent_extraction_model.py
+++ b/tests/Unit/core/test_agent_extraction_model.py
@@ -10,7 +10,6 @@ class _ExtractionAgentProbe:
     def __init__(self, config: ModelsConfig, *, api_key: str | None = None) -> None:
         self.api_key = api_key
         self.models_config = config
-        self.verbose = False
         self._model_http_client = None
         self._model_http_async_client = None
 


### PR DESCRIPTION
## Summary
- remove unused MonitorMiddleware verbose constructor plumbing
- stop passing agent verbose into monitor setup
- drop unused verbose field from extraction-model test probe

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q tests/Unit/platform/test_model_config_enrichment.py tests/Unit/core/test_agent_extraction_model.py
- uv run python -m pytest -q
- git diff --check