### PR TITLE
Dispatch mentioned notification messages

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -26,6 +26,12 @@ from storage.errors import StorageConflictError
 logger = logging.getLogger(__name__)
 
 
+def _should_dispatch_chat_delivery(message_type: MessageType, mentions: list[str] | None) -> bool:
+    # @@@notification-mention-delivery - request notifications are durable chat messages,
+    # but mentioned managed agents still need a runtime wakeup to inspect them.
+    return message_type in {"human", "ai"} or (message_type == "notification" and bool(mentions))
+
+
 class MessagingService:
     """Core messaging operations backed by Supabase repos."""
 
@@ -234,7 +240,7 @@ class MessagingService:
             )
 
         # Deliver to agent recipients
-        if message_type in ("human", "ai"):
+        if _should_dispatch_chat_delivery(message_type, mentions):
             self._delivery_dispatcher.dispatch(chat_id, sender_id, content, mentions or [], signal=signal)
 
         return created

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -752,6 +752,56 @@ def test_messaging_service_event_bus_message_uses_service_owned_projection() -> 
     }
 
 
+def test_messaging_service_notification_mentions_dispatch_to_agent_recipients() -> None:
+    delivered: list[str] = []
+
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [{"user_id": "managed-owner-1"}]),
+        messages_repo=SimpleNamespace(
+            create=lambda row: row,
+            count_unread=lambda _chat_id, _user_id: 1,
+        ),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(
+                    id="visitor-1",
+                    display_name="Visitor",
+                    type="human",
+                    avatar=None,
+                    owner_user_id=None,
+                )
+                if uid == "visitor-1"
+                else SimpleNamespace(
+                    id="managed-owner-1",
+                    display_name="Managed Owner",
+                    type="agent",
+                    avatar=None,
+                    owner_user_id="human-owner-1",
+                )
+                if uid == "managed-owner-1"
+                else None
+            )
+        ),
+        delivery_resolver=SimpleNamespace(
+            resolve=lambda _recipient_id, _chat_id, _sender_id, *, is_mentioned: (
+                DeliveryAction.DELIVER if is_mentioned else DeliveryAction.DROP
+            )
+        ),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    service.send(
+        "chat-1",
+        "visitor-1",
+        "visitor-1 requested to join this chat.",
+        message_type="notification",
+        mentions=["managed-owner-1"],
+    )
+
+    assert delivered == ["managed-owner-1"]
+
+
 def test_messaging_service_send_fails_before_persisting_unknown_sender() -> None:
     created_rows: list[dict[str, Any]] = []
     published: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary
- add a MessagingService delivery policy for notification messages with explicit mentions
- preserve existing human/ai chat delivery behavior
- cover the managed-agent notification path with a RED/GREEN service contract test

## Verification
- uv run ruff check messaging/service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
- uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_notification_mentions_dispatch_to_agent_recipients tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_event_bus_message_uses_service_owned_projection -q

## Notes
- This is the backend notification-policy slice from notes/2026-04-25-relationship-chat-join-design.html.
- Relationship request notifications still need the separate backend notification-port slice; this PR intentionally does not create chats or invent a frontend-side shortcut.
