### PR TITLE
chore: trim web and sync branch noise

### DIFF
--- a/core/tools/web/fetchers/markdownify.py
+++ b/core/tools/web/fetchers/markdownify.py
@@ -140,11 +140,7 @@ class MarkdownifyFetcher(BaseFetcher):
             tag.decompose()
 
         main_content = soup.find("main") or soup.find("article") or soup.find("div", class_="content") or soup.find("body")
-
-        if main_content:
-            text = main_content.get_text(separator="\n\n", strip=True)
-        else:
-            text = soup.get_text(separator="\n\n", strip=True)
+        text = main_content.get_text(separator="\n\n", strip=True) if main_content else soup.get_text(separator="\n\n", strip=True)
 
         return re.sub(r"\n{3,}", "\n\n", text)
 

--- a/core/tools/web/fetchers/markdownify.py
+++ b/core/tools/web/fetchers/markdownify.py
@@ -58,10 +58,7 @@ class MarkdownifyFetcher(BaseFetcher):
             response = await self._do_fetch(url)
             content_type = response.headers.get("Content-Type", "")
 
-            if "text/html" in content_type:
-                content = self._process_html(response.text, result)
-            else:
-                content = response.text
+            content = self._process_html(response.text, result) if "text/html" in content_type else response.text
 
             if len(content) > self.limits.max_chars:
                 content = content[: self.limits.max_chars]

--- a/sandbox/sync/strategy.py
+++ b/sandbox/sync/strategy.py
@@ -173,10 +173,7 @@ class IncrementalSyncStrategy(SyncStrategy):
         if not source_path.exists():
             return
 
-        if files:
-            to_upload = files
-        else:
-            to_upload = self.state.detect_changes(state_key, source_path)
+        to_upload = files or self.state.detect_changes(state_key, source_path)
 
         if not to_upload:
             return

--- a/tests/Unit/backend/web/services/test_streaming_eval_writer.py
+++ b/tests/Unit/backend/web/services/test_streaming_eval_writer.py
@@ -135,10 +135,7 @@ class _VersionedCheckpointSaver:
         return SimpleNamespace(checkpoint=self.checkpoint, metadata=self.metadata)
 
     def get_next_version(self, current: str | None, _channel) -> str:
-        if current is None:
-            current_v = 0
-        else:
-            current_v = int(str(current).split(".")[0])
+        current_v = 0 if current is None else int(str(current).split(".")[0])
         return f"{current_v + 1:032}.test"
 
     async def aput(self, _config, checkpoint, metadata, new_versions):

--- a/tests/Unit/integration_contracts/test_settings_persistence_contract.py
+++ b/tests/Unit/integration_contracts/test_settings_persistence_contract.py
@@ -137,9 +137,8 @@ def test_get_settings_route_does_not_import_preferences_when_repo_row_missing(mo
 
 
 def test_get_settings_route_requires_repo_backed_storage_contract():
-    with pytest.raises(RuntimeError, match="user_settings_repo"):
-        with TestClient(_settings_test_app(None)) as client:
-            client.get("/api/settings")
+    with pytest.raises(RuntimeError, match="user_settings_repo"), TestClient(_settings_test_app(None)) as client:
+        client.get("/api/settings")
 
 
 def test_get_settings_route_merges_repo_backed_model_pool_over_filesystem_loader(monkeypatch):


### PR DESCRIPTION
## Summary
- collapse small markdownify and sync upload branch noise
- trim two focused test helper branches
- avoid core runtime loop/runner ternary rewrites
- net -14 lines across 4 files

## Verification
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q (1726 passed, 8 skipped)
- git diff --check
