### PR TITLE
Materialize snapshot Skills through Library

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -330,13 +330,21 @@ def apply_item(
             owner_user_id=owner_user_id,
             user_repo=user_repo,
             agent_config_repo=agent_config_repo,
+            skill_repo=skill_repo,
         )
         return {"user_id": user_id, "type": "user", "version": source_version}
 
     raise ValueError(f"Unsupported item type: {item_type}")
 
 
-def upgrade(user_id: str, item_id: str, owner_user_id: str, user_repo: Any = None, agent_config_repo: Any = None) -> dict:
+def upgrade(
+    user_id: str,
+    item_id: str,
+    owner_user_id: str,
+    user_repo: Any = None,
+    agent_config_repo: Any = None,
+    skill_repo: Any = None,
+) -> dict:
     """Upgrade a local marketplace-sourced agent user."""
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required to upgrade marketplace user snapshot")
@@ -353,6 +361,7 @@ def upgrade(user_id: str, item_id: str, owner_user_id: str, user_repo: Any = Non
         existing_user_id=user_id,
         user_repo=user_repo,
         agent_config_repo=agent_config_repo,
+        skill_repo=skill_repo,
     )
 
     return {"user_id": user_id, "version": source_version}

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -3,9 +3,101 @@
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
 from typing import Any
 
-from config.agent_config_types import AgentConfig, AgentSnapshot
+from config.agent_config_resolver import validate_agent_skill_content
+from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, Skill, SkillPackage
+from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+
+
+def _skill_id_from_name(name: str) -> str:
+    skill_id = name.strip().lower().replace(" ", "-")
+    if "/" in skill_id or "\\" in skill_id or skill_id in {"", ".", ".."}:
+        raise ValueError(f"Invalid Skill name for Library id: {name}")
+    return skill_id
+
+
+def _materialize_snapshot_skills(
+    *,
+    skills: list[AgentSkill],
+    owner_user_id: str,
+    marketplace_item_id: str,
+    source_version: str,
+    source_at: int,
+    skill_repo: Any = None,
+) -> list[AgentSkill]:
+    if not skills:
+        return []
+    if skill_repo is None:
+        raise RuntimeError("skill_repo is required to apply snapshot Skills")
+
+    seen_names: set[str] = set()
+    for snapshot_skill in skills:
+        validate_agent_skill_content(snapshot_skill)
+        if snapshot_skill.name in seen_names:
+            raise ValueError(f"Duplicate Skill name in snapshot: {snapshot_skill.name}")
+        seen_names.add(snapshot_skill.name)
+
+    result: list[AgentSkill] = []
+    timestamp = datetime.now(UTC)
+    library_skills = skill_repo.list_for_owner(owner_user_id)
+    for snapshot_skill in skills:
+        skill_id = snapshot_skill.skill_id or _skill_id_from_name(snapshot_skill.name)
+        existing = skill_repo.get_by_id(owner_user_id, skill_id)
+        if existing is not None and existing.name != snapshot_skill.name:
+            raise ValueError("Snapshot Skill frontmatter name must match existing Skill name")
+        for library_skill in library_skills:
+            if library_skill.name == snapshot_skill.name and library_skill.id != skill_id:
+                raise ValueError("Snapshot Skill name already exists under a different Library id")
+
+        source = dict(snapshot_skill.source)
+        source.update(
+            {
+                "marketplace_item_id": marketplace_item_id,
+                "source_version": source_version,
+                "source_at": source_at,
+            }
+        )
+        # @@@snapshot-skill-materialization - AgentConfig stores package bindings; Hub snapshots carry resolved Skill content.
+        skill = skill_repo.upsert(
+            Skill(
+                id=skill_id,
+                owner_user_id=owner_user_id,
+                name=snapshot_skill.name,
+                description=snapshot_skill.description,
+                source=source,
+                created_at=getattr(existing, "created_at", timestamp),
+                updated_at=timestamp,
+            )
+        )
+        package_hash = build_skill_package_hash(snapshot_skill.content, snapshot_skill.files)
+        package = skill_repo.create_package(
+            SkillPackage(
+                id=package_hash.removeprefix("sha256:"),
+                owner_user_id=owner_user_id,
+                skill_id=skill.id,
+                version=snapshot_skill.version or source_version,
+                hash=package_hash,
+                manifest=build_skill_package_manifest(snapshot_skill.content, snapshot_skill.files),
+                skill_md=snapshot_skill.content,
+                files=snapshot_skill.files,
+                source=source,
+                created_at=timestamp,
+            )
+        )
+        skill_repo.select_package(owner_user_id, skill.id, package.id)
+        result.append(
+            snapshot_skill.model_copy(
+                update={
+                    "skill_id": skill.id,
+                    "package_id": package.id,
+                    "version": package.version,
+                    "source": source,
+                }
+            )
+        )
+    return result
 
 
 def apply_snapshot(
@@ -17,6 +109,7 @@ def apply_snapshot(
     existing_user_id: str | None = None,
     user_repo: Any = None,
     agent_config_repo: Any = None,
+    skill_repo: Any = None,
 ) -> str:
     from storage.contracts import UserRow, UserType
     from storage.utils import generate_agent_config_id, generate_agent_user_id
@@ -49,11 +142,21 @@ def apply_snapshot(
             )
         )
 
+    source_at = int(now * 1000)
+    skills = _materialize_snapshot_skills(
+        skills=resolved.skills,
+        owner_user_id=owner_user_id,
+        marketplace_item_id=marketplace_item_id,
+        source_version=source_version,
+        source_at=source_at,
+        skill_repo=skill_repo,
+    )
+
     meta = dict(resolved.meta)
     meta["source"] = {
         "marketplace_item_id": marketplace_item_id,
         "source_version": source_version,
-        "source_at": int(now * 1000),
+        "source_at": source_at,
         "modified": False,
     }
 
@@ -71,7 +174,7 @@ def apply_snapshot(
             version=source_version,
             runtime_settings=resolved.runtime_settings,
             compact=resolved.compact,
-            skills=resolved.skills,
+            skills=skills,
             rules=resolved.rules,
             sub_agents=resolved.sub_agents,
             mcp_servers=resolved.mcp_servers,

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -141,6 +141,7 @@ async def upgrade_from_marketplace(
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     agent_config_repo = _agent_config_repo(request)
+    skill_repo = _skill_repo(request)
     await _verify_user_ownership(req.user_id, user_id, user_repo)
 
     return await asyncio.to_thread(
@@ -150,6 +151,7 @@ async def upgrade_from_marketplace(
         owner_user_id=user_id,
         user_repo=user_repo,
         agent_config_repo=agent_config_repo,
+        skill_repo=skill_repo,
     )
 
 

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -136,6 +136,100 @@ async def test_apply_marketplace_item_uses_user_and_agent_config_repos(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_apply_member_snapshot_materializes_skill_through_router(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _SkillRepo:
+        def __init__(self) -> None:
+            self.skills: dict[tuple[str, str], Any] = {}
+            self.packages: dict[tuple[str, str], Any] = {}
+
+        def list_for_owner(self, owner_user_id: str) -> list[Any]:
+            return [skill for (owner, _), skill in self.skills.items() if owner == owner_user_id]
+
+        def get_by_id(self, owner_user_id: str, skill_id: str) -> Any | None:
+            return self.skills.get((owner_user_id, skill_id))
+
+        def upsert(self, skill: Any) -> Any:
+            self.skills[(getattr(skill, "owner_user_id"), getattr(skill, "id"))] = skill
+            return skill
+
+        def create_package(self, package: Any) -> Any:
+            self.packages[(getattr(package, "owner_user_id"), getattr(package, "id"))] = package
+            return package
+
+        def get_package(self, owner_user_id: str, package_id: str) -> Any | None:
+            return self.packages.get((owner_user_id, package_id))
+
+        def select_package(self, owner_user_id: str, skill_id: str, package_id: str) -> None:
+            skill = self.skills[(owner_user_id, skill_id)]
+            self.skills[(owner_user_id, skill_id)] = skill.model_copy(update={"package_id": package_id})
+
+    class _UserRepo:
+        def __init__(self) -> None:
+            self.users: dict[str, Any] = {}
+
+        def get_by_id(self, user_id: str) -> Any | None:
+            return self.users.get(user_id)
+
+        def create(self, row: Any) -> None:
+            self.users[getattr(row, "id")] = row
+
+    class _AgentConfigRepo:
+        def __init__(self) -> None:
+            self.saved: list[Any] = []
+
+        def save_agent_config(self, config: Any) -> None:
+            self.saved.append(config)
+
+    def hub_response(_method: str, _path: str, **_kwargs: object) -> dict[str, object]:
+        return {
+            "item": {"type": "member", "name": "Snapshot Agent"},
+            "version": "1.2.3",
+            "snapshot": {
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "source-cfg",
+                    "name": "Snapshot Agent",
+                    "skills": [
+                        {
+                            "name": "Snapshot Skill",
+                            "description": "skill desc",
+                            "content": "---\nname: Snapshot Skill\n---\nbody",
+                            "files": {"references/routing.md": "route narrowly"},
+                        }
+                    ],
+                },
+            },
+        }
+
+    monkeypatch.setattr(marketplace_router.marketplace_client, "_hub_api", hub_response)
+    skill_repo = _SkillRepo()
+    agent_config_repo = _AgentConfigRepo()
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                user_repo=_UserRepo(),
+                runtime_storage_state=_runtime_storage_state(agent_config_repo, skill_repo),
+            )
+        )
+    )
+
+    result = await marketplace_router.apply_marketplace_item(
+        req=ApplyFromMarketplaceRequest(item_id="item-1"),
+        user_id="owner-1",
+        request=cast(Any, request),
+    )
+
+    saved_config = agent_config_repo.saved[0]
+    saved_skill = saved_config.skills[0]
+    assert result == {"user_id": saved_config.agent_user_id, "type": "user", "version": "1.2.3"}
+    assert saved_skill.skill_id == "snapshot-skill"
+    assert saved_skill.package_id
+    package = skill_repo.get_package("owner-1", saved_skill.package_id)
+    assert package is not None
+    assert getattr(package, "files") == {"references/routing.md": "route narrowly"}
+
+
+@pytest.mark.asyncio
 async def test_apply_marketplace_item_maps_semantic_rejections_to_400(monkeypatch: pytest.MonkeyPatch) -> None:
     def reject(**_kwargs: object) -> dict[str, object]:
         raise ValueError("Skill snapshot frontmatter name must match existing Skill name")

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -104,6 +104,7 @@ async def test_upgrade_from_marketplace_uses_user_repo_not_member_repo(monkeypat
     assert seen["owner_user_id"] == "owner-1"
     assert seen["user_repo"] is request.app.state.user_repo
     assert seen["agent_config_repo"] is request.app.state.runtime_storage_state.storage_container.agent_config_repo()
+    assert seen["skill_repo"] is request.app.state.runtime_storage_state.storage_container.skill_repo()
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1345,6 +1345,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
 
     created_users: list[UserRow] = []
     saved_configs: list[AgentConfig] = []
+    skill_repo = _MemorySkillRepo()
 
     class _UserRepo:
         def create(self, row: UserRow) -> None:
@@ -1374,14 +1375,70 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
         owner_user_id="user-1",
         user_repo=_UserRepo(),
         agent_config_repo=_AgentConfigRepo(),
+        skill_repo=skill_repo,
     )
 
     assert user_id == created_users[0].id
     assert saved_configs[0].name == "Repo Agent"
     assert saved_configs[0].skills[0].description == "skill desc"
+    assert saved_configs[0].skills[0].skill_id == "search"
+    assert saved_configs[0].skills[0].package_id
+    assert skill_repo.get_by_id("user-1", "search") is not None
+    package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id or "")
+    assert package is not None
+    assert package.skill_md == "---\nname: Search\n---\nbody"
     assert saved_configs[0].rules[0].content == "rule body"
     assert saved_configs[0].sub_agents[0].name == "Scout"
     assert saved_configs[0].meta["source"]["source_version"] == "1.0.0"
+
+
+def test_apply_snapshot_with_skills_requires_skill_repo():
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    with pytest.raises(RuntimeError, match="skill_repo is required to apply snapshot Skills"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [{"name": "Search", "content": "---\nname: Search\n---\nbody"}],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+        )
+
+
+def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Duplicate Skill name in snapshot: Search"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [
+                        {"name": "Search", "content": "---\nname: Search\n---\none"},
+                        {"name": "Search", "content": "---\nname: Search\n---\ntwo"},
+                    ],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+            skill_repo=skill_repo,
+        )
+    assert skill_repo.list_for_owner("user-1") == []
 
 
 def _agent_delete_runner(*, contact_error: str | None = None):

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -518,11 +518,13 @@ class TestApplyUser:
                 owner_user_id="owner-1",
                 user_repo=SimpleNamespace(),
                 agent_config_repo=SimpleNamespace(),
+                skill_repo=SimpleNamespace(),
             )
 
         assert result == {"user_id": "agent-user-1", "type": "user", "version": "1.0.0"}
         assert seen["user_repo"] is not None
         assert seen["agent_config_repo"] is not None
+        assert seen["skill_repo"] is not None
 
     def test_member_type_apply_requires_repos(self):
         hub_resp = _make_hub_response("member", "agent-user")
@@ -597,11 +599,13 @@ def test_upgrade_returns_user_id_contract(monkeypatch):
             owner_user_id="owner-1",
             user_repo=SimpleNamespace(),
             agent_config_repo=SimpleNamespace(),
+            skill_repo=SimpleNamespace(),
         )
 
     assert result == {"user_id": "agent-user-1", "version": "2.0.0"}
     assert seen["user_repo"] is not None
     assert seen["agent_config_repo"] is not None
+    assert seen["skill_repo"] is not None
 
 
 def test_upgrade_passes_existing_user_id_to_snapshot_apply(monkeypatch):
@@ -625,6 +629,7 @@ def test_upgrade_passes_existing_user_id_to_snapshot_apply(monkeypatch):
             owner_user_id="owner-1",
             user_repo=SimpleNamespace(),
             agent_config_repo=SimpleNamespace(),
+            skill_repo=SimpleNamespace(),
         )
 
     assert seen["existing_user_id"] == "agent-user-1"


### PR DESCRIPTION
## Summary
- Materialize Skills carried by Hub Agent user snapshots into Library Skill/package records before saving AgentConfig bindings.
- Thread skill_repo through Hub member apply/upgrade and the marketplace upgrade route.
- Add API-level coverage proving /api/marketplace/apply creates a Library package and AgentConfig Skill binding from a member snapshot Skill.

## Verification
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/config/test_agent_snapshot.py tests/Unit/core/test_skills_service.py -q
- uv run ruff check . && uv run ruff format --check .
- uv run pyright backend/hub/snapshot_apply.py backend/hub/client.py backend/web/routers/marketplace.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
- uv run pytest tests/Unit -q
- uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q
- Backend API YATU: POST /api/marketplace/apply and /api/marketplace/upgrade with a member snapshot Skill; package files persisted and AgentConfig bound package_id.
