### PR TITLE
Hard cut enabled state types

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -396,12 +396,15 @@ def _runtime_and_tools_from_patch(current_config: AgentConfig, config_patch: dic
     if "tools" in config_patch and config_patch["tools"] is not None:
         tool_items = [item for item in config_patch["tools"] if isinstance(item, dict) and item.get("name")]
         runtime = {k: v for k, v in runtime.items() if not k.startswith("tools:")}
+        enabled_tools = []
         for item in tool_items:
+            enabled = _enabled_from_patch_item(item, label="Tool patch item")
             runtime[f"tools:{item['name']}"] = {
-                "enabled": item.get("enabled", True),
+                "enabled": enabled,
                 "desc": item.get("desc", ""),
             }
-        enabled_tools = [item["name"] for item in tool_items if item.get("enabled", True)]
+            if enabled:
+                enabled_tools.append(item["name"])
         tools = ["*"] if tool_items and len(enabled_tools) == len(tool_items) else enabled_tools
 
     return runtime, tools
@@ -442,6 +445,7 @@ def _mcp_from_patch(config_patch: dict[str, Any], current_config: AgentConfig) -
             raise RuntimeError("MCP server patch item must include name")
         if "disabled" in item:
             raise RuntimeError("MCP server patch item must use enabled, not disabled")
+        enabled = _enabled_from_patch_item(item, label="MCP server patch item")
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate MCP server name in patch: {name}")
@@ -459,10 +463,19 @@ def _mcp_from_patch(config_patch: dict[str, Any], current_config: AgentConfig) -
                 url=direct_config.get("url"),
                 instructions=direct_config.get("instructions"),
                 allowed_tools=direct_config.get("allowed_tools"),
-                enabled=bool(item.get("enabled", True)),
+                enabled=enabled,
             )
         )
     return servers
+
+
+def _enabled_from_patch_item(item: dict[str, Any], *, label: str) -> bool:
+    if "enabled" not in item:
+        return True
+    enabled = item["enabled"]
+    if not isinstance(enabled, bool):
+        raise RuntimeError(f"{label} enabled must be a boolean")
+    return enabled
 
 
 def _rules_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]) -> list[AgentRule]:
@@ -499,7 +512,13 @@ def _sub_agents_from_patch(current_config: AgentConfig, config_patch: dict[str, 
             seen_names.add(name)
             raw_tools = item.get("tools") or []
             if isinstance(raw_tools, list) and raw_tools and isinstance(raw_tools[0], dict):
-                enabled_tools = [tool["name"] for tool in raw_tools if tool.get("enabled")]
+                enabled_tools = []
+                for tool in raw_tools:
+                    if not isinstance(tool, dict):
+                        continue
+                    enabled = _enabled_from_patch_item(tool, label="SubAgent tool patch item")
+                    if enabled:
+                        enabled_tools.append(tool["name"])
             else:
                 enabled_tools = list(raw_tools)
             sub_agents.append(
@@ -555,13 +574,14 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
             raise RuntimeError("Skill patch item must not include content or files")
         if "disabled" in item:
             raise RuntimeError("Skill patch item must use enabled, not disabled")
+        _enabled_from_patch_item(item, label="Skill patch item")
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate Skill name in patch: {name}")
         seen_names.add(name)
     for item in skill_items:
         name = str(item["name"])
-        enabled = bool(item.get("enabled", True))
+        enabled = _enabled_from_patch_item(item, label="Skill patch item")
         explicit_skill_id = item.get("id") or item.get("skill_id")
         explicit_skill_id_str = str(explicit_skill_id) if explicit_skill_id else None
         current_skill = _current_skill_by_name_or_id(current_config, name, explicit_skill_id_str)

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -174,6 +174,9 @@ class SupabaseAgentConfigRepo:
                 raise RuntimeError(f"Agent config {agent_config_id} mcp_json items must be JSON objects")
             if "disabled" in row:
                 raise RuntimeError(f"Agent config {agent_config_id} mcp_json items must use enabled")
+            enabled = row.get("enabled", True)
+            if not isinstance(enabled, bool):
+                raise RuntimeError(f"Agent config {agent_config_id} mcp_json item enabled must be a boolean")
             servers.append(
                 McpServerConfig(
                     id=row.get("id"),
@@ -185,7 +188,7 @@ class SupabaseAgentConfigRepo:
                     url=row.get("url"),
                     instructions=row.get("instructions"),
                     allowed_tools=row.get("allowed_tools"),
-                    enabled=bool(row.get("enabled", True)),
+                    enabled=enabled,
                 )
             )
         return servers

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -215,6 +215,38 @@ begin
     if exists (
         select 1
         from jsonb_array_elements(coalesce(payload->'skills', '[]'::jsonb)) as skill_item(value)
+        where skill_item.value ? 'enabled'
+          and jsonb_typeof(skill_item.value->'enabled') <> 'boolean'
+    ) then
+        raise exception 'agent_config.skills child.enabled must be a JSON boolean';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'rules', '[]'::jsonb)) as rule_item(value)
+        where rule_item.value ? 'enabled'
+          and jsonb_typeof(rule_item.value->'enabled') <> 'boolean'
+    ) then
+        raise exception 'agent_config.rules child.enabled must be a JSON boolean';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'sub_agents', '[]'::jsonb)) as sub_agent_item(value)
+        where sub_agent_item.value ? 'enabled'
+          and jsonb_typeof(sub_agent_item.value->'enabled') <> 'boolean'
+    ) then
+        raise exception 'agent_config.sub_agents child.enabled must be a JSON boolean';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'mcp_servers', '[]'::jsonb)) as mcp_item(value)
+        where mcp_item.value ? 'enabled'
+          and jsonb_typeof(mcp_item.value->'enabled') <> 'boolean'
+    ) then
+        raise exception 'agent_config.mcp_servers child.enabled must be a JSON boolean';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'skills', '[]'::jsonb)) as skill_item(value)
         where btrim(coalesce(skill_item.value->>'name', '')) = ''
     ) then
         raise exception 'agent_config.skills child.name is required';

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -457,6 +457,37 @@ def test_agent_config_patch_rejects_skill_disabled_flag() -> None:
     assert saved_configs == []
 
 
+def test_agent_config_patch_rejects_skill_enabled_string() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(skills=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="Skill patch item enabled must be a boolean"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"skills": [{"name": "Loadable Skill", "enabled": "false"}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=_MemorySkillRepo(),
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
@@ -940,6 +971,36 @@ def test_agent_config_patch_rejects_mcp_disabled_flag() -> None:
     assert saved_configs == []
 
 
+def test_agent_config_patch_rejects_mcp_enabled_string() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(mcp_servers=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="MCP server patch item enabled must be a boolean"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"mcpServers": [{"name": "demo-mcp", "transport": "stdio", "command": "uv", "enabled": "false"}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="owner-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_duplicate_mcp_server_names() -> None:
     saved_configs: list[AgentConfig] = []
 
@@ -1100,6 +1161,37 @@ def test_agent_config_patch_rejects_duplicate_sub_agent_names() -> None:
     assert saved_configs == []
 
 
+def test_agent_config_patch_rejects_sub_agent_tool_enabled_string() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config()
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="SubAgent tool patch item enabled must be a boolean"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"subAgents": [{"name": "Scout", "tools": [{"name": "Read", "enabled": "false"}]}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=_MemorySkillRepo(),
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_mcp_without_runtime_target() -> None:
     saved_configs: list[AgentConfig] = []
 
@@ -1221,6 +1313,36 @@ def test_agent_config_exposes_and_persists_compaction_trigger_tokens():
     assert after["config"]["compact"] == {"trigger_tokens": 100000}
     assert configs["cfg-1"].compact == {"trigger_tokens": 100000}
     assert configs["cfg-1"].runtime_settings == {"tools:Bash": {"enabled": True, "desc": "shell"}}
+
+
+def test_agent_config_patch_rejects_tool_enabled_string() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(runtime_settings={})
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="Tool patch item enabled must be a boolean"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"tools": [{"name": "Bash", "enabled": "false"}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+        )
+
+    assert saved_configs == []
 
 
 def test_get_agent_user_uses_repo_skill_desc():

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -65,6 +65,10 @@ def test_agent_config_schema_requires_enabled_direction_for_skill_and_mcp_state(
 
     assert "agent_config.skills child state must use enabled" in sql
     assert "agent_config.mcp_servers child state must use enabled" in sql
+    assert "agent_config.skills child.enabled must be a JSON boolean" in sql
+    assert "agent_config.rules child.enabled must be a JSON boolean" in sql
+    assert "agent_config.sub_agents child.enabled must be a JSON boolean" in sql
+    assert "agent_config.mcp_servers child.enabled must be a JSON boolean" in sql
     assert "skill_item.value ? 'disabled'" in sql
     assert "mcp_item.value ? 'disabled'" in sql
 

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -235,6 +235,15 @@ def test_get_agent_config_fails_loudly_when_mcp_json_uses_reverse_state() -> Non
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_mcp_json_enabled_is_not_boolean() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "enabled": "false"}]
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="mcp_json item enabled must be a boolean"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
     client = _FakeClient()
     repo = SupabaseAgentConfigRepo(client)


### PR DESCRIPTION
## Summary
- reject string/non-boolean `enabled` values in AgentConfig Tool, Skill, MCP, and SubAgent tool patches
- reject non-boolean JSON `enabled` values in the AgentConfig SQL boundary
- reject dirty MCP JSON rows with non-boolean `enabled` while reading Supabase AgentConfig

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/storage/test_supabase_agent_config_repo.py -q`
- `uv run pytest tests/Unit -q`
- `uv run pyright backend/threads/agent_user_service.py storage/providers/supabase/agent_config_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py`
- `uv run ruff check . && uv run ruff format --check .`
