### PR TITLE
chore: trim trace log noise

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import logging
 import os
 import time
 from pathlib import Path
@@ -15,8 +14,6 @@ import backend.library.paths as _lib_paths
 from backend.hub.versioning import BumpType, bump_semver
 from config.loader import load_bundle_from_repo
 from config.types import AgentBundle
-
-logger = logging.getLogger(__name__)
 
 HUB_URL = os.environ.get("MYCEL_HUB_URL", "https://hub.mycel.nextmind.space")
 # @@@hub-agent-user-item-type - Hub still names published Agent users "member";
@@ -289,7 +286,6 @@ def download(
                     },
                 },
             )
-            logger.info("Installed skill %s to agent user %s", skill_name, agent_user_id)
             return {"resource_id": skill_name, "type": "skill", "version": installed_version, "agent_user_id": agent_user_id}
 
         slug = item.get("slug", item["name"].lower().replace(" ", "-"))
@@ -315,7 +311,6 @@ def download(
             },
         }
         _write_json(skill_dir / "meta.json", meta_data)
-        logger.info("Downloaded skill %s to library", slug)
         return {"resource_id": slug, "type": "skill", "version": installed_version}
 
     if item_type == "agent":
@@ -341,7 +336,6 @@ def download(
             },
         }
         _write_json(agent_dir / f"{slug}.json", meta_data)
-        logger.info("Downloaded agent %s to library", slug)
         return {"resource_id": slug, "type": "agent", "version": installed_version}
 
     if item_type == HUB_AGENT_USER_ITEM_TYPE:

--- a/backend/threads/run/stream_loop.py
+++ b/backend/threads/run/stream_loop.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import random
 from typing import Any
 
 from backend.threads.message_content import extract_text_content
-
-logger = logging.getLogger(__name__)
 
 
 def _is_retryable_stream_error(err: Exception) -> bool:
@@ -42,7 +39,6 @@ async def run_stream_loop(
     max_stream_retries: int = 10,
 ) -> str:
     async def run_agent_stream(input_data: dict | None = initial_input):
-        chunk_count = 0
         # @@@astream-reentry — LangGraph's astream(input) silently returns
         # 0 chunks when the graph is at __end__ (completed previous run).
         # The fix: always use aupdate_state to inject input, then astream(None).
@@ -60,9 +56,7 @@ async def run_stream_loop(
             config=config,
             stream_mode=["messages", "updates"],
         ):
-            chunk_count += 1
             yield chunk
-        logger.debug("[stream] thread=%s STREAM DONE chunks=%d", thread_id[:15], chunk_count)
 
     stream_attempt = 0
     stream_gen = None
@@ -193,14 +187,6 @@ async def run_stream_loop(
                                     tc_id = tc.get("id")
                                     tc_name = tc.get("name", "unknown")
                                     full_args = tc.get("args", {})
-                                    logger.debug(
-                                        "[stream:update] tc=%s name=%s dup=%s chk=%s thread=%s",
-                                        tc_id or "?",
-                                        tc_name,
-                                        dedup.already_emitted(tc_id),
-                                        dedup.is_duplicate(tc_id),
-                                        thread_id,
-                                    )
                                     # @@@checkpoint-dedup — skip tool_calls from previous runs
                                     # but allow current run's updates (delivers full args after early emission)
                                     if dedup.is_duplicate(tc_id):

--- a/core/identity/agent_registry.py
+++ b/core/identity/agent_registry.py
@@ -56,5 +56,4 @@ def get_or_create_agent_id(
 
     instances[agent_id] = entry
     _save(instances)
-    logger.info("Created agent identity %s for user_id=%s thread=%s", agent_id, user_id, thread_id)
     return agent_id

--- a/core/tools/command/service.py
+++ b/core/tools/command/service.py
@@ -158,7 +158,6 @@ class CommandService:
         from sandbox.thread_context import get_current_thread_id
 
         parent_thread_id = get_current_thread_id()
-        logger.debug("[CommandService] _execute_async: parent_thread_id=%s task_id=%s", parent_thread_id, task_id)
         if parent_thread_id and self._event_bus_factory is not None:
             event_bus = self._event_bus_factory()
             emit_fn = event_bus.make_emitter(

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -417,12 +417,10 @@ class _LSPSessionPool:
         if key not in self._starting:
 
             async def _start() -> _LSPSession:
-                logger.info("[LSPPool] starting %s language server (workspace=%s)...", language, workspace_root)
                 s = _LSPSession(language, workspace_root)
                 await s.start()
                 self._sessions[key] = s
                 self._starting.pop(key, None)
-                logger.info("[LSPPool] %s language server ready", language)
                 return s
 
             self._starting[key] = asyncio.create_task(_start(), name=f"lsp-start-{language}")
@@ -434,12 +432,10 @@ class _LSPSessionPool:
         if workspace_root not in self._starting_pyright:
 
             async def _start() -> _PyrightSession:
-                logger.info("[LSPPool] starting pyright (workspace=%s)...", workspace_root)
                 s = _PyrightSession(workspace_root)
                 await s.start()
                 self._pyright[workspace_root] = s
                 self._starting_pyright.pop(workspace_root, None)
-                logger.info("[LSPPool] pyright ready")
                 return s
 
             self._starting_pyright[workspace_root] = asyncio.create_task(_start(), name="lsp-start-pyright")


### PR DESCRIPTION
## Summary
- remove success-path hub install/download logs
- remove agent registry creation success log
- remove LSP startup info logs
- remove command async and stream debug trace logs

## Diff
- 5 commits
- 5 files changed, 26 deletions

## Verification
- uv run python -m pytest -q tests/Unit/platform/test_marketplace_client.py tests/Unit/core/test_agent_registry.py tests/Unit/platform/test_lsp_service.py tests/Unit/core/test_command_service.py tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check

## Dev sync
- origin/dev checked before work and before push: 3bd9e6007ce16abc994e8b2953ad753649c230c7