### PR TITLE
Expose public chat unread and caught-up send

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -18,6 +18,7 @@ from backend.chat.api.http.dependencies import (
     get_thread_repo,
     get_user_repo,
 )
+from messaging.errors import ChatNotCaughtUpError
 from messaging.social_access import can_group_chat_with_participant
 from messaging.user_ownership import is_owned_by_viewer
 
@@ -35,6 +36,8 @@ class SendMessageBody(BaseModel):
     mentioned_ids: list[str] | None = None
     message_type: str = "human"
     signal: str | None = None
+    reply_to: str | None = None
+    enforce_caught_up: bool = False
 
 
 class MuteChatBody(BaseModel):
@@ -197,15 +200,31 @@ def send_message(
         raise HTTPException(400, "Content cannot be empty")
     sender_id = body.sender_id or user_id
     _verify_user_ownership(messaging_service, sender_id, user_id)
-    msg = messaging_service.send(
-        chat_id,
-        sender_id,
-        body.content,
-        mentions=body.mentioned_ids,
-        signal=body.signal,
-        message_type=body.message_type,
-    )
+    try:
+        msg = messaging_service.send(
+            chat_id,
+            sender_id,
+            body.content,
+            mentions=body.mentioned_ids,
+            signal=body.signal,
+            message_type=body.message_type,
+            reply_to=body.reply_to,
+            enforce_caught_up=body.enforce_caught_up,
+        )
+    except ChatNotCaughtUpError as exc:
+        raise HTTPException(409, str(exc)) from exc
     return messaging_service.project_message_response(msg)
+
+
+@router.get("/{chat_id}/messages/unread")
+def list_unread_messages(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+):
+    if not messaging_service.is_chat_member(chat_id, user_id):
+        raise HTTPException(403, "Not a participant of this chat")
+    return [messaging_service.project_message_response(msg) for msg in messaging_service.list_unread(chat_id, user_id)]
 
 
 @router.post("/{chat_id}/messages/{message_id}/retract")

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -15,6 +15,7 @@ def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> N
     paths = response.json()["paths"]
 
     assert "/api/chats" in paths
+    assert "/api/chats/{chat_id}/messages/unread" in paths
     assert "/api/relationships" in paths
     assert "/api/conversations" in paths
 

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -595,6 +595,83 @@ def test_send_message_still_rejects_unowned_explicit_sender_id() -> None:
     assert "does not belong" in str(exc_info.value.detail)
 
 
+def test_send_message_can_enforce_authenticated_user_caught_up_state() -> None:
+    seen: list[dict[str, object]] = []
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: SimpleNamespace(id=uid, owner_user_id=None),
+        send=lambda chat_id, sender_id, content, **kwargs: (
+            seen.append({"chat_id": chat_id, "sender_id": sender_id, "content": content, **kwargs})
+            or {
+                "id": "msg-1",
+                "chat_id": chat_id,
+                "sender_id": sender_id,
+                "content": content,
+                "message_type": "human",
+                "created_at": "2026-04-07T00:00:00Z",
+            }
+        ),
+        project_message_response=lambda msg: msg,
+    )
+
+    chats_router.send_message(
+        "chat-1",
+        chats_router.SendMessageBody(content="hello", enforce_caught_up=True, reply_to="msg-0"),
+        user_id="external-user-1",
+        messaging_service=messaging_service,
+    )
+
+    assert seen == [
+        {
+            "chat_id": "chat-1",
+            "sender_id": "external-user-1",
+            "content": "hello",
+            "mentions": None,
+            "signal": None,
+            "message_type": "human",
+            "reply_to": "msg-0",
+            "enforce_caught_up": True,
+        }
+    ]
+
+
+def test_send_message_maps_caught_up_conflict_to_409() -> None:
+    from messaging.errors import ChatNotCaughtUpError
+
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: SimpleNamespace(id=uid, owner_user_id=None),
+        send=lambda *_args, **_kwargs: (_ for _ in ()).throw(ChatNotCaughtUpError("read unread messages first")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        chats_router.send_message(
+            "chat-1",
+            chats_router.SendMessageBody(content="hello", enforce_caught_up=True),
+            user_id="external-user-1",
+            messaging_service=messaging_service,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "read unread" in str(exc_info.value.detail)
+
+
+def test_list_unread_messages_uses_authenticated_user_membership() -> None:
+    seen: list[tuple[str, str]] = []
+    messaging_service = SimpleNamespace(
+        is_chat_member=lambda chat_id, user_id: seen.append((chat_id, user_id)) or True,
+        list_unread=lambda chat_id, user_id: [{"id": "msg-1", "chat_id": chat_id, "sender_id": "human-1"}],
+        project_message_response=lambda msg: {"id": msg["id"], "chat_id": msg["chat_id"], "sender_id": msg["sender_id"]},
+    )
+
+    result = chats_router.list_unread_messages(
+        "chat-1",
+        user_id="external-user-1",
+        messaging_service=messaging_service,
+    )
+
+    assert seen == [("chat-1", "external-user-1")]
+    assert result == [{"id": "msg-1", "chat_id": "chat-1", "sender_id": "human-1"}]
+
+
 def test_send_message_accepts_owned_thread_user_sender_id_via_thread_repo():
     seen: list[tuple[str, str, str]] = []
     app = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add public authenticated unread message list for chats
- let public message send pass reply_to and enforce_caught_up into messaging service
- map caught-up conflicts to HTTP 409 for SDK/CLI clients

## Verification
- rg -n "api/internal|chat-internal|InternalSendMessageBody|internal_identity_router|internal_messaging_router" backend tests -g '*.py' -g '*.md' -g '*.json' || true
- uv run pytest tests/Unit/integration_contracts/test_messaging_router.py::test_send_message_can_enforce_authenticated_user_caught_up_state tests/Unit/integration_contracts/test_messaging_router.py::test_send_message_maps_caught_up_conflict_to_409 tests/Unit/integration_contracts/test_messaging_router.py::test_list_unread_messages_uses_authenticated_user_membership tests/Integration/test_chat_app_router.py -q
- uv run ruff check backend tests
- uv run pytest -q