### PR TITLE
chore: simplify cleanup ignores

### DIFF
--- a/backend/monitor/app/lifespan.py
+++ b/backend/monitor/app/lifespan.py
@@ -1,5 +1,5 @@
 import asyncio
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
 
@@ -28,7 +28,5 @@ async def lifespan(app: FastAPI):
     finally:
         if monitor_resources_task:
             monitor_resources_task.cancel()
-            try:
+            with suppress(asyncio.CancelledError):
                 await monitor_resources_task
-            except asyncio.CancelledError:
-                pass

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -7,6 +7,7 @@ import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1128,11 +1129,9 @@ class AgentService:
         # @@@sa-06-progress-loop - keep prompt-facing coordinator updates on the
         # real thread delivery queue instead of inventing a detached parallel channel.
         while True:
-            try:
+            with suppress(TimeoutError):
                 await asyncio.wait_for(stop_event.wait(), timeout=self._background_progress_interval_s)
                 return
-            except TimeoutError:
-                pass
 
             if self._queue_manager is None:
                 return
@@ -1278,10 +1277,8 @@ class AgentService:
             was_running = not running.task.done()
             if was_running:
                 running.task.cancel()
-                try:
+                with suppress(asyncio.CancelledError):
                     await running.task
-                except asyncio.CancelledError:
-                    pass
             self._tasks.pop(task_id, None)
             return
 

--- a/core/runtime/runner.py
+++ b/core/runtime/runner.py
@@ -7,6 +7,7 @@ import json
 import logging
 import threading
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from typing import Any, cast
 
 from langchain_core.messages import ToolMessage
@@ -268,10 +269,8 @@ class ToolRunner(AgentMiddleware):
         except TimeoutError:
             logger.warning("Async hook %s timed out after %.3fs; ignoring hook result", hook_name, timeout_s)
             task.cancel()
-            try:
+            with suppress(asyncio.CancelledError):
                 await task
-            except asyncio.CancelledError:
-                pass
             return None
 
     @staticmethod

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -487,6 +487,7 @@ import asyncio  # noqa: E402
 import json  # noqa: E402
 import re  # noqa: E402
 from collections.abc import Callable  # noqa: E402
+from contextlib import suppress  # noqa: E402
 
 from sandbox.interfaces.executor import ExecuteResult  # noqa: E402
 from sandbox.runtime import (  # noqa: E402
@@ -809,9 +810,7 @@ class DaytonaSessionRuntime(_RemoteRuntimeBase):
                 current_loop = None
             task_loop = self._snapshot_task.get_loop()
             if current_loop is task_loop:
-                try:
+                with suppress(asyncio.CancelledError):
                     await self._snapshot_task
-                except asyncio.CancelledError:
-                    pass
         self._snapshot_task = None
         await asyncio.to_thread(self._close_shell_sync)

--- a/sandbox/providers/docker.py
+++ b/sandbox/providers/docker.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
@@ -325,10 +326,8 @@ class DockerProvider(SandboxProvider):
             if len(lines) >= 2:
                 df_parts = lines[1].split()
                 if len(df_parts) >= 3:
-                    try:
+                    with suppress(ValueError):
                         disk_used_gb = float(df_parts[2].rstrip("G"))
-                    except ValueError:
-                        pass
 
         return Metrics(
             cpu_percent=cpu_percent,
@@ -351,7 +350,7 @@ class DockerProvider(SandboxProvider):
             return None
         # Output: "8.19kB (virtual 159MB)" — first token is writable layer
         writable = size_str.split(" (")[0]
-        try:
+        with suppress(ValueError):
             if writable.endswith("GB"):
                 return float(writable[:-2])
             if writable.endswith("MB"):
@@ -360,8 +359,6 @@ class DockerProvider(SandboxProvider):
                 return float(writable[:-2]) / (1024.0 * 1024.0)
             if writable.endswith("B"):
                 return float(writable[:-1]) / (1024.0**3)
-        except ValueError:
-            pass
         return None
 
     def _copy_host_path_into_container(self, container_id: str, *, source: str, target: str) -> None:


### PR DESCRIPTION
## Summary
- simplify cancellation/parse ignore blocks with contextlib.suppress
- keep behavior equivalent while reducing cleanup boilerplate
- net -10 lines across backend/core/sandbox files

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1722 passed, 8 skipped)
- git diff --check
