### PR TITLE
chore: simplify ignored parse cleanup

### DIFF
--- a/backend/threads/event_bus.py
+++ b/backend/threads/event_bus.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -20,10 +21,8 @@ class EventBus:
 
         def _unsubscribe() -> None:
             subs = self._subs.get(thread_id, [])
-            try:
+            with suppress(ValueError):
                 subs.remove(callback)
-            except ValueError:
-                pass
             if not subs:
                 self._subs.pop(thread_id, None)
 

--- a/backend/threads/run/observer.py
+++ b/backend/threads/run/observer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 
 from backend.threads.events.buffer import RunEventBuffer, ThreadEventBuffer
 
@@ -44,10 +45,8 @@ async def observe_sse_buffer(
             continue
         for event in events:
             parsed_data = None
-            try:
+            with suppress(json.JSONDecodeError, TypeError):
                 parsed_data = json.loads(event.get("data", "{}"))
-            except (json.JSONDecodeError, TypeError):
-                pass
 
             if after > 0 and isinstance(parsed_data, dict) and "_seq" in parsed_data and parsed_data["_seq"] <= after:
                 continue

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -1324,10 +1325,8 @@ async def stream_thread_events(
 
     last_id = request.headers.get("Last-Event-ID")
     if last_id:
-        try:
+        with contextlib.suppress(ValueError):
             after = max(after, int(last_id))
-        except ValueError:
-            pass
 
     thread_buf = app.state.thread_event_buffers.get(thread_id)
 

--- a/core/tools/command/posix_executor.py
+++ b/core/tools/command/posix_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import uuid
 from typing import ClassVar
@@ -52,10 +53,8 @@ class PosixShellExecutor(BaseExecutor):
             if marker in line_str:
                 parts = line_str.split()
                 if len(parts) >= 2:
-                    try:
+                    with contextlib.suppress(ValueError):
                         exit_code = int(parts[1])
-                    except ValueError:
-                        pass
                 break
             stdout_lines.append(line_str)
         return "".join(stdout_lines), "", exit_code

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -293,10 +294,8 @@ class _SubprocessPtySession:
 
     def close(self) -> None:
         if self._master_fd is not None:
-            try:
+            with suppress(OSError):
                 os.close(self._master_fd)
-            except OSError:
-                pass
             self._master_fd = None
 
         if self._proc and self._proc.poll() is None:


### PR DESCRIPTION
## Summary\n- replace small try/except/pass ignore blocks with contextlib.suppress\n- keep resource-close and parse-failure semantics unchanged\n- preserve net line deletion across five focused commits\n\n## Verification\n- uv run ruff check backend core sandbox storage tests\n- uv run ruff format --check backend core sandbox storage tests\n- uv run python -m compileall -q backend core sandbox storage tests\n- uv run python -m pytest -q\n- git diff --check\n\nResult: 1722 passed, 8 skipped