### PR TITLE
Fix skill adjacent file path normalization

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -83,7 +83,7 @@ def _skill_files_from_snapshot(snapshot: dict[str, Any]) -> dict[str, str]:
         return {}
     if not isinstance(files, dict):
         raise ValueError("Skill snapshot files must be an object")
-    return {str(path): str(content) for path, content in files.items()}
+    return {str(path).replace("\\", "/"): str(content) for path, content in files.items()}
 
 
 def list_items(

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -6,6 +6,12 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 
+def _normalize_skill_file_paths(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    return {str(path).replace("\\", "/"): content for path, content in value.items()}
+
+
 class Skill(BaseModel):
     id: str
     owner_user_id: str
@@ -25,6 +31,11 @@ class Skill(BaseModel):
             raise ValueError(f"skill.{info.field_name} must not be blank")
         return value
 
+    @field_validator("files", mode="before")
+    @classmethod
+    def _normalize_files(cls, value: Any) -> Any:
+        return _normalize_skill_file_paths(value)
+
 
 class AgentSkill(BaseModel):
     id: str | None = None
@@ -43,6 +54,11 @@ class AgentSkill(BaseModel):
         if not value.strip():
             raise ValueError(f"agent_skill.{info.field_name} must not be blank")
         return value
+
+    @field_validator("files", mode="before")
+    @classmethod
+    def _normalize_files(cls, value: Any) -> Any:
+        return _normalize_skill_file_paths(value)
 
 
 class AgentRule(BaseModel):

--- a/config/loader.py
+++ b/config/loader.py
@@ -307,7 +307,7 @@ class AgentLoader:
                 if not file_path.is_file() or file_path.name == "SKILL.md":
                     continue
                 try:
-                    files[str(file_path.relative_to(skill_dir))] = file_path.read_text(encoding="utf-8")
+                    files[file_path.relative_to(skill_dir).as_posix()] = file_path.read_text(encoding="utf-8")
                 except UnicodeDecodeError as exc:
                     raise RuntimeError(f"Local Skill adjacent file could not be read: {file_path}") from exc
             skills.append(

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -54,7 +54,7 @@ class SkillsService:
             self._inline_skills[skill_name] = content
             files = skill.get("files")
             if isinstance(files, dict):
-                self._inline_skill_files[skill_name] = {str(path): str(body) for path, body in files.items()}
+                self._inline_skill_files[skill_name] = {str(path).replace("\\", "/"): str(body) for path, body in files.items()}
             elif files is not None:
                 raise ValueError("Inline Skill files must be an object")
 

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -35,7 +35,7 @@ def _read_files(skill_dir: Path) -> dict[str, str]:
         if not path.is_file() or path.name == "SKILL.md":
             continue
         try:
-            files[str(path.relative_to(skill_dir))] = path.read_text(encoding="utf-8")
+            files[path.relative_to(skill_dir).as_posix()] = path.read_text(encoding="utf-8")
         except UnicodeDecodeError as exc:
             raise RuntimeError(f"Skill adjacent file could not be read: {path}") from exc
     return files

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -1,7 +1,8 @@
 import json
 import os
 import sys
-from pathlib import Path
+from os import PathLike
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -287,6 +288,27 @@ def test_load_resolved_config_from_dir_reads_local_agent_config(tmp_path: Path) 
     agent_names = {agent.name for agent in resolved.sub_agents}
     assert {"bash", "explore", "general", "plan", "Scout"}.issubset(agent_names)
     assert resolved.mcp_servers == []
+
+
+def test_load_resolved_config_from_dir_stores_skill_adjacent_files_as_posix_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    agent_dir = tmp_path / "local-agent"
+    skill_dir = agent_dir / "skills" / "Search"
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("---\nname: Local Agent\n---\nbe helpful\n", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: Search\n---\nsearch skill", encoding="utf-8")
+    (refs_dir / "query.md").write_text("extra", encoding="utf-8")
+    original_relative_to = Path.relative_to
+
+    def windows_relative_to(self: Path, *other: str | PathLike[str]) -> PureWindowsPath:
+        relative_path = original_relative_to(self, *other)
+        return PureWindowsPath(*relative_path.parts)
+
+    monkeypatch.setattr(Path, "relative_to", windows_relative_to)
+
+    resolved = AgentLoader().load_resolved_config_from_dir(agent_dir)
+
+    assert resolved.skills[0].files == {"references/query.md": "extra"}
 
 
 def test_load_resolved_config_from_dir_rejects_invalid_agent_md_yaml(tmp_path: Path) -> None:

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -1,0 +1,23 @@
+from datetime import UTC, datetime
+
+from config.agent_config_types import AgentSkill, Skill
+
+
+def test_skill_models_normalize_file_paths() -> None:
+    skill = Skill(
+        id="query-helper",
+        owner_user_id="owner-1",
+        name="query-helper",
+        content="---\nname: query-helper\n---\nUse exact terms.",
+        files={"references\\query.md": "Prefer precise queries."},
+        created_at=datetime(2026, 4, 25, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 25, tzinfo=UTC),
+    )
+    agent_skill = AgentSkill(
+        name="query-helper",
+        content="---\nname: query-helper\n---\nUse exact terms.",
+        files={"references\\query.md": "Prefer precise queries."},
+    )
+
+    assert skill.files == {"references/query.md": "Prefer precise queries."}
+    assert agent_skill.files == {"references/query.md": "Prefer precise queries."}

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 
 from core.runtime.registry import ToolRegistry
@@ -17,7 +19,7 @@ def test_load_file_skill_returns_adjacent_files(tmp_path) -> None:
     entry = registry.get("load_skill")
     assert entry is not None
 
-    result = entry.handler("query-helper")
+    result = cast(str, entry.handler("query-helper"))
 
     assert "Loaded skill: query-helper" in result
     assert "Use exact terms." in result
@@ -142,9 +144,32 @@ def test_load_inline_skill_returns_adjacent_files() -> None:
     entry = registry.get("load_skill")
     assert entry is not None
 
-    result = entry.handler("query-helper")
+    result = cast(str, entry.handler("query-helper"))
 
     assert "Loaded skill: query-helper" in result
     assert "Use exact terms." in result
     assert "references/query.md" in result
     assert "Prefer precise queries." in result
+
+
+def test_load_inline_skill_normalizes_adjacent_file_paths() -> None:
+    registry = ToolRegistry()
+    SkillsService(
+        registry=registry,
+        skill_paths=[],
+        inline_skills=[
+            {
+                "name": "query-helper",
+                "content": "---\nname: query-helper\n---\nUse exact terms.",
+                "files": {"references\\query.md": "Prefer precise queries."},
+            }
+        ],
+    )
+
+    entry = registry.get("load_skill")
+    assert entry is not None
+
+    result = cast(str, entry.handler("query-helper"))
+
+    assert "--- references/query.md ---" in result
+    assert "references\\query.md" not in result

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -140,6 +140,23 @@ class TestApplySkill:
         assert saved[0].content == "---\nname: My Skill\n---\n# My Skill\nDo stuff"
         assert saved[0].files == {"references/usage.md": "Use carefully"}
 
+    def test_writes_hub_skill_files_as_posix_paths(self):
+        saved: list[Skill] = []
+        hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
+        hub_resp["snapshot"]["files"] = {"references\\usage.md": "Use carefully"}
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda skill: saved.append(skill) or skill,
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            apply_item("item-123", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert saved[0].files == {"references/usage.md": "Use carefully"}
+
     def test_skill_repo_payload_has_source_tracking(self):
         saved: list[Skill] = []
         hub_resp = _make_hub_response(

--- a/tests/Unit/scripts/test_import_file_skills_to_library.py
+++ b/tests/Unit/scripts/test_import_file_skills_to_library.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from os import PathLike
+from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
@@ -88,3 +90,25 @@ def test_import_file_skill_rejects_unreadable_adjacent_file(monkeypatch: pytest.
         import_file_skills_to_library.import_skills("owner-1", library_dir)
 
     assert repo.saved == []
+
+
+def test_import_file_skill_stores_adjacent_files_as_posix_paths(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    library_dir = tmp_path / "library"
+    skill_dir = library_dir / "skills" / "new-skill"
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\n---\nBody", encoding="utf-8")
+    (refs_dir / "query.md").write_text("Use exact queries.", encoding="utf-8")
+    repo = _MemorySkillRepo()
+    original_relative_to = Path.relative_to
+
+    def windows_relative_to(self: Path, *other: str | PathLike[str]) -> PureWindowsPath:
+        relative_path = original_relative_to(self, *other)
+        return PureWindowsPath(*relative_path.parts)
+
+    monkeypatch.setattr(Path, "relative_to", windows_relative_to)
+    monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+
+    import_file_skills_to_library.import_skills("owner-1", library_dir)
+
+    assert repo.saved[0].files == {"references/query.md": "Use exact queries."}


### PR DESCRIPTION
## Summary
- Normalize Skill and AgentSkill adjacent file paths to POSIX-style keys at the model boundary.
- Normalize local AgentConfig discovery, file-skill import, Hub skill snapshots, and runtime inline skills.
- Add regression coverage for Windows-style path keys across config, scripts, Hub, and runtime skill loading.

## Test Plan
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q`
- [x] `uv run pyright tests/Unit/core/test_skills_service.py --pythonversion 3.12`
- [ ] GitHub CI

Note: full-repo `uv run pyright --pythonversion 3.12` is already red on the current dev->main PR with the same broad type-debt class; this branch keeps the skill path changes narrow and uses GitHub CI as the integration signal.
