### PR TITLE
Cut file-backed Agent Library path

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -1,11 +1,9 @@
 """HTTP client for Mycel Hub marketplace API."""
 
 import copy
-import json
 import os
 import time
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -13,7 +11,6 @@ import yaml
 from fastapi import HTTPException
 
 import backend.hub.snapshot_apply as _snapshot_apply
-import backend.library.paths as _lib_paths
 from backend.hub.versioning import BumpType, bump_semver
 from config.agent_config_resolver import resolve_agent_config
 from config.agent_config_types import AgentSkill, Skill, SkillPackage
@@ -118,11 +115,6 @@ def get_item_lineage(item_id: str) -> dict:
 
 def get_item_version_snapshot(item_id: str, version: str) -> dict:
     return _hub_api("GET", f"/items/{item_id}/versions/{version}")
-
-
-def _write_json(path: Path, data: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def _agent_snapshot_payload(config: Any) -> dict:
@@ -325,31 +317,7 @@ def apply_item(
         return {"resource_id": slug, "package_id": package.id, "type": "skill", "version": source_version}
 
     if item_type == "agent":
-        slug = item.get("slug", item["name"].lower().replace(" ", "-"))
-        agent_dir = (_lib_paths.LIBRARY_DIR / "agents").resolve()
-        if not (agent_dir / slug).resolve().is_relative_to(agent_dir):
-            raise ValueError(f"Invalid slug: {slug}")
-        agent_dir.mkdir(parents=True, exist_ok=True)
-
-        content = snapshot.get("content", "")
-        if not isinstance(content, str):
-            raise ValueError("Agent snapshot content must be a string")
-        (agent_dir / f"{slug}.md").write_text(content, encoding="utf-8")
-
-        meta_data = {
-            "name": item["name"],
-            "desc": item.get("description", ""),
-            "created_at": now,
-            "updated_at": now,
-            "source": {
-                "marketplace_item_id": item_id,
-                "source_version": source_version,
-                "source_at": now,
-                "publisher": item.get("publisher_username", ""),
-            },
-        }
-        _write_json(agent_dir / f"{slug}.json", meta_data)
-        return {"resource_id": slug, "type": "agent", "version": source_version}
+        raise ValueError("Marketplace agent items are not supported; apply Agent user items instead")
 
     if item_type == HUB_AGENT_USER_ITEM_TYPE:
         if user_repo is None or agent_config_repo is None:

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -1,16 +1,13 @@
-"""Library CRUD for Skills, Agent templates, and sandbox templates."""
+"""Library CRUD for Skills and sandbox templates."""
 
-import json
 import re
 import time
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 
 import yaml
 
-from backend.library.paths import LIBRARY_DIR
 from backend.sandboxes import provider_availability as sandbox_provider_availability
 from backend.sandboxes.recipe_bootstrap import seed_default_recipes as seed_builtin_recipes
 from config.agent_config_types import Skill, SkillPackage
@@ -19,28 +16,12 @@ from sandbox.recipes import FEATURE_CATALOG, default_recipe_snapshot, normalize_
 from storage.contracts import RecipeRepo, SkillRepo
 
 _SKILL_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-_RESOURCE_TYPES = {"skill", "agent", "sandbox-template"}
+_RESOURCE_TYPES = {"skill", "sandbox-template"}
 
 
 def _require_resource_type(resource_type: str) -> None:
     if resource_type not in _RESOURCE_TYPES:
         raise ValueError(f"Unknown resource type: {resource_type}")
-
-
-def _read_json(path: Path, default: Any = None) -> Any:
-    if not path.exists():
-        return default if default is not None else {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Library JSON file must be valid JSON: {path}") from exc
-    except OSError as exc:
-        raise RuntimeError(f"Library JSON file could not be read: {path}") from exc
-
-
-def _write_json(path: Path, data: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def _require_recipe_owner(owner_user_id: str | None) -> str:
@@ -148,18 +129,6 @@ def _write_skill_package(
     return package
 
 
-def _file_resource_content_path(resource_type: str, resource_id: str) -> Path | None:
-    if resource_type == "agent":
-        return LIBRARY_DIR / "agents" / f"{resource_id}.md"
-    return None
-
-
-def _file_resource_meta_path(resource_type: str, resource_id: str) -> Path | None:
-    if resource_type == "agent":
-        return LIBRARY_DIR / "agents" / f"{resource_id}.json"
-    return None
-
-
 def _library_resource_item(
     resource_type: str,
     resource_id: str,
@@ -209,12 +178,6 @@ def list_library(
             )
             for skill in sorted(skill_repo.list_for_owner(owner_user_id), key=lambda item: item.name.lower())
         ]
-    if resource_type == "agent":
-        agents_dir = LIBRARY_DIR / "agents"
-        if agents_dir.exists():
-            for f in sorted(agents_dir.glob("*.md")):
-                meta = _read_json(f.with_suffix(".json"), {})
-                results.append(_library_resource_item("agent", f.stem, meta))
     return results
 
 
@@ -259,7 +222,6 @@ def create_resource(
     skill_repo: SkillRepo | None = None,
 ) -> dict[str, Any]:
     now = int(time.time() * 1000)
-    cat = category or "未分类"
     if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         recipe_repo = _require_recipe_repo(recipe_repo)
@@ -319,17 +281,6 @@ def create_resource(
                 "updated_at": _dt_millis(skill.updated_at),
             },
         )
-    if resource_type == "agent":
-        rid = name.lower().replace(" ", "-")
-        content_path = _file_resource_content_path(resource_type, rid)
-        meta_path = _file_resource_meta_path(resource_type, rid)
-        if content_path is None or meta_path is None:
-            raise ValueError(f"Unknown resource type: {resource_type}")
-        content_path.parent.mkdir(parents=True, exist_ok=True)
-        meta = {"name": name, "desc": desc, "category": cat, "created_at": now, "updated_at": now}
-        _write_json(meta_path, meta)
-        content_path.write_text(f"---\nname: {rid}\ndescription: {desc}\n---\n\n# {name}\n", encoding="utf-8")
-        return _library_resource_item(resource_type, rid, meta)
     raise ValueError(f"Unknown resource type: {resource_type}")
 
 
@@ -393,15 +344,6 @@ def update_resource(
             },
             updated_at=_dt_millis(updated.updated_at),
         )
-    if resource_type == "agent":
-        meta_path = _file_resource_meta_path(resource_type, resource_id)
-        if meta_path is None or not meta_path.exists():
-            return None
-        meta = _read_json(meta_path, {})
-        meta.update(updates)
-        meta["updated_at"] = now
-        _write_json(meta_path, meta)
-        return _library_resource_item(resource_type, resource_id, meta, updated_at=now)
     return None
 
 
@@ -451,17 +393,6 @@ def delete_resource(
             return False
         skill_repo.delete(owner_user_id, resource_id)
         return True
-    if resource_type == "agent":
-        md_path = LIBRARY_DIR / "agents" / f"{resource_id}.md"
-        json_path = LIBRARY_DIR / "agents" / f"{resource_id}.json"
-        found = False
-        if md_path.exists():
-            md_path.unlink()
-            found = True
-        if json_path.exists():
-            json_path.unlink()
-            found = True
-        return found
     return False
 
 
@@ -490,7 +421,7 @@ def get_resource_used_by(
     _require_resource_type(resource_type)
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required for resource usage reads")
-    config_attr = {"skill": "skills", "agent": "sub_agents"}.get(resource_type, "")
+    config_attr = {"skill": "skills"}.get(resource_type, "")
     if not config_attr:
         return []
     names: list[str] = []
@@ -513,13 +444,13 @@ def get_resource_content(
     recipe_repo: RecipeRepo | None = None,
     skill_repo: SkillRepo | None = None,
 ) -> str | None:
-    """Read the .md content file for a skill or agent resource."""
+    """Read Library resource content."""
     _require_resource_type(resource_type)
     if resource_type == "sandbox-template":
         owner_user_id = _require_recipe_owner(owner_user_id)
         for item in list_library("sandbox-template", owner_user_id=owner_user_id, recipe_repo=recipe_repo):
             if item["id"] == resource_id:
-                return json.dumps(item, ensure_ascii=False, indent=2)
+                return yaml.safe_dump(item, allow_unicode=True, sort_keys=True)
         return None
     if resource_type == "skill":
         owner_user_id = _require_skill_owner(owner_user_id)
@@ -531,11 +462,6 @@ def get_resource_content(
         if package is None:
             raise RuntimeError(f"Skill {resource_id} has no selected package")
         return package.skill_md
-    content_path = _file_resource_content_path(resource_type, resource_id)
-    if content_path is not None:
-        if content_path.exists():
-            return content_path.read_text(encoding="utf-8")
-        return ""
     return None
 
 
@@ -546,9 +472,8 @@ def update_resource_content(
     owner_user_id: str | None = None,
     skill_repo: SkillRepo | None = None,
 ) -> bool:
-    """Write the .md content file for a skill or agent resource."""
+    """Write editable Library resource content."""
     _require_resource_type(resource_type)
-    now = int(time.time() * 1000)
     if resource_type == "sandbox-template":
         return False
     if resource_type == "skill":
@@ -564,17 +489,5 @@ def update_resource_content(
         files = current_package.files if current_package is not None else {}
         updated = skill_repo.upsert(current.model_copy(update={"updated_at": _now_dt()}))
         _write_skill_package(owner_user_id, updated, content, files, skill_repo)
-        return True
-    content_path = _file_resource_content_path(resource_type, resource_id)
-    meta_path = _file_resource_meta_path(resource_type, resource_id)
-    if content_path is not None and meta_path is not None:
-        if resource_type == "skill" and not content_path.parent.is_dir():
-            return False
-        if resource_type == "agent" and not meta_path.exists():
-            return False
-        content_path.write_text(content, encoding="utf-8")
-        meta = _read_json(meta_path, {})
-        meta["updated_at"] = now
-        _write_json(meta_path, meta)
         return True
     return False

--- a/frontend/app/src/components/agent-shell-contract.test.tsx
+++ b/frontend/app/src/components/agent-shell-contract.test.tsx
@@ -47,7 +47,6 @@ describe("frontend agent wording contract", () => {
     useAppStore.setState({
       agentList: [],
       librarySkills: [],
-      libraryAgents: [],
       librarySandboxTemplates: [],
       userProfile: { name: "User", initials: "U", email: "" },
       loaded: true,

--- a/frontend/app/src/lib/marketplace-types.ts
+++ b/frontend/app/src/lib/marketplace-types.ts
@@ -4,12 +4,11 @@ export const HUB_AGENT_USER_ITEM_TYPE = "member";
 
 export function marketplaceTypeLabel(type: string): string {
   if (type === HUB_AGENT_USER_ITEM_TYPE) return "Agent";
-  if (type === "agent") return "Subagent";
   if (type === "skill") return "Skill";
   if (type === "env") return "Env";
   return type;
 }
 
 export function canApplyMarketplaceType(type: string): boolean {
-  return type === "skill" || type === "agent" || type === HUB_AGENT_USER_ITEM_TYPE;
+  return type === "skill" || type === HUB_AGENT_USER_ITEM_TYPE;
 }

--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -52,9 +52,8 @@ export default function AgentDetail() {
   const updateAgentConfig = useAppStore(s => s.updateAgentConfig);
   const ensureLibrary = useAppStore(s => s.ensureLibrary);
   const librarySkills = useAppStore(s => s.librarySkills);
-  const libraryAgents = useAppStore(s => s.libraryAgents);
 
-  const [pickerType, setPickerType] = useState<"skill" | "agent" | null>(null);
+  const [pickerType, setPickerType] = useState<"skill" | null>(null);
   const [editingName, setEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState("");
   const [loadFailure, setLoadFailure] = useState<{ id: string; message: string } | null>(null);
@@ -119,7 +118,7 @@ export default function AgentDetail() {
     } catch (err) { toast.error(`更新失败：${errorText(err)}`); }
   };
 
-  const handleAssign = async (type: "skill" | "agent", names: string[]) => {
+  const handleAssign = async (type: "skill", names: string[]) => {
     if (!agent) return;
     try {
       if (type === "skill") {
@@ -129,13 +128,6 @@ export default function AgentDetail() {
           return { name: n, desc: lib?.desc || "", enabled: true };
         });
         if (newSkills.length) await updateAgentConfig(agent.id, { skills: [...agent.config.skills, ...newSkills] });
-      } else {
-        const existing = new Set(agent.config.subAgents.map(a => a.name));
-        const newAgents = names.filter(n => !existing.has(n)).map(n => {
-          const lib = libraryAgents.find(a => a.name === n);
-          return { name: n, desc: lib?.desc || "", tools: [] as CrudItem[], system_prompt: "" };
-        });
-        if (newAgents.length) await updateAgentConfig(agent.id, { subAgents: [...agent.config.subAgents, ...newAgents] });
       }
       toast.success("已添加");
     } catch (err) { toast.error(`添加失败：${errorText(err)}`); }
@@ -208,7 +200,6 @@ export default function AgentDetail() {
               await updateAgentConfig(agent.id, { subAgents: updated });
               toast.success("Agent 配置已保存");
             }}
-            onAdd={() => setPickerType("agent")}
             onDelete={(name) => handleRemove("subagents", name)}
           />
         );
@@ -288,16 +279,11 @@ export default function AgentDetail() {
 
       {showPublish && <PublishDialog open={showPublish} onOpenChange={setShowPublish} agentId={agent.id} />}
       {pickerType && (() => {
-        const libraryMap = { skill: librarySkills, agent: libraryAgents };
-        const assignedMap = {
-          skill: agent.config.skills.map(s => s.name),
-          agent: agent.config.subAgents.map(a => a.name),
-        };
         return (
           <ResourcePicker
             type={pickerType}
-            library={libraryMap[pickerType]}
-            assigned={assignedMap[pickerType]}
+            library={librarySkills}
+            assigned={agent.config.skills.map(s => s.name)}
             onConfirm={(names) => { handleAssign(pickerType, names); setPickerType(null); }}
             onClose={() => setPickerType(null)}
           />
@@ -537,7 +523,7 @@ function RuleEditor({ rule, onSave, onDelete }: {
 function SubAgentsPanel({ agents, onSave, onAdd, onDelete }: {
   agents: SubAgent[];
   onSave: (updated: SubAgent[]) => Promise<void>;
-  onAdd: () => void;
+  onAdd?: () => void;
   onDelete: (name: string) => void;
 }) {
   const builtinAgents = useMemo(() => agents.filter(a => a.builtin), [agents]);
@@ -590,9 +576,11 @@ function SubAgentsPanel({ agents, onSave, onAdd, onDelete }: {
       <div className="w-52 shrink-0 border-r flex flex-col">
         <div className="flex items-center justify-between px-3 py-2 border-b">
           <span className="text-xs font-medium text-muted-foreground">子 Agent</span>
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onAdd} title="添加子 Agent">
-            <Plus className="h-3.5 w-3.5" />
-          </Button>
+          {onAdd && (
+            <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onAdd} title="添加子 Agent">
+              <Plus className="h-3.5 w-3.5" />
+            </Button>
+          )}
         </div>
         <div className="flex-1 overflow-auto">
           {/* Builtin agents section */}
@@ -623,7 +611,7 @@ function SubAgentsPanel({ agents, onSave, onAdd, onDelete }: {
                 <p className="px-3 py-1 text-2xs font-medium text-muted-foreground">自定义</p>
               )}
               {customAgents.length === 0 ? (
-                <p className="px-3 py-2 text-2xs text-muted-foreground/60">点击 + 添加</p>
+                <p className="px-3 py-2 text-2xs text-muted-foreground/60">暂无自定义子 Agent</p>
               ) : (
                 customAgents.map(a => (
                   <button
@@ -836,13 +824,13 @@ function ResourceCards({ type, items, onToggle, onRemove, onAdd }: {
 // ==================== ResourcePicker ====================
 
 function ResourcePicker({ type, library, assigned, onConfirm, onClose }: {
-  type: "skill" | "agent";
+  type: "skill";
   library: ResourceItem[];
   assigned: string[];
   onConfirm: (names: string[]) => void;
   onClose: () => void;
 }) {
-  const labels = { skill: "Skill", agent: "子 Agent" };
+  const labels = { skill: "Skill" };
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [filter, setFilter] = useState("");
   const assignedSet = useMemo(() => new Set(assigned), [assigned]);

--- a/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
@@ -7,13 +7,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AgentDetailPage from "./AgentDetailPage";
 import { toast } from "sonner";
 
-const { getAgentById, fetchAgent, updateAgent, updateAgentConfig, ensureLibrary, libraryAgents } = vi.hoisted(() => ({
+const { getAgentById, fetchAgent, updateAgent, updateAgentConfig, ensureLibrary } = vi.hoisted(() => ({
   getAgentById: vi.fn(),
   fetchAgent: vi.fn(),
   updateAgent: vi.fn(),
   updateAgentConfig: vi.fn(),
   ensureLibrary: vi.fn(),
-  libraryAgents: [] as Array<{ id: string; name: string; desc: string; type: string; created_at: number; updated_at: number }>,
 }));
 
 const { navigateMock } = vi.hoisted(() => ({
@@ -55,7 +54,6 @@ vi.mock("@/store/app-store", () => ({
       ensureLibrary,
       loadAll: vi.fn(),
       librarySkills: [],
-      libraryAgents,
     }),
 }));
 
@@ -80,7 +78,6 @@ describe("AgentDetailPage wording contract", () => {
     getAgentById.mockReturnValue(agentFixture);
     fetchAgent.mockResolvedValue(agentFixture);
     ensureLibrary.mockResolvedValue(undefined);
-    libraryAgents.splice(0, libraryAgents.length);
     navigateMock.mockReset();
   });
 
@@ -228,7 +225,7 @@ describe("AgentDetailPage wording contract", () => {
     expect(ensureLibrary).not.toHaveBeenCalled();
   });
 
-  it("uses subagent wording in the Library picker for Library agent resources", async () => {
+  it("does not expose a Library picker for subagents", async () => {
     render(
       <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
         <Routes>
@@ -238,15 +235,13 @@ describe("AgentDetailPage wording contract", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /^子 Agent/ }));
-    const addButton = document.querySelector(".lucide-plus")?.closest("button");
-    expect(addButton).toBeTruthy();
-    fireEvent.click(addButton as HTMLButtonElement);
 
-    expect(await screen.findByRole("heading", { name: "从 Library 添加 子 Agent" })).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: ["从 Library 添加", "Agent"].join(" ") })).toBeNull();
+    expect(screen.queryByTitle("添加子 Agent")).toBeNull();
+    expect(screen.queryByRole("heading", { name: /从 Library 添加/ })).toBeNull();
+    expect(ensureLibrary).not.toHaveBeenCalled();
   });
 
-  it("uses subagent wording for the inline subagent add control", () => {
+  it("keeps subagents editable without a Library add control", () => {
     getAgentById.mockReturnValue({
       ...agentFixture,
       config: {
@@ -265,8 +260,8 @@ describe("AgentDetailPage wording contract", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /^子 Agent/ }));
 
-    expect(screen.getByTitle("添加子 Agent")).toBeTruthy();
-    expect(screen.queryByTitle("添加 Agent")).toBeNull();
+    expect(screen.queryByTitle("添加子 Agent")).toBeNull();
+    expect(screen.getAllByText("Helper").length).toBeGreaterThan(0);
   });
 
   it("uses subagent wording for the empty subagent detail prompt", () => {

--- a/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.test.tsx
@@ -32,17 +32,9 @@ describe("LibraryItemDetailPage", () => {
     vi.restoreAllMocks();
     navigateMock.mockReset();
     fetchLibrary = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    fetchResourceContent = vi.fn<(type: string, id: string) => Promise<string>>().mockResolvedValue("# Agent doc");
+    fetchResourceContent = vi.fn<(type: string, id: string) => Promise<string>>().mockResolvedValue("# Skill doc");
     updateResource = vi.fn<(type: string, id: string, fields: Record<string, unknown>) => Promise<void>>().mockResolvedValue(undefined);
     useAppStore.setState({
-      libraryAgents: [{
-        id: "agent-lib-1",
-        name: "Explorer",
-        desc: "inspect repos",
-        type: "agent",
-        created_at: 1,
-        updated_at: 1,
-      }],
       librarySkills: [{
         id: "skill-lib-1",
         name: "Skill One",
@@ -90,34 +82,6 @@ describe("LibraryItemDetailPage", () => {
     expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=library&sub=sandbox-template");
   });
 
-  it("uses the canonical library route for the back button on agent detail pages", async () => {
-    render(
-      <MemoryRouter initialEntries={["/library/agent/agent-lib-1"]}>
-        <Routes>
-          <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByRole("heading", { name: "Explorer" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "返回" }));
-
-    expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=library&sub=agent");
-  });
-
-  it("labels library agent resources as Subagent", async () => {
-    render(
-      <MemoryRouter initialEntries={["/library/agent/agent-lib-1"]}>
-        <Routes>
-          <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByRole("heading", { name: "Explorer" })).toBeTruthy();
-    expect(screen.getByText("Subagent")).toBeTruthy();
-  });
-
   it("uses the canonical library route for the back button on skill detail pages", async () => {
     fetchResourceContent.mockResolvedValue("# Skill doc");
 
@@ -135,18 +99,18 @@ describe("LibraryItemDetailPage", () => {
     expect(navigateMock).toHaveBeenCalledWith("/marketplace?tab=library&sub=skill");
   });
 
-  it("uses bootstrapped library state instead of refetching the whole list", async () => {
+  it("uses bootstrapped skill library state instead of refetching the whole list", async () => {
     render(
-      <MemoryRouter initialEntries={["/library/agent/agent-lib-1"]}>
+      <MemoryRouter initialEntries={["/library/skill/skill-lib-1"]}>
         <Routes>
           <Route path="/library/:type/:id" element={<LibraryItemDetailPage />} />
         </Routes>
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("heading", { name: "Explorer" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Skill One" })).toBeTruthy();
     await waitFor(() => {
-      expect(fetchResourceContent).toHaveBeenCalledWith("agent", "agent-lib-1");
+      expect(fetchResourceContent).toHaveBeenCalledWith("skill", "skill-lib-1");
     });
     expect(fetchLibrary).not.toHaveBeenCalled();
   });

--- a/frontend/app/src/pages/LibraryItemDetailPage.tsx
+++ b/frontend/app/src/pages/LibraryItemDetailPage.tsx
@@ -1,20 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Zap, Users, RefreshCw } from "lucide-react";
+import { ArrowLeft, Zap, RefreshCw } from "lucide-react";
 import SandboxTemplateEditor from "@/components/SandboxTemplateEditor";
 import { marketplaceTypeLabel } from "@/lib/marketplace-types";
 import { useAppStore } from "@/store/app-store";
 import type { ResourceItem } from "@/store/types";
 
-type DetailLibraryType = "skill" | "agent" | "sandbox-template";
+type DetailLibraryType = "skill" | "sandbox-template";
 
 function detailLibraryType(value: string | undefined): DetailLibraryType | null {
-  return value === "skill" || value === "agent" || value === "sandbox-template" ? value : null;
+  return value === "skill" || value === "sandbox-template" ? value : null;
 }
 
 function libraryDetailReturnTarget(type: DetailLibraryType | null): string {
   if (type === "skill") return "/marketplace?tab=library&sub=skill";
-  if (type === "agent") return "/marketplace?tab=library&sub=agent";
   return "/marketplace?tab=library&sub=sandbox-template";
 }
 
@@ -22,7 +21,6 @@ export default function LibraryItemDetailPage() {
   const { type, id } = useParams<{ type: string; id: string }>();
   const navigate = useNavigate();
   const librarySkills = useAppStore((s) => s.librarySkills);
-  const libraryAgents = useAppStore((s) => s.libraryAgents);
   const librarySandboxTemplates = useAppStore((s) => s.librarySandboxTemplates);
   const librariesLoaded = useAppStore((s) => s.librariesLoaded);
   const ensureLibrary = useAppStore((s) => s.ensureLibrary);
@@ -39,9 +37,9 @@ export default function LibraryItemDetailPage() {
 
   const item = useMemo<ResourceItem | null>(() => {
     if (!type || !id) return null;
-    const list = type === "skill" ? librarySkills : type === "agent" ? libraryAgents : type === "sandbox-template" ? librarySandboxTemplates : [];
+    const list = type === "skill" ? librarySkills : type === "sandbox-template" ? librarySandboxTemplates : [];
     return list.find((i) => i.id === id) ?? null;
-  }, [librarySkills, libraryAgents, librarySandboxTemplates, type, id]);
+  }, [librarySkills, librarySandboxTemplates, type, id]);
 
   useEffect(() => {
     if (!libraryType || librariesLoaded[libraryType]) return;
@@ -82,7 +80,7 @@ export default function LibraryItemDetailPage() {
 
   const isSkill = type === "skill";
   const isSandboxTemplate = type === "sandbox-template";
-  const filename = isSkill ? "SKILL.md" : "agent.md";
+  const filename = "SKILL.md";
   const typeLabel = type ? marketplaceTypeLabel(type) : "";
   const loadingLibrary = !!libraryType && !librariesLoaded[libraryType] && !libraryError;
   const loading = loadingLibrary || (!isSandboxTemplate && !!contentKey && contentState.key !== contentKey);
@@ -114,9 +112,7 @@ export default function LibraryItemDetailPage() {
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-1">
                 <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 bg-warning/10">
-                  {isSkill
-                    ? <Zap className="w-4 h-4 text-warning" />
-                    : <Users className="w-4 h-4 text-info" />}
+                  {isSkill && <Zap className="w-4 h-4 text-warning" />}
                 </div>
                 <h1 className="text-xl font-semibold text-foreground">{item?.name ?? id}</h1>
                 <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">

--- a/frontend/app/src/pages/MarketplaceDetailPage.test.tsx
+++ b/frontend/app/src/pages/MarketplaceDetailPage.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import MarketplaceDetailPage from "./MarketplaceDetailPage";
+import type { MarketplaceItemDetail } from "@/store/marketplace-store";
 
 const { navigateMock } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
@@ -26,7 +27,19 @@ vi.mock("@/components/marketplace/MarketplaceActionDialog", () => ({
   default: () => null,
 }));
 
-const marketplaceState = {
+const marketplaceState: {
+  detail: MarketplaceItemDetail;
+  detailLoading: boolean;
+  fetchDetail: ReturnType<typeof vi.fn>;
+  lineage: { ancestors: []; children: [] };
+  fetchLineage: ReturnType<typeof vi.fn>;
+  clearDetail: ReturnType<typeof vi.fn>;
+  error: string | null;
+  versionSnapshot: null;
+  snapshotLoading: boolean;
+  fetchVersionSnapshot: ReturnType<typeof vi.fn>;
+  clearSnapshot: ReturnType<typeof vi.fn>;
+} = {
   detail: {
     id: "item-1",
     slug: "item-one",
@@ -69,10 +82,12 @@ afterEach(() => {
 describe("MarketplaceDetailPage", () => {
   beforeEach(() => {
     navigateMock.mockReset();
+    marketplaceState.fetchVersionSnapshot.mockReset();
     marketplaceState.detail = {
       ...marketplaceState.detail,
       type: "skill",
       name: "Skill One",
+      versions: [],
     };
   });
 
@@ -149,5 +164,27 @@ describe("MarketplaceDetailPage", () => {
     const button = screen.getByRole("button", { name: "暂不支持保存" }) as HTMLButtonElement;
     expect(button.disabled).toBe(true);
     expect(screen.queryByRole("button", { name: "保存到 Library" })).toBeNull();
+  });
+
+  it("does not render Hub agent items as Library files", async () => {
+    marketplaceState.detail = {
+      ...marketplaceState.detail,
+      type: "agent",
+      name: "Old Agent Item",
+      versions: [{ id: "v1", version: "1.0.0", created_at: "2026-04-01T00:00:00Z", release_notes: "" }],
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/marketplace/item-1"]}>
+        <Routes>
+          <Route path="/marketplace/:id" element={<MarketplaceDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Old Agent Item" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "暂不支持保存" })).toHaveProperty("disabled", true);
+    expect(screen.queryByText("agent.md")).toBeNull();
+    expect(marketplaceState.fetchVersionSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/pages/MarketplaceDetailPage.tsx
+++ b/frontend/app/src/pages/MarketplaceDetailPage.tsx
@@ -41,7 +41,7 @@ export default function MarketplaceDetailPage() {
   }, [id, fetchDetail, fetchLineage, clearDetail]);
 
   useEffect(() => {
-    if (detailId && previewVersion && (detailType === "skill" || detailType === "agent")) {
+    if (detailId && previewVersion && detailType === "skill") {
       fetchVersionSnapshot(detailId, previewVersion);
     }
     return () => clearSnapshot();
@@ -146,12 +146,12 @@ export default function MarketplaceDetailPage() {
             </div>
           )}
 
-          {/* File content for skill / agent */}
-          {(detail.type === "skill" || detail.type === "agent") && (
+          {/* File content for skill */}
+          {detail.type === "skill" && (
             <div className="surface-card p-4">
               <div className="flex items-center gap-2 mb-3">
                 <span className="text-xs font-mono text-muted-foreground px-2 py-0.5 rounded bg-muted">
-                  {detail.type === "skill" ? "SKILL.md" : "agent.md"}
+                  SKILL.md
                 </span>
               </div>
               {snapshotLoading ? (

--- a/frontend/app/src/pages/MarketplacePage.tsx
+++ b/frontend/app/src/pages/MarketplacePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Box, Search, Store, Package, TrendingUp, Clock, RefreshCw, Zap, Users, Trash2, Plus, X } from "lucide-react";
+import { Box, Search, Store, Package, TrendingUp, Clock, RefreshCw, Zap, Trash2, Plus, X } from "lucide-react";
 import { useMarketplaceStore } from "@/store/marketplace-store";
 import { useAppStore } from "@/store/app-store";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -13,22 +13,21 @@ import { HUB_AGENT_USER_ITEM_TYPE } from "@/lib/marketplace-types";
 import { toast } from "sonner";
 
 type Tab = "explore" | "library";
-type LibrarySubTab = "agent-user" | "skill" | "agent" | "sandbox-template";
-type TypeFilter = "all" | typeof HUB_AGENT_USER_ITEM_TYPE | "agent" | "skill" | "env";
+type LibrarySubTab = "agent-user" | "skill" | "sandbox-template";
+type TypeFilter = "all" | typeof HUB_AGENT_USER_ITEM_TYPE | "skill" | "env";
 
 function isTab(value: string | null): value is Tab {
   return value === "explore" || value === "library";
 }
 
 function normalizeLibrarySubTab(value: string | null): LibrarySubTab | null {
-  if (value === "agent-user" || value === "skill" || value === "agent" || value === "sandbox-template") return value;
+  if (value === "agent-user" || value === "skill" || value === "sandbox-template") return value;
   return null;
 }
 
 const typeFilters: { id: TypeFilter; label: string }[] = [
   { id: "all", label: "All" },
   { id: HUB_AGENT_USER_ITEM_TYPE, label: "Agent" },
-  { id: "agent", label: "Subagent" },
   { id: "skill", label: "Skill" },
   { id: "env", label: "Env" },
 ];
@@ -63,7 +62,6 @@ export default function MarketplacePage() {
   // Library state
   const agentList = useAppStore((s) => s.agentList);
   const librarySkills = useAppStore((s) => s.librarySkills);
-  const libraryAgents = useAppStore((s) => s.libraryAgents);
   const librarySandboxTemplates = useAppStore((s) => s.librarySandboxTemplates);
   const agentsLoaded = useAppStore((s) => s.agentsLoaded);
   const librariesLoaded = useAppStore((s) => s.librariesLoaded);
@@ -111,13 +109,10 @@ export default function MarketplacePage() {
   const filteredSkills = librarySkills.filter((s) =>
     !librarySearch || s.name.toLowerCase().includes(librarySearch.toLowerCase())
   );
-  const filteredAgents = libraryAgents.filter((a) =>
-    !librarySearch || a.name.toLowerCase().includes(librarySearch.toLowerCase())
-  );
   const filteredSandboxTemplates = librarySandboxTemplates.filter((sandboxTemplate) =>
     !librarySearch || sandboxTemplate.name.toLowerCase().includes(librarySearch.toLowerCase())
   );
-  const handleDeleteResource = async (type: "skill" | "agent" | "sandbox-template", id: string) => {
+  const handleDeleteResource = async (type: "skill" | "sandbox-template", id: string) => {
     try {
       await deleteResource(type, id);
     } catch (err) {
@@ -137,7 +132,6 @@ export default function MarketplacePage() {
   const librarySubTabs: { id: LibrarySubTab; label: string; icon: React.ElementType; count: number }[] = [
     { id: "agent-user", label: "Agent", icon: Package, count: libraryAgentUsers.length },
     { id: "skill", label: "Skill", icon: Zap, count: librarySkills.length },
-    { id: "agent", label: "Subagent", icon: Users, count: libraryAgents.length },
     { id: "sandbox-template", label: "Sandbox", icon: Box, count: librarySandboxTemplates.length },
   ];
   const librarySubTabLoaded = librarySubTab === "agent-user" ? agentsLoaded : librariesLoaded[librarySubTab];
@@ -474,41 +468,6 @@ export default function MarketplacePage() {
                     </div>
                     {filteredSkills.length === 0 && (
                       <div className="text-center py-12 text-sm text-muted-foreground">暂无 Skill</div>
-                    )}
-                  </>
-                )}
-
-                {/* Subagent list */}
-                {librarySubTabLoaded && librarySubTab === "agent" && (
-                  <>
-                    <div className={`grid ${isMobile ? "grid-cols-1" : "grid-cols-2"} gap-3`}>
-                      {filteredAgents.map((agent) => (
-                        <div
-                          key={agent.id}
-                          onClick={() => navigate(`/library/agent/${agent.id}`)}
-                          className="surface-interactive p-4 cursor-pointer group relative"
-                        >
-                          <div className="flex items-start gap-3">
-                            <div className="w-9 h-9 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
-                              <Users className="w-4 h-4 text-info" />
-                            </div>
-                            <div className="min-w-0 flex-1 pr-8">
-                              <h4 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors duration-fast">{agent.name}</h4>
-                              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{agent.desc || "暂无描述"}</p>
-                            </div>
-                          </div>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); void handleDeleteResource("agent", agent.id); }}
-                            className="absolute top-3 right-3 p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all duration-fast"
-                            title="删除"
-                          >
-                            <Trash2 className="w-3.5 h-3.5 text-muted-foreground hover:text-destructive" />
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                    {filteredAgents.length === 0 && (
-                      <div className="text-center py-12 text-sm text-muted-foreground">暂无 Subagent</div>
                     )}
                   </>
                 )}

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -88,7 +88,6 @@ describe("MarketplacePage wording contract", () => {
       agentList: [],
       agentsLoaded: true,
       librarySkills: [],
-      libraryAgents: [],
       librarySandboxTemplates: [
         {
           id: "daytona:selfhost:default",
@@ -105,7 +104,7 @@ describe("MarketplacePage wording contract", () => {
           }],
         },
       ],
-      librariesLoaded: { skill: true, mcp: true, agent: true, "sandbox-template": true },
+      librariesLoaded: { skill: true, "sandbox-template": true },
       fetchLibrary: appStoreFetchLibrary,
       deleteResource: appStoreDeleteResource,
       addResource: appStoreAddResource,
@@ -295,7 +294,7 @@ describe("MarketplacePage wording contract", () => {
     expect(screen.getByText("更新到 v1.1.0")).toBeTruthy();
   });
 
-  it("uses Subagent wording for marketplace agent resources", () => {
+  it("normalizes the removed library agent tab to Agent users", () => {
     render(
       <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent"]}>
         <Routes>
@@ -304,27 +303,13 @@ describe("MarketplacePage wording contract", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("button", { name: /Subagent/ })).toBeTruthy();
-    expect(screen.getByText("暂无 Subagent")).toBeTruthy();
-  });
-
-  it("keeps the library Subagent tab distinct from Agent", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByRole("button", { name: /Subagent/ })).toBeTruthy();
-    expect(screen.getByText("暂无 Subagent")).toBeTruthy();
-    expect(screen.queryByText("暂无 Agent")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Subagent/ })).toBeNull();
+    expect(screen.getByText("暂无 Agent")).toBeTruthy();
   });
 
   it("does not bootstrap marketplace libraries because RootLayout owns panel loading", () => {
     render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent"]}>
+      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=skill"]}>
         <Routes>
           <Route path="/marketplace" element={<MarketplacePage />} />
         </Routes>
@@ -353,7 +338,7 @@ describe("MarketplacePage wording contract", () => {
     appStoreState = {
       ...appStoreState,
       librarySandboxTemplates: [],
-      librariesLoaded: { skill: true, mcp: true, agent: true, "sandbox-template": false },
+      librariesLoaded: { skill: true, "sandbox-template": false },
     };
 
     render(

--- a/frontend/app/src/pages/NewChatPage.test.tsx
+++ b/frontend/app/src/pages/NewChatPage.test.tsx
@@ -170,7 +170,6 @@ describe("NewChatPage", () => {
         updated_at: 0,
       }],
       librarySkills: [],
-      libraryAgents: [],
       librarySandboxTemplates: [],
       userProfile: { name: "User", initials: "U", email: "" },
       loaded: true,

--- a/frontend/app/src/store/app-store.test.ts
+++ b/frontend/app/src/store/app-store.test.ts
@@ -246,9 +246,8 @@ describe("app store agent panel contract", () => {
 
     const urls = fetchMock.mock.calls.map(([url]) => String(url));
     expect(urls).toContain("/api/panel/library/skill");
-    expect(urls).toContain("/api/panel/library/agent");
     expect(urls).toContain("/api/panel/library/sandbox-template");
-    expect(urls.filter((url) => url.startsWith("/api/panel/library/"))).toHaveLength(3);
+    expect(urls.filter((url) => url.startsWith("/api/panel/library/"))).toHaveLength(2);
   });
 
   it("surfaces backend detail text from panel API errors", async () => {

--- a/frontend/app/src/store/app-store.ts
+++ b/frontend/app/src/store/app-store.ts
@@ -11,7 +11,6 @@ interface AppState {
   // ── Data ──
   agentList: Agent[];
   librarySkills: ResourceItem[];
-  libraryAgents: ResourceItem[];
   librarySandboxTemplates: ResourceItem[];
   userProfile: UserProfile;
   loaded: boolean;
@@ -59,18 +58,16 @@ interface AppState {
   getResourceUsedBy: (type: string, name: string) => string[];
 }
 
-type LibraryType = "skill" | "agent" | "sandbox-template";
-type LibraryStateKey = "librarySkills" | "libraryAgents" | "librarySandboxTemplates";
+type LibraryType = "skill" | "sandbox-template";
+type LibraryStateKey = "librarySkills" | "librarySandboxTemplates";
 
 const DEFAULT_PROFILE: UserProfile = { name: "User", initials: "U", email: "" };
 const LIBRARY_STATE_KEYS: Record<LibraryType, LibraryStateKey> = {
   skill: "librarySkills",
-  agent: "libraryAgents",
   "sandbox-template": "librarySandboxTemplates",
 };
 const EMPTY_LIBRARY_LOADED: Record<LibraryType, boolean> = {
   skill: false,
-  agent: false,
   "sandbox-template": false,
 };
 const EMPTY_AGENT_CONFIG: Agent["config"] = {
@@ -95,7 +92,6 @@ function emptySessionState() {
   return {
     agentList: [],
     librarySkills: [],
-    libraryAgents: [],
     librarySandboxTemplates: [],
     userProfile: DEFAULT_PROFILE,
     loaded: false,
@@ -175,7 +171,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
         await Promise.all([
           get().ensureAgents(),
           get().ensureLibrary("skill"),
-          get().ensureLibrary("agent"),
           get().ensureLibrary("sandbox-template"),
           get().fetchProfile(),
         ]);
@@ -388,7 +383,8 @@ export const useAppStore = create<AppState>()((set, get) => ({
 
   getResourceUsedBy: (type, name) => {
     if (type === "sandbox-template") return [];
-    const key = type === "skill" ? "skills" : type === "mcp" ? "mcpServers" : "subAgents";
+    if (type !== "skill") return [];
+    const key = "skills";
     return get().agentList.filter((s) =>
       (s.config?.[key as keyof typeof s.config] as { name: string }[] | undefined)?.some((i) => i.name === name)
     ).map((s) => s.name);

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -759,14 +759,8 @@ def test_library_skill_create_rejects_slug_collision_with_different_name() -> No
     assert stored.description == "Use this skill"
 
 
-def test_file_backed_library_metadata_fails_loudly_when_json_is_corrupt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(library_service, "LIBRARY_DIR", tmp_path / "library")
-    agents_dir = tmp_path / "library" / "agents"
-    agents_dir.mkdir(parents=True)
-    (agents_dir / "broken.md").write_text("agent body", encoding="utf-8")
-    (agents_dir / "broken.json").write_text("{bad json", encoding="utf-8")
-
-    with pytest.raises(ValueError, match="Library JSON file must be valid JSON"):
+def test_library_rejects_agent_resource_type() -> None:
+    with pytest.raises(ValueError, match="Unknown resource type: agent"):
         library_service.list_library("agent")
 
 

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -10,7 +10,6 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
-import backend.library.paths as _lib_paths
 from backend.hub.versioning import bump_semver
 from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, Skill, SkillPackage
 
@@ -491,47 +490,14 @@ class TestApplySkill:
 
 
 class TestApplyAgent:
-    def test_apply_agent_rejects_non_string_snapshot_content(self, tmp_path, monkeypatch):
+    def test_apply_agent_item_type_is_not_supported(self):
         import backend.hub.client as marketplace_client
 
-        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", tmp_path)
-        hub_resp = _make_hub_response("agent", "broken-agent", content="# Agent")
-        hub_resp["snapshot"]["content"] = []
+        hub_resp = _make_hub_response("agent", "old-agent-template", content="# Agent")
 
         with patch("backend.hub.client._hub_api", return_value=hub_resp):
-            with pytest.raises(ValueError, match="Agent snapshot content must be a string"):
+            with pytest.raises(ValueError, match="Marketplace agent items are not supported"):
                 marketplace_client.apply_item("item-agent")
-
-    def test_writes_agent_md(self, tmp_path, monkeypatch):
-        lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
-        hub_resp = _make_hub_response("agent", "cool-agent", content="# Cool Agent")
-
-        with patch("backend.hub.client._hub_api", return_value=hub_resp):
-            from backend.hub.client import apply_item
-
-            result = apply_item("item-a1")
-
-        assert result["type"] == "agent"
-        assert result["resource_id"] == "cool-agent"
-        md_path = lib / "agents" / "cool-agent.md"
-        assert md_path.exists()
-        assert md_path.read_text(encoding="utf-8") == "# Cool Agent"
-
-    def test_meta_json_written(self, tmp_path, monkeypatch):
-        lib = tmp_path / "library"
-        monkeypatch.setattr(_lib_paths, "LIBRARY_DIR", lib)
-        hub_resp = _make_hub_response("agent", "meta-agent", version="3.0.0", publisher="bob")
-
-        with patch("backend.hub.client._hub_api", return_value=hub_resp):
-            from backend.hub.client import apply_item
-
-            apply_item("item-a2")
-
-        meta = json.loads((lib / "agents" / "meta-agent.json").read_text(encoding="utf-8"))
-        assert meta["source"]["marketplace_item_id"] == "item-a2"
-        assert meta["source"]["source_version"] == "3.0.0"
-        assert meta["source"]["publisher"] == "bob"
 
 
 class TestApplyUser:


### PR DESCRIPTION
## Summary
- reject old Hub `agent` item installs instead of writing `LIBRARY_DIR/agents` files
- remove `agent` from backend Library resource types
- remove frontend `libraryAgents`, Marketplace Subagent tab, and Agent-detail Subagent Library picker
- stop rendering Hub `agent` items as Library file documents

## Verification
- `uv run pytest tests/Unit -q`
- `uv run ruff check . && uv run ruff format --check .`
- `cd frontend/app && npm run lint && npx tsc -b --noEmit && npx vitest run`

## Commit Structure
- 6 semantic commits, preserving the review contract
