### PR TITLE
Refactor AgentConfig skill resolution through packages

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -117,8 +117,8 @@ def get_item_version_snapshot(item_id: str, version: str) -> dict:
     return _hub_api("GET", f"/items/{item_id}/versions/{version}")
 
 
-def _agent_snapshot_payload(config: Any) -> dict:
-    return snapshot_from_resolved_config(resolve_agent_config(config)).model_dump(mode="json")
+def _agent_snapshot_payload(config: Any, skill_repo: Any) -> dict:
+    return snapshot_from_resolved_config(resolve_agent_config(config, skill_repo=skill_repo)).model_dump(mode="json")
 
 
 def _load_repo_publish_material(user_id: str, user_repo: Any, agent_config_repo: Any) -> Any:
@@ -142,13 +142,16 @@ def publish(
     publisher_username: str,
     user_repo: Any = None,
     agent_config_repo: Any = None,
+    skill_repo: Any = None,
 ) -> dict:
     """Publish a local AgentSnapshot to the Hub."""
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required for publish()")
+    if skill_repo is None:
+        raise RuntimeError("skill_repo is required for publish()")
 
     config = _load_repo_publish_material(user_id, user_repo, agent_config_repo)
-    snapshot = _agent_snapshot_payload(config)
+    snapshot = _agent_snapshot_payload(config, skill_repo)
     meta = copy.deepcopy(config.meta)
 
     new_version = bump_semver(config.version, bump_type)
@@ -297,8 +300,6 @@ def apply_item(
                     name=skill_name,
                     description=skill_description,
                     version=source_version,
-                    content=content,
-                    files=skill_files,
                     source={
                         "marketplace_item_id": item_id,
                         "source_version": source_version,

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -6,8 +6,8 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
-from config.agent_config_resolver import validate_agent_skill_content
-from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, Skill, SkillPackage
+from config.agent_config_resolver import validate_resolved_skill_content
+from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, ResolvedSkill, Skill, SkillPackage
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 
 
@@ -20,7 +20,7 @@ def _skill_id_from_name(name: str) -> str:
 
 def _materialize_snapshot_skills(
     *,
-    skills: list[AgentSkill],
+    skills: list[ResolvedSkill],
     owner_user_id: str,
     marketplace_item_id: str,
     source_version: str,
@@ -34,7 +34,7 @@ def _materialize_snapshot_skills(
 
     seen_names: set[str] = set()
     for snapshot_skill in skills:
-        validate_agent_skill_content(snapshot_skill)
+        validate_resolved_skill_content(snapshot_skill)
         if snapshot_skill.name in seen_names:
             raise ValueError(f"Duplicate Skill name in snapshot: {snapshot_skill.name}")
         seen_names.add(snapshot_skill.name)
@@ -43,7 +43,7 @@ def _materialize_snapshot_skills(
     timestamp = datetime.now(UTC)
     library_skills = skill_repo.list_for_owner(owner_user_id)
     for snapshot_skill in skills:
-        skill_id = snapshot_skill.skill_id or _skill_id_from_name(snapshot_skill.name)
+        skill_id = _skill_id_from_name(snapshot_skill.name)
         existing = skill_repo.get_by_id(owner_user_id, skill_id)
         if existing is not None and existing.name != snapshot_skill.name:
             raise ValueError("Snapshot Skill frontmatter name must match existing Skill name")
@@ -88,13 +88,13 @@ def _materialize_snapshot_skills(
         )
         skill_repo.select_package(owner_user_id, skill.id, package.id)
         result.append(
-            snapshot_skill.model_copy(
-                update={
-                    "skill_id": skill.id,
-                    "package_id": package.id,
-                    "version": package.version,
-                    "source": source,
-                }
+            AgentSkill(
+                skill_id=skill.id,
+                package_id=package.id,
+                name=snapshot_skill.name,
+                description=snapshot_skill.description,
+                version=package.version,
+                source=source,
             )
         )
     return result

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -577,9 +577,6 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
         if library_skill is None:
             raise RuntimeError(f"Library skill not found: {name}")
         library_package = _selected_library_package(owner_user_id, library_skill, skill_repo)
-        content = str(library_package.skill_md)
-        if enabled and not content.strip():
-            raise RuntimeError(f"Skill {name!r} has no content")
         description = item.get("desc") or item.get("description")
         if description is None and library_skill is not None:
             description = library_skill.description
@@ -599,12 +596,6 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
                     or item.get("version")
                     or (current_skill.version if current_skill is not None else "")
                     or "0.1.0"
-                ),
-                content=content,
-                files=dict(
-                    (library_package.files if library_package is not None else {})
-                    or item.get("files")
-                    or (current_skill.files if current_skill is not None else {})
                 ),
                 source=dict(
                     (library_package.source if library_package is not None else {})

--- a/backend/threads/pool/factory.py
+++ b/backend/threads/pool/factory.py
@@ -14,6 +14,7 @@ def create_agent_sync(
     agent: str | None = None,
     agent_config_id: str | None = None,
     agent_config_repo: Any = None,
+    skill_repo: Any = None,
     thread_repo: Any = None,
     user_repo: Any = None,
     queue_manager: Any = None,
@@ -46,5 +47,6 @@ def create_agent_sync(
         agent=agent,
         agent_config_id=agent_config_id,
         agent_config_repo=agent_config_repo,
+        skill_repo=skill_repo,
         extra_allowed_paths=extra_allowed_paths,
     )

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -75,9 +75,9 @@ async def get_or_create_agent(
         model_name = thread_data.get("model") if thread_data else None
         models_config_override = None
         runtime_storage = getattr(app_obj.state, "runtime_storage_state", None)
-        storage_container = getattr(runtime_storage, "storage_container", None)
+        storage_container: Any = getattr(runtime_storage, "storage_container", None)
         user_settings_repo_factory = getattr(storage_container, "user_settings_repo", None)
-        user_settings_repo = user_settings_repo_factory() if callable(user_settings_repo_factory) else None
+        user_settings_repo: Any = user_settings_repo_factory() if callable(user_settings_repo_factory) else None
         owner_user_id = getattr(agent_user, "owner_user_id", None) if agent_user is not None else None
         if user_settings_repo is not None and owner_user_id is not None:
             settings_row = user_settings_repo.get(owner_user_id) or {}
@@ -93,9 +93,11 @@ async def get_or_create_agent(
         agent_config_id = None
         memory_config_override = None
         runtime_storage = getattr(app_obj.state, "runtime_storage_state", None)
-        storage_container = getattr(runtime_storage, "storage_container", None)
+        storage_container: Any = getattr(runtime_storage, "storage_container", None)
         agent_config_repo_factory = getattr(storage_container, "agent_config_repo", None)
-        agent_config_repo = agent_config_repo_factory() if callable(agent_config_repo_factory) else None
+        agent_config_repo: Any = agent_config_repo_factory() if callable(agent_config_repo_factory) else None
+        skill_repo_factory = getattr(storage_container, "skill_repo", None)
+        skill_repo: Any = skill_repo_factory() if callable(skill_repo_factory) else None
         if thread_data and thread_data.get("agent_user_id"):
             if user_repo is None:
                 raise RuntimeError(f"user_repo is required to resolve agent_config_id for thread {thread_id}")
@@ -173,6 +175,7 @@ async def get_or_create_agent(
         if agent_config_id is not None:
             create_kwargs["agent_config_id"] = agent_config_id
             create_kwargs["agent_config_repo"] = agent_config_repo
+            create_kwargs["skill_repo"] = skill_repo
         agent_obj = await asyncio.to_thread(create_agent_sync, **create_kwargs)
         agent_identity_user_id = str(thread_data.get("agent_user_id") or "").strip() if thread_data else ""
         if not agent_identity_user_id:

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -87,6 +87,7 @@ async def publish_agent_user_to_marketplace(
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     agent_config_repo = _agent_config_repo(request)
+    skill_repo = _skill_repo(request)
     await _verify_user_ownership(req.user_id, user_id, user_repo)
 
     publisher_user = user_repo.get_by_id(user_id)
@@ -105,6 +106,7 @@ async def publish_agent_user_to_marketplace(
         publisher_username=username,
         user_repo=user_repo,
         agent_config_repo=agent_config_repo,
+        skill_repo=skill_repo,
     )
 
 

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 import yaml
 
-from config.agent_config_types import AgentConfig, AgentSkill, ResolvedAgentConfig
+from config.agent_config_types import AgentConfig, ResolvedAgentConfig, ResolvedSkill
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
-def resolve_agent_config(config: AgentConfig) -> ResolvedAgentConfig:
+def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> ResolvedAgentConfig:
     enabled_skills = []
     seen_skill_names: set[str] = set()
     for skill in config.skills:
@@ -18,7 +19,7 @@ def resolve_agent_config(config: AgentConfig) -> ResolvedAgentConfig:
         if skill.name in seen_skill_names:
             raise ValueError(f"Duplicate Skill name in AgentConfig: {skill.name}")
         seen_skill_names.add(skill.name)
-        enabled_skills.append(validate_agent_skill_content(skill))
+        enabled_skills.append(_resolve_skill(config.owner_user_id, skill, skill_repo))
     enabled_mcp_servers = []
     seen_mcp_server_names: set[str] = set()
     for server in config.mcp_servers:
@@ -45,7 +46,31 @@ def resolve_agent_config(config: AgentConfig) -> ResolvedAgentConfig:
     )
 
 
-def validate_agent_skill_content(skill: AgentSkill) -> AgentSkill:
+def _resolve_skill(owner_user_id: str, skill: Any, skill_repo: Any) -> ResolvedSkill:
+    if skill_repo is None:
+        raise RuntimeError("skill_repo is required to resolve AgentConfig Skills")
+    if not skill.skill_id:
+        raise ValueError(f"AgentConfig Skill {skill.name!r} is missing skill_id")
+    if not skill.package_id:
+        raise ValueError(f"AgentConfig Skill {skill.name!r} is missing package_id")
+
+    package = skill_repo.get_package(owner_user_id, skill.package_id)
+    if package is None:
+        raise RuntimeError(f"Skill package not found while resolving AgentConfig: {skill.package_id}")
+    if package.skill_id != skill.skill_id:
+        raise RuntimeError(f"Skill package {skill.package_id} does not belong to Skill {skill.skill_id}")
+    resolved = ResolvedSkill(
+        name=skill.name,
+        description=skill.description,
+        version=package.version or skill.version,
+        content=package.skill_md,
+        files=dict(package.files),
+        source=dict(package.source or skill.source),
+    )
+    return validate_resolved_skill_content(resolved)
+
+
+def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
     if not skill.content.strip():
         raise ValueError(f"Skill {skill.name!r} on Agent config has blank content")
     frontmatter_result = _FRONTMATTER_RE.search(skill.content)

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -58,16 +58,30 @@ class AgentSkill(BaseModel):
     name: str
     description: str = ""
     version: str = "0.1.0"
+    enabled: bool = True
+    source: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def _non_blank(cls, value: str, info: ValidationInfo) -> str:
+        if not value.strip():
+            raise ValueError(f"agent_skill.{info.field_name} must not be blank")
+        return value
+
+
+class ResolvedSkill(BaseModel):
+    name: str
+    description: str = ""
+    version: str = "0.1.0"
     content: str
     files: dict[str, str] = Field(default_factory=dict)
-    enabled: bool = True
     source: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("name", "content")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():
-            raise ValueError(f"agent_skill.{info.field_name} must not be blank")
+            raise ValueError(f"resolved_skill.{info.field_name} must not be blank")
         return value
 
     @field_validator("files", mode="before")
@@ -163,7 +177,7 @@ class ResolvedAgentConfig(BaseModel):
     system_prompt: str = ""
     runtime_settings: dict[str, Any] = Field(default_factory=dict)
     compact: dict[str, Any] = Field(default_factory=dict)
-    skills: list[AgentSkill] = Field(default_factory=list)
+    skills: list[ResolvedSkill] = Field(default_factory=list)
     rules: list[AgentRule] = Field(default_factory=list)
     sub_agents: list[AgentSubAgent] = Field(default_factory=list)
     mcp_servers: list[McpServerConfig] = Field(default_factory=list)

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -115,6 +115,7 @@ class LeonAgent:
         agent: str | None = None,
         agent_config_id: str | None = None,
         agent_config_repo: Any = None,
+        skill_repo: Any = None,
         allowed_file_extensions: list[str] | None = None,
         block_dangerous_commands: bool | None = None,
         block_network_commands: bool | None = None,
@@ -165,6 +166,9 @@ class LeonAgent:
 
             if uses_supabase_storage():
                 runtime_storage = build_storage_container()
+        if skill_repo is None and runtime_storage is not None:
+            skill_repo_factory = getattr(runtime_storage, "skill_repo", None)
+            skill_repo = skill_repo_factory() if callable(skill_repo_factory) else None
 
         self.agent_id: str | None = None
         self.extra_allowed_paths = extra_allowed_paths
@@ -192,6 +196,7 @@ class LeonAgent:
             agent_name=agent,
             agent_config_id=agent_config_id,
             agent_config_repo=agent_config_repo,
+            skill_repo=skill_repo,
             workspace_root=workspace_root,
             sandbox_name=requested_sandbox_name,
             model_name=model_name,
@@ -441,11 +446,11 @@ class LeonAgent:
         """
         from config.defaults.tool_catalog import TOOLS_BY_NAME, tool_enabled_for_agent
 
-        if getattr(self, "_resolved_agent_config", None) is not None:
-            runtime = self._resolved_agent_config.runtime_settings
-            configured_tools = list(self._resolved_agent_config.tools or ["*"])
-        else:
+        resolved_config = getattr(self, "_resolved_agent_config", None)
+        if resolved_config is None:
             return set()
+        runtime = resolved_config.runtime_settings
+        configured_tools = list(resolved_config.tools or ["*"])
         return {
             tool_name
             for tool_name in TOOLS_BY_NAME
@@ -453,8 +458,9 @@ class LeonAgent:
         }
 
     def _get_mcp_server_configs(self) -> dict[str, Any]:
-        if getattr(self, "_resolved_agent_config", None) is not None:
-            return {server.name: server for server in self._resolved_agent_config.mcp_servers if server.enabled}
+        resolved_config = getattr(self, "_resolved_agent_config", None)
+        if resolved_config is not None:
+            return {server.name: server for server in resolved_config.mcp_servers if server.enabled}
         return self.config.mcp.servers
 
     def _get_integration_instruction_blocks(self) -> dict[str, str]:
@@ -465,6 +471,7 @@ class LeonAgent:
         agent_name: str | None,
         agent_config_id: str | None,
         agent_config_repo: Any,
+        skill_repo: Any,
         workspace_root: str | Path | None,
         sandbox_name: str | None,
         model_name: str | None,
@@ -536,7 +543,7 @@ class LeonAgent:
             agent_config = agent_config_repo.get_agent_config(agent_config_id)
             if agent_config is None:
                 raise RuntimeError(f"Agent config not found: {agent_config_id}")
-            self._resolved_agent_config = resolve_agent_config(agent_config)
+            self._resolved_agent_config = resolve_agent_config(agent_config, skill_repo=skill_repo)
             self._agent_override = RuntimeAgentDefinition(
                 name=self._resolved_agent_config.name,
                 description=self._resolved_agent_config.description,
@@ -1158,10 +1165,11 @@ class LeonAgent:
 
         # Skills tools
         resolved_skills = []
-        if getattr(self, "_resolved_agent_config", None) is not None:
+        resolved_config = getattr(self, "_resolved_agent_config", None)
+        if resolved_config is not None:
             resolved_skills = [
                 {"name": skill.name, "content": skill.content, "files": skill.files, "meta": skill.source}
-                for skill in self._resolved_agent_config.skills
+                for skill in resolved_config.skills
             ]
         if resolved_skills:
             self._skills_service = SkillsService(
@@ -1254,8 +1262,9 @@ class LeonAgent:
         # If agent override is set, use its system_prompt + rules.
         if hasattr(self, "_agent_override") and self._agent_override:
             prompt = self._agent_override.system_prompt
-            if getattr(self, "_resolved_agent_config", None) is not None and self._resolved_agent_config.rules:
-                rule_parts = [f"## {rule.name}\n{rule.content}" for rule in self._resolved_agent_config.rules if rule.content.strip()]
+            resolved_config = getattr(self, "_resolved_agent_config", None)
+            if resolved_config is not None and resolved_config.rules:
+                rule_parts = [f"## {rule.name}\n{rule.content}" for rule in resolved_config.rules if rule.content.strip()]
                 if rule_parts:
                     prompt += "\n\n---\n\n" + "\n\n".join(rule_parts)
                 return prompt

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from config.agent_config_resolver import resolve_agent_config, validate_agent_skill_content
 from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig
 from storage.providers.supabase import _query as q
 
@@ -72,9 +71,6 @@ class SupabaseAgentConfigRepo:
 
     def save_agent_config(self, config: AgentConfig) -> None:
         _reject_duplicate_child_names(config)
-        resolve_agent_config(config)
-        for skill in config.skills:
-            validate_agent_skill_content(skill)
         payload = config.model_dump(mode="json")
         q.schema_rpc(self._client, _SCHEMA, "save_agent_config", {"payload": payload}, _REPO).execute()
 
@@ -104,8 +100,6 @@ class SupabaseAgentConfigRepo:
                     name=skill["name"],
                     description=skill.get("description") or "",
                     version=package.get("version") or "0.1.0",
-                    content=package["skill_md"],
-                    files=dict(package.get("files_json") or {}),
                     enabled=bool(row.get("enabled", True)),
                     source=dict(package.get("source_json") or skill.get("source_json") or {}),
                 )

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -9,28 +9,60 @@ from config.agent_config_types import (
     AgentSkill,
     AgentSubAgent,
     McpServerConfig,
+    SkillPackage,
 )
 
 
-def _skill(name: str = "github", *, enabled: bool = True, content: str | None = None) -> AgentSkill:
+def _skill(name: str = "github", *, enabled: bool = True) -> AgentSkill:
     return AgentSkill(
+        skill_id=name,
+        package_id=f"{name}-package",
         name=name,
         description="GitHub guidance",
         version="1.0.0",
         enabled=enabled,
-        content=content
-        or """---
-name: github
+        source={"marketplace_item_id": "skill-github", "source_version": "1.0.0"},
+    )
+
+
+def _skill_md(name: str = "github") -> str:
+    return f"""---
+name: {name}
 description: Use gh.
 ---
 
 # GitHub
 
 Use gh with explicit repositories.
-""",
-        files={"references/query.md": "Prefer precise queries."},
-        source={"marketplace_item_id": "skill-github", "source_version": "1.0.0"},
-    )
+"""
+
+
+class _SkillRepo:
+    def __init__(self, packages: dict[str, SkillPackage] | None = None) -> None:
+        self.packages = packages or {
+            "github-package": SkillPackage(
+                id="github-package",
+                owner_user_id="owner-1",
+                skill_id="github",
+                version="1.0.0",
+                hash="sha256:github",
+                skill_md=_skill_md("github"),
+                files={"references/query.md": "Prefer precise queries."},
+                created_at="2026-04-25T00:00:00+00:00",
+            ),
+            "disabled-package": SkillPackage(
+                id="disabled-package",
+                owner_user_id="owner-1",
+                skill_id="disabled",
+                version="1.0.0",
+                hash="sha256:disabled",
+                skill_md=_skill_md("disabled"),
+                created_at="2026-04-25T00:00:00+00:00",
+            ),
+        }
+
+    def get_package(self, _owner_user_id: str, package_id: str) -> SkillPackage | None:
+        return self.packages.get(package_id)
 
 
 def _config(**overrides: object) -> AgentConfig:
@@ -68,7 +100,7 @@ def test_resolved_config_contains_only_enabled_children():
         ],
     )
 
-    resolved = resolve_agent_config(config)
+    resolved = resolve_agent_config(config, skill_repo=_SkillRepo())
 
     assert resolved.id == "cfg-1"
     assert resolved.name == "Researcher"
@@ -79,11 +111,13 @@ def test_resolved_config_contains_only_enabled_children():
     assert [server.name for server in resolved.mcp_servers] == ["filesystem"]
 
 
-def test_agent_skill_rejects_blank_content():
-    with pytest.raises(ValueError) as excinfo:
-        AgentSkill(name="broken", content="")
+def test_resolver_rejects_skill_without_package_id():
+    config = _config(skills=[AgentSkill(skill_id="broken", name="broken")])
 
-    assert "agent_skill.content must not be blank" in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        resolve_agent_config(config, skill_repo=_SkillRepo())
+
+    assert "missing package_id" in str(excinfo.value)
 
 
 def test_agent_named_children_reject_blank_names():
@@ -116,10 +150,25 @@ def test_agent_config_rejects_blank_identity_fields():
 
 
 def test_resolver_rejects_skill_without_frontmatter():
-    config = _config(skills=[AgentSkill.model_construct(name="broken", content="# Missing")])
+    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package", name="broken")])
 
     with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config)
+        resolve_agent_config(
+            config,
+            skill_repo=_SkillRepo(
+                {
+                    "broken-package": SkillPackage(
+                        id="broken-package",
+                        owner_user_id="owner-1",
+                        skill_id="broken",
+                        version="1.0.0",
+                        hash="sha256:broken",
+                        skill_md="# Missing",
+                        created_at="2026-04-25T00:00:00+00:00",
+                    )
+                }
+            ),
+        )
 
     assert "missing SKILL.md frontmatter" in str(excinfo.value)
 
@@ -127,20 +176,31 @@ def test_resolver_rejects_skill_without_frontmatter():
 def test_resolver_rejects_skill_frontmatter_without_name():
     config = _config(
         skills=[
-            AgentSkill.model_construct(
+            AgentSkill(
+                skill_id="broken",
+                package_id="broken-package",
                 name="broken",
-                content="""---
-description: Missing canonical name.
----
-
-# Broken
-""",
             )
         ]
     )
 
     with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config)
+        resolve_agent_config(
+            config,
+            skill_repo=_SkillRepo(
+                {
+                    "broken-package": SkillPackage(
+                        id="broken-package",
+                        owner_user_id="owner-1",
+                        skill_id="broken",
+                        version="1.0.0",
+                        hash="sha256:broken",
+                        skill_md="---\ndescription: Missing canonical name.\n---\n\n# Broken\n",
+                        created_at="2026-04-25T00:00:00+00:00",
+                    )
+                }
+            ),
+        )
 
     assert "frontmatter is missing name" in str(excinfo.value)
 
@@ -148,20 +208,31 @@ description: Missing canonical name.
 def test_resolver_rejects_display_name_without_name():
     config = _config(
         skills=[
-            AgentSkill.model_construct(
+            AgentSkill(
+                skill_id="broken",
+                package_id="broken-package",
                 name="broken",
-                content="""---
-display_name: Pretty label only.
----
-
-# Broken
-""",
             )
         ]
     )
 
     with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config)
+        resolve_agent_config(
+            config,
+            skill_repo=_SkillRepo(
+                {
+                    "broken-package": SkillPackage(
+                        id="broken-package",
+                        owner_user_id="owner-1",
+                        skill_id="broken",
+                        version="1.0.0",
+                        hash="sha256:broken",
+                        skill_md="---\ndisplay_name: Pretty label only.\n---\n\n# Broken\n",
+                        created_at="2026-04-25T00:00:00+00:00",
+                    )
+                }
+            ),
+        )
 
     assert "frontmatter is missing name" in str(excinfo.value)
 
@@ -169,20 +240,31 @@ display_name: Pretty label only.
 def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill_name():
     config = _config(
         skills=[
-            AgentSkill.model_construct(
+            AgentSkill(
+                skill_id="visible-skill",
+                package_id="visible-package",
                 name="Visible Skill",
-                content="""---
-name: Runtime Skill
----
-
-# Runtime Skill
-""",
             )
         ]
     )
 
     with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config)
+        resolve_agent_config(
+            config,
+            skill_repo=_SkillRepo(
+                {
+                    "visible-package": SkillPackage(
+                        id="visible-package",
+                        owner_user_id="owner-1",
+                        skill_id="visible-skill",
+                        version="1.0.0",
+                        hash="sha256:visible",
+                        skill_md="---\nname: Runtime Skill\n---\n\n# Runtime Skill\n",
+                        created_at="2026-04-25T00:00:00+00:00",
+                    )
+                }
+            ),
+        )
 
     assert "frontmatter name must match AgentSkill.name" in str(excinfo.value)
 
@@ -196,7 +278,7 @@ def test_resolver_rejects_duplicate_enabled_skill_names():
     )
 
     with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config)
+        resolve_agent_config(config, skill_repo=_SkillRepo())
 
     assert "Duplicate Skill name in AgentConfig: github" in str(excinfo.value)
 
@@ -210,12 +292,12 @@ def test_resolver_rejects_duplicate_enabled_mcp_server_names():
     )
 
     with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config)
+        resolve_agent_config(config, skill_repo=_SkillRepo())
 
     assert "Duplicate MCP server name in AgentConfig: filesystem" in str(excinfo.value)
 
 
-def test_resolver_has_no_repo_inputs():
+def test_resolver_requires_explicit_skill_repo_input():
     signature = inspect.signature(resolve_agent_config)
 
-    assert list(signature.parameters) == ["config"]
+    assert list(signature.parameters) == ["config", "skill_repo"]

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -2,20 +2,20 @@ from datetime import UTC, datetime
 
 import pytest
 
-from config.agent_config_types import AgentSkill, SkillPackage
+from config.agent_config_types import AgentSkill, ResolvedSkill, SkillPackage
 
 
-def test_agent_skill_model_normalizes_file_paths() -> None:
-    agent_skill = AgentSkill(
+def test_resolved_skill_model_normalizes_file_paths() -> None:
+    resolved_skill = ResolvedSkill(
         name="query-helper",
         content="---\nname: query-helper\n---\nUse exact terms.",
         files={"references\\query.md": "Prefer precise queries."},
     )
 
-    assert agent_skill.files == {"references/query.md": "Prefer precise queries."}
+    assert resolved_skill.files == {"references/query.md": "Prefer precise queries."}
 
 
-def test_agent_skill_model_rejects_duplicate_file_paths_after_normalization() -> None:
+def test_resolved_skill_model_rejects_duplicate_file_paths_after_normalization() -> None:
     common = {
         "content": "---\nname: query-helper\n---\nUse exact terms.",
         "files": {
@@ -25,7 +25,14 @@ def test_agent_skill_model_rejects_duplicate_file_paths_after_normalization() ->
     }
 
     with pytest.raises(ValueError, match="Skill files contain duplicate path after normalization: references/query.md"):
-        AgentSkill(name="query-helper", **common)
+        ResolvedSkill(name="query-helper", **common)
+
+
+def test_agent_skill_model_has_no_resolved_content() -> None:
+    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper")
+
+    assert "content" not in agent_skill.model_dump()
+    assert "files" not in agent_skill.model_dump()
 
 
 def test_skill_package_requires_package_identity_and_skill_md() -> None:

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -1,5 +1,5 @@
 from config.agent_config_resolver import resolve_agent_config
-from config.agent_config_types import AgentConfig, AgentSkill
+from config.agent_config_types import AgentConfig, AgentSkill, SkillPackage
 from config.agent_snapshot import snapshot_from_resolved_config
 
 
@@ -12,17 +12,28 @@ def test_snapshot_contains_resolved_agent_config_only():
             name="Researcher",
             skills=[
                 AgentSkill(
+                    skill_id="github",
+                    package_id="github-package",
                     name="github",
-                    content="""---
-name: github
----
-
-# GitHub
-""",
-                    files={"references/query.md": "Prefer precise queries."},
                 )
             ],
-        )
+        ),
+        skill_repo=type(
+            "_SkillRepo",
+            (),
+            {
+                "get_package": lambda self, _owner_user_id, package_id: SkillPackage(
+                    id=package_id,
+                    owner_user_id="owner-1",
+                    skill_id="github",
+                    version="1.0.0",
+                    hash="sha256:github",
+                    skill_md="---\nname: github\n---\n\n# GitHub\n",
+                    files={"references/query.md": "Prefer precise queries."},
+                    created_at="2026-04-25T00:00:00+00:00",
+                )
+            },
+        )(),
     )
 
     snapshot = snapshot_from_resolved_config(resolved)

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, SystemMessage, ToolMessage
 
-from config.agent_config_types import AgentConfig, AgentSkill, McpServerConfig
+from config.agent_config_types import AgentConfig, AgentSkill, McpServerConfig, SkillPackage
 
 
 def _mock_model(text="Integration test response"):
@@ -57,6 +57,25 @@ def _agent_config(**overrides: object) -> AgentConfig:
     }
     data.update(overrides)
     return AgentConfig(**data)
+
+
+class _SkillRepo:
+    def __init__(self, *, files: dict[str, str] | None = None) -> None:
+        self.files = files or {}
+
+    def get_package(self, _owner_user_id: str, package_id: str) -> SkillPackage | None:
+        if package_id != "fastapi-package":
+            return None
+        return SkillPackage(
+            id=package_id,
+            owner_user_id="owner-1",
+            skill_id="fastapi",
+            version="1.0.0",
+            hash="sha256:fastapi",
+            skill_md="---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
+            files=self.files,
+            created_at="2026-04-25T00:00:00+00:00",
+        )
 
 
 def _write_file_skill_dir(tmp_path, *, name: str, body: str, description: str = "file skill") -> None:
@@ -718,9 +737,9 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
                 runtime_settings={"skills:FastAPI": {"enabled": True, "desc": "Use FastAPI conventions"}},
                 skills=[
                     AgentSkill(
+                        skill_id="fastapi",
+                        package_id="fastapi-package",
                         name="FastAPI",
-                        content="---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
-                        files={"references/routing.md": "Prefer APIRouter over app-level route decorators."},
                         source={"desc": "Build FastAPI services"},
                     )
                 ],
@@ -738,6 +757,7 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
             workspace_root=str(tmp_path),
             agent_config_id="cfg-1",
             agent_config_repo=_Repo(),
+            skill_repo=_SkillRepo(files={"references/routing.md": "Prefer APIRouter over app-level route decorators."}),
             api_key="sk-test-integration",
         )
         await agent.ainit()
@@ -776,8 +796,9 @@ async def test_leon_agent_agent_config_id_does_not_register_host_file_skills(tmp
                 system_prompt="You are Repo Toad.",
                 skills=[
                     AgentSkill(
+                        skill_id="fastapi",
+                        package_id="fastapi-package",
                         name="FastAPI",
-                        content="---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
                     )
                 ],
             )
@@ -794,6 +815,7 @@ async def test_leon_agent_agent_config_id_does_not_register_host_file_skills(tmp
             workspace_root=str(tmp_path),
             agent_config_id="cfg-1",
             agent_config_repo=_Repo(),
+            skill_repo=_SkillRepo(),
             api_key="sk-test-integration",
         )
         await agent.ainit()
@@ -926,8 +948,9 @@ async def test_leon_agent_agent_config_id_does_not_read_stale_runtime_skill_togg
                 system_prompt="You are Repo Toad.",
                 skills=[
                     AgentSkill(
+                        skill_id="fastapi",
+                        package_id="fastapi-package",
                         name="FastAPI",
-                        content="---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
                     )
                 ],
             )
@@ -944,6 +967,7 @@ async def test_leon_agent_agent_config_id_does_not_read_stale_runtime_skill_togg
             workspace_root=str(tmp_path),
             agent_config_id="cfg-1",
             agent_config_repo=_Repo(),
+            skill_repo=_SkillRepo(),
             api_key="sk-test-integration",
         )
         await agent.ainit()

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -661,7 +661,7 @@ def test_agent_config_patch_explicit_library_id_uses_library_content() -> None:
     assert result is not None
     assert saved_configs[-1].skills[0].skill_id == "loadable-skill"
     assert saved_configs[-1].skills[0].package_id == library_skill.package_id
-    assert saved_configs[-1].skills[0].content == "---\nname: Loadable Skill\n---\nLibrary content."
+    assert "content" not in saved_configs[-1].skills[0].model_dump()
 
 
 def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None:
@@ -1153,7 +1153,7 @@ def test_get_agent_user_uses_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(name="Search", description="repo desc", content="---\nname: Search\n---\n")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1183,7 +1183,7 @@ def test_get_agent_user_keeps_runtime_skill_desc_override_ahead_of_repo_meta():
                 model="leon:large",
                 system_prompt="",
                 runtime_settings={"skills:Search": {"desc": "runtime desc"}},
-                skills=[AgentSkill(name="Search", description="repo desc", content="---\nname: Search\n---\n")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1328,7 +1328,7 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(name="Search", description="", content="---\nname: Search\n---\n")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="")],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1557,7 +1557,6 @@ def test_library_used_by_reads_agent_configs_without_display_projection(monkeypa
                     skill_id="skill-1",
                     package_id="skill-1-package",
                     name="api-design-reviewer",
-                    content="---\nname: api-design-reviewer\n---\nBody",
                     enabled=True,
                 )
             ],
@@ -1593,7 +1592,6 @@ async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypa
                     skill_id="skill-1",
                     package_id="skill-1-package",
                     name="api-design-reviewer",
-                    content="---\nname: api-design-reviewer\n---\nBody",
                     enabled=True,
                 )
             ],

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -340,7 +340,7 @@ class TestApplySkill:
         class _AgentConfigRepo:
             def get_agent_config(self, agent_config_id: str) -> AgentConfig | None:
                 assert agent_config_id == "cfg-1"
-                return _agent_config(skills=[AgentSkill(name="Existing", content="---\nname: Existing\n---\nBody")])
+                return _agent_config(skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing")])
 
             def save_agent_config(self, config: AgentConfig) -> None:
                 saved.append(config)
@@ -661,8 +661,9 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                 sub_agents=[AgentSubAgent(name="Scout", description="helper", tools=["search"], system_prompt="look around")],
                 skills=[
                     AgentSkill(
+                        skill_id="search",
+                        package_id="search-package",
                         name="Search",
-                        content="---\nname: Search\n---\nskill content",
                         source={"name": "Search", "desc": "Repo Search"},
                     )
                 ],
@@ -688,6 +689,18 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
         publisher_username="owner-name",
         user_repo=user_repo,
         agent_config_repo=_AgentConfigRepo(),
+        skill_repo=SimpleNamespace(
+            get_package=lambda _owner_user_id, package_id: SkillPackage(
+                id=package_id,
+                owner_user_id="owner-1",
+                skill_id="search",
+                version="1.0.0",
+                hash="sha256:search",
+                skill_md="---\nname: Search\n---\nskill content",
+                source={"name": "Search", "desc": "Repo Search"},
+                created_at="2026-04-25T00:00:00+00:00",
+            )
+        ),
     )
 
     assert result == {"item_id": "item-123"}
@@ -756,6 +769,7 @@ def test_publish_prefers_repo_lineage_even_when_stale_member_dir_exists(tmp_path
         publisher_username="owner-name",
         user_repo=user_repo,
         agent_config_repo=_AgentConfigRepo(),
+        skill_repo=SimpleNamespace(),
     )
 
     assert result == {"item_id": "item-123"}

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -181,8 +181,6 @@ def test_get_agent_config_reads_full_aggregate_from_final_tables() -> None:
                 name="github",
                 description="GitHub guidance",
                 version="1.0.0",
-                content="---\nname: github\n---\n",
-                files={"references/query.md": "Prefer precise queries."},
                 source={"source_version": "1.0.0"},
             )
         ],
@@ -247,8 +245,6 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
                     skill_id="skill-1",
                     package_id="package-1",
                     name="github",
-                    content="---\nname: github\n---\n",
-                    files={"references/query.md": "Prefer precise queries."},
                 )
             ],
             rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -266,38 +262,9 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
     assert payload["runtime_settings"] == {"shell": {"enabled": False}}
     assert payload["compact"] == {"trigger_tokens": 1000}
     assert payload["skills"][0]["skill_id"] == "skill-1"
-    assert payload["skills"][0]["files"] == {"references/query.md": "Prefer precise queries."}
+    assert "content" not in payload["skills"][0]
+    assert "files" not in payload["skills"][0]
     assert "runtime_" + "settings_json" not in payload
-
-
-def test_save_agent_config_rejects_blank_enabled_skill_content() -> None:
-    repo = SupabaseAgentConfigRepo(_FakeClient())
-    config = AgentConfig(
-        id="cfg-1",
-        owner_user_id="owner-1",
-        agent_user_id="agent-1",
-        name="Researcher",
-        skills=[AgentSkill.model_construct(name="broken", content="", enabled=True)],
-    )
-
-    with pytest.raises(ValueError) as excinfo:
-        repo.save_agent_config(config)
-
-    assert "has blank content" in str(excinfo.value)
-
-
-def test_save_agent_config_rejects_skill_frontmatter_name_drift() -> None:
-    repo = SupabaseAgentConfigRepo(_FakeClient())
-    config = AgentConfig(
-        id="cfg-1",
-        owner_user_id="owner-1",
-        agent_user_id="agent-1",
-        name="Researcher",
-        skills=[AgentSkill.model_construct(name="Visible Skill", content="---\nname: Runtime Skill\n---\nBody")],
-    )
-
-    with pytest.raises(ValueError, match="frontmatter name must match AgentSkill.name"):
-        repo.save_agent_config(config)
 
 
 def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
@@ -309,8 +276,8 @@ def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
         agent_user_id="agent-1",
         name="Researcher",
         skills=[
-            AgentSkill(name="github", content="---\nname: github\n---\nOne"),
-            AgentSkill(name="github", content="---\nname: github\n---\nTwo"),
+            AgentSkill(skill_id="github", package_id="package-1", name="github"),
+            AgentSkill(skill_id="github-two", package_id="package-2", name="github"),
         ],
     )
 
@@ -349,8 +316,8 @@ def test_save_agent_config_rejects_duplicate_disabled_child_names_before_rpc() -
         agent_user_id="agent-1",
         name="Researcher",
         skills=[
-            AgentSkill(name="github", content="---\nname: github\n---\nOne", enabled=False),
-            AgentSkill(name="github", content="---\nname: github\n---\nTwo", enabled=False),
+            AgentSkill(skill_id="github", package_id="package-1", name="github", enabled=False),
+            AgentSkill(skill_id="github-two", package_id="package-2", name="github", enabled=False),
         ],
         mcp_servers=[
             McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),


### PR DESCRIPTION
## Summary
- keep AgentConfig Skill entries as Library Skill/package selections, without runnable content/files
- resolve package content into ResolvedAgentConfig through skill_repo for runtime and Hub publish
- wire runtime, thread pool, Hub publish, and Agent config patch writes through the package-selection contract

## Verification
- uv run ruff check . && uv run ruff format --check .
- uv run pyright config/agent_config_types.py config/agent_config_resolver.py storage/providers/supabase/agent_config_repo.py backend/hub/snapshot_apply.py backend/hub/client.py backend/web/routers/marketplace.py core/runtime/agent.py backend/threads/pool/factory.py backend/threads/pool/registry.py backend/threads/agent_user_service.py
- uv run pytest tests/Unit -q
- uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q