### PR TITLE
Add owner review UI for chat join requests

### DIFF
--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -355,8 +355,21 @@ export interface ChatDetail {
   id: string;
   title: string | null;
   status: string;
+  created_by_user_id: string;
   created_at: number;
   members: ChatMember[];
+}
+
+export interface ChatJoinRequest {
+  id: string;
+  chat_id: string;
+  requester_user_id: string;
+  state: "pending" | "approved" | "rejected";
+  message?: string | null;
+  decided_by_user_id?: string | null;
+  decided_at?: number | null;
+  created_at: number;
+  updated_at: number;
 }
 
 export interface ChatMessage {

--- a/frontend/app/src/pages/ChatConversationPage.test.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -60,6 +60,7 @@ describe("ChatConversationPage SSE teardown", () => {
     vi.restoreAllMocks();
     authFetchMocks.authFetch.mockReset();
     authFetchMocks.streamChatEvents.mockReset();
+    authFetchMocks.streamChatEvents.mockResolvedValue(undefined);
     authFetchMocks.useOutletContext.mockReset();
     authFetchMocks.useOutletContext.mockReturnValue({
       setSidebarCollapsed: vi.fn(),
@@ -89,6 +90,7 @@ describe("ChatConversationPage SSE teardown", () => {
           json: async () => ({
             id: "chat-1",
             title: "chat title",
+            created_by_user_id: "user-1",
             members: [{ id: "user-1", name: "tester", type: "human" }],
           }),
         };
@@ -103,6 +105,12 @@ describe("ChatConversationPage SSE teardown", () => {
         return {
           ok: true,
           json: async () => ({}),
+        };
+      }
+      if (url === "/api/chats/chat-1/join-requests") {
+        return {
+          ok: true,
+          json: async () => [],
         };
       }
       throw new Error(`Unexpected authFetch url: ${url}`);
@@ -145,5 +153,130 @@ describe("ChatConversationPage SSE teardown", () => {
     await waitFor(() => {
       expect(consoleError).not.toHaveBeenCalled();
     });
+  });
+
+  it("lets the chat owner review and approve join requests", async () => {
+    let chatDetailCalls = 0;
+    authFetchMocks.authFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/chats/chat-1") {
+        chatDetailCalls += 1;
+        return {
+          ok: true,
+          json: async () => ({
+            id: "chat-1",
+            title: "join room",
+            created_by_user_id: "user-1",
+            status: "active",
+            created_at: 1,
+            members: chatDetailCalls === 1
+              ? [{ id: "user-1", name: "tester", type: "human" }]
+              : [
+                  { id: "user-1", name: "tester", type: "human" },
+                  { id: "visitor-1", name: "Visitor", type: "external" },
+                ],
+          }),
+        };
+      }
+      if (url === "/api/chats/chat-1/messages?limit=100") {
+        return { ok: true, json: async () => [] };
+      }
+      if (url === "/api/chats/chat-1/read") {
+        return { ok: true, json: async () => ({}) };
+      }
+      if (url === "/api/chats/chat-1/join-requests" && !init?.method) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: "request-1",
+              chat_id: "chat-1",
+              requester_user_id: "visitor-1",
+              state: "pending",
+              message: "Please add me.",
+              created_at: 1,
+              updated_at: 1,
+            },
+          ],
+        };
+      }
+      if (url === "/api/chats/chat-1/join-requests/request-1/approve" && init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "request-1",
+            chat_id: "chat-1",
+            requester_user_id: "visitor-1",
+            state: "approved",
+            message: "Please add me.",
+            created_at: 1,
+            updated_at: 2,
+          }),
+        };
+      }
+      throw new Error(`Unexpected authFetch url: ${url}`);
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/chat/visit/chat-1"]}>
+        <Routes>
+          <Route path="/chat/visit/:chatId" element={<ChatConversationPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("入群申请")).toBeTruthy();
+    expect(screen.getByText("visitor-1")).toBeTruthy();
+    expect(screen.getByText("Please add me.")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "同意 visitor-1 入群" }));
+
+    await waitFor(() => {
+      expect(authFetchMocks.authFetch).toHaveBeenCalledWith(
+        "/api/chats/chat-1/join-requests/request-1/approve",
+        { method: "POST", body: JSON.stringify({}) },
+      );
+    });
+    expect(await screen.findByText("2 位成员")).toBeTruthy();
+  });
+
+  it("does not fetch owner-only join requests for a non-owner member", async () => {
+    authFetchMocks.authFetch.mockImplementation(async (url: string) => {
+      if (url === "/api/chats/chat-1") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "chat-1",
+            title: "member room",
+            created_by_user_id: "owner-1",
+            status: "active",
+            created_at: 1,
+            members: [{ id: "user-1", name: "tester", type: "human" }],
+          }),
+        };
+      }
+      if (url === "/api/chats/chat-1/messages?limit=100") {
+        return { ok: true, json: async () => [] };
+      }
+      if (url === "/api/chats/chat-1/read") {
+        return { ok: true, json: async () => ({}) };
+      }
+      if (url === "/api/chats/chat-1/join-requests") {
+        throw new Error("non-owner should not request join approvals");
+      }
+      throw new Error(`Unexpected authFetch url: ${url}`);
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/chat/visit/chat-1"]}>
+        <Routes>
+          <Route path="/chat/visit/:chatId" element={<ChatConversationPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("member room")).toBeTruthy();
+    });
+    expect(screen.queryByText("入群申请")).toBeNull();
   });
 });

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router-dom";
-import { PanelLeft, Send } from "lucide-react";
+import { Check, PanelLeft, Send, X } from "lucide-react";
 import { authFetch, useAuthStore } from "../store/auth-store";
 import { parseChatMessageEventData, parseChatTypingUserId, streamChatEvents } from "../api/chat-events";
 import { UserBubble } from "../components/chat-area/UserBubble";
 import { ChatBubble } from "../components/chat-area/ChatBubble";
-import type { ChatMember, ChatMessage, ChatDetail } from "../api/types";
+import type { ChatMember, ChatMessage, ChatDetail, ChatJoinRequest } from "../api/types";
 
 // @@@time-gap — only show timestamp when gap >= 5 minutes
 function shouldShowTime(prev: ChatMessage | null, curr: ChatMessage): boolean {
@@ -50,6 +50,9 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
+  const [joinRequests, setJoinRequests] = useState<ChatJoinRequest[]>([]);
+  const [joinRequestError, setJoinRequestError] = useState<string | null>(null);
+  const [joinRequestBusyId, setJoinRequestBusyId] = useState<string | null>(null);
   const [typingUsers, setTypingUsers] = useState<Set<string>>(new Set());
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -60,6 +63,31 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
     chat?.members.forEach(member => m.set(member.id, member));
     return m;
   }, [chat?.members]);
+
+  const isOwner = Boolean(chat && chat.created_by_user_id === myUserId);
+  const pendingJoinRequests = useMemo(
+    () => joinRequests.filter(request => request.state === "pending"),
+    [joinRequests],
+  );
+
+  const loadJoinRequests = useCallback(async () => {
+    if (!isOwner) {
+      setJoinRequests([]);
+      setJoinRequestError(null);
+      return;
+    }
+    const res = await authFetch(`/api/chats/${chatId}/join-requests`);
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(body || `Join requests load failed (${res.status})`);
+    }
+    setJoinRequests(await res.json());
+    setJoinRequestError(null);
+  }, [chatId, isOwner]);
+
+  useEffect(() => {
+    loadJoinRequests().catch(err => setJoinRequestError(err.message));
+  }, [loadJoinRequests]);
   // Track if user is at bottom for sticky scroll
   const onScroll = useCallback(() => {
     const el = scrollContainerRef.current;
@@ -234,6 +262,34 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
     }
   };
 
+  const decideJoinRequest = useCallback(async (requestId: string, decision: "approve" | "reject") => {
+    setJoinRequestBusyId(requestId);
+    setJoinRequestError(null);
+    try {
+      const res = await authFetch(
+        `/api/chats/${chatId}/join-requests/${encodeURIComponent(requestId)}/${decision}`,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(body || `Join request ${decision} failed (${res.status})`);
+      }
+      const updated: ChatJoinRequest = await res.json();
+      setJoinRequests(prev => prev.map(request => request.id === updated.id ? updated : request));
+      const chatRes = await authFetch(`/api/chats/${chatId}`);
+      if (!chatRes.ok) {
+        const body = await chatRes.text();
+        throw new Error(body || `Chat reload failed (${chatRes.status})`);
+      }
+      setChat(await chatRes.json());
+      refreshChatList();
+    } catch (err) {
+      setJoinRequestError(err instanceof Error ? err.message : "Join request action failed");
+    } finally {
+      setJoinRequestBusyId(null);
+    }
+  }, [chatId, refreshChatList]);
+
   // Typing indicator display — works for both 1:1 and group
   const typingNames = [...typingUsers]
     .map(id => memberMap.get(id)?.name)
@@ -294,6 +350,59 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
           )}
         </div>
       </header>
+
+      {isOwner && (pendingJoinRequests.length > 0 || joinRequestError) && (
+        <section className="shrink-0 border-b border-border bg-muted/20 px-4 py-2.5">
+          <div className="max-w-3xl mx-auto space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <h2 className="text-xs font-semibold text-foreground">入群申请</h2>
+                <p className="text-2xs text-muted-foreground">
+                  {pendingJoinRequests.length} 个待处理申请
+                </p>
+              </div>
+            </div>
+            {joinRequestError && (
+              <p className="text-2xs text-destructive">{joinRequestError}</p>
+            )}
+            {pendingJoinRequests.map(request => (
+              <div
+                key={request.id}
+                className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium text-foreground">{request.requester_user_id}</p>
+                  {request.message && (
+                    <p className="mt-0.5 truncate text-2xs text-muted-foreground">{request.message}</p>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <button
+                    type="button"
+                    aria-label={`同意 ${request.requester_user_id} 入群`}
+                    disabled={joinRequestBusyId === request.id}
+                    onClick={() => void decideJoinRequest(request.id, "approve")}
+                    className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-2xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    同意
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`拒绝 ${request.requester_user_id} 入群`}
+                    disabled={joinRequestBusyId === request.id}
+                    onClick={() => void decideJoinRequest(request.id, "reject")}
+                    className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-2xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                    拒绝
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Messages */}
       <div

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -317,6 +317,7 @@ class MessagingService:
             "id": chat.id,
             "title": chat.title,
             "status": chat.status,
+            "created_by_user_id": chat.created_by_user_id,
             "created_at": chat.created_at,
             "members": self._build_chat_members(chat.id),
         }

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -983,7 +983,13 @@ def test_messaging_service_chat_detail_fails_on_unknown_member_identity() -> Non
         ),
     )
 
-    chat = SimpleNamespace(id="chat-1", title=None, status="active", created_at="2026-04-07T00:00:00Z")
+    chat = SimpleNamespace(
+        id="chat-1",
+        title=None,
+        status="active",
+        created_by_user_id="human-user-1",
+        created_at="2026-04-07T00:00:00Z",
+    )
 
     with pytest.raises(RuntimeError) as excinfo:
         service.get_chat_detail(chat)
@@ -1632,6 +1638,7 @@ def test_messaging_service_get_chat_detail_exposes_agent_user_participant_id() -
             id="chat-1",
             title="Chat title",
             status="active",
+            created_by_user_id="human-user-1",
             created_at="2026-04-07T00:00:00Z",
         )
     )
@@ -1640,6 +1647,7 @@ def test_messaging_service_get_chat_detail_exposes_agent_user_participant_id() -
         "id": "chat-1",
         "title": "Chat title",
         "status": "active",
+        "created_by_user_id": "human-user-1",
         "created_at": "2026-04-07T00:00:00Z",
         "members": [
             {


### PR DESCRIPTION
## Summary
- expose `created_by_user_id` in chat detail so the frontend can use backend owner truth
- add owner-only join request review UI in the chat conversation page
- refresh chat detail after approve/reject so member counts follow backend state

## Verification
- `npm test && npm run lint && npm run typecheck && npm run build` in `frontend/app`
  - 51 test files passed, 233 tests passed
  - build passed with existing Vite chunk-size warning
- `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q`
  - 1787 passed, 8 skipped, 15 existing mock-model warnings
- `uv run ruff check messaging/service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run ruff format --check messaging/service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`

## YATU
- Backend restarted from this rebased branch on `http://127.0.0.1:8042`; frontend on `http://127.0.0.1:5173`.
- Real CLI created pending request `join-frontend-final-20260425211150` with `mycel chat join-requests request`.
- Playwright CLI as group owner showed `入群申请`, pending requester, and `9 位成员`.
- Clicking the real UI approve button updated the page to `10 位成员` and showed `Approved chat join request for join-frontend-final-20260425211150.`

Runbook updated: `/Users/lexicalmathical/Codebase/mycel/notes/2026-04-25-mycel-cli-real-runbook.html`.
