### PR TITLE
Reject duplicate skill adjacent file paths

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -18,6 +18,7 @@ from backend.hub.versioning import BumpType, bump_semver
 from config.agent_config_resolver import resolve_agent_config
 from config.agent_config_types import AgentSkill, Skill
 from config.agent_snapshot import snapshot_from_resolved_config
+from config.skill_files import normalize_skill_file_map
 
 HUB_URL = os.environ.get("MYCEL_HUB_URL", "https://hub.mycel.nextmind.space")
 # @@@hub-agent-user-item-type - Hub still names published Agent users "member";
@@ -83,7 +84,7 @@ def _skill_files_from_snapshot(snapshot: dict[str, Any]) -> dict[str, str]:
         return {}
     if not isinstance(files, dict):
         raise ValueError("Skill snapshot files must be an object")
-    return {str(path).replace("\\", "/"): str(content) for path, content in files.items()}
+    return normalize_skill_file_map(files, context="Skill snapshot files")
 
 
 def list_items(

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -5,11 +5,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
-
-def _normalize_skill_file_paths(value: Any) -> Any:
-    if not isinstance(value, dict):
-        return value
-    return {str(path).replace("\\", "/"): content for path, content in value.items()}
+from config.skill_files import normalize_skill_file_map
 
 
 class Skill(BaseModel):
@@ -34,7 +30,7 @@ class Skill(BaseModel):
     @field_validator("files", mode="before")
     @classmethod
     def _normalize_files(cls, value: Any) -> Any:
-        return _normalize_skill_file_paths(value)
+        return normalize_skill_file_map(value, context="Skill files") if isinstance(value, dict) else value
 
 
 class AgentSkill(BaseModel):
@@ -58,7 +54,7 @@ class AgentSkill(BaseModel):
     @field_validator("files", mode="before")
     @classmethod
     def _normalize_files(cls, value: Any) -> Any:
-        return _normalize_skill_file_paths(value)
+        return normalize_skill_file_map(value, context="Skill files") if isinstance(value, dict) else value
 
 
 class AgentRule(BaseModel):

--- a/config/loader.py
+++ b/config/loader.py
@@ -26,6 +26,7 @@ import yaml
 from config.agent_config_resolver import resolve_agent_config
 from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, ResolvedAgentConfig
 from config.schema import LeonSettings
+from config.skill_files import normalize_skill_file_entries
 from config.types import RuntimeAgentDefinition
 from config.user_paths import remap_default_user_home_string, user_home_path, user_home_read_candidates
 
@@ -302,14 +303,15 @@ class AgentLoader:
                 raise ValueError(f"Local Skill directory must contain SKILL.md: {skill_dir}")
             content = skill_md.read_text(encoding="utf-8")
             metadata = AgentLoader._skill_frontmatter(content)
-            files: dict[str, str] = {}
+            file_entries: list[tuple[Path, str]] = []
             for file_path in sorted(skill_dir.rglob("*")):
                 if not file_path.is_file() or file_path.name == "SKILL.md":
                     continue
                 try:
-                    files[file_path.relative_to(skill_dir).as_posix()] = file_path.read_text(encoding="utf-8")
+                    file_entries.append((file_path.relative_to(skill_dir), file_path.read_text(encoding="utf-8")))
                 except UnicodeDecodeError as exc:
                     raise RuntimeError(f"Local Skill adjacent file could not be read: {file_path}") from exc
+            files = normalize_skill_file_entries(file_entries, context="Local Skill files")
             skills.append(
                 AgentSkill(
                     name=str(metadata["name"]),

--- a/config/skill_files.py
+++ b/config/skill_files.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def normalize_skill_file_map(files: Mapping[Any, Any], *, context: str) -> dict[str, str]:
+    return normalize_skill_file_entries(files.items(), context=context)
+
+
+def normalize_skill_file_entries(entries: Iterable[tuple[Any, Any]], *, context: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path, content in entries:
+        normalized_path = str(path).replace("\\", "/")
+        if normalized_path in result:
+            raise ValueError(f"{context} contain duplicate path after normalization: {normalized_path}")
+        result[normalized_path] = str(content)
+    return result

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import yaml
 
+from config.skill_files import normalize_skill_file_map
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
 
 
@@ -54,7 +55,7 @@ class SkillsService:
             self._inline_skills[skill_name] = content
             files = skill.get("files")
             if isinstance(files, dict):
-                self._inline_skill_files[skill_name] = {str(path).replace("\\", "/"): str(body) for path, body in files.items()}
+                self._inline_skill_files[skill_name] = normalize_skill_file_map(files, context="Inline Skill files")
             elif files is not None:
                 raise ValueError("Inline Skill files must be an object")
 

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -12,6 +12,7 @@ import yaml
 
 from backend.library.paths import LIBRARY_DIR
 from config.agent_config_types import Skill
+from config.skill_files import normalize_skill_file_entries
 from storage.runtime import build_storage_container
 
 
@@ -30,15 +31,15 @@ def _frontmatter(content: str) -> dict[str, Any]:
 
 
 def _read_files(skill_dir: Path) -> dict[str, str]:
-    files: dict[str, str] = {}
+    file_entries: list[tuple[Path, str]] = []
     for path in sorted(skill_dir.rglob("*")):
         if not path.is_file() or path.name == "SKILL.md":
             continue
         try:
-            files[path.relative_to(skill_dir).as_posix()] = path.read_text(encoding="utf-8")
+            file_entries.append((path.relative_to(skill_dir), path.read_text(encoding="utf-8")))
         except UnicodeDecodeError as exc:
             raise RuntimeError(f"Skill adjacent file could not be read: {path}") from exc
-    return files
+    return normalize_skill_file_entries(file_entries, context="File Skill files")
 
 
 def import_skills(owner_user_id: str, library_dir: Path) -> int:

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 from os import PathLike
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
 
@@ -309,6 +309,31 @@ def test_load_resolved_config_from_dir_stores_skill_adjacent_files_as_posix_path
     resolved = AgentLoader().load_resolved_config_from_dir(agent_dir)
 
     assert resolved.skills[0].files == {"references/query.md": "extra"}
+
+
+def test_load_resolved_config_from_dir_rejects_skill_adjacent_file_path_collision(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    agent_dir = tmp_path / "local-agent"
+    skill_dir = agent_dir / "skills" / "Search"
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("---\nname: Local Agent\n---\nbe helpful\n", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: Search\n---\nsearch skill", encoding="utf-8")
+    (refs_dir / "a.md").write_text("Windows-shaped key.", encoding="utf-8")
+    (refs_dir / "b.md").write_text("POSIX-shaped key.", encoding="utf-8")
+    original_relative_to = Path.relative_to
+
+    def colliding_relative_to(self: Path, *other: str | PathLike[str]) -> PureWindowsPath | PurePosixPath:
+        if self.name == "a.md":
+            return PureWindowsPath("references", "query.md")
+        if self.name == "b.md":
+            return PurePosixPath("references/query.md")
+        relative_path = original_relative_to(self, *other)
+        return PurePosixPath(*relative_path.parts)
+
+    monkeypatch.setattr(Path, "relative_to", colliding_relative_to)
+
+    with pytest.raises(ValueError, match="Local Skill files contain duplicate path after normalization: references/query.md"):
+        AgentLoader().load_resolved_config_from_dir(agent_dir)
 
 
 def test_load_resolved_config_from_dir_rejects_invalid_agent_md_yaml(tmp_path: Path) -> None:

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
 
+import pytest
+
 from config.agent_config_types import AgentSkill, Skill
 
 
@@ -21,3 +23,26 @@ def test_skill_models_normalize_file_paths() -> None:
 
     assert skill.files == {"references/query.md": "Prefer precise queries."}
     assert agent_skill.files == {"references/query.md": "Prefer precise queries."}
+
+
+def test_skill_models_reject_duplicate_file_paths_after_normalization() -> None:
+    common = {
+        "content": "---\nname: query-helper\n---\nUse exact terms.",
+        "files": {
+            "references\\query.md": "Windows-shaped key.",
+            "references/query.md": "POSIX-shaped key.",
+        },
+    }
+
+    with pytest.raises(ValueError, match="Skill files contain duplicate path after normalization: references/query.md"):
+        Skill(
+            id="query-helper",
+            owner_user_id="owner-1",
+            name="query-helper",
+            created_at=datetime(2026, 4, 25, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 25, tzinfo=UTC),
+            **common,
+        )
+
+    with pytest.raises(ValueError, match="Skill files contain duplicate path after normalization: references/query.md"):
+        AgentSkill(name="query-helper", **common)

--- a/tests/Unit/config/test_skill_files.py
+++ b/tests/Unit/config/test_skill_files.py
@@ -1,0 +1,31 @@
+import pytest
+
+from config.skill_files import normalize_skill_file_entries, normalize_skill_file_map
+
+
+def test_normalize_skill_file_map_converts_paths_to_posix_keys() -> None:
+    assert normalize_skill_file_map({"references\\query.md": "Use exact queries."}, context="Skill files") == {
+        "references/query.md": "Use exact queries."
+    }
+
+
+def test_normalize_skill_file_map_rejects_duplicate_paths_after_normalization() -> None:
+    with pytest.raises(ValueError, match="Skill files contain duplicate path after normalization: references/query.md"):
+        normalize_skill_file_map(
+            {
+                "references\\query.md": "Windows-shaped key.",
+                "references/query.md": "POSIX-shaped key.",
+            },
+            context="Skill files",
+        )
+
+
+def test_normalize_skill_file_entries_rejects_duplicate_paths_after_normalization() -> None:
+    with pytest.raises(ValueError, match="Local Skill files contain duplicate path after normalization: references/query.md"):
+        normalize_skill_file_entries(
+            [
+                ("references\\query.md", "Windows-shaped key."),
+                ("references/query.md", "POSIX-shaped key."),
+            ],
+            context="Local Skill files",
+        )

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -173,3 +173,23 @@ def test_load_inline_skill_normalizes_adjacent_file_paths() -> None:
 
     assert "--- references/query.md ---" in result
     assert "references\\query.md" not in result
+
+
+def test_inline_skill_rejects_adjacent_file_path_collision() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(ValueError, match="Inline Skill files contain duplicate path after normalization: references/query.md"):
+        SkillsService(
+            registry=registry,
+            skill_paths=[],
+            inline_skills=[
+                {
+                    "name": "query-helper",
+                    "content": "---\nname: query-helper\n---\nUse exact terms.",
+                    "files": {
+                        "references\\query.md": "Windows-shaped key.",
+                        "references/query.md": "POSIX-shaped key.",
+                    },
+                }
+            ],
+        )

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -157,6 +157,27 @@ class TestApplySkill:
 
         assert saved[0].files == {"references/usage.md": "Use carefully"}
 
+    def test_apply_rejects_hub_skill_file_path_collision(self):
+        saved: list[Skill] = []
+        hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
+        hub_resp["snapshot"]["files"] = {
+            "references\\usage.md": "Windows-shaped key.",
+            "references/usage.md": "POSIX-shaped key.",
+        }
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda skill: saved.append(skill) or skill,
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            with pytest.raises(ValueError, match="Skill snapshot files contain duplicate path after normalization: references/usage.md"):
+                apply_item("item-123", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert saved == []
+
     def test_skill_repo_payload_has_source_tracking(self):
         saved: list[Skill] = []
         hub_resp = _make_hub_response(

--- a/tests/Unit/scripts/test_import_file_skills_to_library.py
+++ b/tests/Unit/scripts/test_import_file_skills_to_library.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from os import PathLike
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
@@ -112,3 +112,31 @@ def test_import_file_skill_stores_adjacent_files_as_posix_paths(monkeypatch: pyt
     import_file_skills_to_library.import_skills("owner-1", library_dir)
 
     assert repo.saved[0].files == {"references/query.md": "Use exact queries."}
+
+
+def test_import_file_skill_rejects_adjacent_file_path_collision(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    library_dir = tmp_path / "library"
+    skill_dir = library_dir / "skills" / "new-skill"
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\n---\nBody", encoding="utf-8")
+    (refs_dir / "a.md").write_text("Windows-shaped key.", encoding="utf-8")
+    (refs_dir / "b.md").write_text("POSIX-shaped key.", encoding="utf-8")
+    repo = _MemorySkillRepo()
+    original_relative_to = Path.relative_to
+
+    def colliding_relative_to(self: Path, *other: str | PathLike[str]) -> PureWindowsPath | PurePosixPath:
+        if self.name == "a.md":
+            return PureWindowsPath("references", "query.md")
+        if self.name == "b.md":
+            return PurePosixPath("references/query.md")
+        relative_path = original_relative_to(self, *other)
+        return PurePosixPath(*relative_path.parts)
+
+    monkeypatch.setattr(Path, "relative_to", colliding_relative_to)
+    monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+
+    with pytest.raises(ValueError, match="File Skill files contain duplicate path after normalization: references/query.md"):
+        import_file_skills_to_library.import_skills("owner-1", library_dir)
+
+    assert repo.saved == []


### PR DESCRIPTION
## Summary
- Define one shared Skill file-map invariant for logical adjacent-file paths.
- Reject path collisions after separator normalization at model, Hub, runtime, local AgentConfig, and file-import entry points.
- Keep Skill file keys POSIX-style while failing loudly instead of overwriting content.

## Test Plan
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest tests/Config/test_loader.py tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/config/test_skill_files.py tests/Unit/config/test_agent_config_types.py tests/Unit/core/test_skills_service.py tests/Unit/platform/test_marketplace_client.py -q`
- [x] `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q`
- [ ] GitHub CI
