### PR TITLE
chore: trim small branch noise

### DIFF
--- a/backend/threads/history.py
+++ b/backend/threads/history.py
@@ -140,10 +140,7 @@ async def get_thread_history_payload(
     truncate: int = 300,
 ) -> dict[str, Any]:
     live_messages = await load_live_messages(thread_id)
-    if live_messages is None:
-        all_messages = await load_checkpoint_messages(thread_id)
-    else:
-        all_messages = live_messages
+    all_messages = live_messages if live_messages is not None else await load_checkpoint_messages(thread_id)
     all_messages = repair_interrupted_tool_call_messages(list(all_messages))
     total = len(all_messages)
     messages = all_messages[-limit:] if limit > 0 else all_messages

--- a/backend/threads/run/observer.py
+++ b/backend/threads/run/observer.py
@@ -52,7 +52,4 @@ async def observe_sse_buffer(
                 continue
 
             seq_id = str(parsed_data["_seq"]) if isinstance(parsed_data, dict) and "_seq" in parsed_data else None
-            if seq_id:
-                yield {**event, "id": seq_id}
-            else:
-                yield event
+            yield {**event, "id": seq_id} if seq_id else event

--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -407,12 +407,10 @@ async def toggle_model(
     pool = data.setdefault("pool", {"enabled": [], "custom": []})
     enabled = pool.setdefault("enabled", [])
 
-    if request.enabled:
-        if request.model_id not in enabled:
-            enabled.append(request.model_id)
-    else:
-        if request.model_id in enabled:
-            enabled.remove(request.model_id)
+    if request.enabled and request.model_id not in enabled:
+        enabled.append(request.model_id)
+    elif not request.enabled and request.model_id in enabled:
+        enabled.remove(request.model_id)
 
     repo.set_models_config(user_id, data)
     return {"success": True, "enabled_models": enabled}

--- a/backend/web/routers/thread_files.py
+++ b/backend/web/routers/thread_files.py
@@ -27,14 +27,12 @@ async def _call_channel_file_service(
     missing_status: int | None = None,
 ) -> Any:
     try:
-        if callable(method_name):
-            method = method_name
-        else:
+        if not callable(method_name):
             source = file_channel_service.get_file_channel_source(thread_id)
-            method = getattr(source, method_name)
+            method_name = getattr(source, method_name)
         if relative_path is None:
-            return await asyncio.to_thread(method)
-        return await asyncio.to_thread(method, relative_path)
+            return await asyncio.to_thread(method_name)
+        return await asyncio.to_thread(method_name, relative_path)
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
     except FileNotFoundError as e:

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1391,10 +1391,9 @@ def _background_run_type(run: Any) -> str:
 def _serialize_background_run(task_id: str, run: Any, *, include_result: bool) -> dict[str, Any]:
     run_type = _background_run_type(run)
     result_text = _background_run_result(run) if include_result and run.is_done else None
+    status = "completed" if run.is_done else "running"
     if _background_run_cancelled(run):
         status = "cancelled"
-    else:
-        status = "completed" if run.is_done else "running"
     payload = {
         "task_id": task_id,
         "task_type": run_type,

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -86,9 +86,9 @@ async def test_gateway_thread_input_requires_agent_runtime() -> None:
         patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=SimpleNamespace())),
         patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
         patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
+        pytest.raises(AttributeError),
     ):
-        with pytest.raises(AttributeError):
-            await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_thread_input())
+        await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_thread_input())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- collapse small status/source dispatch branches without changing behavior
- flatten one gateway test context
- keep this slice net-deleting: 13 insertions / 24 deletions

## Verification
- uv run pytest -q tests/Unit/integration_contracts/test_thread_files_channel_shell.py tests/Unit/integration_contracts/test_settings_persistence_contract.py tests/Unit/integration_contracts/test_query_loop_backend_contracts.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
- uv run ruff check backend core sandbox storage tests
- uv run ruff format --check backend core sandbox storage tests
- uv run python -m compileall -q backend core sandbox storage tests
- uv run python -m pytest -q
- git diff --check