### PR TITLE
chore: prune remaining simple cleanup branches

### DIFF
--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import is_dataclass, replace
 from types import SimpleNamespace
 
@@ -123,10 +123,8 @@ async def lifespan(app: FastAPI):
             task = getattr(app.state, task_name, None)
             if task:
                 task.cancel()
-                try:
+                with suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
 
         if hasattr(app.state, "recipe_repo"):
             runtime_storage.recipe_repo.close()

--- a/core/runtime/validator.py
+++ b/core/runtime/validator.py
@@ -10,10 +10,7 @@ def _required_sets(parameters: dict, key: str) -> list[list[str]]:
         return []
     sets: list[list[str]] = []
     for item in value:
-        if isinstance(item, dict):
-            required = item.get("required", [])
-        else:
-            required = item
+        required = item.get("required", []) if isinstance(item, dict) else item
         if isinstance(required, list):
             sets.append([field for field in required if isinstance(field, str)])
     return sets
@@ -25,9 +22,7 @@ def _arg_counts_as_present(args: dict, field: str) -> bool:
     value = args[field]
     if value is None:
         return False
-    if isinstance(value, str) and value == "":
-        return False
-    return True
+    return not (isinstance(value, str) and value == "")
 
 
 def _required_sets_match(parameters: dict, args: dict) -> bool:

--- a/sandbox/clock.py
+++ b/sandbox/clock.py
@@ -12,10 +12,7 @@ def utc_now_iso() -> str:
 
 
 def parse_runtime_datetime(raw: str | datetime) -> datetime:
-    if isinstance(raw, datetime):
-        parsed = raw
-    else:
-        parsed = datetime.fromisoformat(str(raw))
+    parsed = raw if isinstance(raw, datetime) else datetime.fromisoformat(str(raw))
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed

--- a/sandbox/providers/daytona.py
+++ b/sandbox/providers/daytona.py
@@ -536,10 +536,8 @@ class DaytonaSessionRuntime(_RemoteRuntimeBase):
 
     def _close_shell_sync(self) -> None:
         if self._pty_handle is not None:
-            try:
+            with suppress(Exception):
                 self._pty_handle.disconnect()
-            except Exception:
-                pass
         self._pty_handle = None
         self._hydrated = False
         if not self._bound_instance_id:

--- a/storage/providers/supabase/_query.py
+++ b/storage/providers/supabase/_query.py
@@ -74,10 +74,7 @@ def schema_rpc(client: Any, schema: str, function_name: str, params: dict[str, A
 
 
 def rows(response: Any, repo: str, operation: str) -> list[dict[str, Any]]:
-    if isinstance(response, dict):
-        payload = response.get("data")
-    else:
-        payload = getattr(response, "data", None)
+    payload = response.get("data") if isinstance(response, dict) else getattr(response, "data", None)
     if payload is None:
         raise RuntimeError(f"Supabase {repo} expected supabase-py `.data` payload for {operation}.")
     if not isinstance(payload, list):


### PR DESCRIPTION
## Summary
- remove remaining simple try/except/pass cleanup blocks
- simplify tiny validator/query/clock branches
- net -15 lines across backend/core/sandbox/storage files

## Verification
- uv run ruff check --select SIM105 backend core sandbox storage tests
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1721 passed, 8 skipped)
- git diff --check
