### PR TITLE
Cut user project runtime agent discovery

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -4,8 +4,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from backend.hub.versioning import BumpType, bump_semver
 from backend.identity.avatar.urls import avatar_url
 from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig
@@ -14,27 +12,6 @@ from config.loader import AgentLoader
 
 _SYSTEM_AGENTS_DIR = (Path(__file__).resolve().parents[2] / "config" / "defaults" / "agents").resolve()
 _MCP_CONFIG_KEYS = ("transport", "command", "args", "env", "url", "allowed_tools", "instructions")
-
-
-def _parse_agent_md_content(content: str) -> dict[str, Any] | None:
-    if not content.startswith("---"):
-        return None
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return None
-    try:
-        fm = yaml.safe_load(parts[1])
-    except yaml.YAMLError:
-        return None
-    if not fm or "name" not in fm:
-        return None
-    return {
-        "name": fm["name"],
-        "description": fm.get("description", ""),
-        "model": fm.get("model"),
-        "tools": fm.get("tools", ["*"]),
-        "system_prompt": parts[2].strip(),
-    }
 
 
 def _tools_from_repo(config: AgentConfig) -> list[dict[str, Any]]:

--- a/config/loader.py
+++ b/config/loader.py
@@ -2,7 +2,7 @@
 
 Combines:
 - Three-tier runtime config merge (system > user > project) — for default agent
-- Agent .md parsing (YAML frontmatter + system prompt)
+- Built-in runtime agent .md parsing (YAML frontmatter + system prompt)
 
 Configuration priority (highest to lowest):
 1. CLI overrides
@@ -84,7 +84,7 @@ class AgentLoader:
 
         return LeonSettings(**final_config)
 
-    # ── Agent .md parsing (merged from core/task/loader) ──
+    # ── Built-in runtime agent .md parsing ──
 
     def load_runtime_agents(self) -> dict[str, RuntimeAgentDefinition]:
         """Load runtime-facing agent definitions."""
@@ -93,17 +93,7 @@ class AgentLoader:
 
     def _load_agent_layers(self) -> None:
         self._agents = {}
-
-        # 1. Built-in agents (lowest priority)
         self._load_agents_from_dir(self._system_defaults_dir / "agents")
-
-        # 2. User-level agents
-        for path in user_home_read_candidates("agents"):
-            self._load_agents_from_dir(path)
-
-        # 3. Project-level agents
-        if self.workspace_root:
-            self._load_agents_from_dir(self.workspace_root / ".leon" / "agents")
 
     def _load_agents_from_dir(self, dir_path: Path) -> None:
         """Load all .md files from a directory."""

--- a/config/types.py
+++ b/config/types.py
@@ -1,10 +1,10 @@
-"""Type definitions for local runtime agent definitions."""
+"""Type definitions for built-in runtime agent definitions."""
 
 from pydantic import BaseModel, Field
 
 
 class RuntimeAgentDefinition(BaseModel):
-    """Agent configuration parsed from .md file."""
+    """Built-in Agent configuration parsed from a bundled .md file."""
 
     name: str
     description: str = ""

--- a/core/agents/service.py
+++ b/core/agents/service.py
@@ -75,7 +75,6 @@ def _get_subagent_agent_name(subagent_type: str) -> str:
 
 
 def _resolve_subagent_model(
-    workspace_root: Path,
     subagent_type: str,
     requested_model: str | None,
     inherited_model: str,
@@ -90,7 +89,7 @@ def _resolve_subagent_model(
     if requested_model and not _is_inherit_marker(requested_model):
         return requested_model
 
-    agent_def = AgentLoader(workspace_root=workspace_root).load_runtime_agents().get(_get_subagent_agent_name(subagent_type))
+    agent_def = AgentLoader().load_runtime_agents().get(_get_subagent_agent_name(subagent_type))
     if agent_def and agent_def.model:
         return agent_def.model
 
@@ -788,7 +787,6 @@ class AgentService:
                 elif parent_bootstrap is not None:
                     child_bootstrap = fork_bootstrap(parent_bootstrap)
                     selected_model = _resolve_subagent_model(
-                        self._workspace_root,
                         subagent_type,
                         model,
                         child_bootstrap.model_name,
@@ -815,7 +813,6 @@ class AgentService:
                     # be resolved explicitly here instead of leaking through
                     # prompt text or whichever defaults happen to win later.
                     selected_model = _resolve_subagent_model(
-                        self._workspace_root,
                         subagent_type,
                         model,
                         child_bootstrap.model_name,
@@ -844,7 +841,6 @@ class AgentService:
             except (AttributeError, ImportError):
                 inherited_model = getattr(parent_tool_context.bootstrap, "model_name", None) if parent_tool_context else None
                 selected_model = _resolve_subagent_model(
-                    self._workspace_root,
                     subagent_type,
                     model,
                     inherited_model or self._model_name,

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -184,7 +184,7 @@ class TestLoadConfigFunction:
         assert isinstance(settings, LeonSettings)
 
 
-def test_project_agent_file_stays_runtime_definition_only(tmp_path: Path):
+def test_project_agent_file_does_not_override_builtin_runtime_agent(tmp_path: Path):
     agents_dir = tmp_path / ".leon" / "agents"
     agents_dir.mkdir(parents=True)
     (agents_dir / "explore.md").write_text(
@@ -194,7 +194,21 @@ def test_project_agent_file_stays_runtime_definition_only(tmp_path: Path):
 
     agent = AgentLoader(workspace_root=tmp_path).load_runtime_agents()["explore"]
 
-    assert agent.model == "project-model"
+    assert agent.model is None
+    assert agent.system_prompt != "project prompt"
+
+
+def test_user_agent_file_does_not_enter_runtime_agent_discovery(tmp_path: Path, monkeypatch):
+    home_root = tmp_path
+    monkeypatch.setattr("config.loader.user_home_read_candidates", lambda *parts: (home_root.joinpath(*parts),))
+    agents_dir = home_root / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "custom.md").write_text(
+        "---\nname: custom\nmodel: user-model\n---\nuser prompt\n",
+        encoding="utf-8",
+    )
+
+    assert "custom" not in AgentLoader(workspace_root=tmp_path).load_runtime_agents()
 
 
 def test_runtime_agent_discovery_excludes_member_dirs(tmp_path: Path, monkeypatch):

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -790,13 +790,7 @@ async def test_agent_tool_live_runner_path_applies_role_specific_tool_filters(mo
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_model_priority_prefers_env_over_tool_frontmatter_and_parent(monkeypatch, tmp_path):
-    agent_dir = tmp_path / ".leon" / "agents"
-    agent_dir.mkdir(parents=True)
-    (agent_dir / "explore.md").write_text(
-        "---\nname: explore\nmodel: frontmatter-model\ntools:\n  - Read\n---\nfrontmatter prompt\n",
-        encoding="utf-8",
-    )
+async def test_agent_tool_model_priority_prefers_env_over_tool_and_parent(monkeypatch, tmp_path):
     captured: dict[str, Any] = {}
     _patch_create_leon_agent(monkeypatch, captured=captured)
     monkeypatch.setenv("CLAUDE_CODE_SUBAGENT_MODEL", "env-model")
@@ -821,18 +815,17 @@ async def test_agent_tool_model_priority_prefers_env_over_tool_frontmatter_and_p
     assert captured["kwargs"]["agent"] == "explore"
 
 
-def test_resolve_subagent_model_ignores_member_dir_frontmatter(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_resolve_subagent_model_ignores_user_home_agent_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     home_root = tmp_path
     monkeypatch.setattr("config.loader.user_home_read_candidates", lambda *parts: (home_root.joinpath(*parts),))
-    member_dir = home_root / "members" / "explore"
-    member_dir.mkdir(parents=True)
-    (member_dir / "agent.md").write_text(
-        "---\nname: explore\nmodel: member-model\ntools:\n  - Read\n---\nmember prompt\n",
+    agent_dir = home_root / "agents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "explore.md").write_text(
+        "---\nname: explore\nmodel: user-model\ntools:\n  - Read\n---\nuser prompt\n",
         encoding="utf-8",
     )
 
     resolved = _resolve_subagent_model(
-        workspace_root=tmp_path,
         subagent_type="explore",
         requested_model=None,
         inherited_model="parent-model",
@@ -842,13 +835,7 @@ def test_resolve_subagent_model_ignores_member_dir_frontmatter(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_model_priority_prefers_tool_over_frontmatter_and_parent(monkeypatch, tmp_path):
-    agent_dir = tmp_path / ".leon" / "agents"
-    agent_dir.mkdir(parents=True)
-    (agent_dir / "explore.md").write_text(
-        "---\nname: explore\nmodel: frontmatter-model\ntools:\n  - Read\n---\nfrontmatter prompt\n",
-        encoding="utf-8",
-    )
+async def test_agent_tool_model_priority_prefers_tool_over_parent(monkeypatch, tmp_path):
     captured: dict[str, Any] = {}
     _patch_create_leon_agent(monkeypatch, captured=captured)
 
@@ -943,7 +930,7 @@ async def test_agent_tool_inherited_default_bootstrap_model_uses_parent_service_
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_model_priority_prefers_frontmatter_over_parent(monkeypatch, tmp_path):
+async def test_agent_tool_model_priority_ignores_project_agent_file(monkeypatch, tmp_path):
     agent_dir = tmp_path / ".leon" / "agents"
     agent_dir.mkdir(parents=True)
     (agent_dir / "explore.md").write_text(
@@ -964,7 +951,7 @@ async def test_agent_tool_model_priority_prefers_frontmatter_over_parent(monkeyp
 
     await runner.awrap_tool_call(request, AsyncMock())
 
-    assert captured["model_name"] == "frontmatter-model"
+    assert captured["model_name"] == "parent-model"
     assert captured["kwargs"]["agent"] == "explore"
 
 


### PR DESCRIPTION
## Summary
- restrict runtime agent discovery to bundled definitions under `config/defaults/agents`
- stop reading user/project agent definition directories for subagent runtime behavior
- simplify subagent model resolution so workspace files cannot override model choice
- remove an unused `agent.md` parser and align type wording to bundled definitions

## Verification
- `uv run pytest tests/Unit -q`
- `uv run ruff check . && uv run ruff format --check .`
- `cd frontend/app && npm run lint && npx tsc -b --noEmit && npx vitest run`

## Commit Structure
- 5 semantic commits, preserving the review contract
