### PR TITLE
chore: prune small data path branches

### DIFF
--- a/backend/identity/avatar/files.py
+++ b/backend/identity/avatar/files.py
@@ -12,10 +12,7 @@ AVATARS_DIR = avatars_dir()
 def process_and_save_avatar(source: Path | bytes, user_id: str) -> str:
     from PIL import Image, ImageOps
 
-    if isinstance(source, (bytes, bytearray)):
-        img = Image.open(io.BytesIO(source))
-    else:
-        img = Image.open(source)
+    img = Image.open(io.BytesIO(source)) if isinstance(source, (bytes, bytearray)) else Image.open(source)
     img = ImageOps.exif_transpose(img)
     if img.mode not in ("RGB", "RGBA"):
         img = img.convert("RGB")

--- a/backend/web/utils/helpers.py
+++ b/backend/web/utils/helpers.py
@@ -45,10 +45,7 @@ def resolve_local_workspace_path(
     if not raw_path:
         return base
     requested = Path(raw_path).expanduser()
-    if requested.is_absolute():
-        target = requested.resolve()
-    else:
-        target = (base / requested).resolve()
+    target = requested.resolve() if requested.is_absolute() else (base / requested).resolve()
     try:
         target.relative_to(base)
     except ValueError as exc:

--- a/core/tools/filesystem/read/readers/notebook.py
+++ b/core/tools/filesystem/read/readers/notebook.py
@@ -85,10 +85,7 @@ def _format_cell(cell: dict, cell_num: int, total_cells: int) -> str:
     cell_type = cell.get("cell_type", "unknown")
     source = cell.get("source", [])
 
-    if isinstance(source, list):
-        source_text = "".join(source)
-    else:
-        source_text = str(source)
+    source_text = "".join(source) if isinstance(source, list) else str(source)
 
     parts = [
         f"\n{'─' * 60}",

--- a/storage/providers/supabase/recipe_repo.py
+++ b/storage/providers/supabase/recipe_repo.py
@@ -92,10 +92,7 @@ class SupabaseRecipeRepo:
 
     def _hydrate(self, row: dict[str, Any]) -> dict[str, Any]:
         raw = row.get("data_json") or row.get("data") or "{}"
-        if isinstance(raw, dict):
-            payload = raw
-        else:
-            payload = json.loads(str(raw))
+        payload = raw if isinstance(raw, dict) else json.loads(str(raw))
         if not isinstance(payload, dict):
             raise ValueError("recipe payload must be an object")
         return {

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -105,10 +105,7 @@ class SupabaseUserRepo:
             {"p_user_id": user_id},
             _USER_REPO,
         ).execute()
-        if isinstance(response, dict):
-            data = response.get("data")
-        else:
-            data = getattr(response, "data", None)
+        data = response.get("data") if isinstance(response, dict) else getattr(response, "data", None)
         if data is None:
             raise RuntimeError(
                 f"Supabase {_USER_REPO} expected data from increment_user_thread_seq RPC. Check the function exists and user_id is valid."


### PR DESCRIPTION
## Summary
- collapse small equivalent branches in avatar, workspace, notebook, and Supabase data paths
- avoid core runtime ternary rewrites that would reduce readability
- net -15 lines across 5 files

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1726 passed, 8 skipped)
- git diff --check
