### PR TITLE
refactor: stop runtime startup from preparing host-local state

### DIFF
--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -54,22 +54,13 @@ async def get_or_create_agent(
         thread_data = app_obj.state.thread_repo.get_by_id(thread_id) if hasattr(app_obj.state, "thread_repo") else None
         if sandbox_type == "local":
             cwd = app_obj.state.thread_cwd.get(thread_id)
-            cwd_from_live_map = cwd is not None
             if not cwd and thread_data and thread_data.get("cwd"):
                 cwd = thread_data["cwd"]
             if cwd:
                 path = Path(cwd).expanduser()
-                # @@@fresh-local-cwd-owns-workspace - a cwd chosen in this live backend session is
-                # the caller contract for local threads; create it instead of silently falling
-                # using the repo root. Persisted paths from another host stay advisory.
-                if cwd_from_live_map:
-                    path.mkdir(parents=True, exist_ok=True)
-                    workspace_root = path.resolve()
-                    app_obj.state.thread_cwd[thread_id] = str(workspace_root)
                 # @@@host-local-cwd-is-advisory - persisted local thread cwd can come from another
-                # host (for example a macOS path stored in shared Supabase but replayed inside a
-                # Linux deployment container). Only pin workspace_root when that path exists here.
-                elif path.exists() and path.is_dir():
+                # host, request, or frontend state. Only pin workspace_root when that path exists here.
+                if path.exists() and path.is_dir():
                     workspace_root = path.resolve()
                     app_obj.state.thread_cwd[thread_id] = str(workspace_root)
                 else:

--- a/core/identity/agent_registry.py
+++ b/core/identity/agent_registry.py
@@ -1,32 +1,6 @@
 from __future__ import annotations
 
-import json
-import logging
-import uuid
-from typing import Any
-
-from config.user_paths import user_home_path, user_home_read_candidates
-
-logger = logging.getLogger(__name__)
-
-INSTANCES_FILE = user_home_path("agent_instances.json")
-
-
-def _load() -> dict[str, Any]:
-    merged: dict[str, Any] = {}
-    for path in user_home_read_candidates("agent_instances.json"):
-        if not path.exists():
-            continue
-        try:
-            merged.update(json.loads(path.read_text()))
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load agent_instances.json: %s", e)
-    return merged
-
-
-def _save(data: dict[str, Any]) -> None:
-    INSTANCES_FILE.parent.mkdir(parents=True, exist_ok=True)
-    INSTANCES_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+import hashlib
 
 
 def get_or_create_agent_id(
@@ -36,24 +10,7 @@ def get_or_create_agent_id(
     sandbox_type: str,
     user_path: str | None = None,
 ) -> str:
-    instances = _load()
-
-    for aid, info in instances.items():
-        if info.get("user_id") == user_id and info.get("thread_id") == thread_id and info.get("sandbox_type") == sandbox_type:
-            return aid
-
-    import time
-
-    agent_id = uuid.uuid4().hex[:8]
-    entry: dict[str, Any] = {
-        "user_id": user_id,
-        "thread_id": thread_id,
-        "sandbox_type": sandbox_type,
-        "created_at": int(time.time()),
-    }
-    if user_path:
-        entry["user_path"] = user_path
-
-    instances[agent_id] = entry
-    _save(instances)
-    return agent_id
+    # @@@derived-agent-id - runtime identity is already anchored by database rows;
+    # do not mint stability by writing a process-local registry file.
+    key = f"{user_id}\0{thread_id}\0{sandbox_type}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -235,8 +235,6 @@ class LeonAgent:
         # Override workspace_root for sandbox mode
         if self._sandbox.name != "local":
             self.workspace_root = Path(self._sandbox.working_dir)
-        else:
-            self.workspace_root.mkdir(parents=True, exist_ok=True)
 
         # Initialize model
         self._model_http_client: httpx.Client | None = None

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -586,10 +586,14 @@ class LeonAgent:
         self._session_pool: dict[str, Any] = {}
         env_db_path = os.getenv("LEON_DB_PATH")
         env_sandbox_db_path = os.getenv("LEON_SANDBOX_DB_PATH")
-        self.db_path = Path(env_db_path).expanduser() if env_db_path else (Path.home() / ".leon" / "leon.db")
-        self.sandbox_db_path = Path(env_sandbox_db_path).expanduser() if env_sandbox_db_path else (Path.home() / ".leon" / "sandbox.db")
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.sandbox_db_path.parent.mkdir(parents=True, exist_ok=True)
+        # @@@operator-owned-db-paths - server Agent construction must not create
+        # host-local state directories. SQLite paths only exist when explicitly configured.
+        self.db_path = Path(env_db_path).expanduser() if env_db_path else None
+        self.sandbox_db_path = Path(env_sandbox_db_path).expanduser() if env_sandbox_db_path else None
+        if self.db_path is not None:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.sandbox_db_path is not None:
+            self.sandbox_db_path.parent.mkdir(parents=True, exist_ok=True)
 
     def _init_sandbox(self, sandbox: Any) -> Any:
         """Initialize sandbox infrastructure layer."""

--- a/core/runtime/middleware/memory/middleware.py
+++ b/core/runtime/middleware/memory/middleware.py
@@ -64,8 +64,7 @@ class MemoryMiddleware(AgentMiddleware):
             self.compactor = ContextCompactor()
 
         # Persistent storage
-        summary_db_path = db_path or Path.home() / ".leon" / "leon.db"
-        self.summary_store = SummaryStore(summary_db_path, summary_repo=summary_repo) if (db_path or summary_repo) else None
+        self.summary_store = SummaryStore(db_path, summary_repo=summary_repo) if (db_path or summary_repo) else None
         self._checkpointer: Any = None
         self._checkpoint_store: CheckpointStore | None = None
         self.checkpointer = checkpointer

--- a/core/tools/command/hooks/file_access_logger.py
+++ b/core/tools/command/hooks/file_access_logger.py
@@ -8,7 +8,6 @@ class FileAccessLoggerHook:
     def __init__(self, workspace_root: Path | str | None = None, log_file: str = "file_access.log"):
         self.workspace_root = Path(workspace_root) if workspace_root else None
         self.log_path = (Path(workspace_root) / log_file) if workspace_root else Path(log_file)
-        self.log_path.parent.mkdir(parents=True, exist_ok=True)
 
     def check_file_operation(self, file_path: str, operation: str) -> HookResult:
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/core/tools/filesystem/service.py
+++ b/core/tools/filesystem/service.py
@@ -118,8 +118,8 @@ class FileSystemService:
         self.extra_allowed_paths = [_remote_path(p) if backend.is_remote else Path(p).resolve() for p in (extra_allowed_paths or [])]
         self._edit_critical_section = threading.Lock()
 
-        if not backend.is_remote and isinstance(self.workspace_root, Path):
-            self.workspace_root.mkdir(parents=True, exist_ok=True)
+        if not backend.is_remote and isinstance(self.workspace_root, Path) and not self.workspace_root.is_dir():
+            raise RuntimeError(f"workspace_root must exist for local filesystem service: {self.workspace_root}")
 
         self._register(registry)
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -297,7 +297,7 @@ async def test_get_or_create_agent_ignores_unavailable_local_cwd(monkeypatch: py
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_agent_honors_fresh_local_thread_cwd_even_when_missing(monkeypatch: pytest.MonkeyPatch, tmp_path):
+async def test_get_or_create_agent_does_not_create_unavailable_live_local_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path):
     captured: dict[str, object] = {}
     requested = tmp_path / "fresh-workspace"
 
@@ -341,9 +341,9 @@ async def test_get_or_create_agent_honors_fresh_local_thread_cwd_even_when_missi
 
     await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-3")
 
-    assert captured["workspace_root"] == requested.resolve()
-    assert requested.is_dir()
-    assert app.state.thread_cwd["thread-3"] == str(requested.resolve())
+    assert captured["workspace_root"] is None
+    assert not requested.exists()
+    assert "thread-3" not in app.state.thread_cwd
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_agent_registry.py
+++ b/tests/Unit/core/test_agent_registry.py
@@ -3,19 +3,39 @@ from __future__ import annotations
 from core.identity import agent_registry
 
 
-def test_get_or_create_agent_id_persists_user_id_contract(monkeypatch):
-    saved: dict[str, object] = {}
-
-    monkeypatch.setattr(agent_registry, "_load", lambda: {})
-    monkeypatch.setattr(agent_registry, "_save", lambda data: saved.update(data))
-    monkeypatch.setattr(agent_registry.uuid, "uuid4", lambda: type("U", (), {"hex": "abcdef1234567890"})())
-
+def test_get_or_create_agent_id_derives_stable_user_id_contract():
     agent_id = agent_registry.get_or_create_agent_id(
         user_id="agent-user-1",
         thread_id="thread-1",
         sandbox_type="local",
     )
 
-    assert agent_id == "abcdef12"
-    assert saved[agent_id]["user_id"] == "agent-user-1"
-    assert "member" not in saved[agent_id]
+    assert agent_id == agent_registry.get_or_create_agent_id(
+        user_id="agent-user-1",
+        thread_id="thread-1",
+        sandbox_type="local",
+    )
+    assert agent_id != agent_registry.get_or_create_agent_id(
+        user_id="agent-user-2",
+        thread_id="thread-1",
+        sandbox_type="local",
+    )
+
+
+def test_get_or_create_agent_id_does_not_write_process_local_registry(tmp_path):
+    registry_file = tmp_path / ".leon" / "agent_instances.json"
+
+    first = agent_registry.get_or_create_agent_id(
+        user_id="agent-user-1",
+        thread_id="thread-1",
+        sandbox_type="local",
+    )
+    second = agent_registry.get_or_create_agent_id(
+        user_id="agent-user-1",
+        thread_id="thread-1",
+        sandbox_type="local",
+    )
+
+    assert first == second
+    assert not registry_file.exists()
+    assert not registry_file.parent.exists()

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from core.runtime.middleware.memory.middleware import MemoryMiddleware
 from core.runtime.middleware.memory.summary_store import SummaryStore
 from core.runtime.middleware.queue.manager import MessageQueueManager
 from storage.providers.sqlite.queue_repo import SQLiteQueueRepo
@@ -146,3 +147,21 @@ def test_summary_store_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch,
         assert isinstance(store._repo, SQLiteSummaryRepo)
     finally:
         store._repo.close()
+
+
+def test_memory_middleware_repo_injection_does_not_pass_default_home_db_path(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    fake_repo = _FakeSummaryRepo()
+
+    class _SummaryStoreProbe:
+        def __init__(self, db_path=None, summary_repo=None):
+            captured["db_path"] = db_path
+            captured["summary_repo"] = summary_repo
+
+    monkeypatch.setattr("core.runtime.middleware.memory.middleware.SummaryStore", _SummaryStoreProbe)
+
+    middleware = MemoryMiddleware(summary_repo=fake_repo)
+
+    assert middleware.summary_store is not None
+    assert captured["summary_repo"] is fake_repo
+    assert captured["db_path"] is None

--- a/tests/Unit/filesystem/test_filesystem_service.py
+++ b/tests/Unit/filesystem/test_filesystem_service.py
@@ -4,6 +4,8 @@ import threading
 import time
 from pathlib import Path, PurePosixPath
 
+import pytest
+
 from core.runtime.registry import ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope
 from core.tools.filesystem.service import FileSystemService, _ReadFileStateCache
@@ -27,6 +29,15 @@ def _make_service(
 def _require_text_result(result: str | ToolResultEnvelope) -> str:
     assert isinstance(result, str)
     return result
+
+
+def test_filesystem_service_rejects_missing_local_workspace(tmp_path: Path):
+    missing = tmp_path / "missing-workspace"
+
+    with pytest.raises(RuntimeError, match="workspace_root must exist"):
+        _make_service(missing)
+
+    assert not missing.exists()
 
 
 def test_edit_rejects_if_last_read_was_partial_view(tmp_path: Path):

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -564,6 +565,53 @@ def test_leon_agent_does_not_create_default_home_db_directory(monkeypatch, tmp_p
         assert not (tmp_path / ".leon").exists()
     finally:
         agent.close()
+
+
+@_patch_env_api_key()
+def test_leon_agent_does_not_prepare_local_workspace_directory(monkeypatch, tmp_path):
+    from core.runtime.agent import LeonAgent
+    from sandbox import Sandbox
+
+    class _FakeLocalSandbox(Sandbox):
+        @property
+        def name(self) -> str:
+            return "local"
+
+        @property
+        def working_dir(self) -> str:
+            return str(tmp_path)
+
+        @property
+        def env_label(self) -> str:
+            return "Test local"
+
+        def fs(self):
+            return None
+
+        def shell(self):
+            return None
+
+    original_mkdir = Path.mkdir
+
+    def _raise_on_workspace_mkdir(self, *args, **kwargs):
+        if self.resolve() == tmp_path.resolve():
+            raise AssertionError("LeonAgent must not mkdir the local workspace during runtime startup")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _raise_on_workspace_mkdir)
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=_mock_model("No workspace mkdir")),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+    ):
+        agent = LeonAgent(
+            workspace_root=str(tmp_path),
+            sandbox=_FakeLocalSandbox(),
+            queue_manager=SimpleNamespace(drain_all=lambda _thread_id: [], enqueue=lambda *_args, **_kwargs: None),
+            api_key="sk-test-integration",
+        )
+
+    agent.close()
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -521,6 +521,51 @@ def test_leon_agent_rejects_process_local_config_source(tmp_path):
         )
 
 
+@_patch_env_api_key()
+def test_leon_agent_does_not_create_default_home_db_directory(monkeypatch, tmp_path):
+    from core.runtime.agent import LeonAgent
+    from sandbox import Sandbox
+
+    class _FakeLocalSandbox(Sandbox):
+        @property
+        def name(self) -> str:
+            return "local"
+
+        @property
+        def working_dir(self) -> str:
+            return str(tmp_path)
+
+        @property
+        def env_label(self) -> str:
+            return "Test local"
+
+        def fs(self):
+            return None
+
+        def shell(self):
+            return None
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("LEON_DB_PATH", raising=False)
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=_mock_model("No default home DB dir")),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+    ):
+        agent = LeonAgent(
+            workspace_root=str(tmp_path),
+            sandbox=_FakeLocalSandbox(),
+            queue_manager=SimpleNamespace(drain_all=lambda _thread_id: [], enqueue=lambda *_args, **_kwargs: None),
+            api_key="sk-test-integration",
+        )
+
+    try:
+        assert not (tmp_path / ".leon").exists()
+    finally:
+        agent.close()
+
+
 @pytest.mark.asyncio
 @_patch_env_api_key()
 async def test_leon_agent_agent_config_id_registers_mcp_resource_tools(tmp_path):


### PR DESCRIPTION
## Summary
- stop local thread cwd startup from creating missing host directories
- make Agent sqlite paths explicit instead of defaulting to HOME/.leon
- derive runtime agent ids without writing agent_instances.json
- require existing local filesystem workspaces and keep injected memory storage pathless

## Verification
- uv run pytest tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_does_not_create_unavailable_live_local_cwd tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_ignores_unavailable_local_cwd tests/Unit/core/test_agent_registry.py tests/Unit/filesystem/test_filesystem_service.py::test_filesystem_service_rejects_missing_local_workspace tests/Unit/core/test_runtime_side_store_defaults.py::test_memory_middleware_repo_injection_does_not_pass_default_home_db_path tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_does_not_create_default_home_db_directory tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_does_not_prepare_local_workspace_directory -q
- uv run pytest tests/Unit/core/test_agent_pool.py tests/Unit/core/test_agent_registry.py tests/Unit/filesystem/test_filesystem_service.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_leon_agent.py -q
- uv run pytest tests/Unit -q
- uv run ruff check backend/threads/pool/registry.py core/runtime/agent.py core/identity/agent_registry.py core/tools/filesystem/service.py core/tools/command/hooks/file_access_logger.py core/runtime/middleware/memory/middleware.py tests/Unit/core/test_agent_pool.py tests/Unit/core/test_agent_registry.py tests/Unit/filesystem/test_filesystem_service.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_leon_agent.py
- uv run ruff format --check backend/threads/pool/registry.py core/runtime/agent.py core/identity/agent_registry.py core/tools/filesystem/service.py core/tools/command/hooks/file_access_logger.py core/runtime/middleware/memory/middleware.py tests/Unit/core/test_agent_pool.py tests/Unit/core/test_agent_registry.py tests/Unit/filesystem/test_filesystem_service.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_leon_agent.py