### PR TITLE
Hard cut agent config DB residue

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -20,7 +20,7 @@ from config.skill_package import build_skill_package_hash, build_skill_package_m
 
 HUB_URL = os.environ.get("MYCEL_HUB_URL", "https://hub.mycel.nextmind.space")
 # @@@hub-agent-user-item-type - Hub still names published Agent users "member";
-# local Mycel domain code must keep exposing them as Agent users.
+# Mycel app domain code exposes them as Agent users.
 HUB_AGENT_USER_ITEM_TYPE = "member"
 
 _hub_client = httpx.Client(timeout=30.0, trust_env=False)
@@ -144,7 +144,7 @@ def publish(
     agent_config_repo: Any = None,
     skill_repo: Any = None,
 ) -> dict:
-    """Publish a local AgentSnapshot to the Hub."""
+    """Publish an AgentConfig snapshot to the Hub."""
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required for publish()")
     if skill_repo is None:
@@ -210,10 +210,10 @@ def apply_item(
     skill_repo: Any = None,
     agent_user_id: str | None = None,
 ) -> dict:
-    """Apply a Hub item into the local account.
+    """Apply a Hub item into the owner account.
 
-    The Hub protocol still exposes this as /download; Mycel's local product
-    semantics are save-to-Library or add Agent User.
+    The Hub endpoint is /download; Mycel product semantics are save-to-Library
+    or add Agent User.
     """
     result = _hub_api("POST", f"/items/{item_id}/download")
     snapshot = result["snapshot"]
@@ -346,7 +346,7 @@ def upgrade(
     agent_config_repo: Any = None,
     skill_repo: Any = None,
 ) -> dict:
-    """Upgrade a local marketplace-sourced agent user."""
+    """Upgrade a marketplace-sourced Agent user."""
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required to upgrade marketplace user snapshot")
 

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -168,18 +168,24 @@ class SupabaseAgentConfigRepo:
         mcp_rows = rows[0].get("mcp_json") or []
         if not isinstance(mcp_rows, list):
             raise RuntimeError(f"Agent config {agent_config_id} mcp_json must be a JSON array")
-        return [
-            McpServerConfig(
-                id=row.get("id"),
-                name=row["name"],
-                transport=row.get("transport"),
-                command=row.get("command"),
-                args=list(row.get("args") or []),
-                env=dict(row.get("env") or {}),
-                url=row.get("url"),
-                instructions=row.get("instructions"),
-                allowed_tools=row.get("allowed_tools"),
-                enabled=bool(row.get("enabled", True)),
+        servers: list[McpServerConfig] = []
+        for row in mcp_rows:
+            if not isinstance(row, dict):
+                raise RuntimeError(f"Agent config {agent_config_id} mcp_json items must be JSON objects")
+            if "disabled" in row:
+                raise RuntimeError(f"Agent config {agent_config_id} mcp_json items must use enabled")
+            servers.append(
+                McpServerConfig(
+                    id=row.get("id"),
+                    name=row["name"],
+                    transport=row.get("transport"),
+                    command=row.get("command"),
+                    args=list(row.get("args") or []),
+                    env=dict(row.get("env") or {}),
+                    url=row.get("url"),
+                    instructions=row.get("instructions"),
+                    allowed_tools=row.get("allowed_tools"),
+                    enabled=bool(row.get("enabled", True)),
+                )
             )
-            for row in mcp_rows
-        ]
+        return servers

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -157,37 +157,10 @@ begin
     if exists (
         select 1
         from agent.agent_configs
-        where jsonb_typeof(mcp_json) not in ('array', 'object')
+        where jsonb_typeof(mcp_json) <> 'array'
     ) then
-        raise exception 'agent.agent_configs.mcp_json must be a JSON array or object before hard cut';
+        raise exception 'agent.agent_configs.mcp_json must be a JSON array before hard cut';
     end if;
-
-    if exists (
-        select 1
-        from agent.agent_configs c,
-             jsonb_each(c.mcp_json) item
-        where jsonb_typeof(c.mcp_json) = 'object'
-          and jsonb_typeof(item.value) <> 'object'
-    ) then
-        raise exception 'agent.agent_configs.mcp_json object values must be JSON objects before hard cut';
-    end if;
-
-    update agent.agent_configs c
-    set mcp_json = coalesce(
-        (
-            select jsonb_agg(
-                (item.value - 'disabled')
-                || jsonb_build_object(
-                    'name', item.key,
-                    'enabled', not coalesce((item.value->>'disabled')::boolean, false)
-                )
-                order by item.key
-            )
-            from jsonb_each(c.mcp_json) item
-        ),
-        '[]'::jsonb
-    )
-    where jsonb_typeof(c.mcp_json) = 'object';
 end $$;
 
 create or replace function agent.save_agent_config(payload jsonb)
@@ -224,6 +197,20 @@ begin
     end if;
     if jsonb_typeof(coalesce(payload->'mcp_servers', '[]'::jsonb)) <> 'array' then
         raise exception 'agent_config.mcp_servers must be a JSON array';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'skills', '[]'::jsonb)) as skill_item(value)
+        where skill_item.value ? 'disabled'
+    ) then
+        raise exception 'agent_config.skills child state must use enabled';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'mcp_servers', '[]'::jsonb)) as mcp_item(value)
+        where mcp_item.value ? 'disabled'
+    ) then
+        raise exception 'agent_config.mcp_servers child state must use enabled';
     end if;
     if exists (
         select 1

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -60,6 +60,24 @@ def test_agent_config_schema_rejects_duplicate_child_names_inside_rpc() -> None:
     assert "group by child->>'name'" not in sql
 
 
+def test_agent_config_schema_requires_enabled_direction_for_skill_and_mcp_state() -> None:
+    sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
+
+    assert "agent_config.skills child state must use enabled" in sql
+    assert "agent_config.mcp_servers child state must use enabled" in sql
+    assert "skill_item.value ? 'disabled'" in sql
+    assert "mcp_item.value ? 'disabled'" in sql
+
+
+def test_agent_config_schema_does_not_convert_object_mcp_json() -> None:
+    sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
+
+    assert "agent.agent_configs.mcp_json must be a JSON array before hard cut" in sql
+    assert "jsonb_typeof(mcp_json) not in ('array', 'object')" not in sql
+    assert "jsonb_each(c.mcp_json)" not in sql
+    assert "(item.value - 'disabled')" not in sql
+
+
 def test_agent_config_schema_constrains_named_child_tables() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -226,6 +226,15 @@ def test_get_agent_config_fails_loudly_when_mcp_json_is_not_an_array() -> None:
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_mcp_json_uses_reverse_state() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "disabled": False}]
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="mcp_json items must use enabled"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
     client = _FakeClient()
     repo = SupabaseAgentConfigRepo(client)
@@ -307,7 +316,7 @@ def test_save_agent_config_rejects_duplicate_mcp_server_names_before_rpc() -> No
     assert client.rpc_calls == []
 
 
-def test_save_agent_config_rejects_duplicate_disabled_child_names_before_rpc() -> None:
+def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -> None:
     client = _FakeClient()
     repo = SupabaseAgentConfigRepo(client)
     config = AgentConfig(


### PR DESCRIPTION
## Summary
- require array-shaped `agent.agent_configs.mcp_json` in the hard-cut schema
- remove DB conversion from object-shaped MCP config into current rows
- reject reverse Skill/MCP state at the AgentConfig RPC boundary
- reject dirty Supabase MCP rows during AgentConfig reads
- clarify Hub client comments around owner account / Library / AgentConfig semantics

## Verification
- `uv run pytest tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/storage/test_supabase_agent_config_repo.py -q`
- `uv run pytest tests/Unit -q`
- `uv run pyright backend/hub/client.py storage/providers/supabase/agent_config_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py`
- `uv run ruff check . && uv run ruff format --check .`
