### PR TITLE
Lock Skill package lifecycle through Agent config

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -33,21 +33,13 @@ def _tools_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
 
 
 def _skills_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
-    runtime = config.runtime_settings
     skills_list = []
     for skill in config.skills:
-        runtime_key = f"skills:{skill.name}"
-        override = runtime.get(runtime_key, {}) if isinstance(runtime.get(runtime_key), dict) else {}
-        desc = ""
-        if "desc" in override and override.get("desc") is not None:
-            desc = str(override.get("desc") or "")
-        elif skill.description:
-            desc = skill.description
         skills_list.append(
             {
                 "name": skill.name,
-                "enabled": bool(override.get("enabled", skill.enabled)),
-                "desc": desc,
+                "enabled": skill.enabled,
+                "desc": skill.description,
             }
         )
     return skills_list
@@ -559,6 +551,8 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
     for item in skill_items:
         if not (isinstance(item, dict) and item.get("name")):
             raise RuntimeError("Skill patch item must include name")
+        if "content" in item or "files" in item:
+            raise RuntimeError("Skill patch item must not include content or files")
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate Skill name in patch: {name}")
@@ -577,29 +571,24 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
         if library_skill is None:
             raise RuntimeError(f"Library skill not found: {name}")
         library_package = _selected_library_package(owner_user_id, library_skill, skill_repo)
-        description = item.get("desc") or item.get("description")
-        if description is None and library_skill is not None:
-            description = library_skill.description
-        if description is None and current_skill is not None:
-            description = current_skill.description
-        if library_skill is not None:
-            description = library_skill.description
+        description = library_skill.description
+        agent_skill_id = item.get("agent_skill_id") or item.get("row_id") or (current_skill.id if current_skill is not None else None)
         skills.append(
             AgentSkill(
-                id=str(item.get("agent_skill_id") or item.get("row_id") or (current_skill.id if current_skill is not None else "")),
+                id=str(agent_skill_id) if agent_skill_id else None,
                 skill_id=library_skill.id,
                 package_id=library_package.id,
                 name=library_skill.name,
-                description=str(description or ""),
+                description=description,
                 version=str(
-                    (library_package.version if library_package is not None else "")
+                    library_package.version
                     or item.get("version")
                     or (current_skill.version if current_skill is not None else "")
                     or "0.1.0"
                 ),
                 source=dict(
-                    (library_package.source if library_package is not None else {})
-                    or (library_skill.source if library_skill is not None else {})
+                    library_package.source
+                    or library_skill.source
                     or item.get("source")
                     or (current_skill.source if current_skill is not None else {})
                 ),

--- a/backend/web/models/marketplace.py
+++ b/backend/web/models/marketplace.py
@@ -17,8 +17,8 @@ class ApplyFromMarketplaceRequest(BaseModel):
 
 
 class UpgradeFromMarketplaceRequest(BaseModel):
-    user_id: str  # local agent user id
-    item_id: str  # marketplace item id
+    user_id: str  # Agent user id
+    item_id: str  # Marketplace item id
 
 
 class MarketplaceSourceInfo(BaseModel):

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -734,7 +734,6 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
             return _agent_config(
                 name="Repo Toad",
                 system_prompt="You are Repo Toad.",
-                runtime_settings={"skills:FastAPI": {"enabled": True, "desc": "Use FastAPI conventions"}},
                 skills=[
                     AgentSkill(
                         skill_id="fastapi",

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from backend.web.models.marketplace import (
     ApplyFromMarketplaceRequest,
@@ -12,6 +13,9 @@ from backend.web.models.marketplace import (
     UpgradeFromMarketplaceRequest,
 )
 from backend.web.routers import marketplace as marketplace_router
+from backend.web.routers import panel as panel_router
+from config.agent_config_types import AgentConfig
+from storage.contracts import UserRow, UserType
 
 
 def _runtime_storage_state(agent_config_repo: object, skill_repo: object | None = None) -> SimpleNamespace:
@@ -21,6 +25,29 @@ def _runtime_storage_state(agent_config_repo: object, skill_repo: object | None 
             skill_repo=lambda: skill_repo,
         )
     )
+
+
+def _agent_config(**updates: object) -> AgentConfig:
+    data = {
+        "id": "cfg-1",
+        "owner_user_id": "owner-1",
+        "agent_user_id": "agent-1",
+        "name": "Demo Agent",
+        "description": "probe",
+        "tools": ["*"],
+        "system_prompt": "hello",
+        "status": "draft",
+        "version": "0.1.0",
+        "runtime_settings": {},
+        "compact": {},
+        "skills": [],
+        "rules": [],
+        "sub_agents": [],
+        "mcp_servers": [],
+        "meta": {},
+    }
+    data.update(updates)
+    return AgentConfig(**data)
 
 
 def test_marketplace_router_exposes_agent_user_marketplace_routes() -> None:
@@ -33,6 +60,150 @@ def test_marketplace_router_exposes_agent_user_marketplace_routes() -> None:
     assert "/api/marketplace/items/{item_id}/versions/{version}" in paths
     assert "/api/marketplace/apply" in paths
     assert "/api/marketplace/" + "download" not in paths
+
+
+def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _SkillRepo:
+        def __init__(self) -> None:
+            self.skills: dict[tuple[str, str], Any] = {}
+            self.packages: dict[tuple[str, str], Any] = {}
+
+        def list_for_owner(self, owner_user_id: str) -> list[Any]:
+            return [skill for (owner, _), skill in self.skills.items() if owner == owner_user_id]
+
+        def get_by_id(self, owner_user_id: str, skill_id: str) -> Any | None:
+            return self.skills.get((owner_user_id, skill_id))
+
+        def upsert(self, skill: Any) -> Any:
+            self.skills[(getattr(skill, "owner_user_id"), getattr(skill, "id"))] = skill
+            return skill
+
+        def create_package(self, package: Any) -> Any:
+            self.packages[(getattr(package, "owner_user_id"), getattr(package, "id"))] = package
+            return package
+
+        def get_package(self, owner_user_id: str, package_id: str) -> Any | None:
+            return self.packages.get((owner_user_id, package_id))
+
+        def select_package(self, owner_user_id: str, skill_id: str, package_id: str) -> None:
+            skill = self.skills[(owner_user_id, skill_id)]
+            self.skills[(owner_user_id, skill_id)] = skill.model_copy(update={"package_id": package_id})
+
+        def delete(self, owner_user_id: str, skill_id: str) -> None:
+            self.skills.pop((owner_user_id, skill_id), None)
+
+    class _UserRepo:
+        def __init__(self) -> None:
+            self.agent = UserRow(
+                id="agent-1",
+                type=UserType.AGENT,
+                display_name="Demo Agent",
+                owner_user_id="owner-1",
+                agent_config_id="cfg-1",
+                created_at=1.0,
+            )
+
+        def get_by_id(self, user_id: str) -> Any | None:
+            if user_id == "agent-1":
+                return self.agent
+            return None
+
+        def list_by_owner_user_id(self, owner_user_id: str) -> list[Any]:
+            return [self.agent] if owner_user_id == "owner-1" else []
+
+    class _AgentConfigRepo:
+        def __init__(self) -> None:
+            self.config = _agent_config()
+
+        def get_agent_config(self, agent_config_id: str) -> AgentConfig | None:
+            return self.config if agent_config_id == "cfg-1" else None
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            self.config = config
+
+    def hub_response(_method: str, path: str, **_kwargs: object) -> dict[str, object]:
+        item_id = path.removeprefix("/items/").removesuffix("/download")
+        rows = {
+            "skillsmp:alpha": {
+                "slug": "alpha-skill",
+                "name": "Alpha Skill",
+                "description": "Alpha desc",
+                "body": "Use alpha routing.",
+            },
+            "skillsmp:beta": {
+                "slug": "beta-skill",
+                "name": "Beta Skill",
+                "description": "Beta desc",
+                "body": "Use beta routing.",
+            },
+        }
+        row = rows[item_id]
+        return {
+            "item": {
+                "type": "skill",
+                "slug": row["slug"],
+                "name": row["name"],
+                "description": row["description"],
+                "publisher_username": "skillsmp",
+            },
+            "version": "1.0.0",
+            "snapshot": {
+                "content": f"---\nname: {row['name']}\n---\n{row['body']}",
+                "meta": {"desc": row["description"]},
+                "files": {"references/routing.md": row["body"]},
+            },
+        }
+
+    monkeypatch.setattr(marketplace_router.marketplace_client, "_hub_api", hub_response)
+
+    app = FastAPI()
+    app.include_router(marketplace_router.router)
+    app.include_router(panel_router.router)
+    app.dependency_overrides[marketplace_router.get_current_user_id] = lambda: "owner-1"
+    app.dependency_overrides[panel_router.get_current_user_id] = lambda: "owner-1"
+    user_repo = _UserRepo()
+    agent_config_repo = _AgentConfigRepo()
+    skill_repo = _SkillRepo()
+    app.state.user_repo = user_repo
+    app.state.runtime_storage_state = _runtime_storage_state(agent_config_repo, skill_repo)
+
+    with TestClient(app) as client:
+        alpha_apply = client.post("/api/marketplace/apply", json={"item_id": "skillsmp:alpha", "agent_user_id": "agent-1"})
+        beta_apply = client.post("/api/marketplace/apply", json={"item_id": "skillsmp:beta"})
+        library_after_apply = client.get("/api/panel/library/skill")
+        agent_after_apply = client.get("/api/panel/agents/agent-1")
+
+        assign_both = client.put(
+            "/api/panel/agents/agent-1/config",
+            json={"skills": [{"name": "Alpha Skill", "enabled": True}, {"name": "Beta Skill", "enabled": True}]},
+        )
+        blocked_alpha_delete = client.delete("/api/panel/library/skill/alpha-skill")
+
+        keep_beta = client.put("/api/panel/agents/agent-1/config", json={"skills": [{"name": "Beta Skill", "enabled": True}]})
+        deleted_alpha = client.delete("/api/panel/library/skill/alpha-skill")
+        blocked_beta_delete = client.delete("/api/panel/library/skill/beta-skill")
+
+        clear_skills = client.put("/api/panel/agents/agent-1/config", json={"skills": []})
+        deleted_beta = client.delete("/api/panel/library/skill/beta-skill")
+        library_after_delete = client.get("/api/panel/library/skill")
+
+    assert alpha_apply.status_code == 200
+    assert alpha_apply.json()["agent_user_id"] == "agent-1"
+    assert beta_apply.status_code == 200
+    assert sorted(item["name"] for item in library_after_apply.json()["items"]) == ["Alpha Skill", "Beta Skill"]
+    assert agent_after_apply.status_code == 200
+    assert [item["name"] for item in agent_after_apply.json()["config"]["skills"]] == ["Alpha Skill"]
+    assert assign_both.status_code == 200
+    assert [item["name"] for item in assign_both.json()["config"]["skills"]] == ["Alpha Skill", "Beta Skill"]
+    assert blocked_alpha_delete.status_code == 409
+    assert blocked_alpha_delete.json()["detail"] == "Skill is still assigned to Agent: Demo Agent"
+    assert keep_beta.status_code == 200
+    assert deleted_alpha.status_code == 200
+    assert blocked_beta_delete.status_code == 409
+    assert clear_skills.status_code == 200
+    assert deleted_beta.status_code == 200
+    assert library_after_delete.status_code == 200
+    assert library_after_delete.json()["items"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -346,7 +346,7 @@ def test_repo_backed_tools_star_keeps_panel_and_runtime_tool_state_aligned() -> 
     assert "LSP" not in agent._get_agent_blocked_tools()
 
 
-def test_agent_config_patch_pins_library_skill_content() -> None:
+def test_agent_config_patch_saves_library_skill_package_choice() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
     library_skill = _put_skill(
@@ -385,18 +385,17 @@ def test_agent_config_patch_pins_library_skill_content() -> None:
     assert result is not None
     assert saved_configs[-1].skills == [
         AgentSkill(
-            id="",
+            id=None,
             skill_id="loadable-skill",
             package_id=library_skill.package_id,
             name="Loadable Skill",
             description="loadable",
             version="1.0.0",
-            content="---\nname: Loadable Skill\n---\nUse it.",
         )
     ]
 
 
-def test_agent_config_patch_rejects_inline_skill_without_library_id() -> None:
+def test_agent_config_patch_rejects_inline_skill_content() -> None:
     saved_configs: list[AgentConfig] = []
 
     class _AgentConfigRepo:
@@ -406,7 +405,7 @@ def test_agent_config_patch_rejects_inline_skill_without_library_id() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Library skill not found: Inline Skill"):
+    with pytest.raises(RuntimeError, match="Skill patch item must not include content or files"):
         agent_user_service.update_agent_user_config(
             "agent-1",
             {"skills": [{"name": "Inline Skill", "content": "---\nname: Inline Skill\n---\nUse it.", "enabled": True}]},
@@ -513,8 +512,8 @@ def test_agent_config_patch_rejects_duplicate_skill_names() -> None:
             "agent-1",
             {
                 "skills": [
-                    {"name": "Loadable Skill", "content": "---\nname: Loadable Skill\n---\nOne"},
-                    {"name": "Loadable Skill", "content": "---\nname: Loadable Skill\n---\nTwo"},
+                    {"name": "Loadable Skill"},
+                    {"name": "Loadable Skill"},
                 ]
             },
             user_repo=SimpleNamespace(
@@ -536,19 +535,18 @@ def test_agent_config_patch_rejects_duplicate_skill_names() -> None:
 
 def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
     saved_configs: list[AgentConfig] = []
-    pinned = AgentSkill(
+    selected = AgentSkill(
         id="agent-skill-1",
         skill_id="loadable-skill",
+        package_id="loadable-package",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nPinned content.",
-        files={"references/usage.md": "Pinned file."},
         source={"source_version": "1.0.0"},
     )
 
     class _AgentConfigRepo:
         def get_agent_config(self, _agent_config_id: str):
-            return _agent_config(skills=[pinned])
+            return _agent_config(skills=[selected])
 
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
@@ -592,7 +590,6 @@ def test_agent_config_patch_rejects_missing_explicit_library_skill_id() -> None:
                     {
                         "skill_id": "missing-skill",
                         "name": "Inline Skill",
-                        "content": "---\nname: Inline Skill\n---\nUse it.",
                     }
                 ]
             },
@@ -613,7 +610,7 @@ def test_agent_config_patch_rejects_missing_explicit_library_skill_id() -> None:
     assert saved_configs == []
 
 
-def test_agent_config_patch_explicit_library_id_uses_library_content() -> None:
+def test_agent_config_patch_explicit_library_id_uses_library_package_choice() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
     library_skill = _put_skill(
@@ -639,7 +636,6 @@ def test_agent_config_patch_explicit_library_id_uses_library_content() -> None:
                 {
                     "skill_id": "loadable-skill",
                     "name": "Loadable Skill",
-                    "content": "---\nname: Loadable Skill\n---\nPatch content.",
                     "enabled": True,
                 }
             ]
@@ -1165,7 +1161,7 @@ def test_get_agent_user_uses_repo_skill_desc():
     assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "repo desc"}]
 
 
-def test_get_agent_user_keeps_runtime_skill_desc_override_ahead_of_repo_meta():
+def test_get_agent_user_ignores_runtime_skill_desc_override():
     agent = UserRow(
         id="agent-1",
         type=UserType.AGENT,
@@ -1182,7 +1178,7 @@ def test_get_agent_user_keeps_runtime_skill_desc_override_ahead_of_repo_meta():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                runtime_settings={"skills:Search": {"desc": "runtime desc"}},
+                runtime_settings={"skills:Search": {"desc": "runtime desc", "enabled": False}},
                 skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
             )
 
@@ -1192,7 +1188,7 @@ def test_get_agent_user_keeps_runtime_skill_desc_override_ahead_of_repo_meta():
         agent_config_repo=_AgentConfigRepo(),
     )
 
-    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "runtime desc"}]
+    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "repo desc"}]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -321,7 +321,7 @@ class TestApplySkill:
             with pytest.raises(ValueError, match="Invalid slug"):
                 apply_item("item-evil", owner_user_id="owner-1", skill_repo=skill_repo)
 
-    def test_apply_with_agent_user_id_pins_skill_to_agent_config(self):
+    def test_apply_with_agent_user_id_selects_skill_package_for_agent_config(self):
         import backend.hub.client as marketplace_client
 
         saved: list[AgentConfig] = []
@@ -441,7 +441,7 @@ class TestApplySkill:
         assert saved_configs[0].skills[0].skill_id == "fastapi"
         assert saved_configs[0].skills[0].package_id == packages[0].id
 
-    def test_apply_with_agent_user_id_pins_trimmed_frontmatter_name(self):
+    def test_apply_with_agent_user_id_selects_trimmed_frontmatter_name(self):
         import backend.hub.client as marketplace_client
 
         saved: list[AgentConfig] = []


### PR DESCRIPTION
## Summary

This slice tightens the Skill-first model after the AgentConfig/resolved_config hard cut:

- Panel Agent reads now show Skill metadata from `AgentConfig.skills` only; `runtime_settings["skills:<name>"]` no longer overrides Skill display state.
- Agent config Skill patch writes reject inline `content` / `files`; config chooses a Library Skill package, resolved_config carries runnable content.
- Agent Skill writes keep absent row identity as `None` instead of an empty string.
- Added backend API YATU for Marketplace -> Library -> Agent assignment -> delete guard -> remove -> delete.
- Clarified Marketplace request model comments so Agent user ids are not described as local machine state.

## Verification

```bash
uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_agent_config_id_registers_repo_backed_skills tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_agent_config_id_does_not_read_stale_runtime_skill_toggle -q
# 98 passed

uv run pytest tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/core/test_skills_service.py -q
# 24 passed

uv run ruff check backend/threads/agent_user_service.py backend/web/models/marketplace.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_leon_agent.py
# All checks passed

uv run ruff format --check backend/threads/agent_user_service.py backend/web/models/marketplace.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_leon_agent.py
# 6 files already formatted

uv run pyright backend/threads/agent_user_service.py backend/web/models/marketplace.py
# 0 errors, 0 warnings, 0 informations

uv run pytest tests/Unit -q
# 1739 passed, 3 skipped

npm test -- --run src/components/marketplace/MarketplaceActionDialog.wording.test.tsx src/pages/AgentDetailPage.wording.test.tsx src/pages/MarketplacePage.wording.test.tsx src/store/app-store.test.ts src/store/marketplace-store.test.ts
# Test Files 5 passed; Tests 58 passed

npm run typecheck
# passed

npm run build
# built successfully; existing chunk-size warning only
```

Frontend YATU was run through Playwright CLI against the current branch frontend plus a temporary API contract server:

```bash
NODE_PATH=/tmp/mycel-playwright-runner/node_modules /tmp/mycel-playwright-runner/node_modules/.bin/playwright test --config=/tmp/mycel-playwright-yatu/playwright.config.js --browser=chromium --reporter=line
# 1 passed
```

The browser flow covered login, Marketplace Skill detail, save to Library and assign to Agent, Library Skill visibility, Agent Skill config visibility, delete blocked while assigned, remove from Agent, and final Library delete.

## Live Environment Fact Check

- ZGC/PGL SSH works with the ZGC key.
- Current live Mycel backend answers OpenAPI on `127.0.0.1:8900`; frontend answers on `127.0.0.1:5173`.
- The live deployment is an older server-side checkout, so it is recorded as environment truth only, not branch closure evidence.
