### PR TITLE
chore: trim runtime fallback noise

### DIFF
--- a/backend/sandboxes/resources/projection.py
+++ b/backend/sandboxes/resources/projection.py
@@ -59,8 +59,7 @@ def _resource_row_identity(resource_row: dict[str, Any]) -> str:
 
 
 def _resource_running_identity(resource_row: dict[str, Any]) -> str:
-    sandbox_id = str(resource_row.get("sandbox_id") or "").strip()
-    return sandbox_id
+    return str(resource_row.get("sandbox_id") or "").strip()
 
 
 def _resource_display_status(

--- a/backend/threads/display/builder.py
+++ b/backend/threads/display/builder.py
@@ -338,7 +338,6 @@ class DisplayBuilder:
     ) -> tuple[dict | None, str | None]:
         display = msg.get("display") or {}
 
-        # Hidden: skip
         if display.get("showing") is False:
             return current_turn, current_run_id
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -892,8 +892,7 @@ async def get_default_thread_config(
     user_id: Annotated[str, Depends(get_current_user_id)],
     app: Annotated[Any, Depends(get_app)] = None,
 ) -> dict[str, Any]:
-    config = await asyncio.to_thread(_resolve_default_config_for_owned_agent, app, user_id, agent_user_id)
-    return config
+    return await asyncio.to_thread(_resolve_default_config_for_owned_agent, app, user_id, agent_user_id)
 
 
 @router.get("")

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1227,15 +1227,12 @@ class LeonAgent:
 
         # LSP tools — DEFERRED, always registered, multilspy checked at call time
         self._lsp_service = None
-        try:
-            from core.tools.lsp.service import LSPService
+        from core.tools.lsp.service import LSPService
 
-            self._lsp_service = LSPService(
-                registry=self._tool_registry,
-                workspace_root=self.workspace_root,
-            )
-        except Exception:
-            pass
+        self._lsp_service = LSPService(
+            registry=self._tool_registry,
+            workspace_root=self.workspace_root,
+        )
 
     async def _init_mcp_tools(self) -> list:
         client, tools = await mcp_gateway.init_client_tools(

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -667,7 +667,6 @@ class LeonAgent:
         if provider == "anthropic":
             return base_url
 
-        # Default: add /v1
         return f"{base_url}/v1"
 
     def _create_model(self):

--- a/core/runtime/loop.py
+++ b/core/runtime/loop.py
@@ -1728,11 +1728,7 @@ class QueryLoop:
     async def _load_thread_checkpoint_state(self, thread_id: str) -> ThreadCheckpointState | None:
         if self._checkpoint_store is None:
             return None
-        try:
-            return await self._checkpoint_store.load(thread_id)
-        except Exception:
-            pass
-            return None
+        return await self._checkpoint_store.load(thread_id)
 
     async def _load_checkpoint_channel_values(self, thread_id: str) -> dict[str, Any]:
         state = await self._load_thread_checkpoint_state(thread_id)
@@ -1894,23 +1890,20 @@ class QueryLoop:
     async def _save_messages(self, thread_id: str, messages: list) -> None:
         if self._checkpoint_store is None:
             return
-        try:
-            permission_context, pending_requests, resolved_requests = self._thread_permission_state_snapshot(thread_id)
-            memory_state = self._thread_memory_state_snapshot(thread_id)
-            integration_instruction_state = self._thread_integration_instruction_state_snapshot(thread_id)
-            await self._checkpoint_store.save(
-                thread_id,
-                ThreadCheckpointState(
-                    messages=list(messages),
-                    tool_permission_context=permission_context,
-                    pending_permission_requests=pending_requests,
-                    resolved_permission_requests=resolved_requests,
-                    memory_compaction_state=memory_state,
-                    integration_instruction_state=integration_instruction_state,
-                ),
-            )
-        except Exception:
-            pass
+        permission_context, pending_requests, resolved_requests = self._thread_permission_state_snapshot(thread_id)
+        memory_state = self._thread_memory_state_snapshot(thread_id)
+        integration_instruction_state = self._thread_integration_instruction_state_snapshot(thread_id)
+        await self._checkpoint_store.save(
+            thread_id,
+            ThreadCheckpointState(
+                messages=list(messages),
+                tool_permission_context=permission_context,
+                pending_permission_requests=pending_requests,
+                resolved_permission_requests=resolved_requests,
+                memory_compaction_state=memory_state,
+                integration_instruction_state=integration_instruction_state,
+            ),
+        )
 
     def _collect_memory_system_notices(self, pending_notices: list[HumanMessage]) -> None:
         if self._memory_middleware is None:

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -150,7 +150,6 @@ class _FakeChildAgent:
     def close(self, **kwargs):
         self.closed = True
         self.close_kwargs = kwargs
-        return None
 
     def apply_forked_child_context(
         self,

--- a/tests/Unit/core/test_loop.py
+++ b/tests/Unit/core/test_loop.py
@@ -2149,7 +2149,6 @@ async def test_handle_model_error_recovery_uses_ordered_strategy_chain(monkeypat
 
     async def first(_ctx):
         calls.append("first")
-        return None
 
     async def second(_ctx):
         calls.append("second")

--- a/tests/Unit/core/test_tool_registry_runner.py
+++ b/tests/Unit/core/test_tool_registry_runner.py
@@ -739,11 +739,9 @@ class TestToolRunnerErrorNormalization:
 
         async def post_hook_one(message, request):
             await wait_for_peer("one")
-            return None
 
         async def post_hook_two(message, request):
             await wait_for_peer("two")
-            return None
 
         req.state.post_tool_use = [post_hook_one, post_hook_two]
 
@@ -1419,11 +1417,9 @@ class TestToolRunnerErrorNormalization:
 
         async def hook_one(payload, request):
             await wait_for_peer("one")
-            return None
 
         async def hook_two(payload, request):
             await wait_for_peer("two")
-            return None
 
         req.state.pre_tool_use = [hook_one, hook_two]
 

--- a/tests/Unit/integration_contracts/test_background_task_cleanup.py
+++ b/tests/Unit/integration_contracts/test_background_task_cleanup.py
@@ -60,11 +60,10 @@ class _SlowChildAgent:
         await self._release_event.wait()
 
     async def _cleanup_background_runs(self):
-        return None
+        pass
 
     def close(self):
         self.closed = True
-        return None
 
 
 class _CompleteChildAgent:
@@ -79,17 +78,16 @@ class _CompleteChildAgent:
         self.closed = False
 
     async def ainit(self):
-        return None
+        pass
 
     async def _astream(self, *args, **kwargs):
         yield {"agent": {"messages": [AIMessage(content=self._text)]}}
 
     async def _cleanup_background_runs(self):
-        return None
+        pass
 
     def close(self):
         self.closed = True
-        return None
 
 
 class _FailingInitChildAgent:

--- a/tests/Unit/integration_contracts/test_thread_launch_config_contract.py
+++ b/tests/Unit/integration_contracts/test_thread_launch_config_contract.py
@@ -717,7 +717,6 @@ async def test_resolve_main_thread_uses_owned_agent_lookup(monkeypatch: pytest.M
 
     def _fake_find_owned_agent(app_obj, agent_user_id: str, owner_user_id: str):
         calls.append((app_obj, agent_user_id, owner_user_id))
-        return None
 
     monkeypatch.setattr(threads_router, "_find_owned_agent", _fake_find_owned_agent)
 

--- a/tests/Unit/integration_contracts/test_webhooks_router_contract.py
+++ b/tests/Unit/integration_contracts/test_webhooks_router_contract.py
@@ -16,7 +16,7 @@ async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch
             return None
 
         def close(self) -> None:
-            return None
+            pass
 
     class _EventRepo:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary\n- fail loud on checkpoint persistence and LSP setup instead of silently disabling them\n- trim redundant return assignments/comments\n- remove explicit None returns from test hooks/stubs\n\n## Verification\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- uv run python -m pytest -q\n- git diff --check\n\nResult: 1711 passed, 8 skipped