### PR TITLE
Keep repo-backed agent skills off configured file paths

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1147,13 +1147,14 @@ class LeonAgent:
 
         # Skills tools
         resolved_skills = []
-        if getattr(self, "_resolved_agent_config", None) is not None:
+        has_resolved_agent_config = getattr(self, "_resolved_agent_config", None) is not None
+        if has_resolved_agent_config:
             resolved_skills = [
                 {"name": skill.name, "content": skill.content, "files": skill.files, "meta": skill.source}
                 for skill in self._resolved_agent_config.skills
             ]
         inline_skills = resolved_skills
-        skill_paths = self.config.skills.paths if self.config.skills.enabled else []
+        skill_paths = [] if has_resolved_agent_config else self.config.skills.paths if self.config.skills.enabled else []
         if skill_paths or inline_skills:
             enabled_skills = self.config.skills.skills
             if resolved_skills:

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1147,14 +1147,14 @@ class LeonAgent:
 
         # Skills tools
         resolved_skills = []
-        has_resolved_agent_config = getattr(self, "_resolved_agent_config", None) is not None
-        if has_resolved_agent_config:
+        has_repo_backed_agent_config = getattr(self, "_resolved_agent_config", None) is not None
+        if has_repo_backed_agent_config:
             resolved_skills = [
                 {"name": skill.name, "content": skill.content, "files": skill.files, "meta": skill.source}
                 for skill in self._resolved_agent_config.skills
             ]
         inline_skills = resolved_skills
-        skill_paths = [] if has_resolved_agent_config else self.config.skills.paths if self.config.skills.enabled else []
+        skill_paths = [] if has_repo_backed_agent_config else self.config.skills.paths if self.config.skills.enabled else []
         if skill_paths or inline_skills:
             enabled_skills = self.config.skills.skills
             if resolved_skills:

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -1,3 +1,5 @@
+import inspect
+
 from config.loader import AgentLoader
 from core.runtime.agent import LeonAgent
 
@@ -8,3 +10,11 @@ def test_runtime_api_has_no_process_local_agent_config_source() -> None:
 
     assert blocked_arg not in LeonAgent.__init__.__annotations__
     assert blocked_loader not in vars(AgentLoader)
+
+
+def test_repo_backed_skill_registration_does_not_read_configured_skill_paths() -> None:
+    source = inspect.getsource(LeonAgent._init_services)
+    blocked_assignment = "skill_paths = self.config.skills.paths"
+
+    assert blocked_assignment not in source
+    assert "has_resolved_agent_config" in source

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -14,7 +14,7 @@ def test_runtime_api_has_no_process_local_agent_config_source() -> None:
 
 def test_repo_backed_skill_registration_does_not_read_configured_skill_paths() -> None:
     source = inspect.getsource(LeonAgent._init_services)
-    blocked_assignment = "skill_paths = self.config.skills.paths"
+    blocked_assignment = "skill_paths = " + "self.config.skills.paths"
 
     assert blocked_assignment not in source
-    assert "has_resolved_agent_config" in source
+    assert "has_repo_backed_agent_config" in source

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -606,6 +606,106 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
+async def test_leon_agent_agent_config_id_does_not_register_configured_file_skills(tmp_path):
+    from core.runtime.agent import LeonAgent
+
+    disk_skill_dir = tmp_path / "disk-skills" / "DiskOnly"
+    disk_skill_dir.mkdir(parents=True)
+    (disk_skill_dir / "SKILL.md").write_text(
+        "---\nname: DiskOnly\ndescription: must not leak into repo-backed agents\n---\nUse host-local state.",
+        encoding="utf-8",
+    )
+    (tmp_path / ".leon").mkdir()
+    (tmp_path / ".leon" / "runtime.json").write_text(
+        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "disk-skills")], "skills": {}}}),
+        encoding="utf-8",
+    )
+
+    class _Repo:
+        def get_agent_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return _agent_config(
+                name="Repo Toad",
+                system_prompt="You are Repo Toad.",
+                skills=[
+                    AgentSkill(
+                        name="FastAPI",
+                        content="---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
+                    )
+                ],
+            )
+
+    mock_model = _mock_model("Repo skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+    ):
+        agent = LeonAgent(
+            workspace_root=str(tmp_path),
+            agent_config_id="cfg-1",
+            agent_config_repo=_Repo(),
+            api_key="sk-test-integration",
+        )
+        await agent.ainit()
+
+        skill_tool = agent._tool_registry.get("load_skill")
+        assert skill_tool is not None
+        assert "FastAPI" in skill_tool.get_schema()["description"]
+        assert "DiskOnly" not in skill_tool.get_schema()["description"]
+        with pytest.raises(ValueError, match="Skill 'DiskOnly' not found"):
+            skill_tool.handler("DiskOnly")
+
+        agent.close()
+
+
+@pytest.mark.asyncio
+@_patch_env_api_key()
+async def test_leon_agent_empty_agent_config_skills_do_not_enable_configured_file_skills(tmp_path):
+    from core.runtime.agent import LeonAgent
+
+    disk_skill_dir = tmp_path / "disk-skills" / "DiskOnly"
+    disk_skill_dir.mkdir(parents=True)
+    (disk_skill_dir / "SKILL.md").write_text(
+        "---\nname: DiskOnly\ndescription: must not leak into repo-backed agents\n---\nUse host-local state.",
+        encoding="utf-8",
+    )
+    (tmp_path / ".leon").mkdir()
+    (tmp_path / ".leon" / "runtime.json").write_text(
+        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "disk-skills")], "skills": {}}}),
+        encoding="utf-8",
+    )
+
+    class _Repo:
+        def get_agent_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return _agent_config(name="Repo Toad", system_prompt="You are Repo Toad.", skills=[])
+
+    mock_model = _mock_model("Repo skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+    ):
+        agent = LeonAgent(
+            workspace_root=str(tmp_path),
+            agent_config_id="cfg-1",
+            agent_config_repo=_Repo(),
+            api_key="sk-test-integration",
+        )
+        await agent.ainit()
+
+        assert agent._tool_registry.get("load_skill") is None
+
+        agent.close()
+
+
+@pytest.mark.asyncio
+@_patch_env_api_key()
 async def test_leon_agent_agent_config_skills_ignore_file_skill_toggle(tmp_path):
     from core.runtime.agent import LeonAgent
 

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -706,6 +706,41 @@ async def test_leon_agent_empty_agent_config_skills_do_not_enable_configured_fil
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
+async def test_leon_agent_default_runtime_still_registers_configured_file_skills(tmp_path):
+    from core.runtime.agent import LeonAgent
+
+    skill_dir = tmp_path / "file-skills" / "FileSkill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: FileSkill\ndescription: local runtime skill\n---\nUse configured local guidance.",
+        encoding="utf-8",
+    )
+    (tmp_path / ".leon").mkdir()
+    (tmp_path / ".leon" / "runtime.json").write_text(
+        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "file-skills")], "skills": {}}}),
+        encoding="utf-8",
+    )
+
+    mock_model = _mock_model("File skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+    ):
+        agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
+        await agent.ainit()
+
+        skill_tool = agent._tool_registry.get("load_skill")
+        assert skill_tool is not None
+        assert skill_tool.handler("FileSkill") == "Loaded skill: FileSkill\n\nUse configured local guidance."
+
+        agent.close()
+
+
+@pytest.mark.asyncio
+@_patch_env_api_key()
 async def test_leon_agent_agent_config_skills_ignore_file_skill_toggle(tmp_path):
     from core.runtime.agent import LeonAgent
 

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -58,6 +58,20 @@ def _agent_config(**overrides: object) -> AgentConfig:
     return AgentConfig(**data)
 
 
+def _write_configured_file_skill(tmp_path, *, name: str, body: str, description: str = "configured file skill") -> None:
+    skill_dir = tmp_path / "file-skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n{body}",
+        encoding="utf-8",
+    )
+    (tmp_path / ".leon").mkdir()
+    (tmp_path / ".leon" / "runtime.json").write_text(
+        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "file-skills")], "skills": {}}}),
+        encoding="utf-8",
+    )
+
+
 class _FakeToolTaskRepo:
     def __init__(self) -> None:
         self._rows: dict[str, dict[str, dict[str, Any]]] = {}
@@ -609,16 +623,11 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
 async def test_leon_agent_agent_config_id_does_not_register_configured_file_skills(tmp_path):
     from core.runtime.agent import LeonAgent
 
-    disk_skill_dir = tmp_path / "disk-skills" / "DiskOnly"
-    disk_skill_dir.mkdir(parents=True)
-    (disk_skill_dir / "SKILL.md").write_text(
-        "---\nname: DiskOnly\ndescription: must not leak into repo-backed agents\n---\nUse host-local state.",
-        encoding="utf-8",
-    )
-    (tmp_path / ".leon").mkdir()
-    (tmp_path / ".leon" / "runtime.json").write_text(
-        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "disk-skills")], "skills": {}}}),
-        encoding="utf-8",
+    _write_configured_file_skill(
+        tmp_path,
+        name="DiskOnly",
+        body="Use host-local state.",
+        description="must not leak into repo-backed agents",
     )
 
     class _Repo:
@@ -666,16 +675,11 @@ async def test_leon_agent_agent_config_id_does_not_register_configured_file_skil
 async def test_leon_agent_empty_agent_config_skills_do_not_enable_configured_file_skills(tmp_path):
     from core.runtime.agent import LeonAgent
 
-    disk_skill_dir = tmp_path / "disk-skills" / "DiskOnly"
-    disk_skill_dir.mkdir(parents=True)
-    (disk_skill_dir / "SKILL.md").write_text(
-        "---\nname: DiskOnly\ndescription: must not leak into repo-backed agents\n---\nUse host-local state.",
-        encoding="utf-8",
-    )
-    (tmp_path / ".leon").mkdir()
-    (tmp_path / ".leon" / "runtime.json").write_text(
-        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "disk-skills")], "skills": {}}}),
-        encoding="utf-8",
+    _write_configured_file_skill(
+        tmp_path,
+        name="DiskOnly",
+        body="Use host-local state.",
+        description="must not leak into repo-backed agents",
     )
 
     class _Repo:
@@ -709,16 +713,11 @@ async def test_leon_agent_empty_agent_config_skills_do_not_enable_configured_fil
 async def test_leon_agent_default_runtime_still_registers_configured_file_skills(tmp_path):
     from core.runtime.agent import LeonAgent
 
-    skill_dir = tmp_path / "file-skills" / "FileSkill"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: FileSkill\ndescription: local runtime skill\n---\nUse configured local guidance.",
-        encoding="utf-8",
-    )
-    (tmp_path / ".leon").mkdir()
-    (tmp_path / ".leon" / "runtime.json").write_text(
-        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "file-skills")], "skills": {}}}),
-        encoding="utf-8",
+    _write_configured_file_skill(
+        tmp_path,
+        name="FileSkill",
+        body="Use configured local guidance.",
+        description="local runtime skill",
     )
 
     mock_model = _mock_model("File skill response")


### PR DESCRIPTION
## Summary
- prevent repo-backed AgentConfig runtime from scanning configured file skill paths
- keep configured file skills available for default non-repo runtime agents
- add behavior tests for repo-backed agents with and without selected Skills
- add a source-boundary test for the repo-backed skill registration path

## Verification
- uv run pytest tests/Unit tests/Config -q
- uv run ruff check . && uv run ruff format --check .
- rg -n "agent_config_dir|load_resolved_config_from_dir|skill_paths = self\.config\.skills\.paths|SkillsService\([^\n]*skill_paths" -S core config backend storage