### PR TITLE
Remove runtime Skill path configuration

### DIFF
--- a/config/defaults/runtime.json
+++ b/config/defaults/runtime.json
@@ -64,10 +64,5 @@
   "mcp": {
     "enabled": true,
     "servers": {}
-  },
-  "skills": {
-    "enabled": true,
-    "paths": [],
-    "skills": {}
   }
 }

--- a/config/loader.py
+++ b/config/loader.py
@@ -61,9 +61,10 @@ class AgentLoader:
             project_config.get("tools", {}),
         )
 
-        # Lookup strategy for mcp/skills (first found wins)
+        self._reject_removed_runtime_key("skills", system_config, user_config, project_config)
+
+        # Lookup strategy for mcp (first found wins)
         merged_mcp = self._lookup_merge("mcp", project_config, user_config, system_config)
-        merged_skills = self._lookup_merge("skills", project_config, user_config, system_config)
 
         system_prompt = project_config.get("system_prompt") or user_config.get("system_prompt") or system_config.get("system_prompt")
 
@@ -72,7 +73,6 @@ class AgentLoader:
             "memory": merged_memory,
             "tools": merged_tools,
             "mcp": merged_mcp,
-            "skills": merged_skills,
             "system_prompt": system_prompt,
         }
 
@@ -213,6 +213,12 @@ class AgentLoader:
             if key in config and config[key] is not None:
                 return config[key]
         return {}
+
+    @staticmethod
+    def _reject_removed_runtime_key(key: str, *configs: dict[str, Any]) -> None:
+        for config in configs:
+            if key in config:
+                raise ValueError(f"runtime.json must not define top-level {key!r}; assign Skills through AgentConfig.")
 
     def _expand_env_vars(self, obj: Any) -> Any:
         """Recursively expand ${VAR} and ~ in string values."""

--- a/config/schema.py
+++ b/config/schema.py
@@ -200,19 +200,6 @@ class MCPConfig(BaseModel):
 
 
 # ============================================================================
-# Skills Configuration
-# ============================================================================
-
-
-class SkillsConfig(BaseModel):
-    """Skills configuration."""
-
-    enabled: bool = True
-    paths: list[str] = Field(default_factory=list, description="Explicit Skill search paths")
-    skills: dict[str, bool] = Field(default_factory=dict, description="Skill enable/disable map")
-
-
-# ============================================================================
 # Main Settings
 # ============================================================================
 
@@ -237,7 +224,6 @@ class LeonSettings(BaseModel):
     memory: MemoryConfig = Field(default_factory=lambda: MemoryConfig(), description="Memory management")
     tools: ToolsConfig = Field(default_factory=lambda: ToolsConfig(), description="Tools configuration")
     mcp: MCPConfig = Field(default_factory=lambda: MCPConfig(), description="MCP configuration")
-    skills: SkillsConfig = Field(default_factory=lambda: SkillsConfig(), description="Skills configuration")
 
     # Agent configuration
     system_prompt: str | None = Field(None, description="Custom system prompt")

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1158,23 +1158,17 @@ class LeonAgent:
 
         # Skills tools
         resolved_skills = []
-        has_repo_backed_agent_config = getattr(self, "_resolved_agent_config", None) is not None
-        if has_repo_backed_agent_config:
+        if getattr(self, "_resolved_agent_config", None) is not None:
             resolved_skills = [
                 {"name": skill.name, "content": skill.content, "files": skill.files, "meta": skill.source}
                 for skill in self._resolved_agent_config.skills
             ]
-        inline_skills = resolved_skills
-        skill_paths = [] if has_repo_backed_agent_config else self.config.skills.paths if self.config.skills.enabled else []
-        if skill_paths or inline_skills:
-            enabled_skills = self.config.skills.skills
-            if resolved_skills:
-                enabled_skills = {skill["name"]: True for skill in resolved_skills}
+        if resolved_skills:
             self._skills_service = SkillsService(
                 registry=self._tool_registry,
-                skill_paths=skill_paths,
-                enabled_skills=enabled_skills,
-                inline_skills=inline_skills,
+                skill_paths=[],
+                enabled_skills={skill["name"]: True for skill in resolved_skills},
+                inline_skills=resolved_skills,
             )
 
         # Task tools (DEFERRED - discoverable via tool_search)
@@ -1384,7 +1378,7 @@ class LeonAgent:
 
         return self._get_cached_prompt_section(
             "common_sections",
-            lambda: build_common_sections(bool(self.config.skills.enabled and self.config.skills.paths)),
+            build_common_sections,
         )
 
     def invoke(self, message: str, thread_id: str = "default") -> dict:

--- a/core/runtime/prompts.py
+++ b/core/runtime/prompts.py
@@ -201,5 +201,5 @@ _AGENT_TOOL_SECTION = """
 """
 
 
-def build_common_sections(skills_enabled: bool) -> str:
+def build_common_sections() -> str:
     return _AGENT_TOOL_SECTION

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -1,9 +1,9 @@
 ---
 title: Configuration
 sidebarTitle: Configuration
-description: runtime.json, models.json, Skills, advanced integrations, and environment variables
+description: runtime.json, models.json, advanced integrations, and environment variables
 icon: sliders
-keywords: [runtime.json, models.json, MCP, skills, configuration, environment variables, memory]
+keywords: [runtime.json, models.json, MCP, configuration, environment variables, memory]
 ---
 
 Mycel uses a split configuration system with three-tier merge: system defaults → user config (`~/.leon/`) → project config (`.leon/` in workspace root). CLI arguments override everything.
@@ -16,7 +16,7 @@ Mycel uses a split configuration system with three-tier merge: system defaults �
 
     | File | Purpose |
     |------|---------|
-    | `runtime.json` | Tools, memory, skills, advanced integrations, security |
+    | `runtime.json` | Tools, memory, advanced integrations, security |
     | `models.json` | Providers, API keys, model mapping |
     | `observation.json` | Langfuse / LangSmith tracing |
   </div>
@@ -38,7 +38,7 @@ Mycel uses a split configuration system with three-tier merge: system defaults �
 | Domain | Strategy |
 |--------|----------|
 | `runtime`, `memory`, `tools` | Deep merge — higher-priority tiers override individual fields |
-| `skills`, `mcp` | Lookup — first tier that defines a key wins; no merging |
+| `mcp` | Lookup — first tier that defines a key wins; no merging |
 | `system_prompt` | Lookup — project → user → system |
 | `providers`, `mapping` (models.json) | Deep merge per-key |
 | `pool` (models.json) | Last wins — no list merging |
@@ -227,26 +227,6 @@ MODEL_NAME=claude-sonnet-4-5-20250929
     `based_on` tells Mycel which tokenizer to use. `context_limit` overrides auto-detection.
   </Accordion>
 </AccordionGroup>
-
-## Skills
-
-```json
-{
-  "skills": {
-    "enabled": true,
-    "paths": [],
-    "skills": {
-      "code-review": true,
-      "debugging": false
-    }
-  }
-}
-```
-
-<Warning>
-  Runtime config does not read a default host directory. Use Hub/Library managed Skills for product flows, or declare explicit
-  `paths` only for controlled file-based development and import workflows.
-</Warning>
 
 ## Advanced MCP servers
 

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -1,9 +1,9 @@
 ---
 title: 配置参考
 sidebarTitle: 配置
-description: runtime.json、models.json、Skills、高级集成和环境变量
+description: runtime.json、models.json、高级集成和环境变量
 icon: sliders
-keywords: [runtime.json, models.json, MCP, skills, 配置, 环境变量, 记忆]
+keywords: [runtime.json, models.json, MCP, 配置, 环境变量, 记忆]
 ---
 
 Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置（`~/.leon/`）→ 项目配置（工作区根目录下的 `.leon/`）。CLI 参数优先级最高，覆盖一切。
@@ -12,7 +12,7 @@ Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置
 
 | 文件 | 用途 |
 |------|------|
-| `runtime.json` | 工具、记忆、Skills、高级集成、安全 |
+| `runtime.json` | 工具、记忆、高级集成、安全 |
 | `models.json` | 模型身份、提供商、API Key、虚拟模型映射 |
 | `observation.json` | Langfuse / LangSmith 追踪 |
 | `config.env` | 快速 API Key 配置（加载为环境变量） |
@@ -28,7 +28,7 @@ Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置
 | 域 | 策略 |
 |----|------|
 | `runtime`、`memory`、`tools` | 深度合并 — 高优先级层的字段覆盖低优先级层 |
-| `skills`、`mcp` | 查找优先 — 首个定义某 key 的层级获胜，不合并 |
+| `mcp` | 查找优先 — 首个定义某 key 的层级获胜，不合并 |
 | `system_prompt` | 查找 — 项目 → 用户 → 系统 |
 | `providers`、`mapping`（models.json） | 按 key 深度合并 |
 | `pool`（models.json） | 最后者胜 — 不合并列表 |
@@ -46,7 +46,7 @@ MODEL_NAME=claude-sonnet-4-5-20250929
 
 ## runtime.json
 
-控制 Agent 行为、工具、记忆、Skills 和高级集成。
+控制 Agent 行为、工具、记忆和高级集成。
 
 ```json
 {
@@ -73,8 +73,7 @@ MODEL_NAME=claude-sonnet-4-5-20250929
   },
   "system_prompt": null,
   "tools": { ... },
-  "mcp": { "enabled": true, "servers": {} },
-  "skills": { "enabled": true, "paths": [], "skills": {} }
+  "mcp": { "enabled": true, "servers": {} }
 }
 ```
 
@@ -215,27 +214,6 @@ Mycel 提供四个 `leon:*` 别名：
   }
 }
 ```
-
-## Skills
-
-Skills 是可加载的专业能力模块 — 按需注入专业指令的 Markdown 文件。
-
-```json
-{
-  "skills": {
-    "enabled": true,
-    "paths": [],
-    "skills": {
-      "code-review": true,
-      "debugging": false
-    }
-  }
-}
-```
-
-运行时配置不会读取默认宿主机目录。产品链路应使用 Hub/Library 管理的 Skills；只有受控的文件开发和导入流程才显式声明 `paths`。
-
-Agent 在运行时加载：`load_skill("code-review")`。
 
 ## 高级 MCP 服务器
 

--- a/tests/Config/test_loader_skill_dir_boundary.py
+++ b/tests/Config/test_loader_skill_dir_boundary.py
@@ -1,8 +1,7 @@
 from config.loader import AgentLoader
-from config.schema import SkillsConfig
 
 
-def test_load_has_no_default_home_skill_dir(monkeypatch, tmp_path):
+def test_load_has_no_runtime_skill_config(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     expected_path = tmp_path / ".leon" / "skills"
     assert not expected_path.exists()
@@ -10,13 +9,19 @@ def test_load_has_no_default_home_skill_dir(monkeypatch, tmp_path):
     settings = AgentLoader().load()
 
     assert not expected_path.exists()
-    assert settings.skills.paths == []
+    assert not hasattr(settings, "skills")
 
 
-def test_skills_config_allows_declared_paths_that_do_not_exist(tmp_path):
-    missing_path = tmp_path / "missing-skills"
+def test_runtime_skill_config_key_fails_loudly(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project_root = tmp_path / "project"
+    runtime_dir = project_root / ".leon"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "runtime.json").write_text('{"skills": {"paths": []}}', encoding="utf-8")
 
-    config = SkillsConfig(paths=[str(missing_path)])
-
-    assert config.paths == [str(missing_path)]
-    assert not missing_path.exists()
+    try:
+        AgentLoader(project_root).load()
+    except ValueError as exc:
+        assert "runtime.json must not define top-level 'skills'" in str(exc)
+    else:
+        raise AssertionError("AgentLoader accepted removed runtime skills config")

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -3,7 +3,6 @@ import json
 from pathlib import Path
 
 from config.loader import AgentLoader
-from config.schema import SkillsConfig
 from core.runtime.agent import LeonAgent
 
 
@@ -15,25 +14,23 @@ def test_runtime_api_has_no_process_local_agent_config_source() -> None:
     assert blocked_loader not in vars(AgentLoader)
 
 
-def test_repo_backed_skill_registration_does_not_read_configured_skill_paths() -> None:
+def test_runtime_skill_registration_reads_resolved_config_only() -> None:
     source = inspect.getsource(LeonAgent._init_services)
-    blocked_assignment = "skill_paths = " + "self.config.skills.paths"
 
-    assert blocked_assignment not in source
-    assert "has_repo_backed_agent_config" in source
+    assert "self.config.skills" not in source
+    assert "skill_paths=[]" in source
+    assert "resolved_skills" in source
 
 
 def test_config_loading_does_not_create_skill_directories() -> None:
     loader_source = inspect.getsource(AgentLoader.load)
-    skills_config_source = inspect.getsource(SkillsConfig)
 
     assert "mkdir" not in loader_source
-    assert "path.exists()" not in skills_config_source
 
 
-def test_runtime_defaults_do_not_read_host_skill_directory() -> None:
+def test_runtime_defaults_do_not_define_skill_runtime_config() -> None:
     runtime_defaults_path = Path(__file__).parents[3] / "config" / "defaults" / "runtime.json"
     runtime_defaults = json.loads(runtime_defaults_path.read_text())
 
-    assert runtime_defaults["skills"]["paths"] == []
-    assert AgentLoader().load().skills.paths == []
+    assert "skills" not in runtime_defaults
+    assert not hasattr(AgentLoader().load(), "skills")

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -59,16 +59,11 @@ def _agent_config(**overrides: object) -> AgentConfig:
     return AgentConfig(**data)
 
 
-def _write_configured_file_skill(tmp_path, *, name: str, body: str, description: str = "configured file skill") -> None:
+def _write_file_skill_dir(tmp_path, *, name: str, body: str, description: str = "file skill") -> None:
     skill_dir = tmp_path / "file-skills" / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {name}\ndescription: {description}\n---\n{body}",
-        encoding="utf-8",
-    )
-    (tmp_path / ".leon").mkdir()
-    (tmp_path / ".leon" / "runtime.json").write_text(
-        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "file-skills")], "skills": {}}}),
         encoding="utf-8",
     )
 
@@ -763,10 +758,10 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_agent_config_id_does_not_register_configured_file_skills(tmp_path):
+async def test_leon_agent_agent_config_id_does_not_register_host_file_skills(tmp_path):
     from core.runtime.agent import LeonAgent
 
-    _write_configured_file_skill(
+    _write_file_skill_dir(
         tmp_path,
         name="DiskOnly",
         body="Use host-local state.",
@@ -815,10 +810,10 @@ async def test_leon_agent_agent_config_id_does_not_register_configured_file_skil
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_empty_agent_config_skills_do_not_enable_configured_file_skills(tmp_path):
+async def test_leon_agent_empty_agent_config_skills_do_not_enable_host_file_skills(tmp_path):
     from core.runtime.agent import LeonAgent
 
-    _write_configured_file_skill(
+    _write_file_skill_dir(
         tmp_path,
         name="DiskOnly",
         body="Use host-local state.",
@@ -853,37 +848,29 @@ async def test_leon_agent_empty_agent_config_skills_do_not_enable_configured_fil
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_default_runtime_still_registers_configured_file_skills(tmp_path):
+async def test_leon_agent_default_runtime_rejects_runtime_skill_config(tmp_path):
     from core.runtime.agent import LeonAgent
 
-    _write_configured_file_skill(
+    _write_file_skill_dir(
         tmp_path,
         name="FileSkill",
         body="Use configured local guidance.",
         description="local runtime skill",
     )
+    (tmp_path / ".leon").mkdir()
+    (tmp_path / ".leon" / "runtime.json").write_text(
+        json.dumps({"skills": {"enabled": True, "paths": [str(tmp_path / "file-skills")], "skills": {}}}),
+        encoding="utf-8",
+    )
 
-    mock_model = _mock_model("File skill response")
-
-    with (
-        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
-        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
-        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
-        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
-    ):
+    with pytest.raises(ValueError, match="runtime.json must not define top-level 'skills'"):
         agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
-        await agent.ainit()
-
-        skill_tool = agent._tool_registry.get("load_skill")
-        assert skill_tool is not None
-        assert skill_tool.handler("FileSkill") == "Loaded skill: FileSkill\n\nUse configured local guidance."
-
         agent.close()
 
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_default_runtime_ignores_missing_configured_file_skill_path(tmp_path):
+async def test_leon_agent_default_runtime_rejects_missing_runtime_skill_path(tmp_path):
     from core.runtime.agent import LeonAgent
 
     missing_skills = tmp_path / "missing-file-skills"
@@ -893,26 +880,15 @@ async def test_leon_agent_default_runtime_ignores_missing_configured_file_skill_
         encoding="utf-8",
     )
 
-    mock_model = _mock_model("No file skill response")
-
-    with (
-        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
-        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
-        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
-        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
-    ):
+    with pytest.raises(ValueError, match="runtime.json must not define top-level 'skills'"):
         agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
-        await agent.ainit()
-
-        assert not missing_skills.exists()
-        assert agent._tool_registry.get("load_skill") is None
-
         agent.close()
+    assert not missing_skills.exists()
 
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_agent_config_skills_ignore_file_skill_toggle(tmp_path):
+async def test_leon_agent_agent_config_id_rejects_stale_runtime_skill_toggle(tmp_path):
     from core.runtime.agent import LeonAgent
 
     leon_dir = tmp_path / ".leon"
@@ -936,26 +912,13 @@ async def test_leon_agent_agent_config_skills_ignore_file_skill_toggle(tmp_path)
                 ],
             )
 
-    mock_model = _mock_model("Repo skill response")
-
-    with (
-        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
-        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
-        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
-        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
-    ):
+    with pytest.raises(ValueError, match="runtime.json must not define top-level 'skills'"):
         agent = LeonAgent(
             workspace_root=str(tmp_path),
             agent_config_id="cfg-1",
             agent_config_repo=_Repo(),
             api_key="sk-test-integration",
         )
-        await agent.ainit()
-
-        skill_tool = agent._tool_registry.get("load_skill")
-        assert skill_tool is not None
-        assert skill_tool.handler("FastAPI") == "Loaded skill: FastAPI\n\nAlways use APIRouter."
-
         agent.close()
 
 
@@ -1345,7 +1308,6 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
             web=SimpleNamespace(enabled=False),
             command=SimpleNamespace(enabled=False),
         ),
-        skills=SimpleNamespace(enabled=False, paths=[], skills={}),
     )
 
     LeonAgent._init_services(agent)
@@ -1407,7 +1369,6 @@ def test_leon_agent_init_services_passes_child_thread_live_runner(monkeypatch: p
             web=SimpleNamespace(enabled=False),
             command=SimpleNamespace(enabled=False),
         ),
-        skills=SimpleNamespace(enabled=False, paths=[], skills={}),
     )
 
     LeonAgent._init_services(agent)


### PR DESCRIPTION
## Summary

This hard-cuts runtime Skill path configuration.

- Removes top-level `skills` from `config/defaults/runtime.json` and `LeonSettings`.
- Makes `AgentLoader.load()` fail loudly if any runtime config tier defines top-level `skills`.
- Makes `LeonAgent` register `load_skill` only from `ResolvedAgentConfig.skills`.
- Removes the unused Skill toggle argument from common prompt section construction.
- Updates boundary tests and EN/ZH configuration docs so runtime Skill paths are no longer a product/config model.

The remaining file-based Skill reader is not wired into Agent runtime; it stays covered as a low-level parser/import surface.

## Verification

```bash
uv run pytest tests/Config/test_loader_skill_dir_boundary.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py tests/Unit/integration_contracts/test_leon_agent.py tests/Unit/core/test_skills_service.py -q
# 62 passed

uv run pytest tests/Unit -q
# 1718 passed, 3 skipped

uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q
# 1770 passed, 8 skipped

uv run ruff check . && uv run ruff format --check .
# All checks passed
# 638 files already formatted

cd frontend/app && npm run lint
# passed

cd frontend/app && npx tsc -b --noEmit
# passed

cd frontend/app && npx vitest run
# 51 files passed, 231 tests passed

cd frontend/app && npm run build
# built successfully; Vite reported the existing chunk-size warning

uv run pyright
# failed with 372 existing repository type errors; CI runs pyright with continue-on-error
```
