### PR TITLE
Require explicit sandbox provider config directory

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -59,19 +59,19 @@ def _build_providers_and_managers(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     from sandbox.providers.local import LocalSessionProvider
 
-    config_dir = sandboxes_dir or SANDBOXES_DIR
+    config_dir = sandboxes_dir if sandboxes_dir is not None else SANDBOXES_DIR
     workspace_root = local_workspace_root_path or local_workspace_root()
     providers: dict[str, Any] = {
         "local": LocalSessionProvider(default_cwd=str(workspace_root)),
     }
-    if not config_dir.exists():
+    if config_dir is None or not config_dir.exists():
         managers = {name: sandbox_manager_cls(provider=provider) for name, provider in providers.items()}
         return providers, managers
 
     for config_file in config_dir.glob("*.json"):
         name = config_file.stem
         try:
-            config = sandbox_config_cls.load(name)
+            config = sandbox_config_cls.load(name, sandboxes_dir=config_dir)
             if config.provider == "agentbay":
                 from sandbox.providers.agentbay import AgentBayProvider
 
@@ -155,13 +155,13 @@ def available_sandbox_types(
             "capability": _capability_to_dict(local_capability),
         }
     ]
-    config_dir = sandboxes_dir or SANDBOXES_DIR
-    if not config_dir.exists():
+    config_dir = sandboxes_dir if sandboxes_dir is not None else SANDBOXES_DIR
+    if config_dir is None or not config_dir.exists():
         return types
     for config_file in sorted(config_dir.glob("*.json")):
         name = config_file.stem
         try:
-            config = sandbox_config_cls.load(name)
+            config = sandbox_config_cls.load(name, sandboxes_dir=config_dir)
             provider_obj = providers.get(name)
             if provider_obj is None:
                 types.append(

--- a/backend/sandboxes/paths.py
+++ b/backend/sandboxes/paths.py
@@ -1,3 +1,5 @@
-from config.user_paths import user_home_path
+from pathlib import Path
 
-SANDBOXES_DIR = user_home_path("sandboxes")
+from sandbox.config import sandbox_config_dir
+
+SANDBOXES_DIR: Path | None = sandbox_config_dir()

--- a/backend/sandboxes/resources/common.py
+++ b/backend/sandboxes/resources/common.py
@@ -33,7 +33,7 @@ CATALOG: dict[str, CatalogEntry] = {
 }
 
 
-def resolve_provider_name(config_name: str, *, sandboxes_dir: Path) -> str:
+def resolve_provider_name(config_name: str, *, sandboxes_dir: Path | None) -> str:
     payload = _load_sandbox_config(config_name, sandboxes_dir)
     provider = str(payload.get("provider") or "").strip()
     if not provider:
@@ -50,7 +50,7 @@ def resolve_provider_type(provider_name: str) -> str:
     return entry.provider_type
 
 
-def resolve_console_url(provider_name: str, config_name: str, *, sandboxes_dir: Path) -> str | None:
+def resolve_console_url(provider_name: str, config_name: str, *, sandboxes_dir: Path | None) -> str | None:
     payload = _load_sandbox_config(config_name, sandboxes_dir)
     override = str(payload.get("console_url") or "").strip()
     if override:
@@ -70,9 +70,11 @@ def resolve_console_url(provider_name: str, config_name: str, *, sandboxes_dir: 
     return None
 
 
-def _load_sandbox_config(config_name: str, sandboxes_dir: Path) -> dict[str, Any]:
+def _load_sandbox_config(config_name: str, sandboxes_dir: Path | None) -> dict[str, Any]:
     if config_name == "local":
         return {"provider": "local"}
+    if sandboxes_dir is None:
+        raise RuntimeError(f"LEON_SANDBOXES_DIR is required for sandbox config: {config_name}")
     config_path = sandboxes_dir / f"{config_name}.json"
     payload = json.loads(config_path.read_text())
     if not isinstance(payload, dict):

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -147,11 +147,8 @@ async def get_or_create_agent(
         # Merge user-configured allowed_paths from sandbox config
         from sandbox.config import SandboxConfig
 
-        try:
-            sandbox_config = SandboxConfig.load(sandbox_type)
-            extra_allowed_paths.extend(sandbox_config.allowed_paths)
-        except FileNotFoundError:
-            pass
+        sandbox_config = SandboxConfig.load(sandbox_type)
+        extra_allowed_paths.extend(sandbox_config.allowed_paths)
 
         extra_allowed_paths_or_none: list[str] | None = extra_allowed_paths or None
 

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -26,7 +26,7 @@ Mycel uses a split configuration system with three-tier merge: system defaults â
     | File | Purpose |
     |------|---------|
     | `config.env` | Quick API key setup |
-    | `sandboxes/<name>.json` | Per-provider sandbox config |
+    | `$LEON_SANDBOXES_DIR/<name>.json` | Per-provider sandbox config |
     | `.mcp.json` | Advanced MCP servers for local runtime config |
   </div>
 </Columns>

--- a/docs/en/deployment.mdx
+++ b/docs/en/deployment.mdx
@@ -113,7 +113,7 @@ See [Sandbox](/en/sandbox) for full provider configuration. Quick reference:
 
 ### Docker
 
-Create `~/.leon/sandboxes/docker.json`:
+Set `LEON_SANDBOXES_DIR` to your sandbox provider config directory, then create `docker.json` in that directory:
 
 ```json
 {
@@ -264,7 +264,7 @@ env -u ALL_PROXY -u all_proxy uv run python -m backend.web.main
   </Accordion>
 
   <Accordion title="Docker provider hangs">
-    Proxy environment variables inherited by the Docker CLI. Mycel strips these automatically, but if issues persist, check the `docker_host` config field in `~/.leon/sandboxes/docker.json`.
+    Proxy environment variables inherited by the Docker CLI. Mycel strips these automatically, but if issues persist, check the `docker_host` config field in `$LEON_SANDBOXES_DIR/docker.json`.
   </Accordion>
 
   <Accordion title="Daytona PTY bootstrap fails">

--- a/docs/en/sandbox.mdx
+++ b/docs/en/sandbox.mdx
@@ -49,7 +49,7 @@ flowchart LR
     | Daytona | API key, API URL |
     | AgentBay | API key |
 
-    Config is stored at `~/.leon/sandboxes/<provider>.json`.
+    Set `LEON_SANDBOXES_DIR` to the sandbox provider config directory. Config is stored as `<provider>.json` inside that directory.
   </Step>
   <Step title="Start a sandboxed thread">
     In the new conversation view, use the **sandbox dropdown** in the input area to select your provider. Send your first message — the Thread is now permanently bound to that sandbox.

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -16,7 +16,7 @@ Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置
 | `models.json` | 模型身份、提供商、API Key、虚拟模型映射 |
 | `observation.json` | Langfuse / LangSmith 追踪 |
 | `config.env` | 快速 API Key 配置（加载为环境变量） |
-| `sandboxes/<name>.json` | 各提供商的沙箱配置 |
+| `$LEON_SANDBOXES_DIR/<name>.json` | 各提供商的沙箱配置 |
 
 每个 JSON 文件从三个层级加载（优先级从高到低）：
 1. 工作区根目录下的 `.leon/<file>`（项目配置）

--- a/docs/zh/deployment.mdx
+++ b/docs/zh/deployment.mdx
@@ -113,7 +113,7 @@ LEON_BACKEND_PORT=9000 uv run python -m backend.web.main
 
 ### Docker
 
-创建 `~/.leon/sandboxes/docker.json`：
+设置 `LEON_SANDBOXES_DIR` 指向沙箱提供商配置目录，然后在该目录下创建 `docker.json`：
 
 ```json
 {
@@ -264,7 +264,7 @@ env -u ALL_PROXY -u all_proxy uv run python -m backend.web.main
   </Accordion>
 
   <Accordion title="Docker 提供商卡住">
-    Docker CLI 继承了代理环境变量。Mycel 会自动清理这些变量，若问题仍然存在，检查 `~/.leon/sandboxes/docker.json` 中的 `docker_host` 配置。
+    Docker CLI 继承了代理环境变量。Mycel 会自动清理这些变量，若问题仍然存在，检查 `$LEON_SANDBOXES_DIR/docker.json` 中的 `docker_host` 配置。
   </Accordion>
 
   <Accordion title="Daytona PTY bootstrap 失败">

--- a/docs/zh/sandbox.mdx
+++ b/docs/zh/sandbox.mdx
@@ -31,7 +31,7 @@ keywords: [沙箱, docker, e2b, daytona, agentbay, 隔离, 生命周期]
     | Daytona | API Key、API URL |
     | AgentBay | API Key |
 
-    点击**保存**，配置存储到 `~/.leon/sandboxes/<provider>.json`。
+    先设置 `LEON_SANDBOXES_DIR` 指向沙箱提供商配置目录。点击**保存**后，配置以 `<provider>.json` 存储在该目录下。
   </Step>
 
   <Step title="启动沙箱 Thread">

--- a/sandbox/config.py
+++ b/sandbox/config.py
@@ -7,6 +7,22 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+SANDBOX_CONFIG_DIR_ENV = "LEON_SANDBOXES_DIR"
+
+
+def sandbox_config_dir() -> Path | None:
+    raw_path = os.environ.get(SANDBOX_CONFIG_DIR_ENV)
+    if not raw_path:
+        return None
+    return Path(raw_path).expanduser().resolve()
+
+
+def _sandbox_config_path(name: str, sandboxes_dir: Path | None) -> Path:
+    config_dir = sandboxes_dir or sandbox_config_dir()
+    if config_dir is None:
+        raise RuntimeError(f"{SANDBOX_CONFIG_DIR_ENV} is required for sandbox config: {name}")
+    return config_dir / f"{name}.json"
+
 
 class MountSpec(BaseModel):
     source: str
@@ -61,11 +77,11 @@ class SandboxConfig(BaseModel):
     allowed_paths: list[str] = Field(default_factory=list)
 
     @classmethod
-    def load(cls, name: str) -> SandboxConfig:
+    def load(cls, name: str, *, sandboxes_dir: Path | None = None) -> SandboxConfig:
         if name == "local":
             return cls()
 
-        path = Path.home() / ".leon" / "sandboxes" / f"{name}.json"
+        path = _sandbox_config_path(name, sandboxes_dir)
         if not path.exists():
             raise FileNotFoundError(f"Sandbox config not found: {path}")
 
@@ -74,8 +90,8 @@ class SandboxConfig(BaseModel):
         config.name = name
         return config
 
-    def save(self, name: str) -> Path:
-        path = Path.home() / ".leon" / "sandboxes" / f"{name}.json"
+    def save(self, name: str, *, sandboxes_dir: Path | None = None) -> Path:
+        path = _sandbox_config_path(name, sandboxes_dir)
         path.parent.mkdir(parents=True, exist_ok=True)
 
         data: dict[str, object] = {"provider": self.provider, "on_exit": self.on_exit}

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -559,6 +559,35 @@ async def test_get_or_create_agent_uses_binding_local_staging_root_for_extra_all
 
 
 @pytest.mark.asyncio
+async def test_registry_non_local_sandbox_requires_explicit_config_dir(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEON_SANDBOXES_DIR", raising=False)
+    monkeypatch.setattr(
+        agent_pool._registry,
+        "create_agent_sync",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("agent should not be created")),
+    )
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-no-config")
+    monkeypatch.setattr(
+        agent_pool._registry,
+        "get_file_channel_binding",
+        lambda _thread_id: (_ for _ in ()).throw(ValueError()),
+        raising=False,
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_FakeThreadRepo(),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="LEON_SANDBOXES_DIR"):
+        await agent_pool._registry.get_or_create_agent(cast(Any, app), "daytona", thread_id="thread-no-config")
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_requires_thread_agent_user_id_for_chat_identity(monkeypatch: pytest.MonkeyPatch):
     def _fake_create_agent_sync(**kwargs) -> object:
         return SimpleNamespace()

--- a/tests/Unit/sandbox/test_sandbox_config_paths.py
+++ b/tests/Unit/sandbox/test_sandbox_config_paths.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sandbox.config import SANDBOX_CONFIG_DIR_ENV, SandboxConfig, sandbox_config_dir
+
+
+def test_sandbox_config_dir_is_empty_when_env_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SANDBOX_CONFIG_DIR_ENV, raising=False)
+
+    assert sandbox_config_dir() is None
+
+
+def test_sandbox_config_dir_uses_explicit_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_dir = tmp_path / "sandbox-configs"
+    monkeypatch.setenv(SANDBOX_CONFIG_DIR_ENV, str(config_dir))
+
+    assert sandbox_config_dir() == config_dir.resolve()
+
+
+def test_non_local_sandbox_load_requires_config_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SANDBOX_CONFIG_DIR_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match=SANDBOX_CONFIG_DIR_ENV):
+        SandboxConfig.load("daytona")
+
+
+def test_non_local_sandbox_load_reads_explicit_config_dir(tmp_path: Path) -> None:
+    (tmp_path / "docker.json").write_text('{"provider": "docker", "allowed_paths": ["/shared"]}')
+
+    config = SandboxConfig.load("docker", sandboxes_dir=tmp_path)
+
+    assert config.name == "docker"
+    assert config.provider == "docker"
+    assert config.allowed_paths == ["/shared"]
+
+
+def test_sandbox_config_save_requires_config_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SANDBOX_CONFIG_DIR_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match=SANDBOX_CONFIG_DIR_ENV):
+        SandboxConfig(provider="docker").save("docker")
+
+
+def test_sandbox_config_save_writes_explicit_config_dir(tmp_path: Path) -> None:
+    path = SandboxConfig(provider="docker", allowed_paths=["/shared"]).save("docker", sandboxes_dir=tmp_path)
+
+    assert path == tmp_path / "docker.json"
+    assert json.loads(path.read_text()) == {
+        "provider": "docker",
+        "on_exit": "pause",
+        "allowed_paths": ["/shared"],
+        "docker": {
+            "image": "python:3.12-slim",
+            "mount_path": "/workspace",
+            "docker_host": None,
+            "cwd": "/workspace",
+            "bind_mounts": [],
+        },
+    }

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -20,7 +20,7 @@ def test_available_sandbox_types_marks_configured_but_unavailable_provider(monke
     monkeypatch.setattr(
         sandbox_service.SandboxConfig,
         "load",
-        classmethod(lambda cls, name: SimpleNamespace(provider="daytona", name=name)),
+        classmethod(lambda cls, name, **_kwargs: SimpleNamespace(provider="daytona", name=name)),
     )
 
     types = sandbox_service.available_sandbox_types()
@@ -44,7 +44,7 @@ def test_available_sandbox_types_marks_e2b_unavailable_when_sdk_missing(monkeypa
     monkeypatch.setattr(
         sandbox_service.SandboxConfig,
         "load",
-        classmethod(lambda cls, name: SimpleNamespace(provider="e2b", name=name)),
+        classmethod(lambda cls, name, **_kwargs: SimpleNamespace(provider="e2b", name=name)),
     )
 
     types = sandbox_service.available_sandbox_types()
@@ -64,6 +64,18 @@ def test_build_providers_and_managers_uses_explicit_local_workspace_root(monkeyp
     providers, _managers = sandbox_service._build_providers_and_managers()
 
     assert providers["local"].default_cwd == str(workspace_root.resolve())
+
+
+def test_build_providers_and_managers_accepts_empty_sandbox_config_set(monkeypatch, tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(workspace_root))
+    monkeypatch.setenv("LEON_SANDBOX_DB_PATH", str(tmp_path / "sandbox.db"))
+    monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", None)
+
+    providers, managers = sandbox_service._build_providers_and_managers()
+
+    assert list(providers) == ["local"]
+    assert list(managers) == ["local"]
 
 
 def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides(monkeypatch, tmp_path: Path) -> None:
@@ -91,7 +103,7 @@ def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides
         sandbox_service.SandboxConfig,
         "load",
         classmethod(
-            lambda cls, name: SimpleNamespace(
+            lambda cls, name, **_kwargs: SimpleNamespace(
                 provider="agentbay",
                 agentbay=SimpleNamespace(
                     api_key="test-key",
@@ -142,7 +154,7 @@ def test_build_providers_and_managers_uses_current_daytona_contract(monkeypatch,
         sandbox_service.SandboxConfig,
         "load",
         classmethod(
-            lambda cls, name: SimpleNamespace(
+            lambda cls, name, **_kwargs: SimpleNamespace(
                 provider="daytona",
                 daytona=SimpleNamespace(
                     api_key="test-key",
@@ -190,7 +202,7 @@ def test_available_sandbox_types_marks_daytona_unavailable_when_api_key_missing(
         sandbox_service.SandboxConfig,
         "load",
         classmethod(
-            lambda cls, name: SimpleNamespace(
+            lambda cls, name, **_kwargs: SimpleNamespace(
                 provider="daytona",
                 name=name,
             )

--- a/tests/Unit/sandbox/test_sandbox_resource_config_paths.py
+++ b/tests/Unit/sandbox/test_sandbox_resource_config_paths.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.sandboxes.resources.common import resolve_console_url, resolve_provider_name
+
+
+def test_local_provider_display_contract_does_not_require_config_dir() -> None:
+    assert resolve_provider_name("local", sandboxes_dir=None) == "local"
+    assert resolve_console_url("local", "local", sandboxes_dir=None) is None
+
+
+def test_non_local_provider_display_contract_requires_config_dir() -> None:
+    with pytest.raises(RuntimeError, match="LEON_SANDBOXES_DIR"):
+        resolve_provider_name("daytona", sandboxes_dir=None)
+
+
+def test_provider_display_contract_reads_explicit_config_dir(tmp_path: Path) -> None:
+    (tmp_path / "daytona.json").write_text('{"provider": "daytona", "daytona": {"target": "cloud", "api_url": "https://example.test/api"}}')
+
+    assert resolve_provider_name("daytona", sandboxes_dir=tmp_path) == "daytona"
+    assert resolve_console_url("daytona", "daytona", sandboxes_dir=tmp_path) == "https://app.daytona.io"


### PR DESCRIPTION
## Summary
- replace implicit sandbox provider config path with explicit LEON_SANDBOXES_DIR
- pass sandbox config directory through inventory/resource contracts
- make non-local agent startup fail loudly when provider config cannot be resolved
- update sandbox docs to point operators at LEON_SANDBOXES_DIR

## Verification
- uv run pytest tests/Unit/sandbox/test_sandbox_config_paths.py tests/Unit/sandbox/test_sandbox_resource_config_paths.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/core/test_agent_pool.py -q
- uv run ruff check sandbox/config.py backend/sandboxes/paths.py backend/sandboxes/inventory.py backend/sandboxes/resources/common.py backend/threads/pool/registry.py tests/Unit/sandbox/test_sandbox_config_paths.py tests/Unit/sandbox/test_sandbox_resource_config_paths.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/core/test_agent_pool.py
- uv run ruff format --check sandbox/config.py backend/sandboxes/paths.py backend/sandboxes/inventory.py backend/sandboxes/resources/common.py backend/threads/pool/registry.py tests/Unit/sandbox/test_sandbox_config_paths.py tests/Unit/sandbox/test_sandbox_resource_config_paths.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/core/test_agent_pool.py
- rg -n "Path\.home\(\)|~/.leon/sandboxes|\.leon.*sandboxes|user_home_path\(\\"sandboxes\\"\)" sandbox backend docs tests/Unit -S
- uv run pytest tests/Unit -q