### PR TITLE
chore: trim sync perf log noise

### DIFF
--- a/sandbox/sync/strategy.py
+++ b/sandbox/sync/strategy.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 def _native_upload(session_id: str, provider, workspace: Path, workspace_root: str, files: list[str]):
-    t0 = time.time()
-    total_bytes = 0
     # @@@mkdir-batch - collect all needed dirs, create in one command
     dirs_needed = {workspace_root}
     upload_items: list[tuple[str, bytes]] = []
@@ -32,20 +30,15 @@ def _native_upload(session_id: str, provider, workspace: Path, workspace_root: s
     provider.execute(session_id, "mkdir -p " + " ".join(sorted(dirs_needed)), timeout_ms=10000)
     for remote, data in upload_items:
         provider.upload_bytes(session_id, remote, data)
-        total_bytes += len(data)
-    logger.info("[SYNC-PERF] native_upload: %d files, %d bytes, %.3fs", len(files), total_bytes, time.time() - t0)
 
 
 def _native_download(session_id: str, provider, workspace: Path, workspace_root: str):
-    t0 = time.time()
     try:
         entries = provider.list_dir(session_id, workspace_root)
     except Exception:
-        logger.info("[SYNC] native_download skipped: cannot list %s", workspace_root)
         return
 
     workspace.mkdir(parents=True, exist_ok=True)
-    total_bytes = 0
     stack = [(workspace_root, entries)]
     while stack:
         current_remote, items = stack.pop()
@@ -64,12 +57,9 @@ def _native_download(session_id: str, provider, workspace: Path, workspace_root:
                 local = workspace / rel
                 local.parent.mkdir(parents=True, exist_ok=True)
                 try:
-                    data = provider.download_bytes(session_id, remote_path)
-                    local.write_bytes(data)
-                    total_bytes += len(data)
+                    local.write_bytes(provider.download_bytes(session_id, remote_path))
                 except Exception:
                     logger.warning("[SYNC] native_download: failed to download %s", remote_path, exc_info=True)
-    logger.info("[SYNC-PERF] native_download: %d bytes, %.3fs", total_bytes, time.time() - t0)
 
 
 def _pack_tar(workspace: Path, files: list[str]) -> bytes:
@@ -85,7 +75,6 @@ def _pack_tar(workspace: Path, files: list[str]) -> bytes:
 
 
 def _batch_upload_tar(session_id: str, provider, workspace: Path, workspace_root: str, files: list[str]):
-    t0 = time.time()
     tar_bytes = _pack_tar(workspace, files)
     if not tar_bytes or len(tar_bytes) < 10:
         return
@@ -102,15 +91,12 @@ def _batch_upload_tar(session_id: str, provider, workspace: Path, workspace_root
     if exit_code is not None and exit_code != 0:
         error_msg = getattr(result, "error", "") or getattr(result, "output", "")
         raise RuntimeError(f"Batch upload failed (exit {exit_code}): {error_msg}")
-    logger.info("[SYNC-PERF] batch_upload_tar: %d files, %d bytes tar, %.3fs", len(files), len(tar_bytes), time.time() - t0)
 
 
 def _batch_download_tar(session_id: str, provider, workspace: Path, workspace_root: str):
-    t0 = time.time()
     check = provider.execute(session_id, f"test -d {workspace_root} && echo EXISTS", timeout_ms=10000)
     check_out = (getattr(check, "output", "") or "").strip()
     if check_out != "EXISTS":
-        logger.info("[SYNC] download skipped: %s does not exist in sandbox", workspace_root)
         return
 
     cmd = f"cd {workspace_root} && tar czf - . | base64"
@@ -131,7 +117,6 @@ def _batch_download_tar(session_id: str, provider, workspace: Path, workspace_ro
     buf = io.BytesIO(tar_bytes)
     with tarfile.open(fileobj=buf, mode="r:gz") as tar:
         tar.extractall(path=str(workspace), filter="data")
-    logger.info("[SYNC-PERF] batch_download_tar: %d bytes, %.3fs", len(tar_bytes), time.time() - t0)
 
 
 class SyncStrategy(ABC):


### PR DESCRIPTION
## Summary
- remove sync success-path perf timing logs
- remove no-op download skipped info logs
- keep warnings and RuntimeError failure diagnostics intact

## Diff
- 1 file changed, 1 insertion, 16 deletions

## Verification
- uv run python -m pytest -q tests/Unit/sandbox/test_sync_manager.py tests/Unit/sandbox/test_sync_state.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check