### PR TITLE
Move sandbox terminal control plane to Supabase storage

### DIFF
--- a/backend/threads/convergence.py
+++ b/backend/threads/convergence.py
@@ -12,9 +12,10 @@ from storage.runtime import uses_supabase_runtime_defaults
 def delete_thread_in_db(thread_id: str) -> None:
     _get_container().purge_thread(thread_id)
 
-    sandbox_db = resolve_sandbox_db_path()
-    if not uses_supabase_runtime_defaults() and not sandbox_db.exists():
-        return
+    if not uses_supabase_runtime_defaults():
+        sandbox_db = resolve_sandbox_db_path()
+        if not sandbox_db.exists():
+            return
 
     session_repo = make_chat_session_repo()
     terminal_repo = make_terminal_repo()

--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -4,7 +4,6 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 
 from backend.sandboxes.inventory import init_providers_and_managers
-from sandbox.control_plane_repos import resolve_sandbox_db_path
 from sandbox.runtime_handle import sandbox_runtime_from_row
 from storage.container_cache import get_storage_container as _get_container
 from storage.runtime import build_sandbox_runtime_repo as make_sandbox_runtime_repo
@@ -38,7 +37,7 @@ async def ingest_provider_webhook(provider_name: str, payload: dict[str, Any]) -
     event_repo = _get_container().provider_event_repo()
     try:
         runtime_row = await asyncio.to_thread(runtime_repo.find_by_instance, provider_name=provider_name, instance_id=instance_id)
-        sandbox_runtime = sandbox_runtime_from_row(runtime_row, resolve_sandbox_db_path()) if runtime_row else None
+        sandbox_runtime = sandbox_runtime_from_row(runtime_row) if runtime_row else None
         matched_runtime_handle = sandbox_runtime.sandbox_runtime_id if sandbox_runtime else None
         matched_sandbox_id = str((runtime_row or {}).get("sandbox_id") or "").strip() or None
 

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -616,6 +616,7 @@ class LeonAgent:
                 sandbox_config,
                 workspace_root=str(self.workspace_root),
                 db_path=self.sandbox_db_path,
+                thread_repo=self._thread_repo,
             )
 
         raise TypeError(f"sandbox must be Sandbox, str, or None, got {type(sandbox)}")

--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -12,11 +12,12 @@ def create_sandbox(
     config: SandboxConfig,
     workspace_root: str | None = None,
     db_path: Path | None = None,
+    thread_repo=None,
 ) -> Sandbox:
     p = config.provider
 
     if p == "local":
-        return LocalSandbox(workspace_root=workspace_root or str(Path.cwd()), db_path=db_path)
+        return LocalSandbox(workspace_root=workspace_root or str(Path.cwd()), db_path=db_path, thread_repo=thread_repo)
 
     if p == "agentbay":
         from sandbox.providers.agentbay import AgentBayProvider
@@ -36,6 +37,7 @@ def create_sandbox(
             config=config,
             default_cwd=ab.context_path,
             db_path=db_path,
+            thread_repo=thread_repo,
             name=config.name,
             working_dir=ab.context_path,
             env_label="Remote Linux sandbox (Ubuntu)",
@@ -50,6 +52,7 @@ def create_sandbox(
             config=config,
             default_cwd=dc.mount_path,
             db_path=db_path,
+            thread_repo=thread_repo,
             name=config.name,
             working_dir=dc.mount_path,
             env_label="Local Docker sandbox (Ubuntu)",
@@ -73,6 +76,7 @@ def create_sandbox(
             config=config,
             default_cwd=e.cwd,
             db_path=db_path,
+            thread_repo=thread_repo,
             name=config.name,
             working_dir=e.cwd,
             env_label="Remote Linux sandbox (E2B)",
@@ -96,6 +100,7 @@ def create_sandbox(
             config=config,
             default_cwd=dt.cwd,
             db_path=db_path,
+            thread_repo=thread_repo,
             name=config.name,
             working_dir=dt.cwd,
             env_label="Remote Linux sandbox (Daytona)",

--- a/sandbox/base.py
+++ b/sandbox/base.py
@@ -118,6 +118,7 @@ class RemoteSandbox(Sandbox):
         default_cwd: str,
         db_path: Path | None = None,
         *,
+        thread_repo: Any | None = None,
         name: str | None = None,
         working_dir: str | None = None,
         env_label: str = "Remote sandbox",
@@ -125,9 +126,10 @@ class RemoteSandbox(Sandbox):
         self._config = config
         self._default_cwd = default_cwd
         self._provider = provider
+        self._thread_repo = thread_repo
         from sandbox.manager import SandboxManager
 
-        self._manager = SandboxManager(provider=provider, db_path=db_path)
+        self._manager = SandboxManager(provider=provider, db_path=db_path, thread_repo=thread_repo)
         self._on_exit = config.on_exit
         self._name = name or config.name
         self._working_dir = working_dir or default_cwd
@@ -225,11 +227,12 @@ class _LazyLocalExecutor:
 
 
 class LocalSandbox(Sandbox):
-    def __init__(self, workspace_root: str, db_path: Path | None = None) -> None:
+    def __init__(self, workspace_root: str, db_path: Path | None = None, thread_repo: Any | None = None) -> None:
         from sandbox.providers.local import LocalSessionProvider
 
         self._workspace_root = workspace_root
         self._db_path = db_path
+        self._thread_repo = thread_repo
         self._provider = LocalSessionProvider(default_cwd=workspace_root)
         self._manager: SandboxManager | None = None
         self._capability_cache: dict[str, SandboxCapability] = {}
@@ -255,7 +258,7 @@ class LocalSandbox(Sandbox):
             # @@@lazy-local-control-plane - local Agent construction is allowed
             # without sandbox storage; terminal/session use is the boundary that
             # requires an explicit control-plane DB path.
-            self._manager = SandboxManager(provider=self._provider, db_path=self._db_path)
+            self._manager = SandboxManager(provider=self._provider, db_path=self._db_path, thread_repo=self._thread_repo)
         return self._manager
 
     def _get_capability(self) -> SandboxCapability:

--- a/sandbox/capability.py
+++ b/sandbox/capability.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import shlex
 import uuid
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 from sandbox.interfaces.executor import BaseExecutor
 from sandbox.interfaces.filesystem import FileSystemBackend
-from storage.providers.sqlite.kernel import connect_sqlite
 
 if TYPE_CHECKING:
     from sandbox.chat_session import ChatSession
@@ -52,8 +51,6 @@ class _CommandWrapper(BaseExecutor):
         super().__init__(default_cwd=session.terminal.get_state().cwd)
         self._session = session
         self._manager = manager
-        db_path = getattr(session.terminal, "db_path", None)
-        self._db_path: Path | None = Path(db_path) if db_path else None
 
     def _wrap_command(self, command: str, cwd: str | None, env: dict[str, str] | None) -> tuple[str, str]:
         wrapped = command
@@ -85,27 +82,13 @@ class _CommandWrapper(BaseExecutor):
 
     def _lookup_command_terminal_id(self, command_id: str) -> str | None:
         command_repo = getattr(self._session, "_session_repo", None)
-        if command_repo is not None:
-            terminal_id = command_repo.find_command_terminal_id(
-                command_id=command_id,
-                thread_id=self._session.thread_id,
-            )
-            if terminal_id is not None:
-                return terminal_id
-            return None
-        if self._db_path is None:
-            return None
-        with connect_sqlite(self._db_path) as conn:
-            row = conn.execute(
-                """
-                SELECT tc.terminal_id
-                FROM terminal_commands tc
-                JOIN abstract_terminals at ON at.terminal_id = tc.terminal_id
-                WHERE tc.command_id = ? AND at.thread_id = ?
-                """,
-                (command_id, self._session.thread_id),
-            ).fetchone()
-        return str(row[0]) if row else None
+        if command_repo is None:
+            raise RuntimeError("Command lookup requires chat session repo")
+        terminal_id = command_repo.find_command_terminal_id(
+            command_id=command_id,
+            thread_id=self._session.thread_id,
+        )
+        return str(terminal_id) if terminal_id is not None else None
 
     def _resolve_session_for_terminal(self, terminal_id: str):
         if terminal_id == self._session.terminal.terminal_id:
@@ -120,7 +103,7 @@ class _CommandWrapper(BaseExecutor):
             raise RuntimeError(f"Terminal {terminal_id} not found")
         from sandbox.terminal import terminal_from_row
 
-        terminal = terminal_from_row(terminal_row, self._manager.db_path)
+        terminal = terminal_from_row(terminal_row, self._manager.db_path, terminal_repo=self._manager.terminal_store)
         if terminal.thread_id != self._session.thread_id:
             raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal.thread_id}, not {self._session.thread_id}")
         sandbox_runtime = self._manager.get_sandbox_runtime(terminal.sandbox_runtime_id)

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -12,7 +12,6 @@ from sandbox.control_plane_repos import (
     make_chat_session_repo,
     make_sandbox_runtime_repo,
     make_terminal_repo,
-    resolve_sandbox_db_path,
 )
 from sandbox.lifecycle import (
     ChatSessionState,
@@ -90,7 +89,7 @@ class ChatSession:
         self.budget_json = budget_json
         self.ended_at = ended_at
         self.close_reason = close_reason
-        self._db_path = resolve_sandbox_db_path(db_path) if session_repo is None else db_path
+        self._db_path = db_path
         self._session_repo = session_repo or make_chat_session_repo(db_path=self._db_path)
 
     def is_expired(self) -> bool:
@@ -135,16 +134,27 @@ class ChatSessionManager:
         sandbox_runtime_repo=None,
     ):
         self.provider = provider
-        needs_db_path = chat_session_repo is None or terminal_repo is None or sandbox_runtime_repo is None
-        self.db_path = resolve_sandbox_db_path(db_path) if needs_db_path else db_path
+        self.db_path = db_path
         self.default_policy = default_policy or ChatSessionPolicy()
         self._live_sessions: dict[str, ChatSession] = {}
         if chat_session_repo:
             self._repo = chat_session_repo
+            self._owns_repo = False
         else:
             self._repo = make_chat_session_repo(db_path=self.db_path)
-        self._terminal_repo = terminal_repo
-        self._sandbox_runtime_repo = sandbox_runtime_repo
+            self._owns_repo = True
+        if terminal_repo:
+            self._terminal_repo = terminal_repo
+            self._owns_terminal_repo = False
+        else:
+            self._terminal_repo = make_terminal_repo(db_path=self.db_path)
+            self._owns_terminal_repo = True
+        if sandbox_runtime_repo:
+            self._sandbox_runtime_repo = sandbox_runtime_repo
+            self._owns_sandbox_runtime_repo = False
+        else:
+            self._sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=self.db_path)
+            self._owns_sandbox_runtime_repo = True
 
     def _close_runtime(self, session: ChatSession, reason: str) -> None:
         try:
@@ -175,18 +185,8 @@ class ChatSessionManager:
 
     def get(self, thread_id: str, terminal_id: str | None = None) -> ChatSession | None:
         if terminal_id is None:
-            from sandbox.terminal import terminal_from_row
-
             # @@@thread-scoped-get - Thread-level callers resolve through the current active terminal.
-            _term_repo = self._terminal_repo
-            own_term_repo = _term_repo is None
-            if _term_repo is None:
-                _term_repo = make_terminal_repo(db_path=self.db_path)
-            try:
-                _term_row = _term_repo.get_active(thread_id)
-            finally:
-                if own_term_repo:
-                    _term_repo.close()
+            _term_row = self._terminal_repo.get_active(thread_id)
             if _term_row is None:
                 return None
             terminal_id = _require_row_text(dict(_term_row), "terminal_id")
@@ -206,25 +206,9 @@ class ChatSessionManager:
         from sandbox.runtime_handle import sandbox_runtime_from_row
         from sandbox.terminal import terminal_from_row
 
-        _term_repo = self._terminal_repo
-        own_term_repo = _term_repo is None
-        if _term_repo is None:
-            _term_repo = make_terminal_repo(db_path=self.db_path)
-        try:
-            _term_row = _term_repo.get_by_id(row["terminal_id"])
-        finally:
-            if own_term_repo:
-                _term_repo.close()
-        terminal = terminal_from_row(_term_row, self.db_path) if _term_row else None
-        _sandbox_runtime_repo = self._sandbox_runtime_repo
-        own_sandbox_runtime_repo = _sandbox_runtime_repo is None
-        if _sandbox_runtime_repo is None:
-            _sandbox_runtime_repo = make_sandbox_runtime_repo(db_path=self.db_path)
-        try:
-            _sandbox_runtime_row = _sandbox_runtime_repo.get(row["sandbox_runtime_id"])
-        finally:
-            if own_sandbox_runtime_repo:
-                _sandbox_runtime_repo.close()
+        _term_row = self._terminal_repo.get_by_id(row["terminal_id"])
+        terminal = terminal_from_row(_term_row, self.db_path, terminal_repo=self._terminal_repo) if _term_row else None
+        _sandbox_runtime_row = self._sandbox_runtime_repo.get(row["sandbox_runtime_id"])
         sandbox_runtime = sandbox_runtime_from_row(_sandbox_runtime_row, self.db_path) if _sandbox_runtime_row else None
         if not terminal or not sandbox_runtime:
             return None
@@ -395,7 +379,12 @@ class ChatSessionManager:
             self._live_sessions.pop(live_terminal_id, None)
 
         self._repo.close_all_active(reason)
-        self._repo.close()
+        if self._owns_repo:
+            self._repo.close()
+        if self._owns_terminal_repo:
+            self._terminal_repo.close()
+        if self._owns_sandbox_runtime_repo:
+            self._sandbox_runtime_repo.close()
 
     def list_active(self) -> list[dict]:
         return self._repo.list_active()

--- a/sandbox/chat_session.py
+++ b/sandbox/chat_session.py
@@ -137,12 +137,7 @@ class ChatSessionManager:
         self.db_path = db_path
         self.default_policy = default_policy or ChatSessionPolicy()
         self._live_sessions: dict[str, ChatSession] = {}
-        if chat_session_repo:
-            self._repo = chat_session_repo
-            self._owns_repo = False
-        else:
-            self._repo = make_chat_session_repo(db_path=self.db_path)
-            self._owns_repo = True
+        self._repo = chat_session_repo or make_chat_session_repo(db_path=self.db_path)
         if terminal_repo:
             self._terminal_repo = terminal_repo
             self._owns_terminal_repo = False
@@ -379,8 +374,7 @@ class ChatSessionManager:
             self._live_sessions.pop(live_terminal_id, None)
 
         self._repo.close_all_active(reason)
-        if self._owns_repo:
-            self._repo.close()
+        self._repo.close()
         if self._owns_terminal_repo:
             self._terminal_repo.close()
         if self._owns_sandbox_runtime_repo:

--- a/sandbox/control_plane_repos.py
+++ b/sandbox/control_plane_repos.py
@@ -4,7 +4,9 @@ import os
 from pathlib import Path
 
 from storage.runtime import (
+    build_chat_session_repo,
     build_sandbox_runtime_repo,
+    build_terminal_repo,
     uses_supabase_runtime_defaults,
 )
 
@@ -28,6 +30,8 @@ def _use_strategy_control_plane_repo(db_path: Path | None = None) -> bool:
 
 
 def make_chat_session_repo(db_path: Path | None = None):
+    if _use_strategy_control_plane_repo(db_path):
+        return build_chat_session_repo()
     from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 
     return SQLiteChatSessionRepo(db_path=resolve_sandbox_db_path(db_path))
@@ -42,6 +46,8 @@ def make_sandbox_runtime_repo(db_path: Path | None = None):
 
 
 def make_terminal_repo(db_path: Path | None = None):
+    if _use_strategy_control_plane_repo(db_path):
+        return build_terminal_repo()
     from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 
     return SQLiteTerminalRepo(db_path=resolve_sandbox_db_path(db_path))

--- a/sandbox/manager.py
+++ b/sandbox/manager.py
@@ -9,12 +9,18 @@ from config.user_paths import user_home_path
 from sandbox.capability import SandboxCapability
 from sandbox.chat_session import ChatSessionManager, ChatSessionPolicy
 from sandbox.clock import parse_runtime_datetime, utc_now
-from sandbox.control_plane_repos import make_chat_session_repo, make_sandbox_runtime_repo, make_terminal_repo, resolve_sandbox_db_path
+from sandbox.control_plane_repos import (
+    configured_sandbox_db_path,
+    make_chat_session_repo,
+    make_sandbox_runtime_repo,
+    make_terminal_repo,
+    resolve_sandbox_db_path,
+)
 from sandbox.provider import SandboxProvider
 from sandbox.recipes import bootstrap_recipe
 from sandbox.runtime_handle import sandbox_runtime_from_row
 from sandbox.terminal import TerminalState, terminal_from_row
-from storage.runtime import build_storage_container
+from storage.runtime import build_storage_container, uses_supabase_runtime_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +39,17 @@ def _build_provider_from_name(name: str):
     return build_provider_from_config_name(name)
 
 
+def _resolve_manager_db_path(db_path: Path | None) -> Path | None:
+    if db_path is not None:
+        return db_path
+    configured = configured_sandbox_db_path()
+    if configured is not None:
+        return configured
+    if uses_supabase_runtime_defaults():
+        return None
+    return resolve_sandbox_db_path(None)
+
+
 def lookup_sandbox_for_thread(
     thread_id: str,
     db_path: Path | None = None,
@@ -40,9 +57,8 @@ def lookup_sandbox_for_thread(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> str | None:
-    target_db = resolve_sandbox_db_path(db_path) if terminal_repo is None or sandbox_runtime_repo is None else db_path
-    uses_strategy_default_sandbox = False
-    if terminal_repo is None and sandbox_runtime_repo is None and not target_db.exists() and not uses_strategy_default_sandbox:
+    target_db = _resolve_manager_db_path(db_path) if terminal_repo is None or sandbox_runtime_repo is None else db_path
+    if terminal_repo is None and sandbox_runtime_repo is None and target_db is not None and not target_db.exists():
         return None
 
     _terminal_repo = terminal_repo
@@ -77,7 +93,7 @@ def resolve_existing_sandbox_runtime_cwd(
     if requested_cwd:
         return requested_cwd
 
-    target_db = resolve_sandbox_db_path(db_path) if sandbox_runtime_repo is None else db_path
+    target_db = _resolve_manager_db_path(db_path) if sandbox_runtime_repo is None else db_path
     _sandbox_runtime_repo = sandbox_runtime_repo
     own_sandbox_runtime_repo = _sandbox_runtime_repo is None
     if _sandbox_runtime_repo is None:
@@ -103,7 +119,7 @@ def bind_thread_to_existing_sandbox_runtime(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> str:
-    target_db = resolve_sandbox_db_path(db_path) if terminal_repo is None or sandbox_runtime_repo is None else db_path
+    target_db = _resolve_manager_db_path(db_path) if terminal_repo is None or sandbox_runtime_repo is None else db_path
     _terminal_repo = terminal_repo
     own_terminal_repo = _terminal_repo is None
     if _terminal_repo is None:
@@ -149,7 +165,7 @@ def resolve_existing_sandbox_runtime(
 
     # @@@existing-sandbox-runtime-identity - existing-sandbox reuse must bind
     # through live runtime identity; stored runtime config is not a resolution source.
-    target_db = resolve_sandbox_db_path(db_path) if sandbox_runtime_repo is None else db_path
+    target_db = _resolve_manager_db_path(db_path) if sandbox_runtime_repo is None else db_path
     _sandbox_runtime_repo = sandbox_runtime_repo
     own_sandbox_runtime_repo = _sandbox_runtime_repo is None
     if _sandbox_runtime_repo is None:
@@ -203,7 +219,7 @@ def bind_thread_to_existing_thread_sandbox_runtime(
     terminal_repo: Any | None = None,
     sandbox_runtime_repo: Any | None = None,
 ) -> str | None:
-    target_db = resolve_sandbox_db_path(db_path) if terminal_repo is None else db_path
+    target_db = _resolve_manager_db_path(db_path) if terminal_repo is None else db_path
     if not cwd:
         raise ValueError("thread reuse cwd is required")
     _terminal_repo = terminal_repo
@@ -236,12 +252,14 @@ class SandboxManager:
         provider: SandboxProvider,
         db_path: Path | None = None,
         on_session_ready: Callable[[str, str], None] | None = None,
+        thread_repo: Any | None = None,
     ):
         self.provider = provider
         self.provider_capability = provider.get_capability()
         self._on_session_ready = on_session_ready
+        self._thread_repo = thread_repo
 
-        self.db_path = resolve_sandbox_db_path(db_path)
+        self.db_path = _resolve_manager_db_path(db_path)
         self.terminal_store = make_terminal_repo(db_path=self.db_path)
         self.sandbox_runtime_store = make_sandbox_runtime_repo(db_path=self.db_path)
 
@@ -267,8 +285,25 @@ class SandboxManager:
             return None
         return sandbox_runtime_from_row(row, self.db_path)
 
-    def _create_sandbox_runtime(self, sandbox_runtime_id: str, provider_name: str):
-        row = self.sandbox_runtime_store.create(sandbox_runtime_id, provider_name)
+    def _owner_user_id_for_thread(self, thread_id: str) -> str | None:
+        if self._thread_repo is None:
+            return None
+        thread = self._thread_repo.get_by_id(thread_id)
+        if thread is None:
+            return None
+        if isinstance(thread, dict):
+            owner_user_id = thread.get("owner_user_id")
+        else:
+            owner_user_id = getattr(thread, "owner_user_id", None)
+        owner = str(owner_user_id or "").strip()
+        return owner or None
+
+    def _create_sandbox_runtime(self, sandbox_runtime_id: str, provider_name: str, *, thread_id: str | None = None):
+        row = self.sandbox_runtime_store.create(
+            sandbox_runtime_id,
+            provider_name,
+            owner_user_id=self._owner_user_id_for_thread(thread_id) if thread_id else None,
+        )
         return sandbox_runtime_from_row(row, self.db_path)
 
     def get_terminal(self, thread_id: str):
@@ -344,7 +379,7 @@ class SandboxManager:
     def _get_active_terminal(self, thread_id: str):
         row = self.terminal_store.get_active(thread_id)
         if row:
-            return terminal_from_row(row, self.db_path)
+            return terminal_from_row(row, self.db_path, terminal_repo=self.terminal_store)
         thread_terminals = self.terminal_store.list_by_thread(thread_id)
         # @@@thread-pointer-consistency - If terminals exist but no active pointer, DB is inconsistent and must fail loudly.
         if thread_terminals:
@@ -353,7 +388,7 @@ class SandboxManager:
 
     def _get_thread_terminals(self, thread_id: str):
         rows = self.terminal_store.list_by_thread(thread_id)
-        return [terminal_from_row(row, self.db_path) for row in rows]
+        return [terminal_from_row(row, self.db_path, terminal_repo=self.terminal_store) for row in rows]
 
     def _get_thread_sandbox_runtime(self, thread_id: str):
         terminals = self._get_thread_terminals(thread_id)
@@ -460,7 +495,7 @@ class SandboxManager:
         if not terminal:
             terminal_id = f"term-{uuid.uuid4().hex[:12]}"
             sandbox_runtime_id = f"runtime-{uuid.uuid4().hex[:12]}"
-            sandbox_runtime = self._create_sandbox_runtime(sandbox_runtime_id, self.provider.name)
+            sandbox_runtime = self._create_sandbox_runtime(sandbox_runtime_id, self.provider.name, thread_id=thread_id)
             initial_cwd = self._default_terminal_cwd()
             terminal = terminal_from_row(
                 self.terminal_store.create(
@@ -470,11 +505,12 @@ class SandboxManager:
                     initial_cwd=initial_cwd,
                 ),
                 self.db_path,
+                terminal_repo=self.terminal_store,
             )
         else:
             sandbox_runtime = self._get_sandbox_runtime(terminal.sandbox_runtime_id)
             if not sandbox_runtime:
-                sandbox_runtime = self._create_sandbox_runtime(terminal.sandbox_runtime_id, self.provider.name)
+                sandbox_runtime = self._create_sandbox_runtime(terminal.sandbox_runtime_id, self.provider.name, thread_id=thread_id)
             self._assert_sandbox_runtime_provider(sandbox_runtime, thread_id)
             if sandbox_runtime.observed_state == "paused":
                 # @@@paused-runtime-rehydrate - a persisted thread can lose its in-memory chat session
@@ -539,7 +575,7 @@ class SandboxManager:
         default_row = self.terminal_store.get_default(thread_id)
         if default_row is None:
             raise RuntimeError(f"Thread {thread_id} has no default terminal")
-        default_terminal = terminal_from_row(default_row, self.db_path)
+        default_terminal = terminal_from_row(default_row, self.db_path, terminal_repo=self.terminal_store)
         sandbox_runtime = self._get_sandbox_runtime(default_terminal.sandbox_runtime_id)
         if sandbox_runtime is None:
             raise RuntimeError(f"Missing sandbox runtime {default_terminal.sandbox_runtime_id} for thread {thread_id}")
@@ -555,6 +591,7 @@ class SandboxManager:
                 initial_cwd=initial_cwd,
             ),
             self.db_path,
+            terminal_repo=self.terminal_store,
         )
         # @@@async-terminal-inherit-state - non-blocking commands fork from default terminal cwd/env snapshot.
         terminal.update_state(
@@ -635,7 +672,7 @@ class SandboxManager:
 
             terminal_id = row.get("terminal_id")
             terminal_row = self.terminal_store.get_by_id(str(terminal_id)) if terminal_id else None
-            terminal = terminal_from_row(terminal_row, self.db_path) if terminal_row else None
+            terminal = terminal_from_row(terminal_row, self.db_path, terminal_repo=self.terminal_store) if terminal_row else None
             sandbox_runtime = self._get_sandbox_runtime(terminal.sandbox_runtime_id) if terminal else None
             if sandbox_runtime and sandbox_runtime.provider_name != self.provider.name:
                 continue
@@ -803,7 +840,7 @@ class SandboxManager:
 
     def destroy_thread_resources(self, thread_id: str) -> bool:
         terminal_rows = self.terminal_store.list_by_thread(thread_id)
-        terminals = [terminal_from_row(r, self.db_path) for r in terminal_rows]
+        terminals = [terminal_from_row(r, self.db_path, terminal_repo=self.terminal_store) for r in terminal_rows]
         if not terminals:
             return False
 

--- a/sandbox/runtime_handle.py
+++ b/sandbox/runtime_handle.py
@@ -73,7 +73,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _use_supabase_storage(db_path: Path | None = None) -> bool:
-    return uses_supabase_runtime_defaults() and resolve_sandbox_db_path(db_path) == resolve_sandbox_db_path()
+    return db_path is None and uses_supabase_runtime_defaults()
 
 
 def _make_sandbox_runtime_repo(db_path: Path | None = None):
@@ -210,7 +210,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
             needs_refresh=needs_refresh,
             refresh_hint_at=refresh_hint_at,
         )
-        self.db_path = resolve_sandbox_db_path(db_path)
+        self.db_path = None if _use_supabase_storage(db_path) else resolve_sandbox_db_path(db_path)
         self._detached_instance: SandboxInstance | None = None
 
     def _instance_lock(self) -> threading.RLock:
@@ -1091,7 +1091,7 @@ class SQLiteSandboxRuntimeHandle(SandboxRuntimeHandle):
         self._persist_runtime_metadata()
 
 
-def sandbox_runtime_from_row(row: dict, db_path: Path) -> SQLiteSandboxRuntimeHandle:
+def sandbox_runtime_from_row(row: dict, db_path: Path | None = None) -> SQLiteSandboxRuntimeHandle:
     instance = None
     inst_data = row.get("_instance")
     if inst_data:

--- a/sandbox/terminal.py
+++ b/sandbox/terminal.py
@@ -113,12 +113,41 @@ class SQLiteTerminal(AbstractTerminal):
             conn.commit()
 
 
-def terminal_from_row(row: dict, db_path: Path) -> AbstractTerminal:
+class RepoBackedTerminal(AbstractTerminal):
+    def __init__(
+        self,
+        terminal_id: str,
+        thread_id: str,
+        sandbox_runtime_id: str,
+        state: TerminalState,
+        terminal_repo,
+    ):
+        super().__init__(terminal_id, thread_id, sandbox_runtime_id, state)
+        self._terminal_repo = terminal_repo
+
+    def _persist_state(self) -> None:
+        self._terminal_repo.persist_state(
+            terminal_id=self.terminal_id,
+            cwd=self._state.cwd,
+            env_delta_json=json.dumps(self._state.env_delta),
+            state_version=self._state.state_version,
+        )
+
+
+def terminal_from_row(row: dict, db_path: Path | None = None, *, terminal_repo=None) -> AbstractTerminal:
     state = TerminalState(
         cwd=row.get("cwd", "/root"),
         env_delta=json.loads(row.get("env_delta_json", "{}")),
         state_version=int(row.get("state_version", 0)),
     )
+    if terminal_repo is not None:
+        return RepoBackedTerminal(
+            terminal_id=row["terminal_id"],
+            thread_id=row["thread_id"],
+            sandbox_runtime_id=row["sandbox_runtime_id"],
+            state=state,
+            terminal_repo=terminal_repo,
+        )
     return SQLiteTerminal(
         terminal_id=row["terminal_id"],
         thread_id=row["thread_id"],

--- a/storage/container.py
+++ b/storage/container.py
@@ -42,6 +42,8 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "queue_repo": ("storage.providers.supabase.queue_repo", "SupabaseQueueRepo"),
     "provider_event_repo": ("storage.providers.supabase.provider_event_repo", "SupabaseProviderEventRepo"),
     "sandbox_runtime_repo": ("storage.providers.supabase.sandbox_runtime_repo", "SupabaseSandboxRuntimeRepo"),
+    "terminal_repo": ("storage.providers.supabase.terminal_repo", "SupabaseTerminalRepo"),
+    "chat_session_repo": ("storage.providers.supabase.chat_session_repo", "SupabaseChatSessionRepo"),
     "tool_task_repo": ("storage.providers.supabase.tool_task_repo", "SupabaseToolTaskRepo"),
     "resource_snapshot_repo": ("storage.providers.supabase.resource_snapshot_repo", "SupabaseResourceSnapshotRepo"),
     "user_repo": ("storage.providers.supabase.user_repo", "SupabaseUserRepo"),
@@ -105,6 +107,12 @@ class StorageContainer:
 
     def sandbox_runtime_repo(self) -> SandboxRuntimeRepo:
         return self._build("sandbox_runtime_repo")
+
+    def terminal_repo(self) -> Any:
+        return self._build("terminal_repo")
+
+    def chat_session_repo(self) -> Any:
+        return self._build("chat_session_repo")
 
     def tool_task_repo(self) -> ToolTaskRepo:
         return self._build("tool_task_repo")

--- a/storage/providers/sqlite/sandbox_runtime_repo.py
+++ b/storage/providers/sqlite/sandbox_runtime_repo.py
@@ -103,6 +103,8 @@ class SQLiteSandboxRuntimeRepo:
         provider_name: str,
         recipe_id: str | None = None,
         recipe_json: str | None = None,
+        *,
+        owner_user_id: str | None = None,
     ) -> dict[str, Any]:
         now = datetime.now().isoformat()
         with self._lock:

--- a/storage/providers/supabase/chat_session_repo.py
+++ b/storage/providers/supabase/chat_session_repo.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from storage.providers.supabase import _query as q
+
+_REPO = "chat session repo"
+_SCHEMA = "container"
+_SESSIONS = "chat_sessions"
+_COMMANDS = "terminal_commands"
+_CHUNKS = "terminal_command_chunks"
+_TERMINALS = "abstract_terminals"
+_ACTIVE_STATUSES = ["active", "idle", "paused"]
+_SESSION_COLS = (
+    "chat_session_id,thread_id,terminal_id,sandbox_runtime_id,runtime_id,status,"
+    "idle_ttl_sec,max_duration_sec,budget_json,started_at,last_active_at,ended_at,close_reason"
+)
+_COMMAND_COLS = "command_id,terminal_id,chat_session_id,command_line,cwd,status,stdout,stderr,exit_code,created_at,updated_at,finished_at"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _session_row(row: dict[str, Any]) -> dict[str, Any]:
+    result = dict(row)
+    result["session_id"] = result.pop("chat_session_id")
+    return result
+
+
+class SupabaseChatSessionRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def _sessions(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _SESSIONS, _REPO)
+
+    def _commands(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _COMMANDS, _REPO)
+
+    def _chunks(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _CHUNKS, _REPO)
+
+    def _terminals(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _TERMINALS, _REPO)
+
+    def _active_query(self, operation: str) -> Any:
+        return q.in_(self._sessions().select(_SESSION_COLS), "status", _ACTIVE_STATUSES, _REPO, operation)
+
+    def get_session(self, thread_id: str, terminal_id: str | None = None) -> dict[str, Any] | None:
+        query = self._active_query("get session").eq("thread_id", thread_id)
+        if terminal_id is not None:
+            query = query.eq("terminal_id", terminal_id)
+        rows = q.rows(
+            q.limit(q.order(query, "started_at", desc=True, repo=_REPO, operation="get session"), 1, _REPO, "get session").execute(),
+            _REPO,
+            "get session",
+        )
+        return _session_row(rows[0]) if rows else None
+
+    def get_session_by_id(self, session_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(self._sessions().select(_SESSION_COLS).eq("chat_session_id", session_id), 1, _REPO, "get session by id").execute(),
+            _REPO,
+            "get session by id",
+        )
+        return _session_row(rows[0]) if rows else None
+
+    def load_status(self, session_id: str) -> str | None:
+        row = self.get_session_by_id(session_id)
+        return str(row.get("status")) if row else None
+
+    def get_session_policy(self, session_id: str) -> dict[str, Any] | None:
+        row = self.get_session_by_id(session_id)
+        if row is None:
+            return None
+        return {"idle_ttl_sec": row["idle_ttl_sec"], "max_duration_sec": row["max_duration_sec"]}
+
+    def list_active(self) -> list[dict[str, Any]]:
+        rows = q.rows(
+            q.order(self._active_query("list active"), "started_at", desc=True, repo=_REPO, operation="list active").execute(),
+            _REPO,
+            "list active",
+        )
+        return [_session_row(row) for row in rows]
+
+    def list_all(self) -> list[dict[str, Any]]:
+        rows = q.rows(
+            q.order(self._sessions().select(_SESSION_COLS), "started_at", desc=True, repo=_REPO, operation="list all").execute(),
+            _REPO,
+            "list all",
+        )
+        return [_session_row(row) for row in rows]
+
+    def create_session(
+        self,
+        session_id: str,
+        thread_id: str,
+        terminal_id: str,
+        sandbox_runtime_id: str,
+        *,
+        runtime_id: str | None = None,
+        status: str = "active",
+        idle_ttl_sec: int = 600,
+        max_duration_sec: int = 86400,
+        budget_json: str | None = None,
+        started_at: str | None = None,
+        last_active_at: str | None = None,
+    ) -> dict[str, Any]:
+        now = started_at or _now()
+        last_active = last_active_at or now
+        for row in self._sessions_for_terminal(terminal_id, active_only=True):
+            self._sessions().update({"status": "closed", "ended_at": now, "close_reason": "superseded"}).eq(
+                "chat_session_id", row["chat_session_id"]
+            ).execute()
+        payload = {
+            "chat_session_id": session_id,
+            "thread_id": thread_id,
+            "terminal_id": terminal_id,
+            "sandbox_runtime_id": sandbox_runtime_id,
+            "runtime_id": runtime_id,
+            "status": status,
+            "idle_ttl_sec": idle_ttl_sec,
+            "max_duration_sec": max_duration_sec,
+            "budget_json": budget_json,
+            "started_at": now,
+            "last_active_at": last_active,
+            "ended_at": None,
+            "close_reason": None,
+        }
+        self._sessions().insert(payload).execute()
+        return _session_row(payload)
+
+    def _sessions_for_terminal(self, terminal_id: str, *, active_only: bool) -> list[dict[str, Any]]:
+        query = self._sessions().select(_SESSION_COLS).eq("terminal_id", terminal_id)
+        if active_only:
+            query = q.in_(query, "status", _ACTIVE_STATUSES, _REPO, "sessions for terminal")
+        return q.rows(query.execute(), _REPO, "sessions for terminal")
+
+    def touch(self, session_id: str, last_active_at: str | None = None, status: str | None = None) -> None:
+        payload: dict[str, Any] = {"last_active_at": last_active_at or _now()}
+        if status is not None:
+            payload["status"] = status
+        self._sessions().update(payload).eq("chat_session_id", session_id).execute()
+
+    def touch_thread_activity(self, thread_id: str, last_active_at: str | None = None) -> None:
+        now = last_active_at or _now()
+        for row in q.rows(
+            self._sessions().select(_SESSION_COLS).eq("thread_id", thread_id).neq("status", "closed").execute(), _REPO, "touch thread"
+        ):
+            self._sessions().update({"last_active_at": now}).eq("chat_session_id", row["chat_session_id"]).execute()
+
+    def pause(self, session_id: str) -> None:
+        self._sessions().update({"status": "paused", "close_reason": "paused"}).eq("chat_session_id", session_id).execute()
+
+    def resume(self, session_id: str) -> None:
+        self._sessions().update({"status": "active", "close_reason": None}).eq("chat_session_id", session_id).execute()
+
+    def upsert_command(
+        self,
+        *,
+        command_id: str,
+        terminal_id: str,
+        chat_session_id: str | None,
+        command_line: str,
+        cwd: str,
+        status: str,
+        stdout: str,
+        stderr: str,
+        exit_code: int | None,
+        updated_at: str,
+        finished_at: str | None,
+        created_at: str | None = None,
+    ) -> None:
+        existing = self._command_by_id(command_id)
+        if existing is not None:
+            self._commands().update(
+                {
+                    "status": status,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "exit_code": exit_code,
+                    "updated_at": updated_at,
+                    "finished_at": finished_at,
+                }
+            ).eq("command_id", command_id).execute()
+            return
+        self._commands().insert(
+            {
+                "command_id": command_id,
+                "terminal_id": terminal_id,
+                "chat_session_id": chat_session_id,
+                "command_line": command_line,
+                "cwd": cwd,
+                "status": status,
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": exit_code,
+                "created_at": created_at or updated_at,
+                "updated_at": updated_at,
+                "finished_at": finished_at,
+            }
+        ).execute()
+
+    def _command_by_id(self, command_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(self._commands().select(_COMMAND_COLS).eq("command_id", command_id), 1, _REPO, "command by id").execute(),
+            _REPO,
+            "command by id",
+        )
+        return dict(rows[0]) if rows else None
+
+    def append_command_chunks(self, *, command_id: str, stdout_chunks: list[str], stderr_chunks: list[str], created_at: str) -> None:
+        payloads = [
+            {"command_id": command_id, "stream": "stdout", "content": chunk, "created_at": created_at} for chunk in stdout_chunks
+        ] + [{"command_id": command_id, "stream": "stderr", "content": chunk, "created_at": created_at} for chunk in stderr_chunks]
+        if payloads:
+            self._chunks().insert(payloads).execute()
+
+    def get_command(self, *, command_id: str, terminal_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(
+                self._commands().select(_COMMAND_COLS).eq("command_id", command_id).eq("terminal_id", terminal_id),
+                1,
+                _REPO,
+                "get command",
+            ).execute(),
+            _REPO,
+            "get command",
+        )
+        return dict(rows[0]) if rows else None
+
+    def list_command_chunks(self, *, command_id: str) -> list[dict[str, Any]]:
+        rows = q.rows(
+            q.order(
+                self._chunks().select("stream,content,chunk_id").eq("command_id", command_id),
+                "chunk_id",
+                desc=False,
+                repo=_REPO,
+                operation="chunks",
+            ).execute(),
+            _REPO,
+            "chunks",
+        )
+        return [{"stream": row["stream"], "content": row["content"]} for row in rows]
+
+    def find_command_terminal_id(self, *, command_id: str, thread_id: str) -> str | None:
+        command = self._command_by_id(command_id)
+        if command is None:
+            return None
+        terminal_id = str(command.get("terminal_id") or "")
+        terminal = self._terminal_by_id(terminal_id)
+        if terminal is None or terminal.get("thread_id") != thread_id:
+            return None
+        return terminal_id
+
+    def _terminal_by_id(self, terminal_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(
+                self._terminals().select("terminal_id,thread_id,sandbox_runtime_id").eq("terminal_id", terminal_id),
+                1,
+                _REPO,
+                "terminal by id",
+            ).execute(),
+            _REPO,
+            "terminal by id",
+        )
+        return dict(rows[0]) if rows else None
+
+    def delete_session(self, session_id: str, *, reason: str = "closed") -> None:
+        self._sessions().update({"status": "closed", "ended_at": _now(), "close_reason": reason}).eq(
+            "chat_session_id", session_id
+        ).execute()
+
+    def delete_by_thread(self, thread_id: str) -> None:
+        terminals = q.rows(self._terminals().select("terminal_id").eq("thread_id", thread_id).execute(), _REPO, "thread terminals")
+        terminal_ids = [str(row["terminal_id"]) for row in terminals]
+        if terminal_ids:
+            commands = q.rows_in_chunks(
+                lambda: self._commands().select("command_id"), "terminal_id", terminal_ids, _REPO, "thread commands"
+            )
+            command_ids = [str(row["command_id"]) for row in commands]
+            if command_ids:
+                q.execute_in_chunks(lambda: self._chunks().delete(), "command_id", command_ids, _REPO, "delete command chunks")
+            q.execute_in_chunks(lambda: self._commands().delete(), "terminal_id", terminal_ids, _REPO, "delete commands")
+        self._sessions().delete().eq("thread_id", thread_id).execute()
+
+    def terminal_has_running_command(self, terminal_id: str) -> bool:
+        rows = q.rows(
+            q.limit(
+                self._commands().select("command_id").eq("terminal_id", terminal_id).eq("status", "running"),
+                1,
+                _REPO,
+                "terminal running command",
+            ).execute(),
+            _REPO,
+            "terminal running command",
+        )
+        return bool(rows)
+
+    def sandbox_runtime_has_running_command(self, sandbox_runtime_id: str) -> bool:
+        terminals = q.rows(
+            self._terminals().select("terminal_id").eq("sandbox_runtime_id", sandbox_runtime_id).execute(), _REPO, "runtime terminals"
+        )
+        terminal_ids = [str(row["terminal_id"]) for row in terminals]
+        if not terminal_ids:
+            return False
+        for chunk in q.value_chunks(terminal_ids):
+            rows = q.rows(
+                q.limit(
+                    q.in_(
+                        self._commands().select("command_id").eq("status", "running"),
+                        "terminal_id",
+                        chunk,
+                        _REPO,
+                        "runtime running command",
+                    ),
+                    1,
+                    _REPO,
+                    "runtime running command",
+                ).execute(),
+                _REPO,
+                "runtime running command",
+            )
+            if rows:
+                return True
+        return False
+
+    def close_all_active(self, reason: str, ended_at: str | None = None) -> None:
+        ts = ended_at or _now()
+        for row in self.list_active():
+            self._sessions().update({"status": "closed", "ended_at": ts, "close_reason": reason}).eq(
+                "chat_session_id", row["session_id"]
+            ).execute()
+
+    def cleanup_expired(self) -> list[str]:
+        active = self.list_active()
+        now = datetime.now(UTC)
+        expired: list[str] = []
+        for session in active:
+            started_at = datetime.fromisoformat(session["started_at"])
+            last_active_at = datetime.fromisoformat(session["last_active_at"])
+            if (now - last_active_at).total_seconds() > int(session.get("idle_ttl_sec") or 0):
+                expired.append(session["session_id"])
+                continue
+            if (now - started_at).total_seconds() > int(session.get("max_duration_sec") or 0):
+                expired.append(session["session_id"])
+        return expired

--- a/storage/providers/supabase/terminal_repo.py
+++ b/storage/providers/supabase/terminal_repo.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from storage.providers.supabase import _query as q
+
+_REPO = "terminal repo"
+_SCHEMA = "container"
+_TERMINALS = "abstract_terminals"
+_POINTERS = "thread_terminal_pointers"
+_TERMINAL_COLS = "terminal_id,thread_id,sandbox_runtime_id,cwd,env_delta_json,state_version,created_at,updated_at"
+_POINTER_COLS = "thread_id,active_terminal_id,default_terminal_id,updated_at"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class SupabaseTerminalRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _REPO)
+
+    def close(self) -> None:
+        return None
+
+    def _terminals(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _TERMINALS, _REPO)
+
+    def _pointers(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, _POINTERS, _REPO)
+
+    def _get_pointer_row(self, thread_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(self._pointers().select(_POINTER_COLS).eq("thread_id", thread_id), 1, _REPO, "get pointer").execute(),
+            _REPO,
+            "get pointer",
+        )
+        return dict(rows[0]) if rows else None
+
+    def get_active(self, thread_id: str) -> dict[str, Any] | None:
+        pointer = self._get_pointer_row(thread_id)
+        if pointer is None:
+            return None
+        row = self.get_by_id(str(pointer["active_terminal_id"]))
+        if row is not None:
+            return row
+        latest = self.list_by_thread(thread_id)
+        if not latest:
+            return None
+        self._ensure_thread_pointer(thread_id, str(latest[0]["terminal_id"]))
+        return self.get_by_id(str(latest[0]["terminal_id"])) or latest[0]
+
+    def get_default(self, thread_id: str) -> dict[str, Any] | None:
+        pointer = self._get_pointer_row(thread_id)
+        if pointer is None:
+            return None
+        row = self.get_by_id(str(pointer["default_terminal_id"]))
+        if row is not None:
+            return row
+        latest = self.list_by_thread(thread_id)
+        if not latest:
+            return None
+        self._ensure_thread_pointer(thread_id, str(latest[0]["terminal_id"]))
+        return self.get_by_id(str(latest[0]["terminal_id"])) or latest[0]
+
+    def get_by_id(self, terminal_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(self._terminals().select(_TERMINAL_COLS).eq("terminal_id", terminal_id), 1, _REPO, "get terminal").execute(),
+            _REPO,
+            "get terminal",
+        )
+        return dict(rows[0]) if rows else None
+
+    def summarize_threads(self, thread_ids: list[str]) -> dict[str, dict[str, str | None]]:
+        normalized_ids = [str(thread_id or "").strip() for thread_id in thread_ids if str(thread_id or "").strip()]
+        if not normalized_ids:
+            return {}
+        summary: dict[str, dict[str, str | None]] = {
+            thread_id: {"active_terminal_id": None, "latest_terminal_id": None} for thread_id in normalized_ids
+        }
+        pointer_rows = q.rows_in_chunks(
+            lambda: self._pointers().select(_POINTER_COLS), "thread_id", normalized_ids, _REPO, "summarize pointers"
+        )
+        for row in pointer_rows:
+            thread_id = str(row.get("thread_id") or "").strip()
+            if thread_id:
+                summary.setdefault(thread_id, {"active_terminal_id": None, "latest_terminal_id": None})["active_terminal_id"] = (
+                    str(row.get("active_terminal_id") or "").strip() or None
+                )
+        terminal_rows = q.rows_in_chunks(
+            lambda: self._terminals().select(_TERMINAL_COLS), "thread_id", normalized_ids, _REPO, "summarize terminals"
+        )
+        terminal_rows = sorted(
+            terminal_rows, key=lambda row: (str(row.get("thread_id") or ""), str(row.get("created_at") or "")), reverse=True
+        )
+        for row in terminal_rows:
+            thread_id = str(row.get("thread_id") or "").strip()
+            terminal_id = str(row.get("terminal_id") or "").strip()
+            if not thread_id or not terminal_id:
+                continue
+            bucket = summary.setdefault(thread_id, {"active_terminal_id": None, "latest_terminal_id": None})
+            if bucket["latest_terminal_id"] is None:
+                bucket["latest_terminal_id"] = terminal_id
+        return summary
+
+    def get_latest_by_sandbox_runtime(self, sandbox_runtime_id: str) -> dict[str, Any] | None:
+        rows = q.rows(
+            q.limit(
+                q.order(
+                    self._terminals().select(_TERMINAL_COLS).eq("sandbox_runtime_id", sandbox_runtime_id),
+                    "created_at",
+                    desc=True,
+                    repo=_REPO,
+                    operation="latest by runtime",
+                ),
+                1,
+                _REPO,
+                "latest by runtime",
+            ).execute(),
+            _REPO,
+            "latest by runtime",
+        )
+        return dict(rows[0]) if rows else None
+
+    def get_timestamps(self, terminal_id: str) -> tuple[str | None, str | None]:
+        row = self.get_by_id(terminal_id)
+        if row is None:
+            return None, None
+        return str(row.get("created_at") or "") or None, str(row.get("updated_at") or "") or None
+
+    def list_by_thread(self, thread_id: str) -> list[dict[str, Any]]:
+        return [
+            dict(row)
+            for row in q.rows(
+                q.order(
+                    self._terminals().select(_TERMINAL_COLS).eq("thread_id", thread_id),
+                    "created_at",
+                    desc=True,
+                    repo=_REPO,
+                    operation="list by thread",
+                ).execute(),
+                _REPO,
+                "list by thread",
+            )
+        ]
+
+    def list_all(self) -> list[dict[str, Any]]:
+        return [
+            dict(row)
+            for row in q.rows(
+                q.order(self._terminals().select(_TERMINAL_COLS), "created_at", desc=True, repo=_REPO, operation="list all").execute(),
+                _REPO,
+                "list all",
+            )
+        ]
+
+    def _ensure_thread_pointer(self, thread_id: str, terminal_id: str) -> None:
+        now = _now()
+        pointer = self._get_pointer_row(thread_id)
+        if pointer is None:
+            self._pointers().insert(
+                {
+                    "thread_id": thread_id,
+                    "active_terminal_id": terminal_id,
+                    "default_terminal_id": terminal_id,
+                    "updated_at": now,
+                }
+            ).execute()
+            return
+        active_exists = self.get_by_id(str(pointer["active_terminal_id"])) is not None
+        default_exists = self.get_by_id(str(pointer["default_terminal_id"])) is not None
+        if active_exists and default_exists:
+            return
+        self._pointers().update(
+            {
+                "active_terminal_id": str(pointer["active_terminal_id"]) if active_exists else terminal_id,
+                "default_terminal_id": str(pointer["default_terminal_id"]) if default_exists else terminal_id,
+                "updated_at": now,
+            }
+        ).eq("thread_id", thread_id).execute()
+
+    def create(self, terminal_id: str, thread_id: str, sandbox_runtime_id: str, initial_cwd: str = "/root") -> dict[str, Any]:
+        now = _now()
+        row = {
+            "terminal_id": terminal_id,
+            "thread_id": thread_id,
+            "sandbox_runtime_id": sandbox_runtime_id,
+            "cwd": initial_cwd,
+            "env_delta_json": "{}",
+            "state_version": 0,
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._terminals().insert(row).execute()
+        self._ensure_thread_pointer(thread_id, terminal_id)
+        return dict(row)
+
+    def persist_state(self, *, terminal_id: str, cwd: str, env_delta_json: str, state_version: int) -> None:
+        self._terminals().update(
+            {
+                "cwd": cwd,
+                "env_delta_json": env_delta_json,
+                "state_version": state_version,
+                "updated_at": _now(),
+            }
+        ).eq("terminal_id", terminal_id).execute()
+
+    def set_active(self, thread_id: str, terminal_id: str) -> None:
+        terminal = self.get_by_id(terminal_id)
+        if terminal is None:
+            raise RuntimeError(f"Terminal {terminal_id} not found")
+        if terminal["thread_id"] != thread_id:
+            raise RuntimeError(f"Terminal {terminal_id} belongs to thread {terminal['thread_id']}, not thread {thread_id}")
+        pointer = self._get_pointer_row(thread_id)
+        if pointer is None:
+            self._pointers().insert(
+                {
+                    "thread_id": thread_id,
+                    "active_terminal_id": terminal_id,
+                    "default_terminal_id": terminal_id,
+                    "updated_at": _now(),
+                }
+            ).execute()
+            return
+        self._pointers().update({"active_terminal_id": terminal_id, "updated_at": _now()}).eq("thread_id", thread_id).execute()
+
+    def delete_by_thread(self, thread_id: str) -> None:
+        for terminal in self.list_by_thread(thread_id):
+            self.delete(str(terminal["terminal_id"]))
+
+    def delete(self, terminal_id: str) -> None:
+        terminal = self.get_by_id(terminal_id)
+        if terminal is None:
+            return
+        thread_id = str(terminal["thread_id"])
+        commands = q.rows(self._commands().select("command_id").eq("terminal_id", terminal_id).execute(), _REPO, "terminal commands")
+        command_ids = [str(row["command_id"]) for row in commands]
+        if command_ids:
+            q.execute_in_chunks(lambda: self._chunks().delete(), "command_id", command_ids, _REPO, "delete terminal command chunks")
+        self._commands().delete().eq("terminal_id", terminal_id).execute()
+        self._terminals().delete().eq("terminal_id", terminal_id).execute()
+        pointer = self._get_pointer_row(thread_id)
+        if pointer is None:
+            return
+        remaining = self.list_by_thread(thread_id)
+        if not remaining:
+            self._pointers().delete().eq("thread_id", thread_id).execute()
+            return
+        next_terminal_id = str(remaining[0]["terminal_id"])
+        self._pointers().update(
+            {
+                "active_terminal_id": next_terminal_id
+                if str(pointer["active_terminal_id"]) == terminal_id
+                else str(pointer["active_terminal_id"]),
+                "default_terminal_id": next_terminal_id
+                if str(pointer["default_terminal_id"]) == terminal_id
+                else str(pointer["default_terminal_id"]),
+                "updated_at": _now(),
+            }
+        ).eq("thread_id", thread_id).execute()
+
+    def _commands(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "terminal_commands", _REPO)
+
+    def _chunks(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "terminal_command_chunks", _REPO)

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -76,6 +76,18 @@ def build_sandbox_runtime_repo(*, supabase_client: Any | None = None, supabase_c
     )
 
 
+def build_terminal_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo("terminal_repo", supabase_client=supabase_client, supabase_client_factory=supabase_client_factory)
+
+
+def build_chat_session_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
+    return _build_storage_repo(
+        "chat_session_repo",
+        supabase_client=supabase_client,
+        supabase_client_factory=supabase_client_factory,
+    )
+
+
 def build_resource_snapshot_repo(*, supabase_client: Any | None = None, supabase_client_factory: str | None = None):
     return _build_storage_repo(
         "resource_snapshot_repo",

--- a/storage/schema/2026_04_25_sandbox_control_plane_supabase.sql
+++ b/storage/schema/2026_04_25_sandbox_control_plane_supabase.sql
@@ -1,0 +1,94 @@
+create schema if not exists container;
+
+create table if not exists container.abstract_terminals (
+    terminal_id text primary key,
+    thread_id text not null,
+    sandbox_runtime_id text not null,
+    cwd text not null,
+    env_delta_json text not null default '{}',
+    state_version integer not null default 0,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists container.thread_terminal_pointers (
+    thread_id text primary key,
+    active_terminal_id text not null references container.abstract_terminals(terminal_id) on delete cascade,
+    default_terminal_id text not null references container.abstract_terminals(terminal_id) on delete cascade,
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists container.chat_sessions (
+    chat_session_id text primary key,
+    thread_id text not null,
+    terminal_id text not null references container.abstract_terminals(terminal_id) on delete cascade,
+    sandbox_runtime_id text not null,
+    runtime_id text,
+    status text not null default 'active',
+    idle_ttl_sec integer not null,
+    max_duration_sec integer not null,
+    budget_json text,
+    started_at timestamptz not null,
+    last_active_at timestamptz not null,
+    ended_at timestamptz,
+    close_reason text
+);
+
+create table if not exists container.terminal_commands (
+    command_id text primary key,
+    terminal_id text not null references container.abstract_terminals(terminal_id) on delete cascade,
+    chat_session_id text references container.chat_sessions(chat_session_id) on delete set null,
+    command_line text not null,
+    cwd text not null,
+    status text not null,
+    stdout text not null default '',
+    stderr text not null default '',
+    exit_code integer,
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    finished_at timestamptz
+);
+
+create table if not exists container.terminal_command_chunks (
+    chunk_id bigserial primary key,
+    command_id text not null references container.terminal_commands(command_id) on delete cascade,
+    stream text not null check (stream in ('stdout', 'stderr')),
+    content text not null,
+    created_at timestamptz not null
+);
+
+create index if not exists idx_container_abstract_terminals_thread_created
+    on container.abstract_terminals(thread_id, created_at desc);
+
+create index if not exists idx_container_abstract_terminals_runtime_created
+    on container.abstract_terminals(sandbox_runtime_id, created_at desc);
+
+create index if not exists idx_container_chat_sessions_thread_status
+    on container.chat_sessions(thread_id, status, started_at desc);
+
+create unique index if not exists uq_container_chat_sessions_active_terminal
+    on container.chat_sessions(terminal_id)
+    where status in ('active', 'idle', 'paused');
+
+create index if not exists idx_container_terminal_commands_terminal_created
+    on container.terminal_commands(terminal_id, created_at desc);
+
+create index if not exists idx_container_terminal_command_chunks_command_order
+    on container.terminal_command_chunks(command_id, chunk_id);
+
+grant usage on schema container to service_role, authenticated, anon;
+revoke all on
+    container.abstract_terminals,
+    container.thread_terminal_pointers,
+    container.chat_sessions,
+    container.terminal_commands,
+    container.terminal_command_chunks
+from anon, authenticated;
+grant select, insert, update, delete on
+    container.abstract_terminals,
+    container.thread_terminal_pointers,
+    container.chat_sessions,
+    container.terminal_commands,
+    container.terminal_command_chunks
+to service_role;
+grant usage, select on sequence container.terminal_command_chunks_chunk_id_seq to service_role;

--- a/tests/Unit/backend/web/utils/test_helpers.py
+++ b/tests/Unit/backend/web/utils/test_helpers.py
@@ -71,15 +71,18 @@ def test_delete_thread_in_db_uses_runtime_repo_factories_without_db_path(monkeyp
     assert sync_state.closed
 
 
-def test_delete_thread_in_db_cleans_runtime_repos_when_supabase_defaults_without_local_db(monkeypatch, tmp_path):
-    sandbox_db = tmp_path / "missing-sandbox.db"
+def test_delete_thread_in_db_cleans_runtime_repos_when_supabase_defaults_without_local_db(monkeypatch):
     container = _FakeContainer()
     session_repo = _ThreadRepo()
     terminal_repo = _ThreadRepo()
     sync_state_holder: dict[str, _SyncState] = {}
 
     monkeypatch.setattr(convergence, "_get_container", lambda: container)
-    monkeypatch.setattr(convergence, "resolve_sandbox_db_path", lambda: sandbox_db)
+    monkeypatch.setattr(
+        convergence,
+        "resolve_sandbox_db_path",
+        lambda: (_ for _ in ()).throw(AssertionError("supabase delete must not resolve sandbox db path")),
+    )
     monkeypatch.setattr(convergence, "uses_supabase_runtime_defaults", lambda: True)
     monkeypatch.setattr(convergence, "make_chat_session_repo", lambda: session_repo)
     monkeypatch.setattr(convergence, "make_terminal_repo", lambda: terminal_repo)

--- a/tests/Unit/core/test_capability_async.py
+++ b/tests/Unit/core/test_capability_async.py
@@ -58,10 +58,19 @@ class _DummyRuntime:
         )
 
 
+class _DummyCommandRepo:
+    def find_command_terminal_id(self, *, command_id: str, thread_id: str) -> str | None:
+        assert command_id.startswith("cmd_")
+        assert thread_id == "thread-1"
+        return "dummy-term"
+
+
 class _DummySession:
     def __init__(self):
+        self.thread_id = "thread-1"
         self.terminal = _DummyTerminal()
         self.runtime = _DummyRuntime()
+        self._session_repo = _DummyCommandRepo()
         self.touches = 0
 
     def touch(self):

--- a/tests/Unit/integration_contracts/test_webhooks_router_contract.py
+++ b/tests/Unit/integration_contracts/test_webhooks_router_contract.py
@@ -63,8 +63,8 @@ async def test_ingest_provider_webhook_keeps_unmatched_payload_shape(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_sandbox_runtime(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+async def test_ingest_provider_webhook_hydrates_matched_sandbox_runtime_without_local_db_path(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _RuntimeRepo:
         def find_by_instance(self, *, provider_name: str, instance_id: str):
@@ -112,18 +112,22 @@ async def test_ingest_provider_webhook_uses_control_plane_db_path_for_matched_sa
         def __init__(self) -> None:
             self.provider = object()
 
-    expected_db_path = tmp_path / "sandbox.db"
     event_repo = _EventRepo()
     sandbox_runtime = _SandboxRuntime()
 
-    monkeypatch.setattr(webhooks, "resolve_sandbox_db_path", lambda: expected_db_path, raising=False)
+    monkeypatch.setattr(
+        webhooks,
+        "resolve_sandbox_db_path",
+        lambda: (_ for _ in ()).throw(AssertionError("webhook hydration must not resolve sandbox db path")),
+        raising=False,
+    )
     monkeypatch.setattr(webhooks, "make_sandbox_runtime_repo", lambda: _RuntimeRepo())
     monkeypatch.setattr(webhooks, "_get_container", lambda: _Container(event_repo))
     monkeypatch.setattr(webhooks, "init_providers_and_managers", lambda: ({}, {"local": _Manager()}))
 
-    def _fake_sandbox_runtime_from_row(row, db_path):
+    def _fake_sandbox_runtime_from_row(row, db_path=None):
         assert row == {"lease_" + "id": "runtime-1", "sandbox_id": "sandbox-1"}
-        assert db_path == expected_db_path
+        assert db_path is None
         return sandbox_runtime
 
     monkeypatch.setattr(webhooks, "sandbox_runtime_from_row", _fake_sandbox_runtime_from_row)

--- a/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
+++ b/tests/Unit/sandbox/test_control_plane_repos_storage_boundary.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from sandbox import control_plane_repos
+from sandbox import manager as sandbox_manager
 from sandbox.manager import SandboxManager
 from storage.providers.sqlite.chat_session_repo import SQLiteChatSessionRepo
 from storage.providers.sqlite.sandbox_runtime_repo import SQLiteSandboxRuntimeRepo
@@ -14,6 +15,39 @@ from storage.providers.sqlite.terminal_repo import SQLiteTerminalRepo
 class _Provider:
     def get_capability(self):
         return SimpleNamespace(runtime_kind="local")
+
+
+class _TerminalRepo:
+    def __init__(self) -> None:
+        self.closed = False
+        self.created: list[dict] = []
+
+    def list_by_thread(self, thread_id: str):
+        assert thread_id == "thread-1"
+        return [{"sandbox_runtime_id": "runtime-1"}]
+
+    def get_active(self, thread_id: str):
+        assert thread_id == "thread-1"
+        return None
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return kwargs
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _SandboxRuntimeRepo:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def get(self, sandbox_runtime_id: str):
+        assert sandbox_runtime_id == "runtime-1"
+        return {"sandbox_runtime_id": "runtime-1", "provider_name": "local"}
+
+    def close(self) -> None:
+        self.closed = True
 
 
 @pytest.mark.parametrize(
@@ -47,6 +81,30 @@ def test_sandbox_runtime_repo_factory_uses_runtime_storage_without_local_path(mo
     assert not (tmp_path / ".leon").exists()
 
 
+@pytest.mark.parametrize(
+    ("factory_name", "builder_name"),
+    [
+        ("make_terminal_repo", "build_terminal_repo"),
+        ("make_chat_session_repo", "build_chat_session_repo"),
+    ],
+)
+def test_terminal_session_repo_factories_use_runtime_storage_without_local_path(
+    factory_name,
+    builder_name,
+    monkeypatch,
+    tmp_path,
+):
+    fake_repo = object()
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.setattr(control_plane_repos, builder_name, lambda: fake_repo, raising=False)
+
+    assert getattr(control_plane_repos, factory_name)() is fake_repo
+    assert not (tmp_path / ".leon").exists()
+
+
 def test_sandbox_manager_requires_explicit_control_plane_db_path(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
@@ -56,6 +114,59 @@ def test_sandbox_manager_requires_explicit_control_plane_db_path(monkeypatch, tm
     with pytest.raises(RuntimeError, match="LEON_SANDBOX_DB_PATH"):
         SandboxManager(provider=_Provider())
 
+    assert not (tmp_path / ".leon").exists()
+
+
+def test_sandbox_manager_uses_runtime_storage_control_plane_without_local_path(monkeypatch, tmp_path):
+    fake_terminal_repo = SimpleNamespace(close=lambda: None)
+    fake_runtime_repo = SimpleNamespace(close=lambda: None)
+    fake_chat_repo = SimpleNamespace(close=lambda: None)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.setattr("sandbox.manager.make_terminal_repo", lambda db_path=None: fake_terminal_repo)
+    monkeypatch.setattr("sandbox.manager.make_sandbox_runtime_repo", lambda db_path=None: fake_runtime_repo)
+    monkeypatch.setattr("sandbox.manager.make_chat_session_repo", lambda db_path=None: fake_chat_repo)
+    monkeypatch.setattr("sandbox.volume.SandboxVolume", lambda **_kwargs: object())
+
+    manager = SandboxManager(provider=_Provider())
+
+    assert manager.db_path is None
+    assert manager.terminal_store is fake_terminal_repo
+    assert manager.sandbox_runtime_store is fake_runtime_repo
+    assert manager.session_manager._repo is fake_chat_repo
+    assert not (tmp_path / ".leon").exists()
+
+
+def test_manager_helper_functions_use_runtime_storage_without_local_path(monkeypatch, tmp_path):
+    terminal_repo = _TerminalRepo()
+    runtime_repo = _SandboxRuntimeRepo()
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LEON_STORAGE_STRATEGY", "supabase")
+    monkeypatch.delenv("LEON_SANDBOX_DB_PATH", raising=False)
+    monkeypatch.setattr(
+        sandbox_manager,
+        "resolve_sandbox_db_path",
+        lambda _db_path=None: (_ for _ in ()).throw(AssertionError("manager helpers must use repo factories")),
+    )
+    monkeypatch.setattr(sandbox_manager, "make_terminal_repo", lambda db_path=None: terminal_repo)
+    monkeypatch.setattr(sandbox_manager, "make_sandbox_runtime_repo", lambda db_path=None: runtime_repo)
+    monkeypatch.setattr(
+        sandbox_manager,
+        "_build_provider_from_name",
+        lambda name: SimpleNamespace(default_cwd="/workspace") if name == "local" else None,
+    )
+
+    assert sandbox_manager.lookup_sandbox_for_thread("thread-1") == "local"
+    assert sandbox_manager.resolve_existing_sandbox_runtime_cwd("runtime-1") == "/workspace"
+    assert sandbox_manager.bind_thread_to_existing_sandbox_runtime("thread-1", "runtime-1") == "/workspace"
+    assert len(terminal_repo.created) == 1
+    assert terminal_repo.created[0]["terminal_id"].startswith("term-")
+    assert terminal_repo.created[0]["thread_id"] == "thread-1"
+    assert terminal_repo.created[0]["sandbox_runtime_id"] == "runtime-1"
+    assert terminal_repo.created[0]["initial_cwd"] == "/workspace"
     assert not (tmp_path / ".leon").exists()
 
 

--- a/tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
+++ b/tests/Unit/sandbox/test_local_sandbox_storage_boundary.py
@@ -7,8 +7,8 @@ def test_local_sandbox_defers_manager_creation_until_control_plane_use(monkeypat
     captured: list[dict[str, object]] = []
 
     class _SandboxManagerProbe:
-        def __init__(self, *, provider, db_path=None):
-            captured.append({"provider": provider, "db_path": db_path})
+        def __init__(self, *, provider, db_path=None, thread_repo=None):
+            captured.append({"provider": provider, "db_path": db_path, "thread_repo": thread_repo})
 
     monkeypatch.setattr("sandbox.manager.SandboxManager", _SandboxManagerProbe)
 

--- a/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
+++ b/tests/Unit/sandbox/test_sandbox_manager_volume_repo.py
@@ -475,7 +475,7 @@ def test_enforce_idle_timeouts_destroys_when_provider_cannot_pause(monkeypatch):
     monkeypatch.setattr(
         sandbox_manager_module,
         "terminal_from_row",
-        lambda _row, _db_path: SimpleNamespace(terminal_id="term-1", sandbox_runtime_id="runtime-1"),
+        lambda _row, _db_path, **_kwargs: SimpleNamespace(terminal_id="term-1", sandbox_runtime_id="runtime-1"),
     )
 
     manager.enforce_idle_timeouts()
@@ -552,7 +552,10 @@ def test_enforce_idle_timeouts_keeps_shared_runtime_alive_when_peer_session_is_s
     monkeypatch.setattr(
         sandbox_manager_module,
         "terminal_from_row",
-        lambda row, _db_path: SimpleNamespace(terminal_id=row["terminal_id"], sandbox_runtime_id=row["sandbox_runtime_id"]),
+        lambda row, _db_path, **_kwargs: SimpleNamespace(
+            terminal_id=row["terminal_id"],
+            sandbox_runtime_id=row["sandbox_runtime_id"],
+        ),
     )
 
     assert manager.enforce_idle_timeouts() == 1
@@ -986,7 +989,7 @@ def test_get_sandbox_creates_runtime_handle_with_runtime_prefix(monkeypatch):
         create=lambda **kwargs: created_terminal_rows.append(kwargs) or kwargs,
     )
 
-    def _create_sandbox_runtime(runtime_id: str, provider_name: str):
+    def _create_sandbox_runtime(runtime_id: str, provider_name: str, **_kwargs):
         created_runtime_ids.append(runtime_id)
         created_runtime.sandbox_runtime_id = runtime_id
         created_runtime.provider_name = provider_name
@@ -997,7 +1000,7 @@ def test_get_sandbox_creates_runtime_handle_with_runtime_prefix(monkeypatch):
         get=lambda _thread_id, _terminal_id: None,
         create=lambda **kwargs: created_sessions.append(kwargs) or SimpleNamespace(**kwargs),
     )
-    monkeypatch.setattr(sandbox_manager_module, "terminal_from_row", lambda _row, _db_path: _CreatedTerminal())
+    monkeypatch.setattr(sandbox_manager_module, "terminal_from_row", lambda _row, _db_path, **_kwargs: _CreatedTerminal())
 
     manager.get_sandbox("thread-1")
 
@@ -1143,7 +1146,7 @@ def test_background_command_inherits_default_terminal_environment(monkeypatch):
     created_rows: list[dict[str, str]] = []
     created_background_commands: list[dict[str, Any]] = []
 
-    def from_row(row, _db_path):
+    def from_row(row, _db_path, **_kwargs):
         if row["terminal_id"] == "term-default":
             return default_terminal
         return created_terminal

--- a/tests/Unit/sandbox/test_terminal_repo_persistence.py
+++ b/tests/Unit/sandbox/test_terminal_repo_persistence.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sandbox.terminal import TerminalState, terminal_from_row
+
+
+class _Repo:
+    def __init__(self) -> None:
+        self.persisted: list[dict] = []
+
+    def persist_state(self, **payload) -> None:
+        self.persisted.append(payload)
+
+
+def test_terminal_from_row_can_persist_through_injected_repo() -> None:
+    repo = _Repo()
+
+    terminal = terminal_from_row(
+        {
+            "terminal_id": "term-1",
+            "thread_id": "thread-1",
+            "sandbox_runtime_id": "runtime-1",
+            "cwd": "/workspace",
+            "env_delta_json": "{}",
+            "state_version": 0,
+        },
+        terminal_repo=repo,
+    )
+
+    terminal.update_state(TerminalState(cwd="/workspace/app", env_delta={"A": "1"}))
+
+    assert repo.persisted == [
+        {
+            "terminal_id": "term-1",
+            "cwd": "/workspace/app",
+            "env_delta_json": '{"A": "1"}',
+            "state_version": 1,
+        }
+    ]

--- a/tests/Unit/storage/test_supabase_terminal_chat_repos.py
+++ b/tests/Unit/storage/test_supabase_terminal_chat_repos.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from storage.providers.supabase.chat_session_repo import SupabaseChatSessionRepo
+from storage.providers.supabase.terminal_repo import SupabaseTerminalRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def _client(tables: dict[str, list[dict]] | None = None) -> FakeSupabaseClient:
+    return FakeSupabaseClient(
+        tables={} if tables is None else tables,
+        auto_seq_tables={"container.terminal_command_chunks"},
+    )
+
+
+def test_supabase_terminal_repo_tracks_active_and_default_terminal() -> None:
+    tables: dict[str, list[dict]] = {}
+    repo = SupabaseTerminalRepo(client=_client(tables))
+
+    first = repo.create("term-1", "thread-1", "runtime-1", initial_cwd="/workspace")
+    second = repo.create("term-2", "thread-1", "runtime-1", initial_cwd="/workspace/app")
+    repo.set_active("thread-1", "term-2")
+    repo.persist_state(terminal_id="term-2", cwd="/workspace/pkg", env_delta_json='{"A":"1"}', state_version=1)
+
+    assert first["terminal_id"] == "term-1"
+    assert second["terminal_id"] == "term-2"
+    assert repo.get_default("thread-1")["terminal_id"] == "term-1"
+    assert repo.get_active("thread-1")["terminal_id"] == "term-2"
+    assert repo.get_by_id("term-2")["cwd"] == "/workspace/pkg"
+    assert repo.summarize_threads(["thread-1"]) == {"thread-1": {"active_terminal_id": "term-2", "latest_terminal_id": "term-2"}}
+
+
+def test_supabase_chat_session_repo_tracks_sessions_and_commands() -> None:
+    tables = {
+        "container.abstract_terminals": [
+            {
+                "terminal_id": "term-1",
+                "thread_id": "thread-1",
+                "sandbox_runtime_id": "runtime-1",
+                "cwd": "/workspace",
+                "env_delta_json": "{}",
+                "state_version": 0,
+                "created_at": "2026-04-25T00:00:00+00:00",
+                "updated_at": "2026-04-25T00:00:00+00:00",
+            }
+        ]
+    }
+    repo = SupabaseChatSessionRepo(client=_client(tables))
+
+    session = repo.create_session(
+        "session-1",
+        "thread-1",
+        "term-1",
+        "runtime-1",
+        runtime_id="provider-session-1",
+        started_at="2026-04-25T00:00:01+00:00",
+        last_active_at="2026-04-25T00:00:01+00:00",
+    )
+    repo.upsert_command(
+        command_id="cmd-1",
+        terminal_id="term-1",
+        chat_session_id="session-1",
+        command_line="pwd",
+        cwd="/workspace",
+        status="running",
+        stdout="",
+        stderr="",
+        exit_code=None,
+        updated_at="2026-04-25T00:00:02+00:00",
+        finished_at=None,
+    )
+    repo.append_command_chunks(command_id="cmd-1", stdout_chunks=["/workspace\n"], stderr_chunks=[], created_at="2026-04-25T00:00:03+00:00")
+
+    assert session["session_id"] == "session-1"
+    assert repo.get_session("thread-1", "term-1")["runtime_id"] == "provider-session-1"
+    assert repo.terminal_has_running_command("term-1") is True
+    assert repo.sandbox_runtime_has_running_command("runtime-1") is True
+    assert repo.get_command(command_id="cmd-1", terminal_id="term-1")["status"] == "running"
+    assert repo.list_command_chunks(command_id="cmd-1") == [{"stream": "stdout", "content": "/workspace\n"}]
+
+    repo.delete_by_thread("thread-1")
+
+    assert repo.get_session("thread-1", "term-1") is None
+    assert tables["container.terminal_commands"] == []
+    assert tables["container.terminal_command_chunks"] == []

--- a/tests/Unit/storage/test_supabase_terminal_chat_repos.py
+++ b/tests/Unit/storage/test_supabase_terminal_chat_repos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from storage.providers.supabase import terminal_repo as terminal_repo_module
 from storage.providers.supabase.chat_session_repo import SupabaseChatSessionRepo
 from storage.providers.supabase.terminal_repo import SupabaseTerminalRepo
 from tests.fakes.supabase import FakeSupabaseClient
@@ -12,9 +13,11 @@ def _client(tables: dict[str, list[dict]] | None = None) -> FakeSupabaseClient:
     )
 
 
-def test_supabase_terminal_repo_tracks_active_and_default_terminal() -> None:
+def test_supabase_terminal_repo_tracks_active_and_default_terminal(monkeypatch) -> None:
     tables: dict[str, list[dict]] = {}
     repo = SupabaseTerminalRepo(client=_client(tables))
+    seconds = iter(range(20))
+    monkeypatch.setattr(terminal_repo_module, "_now", lambda: f"2026-04-25T00:00:{next(seconds):02d}+00:00")
 
     first = repo.create("term-1", "thread-1", "runtime-1", initial_cwd="/workspace")
     second = repo.create("term-2", "thread-1", "runtime-1", initial_cwd="/workspace/app")


### PR DESCRIPTION
## Summary
- add Supabase-backed terminal and chat-session control-plane repos plus schema
- route sandbox control-plane repo factories through runtime storage when Supabase defaults are active
- rehydrate terminals through injected repos and remove direct SQLite command lookup from capability code
- keep thread cleanup and webhook runtime hydration off local sandbox db path resolution
- close chat-session repo resources at manager shutdown so SQLite tests and production repos do not leak handles

## Verification
- uv run pytest tests/Unit -q
- uv run ruff check . && uv run ruff format --check .
- Live YATU on 127.0.0.1:8018 with LEON_STORAGE_STRATEGY=supabase and no LEON_SANDBOX_DB_PATH: register user, create local thread, real Agent Bash marker/cwd, delete thread -> 200

## Notes
- 7 coherent commits for review
- live schema storage/schema/2026_04_25_sandbox_control_plane_supabase.sql has been applied to staging Supabase for YATU