### PR TITLE
chore: trim runtime trace logs

### DIFF
--- a/backend/threads/chat_adapters/thread_handler.py
+++ b/backend/threads/chat_adapters/thread_handler.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any
 
 from core.runtime.middleware.monitor import AgentState
 from protocols import agent_runtime as agent_runtime_protocol
-
-logger = logging.getLogger(__name__)
 
 
 class NativeAgentThreadInputHandler:
@@ -51,9 +48,8 @@ class NativeAgentThreadInputHandler:
                 return agent_runtime_protocol.AgentThreadInputResult(status="cancelled", routing="cancelled", thread_id=thread_id)
 
             state = agent.runtime.current_state
-            logger.debug("[agent-runtime-gateway] thread=%s state=%s source=%s", thread_id[:15], state, envelope.sender.source)
 
-            if agent.runtime.current_state == AgentState.ACTIVE:
+            if state == AgentState.ACTIVE:
                 qm.enqueue(
                     envelope.message.content,
                     thread_id,
@@ -63,7 +59,6 @@ class NativeAgentThreadInputHandler:
                     sender_avatar_url=envelope.sender.avatar_url,
                     is_steer=True,
                 )
-                logger.debug("[agent-runtime-gateway] thread input enqueued")
                 return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
 
             locks = self._thread_locks
@@ -80,9 +75,7 @@ class NativeAgentThreadInputHandler:
                         sender_avatar_url=envelope.sender.avatar_url,
                         is_steer=True,
                     )
-                    logger.debug("[agent-runtime-gateway] thread input enqueued after transition race")
                     return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
-                logger.debug("[agent-runtime-gateway] thread input starts run")
                 meta = {
                     "source": envelope.sender.source,
                     "sender_name": envelope.sender.display_name,

--- a/backend/threads/run/execution.py
+++ b/backend/threads/run/execution.py
@@ -106,7 +106,6 @@ async def run_agent_to_buffer(
             await dedup.prepopulate_from_checkpoint(agent, config)
         except Exception:
             logger.warning("[stream:checkpoint] failed to pre-populate tc_ids for thread=%s", thread_id[:15], exc_info=True)
-        logger.debug("[stream:checkpoint] thread=%s pre-populated dedup state", thread_id[:15])
 
         await repair_incomplete_tool_calls(agent, config)
 

--- a/core/runtime/middleware/queue/middleware.py
+++ b/core/runtime/middleware/queue/middleware.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -15,8 +14,6 @@ from core.runtime.middleware import (
 from core.runtime.notifications import is_terminal_background_notification
 
 from .manager import MessageQueueManager
-
-logger = logging.getLogger(__name__)
 
 _STEER_NON_PREEMPTIVE_SYSTEM_NOTE = (
     "Steer requests accepted during an active run are non-preemptive. "
@@ -90,7 +87,6 @@ class SteeringMiddleware(AgentMiddleware):
     ) -> dict[str, Any] | None:
         thread_id = (config or {}).get("configurable", {}).get("thread_id")
         if not thread_id:
-            logger.debug("SteeringMiddleware: no thread_id in config, skipping steer injection")
             return None
 
         items = self._queue_manager.drain_all(thread_id)

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -445,16 +445,14 @@ class _LSPSessionPool:
         for (lang, ws), session in list(self._sessions.items()):
             try:
                 await session.stop()
-                logger.debug("[LSPPool] stopped %s server (workspace=%s)", lang, ws)
-            except Exception as e:
-                logger.debug("[LSPPool] error stopping %s: %s", lang, e)
+            except Exception:
+                pass
         self._sessions.clear()
         for ws, session in list(self._pyright.items()):
             try:
                 await session.stop()
-                logger.debug("[LSPPool] stopped pyright (workspace=%s)", ws)
-            except Exception as e:
-                logger.debug("[LSPPool] error stopping pyright: %s", e)
+            except Exception:
+                pass
         self._pyright.clear()
 
 

--- a/core/tools/lsp/service.py
+++ b/core/tools/lsp/service.py
@@ -478,7 +478,6 @@ class LSPService:
                 is_concurrency_safe=True,
             )
         )
-        logger.debug("[LSPService] registered (workspace=%s)", self._workspace_root)
 
     async def _get_session(self, language: str) -> _LSPSession:
         return await lsp_pool.get_session(language, self._workspace_root)


### PR DESCRIPTION
## Summary
- remove steering skip debug trace
- remove runtime thread input debug traces
- remove checkpoint prepopulate success debug trace
- remove LSP shutdown/registration debug traces

## Diff
- 5 commits
- 4 files changed, 5 insertions, 20 deletions

## Verification
- uv run python -m pytest -q tests/Unit/backend/test_thread_input_handler.py tests/Unit/platform/test_lsp_service.py tests/Unit/integration_contracts/test_background_task_cleanup.py tests/Unit/backend/thread_runtime/run/test_tool_call_dedup.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check

## Dev sync
- rebased after origin/dev moved to 90c0e597575bf267e40c7363c803e1071e3f0897
- rebased again after origin/dev moved to 8eeaf670edc20ab128bbb3ff6bc7dbde4630e054
- verified origin/dev remained 8eeaf670edc20ab128bbb3ff6bc7dbde4630e054 before push