### PR TITLE
Keep sandbox provider listing off manager construction

### DIFF
--- a/backend/sandboxes/inventory.py
+++ b/backend/sandboxes/inventory.py
@@ -57,6 +57,21 @@ def _build_providers_and_managers(
     sandbox_config_cls=SandboxConfig,
     local_workspace_root_path: Path | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
+    providers = _build_providers(
+        sandboxes_dir=sandboxes_dir,
+        sandbox_config_cls=sandbox_config_cls,
+        local_workspace_root_path=local_workspace_root_path,
+    )
+    managers = {name: sandbox_manager_cls(provider=provider) for name, provider in providers.items()}
+    return providers, managers
+
+
+def _build_providers(
+    *,
+    sandboxes_dir: Path | None = None,
+    sandbox_config_cls=SandboxConfig,
+    local_workspace_root_path: Path | None = None,
+) -> dict[str, Any]:
     from sandbox.providers.local import LocalSessionProvider
 
     config_dir = sandboxes_dir if sandboxes_dir is not None else SANDBOXES_DIR
@@ -65,8 +80,7 @@ def _build_providers_and_managers(
         "local": LocalSessionProvider(default_cwd=str(workspace_root)),
     }
     if config_dir is None or not config_dir.exists():
-        managers = {name: sandbox_manager_cls(provider=provider) for name, provider in providers.items()}
-        return providers, managers
+        return providers
 
     for config_file in config_dir.glob("*.json"):
         name = config_file.stem
@@ -134,18 +148,23 @@ def _build_providers_and_managers(
         except Exception as exc:
             logger.warning("[sandbox] failed to init provider %s: %s", name, exc)
 
-    managers = {name: sandbox_manager_cls(provider=provider) for name, provider in providers.items()}
-    return providers, managers
+    return providers
 
 
 def available_sandbox_types(
     *,
     sandboxes_dir: Path | None = None,
-    init_providers_and_managers_fn=None,
+    build_providers_fn=None,
     sandbox_config_cls=SandboxConfig,
 ) -> list[dict[str, Any]]:
-    init_fn = init_providers_and_managers_fn or init_providers_and_managers
-    providers, _ = init_fn()
+    providers = (
+        build_providers_fn()
+        if build_providers_fn is not None
+        else _build_providers(
+            sandboxes_dir=sandboxes_dir,
+            sandbox_config_cls=sandbox_config_cls,
+        )
+    )
     local_capability = providers["local"].get_capability()
     types = [
         {

--- a/backend/sandboxes/provider_availability.py
+++ b/backend/sandboxes/provider_availability.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from backend.sandboxes.inventory import init_providers_and_managers
 from backend.sandboxes.paths import SANDBOXES_DIR
 from sandbox.config import SandboxConfig
 
@@ -10,13 +9,13 @@ from sandbox.config import SandboxConfig
 def available_sandbox_types(
     *,
     sandboxes_dir=SANDBOXES_DIR,
-    init_providers_and_managers_fn=init_providers_and_managers,
+    build_providers_fn=None,
     sandbox_config_cls=SandboxConfig,
 ) -> list[dict[str, Any]]:
     from backend.sandboxes import inventory as sandbox_inventory
 
     return sandbox_inventory.available_sandbox_types(
         sandboxes_dir=sandboxes_dir,
-        init_providers_and_managers_fn=init_providers_and_managers_fn,
+        build_providers_fn=build_providers_fn,
         sandbox_config_cls=sandbox_config_cls,
     )

--- a/backend/sandboxes/service.py
+++ b/backend/sandboxes/service.py
@@ -81,7 +81,11 @@ def count_user_visible_sandboxes_by_provider(
 def available_sandbox_types() -> list[dict[str, Any]]:
     return _sandbox_provider_availability.available_sandbox_types(
         sandboxes_dir=SANDBOXES_DIR,
-        init_providers_and_managers_fn=init_providers_and_managers,
+        build_providers_fn=lambda: sandbox_inventory._build_providers(
+            sandboxes_dir=SANDBOXES_DIR,
+            sandbox_config_cls=SandboxConfig,
+            local_workspace_root_path=local_workspace_root(),
+        ),
         sandbox_config_cls=SandboxConfig,
     )
 

--- a/backend/threads/pool/idle_reaper.py
+++ b/backend/threads/pool/idle_reaper.py
@@ -22,7 +22,7 @@ def run_idle_reaper_once(app_obj: Any) -> int:
         total += manager.enforce_idle_timeouts()
 
     if init_providers_and_managers is None:
-        raise RuntimeError("thread_runtime.pool.idle_reaper requires init_providers_and_managers binding")
+        return total
     _, managers = init_providers_and_managers()
     for provider_name, manager in managers.items():
         if provider_name in managed_providers:

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -111,8 +111,12 @@ async def lifespan(app: FastAPI):
     try:
         from backend.sandboxes.service import init_providers_and_managers
         from backend.web.core.config import IDLE_REAPER_INTERVAL_SEC
+        from sandbox.control_plane_repos import configured_sandbox_db_path
 
-        idle_reaper_owner.init_providers_and_managers = init_providers_and_managers
+        if configured_sandbox_db_path() is not None:
+            idle_reaper_owner.init_providers_and_managers = init_providers_and_managers
+        else:
+            idle_reaper_owner.init_providers_and_managers = None
         idle_reaper_owner.IDLE_REAPER_INTERVAL_SEC = IDLE_REAPER_INTERVAL_SEC
 
         app.state.idle_reaper_task = asyncio.create_task(idle_reaper_owner.idle_reaper_loop(app))

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -254,6 +254,35 @@ def test_login_repairs_existing_user_sandbox_recipes(monkeypatch: pytest.MonkeyP
     assert sorted(recipe_id for (_owner, recipe_id) in recipe_rows) == ["daytona_selfhost:default"]
 
 
+def test_login_seeds_recipes_without_sandbox_control_plane_path(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    auth_client = _FakeAuthClient()
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.setattr("backend.sandboxes.inventory.SANDBOXES_DIR", None)
+    recipe_rows: dict[tuple[str, str], dict] = {}
+    recipe_repo = SimpleNamespace(
+        get=lambda owner_user_id, recipe_id: recipe_rows.get((owner_user_id, recipe_id)),
+        upsert=lambda **payload: recipe_rows.setdefault(
+            (payload["owner_user_id"], payload["recipe_id"]), {"data": payload["data"], **payload}
+        ),
+    )
+    user_repo = SimpleNamespace(
+        get_by_id=lambda _user_id: SimpleNamespace(display_name="codex", mycel_id=10001, email="codex@example.com", avatar=None),
+        list_by_owner_user_id=lambda _user_id: [],
+    )
+
+    result = _service(
+        supabase_client=SimpleNamespace(auth=None),
+        supabase_auth_client=auth_client,
+        user_repo=user_repo,
+        recipe_repo=recipe_repo,
+    ).login("codex@example.com", "pw-1")
+
+    assert result["token"] == "tok-1"
+    assert sorted(recipe_id for (_owner, recipe_id) in recipe_rows) == ["local:default"]
+
+
 def test_login_uses_fresh_auth_client_from_factory_per_call():
     created: list[_FactoryBackedAuthClient] = []
 

--- a/tests/Unit/backend/web/services/test_idle_reaper.py
+++ b/tests/Unit/backend/web/services/test_idle_reaper.py
@@ -40,3 +40,15 @@ def test_run_idle_reaper_once_snapshots_agent_pool_before_iteration(monkeypatch)
     monkeypatch.setattr(idle_reaper_module, "init_providers_and_managers", lambda: ({}, {}))
 
     assert idle_reaper_module.run_idle_reaper_once(app) == 2
+
+
+def test_run_idle_reaper_once_reaps_loaded_managers_without_global_inventory(monkeypatch) -> None:
+    manager = SimpleNamespace(
+        provider=SimpleNamespace(name="local"),
+        enforce_idle_timeouts=lambda: 1,
+    )
+    app = SimpleNamespace(state=SimpleNamespace(agent_pool={"agent-1": SimpleNamespace(_sandbox=SimpleNamespace(manager=manager))}))
+
+    monkeypatch.setattr(idle_reaper_module, "init_providers_and_managers", None)
+
+    assert idle_reaper_module.run_idle_reaper_once(app) == 1

--- a/tests/Unit/sandbox/test_sandbox_provider_availability.py
+++ b/tests/Unit/sandbox/test_sandbox_provider_availability.py
@@ -4,19 +4,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from backend.sandboxes import service as sandbox_service
-from sandbox.providers.local import LocalSessionProvider
 
 
 def test_available_sandbox_types_marks_configured_but_unavailable_provider(monkeypatch, tmp_path: Path) -> None:
-    local_provider = LocalSessionProvider(default_cwd=str(tmp_path))
     (tmp_path / "daytona.json").write_text("{}")
 
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))
     monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
-    monkeypatch.setattr(
-        sandbox_service,
-        "init_providers_and_managers",
-        lambda: ({"local": local_provider}, {}),
-    )
     monkeypatch.setattr(
         sandbox_service.SandboxConfig,
         "load",
@@ -32,15 +26,10 @@ def test_available_sandbox_types_marks_configured_but_unavailable_provider(monke
 
 
 def test_available_sandbox_types_marks_e2b_unavailable_when_sdk_missing(monkeypatch, tmp_path: Path) -> None:
-    local_provider = LocalSessionProvider(default_cwd=str(tmp_path))
     (tmp_path / "e2b.json").write_text("{}")
 
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))
     monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
-    monkeypatch.setattr(
-        sandbox_service,
-        "init_providers_and_managers",
-        lambda: ({"local": local_provider}, {}),
-    )
     monkeypatch.setattr(
         sandbox_service.SandboxConfig,
         "load",
@@ -76,6 +65,18 @@ def test_build_providers_and_managers_accepts_empty_sandbox_config_set(monkeypat
 
     assert list(providers) == ["local"]
     assert list(managers) == ["local"]
+
+
+def test_available_sandbox_types_does_not_require_sandbox_control_plane_path(monkeypatch, tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(workspace_root))
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", None)
+
+    types = sandbox_service.available_sandbox_types()
+
+    assert [(item["name"], item["provider"], item["available"]) for item in types] == [("local", "local", True)]
 
 
 def test_build_providers_and_managers_passes_agentbay_pause_capability_overrides(monkeypatch, tmp_path: Path) -> None:
@@ -189,15 +190,10 @@ def test_available_sandbox_types_marks_daytona_unavailable_when_api_key_missing(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    local_provider = LocalSessionProvider(default_cwd=str(tmp_path))
     (tmp_path / "daytona_selfhost.json").write_text("{}")
 
+    monkeypatch.setenv("LEON_LOCAL_WORKSPACE_ROOT", str(tmp_path / "workspace"))
     monkeypatch.setattr(sandbox_service, "SANDBOXES_DIR", tmp_path)
-    monkeypatch.setattr(
-        sandbox_service,
-        "init_providers_and_managers",
-        lambda: ({"local": local_provider}, {}),
-    )
     monkeypatch.setattr(
         sandbox_service.SandboxConfig,
         "load",


### PR DESCRIPTION
## Summary
- Split sandbox provider construction from manager construction so read-only provider listing does not open the sandbox control-plane store.
- Route sandbox type listing and auth recipe seeding through provider metadata only.
- Keep idle reaper cleanup for already loaded Agent managers, while global manager inventory is bound only by web lifespan when configured.

## Architecture Boundary
- `available_sandbox_types()` now depends on providers, not `SandboxManager`.
- `SandboxManager` remains a runtime/control-plane concern.
- Backend login and `/api/sandbox/types` can run with `LEON_STORAGE_STRATEGY=supabase` and no `LEON_SANDBOX_DB_PATH`.

## Test Plan
- `uv run pytest tests/Unit/backend/web/services/test_idle_reaper.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/integration_contracts/test_thread_launch_config_contract.py -q`
- `uv run ruff check backend/sandboxes/inventory.py backend/sandboxes/provider_availability.py backend/sandboxes/service.py backend/threads/pool/idle_reaper.py backend/web/core/lifespan.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/web/services/test_idle_reaper.py`
- `uv run ruff format --check backend/sandboxes/inventory.py backend/sandboxes/provider_availability.py backend/sandboxes/service.py backend/threads/pool/idle_reaper.py backend/web/core/lifespan.py tests/Unit/sandbox/test_sandbox_provider_availability.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/backend/web/services/test_idle_reaper.py`
- Live backend on `127.0.0.1:8018` with no `LEON_SANDBOX_DB_PATH`: `POST /api/auth/login -> 200`, `GET /api/sandbox/types -> 200`, provider rows `[(local, local, True)]`, no idle reaper sandbox DB path error after multiple intervals.
