### PR TITLE
Make SkillsService package-backed only

### DIFF
--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1166,9 +1166,8 @@ class LeonAgent:
         if resolved_skills:
             self._skills_service = SkillsService(
                 registry=self._tool_registry,
-                skill_paths=[],
+                skills=resolved_skills,
                 enabled_skills={skill["name"]: True for skill in resolved_skills},
-                inline_skills=resolved_skills,
             )
 
         # Task tools (DEFERRED - discoverable via tool_search)

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any
 
 import yaml
@@ -15,49 +14,30 @@ class SkillsService:
     def __init__(
         self,
         registry: ToolRegistry,
-        skill_paths: Sequence[str | Path],
+        skills: Sequence[dict[str, Any]] | None = None,
         enabled_skills: dict[str, bool] | None = None,
-        inline_skills: Sequence[dict[str, Any]] | None = None,
     ):
-        self.skill_paths = [Path(p).expanduser().resolve() for p in skill_paths]
         self.enabled_skills = enabled_skills or {}
-        self._skills_index: dict[str, Path] = {}
-        self._inline_skills: dict[str, str] = {}
-        self._inline_skill_files: dict[str, dict[str, str]] = {}
-        self._load_skills_index()
-        self._load_inline_skills(inline_skills or [])
+        self._skills: dict[str, str] = {}
+        self._skill_files: dict[str, dict[str, str]] = {}
+        self._load_skills(skills or [])
         self._register(registry)
 
-    def _load_skills_index(self) -> None:
-        for skill_dir in self.skill_paths:
-            if not skill_dir.exists():
-                continue
-            for skill_file in skill_dir.rglob("SKILL.md"):
-                content = skill_file.read_text(encoding="utf-8")
-                metadata = self._parse_frontmatter(content)
-                skill_name = metadata.get("name")
-                if not skill_name:
-                    raise ValueError(f"File Skill content must include frontmatter name: {skill_file}")
-                self._skills_index[skill_name] = skill_file
-
-    def _load_inline_skills(self, skills: Sequence[dict[str, Any]]) -> None:
+    def _load_skills(self, skills: Sequence[dict[str, Any]]) -> None:
         for skill in skills:
             content = skill.get("content")
             if not isinstance(content, str):
-                raise ValueError("Inline Skill content must be a string")
+                raise ValueError("Skill content must be a string")
             metadata = self._parse_frontmatter(content)
             if "name" not in metadata:
-                raise ValueError("Inline Skill content must include frontmatter name")
-            # @@@repo-backed-skill-index - DB-backed Agent configs do not have a
-            # stable filesystem directory; keep their Skill content in memory
-            # while exposing the same load_skill surface as disk-backed skills.
+                raise ValueError("Skill content must include frontmatter name")
             skill_name = metadata["name"]
-            self._inline_skills[skill_name] = content
+            self._skills[skill_name] = content
             files = skill.get("files")
             if isinstance(files, dict):
-                self._inline_skill_files[skill_name] = normalize_skill_file_map(files, context="Inline Skill files")
+                self._skill_files[skill_name] = normalize_skill_file_map(files, context="Skill files")
             elif files is not None:
-                raise ValueError("Inline Skill files must be an object")
+                raise ValueError("Skill files must be an object")
 
     @staticmethod
     def _parse_frontmatter(content: str) -> dict[str, str]:
@@ -74,7 +54,7 @@ class SkillsService:
         return result
 
     def _register(self, registry: ToolRegistry) -> None:
-        if not self._skills_index and not self._inline_skills:
+        if not self._skills:
             return
 
         registry.register(
@@ -90,7 +70,7 @@ class SkillsService:
         )
 
     def _get_schema(self) -> dict:
-        available_skills = sorted({*self._skills_index.keys(), *self._inline_skills.keys()})
+        available_skills = sorted(self._skills)
         skills_list = "\n".join(f"- {name}" for name in available_skills)
 
         return make_tool_schema(
@@ -111,24 +91,15 @@ class SkillsService:
         )
 
     def _load_skill(self, skill_name: str) -> str:
-        if skill_name not in self._skills_index and skill_name not in self._inline_skills:
-            available = ", ".join(sorted({*self._skills_index.keys(), *self._inline_skills.keys()}))
+        if skill_name not in self._skills:
+            available = ", ".join(sorted(self._skills))
             raise ValueError(f"Skill '{skill_name}' not found. Available skills: {available}")
 
         if self.enabled_skills and skill_name in self.enabled_skills and not self.enabled_skills[skill_name]:
             raise ValueError(f"Skill '{skill_name}' is disabled in profile configuration.")
 
-        if skill_name in self._inline_skills:
-            content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", self._inline_skills[skill_name], flags=re.DOTALL)
-            return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._inline_skill_files.get(skill_name, {}))}"
-
-        skill_file = self._skills_index[skill_name]
-        try:
-            content = skill_file.read_text(encoding="utf-8")
-        except OSError as exc:
-            raise RuntimeError(f"Error loading Skill '{skill_name}': {exc}") from exc
-        content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", content, flags=re.DOTALL)
-        return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._read_adjacent_files(skill_file))}"
+        content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", self._skills[skill_name], flags=re.DOTALL)
+        return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._skill_files.get(skill_name, {}))}"
 
     @staticmethod
     def _append_adjacent_files(content: str, files: dict[str, str]) -> str:
@@ -136,13 +107,3 @@ class SkillsService:
             return content
         rendered_files = "\n\n".join(f"--- {path} ---\n{files[path]}" for path in sorted(files))
         return f"{content}\n\nAdjacent files:\n\n{rendered_files}"
-
-    @staticmethod
-    def _read_adjacent_files(skill_file: Path) -> dict[str, str]:
-        files: dict[str, str] = {}
-        skill_dir = skill_file.parent
-        for path in sorted(skill_dir.rglob("*")):
-            if not path.is_file() or path == skill_file:
-                continue
-            files[path.relative_to(skill_dir).as_posix()] = path.read_text(encoding="utf-8")
-        return files

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -6,46 +6,43 @@ from core.runtime.registry import ToolRegistry
 from core.tools.skills.service import SkillsService
 
 
-def test_load_file_skill_returns_adjacent_files(tmp_path) -> None:
-    skill_dir = tmp_path / "query-helper"
-    refs_dir = skill_dir / "references"
-    refs_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: query-helper\n---\nUse exact terms.", encoding="utf-8")
-    (refs_dir / "query.md").write_text("Prefer precise queries.", encoding="utf-8")
+def test_skills_service_does_not_register_without_skills() -> None:
     registry = ToolRegistry()
 
-    SkillsService(registry=registry, skill_paths=[tmp_path])
+    SkillsService(registry=registry)
 
-    entry = registry.get("load_skill")
-    assert entry is not None
-
-    result = cast(str, entry.handler("query-helper"))
-
-    assert "Loaded skill: query-helper" in result
-    assert "Use exact terms." in result
-    assert "references/query.md" in result
-    assert "Prefer precise queries." in result
+    assert registry.get("load_skill") is None
 
 
-def test_file_skill_frontmatter_uses_yaml_parser(tmp_path) -> None:
-    skill_dir = tmp_path / "query-helper"
-    skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text('---\nname: "query-helper"\n---\nUse exact terms.', encoding="utf-8")
+def test_skill_frontmatter_uses_yaml_parser() -> None:
     registry = ToolRegistry()
 
-    SkillsService(registry=registry, skill_paths=[tmp_path])
+    SkillsService(
+        registry=registry,
+        skills=[
+            {
+                "name": "query-helper",
+                "content": '---\nname: "query-helper"\n---\nUse exact terms.',
+            }
+        ],
+    )
 
     entry = registry.get("load_skill")
     assert entry is not None
     assert entry.handler("query-helper") == "Loaded skill: query-helper\n\nUse exact terms."
 
 
-def test_load_missing_skill_fails_loudly(tmp_path) -> None:
-    skill_dir = tmp_path / "query-helper"
-    skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("---\nname: query-helper\n---\nUse exact terms.", encoding="utf-8")
+def test_load_missing_skill_fails_loudly() -> None:
     registry = ToolRegistry()
-    SkillsService(registry=registry, skill_paths=[tmp_path])
+    SkillsService(
+        registry=registry,
+        skills=[
+            {
+                "name": "query-helper",
+                "content": "---\nname: query-helper\n---\nUse exact terms.",
+            }
+        ],
+    )
 
     entry = registry.get("load_skill")
     assert entry is not None
@@ -53,29 +50,13 @@ def test_load_missing_skill_fails_loudly(tmp_path) -> None:
         entry.handler("missing")
 
 
-def test_load_file_skill_read_error_fails_loudly(tmp_path) -> None:
-    skill_dir = tmp_path / "query-helper"
-    skill_dir.mkdir()
-    skill_file = skill_dir / "SKILL.md"
-    skill_file.write_text("---\nname: query-helper\n---\nUse exact terms.", encoding="utf-8")
-    registry = ToolRegistry()
-    SkillsService(registry=registry, skill_paths=[tmp_path])
-    skill_file.unlink()
-
-    entry = registry.get("load_skill")
-    assert entry is not None
-    with pytest.raises(RuntimeError, match="Error loading Skill 'query-helper'"):
-        entry.handler("query-helper")
-
-
-def test_inline_skill_without_frontmatter_name_fails_loudly() -> None:
+def test_skill_without_frontmatter_name_fails_loudly() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(ValueError, match="Inline Skill content must include frontmatter name"):
+    with pytest.raises(ValueError, match="Skill content must include frontmatter name"):
         SkillsService(
             registry=registry,
-            skill_paths=[],
-            inline_skills=[
+            skills=[
                 {
                     "name": "query-helper",
                     "content": "Use exact terms.",
@@ -84,14 +65,13 @@ def test_inline_skill_without_frontmatter_name_fails_loudly() -> None:
         )
 
 
-def test_inline_skill_without_string_content_fails_loudly() -> None:
+def test_skill_without_string_content_fails_loudly() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(ValueError, match="Inline Skill content must be a string"):
+    with pytest.raises(ValueError, match="Skill content must be a string"):
         SkillsService(
             registry=registry,
-            skill_paths=[],
-            inline_skills=[
+            skills=[
                 {
                     "name": "query-helper",
                     "content": None,
@@ -100,14 +80,13 @@ def test_inline_skill_without_string_content_fails_loudly() -> None:
         )
 
 
-def test_inline_skill_files_must_be_an_object() -> None:
+def test_skill_files_must_be_an_object() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(ValueError, match="Inline Skill files must be an object"):
+    with pytest.raises(ValueError, match="Skill files must be an object"):
         SkillsService(
             registry=registry,
-            skill_paths=[],
-            inline_skills=[
+            skills=[
                 {
                     "name": "query-helper",
                     "content": "---\nname: query-helper\n---\nUse exact terms.",
@@ -117,22 +96,11 @@ def test_inline_skill_files_must_be_an_object() -> None:
         )
 
 
-def test_file_skill_without_frontmatter_name_fails_loudly(tmp_path) -> None:
-    skill_dir = tmp_path / "broken-skill"
-    skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("Use exact terms.", encoding="utf-8")
-    registry = ToolRegistry()
-
-    with pytest.raises(ValueError, match="File Skill content must include frontmatter name"):
-        SkillsService(registry=registry, skill_paths=[tmp_path])
-
-
-def test_load_inline_skill_returns_adjacent_files() -> None:
+def test_load_skill_returns_adjacent_files() -> None:
     registry = ToolRegistry()
     SkillsService(
         registry=registry,
-        skill_paths=[],
-        inline_skills=[
+        skills=[
             {
                 "name": "query-helper",
                 "content": "---\nname: query-helper\n---\nUse exact terms.",
@@ -152,12 +120,11 @@ def test_load_inline_skill_returns_adjacent_files() -> None:
     assert "Prefer precise queries." in result
 
 
-def test_load_inline_skill_normalizes_adjacent_file_paths() -> None:
+def test_load_skill_normalizes_adjacent_file_paths() -> None:
     registry = ToolRegistry()
     SkillsService(
         registry=registry,
-        skill_paths=[],
-        inline_skills=[
+        skills=[
             {
                 "name": "query-helper",
                 "content": "---\nname: query-helper\n---\nUse exact terms.",
@@ -175,14 +142,13 @@ def test_load_inline_skill_normalizes_adjacent_file_paths() -> None:
     assert "references\\query.md" not in result
 
 
-def test_inline_skill_rejects_adjacent_file_path_collision() -> None:
+def test_skill_rejects_adjacent_file_path_collision() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(ValueError, match="Inline Skill files contain duplicate path after normalization: references/query.md"):
+    with pytest.raises(ValueError, match="Skill files contain duplicate path after normalization: references/query.md"):
         SkillsService(
             registry=registry,
-            skill_paths=[],
-            inline_skills=[
+            skills=[
                 {
                     "name": "query-helper",
                     "content": "---\nname: query-helper\n---\nUse exact terms.",

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -1,9 +1,18 @@
+import inspect
 from typing import cast
 
 import pytest
 
 from core.runtime.registry import ToolRegistry
 from core.tools.skills.service import SkillsService
+
+
+def test_skills_service_has_no_filesystem_skill_index() -> None:
+    source = inspect.getsource(SkillsService)
+
+    assert "skill_paths" not in source
+    assert "rglob" not in source
+    assert "SKILL.md" not in source
 
 
 def test_skills_service_does_not_register_without_skills() -> None:

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -18,7 +18,7 @@ def test_runtime_skill_registration_reads_resolved_config_only() -> None:
     source = inspect.getsource(LeonAgent._init_services)
 
     assert "self.config.skills" not in source
-    assert "skill_paths=[]" in source
+    assert "skill_paths" not in source
     assert "resolved_skills" in source
 
 


### PR DESCRIPTION
## Summary

This removes the last runtime-service file Skill index.

- `SkillsService` now accepts resolved Skill packages via `skills=[...]` only.
- Removed `skill_paths`, `_skills_index`, `rglob("SKILL.md")`, and adjacent file reads from the runtime service.
- `LeonAgent` passes `ResolvedAgentConfig.skills` directly into `SkillsService`.
- Rewrote Skill service tests around package-backed runtime content.
- Added a source gate proving `SkillsService` has no filesystem Skill index.

File Skill import remains in explicit import/seed scripts; it is no longer part of runtime `load_skill` service ownership.

## Verification

```bash
uv run pytest tests/Unit/core/test_skills_service.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py tests/Unit/integration_contracts/test_leon_agent.py -q
# 59 passed

uv run pytest tests/Unit -q
# 1723 passed, 3 skipped

uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q
# 1775 passed, 8 skipped

uv run ruff check . && uv run ruff format --check .
# All checks passed
# 640 files already formatted

cd frontend/app && npm run lint
# passed

cd frontend/app && npx tsc -b --noEmit
# passed

cd frontend/app && npx vitest run
# 51 files passed, 231 tests passed

cd frontend/app && npm run build
# built successfully; Vite reported the existing chunk-size warning
```
