### PR TITLE
Fix user-level managed agent chat contracts

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -106,11 +106,9 @@ def _validate_chat_participant_ids(
             validated.append(participant_id)
             continue
         candidate = user_repo.get_by_id(participant_id)
-        if candidate is not None and getattr(candidate, "owner_user_id", None) is None:
+        if candidate is not None:
             validated.append(participant_id)
             continue
-        if candidate is not None and getattr(candidate, "owner_user_id", None) is not None:
-            raise ValueError(f"Agent participant ids must be thread user_ids, not agent_user_id: {participant_id}")
         raise ValueError(f"Unknown chat participant id: {participant_id}")
     return validated
 

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -59,7 +59,7 @@ from core.agents.service import _background_run_cancelled, _background_run_resul
 from core.runtime.middleware.monitor import AgentState
 from sandbox.config import MountSpec
 from sandbox.manager import bind_thread_to_existing_sandbox, resolve_existing_sandbox_runtime
-from sandbox.recipes import default_recipe_id, normalize_recipe_snapshot, provider_type_from_name
+from sandbox.recipes import default_recipe_id, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 from sandbox.thread_context import set_current_thread_id
 from storage.contracts import WorkspaceRow
 
@@ -713,6 +713,8 @@ def _resolve_owned_recipe_snapshot(
         raise RuntimeError("recipe_repo is required for thread recipe resolution")
 
     row = recipe_repo.get(owner_user_id, resolved_recipe_id)
+    if row is None and resolved_recipe_id == default_recipe_id(sandbox_type):
+        return default_recipe_snapshot(provider_type_from_name(sandbox_type), provider_name=sandbox_type)
     if row is None:
         raise HTTPException(400, "Recipe not found")
 

--- a/frontend/app/src/components/NewChatDialog.test.tsx
+++ b/frontend/app/src/components/NewChatDialog.test.tsx
@@ -217,7 +217,7 @@ describe("NewChatDialog", () => {
     });
   });
 
-  it("hides owned agents without a default thread from the group-chat picker", async () => {
+  it("shows owned agent users without requiring a default thread", async () => {
     authFetch.mockResolvedValueOnce(okJson([
       {
         user_id: "agent-ready",
@@ -259,6 +259,6 @@ describe("NewChatDialog", () => {
 
     expect(await screen.findByRole("button", { name: /Ready Agent/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Ada/ })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /Cold Agent/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /Cold Agent/ })).toBeTruthy();
   });
 });

--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -54,12 +54,7 @@ export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps
 
   const groupCandidates = useMemo(() => {
     const query = filter.trim().toLowerCase();
-    const items = chatCandidates.filter((item) => {
-      if (item.user_id === myUserId) return false;
-      // @@@owned-agent-group-ingress - group-chat POST only accepts owned agents
-      // once they have a real default thread backing their actor identity.
-      return item.is_owned ? Boolean(item.default_thread_id) : item.can_chat;
-    });
+    const items = chatCandidates.filter((item) => item.user_id !== myUserId && item.can_chat);
     if (!query) return items;
     return items.filter((item) => [item.name, item.owner_name ?? "", item.type].join(" ").toLowerCase().includes(query));
   }, [chatCandidates, filter, myUserId]);

--- a/messaging/delivery/resolver.py
+++ b/messaging/delivery/resolver.py
@@ -107,16 +107,21 @@ class HireVisitDeliveryResolver:
     def _is_blocked(self, contact: Any | None) -> bool:
         if not contact:
             return False
-        if bool(contact.get("blocked")):
+        if bool(self._contact_value(contact, "blocked")):
             return True
-        return contact.get("relation") == "blocked"
+        return self._contact_value(contact, "relation") == "blocked" or self._contact_value(contact, "kind") == "blocked"
 
     def _is_muted(self, contact: Any | None) -> bool:
         if not contact:
             return False
-        if bool(contact.get("muted")):
+        if bool(self._contact_value(contact, "muted")):
             return True
-        return contact.get("relation") == "muted"
+        return self._contact_value(contact, "relation") == "muted" or self._contact_value(contact, "kind") == "muted"
+
+    def _contact_value(self, contact: Any, key: str) -> Any:
+        if isinstance(contact, dict):
+            return contact.get(key)
+        return getattr(contact, key, None)
 
     def _is_chat_muted(self, user_id: str, chat_id: str) -> bool:
         """Check if user has muted this specific chat."""

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -736,7 +736,7 @@ def test_mark_read_rejects_non_member_user() -> None:
     assert exc_info.value.detail == "Not a participant of this chat"
 
 
-def test_create_chat_rejects_template_member_ids_for_group_participants() -> None:
+def test_create_chat_accepts_agent_user_ids_for_group_participants() -> None:
     state, called = _create_chat_route_state(
         users={
             "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", owner_user_id="owner-user-1"),
@@ -746,21 +746,19 @@ def test_create_chat_rejects_template_member_ids_for_group_participants() -> Non
     )
     app = SimpleNamespace(state=state)
 
-    with pytest.raises(HTTPException) as exc_info:
-        _create_chat(
-            app,
-            chats_router.CreateChatBody(
-                user_ids=["human-user-1", "agent-user-1", "agent-user-2"],
-                title="bad-group",
-            ),
-        )
+    result = _create_chat(
+        app,
+        chats_router.CreateChatBody(
+            user_ids=["human-user-1", "agent-user-1", "agent-user-2"],
+            title="agent-group",
+        ),
+    )
 
-    assert exc_info.value.status_code == 400
-    assert "thread user_ids" in str(exc_info.value.detail).lower()
-    assert called == []
+    assert called == [(["human-user-1", "agent-user-1", "agent-user-2"], "agent-group")]
+    assert result["id"] == "chat-1"
 
 
-def test_create_chat_rejects_template_member_id_for_direct_participant() -> None:
+def test_create_chat_accepts_agent_user_id_for_direct_participant() -> None:
     state, called = _create_chat_route_state(
         users={"agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", owner_user_id="owner-user-1")},
         thread_user_ids={"owned-agent-1"},
@@ -768,18 +766,16 @@ def test_create_chat_rejects_template_member_id_for_direct_participant() -> None
     )
     app = SimpleNamespace(state=state)
 
-    with pytest.raises(HTTPException) as exc_info:
-        _create_chat(
-            app,
-            chats_router.CreateChatBody(
-                user_ids=["human-user-1", "agent-user-1"],
-                title=None,
-            ),
-        )
+    result = _create_chat(
+        app,
+        chats_router.CreateChatBody(
+            user_ids=["human-user-1", "agent-user-1"],
+            title=None,
+        ),
+    )
 
-    assert exc_info.value.status_code == 400
-    assert "thread user_ids" in str(exc_info.value.detail).lower()
-    assert called == []
+    assert called == [(["human-user-1", "agent-user-1"], None)]
+    assert result["id"] == "chat-1"
 
 
 def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_participants() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -21,6 +21,7 @@ from messaging.display_user import resolve_messaging_display_user
 from messaging.relationships.service import RelationshipService
 from messaging.service import MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
+from storage.contracts import ContactEdgeRow
 
 _MessagingService = MessagingService
 _ChatDeliveryDispatcher = ChatDeliveryDispatcher
@@ -2428,6 +2429,33 @@ def test_delivery_resolver_drops_when_new_contact_edge_is_blocked() -> None:
     action = resolver.resolve("thread-user-1", "chat-1", "human-user-1")
 
     assert action is DeliveryAction.DROP
+
+
+def test_delivery_resolver_reads_contact_edge_row_objects() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(
+            get=lambda _owner_id, _target_id: ContactEdgeRow(
+                source_user_id="agent-user-1",
+                target_user_id="human-user-1",
+                kind="normal",
+                state="active",
+                muted=False,
+                blocked=False,
+                created_at=1.0,
+            )
+        ),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [
+                {"user_id": "agent-user-1", "muted": False},
+                {"user_id": "human-user-1", "muted": False},
+            ]
+        ),
+        relationship_repo=None,
+    )
+
+    action = resolver.resolve("agent-user-1", "chat-1", "human-user-1")
+
+    assert action is DeliveryAction.DELIVER
 
 
 def test_delivery_resolver_propagates_contact_repo_failures() -> None:

--- a/tests/Unit/integration_contracts/test_thread_launch_config_contract.py
+++ b/tests/Unit/integration_contracts/test_thread_launch_config_contract.py
@@ -202,6 +202,27 @@ def test_normalize_launch_config_payload_uses_sandbox_template_id() -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_create_thread_uses_builtin_default_recipe_when_owner_has_no_recipe_row() -> None:
+    app = _make_threads_app()
+    app.state.runtime_storage_state.recipe_repo.rows.clear()
+    payload = CreateThreadRequest(agent_user_id="agent-user-1", sandbox="local")
+
+    with (
+        patch.object(threads_router, "_validate_mount_capability_gate", AsyncMock(return_value=None)),
+        patch.object(threads_router, "_validate_sandbox_quota_gate", return_value=None),
+        patch.object(threads_router, "_create_thread_sandbox_resources", return_value="workspace-1") as create_resources,
+        patch.object(threads_router, "_invalidate_resource_overview_cache", return_value=None),
+    ):
+        result = _require_thread_result(await threads_router.create_thread(payload, "owner-1", app))
+
+    assert result["thread_id"] == "agent-user-1-1"
+    create_resources.assert_called_once()
+    recipe = create_resources.call_args.args[2]
+    assert recipe["id"] == "local:default"
+    assert recipe["provider_name"] == "local"
+
+
 def test_resolve_default_config_derives_existing_from_workspace_backed_current_workspace_id() -> None:
     thread_repo = _FakeThreadRepo()
     thread_repo.rows["agent-user-1-1"] = {


### PR DESCRIPTION
## Summary
- Keep chat creation at the user-participant layer so owned managed agent users can join group/direct chats without requiring a thread social-user substitute.
- Use the built-in default recipe when creating a managed agent runtime thread and the owner has not persisted a default recipe row.
- Make delivery resolution honor the storage contact row contract instead of assuming dict-shaped contact edges.

## YATU
- Ran a 4-participant natural-language group chat through the public mycel CLI: owner chair, member voter, and two Mycel managed agents.
- Managed agents replied in chat, member hit the read-before-send 409 then voted after reading, chair announced the result, and both managed agents confirmed.
- Recorded the transcript in local notes:
  - /Users/lexicalmathical/Codebase/mycel/notes/2026-04-25-natural-language-multi-agent-yatu.html
  - /Users/lexicalmathical/Codebase/mycel/notes/2026-04-25-mycel-cli-real-runbook.html

## Verification
- uv run pytest tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_thread_launch_config_contract.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q -> 162 passed before latest rebase
- npm test -> 237 passed before latest rebase
- npm run lint && npm run typecheck && npm run build -> passed before latest rebase
- after latest rebase: targeted backend contract tests -> 4 passed
- after latest rebase: npm test -- --run src/components/NewChatDialog.test.tsx -> 4 passed
