### PR TITLE
chore: trim init success log noise

### DIFF
--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -96,7 +96,6 @@ class SummaryStore:
                     created_at=now,
                 )
 
-                logger.info(f"[SummaryStore] Saved summary {summary_id} for thread {thread_id}")
                 return summary_id
 
             except Exception as e:
@@ -161,5 +160,3 @@ class SummaryStore:
 
     def delete_thread_summaries(self, thread_id: str) -> None:
         self._repo.delete_thread_summaries(thread_id)
-
-        logger.info(f"[SummaryStore] Deleted all summaries for thread {thread_id}")

--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import logging
 import os
 from pathlib import Path
 
 from sandbox.base import LocalSandbox, RemoteSandbox, Sandbox
 from sandbox.config import SandboxConfig, resolve_sandbox_name
 from sandbox.thread_context import get_current_thread_id, set_current_thread_id
-
-logger = logging.getLogger(__name__)
 
 
 def create_sandbox(
@@ -28,7 +25,6 @@ def create_sandbox(
         api_key = ab.api_key or os.getenv("AGENTBAY_API_KEY")
         if not api_key:
             raise ValueError("AgentBay sandbox requires AGENTBAY_API_KEY")
-        logger.info("[AgentBaySandbox] Initialized (region=%s)", ab.region_id)
         return RemoteSandbox(
             provider=AgentBayProvider(
                 api_key=api_key,
@@ -49,7 +45,6 @@ def create_sandbox(
         from sandbox.providers.docker import DockerProvider
 
         dc = config.docker
-        logger.info("[DockerSandbox] Initialized (image=%s)", dc.image)
         return RemoteSandbox(
             provider=DockerProvider(image=dc.image, mount_path=dc.mount_path, provider_name=config.name),
             config=config,
@@ -67,7 +62,6 @@ def create_sandbox(
         api_key = e.api_key or os.getenv("E2B_API_KEY")
         if not api_key:
             raise ValueError("E2B sandbox requires E2B_API_KEY")
-        logger.info("[E2BSandbox] Initialized (template=%s)", e.template)
         return RemoteSandbox(
             provider=E2BProvider(
                 api_key=api_key,
@@ -91,7 +85,6 @@ def create_sandbox(
         api_key = dt.api_key or os.getenv("DAYTONA_API_KEY")
         if not api_key:
             raise ValueError("Daytona sandbox requires DAYTONA_API_KEY")
-        logger.info("[DaytonaSandbox] Initialized (target=%s)", dt.target)
         return RemoteSandbox(
             provider=DaytonaProvider(
                 api_key=api_key,


### PR DESCRIPTION
## Summary
- remove SummaryStore success-path info logs
- remove sandbox provider initialization info logs
- keep warning/error/exception diagnostics intact

## Diff
- 2 files changed, 10 deletions

## Verification
- uv run python -m pytest -q tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_memory_middleware_integration.py tests/Integration/test_e2e_summary_persistence.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/sandbox/test_sandbox_manager_provider_runtimes.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check