### PR TITLE
Require explicit local workspace root

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -14,7 +14,6 @@ from sandbox.provider import ProviderCapability
 
 logger = logging.getLogger(__name__)
 
-LOCAL_WORKSPACE_ROOT = local_workspace_root()
 _SANDBOX_INVENTORY_LOCK = threading.Lock()
 _SANDBOX_INVENTORY: tuple[dict[str, Any], dict[str, Any]] | None = None
 
@@ -61,7 +60,7 @@ def _build_providers_and_managers(
     from sandbox.providers.local import LocalSessionProvider
 
     config_dir = sandboxes_dir or SANDBOXES_DIR
-    workspace_root = local_workspace_root_path or LOCAL_WORKSPACE_ROOT
+    workspace_root = local_workspace_root_path or local_workspace_root()
     providers: dict[str, Any] = {
         "local": LocalSessionProvider(default_cwd=str(workspace_root)),
     }

--- a/backend/sandboxes/local_workspace.py
+++ b/backend/sandboxes/local_workspace.py
@@ -5,4 +5,7 @@ from pathlib import Path
 
 
 def local_workspace_root() -> Path:
-    return Path(os.environ.get("LEON_LOCAL_WORKSPACE_ROOT", str(Path.home()))).expanduser().resolve()
+    raw_path = os.environ.get("LEON_LOCAL_WORKSPACE_ROOT")
+    if not raw_path:
+        raise RuntimeError("LEON_LOCAL_WORKSPACE_ROOT is required for local workspace access.")
+    return Path(raw_path).expanduser().resolve()

--- a/backend/sandboxes/service.py
+++ b/backend/sandboxes/service.py
@@ -14,7 +14,7 @@ from backend.sandboxes.runtime import mutations as _sandbox_runtime_mutations
 from backend.sandboxes.runtime import reads as _sandbox_runtime_reads
 from backend.threads.projection import canonical_owner_threads
 from backend.threads.virtual_threads import is_virtual_thread_id
-from backend.web.core.config import LOCAL_WORKSPACE_ROOT
+from backend.sandboxes.local_workspace import local_workspace_root
 from sandbox.config import SandboxConfig
 from sandbox.manager import SandboxManager
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
@@ -95,7 +95,7 @@ def _build_providers_and_managers() -> tuple[dict[str, Any], dict[str, Any]]:
         sandboxes_dir=SANDBOXES_DIR,
         sandbox_manager_cls=SandboxManager,
         sandbox_config_cls=SandboxConfig,
-        local_workspace_root_path=LOCAL_WORKSPACE_ROOT,
+        local_workspace_root_path=local_workspace_root(),
     )
 
 

--- a/backend/sandboxes/service.py
+++ b/backend/sandboxes/service.py
@@ -8,13 +8,13 @@ from backend.sandboxes import provider_availability as _sandbox_provider_availab
 from backend.sandboxes import provider_factory as _sandbox_provider_factory
 from backend.sandboxes import recipe_catalog as _sandbox_recipe_catalog
 from backend.sandboxes import thread_resources as _sandbox_thread_resources
+from backend.sandboxes.local_workspace import local_workspace_root
 from backend.sandboxes.paths import SANDBOXES_DIR
 from backend.sandboxes.runtime import metrics as _sandbox_runtime_metrics
 from backend.sandboxes.runtime import mutations as _sandbox_runtime_mutations
 from backend.sandboxes.runtime import reads as _sandbox_runtime_reads
 from backend.threads.projection import canonical_owner_threads
 from backend.threads.virtual_threads import is_virtual_thread_id
-from backend.sandboxes.local_workspace import local_workspace_root
 from sandbox.config import SandboxConfig
 from sandbox.manager import SandboxManager
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -573,10 +573,13 @@ def _create_thread_sandbox_resources(
     try:
         terminal_id = f"term-{uuid.uuid4().hex[:12]}"
         # @@@initial-cwd - local threads own their requested cwd; remote threads start from provider defaults.
-        from backend.web.core.config import LOCAL_WORKSPACE_ROOT
-
         if sandbox_type == "local":
-            initial_cwd = cwd or str(LOCAL_WORKSPACE_ROOT)
+            if cwd:
+                initial_cwd = cwd
+            else:
+                from backend.sandboxes.local_workspace import local_workspace_root
+
+                initial_cwd = str(local_workspace_root())
         else:
             from sandbox.manager import resolve_provider_cwd
 

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -26,6 +26,7 @@ def _patch_lifespan_runtime_contract(
 ):
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
     monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", "/tmp/mycel-unit-workspace")
 
     async def _no_validate():
         return None
@@ -164,6 +165,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
 
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
     monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", "/tmp/mycel-unit-workspace")
 
     async def _no_validate():
         return None

--- a/tests/Unit/backend/web/routers/test_thread_resource_creation.py
+++ b/tests/Unit/backend/web/routers/test_thread_resource_creation.py
@@ -39,6 +39,7 @@ def test_create_thread_sandbox_resources_uses_runtime_factories_without_db_path(
     workspace_repo = object()
     materialize_calls: list[dict[str, object]] = []
 
+    monkeypatch.delenv("LEON_LOCAL_WORKSPACE_ROOT", raising=False)
     monkeypatch.setattr(container_cache, "get_storage_container", lambda: _Container())
     monkeypatch.setattr("storage.runtime.build_sandbox_runtime_repo", lambda: sandbox_runtime_repo)
     monkeypatch.setattr("sandbox.control_plane_repos.make_terminal_repo", lambda: terminal_repo)

--- a/tests/Unit/backend/web/test_web_config.py
+++ b/tests/Unit/backend/web/test_web_config.py
@@ -1,7 +1,16 @@
-from pathlib import Path
+import pytest
 
-from backend.web.core import config
+from backend.sandboxes.local_workspace import local_workspace_root
 
 
-def test_local_workspace_root_defaults_to_user_home() -> None:
-    assert config.LOCAL_WORKSPACE_ROOT == Path.home().resolve()
+def test_local_workspace_root_requires_explicit_env(monkeypatch) -> None:
+    monkeypatch.delenv("LEON_LOCAL_WORKSPACE_ROOT", raising=False)
+
+    with pytest.raises(RuntimeError, match="LEON_LOCAL_WORKSPACE_ROOT is required"):
+        local_workspace_root()
+
+
+def test_local_workspace_root_uses_explicit_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path))
+
+    assert local_workspace_root() == tmp_path.resolve()

--- a/tests/Unit/backend/web/test_web_config.py
+++ b/tests/Unit/backend/web/test_web_config.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 
 from backend.sandboxes.local_workspace import local_workspace_root
@@ -14,3 +16,13 @@ def test_local_workspace_root_uses_explicit_env(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path))
 
     assert local_workspace_root() == tmp_path.resolve()
+
+
+def test_sandbox_modules_do_not_resolve_workspace_root_at_import(monkeypatch) -> None:
+    monkeypatch.delenv("LEON_LOCAL_WORKSPACE_ROOT", raising=False)
+
+    import backend.sandboxes.inventory as inventory
+    import backend.sandboxes.service as service
+
+    importlib.reload(inventory)
+    importlib.reload(service)

--- a/tests/Unit/backend/web/test_web_config.py
+++ b/tests/Unit/backend/web/test_web_config.py
@@ -26,3 +26,17 @@ def test_sandbox_modules_do_not_resolve_workspace_root_at_import(monkeypatch) ->
 
     importlib.reload(inventory)
     importlib.reload(service)
+
+
+def test_web_config_requires_explicit_local_workspace_root(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path))
+    from backend.web.core import config
+
+    importlib.reload(config)
+    monkeypatch.delenv("LEON_LOCAL_WORKSPACE_ROOT", raising=False)
+    try:
+        with pytest.raises(RuntimeError, match="LEON_LOCAL_WORKSPACE_ROOT is required"):
+            importlib.reload(config)
+    finally:
+        monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path))
+        importlib.reload(config)

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -57,6 +57,7 @@ def test_available_sandbox_types_marks_e2b_unavailable_when_sdk_missing(monkeypa
 
 def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides(monkeypatch, tmp_path: Path) -> None:
     (tmp_path / "agentbay.json").write_text("{}")
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))
     monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
 
     captured: dict[str, object] = {}
@@ -107,6 +108,7 @@ def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides
 
 def test_build_providers_and_managers_uses_current_daytona_contract(monkeypatch, tmp_path: Path) -> None:
     (tmp_path / "daytona_selfhost.json").write_text("{}")
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))
     monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
 
     captured: dict[str, object] = {}

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -55,6 +55,17 @@ def test_available_sandbox_types_marks_e2b_unavailable_when_sdk_missing(monkeypa
     assert "unavailable in the current process" in e2b["reason"]
 
 
+def test_build_providers_and_managers_uses_explicit_local_workspace_root(monkeypatch, tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(workspace_root))
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
+    monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path / "missing-configs")
+
+    providers, _managers = sandbox_service._build_providers_and_managers()
+
+    assert providers["local"].default_cwd == str(workspace_root.resolve())
+
+
 def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides(monkeypatch, tmp_path: Path) -> None:
     (tmp_path / "agentbay.json").write_text("{}")
     monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))


### PR DESCRIPTION
## Summary
- require LEON_LOCAL_WORKSPACE_ROOT instead of using the service process home directory
- move sandbox workspace-root resolution out of module import paths
- keep explicit thread cwd independent from deployment workspace defaults

## Verification
- uv run pytest tests/Unit/backend/web/test_web_config.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/monitor/test_monitor_detail_contracts.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py -q
- uv run ruff check backend/sandboxes/local_workspace.py backend/sandboxes/inventory.py backend/sandboxes/service.py backend/web/routers/threads.py tests/Unit/backend/web/test_web_config.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff format --check backend/sandboxes/local_workspace.py backend/sandboxes/inventory.py backend/sandboxes/service.py backend/web/routers/threads.py tests/Unit/backend/web/test_web_config.py tests/Unit/backend/web/routers/test_thread_resource_creation.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run pytest tests/Unit -q