### PR TITLE
Refactor agent config toggle boundaries

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -16,7 +16,7 @@ _MCP_CONFIG_KEYS = ("transport", "command", "args", "env", "url", "allowed_tools
 
 def _tools_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
     runtime = config.runtime_settings
-    enabled_tools = config.tools or ["*"]
+    enabled_tools = ["*"] if config.tools is None else config.tools
     tools_list = []
     for tool_name, tool_info in TOOLS_BY_NAME.items():
         runtime_key = f"tools:{tool_name}"
@@ -52,7 +52,7 @@ def _rules_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
 def _sub_agents_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
     sub_agents = {item["name"]: item for item in _load_builtin_agents(TOOLS_BY_NAME)}
     for row in config.sub_agents:
-        raw_tools = row.tools or ["*"]
+        raw_tools = ["*"] if row.tools is None else row.tools
         is_all = raw_tools == ["*"]
         tools = [
             {
@@ -378,7 +378,7 @@ def _save_config_to_repo(
             name=name,
             description=description,
             model=model,
-            tools=tools or ["*"],
+            tools=["*"] if tools is None else tools,
             system_prompt=system_prompt,
             status=status,
             version=version,
@@ -391,7 +391,7 @@ def _save_config_to_repo(
 
 def _runtime_and_tools_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     runtime = dict(current_config.runtime_settings)
-    tools = list(current_config.tools or ["*"])
+    tools = list(["*"] if current_config.tools is None else current_config.tools)
 
     if "tools" in config_patch and config_patch["tools"] is not None:
         tool_items = [item for item in config_patch["tools"] if isinstance(item, dict) and item.get("name")]

--- a/config/defaults/tool_catalog.py
+++ b/config/defaults/tool_catalog.py
@@ -93,11 +93,6 @@ def tool_enabled_for_agent(tool_name: str, *, configured_tools: list[str] | None
         if not isinstance(enabled, bool):
             raise RuntimeError("Tool runtime override enabled must be a boolean")
         return enabled
-    if hasattr(override, "enabled"):
-        enabled = override.enabled
-        if not isinstance(enabled, bool):
-            raise RuntimeError("Tool runtime override enabled must be a boolean")
-        return enabled
 
     tools = ["*"] if configured_tools is None else configured_tools
     if tools == ["*"]:

--- a/config/defaults/tool_catalog.py
+++ b/config/defaults/tool_catalog.py
@@ -89,13 +89,19 @@ def tool_enabled_for_agent(tool_name: str, *, configured_tools: list[str] | None
     runtime_key = f"tools:{tool_name}"
     override = runtime.get(runtime_key)
     if isinstance(override, dict) and "enabled" in override:
-        return bool(override["enabled"])
+        enabled = override["enabled"]
+        if not isinstance(enabled, bool):
+            raise RuntimeError("Tool runtime override enabled must be a boolean")
+        return enabled
     if hasattr(override, "enabled"):
-        return bool(override.enabled)
+        enabled = override.enabled
+        if not isinstance(enabled, bool):
+            raise RuntimeError("Tool runtime override enabled must be a boolean")
+        return enabled
 
-    tools = configured_tools or ["*"]
+    tools = ["*"] if configured_tools is None else configured_tools
     if tools == ["*"]:
         return True
     if tool_name in tools:
         return True
-    return TOOLS_BY_NAME[tool_name].default
+    return False

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -27,6 +27,13 @@ def _reject_duplicate_child_names(config: AgentConfig) -> None:
     _reject_duplicate_names("MCP server", [server.name for server in config.mcp_servers])
 
 
+def _enabled_from_row(row: dict[str, Any], *, label: str) -> bool:
+    enabled = row.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise RuntimeError(f"{label} enabled must be a boolean")
+    return enabled
+
+
 class SupabaseAgentConfigRepo:
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
@@ -100,7 +107,7 @@ class SupabaseAgentConfigRepo:
                     name=skill["name"],
                     description=skill.get("description") or "",
                     version=package.get("version") or "0.1.0",
-                    enabled=bool(row.get("enabled", True)),
+                    enabled=_enabled_from_row(row, label="skill_bindings"),
                     source=dict(package.get("source_json") or skill.get("source_json") or {}),
                 )
             )
@@ -137,7 +144,7 @@ class SupabaseAgentConfigRepo:
                 id=row.get("id"),
                 name=row.get("name") or row.get("filename") or "rule",
                 content=row.get("content") or "",
-                enabled=bool(row.get("enabled", True)),
+                enabled=_enabled_from_row(row, label="agent_rules"),
             )
             for row in rows
         ]
@@ -156,7 +163,7 @@ class SupabaseAgentConfigRepo:
                 model=row.get("model"),
                 tools=list(row.get("tools_json") or []),
                 system_prompt=row.get("system_prompt") or "",
-                enabled=bool(row.get("enabled", True)),
+                enabled=_enabled_from_row(row, label="agent_sub_agents"),
             )
             for row in rows
         ]
@@ -174,9 +181,6 @@ class SupabaseAgentConfigRepo:
                 raise RuntimeError(f"Agent config {agent_config_id} mcp_json items must be JSON objects")
             if "disabled" in row:
                 raise RuntimeError(f"Agent config {agent_config_id} mcp_json items must use enabled")
-            enabled = row.get("enabled", True)
-            if not isinstance(enabled, bool):
-                raise RuntimeError(f"Agent config {agent_config_id} mcp_json item enabled must be a boolean")
             servers.append(
                 McpServerConfig(
                     id=row.get("id"),
@@ -188,7 +192,7 @@ class SupabaseAgentConfigRepo:
                     url=row.get("url"),
                     instructions=row.get("instructions"),
                     allowed_tools=row.get("allowed_tools"),
-                    enabled=enabled,
+                    enabled=_enabled_from_row(row, label=f"Agent config {agent_config_id} mcp_json item"),
                 )
             )
         return servers

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -56,6 +56,7 @@ class SupabaseAgentConfigRepo:
         if not rows:
             return None
         root = dict(rows[0])
+        tools_json = root.get("tools_json")
         return AgentConfig(
             id=root["id"],
             owner_user_id=root["owner_user_id"],
@@ -63,7 +64,7 @@ class SupabaseAgentConfigRepo:
             name=root["name"],
             description=root.get("description") or "",
             model=root.get("model"),
-            tools=list(root.get("tools_json") or ["*"]),
+            tools=["*"] if tools_json is None else list(tools_json),
             system_prompt=root.get("system_prompt") or "",
             status=root.get("status") or "draft",
             version=root.get("version") or "0.1.0",

--- a/tests/Unit/config/test_tool_catalog.py
+++ b/tests/Unit/config/test_tool_catalog.py
@@ -1,0 +1,17 @@
+import pytest
+
+from config.defaults.tool_catalog import tool_enabled_for_agent
+
+
+def test_tool_enabled_for_agent_rejects_non_boolean_runtime_override() -> None:
+    with pytest.raises(RuntimeError, match="Tool runtime override enabled must be a boolean"):
+        tool_enabled_for_agent("Bash", configured_tools=["*"], runtime={"tools:Bash": {"enabled": "false"}})
+
+
+def test_tool_enabled_for_agent_treats_empty_tool_list_as_none_enabled() -> None:
+    assert tool_enabled_for_agent("Bash", configured_tools=[], runtime={}) is False
+
+
+def test_tool_enabled_for_agent_treats_named_tool_list_as_enabled_set() -> None:
+    assert tool_enabled_for_agent("Read", configured_tools=["Read"], runtime={}) is True
+    assert tool_enabled_for_agent("Bash", configured_tools=["Read"], runtime={}) is False

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -12,7 +12,7 @@ from backend.library import service as library_service
 from backend.threads import agent_user_service
 from backend.web.models.panel import PublishAgentRequest, UpdateAgentRequest
 from backend.web.routers import panel as panel_router
-from config.agent_config_types import AgentConfig, AgentSkill, McpServerConfig, Skill, SkillPackage
+from config.agent_config_types import AgentConfig, AgentSkill, AgentSubAgent, McpServerConfig, Skill, SkillPackage
 from storage.contracts import UserRow, UserType
 
 
@@ -344,6 +344,38 @@ def test_repo_backed_tools_star_keeps_panel_and_runtime_tool_state_aligned() -> 
 
     assert panel_lsp["enabled"] is True
     assert "LSP" not in agent._get_agent_blocked_tools()
+
+
+def test_repo_backed_empty_tool_list_means_no_tools_enabled() -> None:
+    config = _agent_config(tools=[])
+
+    assert all(item["enabled"] is False for item in agent_user_service._tools_from_repo(config))
+
+
+def test_repo_backed_named_tool_list_enables_only_named_tools() -> None:
+    config = _agent_config(tools=["Read"])
+    tools = {item["name"]: item["enabled"] for item in agent_user_service._tools_from_repo(config)}
+
+    assert tools["Read"] is True
+    assert tools["Bash"] is False
+
+
+def test_repo_backed_empty_sub_agent_tool_list_means_no_tools_enabled() -> None:
+    config = _agent_config(sub_agents=[AgentSubAgent(name="Worker", tools=[])])
+
+    worker = next(item for item in agent_user_service._sub_agents_from_repo(config) if item["name"] == "Worker")
+
+    assert all(item["enabled"] is False for item in worker["tools"])
+
+
+def test_repo_backed_named_sub_agent_tool_list_enables_only_named_tools() -> None:
+    config = _agent_config(sub_agents=[AgentSubAgent(name="Worker", tools=["Read"])])
+
+    worker = next(item for item in agent_user_service._sub_agents_from_repo(config) if item["name"] == "Worker")
+    tools = {item["name"]: item["enabled"] for item in worker["tools"]}
+
+    assert tools["Read"] is True
+    assert tools["Bash"] is False
 
 
 def test_agent_config_patch_saves_library_skill_package_choice() -> None:

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -244,6 +244,33 @@ def test_get_agent_config_fails_loudly_when_mcp_json_enabled_is_not_boolean() ->
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_skill_binding_enabled_is_not_boolean() -> None:
+    tables = _tables()
+    tables["agent.skill_bindings"][0]["enabled"] = "false"
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="skill_bindings enabled must be a boolean"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_rule_enabled_is_not_boolean() -> None:
+    tables = _tables()
+    tables["agent.agent_rules"][0]["enabled"] = "false"
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="agent_rules enabled must be a boolean"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_sub_agent_enabled_is_not_boolean() -> None:
+    tables = _tables()
+    tables["agent.agent_sub_agents"][0]["enabled"] = "false"
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="agent_sub_agents enabled must be a boolean"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
     client = _FakeClient()
     repo = SupabaseAgentConfigRepo(client)

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -217,6 +217,17 @@ def test_get_agent_config_returns_none_when_root_missing() -> None:
     assert repo.get_agent_config("missing") is None
 
 
+def test_get_agent_config_preserves_empty_tool_list() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["tools_json"] = []
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    config = repo.get_agent_config("cfg-1")
+
+    assert config is not None
+    assert config.tools == []
+
+
 def test_get_agent_config_fails_loudly_when_mcp_json_is_not_an_array() -> None:
     tables = _tables()
     tables["agent.agent_configs"][0]["mcp_json"] = {"filesystem": {"command": "fs"}}


### PR DESCRIPTION
## Summary
- reject non-boolean AgentConfig enabled values on Supabase aggregate reads
- make tool runtime enabled overrides JSON-shaped and boolean-only
- preserve explicit empty tool lists across storage and panel read paths

## Test Plan
- uv run pytest tests/Unit/config/test_tool_catalog.py tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q
- uv run pytest tests/Unit -q
- uv run ruff check . && uv run ruff format --check .
- uv run pyright backend/threads/agent_user_service.py config/defaults/tool_catalog.py storage/providers/supabase/agent_config_repo.py tests/Unit/config/test_tool_catalog.py tests/Unit/storage/test_supabase_agent_config_repo.py