### PR TITLE
refactor: require explicit sandbox control-plane storage

### DIFF
--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -873,14 +873,18 @@ class AgentService:
             prompt = _normalize_child_workspace_prompt(prompt, child_workspace_root)
 
             if parent_thread_id and parent_thread_id != thread_id:
+                from sandbox.control_plane_repos import configured_sandbox_db_path
                 from sandbox.manager import bind_thread_to_existing_thread_sandbox_runtime
 
-                parent_workspace_cwd = self._resolve_parent_workspace_path(parent_thread_id) or str(child_workspace_root)
-                bind_thread_to_existing_thread_sandbox_runtime(
-                    thread_id,
-                    parent_thread_id,
-                    cwd=parent_workspace_cwd,
-                )
+                control_plane_db_path = configured_sandbox_db_path()
+                if control_plane_db_path is not None:
+                    parent_workspace_cwd = self._resolve_parent_workspace_path(parent_thread_id) or str(child_workspace_root)
+                    bind_thread_to_existing_thread_sandbox_runtime(
+                        thread_id,
+                        parent_thread_id,
+                        cwd=parent_workspace_cwd,
+                        db_path=control_plane_db_path,
+                    )
 
             # Wire child agent events to the parent's EventBus subscription
             # so the parent SSE stream shows sub-agent activity.

--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -226,12 +226,12 @@ class _LazyLocalExecutor:
 
 class LocalSandbox(Sandbox):
     def __init__(self, workspace_root: str, db_path: Path | None = None) -> None:
-        from sandbox.manager import SandboxManager
         from sandbox.providers.local import LocalSessionProvider
 
         self._workspace_root = workspace_root
+        self._db_path = db_path
         self._provider = LocalSessionProvider(default_cwd=workspace_root)
-        self._manager = SandboxManager(provider=self._provider, db_path=db_path)
+        self._manager: SandboxManager | None = None
         self._capability_cache: dict[str, SandboxCapability] = {}
         self._owned_thread_ids: set[str] = set()
 
@@ -249,6 +249,13 @@ class LocalSandbox(Sandbox):
 
     @property
     def manager(self) -> SandboxManager:
+        if self._manager is None:
+            from sandbox.manager import SandboxManager
+
+            # @@@lazy-local-control-plane - local Agent construction is allowed
+            # without sandbox storage; terminal/session use is the boundary that
+            # requires an explicit control-plane DB path.
+            self._manager = SandboxManager(provider=self._provider, db_path=self._db_path)
         return self._manager
 
     def _get_capability(self) -> SandboxCapability:
@@ -259,10 +266,11 @@ class LocalSandbox(Sandbox):
             raise RuntimeError("No thread_id set. Call set_current_thread_id first.")
         self._owned_thread_ids.add(thread_id)
         cached = self._capability_cache.get(thread_id)
-        if cached is not None and _cached_capability_is_stale(self._manager, thread_id, cached):
+        manager = self.manager
+        if cached is not None and _cached_capability_is_stale(manager, thread_id, cached):
             self._capability_cache.pop(thread_id, None)
         if thread_id not in self._capability_cache:
-            self._capability_cache[thread_id] = self._manager.get_sandbox(thread_id)
+            self._capability_cache[thread_id] = manager.get_sandbox(thread_id)
         return self._capability_cache[thread_id]
 
     def fs(self) -> FileSystemBackend | None:

--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -231,7 +231,7 @@ class LocalSandbox(Sandbox):
 
         self._workspace_root = workspace_root
         self._provider = LocalSessionProvider(default_cwd=workspace_root)
-        self._manager = SandboxManager(provider=self._provider, db_path=db_path or (Path.home() / ".leon" / "sandbox.db"))
+        self._manager = SandboxManager(provider=self._provider, db_path=db_path)
         self._capability_cache: dict[str, SandboxCapability] = {}
         self._owned_thread_ids: set[str] = set()
 

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING
 
 from sandbox.interfaces.executor import BaseExecutor
 from sandbox.interfaces.filesystem import FileSystemBackend
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
-from storage.runtime import uses_supabase_runtime_defaults
+from storage.providers.sqlite.kernel import connect_sqlite
 
 if TYPE_CHECKING:
     from sandbox.chat_session import ChatSession
@@ -94,8 +93,6 @@ class _CommandWrapper(BaseExecutor):
             if terminal_id is not None:
                 return terminal_id
             return None
-        if self._db_path is not None and uses_supabase_runtime_defaults() and self._db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX):
-            raise RuntimeError("strategy-backed command lookup requires a bound command repo")
         if self._db_path is None:
             return None
         with connect_sqlite(self._db_path) as conn:

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -8,13 +8,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from sandbox.clock import parse_runtime_datetime, utc_now, utc_now_iso
-from sandbox.control_plane_repos import make_chat_session_repo, make_sandbox_runtime_repo, make_terminal_repo
+from sandbox.control_plane_repos import (
+    make_chat_session_repo,
+    make_sandbox_runtime_repo,
+    make_terminal_repo,
+    resolve_sandbox_db_path,
+)
 from sandbox.lifecycle import (
     ChatSessionState,
     assert_chat_session_transition,
     parse_chat_session_state,
 )
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 
 if TYPE_CHECKING:
     from sandbox.provider import SandboxProvider
@@ -86,7 +90,7 @@ class ChatSession:
         self.budget_json = budget_json
         self.ended_at = ended_at
         self.close_reason = close_reason
-        self._db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        self._db_path = resolve_sandbox_db_path(db_path) if session_repo is None else db_path
         self._session_repo = session_repo or make_chat_session_repo(db_path=self._db_path)
 
     def is_expired(self) -> bool:
@@ -131,7 +135,8 @@ class ChatSessionManager:
         sandbox_runtime_repo=None,
     ):
         self.provider = provider
-        self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        needs_db_path = chat_session_repo is None or terminal_repo is None or sandbox_runtime_repo is None
+        self.db_path = resolve_sandbox_db_path(db_path) if needs_db_path else db_path
         self.default_policy = default_policy or ChatSessionPolicy()
         self._live_sessions: dict[str, ChatSession] = {}
         if chat_session_repo:

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -18,6 +18,11 @@ def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
     return Path(raw_path)
 
 
+def configured_sandbox_db_path() -> Path | None:
+    raw_path = os.getenv("LEON_SANDBOX_DB_PATH")
+    return Path(raw_path) if raw_path else None
+
+
 def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
     return db_path is None and not os.getenv("LEON_SANDBOX_DB_PATH") and uses_supabase_runtime_defaults()
 

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
 from storage.runtime import (
     build_sandbox_runtime_repo,
     uses_supabase_runtime_defaults,
@@ -16,7 +15,7 @@ def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
     raw_path = os.getenv("LEON_SANDBOX_DB_PATH")
     if not raw_path:
         raise RuntimeError("LEON_SANDBOX_DB_PATH is required for sqlite sandbox control-plane storage.")
-    return resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return Path(raw_path)
 
 
 def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
@@ -10,11 +11,16 @@ from storage.runtime import (
 
 
 def resolve_sandbox_db_path(db_path: Path | None = None) -> Path:
-    return db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    if db_path is not None:
+        return db_path
+    raw_path = os.getenv("LEON_SANDBOX_DB_PATH")
+    if not raw_path:
+        raise RuntimeError("LEON_SANDBOX_DB_PATH is required for sqlite sandbox control-plane storage.")
+    return resolve_role_db_path(SQLiteDBRole.SANDBOX)
 
 
 def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
-    return uses_supabase_runtime_defaults() and resolve_sandbox_db_path(db_path) == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return db_path is None and not os.getenv("LEON_SANDBOX_DB_PATH") and uses_supabase_runtime_defaults()
 
 
 def make_chat_session_repo(db_path: Path | None = None):

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -14,8 +14,7 @@ from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.runtime_handle import sandbox_runtime_from_row
 from sandbox.terminal import TerminalState, terminal_from_row
-from storage.providers.sqlite.kernel import SQLiteDBRole, resolve_role_db_path
-from storage.runtime import build_storage_container, uses_supabase_runtime_defaults
+from storage.runtime import build_storage_container
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +40,8 @@ def lookup_sandbox_for_thread(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> str | None:
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
-    uses_strategy_default_sandbox = uses_supabase_runtime_defaults() and target_db == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    target_db = resolve_sandbox_db_path(db_path) if terminal_repo is None or sandbox_runtime_repo is None else db_path
+    uses_strategy_default_sandbox = False
     if terminal_repo is None and sandbox_runtime_repo is None and not target_db.exists() and not uses_strategy_default_sandbox:
         return None
 
@@ -78,7 +77,7 @@ def resolve_existing_sandbox_runtime_cwd(
     if requested_cwd:
         return requested_cwd
 
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    target_db = resolve_sandbox_db_path(db_path) if sandbox_runtime_repo is None else db_path
     _sandbox_runtime_repo = sandbox_runtime_repo
     own_sandbox_runtime_repo = _sandbox_runtime_repo is None
     if _sandbox_runtime_repo is None:
@@ -104,7 +103,7 @@ def bind_thread_to_existing_sandbox_runtime(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> str:
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    target_db = resolve_sandbox_db_path(db_path) if terminal_repo is None or sandbox_runtime_repo is None else db_path
     _terminal_repo = terminal_repo
     own_terminal_repo = _terminal_repo is None
     if _terminal_repo is None:
@@ -150,7 +149,7 @@ def resolve_existing_sandbox_runtime(
 
     # @@@existing-sandbox-runtime-identity - existing-sandbox reuse must bind
     # through live runtime identity; stored runtime config is not a resolution source.
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    target_db = resolve_sandbox_db_path(db_path) if sandbox_runtime_repo is None else db_path
     _sandbox_runtime_repo = sandbox_runtime_repo
     own_sandbox_runtime_repo = _sandbox_runtime_repo is None
     if _sandbox_runtime_repo is None:
@@ -204,7 +203,7 @@ def bind_thread_to_existing_thread_sandbox_runtime(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> str | None:
-    target_db = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    target_db = resolve_sandbox_db_path(db_path) if terminal_repo is None else db_path
     if not cwd:
         raise ValueError("thread reuse cwd is required")
     _terminal_repo = terminal_repo

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -9,7 +9,7 @@ from config.user_paths import user_home_path
 from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
 from sandbox.clock import parse_runtime_datetime, utc_now
-from sandbox.control_plane_repos import make_chat_session_repo, make_sandbox_runtime_repo, make_terminal_repo
+from sandbox.control_plane_repos import make_chat_session_repo, make_sandbox_runtime_repo, make_terminal_repo, resolve_sandbox_db_path
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.runtime_handle import sandbox_runtime_from_row
@@ -242,7 +242,7 @@ class SandboxManager:
         self.provider_capability = provider.get_capability()
         self._on_session_ready = on_session_ready
 
-        self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        self.db_path = resolve_sandbox_db_path(db_path)
         self.terminal_store = make_terminal_repo(db_path=self.db_path)
         self.sandbox_runtime_store = make_sandbox_runtime_repo(db_path=self.db_path)
 

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 from sandbox.interfaces.executor import AsyncCommand, ExecuteResult
 from sandbox.shell_output import normalize_pty_result
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import connect_sqlite
 from storage.runtime import uses_supabase_runtime_defaults
 
 if platform.system() == "Windows":
@@ -37,7 +37,7 @@ ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _uses_strategy_command_registry(db_path: Path | None) -> bool:
-    return db_path is not None and uses_supabase_runtime_defaults() and db_path == resolve_role_db_path(SQLiteDBRole.SANDBOX)
+    return db_path is None and uses_supabase_runtime_defaults()
 
 
 def _require_select_module():

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_explicit_role_db_path
 
 REQUIRED_ABSTRACT_TERMINAL_COLUMNS = {
     "terminal_id",
@@ -92,7 +92,7 @@ class SQLiteTerminal(AbstractTerminal):
         db_path: Path | None = None,
     ):
         super().__init__(terminal_id, thread_id, sandbox_runtime_id, state)
-        self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        self.db_path = Path(db_path) if db_path is not None else resolve_explicit_role_db_path(SQLiteDBRole.SANDBOX)
 
     def _persist_state(self) -> None:
         with _connect(self.db_path) as conn:

--- a/storage/providers/sqlite/chat_session_repo.py
+++ b/storage/providers/sqlite/chat_session_repo.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from sandbox.chat_session import REQUIRED_CHAT_SESSION_COLUMNS
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_explicit_role_db_path
 
 
 class SQLiteChatSessionRepo:
@@ -19,7 +19,7 @@ class SQLiteChatSessionRepo:
             self._db_path = Path(db_path) if db_path else Path("")
         else:
             if db_path is None:
-                db_path = resolve_role_db_path(SQLiteDBRole.SANDBOX)
+                db_path = resolve_explicit_role_db_path(SQLiteDBRole.SANDBOX)
             self._db_path = Path(db_path)
             self._db_path.parent.mkdir(parents=True, exist_ok=True)
             self._conn = connect_sqlite(db_path, check_same_thread=False)

--- a/storage/providers/sqlite/kernel.py
+++ b/storage/providers/sqlite/kernel.py
@@ -38,6 +38,19 @@ def resolve_role_db_path(role: SQLiteDBRole, db_path: Path | str | None = None) 
     return main_path
 
 
+def resolve_explicit_role_db_path(role: SQLiteDBRole) -> Path:
+    env_by_role = {
+        SQLiteDBRole.MAIN: "LEON_DB_PATH",
+        SQLiteDBRole.SANDBOX: "LEON_SANDBOX_DB_PATH",
+        SQLiteDBRole.QUEUE: "LEON_QUEUE_DB_PATH",
+    }
+    env_var = env_by_role[role]
+    raw_path = os.getenv(env_var)
+    if not raw_path:
+        raise RuntimeError(f"{env_var} is required for sqlite {role.value} storage.")
+    return Path(raw_path)
+
+
 def apply_pragmas(conn: sqlite3.Connection) -> None:
     conn.execute(f"PRAGMA journal_mode={WAL_MODE}")
     conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from sandbox.lifecycle import parse_sandbox_runtime_instance_state
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_explicit_role_db_path
 
 
 class SQLiteSandboxRuntimeRepo:
@@ -21,7 +21,7 @@ class SQLiteSandboxRuntimeRepo:
             self._db_path = Path(db_path) if db_path else Path("")
         else:
             if db_path is None:
-                db_path = resolve_role_db_path(SQLiteDBRole.SANDBOX)
+                db_path = resolve_explicit_role_db_path(SQLiteDBRole.SANDBOX)
             self._db_path = Path(db_path)
             self._db_path.parent.mkdir(parents=True, exist_ok=True)
             self._conn = connect_sqlite(db_path, check_same_thread=False)

--- a/storage/providers/sqlite/terminal_repo.py
+++ b/storage/providers/sqlite/terminal_repo.py
@@ -10,7 +10,7 @@ from sandbox.terminal import (
     REQUIRED_ABSTRACT_TERMINAL_COLUMNS,
     REQUIRED_TERMINAL_POINTER_COLUMNS,
 )
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_explicit_role_db_path
 
 
 class SQLiteTerminalRepo:
@@ -22,7 +22,7 @@ class SQLiteTerminalRepo:
             self._db_path = Path(db_path) if db_path else Path("")
         else:
             if db_path is None:
-                db_path = resolve_role_db_path(SQLiteDBRole.SANDBOX)
+                db_path = resolve_explicit_role_db_path(SQLiteDBRole.SANDBOX)
             self._db_path = Path(db_path)
             self._db_path.parent.mkdir(parents=True, exist_ok=True)
             self._conn = connect_sqlite(db_path, check_same_thread=False)

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -1170,6 +1170,7 @@ async def test_run_agent_reuses_parent_sandbox_runtime_for_child_thread_terminal
 async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
     live_child_thread_runner = AsyncMock(return_value="LIVE_CHILD_DONE")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
 
     thread_repo = _FakeThreadRepo(
         rows={
@@ -1237,6 +1238,7 @@ async def test_run_agent_passes_parent_workspace_path_into_thread_reuse_bind(mon
 async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
     live_child_thread_runner = AsyncMock(return_value="LIVE_CHILD_DONE")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
 
     thread_repo = _FakeThreadRepo(
         rows={
@@ -1279,9 +1281,10 @@ async def test_run_agent_fails_loud_when_parent_workspace_repo_is_missing(monkey
 
 
 @pytest.mark.asyncio
-async def test_run_agent_falls_back_to_child_workspace_root_when_parent_workspace_truth_is_absent(monkeypatch, tmp_path):
+async def test_run_agent_uses_child_workspace_root_when_parent_workspace_truth_is_absent(monkeypatch, tmp_path):
     _patch_create_leon_agent(monkeypatch)
     live_child_thread_runner = AsyncMock(return_value="LIVE_CHILD_DONE")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
 
     captured: dict[str, Any] = {}
 

--- a/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
+++ b/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
@@ -6,6 +6,9 @@ import pytest
 
 from sandbox import control_plane_repos
 from sandbox.manager import SandboxManager
+from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
+from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
+from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
 
 class _Provider:
@@ -52,5 +55,23 @@ def test_sandbox_manager_requires_explicit_control_plane_db_path(monkeypatch, tm
 
     with pytest.raises(RuntimeError, match="LEON_SANDBOX_DB_PATH"):
         SandboxManager(provider=_Provider())
+
+    assert not (tmp_path / ".leon").exists()
+
+
+@pytest.mark.parametrize(
+    "repo_cls",
+    [
+        SQLiteTerminalRepo,
+        SQLiteChatSessionRepo,
+        SQLiteSandboxRuntimeRepo,
+    ],
+)
+def test_sqlite_sandbox_repos_require_explicit_db_path(repo_cls, monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+
+    with pytest.raises(RuntimeError, match="LEON_SANDBOX_DB_PATH"):
+        repo_cls()
 
     assert not (tmp_path / ".leon").exists()

--- a/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
+++ b/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
@@ -75,3 +75,13 @@ def test_sqlite_sandbox_repos_require_explicit_db_path(repo_cls, monkeypatch, tm
         repo_cls()
 
     assert not (tmp_path / ".leon").exists()
+
+
+def test_explicit_sandbox_db_path_is_not_strategy_command_registry(monkeypatch, tmp_path):
+    from sandbox.runtime import _uses_strategy_command_registry
+
+    db_path = tmp_path / "sandbox.db"
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(db_path))
+
+    assert not _uses_strategy_command_registry(db_path)

--- a/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
+++ b/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sandbox import control_plane_repos
+from sandbox.manager import SandboxManager
+
+
+class _Provider:
+    def get_capability(self):
+        return SimpleNamespace(runtime_kind="local")
 
 
 @pytest.mark.parametrize(
@@ -33,4 +41,16 @@ def test_sandbox_runtime_repo_factory_uses_runtime_storage_without_local_path(mo
     monkeypatch.setattr(control_plane_repos, "build_sandbox_runtime_repo", lambda: fake_repo)
 
     assert control_plane_repos.make_sandbox_runtime_repo() is fake_repo
+    assert not (tmp_path / ".leon").exists()
+
+
+def test_sandbox_manager_requires_explicit_control_plane_db_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+
+    with pytest.raises(RuntimeError, match="LEON_SANDBOX_DB_PATH"):
+        SandboxManager(provider=_Provider())
+
     assert not (tmp_path / ".leon").exists()

--- a/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
+++ b/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from sandbox import control_plane_repos
+
+
+@pytest.mark.parametrize(
+    "factory_name",
+    [
+        "make_terminal_repo",
+        "make_chat_session_repo",
+    ],
+)
+def test_sqlite_control_plane_repo_factories_require_explicit_sandbox_db_path(factory_name, monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+
+    factory = getattr(control_plane_repos, factory_name)
+
+    with pytest.raises(RuntimeError, match="LEON_SANDBOX_DB_PATH"):
+        factory()
+
+    assert not (tmp_path / ".leon").exists()
+
+
+def test_sandbox_runtime_repo_factory_uses_runtime_storage_without_local_path(monkeypatch, tmp_path):
+    fake_repo = object()
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.setattr(control_plane_repos, "build_sandbox_runtime_repo", lambda: fake_repo)
+
+    assert control_plane_repos.make_sandbox_runtime_repo() is fake_repo
+    assert not (tmp_path / ".leon").exists()

--- a/tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
+++ b/tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from sandbox.base import LocalSandbox
+
+
+def test_local_sandbox_keeps_missing_db_path_unset(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class _SandboxManagerProbe:
+        def __init__(self, *, provider, db_path=None):
+            captured["provider"] = provider
+            captured["db_path"] = db_path
+
+    monkeypatch.setattr("sandbox.manager.SandboxManager", _SandboxManagerProbe)
+
+    LocalSandbox(str(tmp_path))
+
+    assert captured["db_path"] is None

--- a/tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
+++ b/tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from sandbox.base import LocalSandbox
 
 
-def test_local_sandbox_keeps_missing_db_path_unset(monkeypatch, tmp_path):
-    captured: dict[str, object] = {}
+def test_local_sandbox_defers_manager_creation_until_control_plane_use(monkeypatch, tmp_path):
+    captured: list[dict[str, object]] = []
 
     class _SandboxManagerProbe:
         def __init__(self, *, provider, db_path=None):
-            captured["provider"] = provider
-            captured["db_path"] = db_path
+            captured.append({"provider": provider, "db_path": db_path})
 
     monkeypatch.setattr("sandbox.manager.SandboxManager", _SandboxManagerProbe)
 
-    LocalSandbox(str(tmp_path))
+    sandbox = LocalSandbox(str(tmp_path))
 
-    assert captured["db_path"] is None
+    assert captured == []
+    assert sandbox.manager is sandbox.manager
+    assert captured[0]["db_path"] is None
+    assert len(captured) == 1


### PR DESCRIPTION
## Summary
- make local sandbox manager creation lazy so Agent startup does not open sandbox storage
- require explicit sandbox DB paths for sqlite sandbox control-plane repos
- route sandbox manager/chat/terminal helpers through explicit DB resolution
- bind child sandbox runtime only when control-plane config is present

## Verification
- uv run pytest tests/Unit -q
- uv run ruff check core/agents/service.py sandbox/base.py sandbox/capability.py sandbox/chat_session.py sandbox/control_plane_repos.py sandbox/manager.py sandbox/runtime.py sandbox/terminal.py storage/providers/sqlite/kernel.py storage/providers/sqlite/terminal_repo.py storage/providers/sqlite/chat_session_repo.py storage/providers/sqlite/sandbox_runtime_repo.py tests/Unit/core/test_agent_service.py tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
- uv run ruff format --check core/agents/service.py sandbox/base.py sandbox/capability.py sandbox/chat_session.py sandbox/control_plane_repos.py sandbox/manager.py sandbox/runtime.py sandbox/terminal.py storage/providers/sqlite/kernel.py storage/providers/sqlite/terminal_repo.py storage/providers/sqlite/chat_session_repo.py storage/providers/sqlite/sandbox_runtime_repo.py tests/Unit/core/test_agent_service.py tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py tests/Unit/sandbox/test_local_sandbox_storage_boundary.py