### PR TITLE
fix: derive relationship identity from token

### DIFF
--- a/backend/chat/api/http/relationships_router.py
+++ b/backend/chat/api/http/relationships_router.py
@@ -9,11 +9,9 @@ from pydantic import BaseModel, ConfigDict
 from backend.chat.api.http.dependencies import (
     get_current_user_id,
     get_relationship_service,
-    get_user_repo,
 )
 from messaging.contracts import RelationshipRow
 from messaging.relationships.state_machine import TransitionError
-from messaging.user_ownership import is_owned_by_viewer
 
 logger = logging.getLogger(__name__)
 
@@ -24,13 +22,11 @@ class RelationshipRequestBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     target_user_id: str
-    requester_user_id: str | None = None
 
 
 class RelationshipActionBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
-
-    requester_user_id: str | None = None
+    pass
 
 
 def _get_existing(svc, relationship_id: str, user_id: str) -> dict:
@@ -40,17 +36,6 @@ def _get_existing(svc, relationship_id: str, user_id: str) -> dict:
     if user_id not in (existing["user_low"], existing["user_high"]):
         raise HTTPException(403, "Not a party of this relationship")
     return existing
-
-
-def _resolve_requester_user_id(user_repo: Any, current_user_id: str, requester_user_id: str | None) -> str:
-    if requester_user_id is None or requester_user_id == current_user_id:
-        return current_user_id
-    requester = user_repo.get_by_id(requester_user_id)
-    if requester is None:
-        raise HTTPException(404, "Requester user not found")
-    if not is_owned_by_viewer(current_user_id, requester):
-        raise HTTPException(403, "Requester user does not belong to you")
-    return requester_user_id
 
 
 def _resolve_parties(existing: dict, viewer_user_id: str) -> tuple[str, str]:
@@ -86,14 +71,12 @@ async def request_relationship(
     body: RelationshipRequestBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
-    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    requester_user_id = _resolve_requester_user_id(user_repo, user_id, body.requester_user_id)
-    if requester_user_id == body.target_user_id:
+    if user_id == body.target_user_id:
         raise HTTPException(400, "Cannot request relationship with yourself")
     try:
-        row = relationship_service.request(requester_user_id, body.target_user_id)
-        return _row_to_dict(row, requester_user_id)
+        row = relationship_service.request(user_id, body.target_user_id)
+        return _row_to_dict(row, user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -104,15 +87,13 @@ async def approve_relationship(
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
-    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    requester_user_id = _resolve_requester_user_id(user_repo, user_id, body.requester_user_id)
-    existing = _get_existing(relationship_service, relationship_id, requester_user_id)
-    requester_id, _ = _resolve_parties(existing, requester_user_id)
-    if requester_user_id == requester_id:
+    existing = _get_existing(relationship_service, relationship_id, user_id)
+    requester_id, _ = _resolve_parties(existing, user_id)
+    if user_id == requester_id:
         raise HTTPException(409, "Cannot approve your own request")
     try:
-        return _row_to_dict(relationship_service.approve(requester_user_id, requester_id), requester_user_id)
+        return _row_to_dict(relationship_service.approve(user_id, requester_id), user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -123,15 +104,13 @@ async def reject_relationship(
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
-    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    requester_user_id = _resolve_requester_user_id(user_repo, user_id, body.requester_user_id)
-    existing = _get_existing(relationship_service, relationship_id, requester_user_id)
-    requester_id, _ = _resolve_parties(existing, requester_user_id)
-    if requester_user_id == requester_id:
+    existing = _get_existing(relationship_service, relationship_id, user_id)
+    requester_id, _ = _resolve_parties(existing, user_id)
+    if user_id == requester_id:
         raise HTTPException(409, "Cannot reject your own request")
     try:
-        return _row_to_dict(relationship_service.reject(requester_user_id, requester_id), requester_user_id)
+        return _row_to_dict(relationship_service.reject(user_id, requester_id), user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -142,13 +121,11 @@ async def upgrade_relationship(
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
-    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    requester_user_id = _resolve_requester_user_id(user_repo, user_id, body.requester_user_id)
-    existing = _get_existing(relationship_service, relationship_id, requester_user_id)
-    _, other_id = _resolve_parties(existing, requester_user_id)
+    existing = _get_existing(relationship_service, relationship_id, user_id)
+    _, other_id = _resolve_parties(existing, user_id)
     try:
-        return _row_to_dict(relationship_service.upgrade(requester_user_id, other_id), requester_user_id)
+        return _row_to_dict(relationship_service.upgrade(user_id, other_id), user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -159,13 +136,11 @@ async def revoke_relationship(
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
-    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    requester_user_id = _resolve_requester_user_id(user_repo, user_id, body.requester_user_id)
-    existing = _get_existing(relationship_service, relationship_id, requester_user_id)
-    _, other_id = _resolve_parties(existing, requester_user_id)
+    existing = _get_existing(relationship_service, relationship_id, user_id)
+    _, other_id = _resolve_parties(existing, user_id)
     try:
-        return _row_to_dict(relationship_service.revoke(requester_user_id, other_id), requester_user_id)
+        return _row_to_dict(relationship_service.revoke(user_id, other_id), user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -176,12 +151,10 @@ async def downgrade_relationship(
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
-    user_repo: Annotated[Any, Depends(get_user_repo)],
 ):
-    requester_user_id = _resolve_requester_user_id(user_repo, user_id, body.requester_user_id)
-    existing = _get_existing(relationship_service, relationship_id, requester_user_id)
-    _, other_id = _resolve_parties(existing, requester_user_id)
+    existing = _get_existing(relationship_service, relationship_id, user_id)
+    _, other_id = _resolve_parties(existing, user_id)
     try:
-        return _row_to_dict(relationship_service.downgrade(requester_user_id, other_id), requester_user_id)
+        return _row_to_dict(relationship_service.downgrade(user_id, other_id), user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -4,18 +4,25 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI
+from pydantic import ValidationError
 
 from backend.chat.api.http import relationships_router as owner_relationship_router
 from messaging.contracts import RelationshipRow
 
 
-def _row(*, state: str = "pending", initiator_user_id: str = "requester-user-1") -> RelationshipRow:
+def _row(
+    *,
+    state: str = "pending",
+    initiator_user_id: str = "requester-user-1",
+    user_low: str = "agent-user-1",
+    user_high: str = "requester-user-1",
+) -> RelationshipRow:
     now = datetime(2026, 4, 8, tzinfo=UTC)
     return RelationshipRow(
-        id="hire_visit:agent-user-1:requester-user-1",
-        user_low="agent-user-1",
-        user_high="requester-user-1",
+        id=f"hire_visit:{user_low}:{user_high}",
+        user_low=user_low,
+        user_high=user_high,
         kind="hire_visit",
         state=state,
         initiator_user_id=initiator_user_id,
@@ -24,30 +31,45 @@ def _row(*, state: str = "pending", initiator_user_id: str = "requester-user-1")
     )
 
 
+def test_relationship_public_openapi_uses_token_identity_only() -> None:
+    app = FastAPI()
+    app.include_router(owner_relationship_router.router)
+
+    schemas = app.openapi()["components"]["schemas"]
+    request_properties = schemas["RelationshipRequestBody"]["properties"]
+    action_properties = schemas["RelationshipActionBody"]["properties"]
+
+    assert list(request_properties) == ["target_user_id"]
+    assert action_properties == {}
+
+
 @pytest.mark.asyncio
-async def test_request_relationship_accepts_owned_agent_requester_user_id() -> None:
+async def test_request_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     relationship_service = SimpleNamespace(
-        request=lambda requester_id, target_id: seen.append((requester_id, target_id)) or _row(initiator_user_id=requester_id)
-    )
-    user_repo = SimpleNamespace(
-        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
+        request=lambda requester_id, target_id: (
+            seen.append((requester_id, target_id))
+            or _row(
+                initiator_user_id=requester_id,
+                user_low=requester_id,
+                user_high=target_id,
+            )
+        )
     )
 
     result = await owner_relationship_router.request_relationship(
-        owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1", requester_user_id="agent-user-1"),
+        owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1"),
         user_id="owner-user-1",
         relationship_service=relationship_service,
-        user_repo=user_repo,
     )
 
-    assert seen == [("agent-user-1", "requester-user-1")]
+    assert seen == [("owner-user-1", "requester-user-1")]
     assert result["other_user_id"] == "requester-user-1"
     assert result["is_requester"] is True
 
 
 @pytest.mark.asyncio
-async def test_approve_relationship_accepts_owned_agent_requester_user_id() -> None:
+async def test_approve_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     existing = {
         "id": "hire_visit:agent-user-1:requester-user-1",
@@ -62,16 +84,12 @@ async def test_approve_relationship_accepts_owned_agent_requester_user_id() -> N
             seen.append((approver_id, requester_id)) or _row(state="visit", initiator_user_id=requester_id)
         ),
     )
-    user_repo = SimpleNamespace(
-        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-    )
 
     result = await owner_relationship_router.approve_relationship(
         existing["id"],
-        owner_relationship_router.RelationshipActionBody(requester_user_id="agent-user-1"),
-        user_id="owner-user-1",
+        owner_relationship_router.RelationshipActionBody(),
+        user_id="agent-user-1",
         relationship_service=relationship_service,
-        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -80,7 +98,7 @@ async def test_approve_relationship_accepts_owned_agent_requester_user_id() -> N
 
 
 @pytest.mark.asyncio
-async def test_reject_relationship_accepts_owned_agent_requester_user_id() -> None:
+async def test_reject_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     existing = {
         "id": "hire_visit:agent-user-1:requester-user-1",
@@ -95,16 +113,12 @@ async def test_reject_relationship_accepts_owned_agent_requester_user_id() -> No
             seen.append((rejecting_user_id, requester_id)) or _row(state="none", initiator_user_id=requester_id)
         ),
     )
-    user_repo = SimpleNamespace(
-        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-    )
 
     result = await owner_relationship_router.reject_relationship(
         existing["id"],
-        owner_relationship_router.RelationshipActionBody(requester_user_id="agent-user-1"),
-        user_id="owner-user-1",
+        owner_relationship_router.RelationshipActionBody(),
+        user_id="agent-user-1",
         relationship_service=relationship_service,
-        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -113,7 +127,7 @@ async def test_reject_relationship_accepts_owned_agent_requester_user_id() -> No
 
 
 @pytest.mark.asyncio
-async def test_downgrade_relationship_accepts_owned_agent_requester_user_id() -> None:
+async def test_downgrade_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     existing = {
         "id": "hire_visit:agent-user-1:requester-user-1",
@@ -128,16 +142,12 @@ async def test_downgrade_relationship_accepts_owned_agent_requester_user_id() ->
             seen.append((requester_id, other_id)) or _row(state="visit", initiator_user_id="requester-user-1")
         ),
     )
-    user_repo = SimpleNamespace(
-        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="owner-user-1") if user_id == "agent-user-1" else None
-    )
 
     result = await owner_relationship_router.downgrade_relationship(
         existing["id"],
-        owner_relationship_router.RelationshipActionBody(requester_user_id="agent-user-1"),
-        user_id="owner-user-1",
+        owner_relationship_router.RelationshipActionBody(),
+        user_id="agent-user-1",
         relationship_service=relationship_service,
-        user_repo=user_repo,
     )
 
     assert seen == [("agent-user-1", "requester-user-1")]
@@ -145,19 +155,12 @@ async def test_downgrade_relationship_accepts_owned_agent_requester_user_id() ->
     assert result["state"] == "visit"
 
 
-@pytest.mark.asyncio
-async def test_request_relationship_rejects_unowned_requester_user_id() -> None:
-    relationship_service = SimpleNamespace()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda user_id: SimpleNamespace(id=user_id, owner_user_id="someone-else") if user_id == "agent-user-1" else None
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        await owner_relationship_router.request_relationship(
-            owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1", requester_user_id="agent-user-1"),
-            user_id="owner-user-1",
-            relationship_service=relationship_service,
-            user_repo=user_repo,
+def test_relationship_bodies_reject_identity_injection() -> None:
+    with pytest.raises(ValidationError):
+        owner_relationship_router.RelationshipRequestBody(
+            target_user_id="requester-user-1",
+            requester_user_id="agent-user-1",
         )
 
-    assert exc_info.value.status_code == 403
+    with pytest.raises(ValidationError):
+        owner_relationship_router.RelationshipActionBody(requester_user_id="agent-user-1")

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -121,15 +121,16 @@ def test_messaging_crud_routes_are_sync_threadpool_boundaries() -> None:
     assert [fn.__name__ for fn in sync_routes if inspect.iscoroutinefunction(fn)] == []
 
 
-def test_relationship_bodies_use_requester_user_id_not_actor_id() -> None:
-    request_body = relationships_router.RelationshipRequestBody(
-        target_user_id="user-2",
-        requester_user_id="user-1",
-    )
-    action_body = relationships_router.RelationshipActionBody(requester_user_id="user-1")
+def test_relationship_bodies_do_not_accept_identity_fields() -> None:
+    request_body = relationships_router.RelationshipRequestBody(target_user_id="user-2")
+    action_body = relationships_router.RelationshipActionBody()
 
-    assert request_body.requester_user_id == "user-1"
-    assert action_body.requester_user_id == "user-1"
+    assert request_body.target_user_id == "user-2"
+    assert action_body.model_dump() == {}
+    with pytest.raises(ValidationError):
+        relationships_router.RelationshipRequestBody.model_validate({"target_user_id": "user-2", "requester_user_id": "user-1"})
+    with pytest.raises(ValidationError):
+        relationships_router.RelationshipActionBody.model_validate({"requester_user_id": "user-1"})
     with pytest.raises(ValidationError):
         relationships_router.RelationshipRequestBody.model_validate({"target_user_id": "user-2", "actor_user_id": "user-1"})
 


### PR DESCRIPTION
## Summary
- remove requester_user_id from the public relationship request/action body
- derive relationship requester/actor from the authenticated token user in the backend route
- add OpenAPI and body validation coverage so SDK/CLI cannot inherit identity injection fields

## Verification
- uv run ruff format backend/chat/api/http/relationships_router.py tests/Integration/test_relationship_router.py
- uv run ruff check backend/chat/api/http/relationships_router.py tests/Integration/test_relationship_router.py
- uv run pytest tests/Integration -q
- SDK regenerated and verified separately with APP_REPO=/Users/lexicalmathical/Codebase/mycel/worktrees/mycel-app-openapi-public APP_IMPORT=backend.web.main:app bash scripts/ci_local.sh