### PR TITLE
chore: trim success path log noise

### DIFF
--- a/backend/threads/chat_adapters/chat_handler.py
+++ b/backend/threads/chat_adapters/chat_handler.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import logging
-
 from backend.threads.chat_adapters.chat_runtime_services import AgentChatRuntimeServices
 from protocols import agent_runtime as agent_runtime_protocol
-
-logger = logging.getLogger(__name__)
 
 
 class NativeAgentChatDeliveryHandler:
@@ -20,14 +16,6 @@ class NativeAgentChatDeliveryHandler:
         from langchain_core.runnables.config import var_child_runnable_config  # pyright: ignore[reportMissingImports]
 
         var_child_runnable_config.set(None)
-
-        logger.info(
-            "[agent-runtime-gateway] dispatch_chat: recipient=%s user=%s thread=%s from=%s",
-            envelope.recipient.agent_user_id,
-            envelope.recipient.agent_user_id,
-            envelope.recipient.thread_id,
-            envelope.sender.display_name,
-        )
 
         thread_id = envelope.recipient.thread_id
         if not thread_id:

--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from enum import Enum
 from typing import Any
 
@@ -16,8 +15,6 @@ from protocols.agent_runtime import (
     AgentRuntimeMessage,
 )
 
-logger = logging.getLogger(__name__)
-
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
     import asyncio
@@ -25,7 +22,6 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
     if activity_reader is None:
         raise RuntimeError("Agent runtime thread activity reader is not configured")
     loop = asyncio.get_running_loop()
-    logger.info("[delivery] make_chat_delivery_fn: loop=%s", loop)
 
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
         raw_recipient_type = getattr(request.recipient_user, "type", None)
@@ -72,9 +68,7 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
         await get_agent_runtime_gateway(app).dispatch_chat(envelope)
 
     def _deliver(request: ChatDeliveryRequest) -> None:
-        logger.info("[delivery] _deliver called: recipient=%s", request.recipient_id)
         future = asyncio.run_coroutine_threadsafe(deliver_to_runtime_gateway(request), loop)
         future.result()
-        logger.info("[delivery] async delivery completed for %s", request.recipient_id)
 
     return _deliver

--- a/backend/threads/run/activity_bridge.py
+++ b/backend/threads/run/activity_bridge.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
-
-logger = logging.getLogger(__name__)
 
 
 def build_activity_bridge(
@@ -28,7 +25,6 @@ def build_activity_bridge(
                 act_event = activity_queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
-            logger.info("[stream:drain] emitting activity event: %s", act_event.get("event", "?"))
             await emit(act_event)
 
     def attach() -> None:

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
 
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
 from core.tools.task.types import Task, TaskStatus
 from storage.runtime import build_tool_task_repo
-
-logger = logging.getLogger(__name__)
 
 TASK_CREATE_SCHEMA = make_tool_schema(
     name="TaskCreate",
@@ -118,7 +115,6 @@ class TaskService:
         self._repo = repo or build_tool_task_repo()
         self._default_thread_id = thread_id  # override for tests / single-agent TUI
         self._register(registry)
-        logger.info("TaskService initialized")
 
     def _get_thread_id(self) -> str:
         if self._default_thread_id:

--- a/core/tools/tool_search/service.py
+++ b/core/tools/tool_search/service.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import json
-import logging
 
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
-
-logger = logging.getLogger(__name__)
 
 TOOL_SEARCH_SCHEMA = make_tool_schema(
     name="tool_search",
@@ -39,7 +36,6 @@ class ToolSearchService:
                 is_read_only=True,
             )
         )
-        logger.info("ToolSearchService initialized")
 
     def _search(self, query: str = "", tool_context=None) -> str:
         select_names: list[str] = []


### PR DESCRIPTION
## Summary
- remove success-path chat delivery info logs
- remove per-activity drain info log
- remove tool service initialization info logs

## Diff
- 5 files changed, 30 deletions

## Verification
- uv run python -m pytest -q tests/Unit/backend/thread_runtime/run/test_activity_bridge.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py tests/Unit/core/test_tool_registry_runner.py::TestToolSearchService tests/Unit/core/test_tool_registry_runner.py::TestServiceDeclaredToolModes::test_task_service_registers_deferred tests/Unit/core/test_tool_registry_runner.py::TestServiceDeclaredToolModes::test_task_service_read_only_queries_are_concurrency_safe
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check