### PR TITLE
Remove model and observation local state reads

### DIFF
--- a/config/models_loader.py
+++ b/config/models_loader.py
@@ -1,6 +1,6 @@
-"""Three-tier models.json loader.
+"""Models configuration loader.
 
-Merge priority: system defaults → user (~/.leon/models.json) → project (.leon/models.json) → CLI overrides
+Merge priority: system defaults → explicit user config → CLI overrides
 
 Merge strategies:
 - providers: deep merge (per-provider)
@@ -16,34 +16,25 @@ from pathlib import Path
 from typing import Any
 
 from config.models_schema import ModelsConfig
-from config.user_paths import remap_default_user_home_string, user_home_read_candidates
+from config.user_paths import remap_default_user_home_string
 
 
 class ModelsLoader:
-    """Three-tier models.json loader."""
+    """Load model defaults and explicit model overrides."""
 
-    def __init__(self, workspace_root: str | Path | None = None):
-        self.workspace_root = Path(workspace_root).resolve() if workspace_root else None
+    def __init__(self):
         self._system_dir = Path(__file__).parent / "defaults"
 
     def load(self, cli_overrides: dict[str, Any] | None = None) -> ModelsConfig:
-        """Load and merge models config from all tiers."""
+        """Load model config from system defaults and explicit overrides."""
         system = self._load_json(self._system_dir / "models.json")
-        user = self._load_user()
-        project = self._load_project()
+        merged = system
 
-        # Merge: system → user → project
-        merged = self._merge(system, user)
-        merged = self._merge(merged, project)
-
-        # CLI overrides
         if cli_overrides:
             merged = self._merge(merged, cli_overrides)
 
-        # Expand env vars in string values
         merged = self._expand_env_vars(merged)
 
-        # catalog and virtual_models come only from system
         merged["catalog"] = system.get("catalog", [])
         merged["virtual_models"] = system.get("virtual_models", [])
 
@@ -54,31 +45,19 @@ class ModelsLoader:
         user_config: dict[str, Any] | None,
         cli_overrides: dict[str, Any] | None = None,
     ) -> ModelsConfig:
-        """Load system + explicit user config + project config.
+        """Load system defaults plus explicit repo-backed user config.
 
         Web runtime supplies repo-backed user config explicitly. It must not
         read the local operator's home directory as a silent user-settings layer.
         """
         system = self._load_json(self._system_dir / "models.json")
         merged = self._merge(system, user_config or {})
-        merged = self._merge(merged, self._load_project())
         if cli_overrides:
             merged = self._merge(merged, cli_overrides)
         merged = self._expand_env_vars(merged)
         merged["catalog"] = system.get("catalog", [])
         merged["virtual_models"] = system.get("virtual_models", [])
         return ModelsConfig(**merged)
-
-    def _load_project(self) -> dict[str, Any]:
-        if not self.workspace_root:
-            return {}
-        return self._load_json(self.workspace_root / ".leon" / "models.json")
-
-    def _load_user(self) -> dict[str, Any]:
-        merged: dict[str, Any] = {}
-        for path in user_home_read_candidates("models.json"):
-            merged = self._merge(merged, self._load_json(path))
-        return merged
 
     @staticmethod
     def _load_json(path: Path) -> dict[str, Any]:
@@ -143,9 +122,6 @@ class ModelsLoader:
         return obj
 
 
-def load_models(
-    workspace_root: str | Path | None = None,
-    cli_overrides: dict[str, Any] | None = None,
-) -> ModelsConfig:
+def load_models(cli_overrides: dict[str, Any] | None = None) -> ModelsConfig:
     """Convenience function to load models config."""
-    return ModelsLoader(workspace_root=workspace_root).load(cli_overrides=cli_overrides)
+    return ModelsLoader().load(cli_overrides=cli_overrides)

--- a/config/models_schema.py
+++ b/config/models_schema.py
@@ -84,7 +84,7 @@ class VirtualModelEntry(BaseModel):
 class ModelsConfig(BaseModel):
     """Unified models configuration.
 
-    Merge priority: system defaults → user (~/.leon/models.json) → project (.leon/models.json) → CLI
+    Merge priority: system defaults → explicit repo-backed user config → CLI
     """
 
     active: ActiveModel | None = None

--- a/config/observation_loader.py
+++ b/config/observation_loader.py
@@ -1,7 +1,6 @@
-"""Three-tier observation configuration loader.
+"""Observation configuration loader.
 
-Follows the same pattern as AgentLoader / ModelsLoader:
-system defaults → user (~/.leon/observation.json) → project (.leon/observation.json) → CLI overrides
+Loads system defaults plus explicit call-site overrides.
 """
 
 from __future__ import annotations
@@ -11,25 +10,21 @@ from pathlib import Path
 from typing import Any
 
 from config.observation_schema import ObservationConfig
-from config.user_paths import remap_default_user_home_string, user_home_read_candidates
+from config.user_paths import remap_default_user_home_string
 
 
 class ObservationLoader:
-    """Three-tier observation.json loader."""
+    """Load observation defaults and explicit overrides."""
 
-    def __init__(self, workspace_root: str | Path | None = None):
-        self.workspace_root = Path(workspace_root).resolve() if workspace_root else None
+    def __init__(self):
         self._system_dir = Path(__file__).parent / "defaults"
 
     def load(self, cli_overrides: dict[str, Any] | None = None) -> ObservationConfig:
-        """Load and merge observation config from all tiers."""
+        """Load observation config from system defaults and explicit overrides."""
         system = self._load_json(self._system_dir / "observation.json")
-        user = self._load_user()
-        project = self._load_project()
 
-        merged = self._deep_merge(system, user, project)
+        merged = system
 
-        # CLI overrides: explicit None for "active" means disable, so apply directly
         if cli_overrides:
             for key, value in cli_overrides.items():
                 if isinstance(value, dict) and isinstance(merged.get(key), dict):
@@ -40,17 +35,6 @@ class ObservationLoader:
         merged = self._expand_env_vars(merged)
 
         return ObservationConfig(**merged)
-
-    def _load_project(self) -> dict[str, Any]:
-        if not self.workspace_root:
-            return {}
-        return self._load_json(self.workspace_root / ".leon" / "observation.json")
-
-    def _load_user(self) -> dict[str, Any]:
-        merged: dict[str, Any] = {}
-        for path in user_home_read_candidates("observation.json"):
-            merged = self._deep_merge(merged, self._load_json(path))
-        return merged
 
     @staticmethod
     def _load_json(path: Path) -> dict[str, Any]:

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -205,7 +205,7 @@ class LeonAgent:
             memory_config_override=memory_config_override,
         )
         # Load observation config (langfuse / langsmith)
-        self._observation_config = ObservationLoader(workspace_root=workspace_root).load()
+        self._observation_config = ObservationLoader().load()
         # Resolve virtual model name
         active_model = self.models_config.active.model if self.models_config.active else model_name
         if not active_model:
@@ -520,7 +520,7 @@ class LeonAgent:
         models_cli: dict = {}
         if model_name is not None:
             models_cli["active"] = {"model": model_name}
-        models_loader = ModelsLoader(workspace_root=workspace_root)
+        models_loader = ModelsLoader()
         if models_config_override is None:
             models_config = models_loader.load(cli_overrides=models_cli or None)
         else:
@@ -763,7 +763,7 @@ class LeonAgent:
 
         # Reload models config (picks up new API keys + model changes from disk)
         models_cli = {"active": {"model": model}} if model else None
-        models_loader = ModelsLoader(workspace_root=self.workspace_root)
+        models_loader = ModelsLoader()
         self.models_config = models_loader.load(cli_overrides=models_cli)
 
         if model is None:
@@ -825,7 +825,7 @@ class LeonAgent:
         Args:
             **overrides: Fields to override (e.g. active="langfuse" or active=None)
         """
-        self._observation_config = ObservationLoader(workspace_root=self.workspace_root).load(cli_overrides=overrides or None)
+        self._observation_config = ObservationLoader().load(cli_overrides=overrides or None)
 
     def close(self, *, cleanup_sandbox: bool = True):
         """Clean up resources via CleanupRegistry (priority-ordered).

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -166,13 +166,13 @@ MODEL_NAME=claude-sonnet-4-5-20250929
     | `leon:large` | claude-opus-4-6 | Complex reasoning |
     | `leon:max` | claude-opus-4-6 + temp=0 | Maximum precision |
 
-    Set via **Settings → Models** in the Web UI, or in `~/.leon/models.json`:
+    Set via **Settings → Models** in the Web UI:
 
     ```json
     { "active": { "model": "leon:large" } }
     ```
 
-    Override a mapping in `~/.leon/models.json`:
+    Override a mapping through Settings-backed model configuration:
 
     ```json
     {

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -170,13 +170,13 @@ Mycel 提供四个 `leon:*` 别名：
 | `leon:large` | claude-opus-4-6 | 复杂推理 |
 | `leon:max` | claude-opus-4-6 + temp=0 | 最高精度 |
 
-通过 **Settings → Models** 在 Web UI 中设置，或在 `~/.leon/models.json` 中：
+通过 **Settings → Models** 在 Web UI 中设置：
 
 ```json
 { "active": { "model": "leon:large" } }
 ```
 
-可在 `models.json` 中重新映射这些别名：
+可通过 Settings 持久化的模型配置重新映射这些别名：
 
 ```json
 {

--- a/tests/Config/test_models_loader.py
+++ b/tests/Config/test_models_loader.py
@@ -1,0 +1,39 @@
+import inspect
+from pathlib import Path
+
+from config.models_loader import ModelsLoader
+
+
+def test_models_loader_has_no_workspace_root_source() -> None:
+    signature = inspect.signature(ModelsLoader)
+
+    assert "workspace_root" not in signature.parameters
+
+
+def test_models_loader_does_not_read_user_home_models_json(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_dir = tmp_path / ".leon"
+    user_dir.mkdir(parents=True)
+    (user_dir / "models.json").write_text(
+        '{"active":{"model":"openai:local-user-model"},"providers":{"openai":{"api_key":"local-user-key"}}}',
+        encoding="utf-8",
+    )
+
+    config = ModelsLoader().load()
+
+    assert config.active is None
+    assert config.resolve_api_key("openai") is None
+
+
+def test_models_loader_explicit_user_config_does_not_read_user_home_models_json(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_dir = tmp_path / ".leon"
+    user_dir.mkdir(parents=True)
+    (user_dir / "models.json").write_text(
+        '{"providers":{"openai":{"api_key":"local-user-key"}}}',
+        encoding="utf-8",
+    )
+
+    config = ModelsLoader().load_with_user_config({"providers": {"openai": {"api_key": "repo-key"}}})
+
+    assert config.resolve_api_key("openai") == "repo-key"

--- a/tests/Config/test_observation_loader.py
+++ b/tests/Config/test_observation_loader.py
@@ -1,0 +1,26 @@
+import inspect
+from pathlib import Path
+
+from config.observation_loader import ObservationLoader
+
+
+def test_observation_loader_has_no_workspace_root_source() -> None:
+    signature = inspect.signature(ObservationLoader)
+
+    assert "workspace_root" not in signature.parameters
+
+
+def test_observation_loader_does_not_read_user_home_observation_json(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_dir = tmp_path / ".leon"
+    user_dir.mkdir(parents=True)
+    (user_dir / "observation.json").write_text(
+        '{"active":"langfuse","langfuse":{"secret_key":"local-secret","public_key":"local-public"}}',
+        encoding="utf-8",
+    )
+
+    config = ObservationLoader().load()
+
+    assert config.active is None
+    assert config.langfuse.secret_key is None
+    assert config.langfuse.public_key is None

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -3,6 +3,8 @@ import json
 from pathlib import Path
 
 from config.loader import AgentLoader
+from config.models_loader import ModelsLoader
+from config.observation_loader import ObservationLoader
 from core.runtime.agent import LeonAgent
 
 
@@ -34,6 +36,17 @@ def test_runtime_config_loading_has_no_local_runtime_sources() -> None:
     assert "_load_user_config" not in loader_source
     assert "_load_project_config" not in loader_source
     assert "user_home_read_candidates" not in loader_source
+
+
+def test_models_and_observation_loading_have_no_local_runtime_sources() -> None:
+    models_source = inspect.getsource(ModelsLoader)
+    observation_source = inspect.getsource(ObservationLoader)
+
+    combined = f"{models_source}\n{observation_source}"
+    assert "workspace_root" not in combined
+    assert "_load_user" not in combined
+    assert "_load_project" not in combined
+    assert "user_home_read_candidates" not in combined
 
 
 def test_runtime_defaults_do_not_define_skill_runtime_config() -> None:


### PR DESCRIPTION
## Summary
- make `ModelsLoader` load defaults plus explicit overrides only
- keep repo-backed `load_with_user_config()` as the explicit user settings path
- make `ObservationLoader` defaults/overrides-only and remove workspace-root loader inputs
- update runtime call sites, source gates, and EN/ZH docs

## Verification
- `uv run pytest tests/Config/test_models_loader.py tests/Config/test_observation_loader.py tests/Unit/platform/test_models_schema.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py tests/Unit/integration_contracts/test_leon_agent.py tests/Unit/core/test_agent_pool.py tests/Unit/core/test_agent_service.py -q`
- `uv run pytest tests/Unit -q`
- `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q`
- `uv run ruff check . && uv run ruff format --check .`

## Commit structure
- 5 coherent commits, preserving reviewable architecture steps