### PR TITLE
chore: remove optional event bus import shim

### DIFF
--- a/backend/threads/run/buffer_wiring.py
+++ b/backend/threads/run/buffer_wiring.py
@@ -136,12 +136,9 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
     runtime._bound_thread_app = app
     qm.register_wake(thread_id, wake_handler)
 
-    try:
-        from backend.threads.event_bus import get_event_bus
+    from backend.threads.event_bus import get_event_bus
 
-        unsubscribe = getattr(runtime, "_thread_event_unsubscribe", None)
-        if callable(unsubscribe):
-            unsubscribe()
-        runtime._thread_event_unsubscribe = get_event_bus().subscribe(thread_id, activity_sink)
-    except ImportError:
-        pass
+    unsubscribe = getattr(runtime, "_thread_event_unsubscribe", None)
+    if callable(unsubscribe):
+        unsubscribe()
+    runtime._thread_event_unsubscribe = get_event_bus().subscribe(thread_id, activity_sink)


### PR DESCRIPTION
## Summary
- remove stale optional ImportError shim around backend thread event bus wiring
- let missing event bus fail loudly instead of silently dropping activity subscription

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q tests/Unit/backend/thread_runtime/run tests/Unit/integration_contracts/test_query_loop_backend_contracts.py
- uv run python -m pytest -q
- git diff --check