### PR TITLE
chore: remove runtime verbose remnants

### DIFF
--- a/backend/threads/pool/factory.py
+++ b/backend/threads/pool/factory.py
@@ -44,7 +44,6 @@ def create_agent_sync(
         child_thread_live_runner=run_child_thread_live,
         models_config_override=models_config_override,
         memory_config_override=memory_config_override,
-        verbose=True,
         agent=agent,
         agent_config_dir=agent_config_dir,
         agent_config_id=agent_config_id,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -424,7 +424,7 @@ class LeonAgent:
     def _register_mcp_tools(self, mcp_tools: list) -> None:
         if not mcp_tools:
             return
-        mcp_gateway.register_mcp_tools(self._tool_registry, mcp_tools, logger=logger)
+        mcp_gateway.register_mcp_tools(self._tool_registry, mcp_tools)
 
     def _get_agent_blocked_tools(self) -> set[str]:
         """Return disabled tool names, respecting catalog defaults.

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -143,7 +143,6 @@ class LeonAgent:
         models_config_override: dict[str, Any] | None = None,
         memory_config_override: dict[str, Any] | None = None,
         permission_resolver_scope: str = "none",
-        verbose: bool = False,
     ):
         """
         Initialize Leon Agent
@@ -163,12 +162,10 @@ class LeonAgent:
             user_repo: Optional user repo for backend-integrated subagent registration
             queue_manager: Shared MessageQueueManager instance (created if not provided)
             permission_resolver_scope: Permission request surface for this agent ("none" or "thread")
-            verbose: Whether to output detailed logs (default False)
         """
         runtime_storage = storage_container
 
         self.agent_id: str | None = None
-        self.verbose = verbose
         self.extra_allowed_paths = extra_allowed_paths
         self.queue_manager = queue_manager or (
             MessageQueueManager(repo=runtime_storage.queue_repo()) if runtime_storage is not None else MessageQueueManager()

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1247,7 +1247,6 @@ class LeonAgent:
         client, tools = await mcp_gateway.init_client_tools(
             enabled=self.config.mcp.enabled,
             server_configs=self._get_mcp_server_configs(),
-            verbose=self.verbose,
         )
         self._mcp_client = client
         return tools

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -20,7 +20,6 @@ All paths must be absolute. Full security mechanisms and audit logging.
 import asyncio
 import concurrent.futures
 import inspect
-import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -84,8 +83,6 @@ from core.tools.tool_search.service import ToolSearchService  # noqa: E402
 from core.tools.web.service import WebService  # noqa: E402
 from protocols.event_bus import EventBusFactory  # noqa: E402
 from storage.container import StorageContainer  # noqa: E402
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sandbox import Sandbox
@@ -1237,8 +1234,8 @@ class LeonAgent:
                 registry=self._tool_registry,
                 workspace_root=self.workspace_root,
             )
-        except Exception as e:
-            logger.debug("[LeonAgent] LSPService init skipped: %s", e)
+        except Exception:
+            pass
 
     async def _init_mcp_tools(self) -> list:
         client, tools = await mcp_gateway.init_client_tools(

--- a/core/runtime/loop.py
+++ b/core/runtime/loop.py
@@ -1734,7 +1734,7 @@ class QueryLoop:
         try:
             return await self._checkpoint_store.load(thread_id)
         except Exception:
-            logger.debug("QueryLoop: could not load checkpoint for thread %s", thread_id)
+            pass
             return None
 
     async def _load_checkpoint_channel_values(self, thread_id: str) -> dict[str, Any]:

--- a/core/runtime/loop.py
+++ b/core/runtime/loop.py
@@ -4,7 +4,6 @@ import asyncio
 import copy
 import inspect
 import json
-import logging
 import re
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
@@ -29,8 +28,6 @@ from .permissions import ToolPermissionContext, evaluate_permission_rules
 from .registry import ToolMode, ToolRegistry
 from .state import AppState, BootstrapConfig, ToolPermissionState, ToolUseContext
 from .validator import _required_sets_match
-
-logger = logging.getLogger(__name__)
 
 _ESCALATED_MAX_OUTPUT_TOKENS = 64000
 _FLOOR_OUTPUT_TOKENS = 3000
@@ -1913,7 +1910,7 @@ class QueryLoop:
                 ),
             )
         except Exception:
-            logger.debug("QueryLoop: could not save checkpoint for thread %s", thread_id, exc_info=True)
+            pass
 
     def _collect_memory_system_notices(self, pending_notices: list[HumanMessage]) -> None:
         if self._memory_middleware is None:

--- a/core/runtime/mcp_gateway.py
+++ b/core/runtime/mcp_gateway.py
@@ -75,7 +75,6 @@ async def init_client_tools(
     *,
     enabled: bool,
     server_configs: dict[str, Any],
-    verbose: bool,
 ) -> tuple[Any | None, list[Any]]:
     if not enabled or not server_configs:
         return None, []
@@ -93,8 +92,6 @@ async def init_client_tools(
         tools = _filter_allowed_tools(tools, server_configs)
         return client, tools
     except Exception as exc:
-        if verbose:
-            print(f"[LeonAgent] MCP initialization failed: {exc}")
         raise RuntimeError(f"MCP initialization failed: {exc}") from exc
 
 

--- a/core/runtime/mcp_gateway.py
+++ b/core/runtime/mcp_gateway.py
@@ -50,12 +50,9 @@ def instruction_blocks(server_configs: dict[str, Any]) -> dict[str, str]:
     return blocks
 
 
-def register_mcp_tools(registry: ToolRegistry, mcp_tools: list[Any], *, logger: Any) -> None:
+def register_mcp_tools(registry: ToolRegistry, mcp_tools: list[Any]) -> None:
     for tool in mcp_tools:
-        try:
-            registry.register(make_tool_entry(tool))
-        except Exception as exc:
-            logger.warning("[LeonAgent] Failed to register MCP tool %s: %s", getattr(tool, "name", "<unknown>"), exc)
+        registry.register(make_tool_entry(tool))
 
 
 def register_resource_tools(

--- a/tests/Unit/core/test_runtime_agent.py
+++ b/tests/Unit/core/test_runtime_agent.py
@@ -261,7 +261,6 @@ def test_build_middleware_stack_skips_prompt_caching_for_non_anthropic_provider(
     agent._tool_registry = SimpleNamespace()
     agent._get_integration_instruction_blocks = lambda: []
     agent.model_name = "gpt-5.4"
-    agent.verbose = False
     agent._closed = True
     agent._closing = False
 
@@ -314,7 +313,6 @@ def test_build_middleware_stack_keeps_prompt_caching_for_anthropic_provider(
     agent._tool_registry = SimpleNamespace()
     agent._get_integration_instruction_blocks = lambda: []
     agent.model_name = "claude-sonnet"
-    agent.verbose = False
     agent._closed = True
     agent._closing = False
 
@@ -371,7 +369,6 @@ def test_build_middleware_stack_skips_prompt_caching_when_provider_unknown(
     agent._tool_registry = SimpleNamespace()
     agent._get_integration_instruction_blocks = lambda: []
     agent.model_name = "gpt-5.4"
-    agent.verbose = False
     agent._closed = True
     agent._closing = False
 

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -1042,7 +1042,6 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     agent.enable_audit_log = False
     agent.block_dangerous_commands = False
     agent.block_network_commands = False
-    agent.verbose = False
     agent._get_mcp_server_configs = lambda: {}
     agent._chat_repos = {
         "chat_identity_id": "thread-user-9",
@@ -1113,7 +1112,6 @@ def test_leon_agent_init_services_passes_child_thread_live_runner(monkeypatch: p
     agent.enable_audit_log = False
     agent.block_dangerous_commands = False
     agent.block_network_commands = False
-    agent.verbose = False
     agent._get_mcp_server_configs = lambda: {}
     agent._chat_repos = None
     cast(Any, agent).config = SimpleNamespace(

--- a/tests/Unit/platform/test_mcp_gateway_resource_tools.py
+++ b/tests/Unit/platform/test_mcp_gateway_resource_tools.py
@@ -150,7 +150,6 @@ async def test_mcp_gateway_init_fails_loudly_when_client_initialization_fails(mo
                     allowed_tools=None,
                 )
             },
-            verbose=False,
         )
 
 
@@ -175,7 +174,6 @@ async def test_mcp_gateway_prefixes_tools_by_the_server_they_came_from(monkeypat
             "alpha": SimpleNamespace(transport="stdio", command="uv", args=[], env={}, url=None, allowed_tools=None),
             "beta": SimpleNamespace(transport="stdio", command="uv", args=[], env={}, url=None, allowed_tools=None),
         },
-        verbose=False,
     )
 
     assert calls == ["alpha", "beta"]
@@ -203,7 +201,6 @@ async def test_mcp_gateway_filters_allowed_tools_per_server(monkeypatch: pytest.
             "alpha": SimpleNamespace(transport="stdio", command="uv", args=[], env={}, url=None, allowed_tools=["read"]),
             "beta": SimpleNamespace(transport="stdio", command="uv", args=[], env={}, url=None, allowed_tools=["search"]),
         },
-        verbose=False,
     )
 
     assert [tool.name for tool in tools] == ["mcp__alpha__read", "mcp__beta__search"]

--- a/tests/Unit/platform/test_mcp_transport.py
+++ b/tests/Unit/platform/test_mcp_transport.py
@@ -34,7 +34,6 @@ async def test_init_mcp_tools_respects_explicit_websocket_transport(monkeypatch)
             },
         )
     )
-    agent.verbose = False
     agent._mcp_client = None
 
     mcp_client_path = ".".join(["langchain_mcp_" + "adap" + "ters", "client", "MultiServerMCPClient"])


### PR DESCRIPTION
## Summary\n- remove unused LeonAgent/MCP verbose plumbing\n- remove debug-only optional runtime logs\n- fail loudly on MCP tool registration instead of warning and continuing\n\n## Verification\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- uv run python -m pytest -q\n- git diff --check