### PR TITLE
chore: trim sandbox success log noise

### DIFF
--- a/core/runtime/mcp_gateway.py
+++ b/core/runtime/mcp_gateway.py
@@ -91,8 +91,6 @@ async def init_client_tools(
             _apply_server_prefixes(server_tools, server_name)
             tools.extend(server_tools)
         tools = _filter_allowed_tools(tools, server_configs)
-        if verbose:
-            print(f"[LeonAgent] Loaded {len(tools)} MCP tools from {len(configs)} servers")
         return client, tools
     except Exception as exc:
         if verbose:

--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -201,9 +201,7 @@ class RemoteSandbox(Sandbox):
     def close(self) -> None:
         if self._on_exit == "pause":
             try:
-                count = self._manager.pause_all_sessions()
-                if count > 0:
-                    logger.info("[%s] Paused %d session(s)", self.name, count)
+                self._manager.pause_all_sessions()
             except Exception:
                 logger.exception("[%s] pause_all_sessions failed during close", self.name)
         elif self._on_exit == "destroy":
@@ -212,7 +210,6 @@ class RemoteSandbox(Sandbox):
                     self._manager.destroy_session(thread_id=session["thread_id"])
                 except Exception:
                     logger.exception("[%s] Failed to destroy session %s", self.name, session.get("thread_id"))
-            logger.info("[%s] Destroy pass complete", self.name)
 
 
 class _LazyLocalExecutor:

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -320,7 +320,6 @@ class SandboxManager:
         except Exception as e:
             if "already exists" in str(e):
                 volume_name = f"leon-volume-{sandbox_runtime_id}"
-                logger.info("Daytona volume already exists: %s, reusing", volume_name)
                 self.provider.wait_managed_volume_ready(volume_name)
             else:
                 raise

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -209,7 +209,6 @@ class DaytonaProvider(SandboxProvider):
             logger.warning("[DaytonaProvider] destroy_session error for %s, verifying actual state", session_id)
             actual = self.get_session_status(session_id)
             if actual == "unknown":
-                logger.info("[DaytonaProvider] sandbox %s no longer exists — destroy succeeded", session_id)
                 self._sandboxes.pop(session_id, None)
                 return True
             logger.error("[DaytonaProvider] destroy_session truly failed for %s (state=%s)", session_id, actual)
@@ -226,7 +225,6 @@ class DaytonaProvider(SandboxProvider):
             logger.warning("[DaytonaProvider] pause_session error for %s, verifying actual state", session_id)
             actual = self.get_session_status(session_id)
             if actual == "paused":
-                logger.info("[DaytonaProvider] sandbox %s is actually stopped despite error — pause succeeded", session_id)
                 return True
             logger.error("[DaytonaProvider] pause_session truly failed for %s (state=%s)", session_id, actual)
             return False
@@ -241,7 +239,6 @@ class DaytonaProvider(SandboxProvider):
             logger.warning("[DaytonaProvider] resume_session error for %s, verifying actual state", session_id)
             actual = self.get_session_status(session_id)
             if actual == "running":
-                logger.info("[DaytonaProvider] sandbox %s is actually running despite error — resume succeeded", session_id)
                 return True
             logger.error("[DaytonaProvider] resume_session truly failed for %s (state=%s)", session_id, actual)
             return False

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -127,7 +127,6 @@ class DaytonaProvider(SandboxProvider):
 
     def create_managed_volume(self, managed_ref: str, mount_path: str) -> str:
         volume_name = f"leon-volume-{managed_ref}"
-        logger.info("Creating managed volume: %s", volume_name)
         # @@@volume-ready - volume transitions pending_create → ready (~6s)
         self.client.volume.create(volume_name)
         self.wait_managed_volume_ready(volume_name)
@@ -137,7 +136,6 @@ class DaytonaProvider(SandboxProvider):
         for _ in range(30):
             vol = self.client.volume.get(backend_ref)
             if vol.state == "ready":
-                logger.info("Managed volume ready: %s (id=%s)", backend_ref, vol.id)
                 return
             time.sleep(1)
         raise RuntimeError(f"Volume {backend_ref} did not become ready within 30s")
@@ -146,13 +144,11 @@ class DaytonaProvider(SandboxProvider):
         self._managed_mounts[thread_id] = (backend_ref, mount_path)
 
     def delete_managed_volume(self, backend_ref: str) -> None:
-        logger.info("Deleting managed volume: %s", backend_ref)
         try:
             vol = self.client.volume.get(backend_ref)
         except Exception as exc:
             # @@@daytona-volume-delete-idempotent - thread cleanup may retry after provider volume was already removed.
             if _is_daytona_not_found_error(exc):
-                logger.info("Managed volume already absent: %s", backend_ref)
                 return
             raise
         self.client.volume.delete(vol)


### PR DESCRIPTION
## Summary\n- remove MCP load success output\n- remove sandbox and Daytona success-path info logs\n- keep warnings, errors, and failure diagnostics intact\n\n## Verification\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- uv run python -m pytest -q\n- git diff --check