### PR TITLE
Remove local runtime config state reads

### DIFF
--- a/config/loader.py
+++ b/config/loader.py
@@ -1,14 +1,12 @@
 """Unified agent & runtime configuration loader.
 
 Combines:
-- Three-tier runtime config merge (system > user > project) — for default agent
+- System runtime defaults plus explicit call-site overrides
 - Built-in runtime agent .md parsing (YAML frontmatter + system prompt)
 
 Configuration priority (highest to lowest):
 1. CLI overrides
-2. Project config (.leon/runtime.json in workspace)
-3. User config (~/.leon/runtime.json)
-4. System defaults (config/defaults/runtime.json)
+2. System defaults (config/defaults/runtime.json)
 """
 
 from __future__ import annotations
@@ -22,7 +20,7 @@ import yaml
 
 from config.schema import LeonSettings
 from config.types import RuntimeAgentDefinition
-from config.user_paths import remap_default_user_home_string, user_home_read_candidates
+from config.user_paths import remap_default_user_home_string
 
 logger = logging.getLogger(__name__)
 
@@ -35,46 +33,14 @@ class AgentLoader:
         self._system_defaults_dir = Path(__file__).parent / "defaults"
         self._agents: dict[str, RuntimeAgentDefinition] = {}
 
-    # ── Three-tier runtime config (unchanged) ──
+    # ── Runtime config ──
 
     def load(self, cli_overrides: dict[str, Any] | None = None) -> LeonSettings:
-        """Load runtime configuration with three-tier merge."""
+        """Load runtime configuration from system defaults and explicit overrides."""
         system_config = self._load_system_defaults()
-        user_config = self._load_user_config()
-        project_config = self._load_project_config()
+        self._reject_removed_runtime_key("skills", system_config, cli_overrides or {})
 
-        # Deep merge: runtime, memory, tools
-        merged_runtime = self._deep_merge(
-            system_config.get("runtime", {}),
-            user_config.get("runtime", {}),
-            project_config.get("runtime", {}),
-        )
-
-        merged_memory = self._deep_merge(
-            system_config.get("memory", {}),
-            user_config.get("memory", {}),
-            project_config.get("memory", {}),
-        )
-        merged_tools = self._deep_merge(
-            system_config.get("tools", {}),
-            user_config.get("tools", {}),
-            project_config.get("tools", {}),
-        )
-
-        self._reject_removed_runtime_key("skills", system_config, user_config, project_config)
-
-        # Lookup strategy for mcp (first found wins)
-        merged_mcp = self._lookup_merge("mcp", project_config, user_config, system_config)
-
-        system_prompt = project_config.get("system_prompt") or user_config.get("system_prompt") or system_config.get("system_prompt")
-
-        final_config: dict[str, Any] = {
-            "runtime": merged_runtime,
-            "memory": merged_memory,
-            "tools": merged_tools,
-            "mcp": merged_mcp,
-            "system_prompt": system_prompt,
-        }
+        final_config: dict[str, Any] = dict(system_config)
 
         if cli_overrides:
             final_config = self._deep_merge(final_config, cli_overrides)
@@ -163,19 +129,6 @@ class AgentLoader:
     def _load_system_defaults(self) -> dict[str, Any]:
         """Load system defaults from runtime.json."""
         return self._load_json(self._system_defaults_dir / "runtime.json")
-
-    def _load_user_config(self) -> dict[str, Any]:
-        """Load user config from ~/.leon/runtime.json."""
-        merged: dict[str, Any] = {}
-        for path in user_home_read_candidates("runtime.json"):
-            merged = self._deep_merge(merged, self._load_json(path))
-        return merged
-
-    def _load_project_config(self) -> dict[str, Any]:
-        """Load project config from .leon/runtime.json."""
-        if not self.workspace_root:
-            return {}
-        return self._load_json(self.workspace_root / ".leon" / "runtime.json")
 
     @staticmethod
     def _load_json(path: Path) -> dict[str, Any]:

--- a/config/schema.py
+++ b/config/schema.py
@@ -207,14 +207,12 @@ class MCPConfig(BaseModel):
 class LeonSettings(BaseModel):
     """Main Mycel runtime configuration.
 
-    Contains non-model runtime settings: memory, tools, mcp, skills, behavior params.
+    Contains non-model runtime settings: memory, tools, mcp, and behavior params.
     Model identity (model name, provider, API keys) lives in ModelsConfig.
 
     Configuration priority (highest to lowest):
     1. CLI overrides
-    2. Project config (.leon/runtime.json)
-    3. User config (~/.leon/runtime.json)
-    4. System defaults (config/defaults/runtime.json)
+    2. System defaults (config/defaults/runtime.json)
     """
 
     # Runtime behavior (replaces APIConfig model-identity fields)

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -6,13 +6,13 @@ icon: sliders
 keywords: [runtime.json, models.json, MCP, configuration, environment variables, memory]
 ---
 
-Mycel uses a split configuration system with three-tier merge: system defaults → user config (`~/.leon/`) → project config (`.leon/` in workspace root). CLI arguments override everything.
+Mycel uses split configuration files for runtime defaults, models, observation, and provider-specific infrastructure. Product runtime state is not loaded from workspace-local `runtime.json` files.
 
 ## Config file overview
 
 <Columns>
   <div>
-    **JSON config files** (three-tier merge):
+    **JSON config files:**
 
     | File | Purpose |
     |------|---------|
@@ -31,15 +31,15 @@ Mycel uses a split configuration system with three-tier merge: system defaults �
   </div>
 </Columns>
 
-**Priority** (highest to lowest): `.leon/<file>` in workspace → `~/.leon/<file>` → built-in defaults → CLI flags win over all.
+**Runtime priority:** explicit server/CLI overrides → built-in defaults.
 
 **Merge strategy per domain:**
 
 | Domain | Strategy |
 |--------|----------|
-| `runtime`, `memory`, `tools` | Deep merge — higher-priority tiers override individual fields |
-| `mcp` | Lookup — first tier that defines a key wins; no merging |
-| `system_prompt` | Lookup — project → user → system |
+| `runtime`, `memory`, `tools` | Deep merge — explicit overrides replace built-in defaults by field |
+| `mcp` | Explicit overrides replace built-in defaults |
+| `system_prompt` | Explicit override |
 | `providers`, `mapping` (models.json) | Deep merge per-key |
 | `pool` (models.json) | Last wins — no list merging |
 | `catalog`, `virtual_models` (models.json) | System-only — never overridden |
@@ -133,7 +133,7 @@ MODEL_NAME=claude-sonnet-4-5-20250929
   </Accordion>
 
   <Accordion title="Project-level example" icon="file-code">
-    `.leon/runtime.json` in your workspace root:
+    explicit runtime overrides:
 
     ```json
     {

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -6,7 +6,7 @@ icon: sliders
 keywords: [runtime.json, models.json, MCP, 配置, 环境变量, 记忆]
 ---
 
-Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置（`~/.leon/`）→ 项目配置（工作区根目录下的 `.leon/`）。CLI 参数优先级最高，覆盖一切。
+Mycel 使用拆分配置文件管理运行时默认值、模型、观测和提供商基础设施。产品运行时状态不从工作区本地 `runtime.json` 加载。
 
 ## 配置文件概览
 
@@ -18,18 +18,15 @@ Mycel 使用分层配置系统，三级合并：系统默认值 → 用户配置
 | `config.env` | 快速 API Key 配置（加载为环境变量） |
 | `$LEON_SANDBOXES_DIR/<name>.json` | 各提供商的沙箱配置 |
 
-每个 JSON 文件从三个层级加载（优先级从高到低）：
-1. 工作区根目录下的 `.leon/<file>`（项目配置）
-2. `~/.leon/<file>`（用户配置）
-3. `config/defaults/` 中的内置默认值
+runtime 配置优先级：显式 server/CLI overrides → 内置默认值。
 
 **各域合并策略：**
 
 | 域 | 策略 |
 |----|------|
-| `runtime`、`memory`、`tools` | 深度合并 — 高优先级层的字段覆盖低优先级层 |
-| `mcp` | 查找优先 — 首个定义某 key 的层级获胜，不合并 |
-| `system_prompt` | 查找 — 项目 → 用户 → 系统 |
+| `runtime`、`memory`、`tools` | 深度合并 — 显式 overrides 按字段覆盖内置默认值 |
+| `mcp` | 显式 overrides 覆盖内置默认值 |
+| `system_prompt` | 显式 override |
 | `providers`、`mapping`（models.json） | 按 key 深度合并 |
 | `pool`（models.json） | 最后者胜 — 不合并列表 |
 | `catalog`、`virtual_models`（models.json） | 仅系统层 — 用户不可覆盖 |
@@ -121,7 +118,7 @@ MODEL_NAME=claude-sonnet-4-5-20250929
 
 ### 项目级示例
 
-工作区根目录下的 `.leon/runtime.json`：
+显式 runtime overrides：
 
 ```json
 {

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -24,42 +24,23 @@ class TestAgentLoader:
         result = loader._load_system_defaults()
         assert result == {}
 
-    def test_load_user_config_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
-
-        loader = AgentLoader()
-        result = loader._load_user_config()
-        assert result == {}
-
-    def test_load_project_config_no_workspace(self):
-        loader = AgentLoader()
-        result = loader._load_project_config()
-        assert result == {}
-
-    def test_load_project_config_missing(self, tmp_path):
-        loader = AgentLoader(workspace_root=str(tmp_path))
-        result = loader._load_project_config()
-        assert result == {}
-
-    def test_load_project_config_rejects_invalid_runtime_json(self, tmp_path):
+    def test_load_does_not_read_project_runtime_json(self, tmp_path):
         project_dir = tmp_path / "project"
         (project_dir / ".leon").mkdir(parents=True)
         (project_dir / ".leon" / "runtime.json").write_text("{bad json", encoding="utf-8")
 
         loader = AgentLoader(workspace_root=str(project_dir))
 
-        with pytest.raises(ValueError, match="Runtime config must be valid JSON"):
-            loader._load_project_config()
+        assert isinstance(loader.load(), LeonSettings)
 
-    def test_load_project_config_rejects_non_object_runtime_json(self, tmp_path):
-        project_dir = tmp_path / "project"
-        (project_dir / ".leon").mkdir(parents=True)
-        (project_dir / ".leon" / "runtime.json").write_text("[]", encoding="utf-8")
+    def test_load_does_not_read_user_runtime_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".leon").mkdir(parents=True)
+        (tmp_path / ".leon" / "runtime.json").write_text("{bad json", encoding="utf-8")
 
-        loader = AgentLoader(workspace_root=str(project_dir))
+        loader = AgentLoader()
 
-        with pytest.raises(ValueError, match="Runtime config must be a JSON object"):
-            loader._load_project_config()
+        assert isinstance(loader.load(), LeonSettings)
 
     def test_deep_merge_simple(self):
         loader = AgentLoader()
@@ -198,9 +179,8 @@ def test_project_agent_file_does_not_override_builtin_runtime_agent(tmp_path: Pa
     assert agent.system_prompt != "project prompt"
 
 
-def test_user_agent_file_does_not_enter_runtime_agent_discovery(tmp_path: Path, monkeypatch):
+def test_user_agent_file_does_not_enter_runtime_agent_discovery(tmp_path: Path):
     home_root = tmp_path
-    monkeypatch.setattr("config.loader.user_home_read_candidates", lambda *parts: (home_root.joinpath(*parts),))
     agents_dir = home_root / "agents"
     agents_dir.mkdir(parents=True)
     (agents_dir / "custom.md").write_text(
@@ -211,9 +191,8 @@ def test_user_agent_file_does_not_enter_runtime_agent_discovery(tmp_path: Path, 
     assert "custom" not in AgentLoader(workspace_root=tmp_path).load_runtime_agents()
 
 
-def test_runtime_agent_discovery_excludes_member_dirs(tmp_path: Path, monkeypatch):
+def test_runtime_agent_discovery_excludes_member_dirs(tmp_path: Path):
     home_root = tmp_path
-    monkeypatch.setattr("config.loader.user_home_read_candidates", lambda *parts: (home_root.joinpath(*parts),))
     member_dir = home_root / "members" / "alice"
     member_dir.mkdir(parents=True)
     (member_dir / "agent.md").write_text(

--- a/tests/Config/test_loader_skill_dir_boundary.py
+++ b/tests/Config/test_loader_skill_dir_boundary.py
@@ -12,15 +12,11 @@ def test_load_has_no_runtime_skill_config(monkeypatch, tmp_path):
     assert not hasattr(settings, "skills")
 
 
-def test_runtime_skill_config_key_fails_loudly(monkeypatch, tmp_path):
+def test_cli_skill_config_key_fails_loudly(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    project_root = tmp_path / "project"
-    runtime_dir = project_root / ".leon"
-    runtime_dir.mkdir(parents=True)
-    (runtime_dir / "runtime.json").write_text('{"skills": {"paths": []}}', encoding="utf-8")
 
     try:
-        AgentLoader(project_root).load()
+        AgentLoader().load(cli_overrides={"skills": {"paths": []}})
     except ValueError as exc:
         assert "runtime.json must not define top-level 'skills'" in str(exc)
     else:

--- a/tests/Unit/core/test_agent_service.py
+++ b/tests/Unit/core/test_agent_service.py
@@ -816,9 +816,8 @@ async def test_agent_tool_model_priority_prefers_env_over_tool_and_parent(monkey
 
 
 def test_resolve_subagent_model_ignores_user_home_agent_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    home_root = tmp_path
-    monkeypatch.setattr("config.loader.user_home_read_candidates", lambda *parts: (home_root.joinpath(*parts),))
-    agent_dir = home_root / "agents"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent_dir = tmp_path / ".leon" / "agents"
     agent_dir.mkdir(parents=True)
     (agent_dir / "explore.md").write_text(
         "---\nname: explore\nmodel: user-model\ntools:\n  - Read\n---\nuser prompt\n",

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -28,6 +28,14 @@ def test_config_loading_does_not_create_skill_directories() -> None:
     assert "mkdir" not in loader_source
 
 
+def test_runtime_config_loading_has_no_local_runtime_sources() -> None:
+    loader_source = inspect.getsource(AgentLoader.load)
+
+    assert "_load_user_config" not in loader_source
+    assert "_load_project_config" not in loader_source
+    assert "user_home_read_candidates" not in loader_source
+
+
 def test_runtime_defaults_do_not_define_skill_runtime_config() -> None:
     runtime_defaults_path = Path(__file__).parents[3] / "config" / "defaults" / "runtime.json"
     runtime_defaults = json.loads(runtime_defaults_path.read_text())

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -848,7 +848,7 @@ async def test_leon_agent_empty_agent_config_skills_do_not_enable_host_file_skil
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_default_runtime_rejects_runtime_skill_config(tmp_path):
+async def test_leon_agent_default_runtime_does_not_read_project_runtime_skill_config(tmp_path):
     from core.runtime.agent import LeonAgent
 
     _write_file_skill_dir(
@@ -863,14 +863,24 @@ async def test_leon_agent_default_runtime_rejects_runtime_skill_config(tmp_path)
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="runtime.json must not define top-level 'skills'"):
+    mock_model = _mock_model("File skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+    ):
         agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
+        await agent.ainit()
+
+        assert agent._tool_registry.get("load_skill") is None
         agent.close()
 
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_default_runtime_rejects_missing_runtime_skill_path(tmp_path):
+async def test_leon_agent_default_runtime_does_not_read_missing_runtime_skill_path(tmp_path):
     from core.runtime.agent import LeonAgent
 
     missing_skills = tmp_path / "missing-file-skills"
@@ -880,15 +890,25 @@ async def test_leon_agent_default_runtime_rejects_missing_runtime_skill_path(tmp
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="runtime.json must not define top-level 'skills'"):
+    mock_model = _mock_model("No file skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+    ):
         agent = LeonAgent(workspace_root=str(tmp_path), api_key="sk-test-integration")
+        await agent.ainit()
+
+        assert agent._tool_registry.get("load_skill") is None
         agent.close()
     assert not missing_skills.exists()
 
 
 @pytest.mark.asyncio
 @_patch_env_api_key()
-async def test_leon_agent_agent_config_id_rejects_stale_runtime_skill_toggle(tmp_path):
+async def test_leon_agent_agent_config_id_does_not_read_stale_runtime_skill_toggle(tmp_path):
     from core.runtime.agent import LeonAgent
 
     leon_dir = tmp_path / ".leon"
@@ -912,13 +932,25 @@ async def test_leon_agent_agent_config_id_rejects_stale_runtime_skill_toggle(tmp
                 ],
             )
 
-    with pytest.raises(ValueError, match="runtime.json must not define top-level 'skills'"):
+    mock_model = _mock_model("Repo skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+    ):
         agent = LeonAgent(
             workspace_root=str(tmp_path),
             agent_config_id="cfg-1",
             agent_config_repo=_Repo(),
             api_key="sk-test-integration",
         )
+        await agent.ainit()
+
+        skill_tool = agent._tool_registry.get("load_skill")
+        assert skill_tool is not None
+        assert skill_tool.handler("FastAPI") == "Loaded skill: FastAPI\n\nAlways use APIRouter."
         agent.close()
 
 


### PR DESCRIPTION
## Summary
- make `AgentLoader.load()` use built-in runtime defaults plus explicit overrides only
- remove user/workspace-local `runtime.json` loading from runtime config
- update Skill/runtime boundary tests and EN/ZH docs for the new source model

## Verification
- `uv run pytest tests/Config/test_loader.py tests/Config/test_loader_skill_dir_boundary.py tests/Unit/core/test_agent_service.py::test_resolve_subagent_model_ignores_user_home_agent_files tests/Unit/integration_contracts/test_leon_agent.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py -q`
- `uv run pytest tests/Unit -q`
- `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q`
- `uv run ruff check . && uv run ruff format --check .`
- `npm run lint && npx tsc -b --noEmit && npx vitest run`

## Commit structure
- 5 coherent commits, preserving the review boundary requested for non-trivial PRs