### PR TITLE
Stop runtime Skill defaults from reading host directories

### DIFF
--- a/config/defaults/runtime.json
+++ b/config/defaults/runtime.json
@@ -67,7 +67,7 @@
   },
   "skills": {
     "enabled": true,
-    "paths": ["~/.leon/skills"],
+    "paths": [],
     "skills": {}
   }
 }

--- a/config/schema.py
+++ b/config/schema.py
@@ -208,7 +208,7 @@ class SkillsConfig(BaseModel):
     """Skills configuration."""
 
     enabled: bool = True
-    paths: list[str] = Field(default_factory=lambda: ["./skills"], description="Declared Skill search paths")
+    paths: list[str] = Field(default_factory=list, description="Explicit Skill search paths")
     skills: dict[str, bool] = Field(default_factory=dict, description="Skill enable/disable map")
 
 

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -234,7 +234,7 @@ MODEL_NAME=claude-sonnet-4-5-20250929
 {
   "skills": {
     "enabled": true,
-    "paths": ["~/.leon/skills"],
+    "paths": [],
     "skills": {
       "code-review": true,
       "debugging": false
@@ -244,7 +244,8 @@ MODEL_NAME=claude-sonnet-4-5-20250929
 ```
 
 <Warning>
-  Skill paths must exist on disk — Mycel does not create them automatically. Run `mkdir -p ~/.leon/skills` if needed.
+  Runtime config does not read a default host directory. Use Hub/Library managed Skills for product flows, or declare explicit
+  `paths` only for controlled file-based development and import workflows.
 </Warning>
 
 ## Advanced MCP servers

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -74,7 +74,7 @@ MODEL_NAME=claude-sonnet-4-5-20250929
   "system_prompt": null,
   "tools": { ... },
   "mcp": { "enabled": true, "servers": {} },
-  "skills": { "enabled": true, "paths": ["~/.leon/skills"], "skills": {} }
+  "skills": { "enabled": true, "paths": [], "skills": {} }
 }
 ```
 
@@ -224,7 +224,7 @@ Skills 是可加载的专业能力模块 — 按需注入专业指令的 Markdow
 {
   "skills": {
     "enabled": true,
-    "paths": ["~/.leon/skills"],
+    "paths": [],
     "skills": {
       "code-review": true,
       "debugging": false
@@ -233,7 +233,7 @@ Skills 是可加载的专业能力模块 — 按需注入专业指令的 Markdow
 }
 ```
 
-Skill 目录必须在磁盘上存在，Mycel 不会自动创建。
+运行时配置不会读取默认宿主机目录。产品链路应使用 Hub/Library 管理的 Skills；只有受控的文件开发和导入流程才显式声明 `paths`。
 
 Agent 在运行时加载：`load_skill("code-review")`。
 

--- a/tests/Config/test_loader_skill_dir_boundary.py
+++ b/tests/Config/test_loader_skill_dir_boundary.py
@@ -1,14 +1,8 @@
-import sys
-from pathlib import Path
-
-import pytest
-
 from config.loader import AgentLoader
 from config.schema import SkillsConfig
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="HOME monkeypatch does not affect expanduser on Windows")
-def test_load_does_not_create_default_home_skill_dir(monkeypatch, tmp_path):
+def test_load_has_no_default_home_skill_dir(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     expected_path = tmp_path / ".leon" / "skills"
     assert not expected_path.exists()
@@ -16,7 +10,7 @@ def test_load_does_not_create_default_home_skill_dir(monkeypatch, tmp_path):
     settings = AgentLoader().load()
 
     assert not expected_path.exists()
-    assert Path(settings.skills.paths[0]).expanduser() == expected_path
+    assert settings.skills.paths == []
 
 
 def test_skills_config_allows_declared_paths_that_do_not_exist(tmp_path):

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -1,4 +1,6 @@
 import inspect
+import json
+from pathlib import Path
 
 from config.loader import AgentLoader
 from config.schema import SkillsConfig
@@ -27,3 +29,11 @@ def test_config_loading_does_not_create_skill_directories() -> None:
 
     assert "mkdir" not in loader_source
     assert "path.exists()" not in skills_config_source
+
+
+def test_runtime_defaults_do_not_read_host_skill_directory() -> None:
+    runtime_defaults_path = Path(__file__).parents[3] / "config" / "defaults" / "runtime.json"
+    runtime_defaults = json.loads(runtime_defaults_path.read_text())
+
+    assert runtime_defaults["skills"]["paths"] == []
+    assert AgentLoader().load().skills.paths == []


### PR DESCRIPTION
## Summary

This cuts the remaining default host-directory Skill source from runtime configuration.

- `config/defaults/runtime.json` now defaults `skills.paths` to `[]`.
- `SkillsConfig.paths` now has an empty default and is described as explicit search paths.
- Config/runtime contract tests pin the no-default-host-directory invariant.
- EN/ZH configuration docs now show `paths: []` and point product flows to Hub/Library-managed Skills.

Explicit file Skill paths still work when declared. They are no longer implied by runtime defaults or schema construction.

## Verification

```bash
uv run pytest tests/Config/test_loader_skill_dir_boundary.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py tests/Unit/integration_contracts/test_leon_agent.py tests/Unit/core/test_skills_service.py -q
# 62 passed

uv run pytest tests/Unit -q
# 1718 passed, 3 skipped

uv run ruff check . && uv run ruff format --check .
# All checks passed
# 638 files already formatted

cd frontend/app && npm run lint
# passed

cd frontend/app && npx tsc -b --noEmit
# passed

cd frontend/app && npx vitest run
# 51 files passed, 231 tests passed
```
