### PR TITLE
Remove sandbox path from summary storage

### DIFF
--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -36,7 +36,7 @@ class SummaryData:
 
 class SummaryStore:
     def __init__(self, db_path: Path | None = None, summary_repo: SummaryRepo | None = None):
-        self.db_path = db_path
+        self.db_path = Path(db_path) if db_path is not None else None
         self._repo: SummaryRepo
         if summary_repo is not None:
             self._repo = summary_repo
@@ -47,9 +47,8 @@ class SummaryStore:
         elif db_path is None:
             raise RuntimeError("SummaryStore requires summary_repo or db_path.")
         else:
-            resolved_db_path = Path(db_path)
             # @@@connect_injection - keep _connect as an indirection point so existing retry/rollback tests can patch it.
-            self._repo = SQLiteSummaryRepo(resolved_db_path, connect_fn=lambda p: _connect(Path(p)))
+            self._repo = SQLiteSummaryRepo(self.db_path, connect_fn=lambda p: _connect(Path(p)))
         self._ensure_tables()
 
     def _ensure_tables(self) -> None:

--- a/core/runtime/middleware/memory/summary_store.py
+++ b/core/runtime/middleware/memory/summary_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from storage.contracts import SummaryRepo, SummaryRow
-from storage.providers.sqlite.kernel import SQLiteDBRole, connect_sqlite, resolve_role_db_path
+from storage.providers.sqlite.kernel import connect_sqlite
 from storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
 from storage.runtime import build_summary_repo, uses_supabase_runtime_defaults
 
@@ -36,7 +36,7 @@ class SummaryData:
 
 class SummaryStore:
     def __init__(self, db_path: Path | None = None, summary_repo: SummaryRepo | None = None):
-        self.db_path = db_path or resolve_role_db_path(SQLiteDBRole.SANDBOX)
+        self.db_path = db_path
         self._repo: SummaryRepo
         if summary_repo is not None:
             self._repo = summary_repo
@@ -44,8 +44,10 @@ class SummaryStore:
             # @@@explicit-db-path-wins - an explicit local path is an operator choice,
             # so only path-less construction is allowed to switch to runtime storage.
             self._repo = build_summary_repo()
+        elif db_path is None:
+            raise RuntimeError("SummaryStore requires summary_repo or db_path.")
         else:
-            resolved_db_path = self.db_path
+            resolved_db_path = Path(db_path)
             # @@@connect_injection - keep _connect as an indirection point so existing retry/rollback tests can patch it.
             self._repo = SQLiteSummaryRepo(resolved_db_path, connect_fn=lambda p: _connect(Path(p)))
         self._ensure_tables()

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -113,29 +113,36 @@ def test_summary_store_defaults_to_runtime_repo_when_strategy_missing(monkeypatc
     assert store._repo is fake_repo
 
 
-def test_summary_store_keeps_sqlite_when_strategy_missing_and_runtime_config_missing(monkeypatch) -> None:
+def test_summary_store_requires_runtime_repo_or_explicit_db_path(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
     monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(
         "core.runtime.middleware.memory.summary_store.build_summary_repo",
         lambda **_kwargs: (_ for _ in ()).throw(AssertionError("runtime repo should not be used")),
     )
 
-    class _SQLiteSummaryRepoStub:
-        def __init__(self, db_path, connect_fn=None):
-            self.db_path = db_path
+    try:
+        SummaryStore()
+    except RuntimeError as exc:
+        assert "SummaryStore requires summary_repo or db_path" in str(exc)
+    else:
+        raise AssertionError("SummaryStore should require an explicit storage source")
 
-        def ensure_tables(self) -> None:
-            return None
+    assert not (tmp_path / ".leon").exists()
 
-        def close(self) -> None:
-            return None
 
-    monkeypatch.setattr("core.runtime.middleware.memory.summary_store.SQLiteSummaryRepo", _SQLiteSummaryRepoStub)
+def test_summary_store_repo_injection_does_not_select_local_db_path(monkeypatch, tmp_path) -> None:
+    fake_repo = _FakeSummaryRepo()
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
 
-    store = SummaryStore()
+    store = SummaryStore(summary_repo=fake_repo)
 
-    assert isinstance(store._repo, _SQLiteSummaryRepoStub)
+    assert store._repo is fake_repo
+    assert store.db_path is None
+    assert not (tmp_path / ".leon").exists()
 
 
 def test_summary_store_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch, tmp_path) -> None:

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -156,6 +156,21 @@ def test_summary_store_explicit_db_path_keeps_sqlite_under_supabase(monkeypatch,
         store._repo.close()
 
 
+def test_summary_store_explicit_db_path_works_without_runtime_config(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    store = SummaryStore(Path(tmp_path / "summary.db"))
+
+    try:
+        assert isinstance(store._repo, SQLiteSummaryRepo)
+        assert store.db_path == tmp_path / "summary.db"
+        assert not (tmp_path / "home" / ".leon").exists()
+    finally:
+        store._repo.close()
+
+
 def test_memory_middleware_repo_injection_does_not_pass_default_home_db_path(monkeypatch) -> None:
     captured: dict[str, object] = {}
     fake_repo = _FakeSummaryRepo()

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -172,3 +172,14 @@ def test_memory_middleware_repo_injection_does_not_pass_default_home_db_path(mon
     assert middleware.summary_store is not None
     assert captured["summary_repo"] is fake_repo
     assert captured["db_path"] is None
+
+
+def test_memory_middleware_without_storage_source_has_no_summary_store(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("LEON_STORAGE_STRATEGY", raising=False)
+    monkeypatch.delenv("LEON_SUPABASE_CLIENT_FACTORY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    middleware = MemoryMiddleware()
+
+    assert middleware.summary_store is None
+    assert not (tmp_path / ".leon").exists()

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -269,6 +269,7 @@ def test_create_leon_agent_supabase_defaults_wire_runtime_container(monkeypatch,
         assert agent.queue_manager._repo is _patch_runtime_storage_container.queue_repo()
         assert agent._memory_middleware.summary_store is not None
         assert agent._memory_middleware.summary_store._repo is _patch_runtime_storage_container.summary_repo()
+        assert agent._memory_middleware.summary_store.db_path is None
     finally:
         agent.close()
 
@@ -290,6 +291,7 @@ def test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing
         assert agent.queue_manager._repo is _patch_runtime_storage_container.queue_repo()
         assert agent._memory_middleware.summary_store is not None
         assert agent._memory_middleware.summary_store._repo is _patch_runtime_storage_container.summary_repo()
+        assert agent._memory_middleware.summary_store.db_path is None
     finally:
         agent.close()
 


### PR DESCRIPTION
## Summary
- stop SummaryStore from selecting sandbox sqlite storage when no storage source is provided
- keep injected summary repos pathless and explicit sqlite paths local-only
- assert MemoryMiddleware and LeonAgent runtime-container wiring do not create host-local summary state

## Verification
- uv run pytest tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_memory_middleware_integration.py tests/Unit/core/test_memory_compaction_config.py tests/Unit/integration_contracts/test_leon_agent.py::test_create_leon_agent_supabase_defaults_wire_runtime_container tests/Unit/integration_contracts/test_leon_agent.py::test_create_leon_agent_defaults_wire_runtime_container_when_strategy_missing -q
- uv run ruff check core/runtime/middleware/memory/summary_store.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_leon_agent.py
- uv run ruff format --check core/runtime/middleware/memory/summary_store.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/integration_contracts/test_leon_agent.py
- uv run pytest tests/Unit -q