### PR TITLE
Tighten MCP runtime source under agent config

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -77,10 +77,8 @@ def _mcp_servers_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     for server in config.mcp_servers:
         exposed = server.model_dump(exclude_none=True)
-        exposed.pop("enabled", None)
         if exposed.get("args") == []:
             exposed.pop("args")
-        exposed["disabled"] = not server.enabled
         items.append(exposed)
     return items
 
@@ -442,6 +440,8 @@ def _mcp_from_patch(config_patch: dict[str, Any], current_config: AgentConfig) -
     for item in config_patch["mcpServers"]:
         if not (isinstance(item, dict) and item.get("name")):
             raise RuntimeError("MCP server patch item must include name")
+        if "disabled" in item:
+            raise RuntimeError("MCP server patch item must use enabled, not disabled")
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate MCP server name in patch: {name}")
@@ -459,7 +459,7 @@ def _mcp_from_patch(config_patch: dict[str, Any], current_config: AgentConfig) -
                 url=direct_config.get("url"),
                 instructions=direct_config.get("instructions"),
                 allowed_tools=direct_config.get("allowed_tools"),
-                enabled=not bool(item.get("disabled", False)),
+                enabled=bool(item.get("enabled", True)),
             )
         )
     return servers
@@ -553,13 +553,15 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
             raise RuntimeError("Skill patch item must include name")
         if "content" in item or "files" in item:
             raise RuntimeError("Skill patch item must not include content or files")
+        if "disabled" in item:
+            raise RuntimeError("Skill patch item must use enabled, not disabled")
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate Skill name in patch: {name}")
         seen_names.add(name)
     for item in skill_items:
         name = str(item["name"])
-        enabled = bool(item.get("enabled", not bool(item.get("disabled", False))))
+        enabled = bool(item.get("enabled", True))
         explicit_skill_id = item.get("id") or item.get("skill_id")
         explicit_skill_id_str = str(explicit_skill_id) if explicit_skill_id else None
         current_skill = _current_skill_by_name_or_id(current_config, name, explicit_skill_id_str)

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -463,6 +463,12 @@ class LeonAgent:
             return {server.name: server for server in resolved_config.mcp_servers if server.enabled}
         return self.config.mcp.servers
 
+    def _mcp_enabled(self) -> bool:
+        resolved_config = getattr(self, "_resolved_agent_config", None)
+        if resolved_config is not None:
+            return bool(self._get_mcp_server_configs())
+        return bool(self.config.mcp.enabled)
+
     def _get_integration_instruction_blocks(self) -> dict[str, str]:
         return mcp_gateway.instruction_blocks(self._get_mcp_server_configs())
 
@@ -1234,7 +1240,7 @@ class LeonAgent:
 
     async def _init_mcp_tools(self) -> list:
         client, tools = await mcp_gateway.init_client_tools(
-            enabled=self.config.mcp.enabled,
+            enabled=self._mcp_enabled(),
             server_configs=self._get_mcp_server_configs(),
         )
         self._mcp_client = client

--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -111,7 +111,7 @@ export default function AgentDetail() {
       if (mod === "tools") {
         await updateAgentConfig(agent.id, { tools: agent.config.tools.map(i => i.name === itemName ? { ...i, enabled } : i) });
       } else if (mod === "mcp") {
-        await updateAgentConfig(agent.id, { mcpServers: agent.config.mcpServers.map(i => i.name === itemName ? { ...i, disabled: !enabled } : i) });
+        await updateAgentConfig(agent.id, { mcpServers: agent.config.mcpServers.map(i => i.name === itemName ? { ...i, enabled } : i) });
       } else if (mod === "skills") {
         await updateAgentConfig(agent.id, { skills: agent.config.skills.map(i => i.name === itemName ? { ...i, enabled } : i) });
       }
@@ -187,7 +187,7 @@ export default function AgentDetail() {
         return (
           <ResourceCards
             type="mcp"
-            items={agent.config.mcpServers.map(m => ({ name: m.name, desc: m.command || "未配置", enabled: !m.disabled }))}
+            items={agent.config.mcpServers.map(m => ({ name: m.name, desc: m.command || "未配置", enabled: m.enabled }))}
             onToggle={(name, en) => handleToggle("mcp", name, en)}
             onRemove={(name) => handleRemove("mcp", name)}
           />

--- a/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
@@ -225,6 +225,49 @@ describe("AgentDetailPage wording contract", () => {
     expect(ensureLibrary).not.toHaveBeenCalled();
   });
 
+  it("toggles MCP servers with enabled config", async () => {
+    getAgentById.mockReturnValue({
+      ...agentFixture,
+      config: {
+        ...agentFixture.config,
+        mcpServers: [
+          {
+            name: "demo-mcp",
+            command: "uv",
+            args: [],
+            env: {},
+            enabled: true,
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
+        <Routes>
+          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^MCP 高级/ }));
+    fireEvent.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(updateAgentConfig).toHaveBeenCalledWith("agent-1", {
+        mcpServers: [
+          {
+            name: "demo-mcp",
+            command: "uv",
+            args: [],
+            env: {},
+            enabled: false,
+          },
+        ],
+      });
+    });
+  });
+
   it("does not expose a Library picker for subagents", async () => {
     render(
       <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>

--- a/frontend/app/src/store/types.ts
+++ b/frontend/app/src/store/types.ts
@@ -26,7 +26,7 @@ interface McpItem {
   command: string;
   args: string[];
   env: Record<string, string>;
-  disabled: boolean;
+  enabled: boolean;
 }
 
 export interface AgentConfig {

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -426,6 +426,37 @@ def test_agent_config_patch_rejects_inline_skill_content() -> None:
     assert saved_configs == []
 
 
+def test_agent_config_patch_rejects_skill_disabled_flag() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(skills=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="Skill patch item must use enabled, not disabled"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"skills": [{"name": "Loadable Skill", "disabled": False}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=_MemorySkillRepo(),
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
@@ -787,7 +818,7 @@ def test_agent_config_patch_persists_explicit_mcp_config() -> None:
                     "env": {"DEMO": "1"},
                     "allowed_tools": ["read"],
                     "instructions": "Use demo resources.",
-                    "disabled": False,
+                    "enabled": True,
                 }
             ]
         },
@@ -831,7 +862,7 @@ def test_agent_config_patch_rejects_mcp_item_without_name() -> None:
     with pytest.raises(RuntimeError, match="MCP server patch item must include name"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"mcpServers": [{"disabled": False}]},
+            {"mcpServers": [{"enabled": True}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -844,6 +875,66 @@ def test_agent_config_patch_rejects_mcp_item_without_name() -> None:
             ),
             agent_config_repo=_AgentConfigRepo(),
             skill_repo=_MemorySkillRepo(),
+        )
+
+    assert saved_configs == []
+
+
+def test_agent_config_patch_persists_mcp_enabled_false() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(system_prompt="", mcp_servers=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    result = agent_user_service.update_agent_user_config(
+        "agent-1",
+        {"mcpServers": [{"name": "demo-mcp", "transport": "stdio", "command": "uv", "enabled": False}]},
+        user_repo=SimpleNamespace(
+            get_by_id=lambda _agent_id: UserRow(
+                id="agent-1",
+                type=UserType.AGENT,
+                display_name="Toad",
+                owner_user_id="owner-1",
+                agent_config_id="cfg-1",
+                created_at=1,
+            )
+        ),
+        agent_config_repo=_AgentConfigRepo(),
+    )
+
+    assert result is not None
+    assert saved_configs[-1].mcp_servers == [McpServerConfig(name="demo-mcp", transport="stdio", command="uv", enabled=False)]
+
+
+def test_agent_config_patch_rejects_mcp_disabled_flag() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(mcp_servers=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="MCP server patch item must use enabled, not disabled"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"mcpServers": [{"name": "demo-mcp", "transport": "stdio", "command": "uv", "disabled": False}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="owner-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
         )
 
     assert saved_configs == []
@@ -1022,7 +1113,7 @@ def test_agent_config_patch_rejects_mcp_without_runtime_target() -> None:
     with pytest.raises(RuntimeError, match="MCP server config must include command or url: demo-mcp"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"mcpServers": [{"name": "demo-mcp", "disabled": False}]},
+            {"mcpServers": [{"name": "demo-mcp", "enabled": True}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -1083,7 +1174,7 @@ def test_agent_config_exposes_mcp_config_fields_for_lossless_toggle() -> None:
             "env": {"DEMO": "1"},
             "allowed_tools": ["read"],
             "instructions": "Use demo resources.",
-            "disabled": False,
+            "enabled": True,
         }
     ]
 

--- a/tests/Unit/platform/test_mcp_transport.py
+++ b/tests/Unit/platform/test_mcp_transport.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 
-from config.schema import MCPConfig, MCPServerConfig
+from config.agent_config_types import McpServerConfig as AgentMcpServerConfig
+from config.agent_config_types import ResolvedAgentConfig
+from config.schema import LeonSettings, MCPConfig, MCPServerConfig
 from core.runtime.agent import LeonAgent
 
 
@@ -23,16 +23,22 @@ async def test_init_mcp_tools_respects_explicit_websocket_transport(monkeypatch)
             return None
 
     agent = LeonAgent.__new__(LeonAgent)
-    agent.config = SimpleNamespace(
-        mcp=MCPConfig(
-            enabled=True,
-            servers={
-                "wsdemo": MCPServerConfig(
-                    transport="websocket",
-                    url="ws://example.test/mcp",
-                )
-            },
-        )
+    agent.config = LeonSettings.model_validate(
+        {
+            "mcp": MCPConfig.model_validate(
+                {
+                    "enabled": True,
+                    "servers": {
+                        "wsdemo": MCPServerConfig.model_validate(
+                            {
+                                "transport": "websocket",
+                                "url": "ws://example.test/mcp",
+                            }
+                        )
+                    },
+                }
+            )
+        }
     )
     agent._mcp_client = None
 
@@ -47,3 +53,73 @@ async def test_init_mcp_tools_respects_explicit_websocket_transport(monkeypatch)
             "url": "ws://example.test/mcp",
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_resolved_agent_config_controls_mcp_enablement(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_init_client_tools(*, enabled: bool, server_configs: dict[str, object]):
+        captured["enabled"] = enabled
+        captured["server_configs"] = server_configs
+        return None, []
+
+    agent = LeonAgent.__new__(LeonAgent)
+    agent.config = LeonSettings.model_validate({"mcp": MCPConfig.model_validate({"enabled": False, "servers": {}})})
+    agent._resolved_agent_config = ResolvedAgentConfig(
+        id="cfg-1",
+        name="Agent",
+        mcp_servers=[
+            AgentMcpServerConfig(
+                name="agent-mcp",
+                transport="websocket",
+                url="ws://example.test/mcp",
+            )
+        ],
+    )
+
+    monkeypatch.setattr("core.runtime.agent.mcp_gateway.init_client_tools", fake_init_client_tools)
+
+    await LeonAgent._init_mcp_tools(agent)
+
+    assert captured["enabled"] is True
+    server_configs = captured["server_configs"]
+    assert isinstance(server_configs, dict)
+    assert sorted(server_configs) == ["agent-mcp"]
+
+
+@pytest.mark.asyncio
+async def test_resolved_agent_config_without_mcp_disables_mcp(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_init_client_tools(*, enabled: bool, server_configs: dict[str, object]):
+        captured["enabled"] = enabled
+        captured["server_configs"] = server_configs
+        return None, []
+
+    agent = LeonAgent.__new__(LeonAgent)
+    agent.config = LeonSettings.model_validate(
+        {
+            "mcp": MCPConfig.model_validate(
+                {
+                    "enabled": True,
+                    "servers": {
+                        "runtime-mcp": MCPServerConfig.model_validate(
+                            {
+                                "transport": "websocket",
+                                "url": "ws://runtime.example.test/mcp",
+                            }
+                        )
+                    },
+                }
+            )
+        }
+    )
+    agent._resolved_agent_config = ResolvedAgentConfig(id="cfg-1", name="Agent", mcp_servers=[])
+
+    monkeypatch.setattr("core.runtime.agent.mcp_gateway.init_client_tools", fake_init_client_tools)
+
+    await LeonAgent._init_mcp_tools(agent)
+
+    assert captured["enabled"] is False
+    assert captured["server_configs"] == {}


### PR DESCRIPTION
## Summary
- derive MCP startup from resolved AgentConfig when an Agent config exists
- expose MCP config state as positive `enabled` in panel reads/writes
- reject Skill/MCP config patch payloads that send reverse toggle state
- update Agent detail MCP toggles to send `enabled`

## Verification
- `uv run pytest tests/Unit/platform/test_mcp_transport.py -q`
- `uv run pytest tests/Unit/platform/test_mcp_transport.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py -q`
- `uv run pytest tests/Unit -q`
- `uv run pyright core/runtime/agent.py backend/threads/agent_user_service.py tests/Unit/platform/test_mcp_transport.py`
- `uv run ruff check . && uv run ruff format --check .`
- `npm test -- --run src/pages/AgentDetailPage.wording.test.tsx src/store/app-store.test.ts`
- `npm run build`
