### PR TITLE
Add public external agent auth

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -31,7 +31,7 @@ class CreateChatBody(BaseModel):
 
 class SendMessageBody(BaseModel):
     content: str
-    sender_id: str
+    sender_id: str | None = None
     mentioned_ids: list[str] | None = None
     message_type: str = "human"
     signal: str | None = None
@@ -195,10 +195,11 @@ def send_message(
 ):
     if not body.content.strip():
         raise HTTPException(400, "Content cannot be empty")
-    _verify_user_ownership(messaging_service, body.sender_id, user_id)
+    sender_id = body.sender_id or user_id
+    _verify_user_ownership(messaging_service, sender_id, user_id)
     msg = messaging_service.send(
         chat_id,
-        body.sender_id,
+        sender_id,
         body.content,
         mentions=body.mentioned_ids,
         signal=body.signal,

--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 SUPABASE_JWT_ALGORITHM = "HS256"
 
 
+class ExternalUserAlreadyExistsError(ValueError):
+    pass
+
+
 class AuthService:
     def __init__(
         self,
@@ -184,6 +188,44 @@ class AuthService:
             raise ValueError("Token 已过期，请重新登录")
         except jwt.InvalidTokenError as e:
             raise ValueError(f"Token 无效: {e}")
+
+    def create_external_user_token(self, user_id: str, display_name: str, *, created_by_user_id: str) -> dict:
+        external_user_id = user_id.strip()
+        external_display_name = display_name.strip()
+        if not external_user_id:
+            raise ValueError("external user_id is required")
+        if not external_display_name:
+            raise ValueError("external display_name is required")
+        if self._users.get_by_id(external_user_id) is not None:
+            raise ExternalUserAlreadyExistsError(f"external user already exists: {external_user_id}")
+
+        jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
+        if not jwt_secret:
+            raise RuntimeError("SUPABASE_JWT_SECRET env var required for external user token creation.")
+
+        now = time.time()
+        self._users.create(
+            UserRow(
+                id=external_user_id,
+                type=UserType.EXTERNAL,
+                display_name=external_display_name,
+                created_at=now,
+            )
+        )
+        token = jwt.encode(
+            {
+                "sub": external_user_id,
+                "iat": int(now),
+                "mycel_user_type": "external",
+                "created_by_user_id": created_by_user_id,
+            },
+            jwt_secret,
+            algorithm=SUPABASE_JWT_ALGORITHM,
+        )
+        return {
+            "token": token,
+            "user": {"id": external_user_id, "name": external_display_name, "type": "external"},
+        }
 
     def _resolve_email(self, identifier: str) -> str:
         if identifier.strip().lstrip("0123456789") == "" and identifier.strip().isdigit():

--- a/backend/web/routers/auth.py
+++ b/backend/web/routers/auth.py
@@ -6,7 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.identity.auth.dependencies import _get_auth_service
-from backend.web.core.dependencies import get_app
+from backend.identity.auth.service import ExternalUserAlreadyExistsError
+from backend.web.core.dependencies import get_app, get_current_user, get_current_user_id
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -75,3 +76,41 @@ async def login(payload: LoginRequest, app: Annotated[Any, Depends(get_app)]) ->
         401,
         lambda service: service.login(payload.identifier, payload.password),
     )
+
+
+class CreateExternalUserRequest(BaseModel):
+    user_id: str
+    display_name: str
+
+
+@router.get("/me")
+async def me(user: Annotated[Any, Depends(get_current_user)]) -> dict:
+    user_type = getattr(user.type, "value", user.type)
+    return {
+        "id": user.id,
+        "name": user.display_name,
+        "type": user_type,
+        "email": user.email,
+        "mycel_id": user.mycel_id,
+        "avatar": user.avatar,
+    }
+
+
+@router.post("/external-users")
+async def create_external_user(
+    payload: CreateExternalUserRequest,
+    app: Annotated[Any, Depends(get_app)],
+    current_user_id: Annotated[str, Depends(get_current_user_id)],
+) -> dict:
+    try:
+        return await asyncio.to_thread(
+            lambda: _get_auth_service(app).create_external_user_token(
+                payload.user_id,
+                payload.display_name,
+                created_by_user_id=current_user_id,
+            )
+        )
+    except ExternalUserAlreadyExistsError as e:
+        raise HTTPException(409, str(e))
+    except ValueError as e:
+        raise HTTPException(400, str(e))

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -34,3 +34,20 @@ def test_chat_app_router_does_not_mount_internal_http_surface() -> None:
 
     assert not [path for path in spec["paths"] if path.startswith(forbidden_prefix)]
     assert forbidden_schema not in spec.get("components", {}).get("schemas", {})
+
+
+def test_auth_router_exposes_public_external_agent_contract() -> None:
+    from backend.web.routers import auth
+
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+
+    assert "/api/auth/me" in paths
+    assert "/api/auth/external-users" in paths
+    assert not [path for path in paths if path.startswith("/api/" + "internal")]

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -8,6 +8,7 @@ import jwt
 import pytest
 
 from backend.identity.auth.service import AuthService
+from storage.contracts import UserType
 
 
 class _FakeSupabaseAuth:
@@ -152,6 +153,51 @@ def test_verify_token_accepts_supabase_iat_clock_boundary(monkeypatch: pytest.Mo
     payload = _service().verify_token(token)
 
     assert payload == {"user_id": "user-local"}
+
+
+def test_create_external_user_token_creates_external_user_and_signed_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-1")
+    created_rows: list[Any] = []
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: None if user_id == "external-codex-1" else SimpleNamespace(id=user_id),
+        create=lambda row: created_rows.append(row),
+    )
+
+    result = _service(user_repo=user_repo).create_external_user_token(
+        "external-codex-1",
+        "Codex Local",
+        created_by_user_id="owner-1",
+    )
+
+    assert len(created_rows) == 1
+    assert created_rows[0].id == "external-codex-1"
+    assert created_rows[0].type is UserType.EXTERNAL
+    assert created_rows[0].display_name == "Codex Local"
+    decoded = jwt.decode(result["token"], "secret-1", algorithms=["HS256"], options={"verify_aud": False})
+    assert decoded["sub"] == "external-codex-1"
+    assert decoded["mycel_user_type"] == "external"
+    assert decoded["created_by_user_id"] == "owner-1"
+    assert _service(user_repo=user_repo).verify_token(result["token"]) == {"user_id": "external-codex-1"}
+    assert result["user"] == {"id": "external-codex-1", "name": "Codex Local", "type": "external"}
+
+
+def test_create_external_user_token_rejects_existing_user(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-1")
+    created_rows: list[Any] = []
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: SimpleNamespace(id=user_id),
+        create=lambda row: created_rows.append(row),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _service(user_repo=user_repo).create_external_user_token(
+            "external-codex-1",
+            "Codex Local",
+            created_by_user_id="owner-1",
+        )
+
+    assert "already exists" in str(exc_info.value)
+    assert created_rows == []
 
 
 def test_verify_token_fails_loudly_when_secret_missing_even_with_auth_client(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Unit/integration_contracts/test_auth_router.py
+++ b/tests/Unit/integration_contracts/test_auth_router.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from backend.chat.api.http import chats_router
+from backend.identity.auth.service import ExternalUserAlreadyExistsError
 from backend.web.routers import auth as auth_router
 
 
@@ -13,9 +15,15 @@ class _FakeAuthService:
     def __init__(self) -> None:
         self.send_otp_calls: list[tuple[str, str, str]] = []
         self.login_calls: list[tuple[str, str]] = []
+        self.create_external_user_token_calls: list[tuple[str, str, str]] = []
         self.login_result = {"token": "tok-login"}
+        self.create_external_user_token_result = {
+            "token": "tok-external",
+            "user": {"id": "external-1", "name": "Codex Local", "type": "external"},
+        }
         self.send_otp_error: Exception | None = None
         self.login_error: Exception | None = None
+        self.create_external_user_token_error: Exception | None = None
 
     def send_otp(self, email: str, password: str, invite_code: str) -> None:
         self.send_otp_calls.append((email, password, invite_code))
@@ -27,6 +35,12 @@ class _FakeAuthService:
         if self.login_error is not None:
             raise self.login_error
         return self.login_result
+
+    def create_external_user_token(self, user_id: str, display_name: str, *, created_by_user_id: str) -> dict:
+        self.create_external_user_token_calls.append((user_id, display_name, created_by_user_id))
+        if self.create_external_user_token_error is not None:
+            raise self.create_external_user_token_error
+        return self.create_external_user_token_result
 
 
 @pytest.mark.asyncio
@@ -70,6 +84,87 @@ async def test_login_maps_value_error_to_unauthorized():
 
     assert exc_info.value.status_code == 401
     assert "Invalid username or password" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_external_user_calls_auth_service_with_current_user():
+    service = _FakeAuthService()
+    app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
+
+    result = await auth_router.create_external_user(
+        auth_router.CreateExternalUserRequest(user_id="external-1", display_name="Codex Local"),
+        app,
+        current_user_id="owner-1",
+    )
+
+    assert result == service.create_external_user_token_result
+    assert service.create_external_user_token_calls == [("external-1", "Codex Local", "owner-1")]
+
+
+@pytest.mark.asyncio
+async def test_auth_me_returns_authenticated_user_identity():
+    result = await auth_router.me(
+        SimpleNamespace(
+            id="external-1",
+            display_name="Codex Local",
+            type=SimpleNamespace(value="external"),
+            email=None,
+            mycel_id=None,
+            avatar=None,
+        )
+    )
+
+    assert result == {
+        "id": "external-1",
+        "name": "Codex Local",
+        "type": "external",
+        "email": None,
+        "mycel_id": None,
+        "avatar": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_external_user_maps_duplicate_to_conflict():
+    service = _FakeAuthService()
+    service.create_external_user_token_error = ExternalUserAlreadyExistsError("external user already exists: external-1")
+    app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_router.create_external_user(
+            auth_router.CreateExternalUserRequest(user_id="external-1", display_name="Codex Local"),
+            app,
+            current_user_id="owner-1",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "already exists" in str(exc_info.value.detail)
+
+
+def test_create_external_user_route_requires_current_user_dependency():
+    service = _FakeAuthService()
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(auth_service=service)
+    app.include_router(auth_router.router)
+
+    with TestClient(app) as client:
+        response = client.post("/api/auth/external-users", json={"user_id": "external-1", "display_name": "Codex Local"})
+
+    assert response.status_code == 401
+    assert service.create_external_user_token_calls == []
+
+
+def test_create_external_user_openapi_is_public_auth_surface():
+    app = FastAPI()
+    app.include_router(auth_router.router)
+
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    assert "/api/auth/external-users" in paths
+    assert not [path for path in paths if path.startswith("/api/" + "internal")]
 
 
 class _ChatEventBus:

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -517,6 +517,84 @@ def test_send_message_consumes_service_owned_message_projection() -> None:
     }
 
 
+def test_send_message_defaults_sender_to_authenticated_user() -> None:
+    seen: list[tuple[str, str, str]] = []
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: (
+            SimpleNamespace(
+                id="external-user-1",
+                display_name="Codex Local",
+                type="external",
+                avatar=None,
+                owner_user_id=None,
+            )
+            if uid == "external-user-1"
+            else None
+        ),
+        send=lambda chat_id, sender_id, content, **_kwargs: (
+            seen.append((chat_id, sender_id, content))
+            or {
+                "id": "msg-1",
+                "chat_id": chat_id,
+                "sender_id": sender_id,
+                "content": content,
+                "message_type": "human",
+                "created_at": "2026-04-07T00:00:00Z",
+            }
+        ),
+        project_message_response=lambda msg: {
+            "id": msg["id"],
+            "chat_id": msg["chat_id"],
+            "sender_id": msg["sender_id"],
+            "sender_name": "Codex Local",
+            "content": msg["content"],
+            "message_type": msg["message_type"],
+            "mentioned_ids": [],
+            "signal": None,
+            "retracted_at": None,
+            "created_at": msg["created_at"],
+        },
+    )
+
+    result = chats_router.send_message(
+        "chat-1",
+        chats_router.SendMessageBody(content="hello"),
+        user_id="external-user-1",
+        messaging_service=messaging_service,
+    )
+
+    assert seen == [("chat-1", "external-user-1", "hello")]
+    assert result["sender_id"] == "external-user-1"
+
+
+def test_send_message_still_rejects_unowned_explicit_sender_id() -> None:
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: (
+            SimpleNamespace(
+                id="other-user-1",
+                display_name="Other User",
+                type="external",
+                avatar=None,
+                owner_user_id=None,
+            )
+            if uid == "other-user-1"
+            else None
+        ),
+        send=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("send should not be called")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        chats_router.send_message(
+            "chat-1",
+            chats_router.SendMessageBody(content="hello", sender_id="other-user-1"),
+            user_id="external-user-1",
+            messaging_service=messaging_service,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "does not belong" in str(exc_info.value.detail)
+
+
 def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
     seen: list[tuple[str, str, str]] = []
     app = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add public authenticated external-user token issuance under /api/auth/external-users
- add /api/auth/me for token-derived SDK/CLI identity
- let public chat send default sender_id to the authenticated user while preserving ownership checks for explicit sender overrides

## Verification
- rg -n "api/internal|chat-internal|InternalSendMessageBody|internal_identity_router|internal_messaging_router" backend tests -g '*.py' -g '*.md' -g '*.json' || true
- uv run ruff check backend tests
- uv run pytest -q