### PR TITLE
feat: add chat join requests

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict
 
 from backend.chat.api.http.dependencies import (
     get_chat_event_bus,
+    get_chat_join_request_service,
     get_chat_repo,
     get_contact_repo,
     get_current_user_id,
@@ -43,6 +44,27 @@ class MuteChatBody(BaseModel):
     user_id: str
     muted: bool
     mute_until: float | None = None
+
+
+class ChatJoinRequestBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    message: str | None = None
+
+
+class ChatJoinRequestActionBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    pass
+
+
+def _map_chat_join_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, LookupError):
+        return HTTPException(404, str(exc))
+    if isinstance(exc, PermissionError):
+        return HTTPException(403, str(exc))
+    if isinstance(exc, ValueError):
+        return HTTPException(409, str(exc))
+    raise exc
 
 
 def _verify_user_ownership(messaging_service: Any, sender_id: str, user_id: str) -> None:
@@ -196,6 +218,59 @@ def list_messages(
     if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
     return messaging_service.list_message_responses(chat_id, limit=limit, before=before, viewer_id=user_id)
+
+
+@router.get("/{chat_id}/join-requests")
+def list_chat_join_requests(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_join_request_service: Annotated[Any, Depends(get_chat_join_request_service)],
+):
+    try:
+        return chat_join_request_service.list_for_chat(chat_id, user_id)
+    except Exception as exc:
+        raise _map_chat_join_error(exc) from exc
+
+
+@router.post("/{chat_id}/join-requests")
+def request_chat_join(
+    chat_id: str,
+    body: ChatJoinRequestBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_join_request_service: Annotated[Any, Depends(get_chat_join_request_service)],
+):
+    try:
+        return chat_join_request_service.request(chat_id, user_id, body.message)
+    except Exception as exc:
+        raise _map_chat_join_error(exc) from exc
+
+
+@router.post("/{chat_id}/join-requests/{request_id}/approve")
+def approve_chat_join(
+    chat_id: str,
+    request_id: str,
+    body: ChatJoinRequestActionBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_join_request_service: Annotated[Any, Depends(get_chat_join_request_service)],
+):
+    try:
+        return chat_join_request_service.approve(chat_id, request_id, user_id)
+    except Exception as exc:
+        raise _map_chat_join_error(exc) from exc
+
+
+@router.post("/{chat_id}/join-requests/{request_id}/reject")
+def reject_chat_join(
+    chat_id: str,
+    request_id: str,
+    body: ChatJoinRequestActionBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_join_request_service: Annotated[Any, Depends(get_chat_join_request_service)],
+):
+    try:
+        return chat_join_request_service.reject(chat_id, request_id, user_id)
+    except Exception as exc:
+        raise _map_chat_join_error(exc) from exc
 
 
 @router.post("/{chat_id}/messages")

--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -33,6 +33,11 @@ def get_relationship_service(app: Annotated[Any, Depends(get_app)]) -> Any:
     return runtime_state.relationship_service
 
 
+def get_chat_join_request_service(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat join request service unavailable")
+    return runtime_state.chat_join_request_service
+
+
 def get_user_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "user_repo", "User repo unavailable")
 

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -6,6 +6,7 @@ from typing import Any
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.chat_inlet import make_chat_delivery_fn
 from messaging.delivery.resolver import HireVisitDeliveryResolver
+from messaging.join_requests import ChatJoinRequestService
 from messaging.realtime.events import ChatEventBus
 from messaging.realtime.typing import TypingTracker
 from messaging.relationships.service import RelationshipService
@@ -19,6 +20,7 @@ class ChatRuntimeState:
     contact_repo: Any
     typing_tracker: Any
     relationship_service: Any
+    chat_join_request_service: Any
     messaging_service: Any
 
 
@@ -34,6 +36,7 @@ def attach_chat_runtime(
     chat_member_repo = storage_container.chat_member_repo()
     messages_repo = storage_container.messages_repo()
     relationship_repo = storage_container.relationship_repo()
+    chat_join_request_repo = storage_container.chat_join_request_repo()
     chat_event_bus = ChatEventBus()
     typing_tracker = TypingTracker(chat_event_bus)
     relationship_service = RelationshipService(relationship_repo)
@@ -54,6 +57,12 @@ def attach_chat_runtime(
         delivery_resolver=delivery_resolver,
         avatar_url_builder=avatar_url,
     )
+    chat_join_request_service = ChatJoinRequestService(
+        chat_repo=chat_repo,
+        chat_member_repo=chat_member_repo,
+        chat_join_request_repo=chat_join_request_repo,
+        messaging_service=messaging_service,
+    )
 
     # @@@chat-bootstrap-borrowable-state - chat bootstrap now keeps its owned
     # runtime objects inside the returned chat_runtime_state so the app
@@ -64,6 +73,7 @@ def attach_chat_runtime(
         contact_repo=contact_repo,
         typing_tracker=typing_tracker,
         relationship_service=relationship_service,
+        chat_join_request_service=chat_join_request_service,
         messaging_service=messaging_service,
     )
     app.state.chat_runtime_state = state

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class ChatJoinRequestService:
+    def __init__(
+        self,
+        *,
+        chat_repo: Any,
+        chat_member_repo: Any,
+        chat_join_request_repo: Any,
+        messaging_service: Any,
+    ) -> None:
+        self._chats = chat_repo
+        self._members = chat_member_repo
+        self._requests = chat_join_request_repo
+        self._messaging = messaging_service
+
+    def request(self, chat_id: str, requester_user_id: str, message: str | None = None) -> dict[str, Any]:
+        chat = self._require_joinable_chat(chat_id)
+        if self._members.is_member(chat_id, requester_user_id):
+            raise ValueError("Already a participant of this chat")
+        row = self._requests.upsert_request(chat_id, requester_user_id, message=message)
+        owner_id = chat.created_by_user_id
+        self._messaging.send(
+            chat_id,
+            requester_user_id,
+            self._request_notification(requester_user_id, message),
+            message_type="notification",
+            mentions=[owner_id],
+        )
+        return row
+
+    def list_for_chat(self, chat_id: str, viewer_user_id: str) -> list[dict[str, Any]]:
+        self._require_chat_owner(chat_id, viewer_user_id)
+        return self._requests.list_for_chat(chat_id)
+
+    def approve(self, chat_id: str, request_id: str, approver_user_id: str) -> dict[str, Any]:
+        self._require_chat_owner(chat_id, approver_user_id)
+        request = self._require_pending_request(chat_id, request_id)
+        requester_user_id = request["requester_user_id"]
+        self._members.add_member(chat_id, requester_user_id)
+        row = self._requests.set_state(request_id, state="approved", decided_by_user_id=approver_user_id)
+        self._messaging.send(
+            chat_id,
+            approver_user_id,
+            f"Approved chat join request for {requester_user_id}.",
+            message_type="notification",
+            mentions=[requester_user_id],
+        )
+        return row
+
+    def reject(self, chat_id: str, request_id: str, rejecter_user_id: str) -> dict[str, Any]:
+        self._require_chat_owner(chat_id, rejecter_user_id)
+        request = self._require_pending_request(chat_id, request_id)
+        requester_user_id = request["requester_user_id"]
+        row = self._requests.set_state(request_id, state="rejected", decided_by_user_id=rejecter_user_id)
+        self._messaging.send(
+            chat_id,
+            rejecter_user_id,
+            f"Rejected chat join request for {requester_user_id}.",
+            message_type="notification",
+        )
+        return row
+
+    def _require_joinable_chat(self, chat_id: str) -> Any:
+        chat = self._chats.get_by_id(chat_id)
+        if chat is None:
+            raise LookupError("Chat not found")
+        if chat.type != "group":
+            raise ValueError("Join requests are only supported for group chats")
+        if chat.status != "active":
+            raise ValueError("Chat is not active")
+        return chat
+
+    def _require_chat_owner(self, chat_id: str, user_id: str) -> Any:
+        chat = self._require_joinable_chat(chat_id)
+        if chat.created_by_user_id != user_id:
+            raise PermissionError("Only the chat owner can manage join requests")
+        return chat
+
+    def _require_pending_request(self, chat_id: str, request_id: str) -> dict[str, Any]:
+        request = self._requests.get_by_id(request_id)
+        if request is None or request.get("chat_id") != chat_id:
+            raise LookupError("Chat join request not found")
+        if request.get("state") != "pending":
+            raise ValueError("Chat join request is not pending")
+        return request
+
+    def _request_notification(self, requester_user_id: str, message: str | None) -> str:
+        if message and message.strip():
+            return f"{requester_user_id} requested to join this chat: {message.strip()}"
+        return f"{requester_user_id} requested to join this chat."

--- a/storage/container.py
+++ b/storage/container.py
@@ -54,6 +54,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "recipe_repo": ("storage.providers.supabase.recipe_repo", "SupabaseRecipeRepo"),
     "chat_repo": ("storage.providers.supabase.chat_repo", "SupabaseChatRepo"),
     "chat_member_repo": ("storage.providers.supabase.messaging_repo", "SupabaseChatMemberRepo"),
+    "chat_join_request_repo": ("storage.providers.supabase.messaging_repo", "SupabaseChatJoinRequestRepo"),
     "messages_repo": ("storage.providers.supabase.messaging_repo", "SupabaseMessagesRepo"),
     "relationship_repo": ("storage.providers.supabase.messaging_repo", "SupabaseRelationshipRepo"),
     "invite_code_repo": ("storage.providers.supabase.invite_code_repo", "SupabaseInviteCodeRepo"),
@@ -143,6 +144,9 @@ class StorageContainer:
 
     def chat_member_repo(self) -> Any:
         return self._build("chat_member_repo")
+
+    def chat_join_request_repo(self) -> Any:
+        return self._build("chat_join_request_repo")
 
     def messages_repo(self) -> Any:
         return self._build("messages_repo")

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -243,6 +243,25 @@ class ChatMemberRow(BaseModel):
         return value
 
 
+class ChatJoinRequestRow(BaseModel):
+    id: str
+    chat_id: str
+    requester_user_id: str
+    state: str = "pending"
+    message: str | None = None
+    decided_by_user_id: str | None = None
+    decided_at: float | None = None
+    created_at: float
+    updated_at: float | None = None
+
+    @field_validator("id", "chat_id", "requester_user_id", "state")
+    @classmethod
+    def _validate_chat_join_request_identity_fields(cls, value: str, info: Any) -> str:
+        if not value.strip():
+            raise ValueError(f"chat_join_request.{info.field_name} must not be blank")
+        return value
+
+
 class MessageRow(BaseModel):
     id: str
     chat_id: str

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -77,6 +77,57 @@ class SupabaseChatMemberRepo:
         return q.schema_table(self._client, _SCHEMA, "chat_members", "chat member repo")
 
 
+class SupabaseChatJoinRequestRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def close(self) -> None:
+        pass
+
+    def _request_id(self, chat_id: str, requester_user_id: str) -> str:
+        return f"chat_join:{chat_id}:{requester_user_id}"
+
+    def upsert_request(self, chat_id: str, requester_user_id: str, *, message: str | None = None) -> dict[str, Any]:
+        now = time.time()
+        payload = {
+            "id": self._request_id(chat_id, requester_user_id),
+            "chat_id": chat_id,
+            "requester_user_id": requester_user_id,
+            "state": "pending",
+            "message": message,
+            "decided_by_user_id": None,
+            "decided_at": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+        res = self._t().upsert(payload, on_conflict="chat_id,requester_user_id").execute()
+        return (res.data or [payload])[0]
+
+    def get_by_id(self, request_id: str) -> dict[str, Any] | None:
+        res = self._t().select("*").eq("id", request_id).limit(1).execute()
+        return res.data[0] if res.data else None
+
+    def list_for_chat(self, chat_id: str) -> list[dict[str, Any]]:
+        res = self._t().select("*").eq("chat_id", chat_id).execute()
+        return res.data or []
+
+    def set_state(self, request_id: str, *, state: str, decided_by_user_id: str) -> dict[str, Any]:
+        now = time.time()
+        payload = {
+            "state": state,
+            "decided_by_user_id": decided_by_user_id,
+            "decided_at": now,
+            "updated_at": now,
+        }
+        res = self._t().update(payload).eq("id", request_id).execute()
+        if not res.data:
+            raise RuntimeError(f"Chat join request not found: {request_id}")
+        return res.data[0]
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "join_requests", "chat join request repo")
+
+
 class SupabaseMessagesRepo:
     def __init__(self, client: Any) -> None:
         self._client = client

--- a/storage/schema/2026_04_25_chat_join_requests.sql
+++ b/storage/schema/2026_04_25_chat_join_requests.sql
@@ -1,0 +1,17 @@
+create table if not exists chat.join_requests (
+    id                  text primary key,
+    chat_id             text not null references chat.chats(id),
+    requester_user_id   text not null references identity.users(id),
+    state               text not null default 'pending' check (state in ('pending', 'approved', 'rejected')),
+    message             text,
+    decided_by_user_id  text references identity.users(id),
+    decided_at          double precision,
+    created_at          double precision not null,
+    updated_at          double precision,
+    unique (chat_id, requester_user_id)
+);
+
+grant select, insert, update, delete on chat.join_requests to service_role;
+grant select, insert, update, delete on chat.join_requests to authenticated;
+
+notify pgrst, 'reload schema';

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -16,6 +16,8 @@ def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> N
 
     assert "/api/chats" in paths
     assert "/api/chats/{chat_id}/messages/unread" in paths
+    assert "/api/chats/{chat_id}/join-requests" in paths
+    assert "/api/chats/{chat_id}/join-requests/{request_id}/approve" in paths
     assert "/api/relationships" in paths
     assert "/api/conversations" in paths
 

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -9,6 +9,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     chat_member_repo = object()
     messages_repo = object()
     relationship_repo = object()
+    chat_join_request_repo = object()
 
     storage_container = SimpleNamespace(
         chat_repo=lambda: chat_repo,
@@ -16,6 +17,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         chat_member_repo=lambda: chat_member_repo,
         messages_repo=lambda: messages_repo,
         relationship_repo=lambda: relationship_repo,
+        chat_join_request_repo=lambda: chat_join_request_repo,
     )
 
     class _EventBus:
@@ -37,6 +39,10 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         def set_delivery_fn(self, delivery_fn):
             self.delivery_fn = delivery_fn
 
+    class _ChatJoinRequestService:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
     event_bus = _EventBus()
 
     monkeypatch.setattr(chat_bootstrap, "ChatEventBus", lambda: event_bus)
@@ -44,6 +50,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     monkeypatch.setattr(chat_bootstrap, "RelationshipService", _RelationshipService)
     monkeypatch.setattr(chat_bootstrap, "HireVisitDeliveryResolver", lambda **kwargs: kwargs)
     monkeypatch.setattr(chat_bootstrap, "MessagingService", _MessagingService)
+    monkeypatch.setattr(chat_bootstrap, "ChatJoinRequestService", _ChatJoinRequestService)
     app = SimpleNamespace(
         state=SimpleNamespace(
             user_repo=object(),
@@ -64,6 +71,10 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     assert state.contact_repo is contact_repo
     assert state.typing_tracker.event_bus is event_bus
     assert state.relationship_service.repo is relationship_repo
+    assert state.chat_join_request_service.kwargs["chat_join_request_repo"] is chat_join_request_repo
+    assert state.chat_join_request_service.kwargs["chat_repo"] is chat_repo
+    assert state.chat_join_request_service.kwargs["chat_member_repo"] is chat_member_repo
+    assert state.chat_join_request_service.kwargs["messaging_service"] is state.messaging_service
     assert state.messaging_service.kwargs["chat_repo"] is chat_repo
     assert state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
     assert state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
@@ -78,6 +89,7 @@ def test_attach_chat_runtime_requires_explicit_user_repo_and_thread_repo():
         chat_member_repo=lambda: object(),
         messages_repo=lambda: object(),
         relationship_repo=lambda: object(),
+        chat_join_request_repo=lambda: object(),
     )
 
     try:

--- a/tests/Unit/backend/test_chat_http_dependencies.py
+++ b/tests/Unit/backend/test_chat_http_dependencies.py
@@ -24,11 +24,13 @@ def test_chat_http_dependencies_read_chat_runtime_state():
     contact_repo = object()
     chat_repo = object()
     chat_event_bus = object()
+    chat_join_request_service = object()
 
     app = _app_state(
         chat_runtime_state=SimpleNamespace(
             messaging_service=messaging_service,
             relationship_service=relationship_service,
+            chat_join_request_service=chat_join_request_service,
             contact_repo=contact_repo,
             chat_repo=chat_repo,
             chat_event_bus=chat_event_bus,
@@ -37,6 +39,7 @@ def test_chat_http_dependencies_read_chat_runtime_state():
 
     assert chat_http_dependencies.get_messaging_service(app) is messaging_service
     assert chat_http_dependencies.get_relationship_service(app) is relationship_service
+    assert chat_http_dependencies.get_chat_join_request_service(app) is chat_join_request_service
     assert chat_http_dependencies.get_contact_repo(app) is contact_repo
     assert chat_http_dependencies.get_chat_repo(app) is chat_repo
     assert chat_http_dependencies.get_chat_event_bus(app) is chat_event_bus

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -135,6 +135,73 @@ def test_relationship_bodies_do_not_accept_identity_fields() -> None:
         relationships_router.RelationshipRequestBody.model_validate({"target_user_id": "user-2", "actor_user_id": "user-1"})
 
 
+def test_chat_join_request_bodies_do_not_accept_identity_fields() -> None:
+    request_body = chats_router.ChatJoinRequestBody(message="please add me")
+    action_body = chats_router.ChatJoinRequestActionBody()
+
+    assert request_body.message == "please add me"
+    assert action_body.model_dump() == {}
+    with pytest.raises(ValidationError):
+        chats_router.ChatJoinRequestBody.model_validate({"message": "please add me", "requester_user_id": "user-1"})
+    with pytest.raises(ValidationError):
+        chats_router.ChatJoinRequestActionBody.model_validate({"requester_user_id": "user-1"})
+    with pytest.raises(ValidationError):
+        chats_router.ChatJoinRequestBody.model_validate({"message": "please add me", "actor_user_id": "user-1"})
+
+
+def test_request_chat_join_uses_current_token_user() -> None:
+    seen: list[tuple[str, str, str | None]] = []
+    expected = {
+        "id": "join-request-1",
+        "chat_id": "chat-1",
+        "requester_user_id": "human-user-2",
+        "state": "pending",
+        "message": "please add me",
+        "created_at": 123.0,
+        "updated_at": 123.0,
+    }
+    chat_join_request_service = SimpleNamespace(
+        request=lambda chat_id, requester_user_id, message=None: seen.append((chat_id, requester_user_id, message)) or expected
+    )
+
+    result = chats_router.request_chat_join(
+        "chat-1",
+        chats_router.ChatJoinRequestBody(message="please add me"),
+        user_id="human-user-2",
+        chat_join_request_service=chat_join_request_service,
+    )
+
+    assert seen == [("chat-1", "human-user-2", "please add me")]
+    assert result == expected
+
+
+def test_approve_chat_join_uses_current_token_user() -> None:
+    seen: list[tuple[str, str, str]] = []
+    expected = {
+        "id": "join-request-1",
+        "chat_id": "chat-1",
+        "requester_user_id": "human-user-2",
+        "state": "approved",
+        "message": "please add me",
+        "created_at": 123.0,
+        "updated_at": 124.0,
+    }
+    chat_join_request_service = SimpleNamespace(
+        approve=lambda chat_id, request_id, approver_user_id: seen.append((chat_id, request_id, approver_user_id)) or expected
+    )
+
+    result = chats_router.approve_chat_join(
+        "chat-1",
+        "join-request-1",
+        chats_router.ChatJoinRequestActionBody(),
+        user_id="human-user-1",
+        chat_join_request_service=chat_join_request_service,
+    )
+
+    assert seen == [("chat-1", "join-request-1", "human-user-1")]
+    assert result == expected
+
+
 def test_get_accessible_chat_or_404_returns_chat():
     chat = _chat("chat-1")
     chat_repo = SimpleNamespace(get_by_id=lambda chat_id: chat if chat_id == "chat-1" else None)

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from messaging.join_requests import ChatJoinRequestService
+
+
+class _Members:
+    def __init__(self) -> None:
+        self.members: set[tuple[str, str]] = {("chat-1", "owner-1")}
+        self.added: list[tuple[str, str]] = []
+
+    def is_member(self, chat_id: str, user_id: str) -> bool:
+        return (chat_id, user_id) in self.members
+
+    def add_member(self, chat_id: str, user_id: str) -> None:
+        self.members.add((chat_id, user_id))
+        self.added.append((chat_id, user_id))
+
+
+class _Requests:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict] = {}
+
+    def upsert_request(self, chat_id: str, requester_user_id: str, *, message: str | None = None) -> dict:
+        row = {
+            "id": f"chat_join:{chat_id}:{requester_user_id}",
+            "chat_id": chat_id,
+            "requester_user_id": requester_user_id,
+            "state": "pending",
+            "message": message,
+            "created_at": 1.0,
+            "updated_at": 1.0,
+        }
+        self.rows[row["id"]] = row
+        return row
+
+    def get_by_id(self, request_id: str) -> dict | None:
+        return self.rows.get(request_id)
+
+    def list_for_chat(self, chat_id: str) -> list[dict]:
+        return [row for row in self.rows.values() if row["chat_id"] == chat_id]
+
+    def set_state(self, request_id: str, *, state: str, decided_by_user_id: str) -> dict:
+        row = self.rows[request_id]
+        row.update({"state": state, "decided_by_user_id": decided_by_user_id, "updated_at": 2.0})
+        return row
+
+
+class _Messaging:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str, str, list[str] | None]] = []
+
+    def send(self, chat_id: str, sender_id: str, content: str, *, message_type: str, mentions=None) -> dict:
+        self.sent.append((chat_id, sender_id, content, message_type, mentions))
+        return {"id": "msg-1"}
+
+
+def _service() -> tuple[ChatJoinRequestService, _Members, _Requests, _Messaging]:
+    members = _Members()
+    requests = _Requests()
+    messaging = _Messaging()
+    chats = SimpleNamespace(
+        get_by_id=lambda chat_id: (
+            SimpleNamespace(
+                id=chat_id,
+                type="group",
+                status="active",
+                created_by_user_id="owner-1",
+            )
+            if chat_id == "chat-1"
+            else None
+        )
+    )
+    return (
+        ChatJoinRequestService(
+            chat_repo=chats,
+            chat_member_repo=members,
+            chat_join_request_repo=requests,
+            messaging_service=messaging,
+        ),
+        members,
+        requests,
+        messaging,
+    )
+
+
+def test_chat_join_request_records_pending_row_and_notifies_owner() -> None:
+    service, _members, _requests, messaging = _service()
+
+    row = service.request("chat-1", "visitor-1", "please add me")
+
+    assert row["id"] == "chat_join:chat-1:visitor-1"
+    assert row["state"] == "pending"
+    assert messaging.sent == [
+        (
+            "chat-1",
+            "visitor-1",
+            "visitor-1 requested to join this chat: please add me",
+            "notification",
+            ["owner-1"],
+        )
+    ]
+
+
+def test_chat_join_approve_requires_owner_and_adds_member_before_notification() -> None:
+    service, members, _requests, messaging = _service()
+    pending = service.request("chat-1", "visitor-1", "please add me")
+
+    row = service.approve("chat-1", pending["id"], "owner-1")
+
+    assert row["state"] == "approved"
+    assert members.added == [("chat-1", "visitor-1")]
+    assert messaging.sent[-1] == (
+        "chat-1",
+        "owner-1",
+        "Approved chat join request for visitor-1.",
+        "notification",
+        ["visitor-1"],
+    )
+
+
+def test_chat_join_approve_rejects_non_owner() -> None:
+    service, _members, _requests, _messaging = _service()
+    pending = service.request("chat-1", "visitor-1", "please add me")
+
+    with pytest.raises(PermissionError):
+        service.approve("chat-1", pending["id"], "visitor-1")

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -7,6 +7,7 @@ from storage.errors import StorageConflictError
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
 from storage.providers.supabase.contact_repo import SupabaseContactRepo
 from storage.providers.supabase.messaging_repo import (
+    SupabaseChatJoinRequestRepo,
     SupabaseChatMemberRepo,
     SupabaseMessagesRepo,
     SupabaseRelationshipRepo,
@@ -283,6 +284,22 @@ def test_supabase_chat_member_repo_add_member_persists_numeric_joined_at() -> No
     assert payload["user_id"] == "user-1"
     assert client.tables["chat.chat_members"].on_conflict == "chat_id,user_id"
     assert isinstance(payload["joined_at"], float)
+
+
+def test_supabase_chat_join_request_repo_uses_chat_schema() -> None:
+    client = _FakeClient()
+    repo = SupabaseChatJoinRequestRepo(client)
+
+    repo.upsert_request("chat-1", "user-2", message="please add me")
+
+    payload = client.tables["chat.join_requests"].upsert_payload
+    assert payload is not None
+    assert payload["chat_id"] == "chat-1"
+    assert payload["requester_user_id"] == "user-2"
+    assert payload["state"] == "pending"
+    assert payload["message"] == "please add me"
+    assert client.tables["chat.join_requests"].on_conflict == "chat_id,requester_user_id"
+    assert "join_requests" not in client.tables
 
 
 def test_supabase_messages_repo_create_allocates_seq_and_uses_message_root_fields() -> None:


### PR DESCRIPTION
## Summary
- add backend-owned chat join request storage, service, and public chat routes
- enforce token-derived identity and chat-owner approval for group join requests
- write request/decision notifications into the chat message stream

## Verification
- uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Integration/test_chat_app_router.py -q
- uv run ruff check backend/chat messaging storage tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Integration/test_chat_app_router.py
- uv run ruff format --check backend/chat messaging storage tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_chat_http_dependencies.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Integration/test_chat_app_router.py
- uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q

## YATU
- live local backend on port 8042 against real Supabase
- CLI request/list/approve/read/send flow with separate owner/member/visitor profiles
- non-owner approve returned HTTP 403; owner approve admitted visitor; visitor had to read before writing