### PR TITLE
Close skill deletion and thread cleanup edges

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -487,16 +487,21 @@ def get_resource_used_by(
     agent_config_repo: Any = None,
 ) -> list[str]:
     """Return agent user names under the owner that use a given resource."""
-    from backend.threads.agent_user_service import list_agent_users
-
-    config_key = {"skill": "skills", "mcp": "mcpServers", "agent": "subAgents"}.get(resource_type, "")
-    if not config_key:
+    if user_repo is None or agent_config_repo is None:
+        raise RuntimeError("user_repo and agent_config_repo are required for resource usage reads")
+    config_attr = {"skill": "skills", "mcp": "mcp_servers", "agent": "sub_agents"}.get(resource_type, "")
+    if not config_attr:
         return []
     names: list[str] = []
-    for agent in list_agent_users(owner_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo):
-        items = agent.get("config", {}).get(config_key, [])
-        if any(i.get("name") == resource_name for i in items):
-            names.append(agent.get("name", agent.get("id", "unknown")))
+    for agent in user_repo.list_by_owner_user_id(owner_user_id):
+        agent_config_id = getattr(agent, "agent_config_id", None)
+        if not agent_config_id:
+            raise RuntimeError(f"Agent user {getattr(agent, 'id', 'unknown')} is missing agent_config_id")
+        config = agent_config_repo.get_agent_config(agent_config_id)
+        if config is None:
+            raise RuntimeError(f"Agent config {agent_config_id} is missing for {getattr(agent, 'id', 'unknown')}")
+        if any(getattr(item, "name", None) == resource_name for item in getattr(config, config_attr)):
+            names.append(str(getattr(config, "name", None) or getattr(agent, "display_name", None) or getattr(agent, "id", "unknown")))
     return names
 
 

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -326,13 +326,28 @@ async def delete_resource(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
+    recipe_repo = _recipe_repo_for(resource_type, request)
+    skill_repo = _skill_repo_for(resource_type, request)
+    if resource_type == "skill":
+        skill = await asyncio.to_thread(skill_repo.get_by_id, user_id, resource_id)
+        if skill is not None:
+            used_by = await asyncio.to_thread(
+                library_service.get_resource_used_by,
+                "skill",
+                skill.name,
+                user_id,
+                user_repo=request.app.state.user_repo,
+                agent_config_repo=_agent_config_repo(request),
+            )
+            if used_by:
+                raise HTTPException(409, f"Skill is still assigned to Agent: {', '.join(used_by)}")
     ok = await asyncio.to_thread(
         library_service.delete_resource,
         resource_type,
         resource_id,
         user_id,
-        _recipe_repo_for(resource_type, request),
-        _skill_repo_for(resource_type, request),
+        recipe_repo,
+        skill_repo,
     )
     if not ok:
         raise HTTPException(404, "Resource not found")

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -10,6 +10,7 @@ import SandboxTemplateEditor from "@/components/SandboxTemplateEditor";
 import type { Agent, ResourceItem } from "@/store/types";
 import type { UpdateAvailable } from "@/store/marketplace-store";
 import { HUB_AGENT_USER_ITEM_TYPE } from "@/lib/marketplace-types";
+import { toast } from "sonner";
 
 type Tab = "explore" | "library";
 type LibrarySubTab = "agent-user" | "skill" | "agent" | "sandbox-template";
@@ -116,6 +117,13 @@ export default function MarketplacePage() {
   const filteredSandboxTemplates = librarySandboxTemplates.filter((sandboxTemplate) =>
     !librarySearch || sandboxTemplate.name.toLowerCase().includes(librarySearch.toLowerCase())
   );
+  const handleDeleteResource = async (type: "skill" | "agent" | "sandbox-template", id: string) => {
+    try {
+      await deleteResource(type, id);
+    } catch (err) {
+      toast.error(`删除失败：${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
   const recipeProviderOptions = useMemo<ResourceItem[]>(() => {
     const seen = new Set<string>();
     return librarySandboxTemplates.filter((sandboxTemplate) => {
@@ -455,7 +463,7 @@ export default function MarketplacePage() {
                             </div>
                           </div>
                           <button
-                            onClick={(e) => { e.stopPropagation(); deleteResource("skill", skill.id); }}
+                            onClick={(e) => { e.stopPropagation(); void handleDeleteResource("skill", skill.id); }}
                             className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
                             title="删除"
                           >
@@ -490,7 +498,7 @@ export default function MarketplacePage() {
                             </div>
                           </div>
                           <button
-                            onClick={(e) => { e.stopPropagation(); deleteResource("agent", agent.id); }}
+                            onClick={(e) => { e.stopPropagation(); void handleDeleteResource("agent", agent.id); }}
                             className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
                             title="删除"
                           >
@@ -529,7 +537,7 @@ export default function MarketplacePage() {
                           </div>
                           {!sandboxTemplate.builtin && (
                             <button
-                              onClick={(e) => { e.stopPropagation(); deleteResource("sandbox-template", sandboxTemplate.id); }}
+                              onClick={(e) => { e.stopPropagation(); void handleDeleteResource("sandbox-template", sandboxTemplate.id); }}
                               className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
                               title="删除"
                             >

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -34,11 +34,20 @@ vi.mock("@/store/marketplace-store", () => ({
 const appStoreFetchLibrary = vi.fn();
 const appStoreDeleteResource = vi.fn();
 const appStoreAddResource = vi.fn();
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+}));
 let appStoreState: Record<string, unknown>;
 
 vi.mock("@/store/app-store", () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector(appStoreState),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+  },
 }));
 
 afterEach(() => {
@@ -62,6 +71,7 @@ describe("MarketplacePage wording contract", () => {
     };
     appStoreFetchLibrary.mockReset();
     appStoreDeleteResource.mockReset();
+    toastErrorMock.mockReset();
     appStoreAddResource.mockReset();
     appStoreAddResource.mockResolvedValue({
       id: "daytona_selfhost:custom:probe",
@@ -178,6 +188,35 @@ describe("MarketplacePage wording contract", () => {
 
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
     expect(screen.getByText("暂无 Skill")).toBeTruthy();
+  });
+
+  it("shows the backend reason when deleting a selected Skill is rejected", async () => {
+    appStoreDeleteResource.mockRejectedValue(new Error("Skill is still assigned to Agent: Toad"));
+    appStoreState = {
+      ...appStoreState,
+      librarySkills: [{
+        id: "skill-1",
+        name: "api-design-reviewer",
+        desc: "API Design Reviewer",
+        type: "skill",
+        created_at: 1,
+        updated_at: 1,
+      }],
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=skill"]}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTitle("删除"));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("删除失败：Skill is still assigned to Agent: Toad");
+    });
   });
 
   it("uses Sandbox wording for the library Sandbox tab", () => {

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -832,8 +832,16 @@ class SandboxManager:
             sandbox_runtime_in_use = any(row.get("sandbox_runtime_id") == sandbox_runtime_id for row in self.terminal_store.list_all())
             if sandbox_runtime_in_use:
                 continue
+            # @@@thread-delete-runtime-residue - direct runtime deletion must still fail
+            # when provider state cannot be destroyed. Here the thread terminal
+            # rows are already gone; a missing runtime row is stale control-plane
+            # residue and must not keep the visible thread undeletable.
             if not self.destroy_sandbox_runtime_resources(sandbox_runtime_id):
-                raise RuntimeError(f"Missing sandbox runtime {sandbox_runtime_id} for thread {thread_id}")
+                logger.warning(
+                    "Thread %s referenced sandbox runtime %s that was already absent during deletion",
+                    thread_id,
+                    sandbox_runtime_id,
+                )
         return True
 
     def destroy_sandbox_runtime_resources(self, sandbox_runtime_id: str) -> bool:

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1490,6 +1490,89 @@ async def test_panel_library_used_by_route_uses_user_scope(monkeypatch: pytest.M
     }
 
 
+@pytest.mark.asyncio
+async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypatch: pytest.MonkeyPatch):
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="skill-1",
+        name="api-design-reviewer",
+        description="API Design Reviewer",
+        content="---\nname: api-design-reviewer\n---\nBody",
+    )
+    agent = _agent_user(user_id="agent-1", owner_user_id="user-1")
+    fake_user_repo = SimpleNamespace(list_by_owner_user_id=lambda owner_user_id: [agent] if owner_user_id == "user-1" else [])
+    fake_agent_config_repo = SimpleNamespace(
+        get_agent_config=lambda _config_id: _agent_config(
+            skills=[
+                AgentSkill(
+                    skill_id="skill-1",
+                    package_id="skill-1-package",
+                    name="api-design-reviewer",
+                    content="---\nname: api-design-reviewer\n---\nBody",
+                    enabled=True,
+                )
+            ],
+        )
+    )
+
+    deleted: list[tuple[str, str]] = []
+    monkeypatch.setattr(skill_repo, "delete", lambda owner_user_id, skill_id: deleted.append((owner_user_id, skill_id)))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await panel_router.delete_resource(
+            "skill",
+            "skill-1",
+            request=SimpleNamespace(
+                app=SimpleNamespace(
+                    state=SimpleNamespace(
+                        user_repo=fake_user_repo,
+                        runtime_storage_state=_runtime_storage_state(fake_agent_config_repo, skill_repo=skill_repo),
+                    )
+                )
+            ),
+            user_id="user-1",
+        )
+
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.detail == "Skill is still assigned to Agent: Toad"
+    assert deleted == []
+
+
+@pytest.mark.asyncio
+async def test_delete_skill_route_allows_skill_after_agent_config_removal(monkeypatch: pytest.MonkeyPatch):
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="skill-1",
+        name="api-design-reviewer",
+        description="API Design Reviewer",
+        content="---\nname: api-design-reviewer\n---\nBody",
+    )
+    agent = _agent_user(user_id="agent-1", owner_user_id="user-1")
+    fake_user_repo = SimpleNamespace(list_by_owner_user_id=lambda owner_user_id: [agent] if owner_user_id == "user-1" else [])
+    fake_agent_config_repo = SimpleNamespace(get_agent_config=lambda _config_id: _agent_config(skills=[]))
+
+    result = await panel_router.delete_resource(
+        "skill",
+        "skill-1",
+        request=SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    user_repo=fake_user_repo,
+                    runtime_storage_state=_runtime_storage_state(fake_agent_config_repo, skill_repo=skill_repo),
+                )
+            )
+        ),
+        user_id="user-1",
+    )
+
+    assert result == {"success": True}
+    assert skill_repo.get_by_id("user-1", "skill-1") is None
+
+
 def test_builtin_agent_surface_exposes_chat_tools():
     agent = agent_user_service._leon_builtin()
     tools = {item["name"]: item for item in agent["config"]["tools"]}

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1490,6 +1490,36 @@ async def test_panel_library_used_by_route_uses_user_scope(monkeypatch: pytest.M
     }
 
 
+def test_library_used_by_reads_agent_configs_without_display_projection(monkeypatch: pytest.MonkeyPatch):
+    def explode(*_args, **_kwargs):
+        raise AssertionError("used-by must not depend on agent display projection")
+
+    monkeypatch.setattr(agent_user_service, "list_agent_users", explode)
+    agent = _agent_user(user_id="agent-1", owner_user_id="user-1")
+    fake_user_repo = SimpleNamespace(list_by_owner_user_id=lambda owner_user_id: [agent] if owner_user_id == "user-1" else [])
+    fake_agent_config_repo = SimpleNamespace(
+        get_agent_config=lambda _config_id: _agent_config(
+            skills=[
+                AgentSkill(
+                    skill_id="skill-1",
+                    package_id="skill-1-package",
+                    name="api-design-reviewer",
+                    content="---\nname: api-design-reviewer\n---\nBody",
+                    enabled=True,
+                )
+            ],
+        )
+    )
+
+    assert library_service.get_resource_used_by(
+        "skill",
+        "api-design-reviewer",
+        "user-1",
+        user_repo=fake_user_repo,
+        agent_config_repo=fake_agent_config_repo,
+    ) == ["Toad"]
+
+
 @pytest.mark.asyncio
 async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypatch: pytest.MonkeyPatch):
     skill_repo = _MemorySkillRepo()

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -736,6 +736,37 @@ def test_destroy_thread_resources_keeps_shared_lease_for_surviving_threads():
     assert deleted_leases == []
 
 
+def test_destroy_thread_resources_deletes_thread_residue_when_runtime_row_is_already_missing():
+    manager = _new_test_manager()
+    manager.provider_capability = SimpleNamespace(runtime_kind="local")
+    manager.provider = SimpleNamespace(name="local")
+    manager.volume = _FakeVolume()
+    deleted_thread_chats: list[tuple[str, str]] = []
+    deleted_terminals: list[str] = []
+    all_terminals = [{"terminal_id": "term-1", "sandbox_runtime_id": "runtime-missing", "thread_id": "thread-1"}]
+
+    manager._get_thread_sandbox_runtime = lambda _thread_id: None
+    manager._get_sandbox_runtime = lambda _sandbox_runtime_id: None
+    manager.terminal_store = SimpleNamespace(
+        list_by_thread=lambda thread_id: [row for row in all_terminals if row["thread_id"] == thread_id],
+        delete=lambda terminal_id: (
+            deleted_terminals.append(terminal_id),
+            all_terminals.__setitem__(slice(None), [row for row in all_terminals if row["terminal_id"] != terminal_id]),
+        ),
+        list_all=lambda: list(all_terminals),
+        db_path=Path("/tmp/fake-sandbox.db"),
+    )
+    manager.session_manager = SimpleNamespace(
+        delete_thread=lambda thread_id, reason="thread_deleted": deleted_thread_chats.append((thread_id, reason)),
+    )
+
+    assert manager.destroy_thread_resources("thread-1") is True
+    assert deleted_thread_chats == [("thread-1", "thread_deleted")]
+    assert deleted_terminals == ["term-1"]
+    assert manager.volume.cleared == ["thread-1"]
+    assert all_terminals == []
+
+
 def test_destroy_thread_resources_deletes_daytona_managed_volume_from_runtime_id(tmp_path):
     manager = _new_test_manager()
     provider = _FakeDaytonaProvider()

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -23,6 +24,20 @@ def test_agent_config_schema_uses_library_package_storage() -> None:
     assert "insert into agent.agent_skills" not in sql
     assert "agent.agent_skills.content" not in sql
     assert "agent.agent_skills.files_json" not in sql
+
+
+def test_agent_skill_binding_package_fk_does_not_silently_delete_agent_selection() -> None:
+    sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
+
+    binding_table = re.search(
+        r"create table if not exists agent\.skill_bindings \((?P<body>.*?)\);",
+        sql,
+        flags=re.DOTALL,
+    )
+    assert binding_table is not None
+    body = binding_table.group("body")
+    assert "references library.skill_packages(id)" in body
+    assert "on delete cascade" not in body.lower()
 
 
 def test_agent_config_schema_rejects_duplicate_child_names_inside_rpc() -> None:


### PR DESCRIPTION
## Summary
- treat missing sandbox runtime rows as stale residue during thread deletion after terminal rows are removed
- reject deleting Library Skills that are still assigned to Agents, and surface the backend reason in Marketplace
- read Skill usage directly from AgentConfig rows and document the DB constraint that prevents silent binding deletion

## Verification
- uv run pytest tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/sandbox/test_sandbox_service_cleanup.py tests/Unit/integration_contracts/test_threads_router.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/storage/test_agent_config_schema_sql.py -q
- uv run ruff check sandbox/manager.py backend/web/routers/panel.py backend/library/service.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/storage/test_agent_config_schema_sql.py
- uv run ruff format --check sandbox/manager.py backend/web/routers/panel.py backend/library/service.py tests/Unit/sandbox/test_sandbox_manager_volume_repo.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/storage/test_agent_config_schema_sql.py
- pnpm --dir frontend/app test MarketplacePage.wording.test.tsx
- pnpm --dir frontend/app typecheck
