### PR TITLE
Refactor agent config JSON shape boundaries

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -458,8 +458,8 @@ def _mcp_from_patch(config_patch: dict[str, Any], current_config: AgentConfig) -
                 name=name,
                 transport=direct_config.get("transport"),
                 command=direct_config.get("command"),
-                args=list(direct_config.get("args") or []),
-                env=dict(direct_config.get("env") or {}),
+                args=_json_array_from_patch_item(direct_config.get("args"), label="MCP server patch item args"),
+                env=_json_object_from_patch_item(direct_config.get("env"), label="MCP server patch item env"),
                 url=direct_config.get("url"),
                 instructions=direct_config.get("instructions"),
                 allowed_tools=direct_config.get("allowed_tools"),
@@ -476,6 +476,22 @@ def _enabled_from_patch_item(item: dict[str, Any], *, label: str) -> bool:
     if not isinstance(enabled, bool):
         raise RuntimeError(f"{label} enabled must be a boolean")
     return enabled
+
+
+def _json_array_from_patch_item(value: Any, *, label: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RuntimeError(f"{label} must be a JSON array")
+    return list(value)
+
+
+def _json_object_from_patch_item(value: Any, *, label: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{label} must be a JSON object")
+    return dict(value)
 
 
 def _rules_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]) -> list[AgentRule]:
@@ -510,7 +526,7 @@ def _sub_agents_from_patch(current_config: AgentConfig, config_patch: dict[str, 
             if name in seen_names:
                 raise RuntimeError(f"Duplicate SubAgent name in patch: {name}")
             seen_names.add(name)
-            raw_tools = item.get("tools") or []
+            raw_tools = _json_array_from_patch_item(item.get("tools"), label="SubAgent patch item tools")
             if isinstance(raw_tools, list) and raw_tools and isinstance(raw_tools[0], dict):
                 enabled_tools = []
                 for tool in raw_tools:

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -34,6 +34,22 @@ def _enabled_from_row(row: dict[str, Any], *, label: str) -> bool:
     return enabled
 
 
+def _json_array(value: Any, *, label: str, default: list[Any] | None = None) -> list[Any]:
+    if value is None:
+        return list(default or [])
+    if not isinstance(value, list):
+        raise RuntimeError(f"{label} must be a JSON array")
+    return list(value)
+
+
+def _json_object(value: Any, *, label: str, default: dict[str, Any] | None = None) -> dict[str, Any]:
+    if value is None:
+        return dict(default or {})
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{label} must be a JSON object")
+    return dict(value)
+
+
 class SupabaseAgentConfigRepo:
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
@@ -56,7 +72,6 @@ class SupabaseAgentConfigRepo:
         if not rows:
             return None
         root = dict(rows[0])
-        tools_json = root.get("tools_json")
         return AgentConfig(
             id=root["id"],
             owner_user_id=root["owner_user_id"],
@@ -64,13 +79,13 @@ class SupabaseAgentConfigRepo:
             name=root["name"],
             description=root.get("description") or "",
             model=root.get("model"),
-            tools=["*"] if tools_json is None else list(tools_json),
+            tools=_json_array(root.get("tools_json"), label="tools_json", default=["*"]),
             system_prompt=root.get("system_prompt") or "",
             status=root.get("status") or "draft",
             version=root.get("version") or "0.1.0",
-            runtime_settings=dict(root.get("runtime_json") or {}),
-            compact=dict(root.get("compact_json") or {}),
-            meta=dict(root.get("meta_json") or {}),
+            runtime_settings=_json_object(root.get("runtime_json"), label="runtime_json"),
+            compact=_json_object(root.get("compact_json"), label="compact_json"),
+            meta=_json_object(root.get("meta_json"), label="meta_json"),
             skills=self._list_skill_rows(agent_config_id, root["owner_user_id"]),
             rules=self._list_rule_rows(agent_config_id),
             sub_agents=self._list_sub_agent_rows(agent_config_id),
@@ -100,6 +115,9 @@ class SupabaseAgentConfigRepo:
             package_id = row["package_id"]
             skill = self._get_library_skill(owner_user_id, skill_id)
             package = self._get_skill_package(owner_user_id, package_id)
+            source_json = package.get("source_json")
+            if source_json is None or source_json == {}:
+                source_json = skill.get("source_json")
             skills.append(
                 AgentSkill(
                     id=row.get("id"),
@@ -109,7 +127,7 @@ class SupabaseAgentConfigRepo:
                     description=skill.get("description") or "",
                     version=package.get("version") or "0.1.0",
                     enabled=_enabled_from_row(row, label="skill_bindings"),
-                    source=dict(package.get("source_json") or skill.get("source_json") or {}),
+                    source=_json_object(source_json, label="skill source_json"),
                 )
             )
         return skills
@@ -162,7 +180,7 @@ class SupabaseAgentConfigRepo:
                 name=row["name"],
                 description=row.get("description") or "",
                 model=row.get("model"),
-                tools=list(row.get("tools_json") or []),
+                tools=_json_array(row.get("tools_json"), label="agent_sub_agents tools_json"),
                 system_prompt=row.get("system_prompt") or "",
                 enabled=_enabled_from_row(row, label="agent_sub_agents"),
             )
@@ -173,7 +191,9 @@ class SupabaseAgentConfigRepo:
         rows = q.rows(self._table("agent_configs").select("mcp_json").eq("id", agent_config_id).execute(), _REPO, "_list_mcp_rows")
         if not rows:
             raise RuntimeError(f"Agent config {agent_config_id} disappeared while reading mcp_json")
-        mcp_rows = rows[0].get("mcp_json") or []
+        mcp_rows = rows[0].get("mcp_json")
+        if mcp_rows is None:
+            mcp_rows = []
         if not isinstance(mcp_rows, list):
             raise RuntimeError(f"Agent config {agent_config_id} mcp_json must be a JSON array")
         servers: list[McpServerConfig] = []
@@ -188,8 +208,8 @@ class SupabaseAgentConfigRepo:
                     name=row["name"],
                     transport=row.get("transport"),
                     command=row.get("command"),
-                    args=list(row.get("args") or []),
-                    env=dict(row.get("env") or {}),
+                    args=_json_array(row.get("args"), label="mcp_json item args"),
+                    env=_json_object(row.get("env"), label="mcp_json item env"),
                     url=row.get("url"),
                     instructions=row.get("instructions"),
                     allowed_tools=row.get("allowed_tools"),

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -156,6 +156,62 @@ do $$
 begin
     if exists (
         select 1
+        from library.skills
+        where jsonb_typeof(source_json) <> 'object'
+    ) then
+        raise exception 'library.skills.source_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
+        from library.skill_packages
+        where jsonb_typeof(manifest_json) <> 'object'
+    ) then
+        raise exception 'library.skill_packages.manifest_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
+        from library.skill_packages
+        where jsonb_typeof(files_json) <> 'object'
+    ) then
+        raise exception 'library.skill_packages.files_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
+        from library.skill_packages
+        where jsonb_typeof(source_json) <> 'object'
+    ) then
+        raise exception 'library.skill_packages.source_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
+        from agent.agent_configs
+        where jsonb_typeof(tools_json) <> 'array'
+    ) then
+        raise exception 'agent.agent_configs.tools_json must be a JSON array before hard cut';
+    end if;
+    if exists (
+        select 1
+        from agent.agent_configs
+        where jsonb_typeof(runtime_json) <> 'object'
+    ) then
+        raise exception 'agent.agent_configs.runtime_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
+        from agent.agent_configs
+        where jsonb_typeof(compact_json) <> 'object'
+    ) then
+        raise exception 'agent.agent_configs.compact_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
+        from agent.agent_configs
+        where jsonb_typeof(meta_json) <> 'object'
+    ) then
+        raise exception 'agent.agent_configs.meta_json must be a JSON object before hard cut';
+    end if;
+    if exists (
+        select 1
         from agent.agent_configs
         where jsonb_typeof(mcp_json) <> 'array'
     ) then
@@ -185,6 +241,18 @@ begin
     end if;
     if payload->>'name' is null or btrim(payload->>'name') = '' then
         raise exception 'agent_config.name is required';
+    end if;
+    if jsonb_typeof(coalesce(payload->'tools', '["*"]'::jsonb)) <> 'array' then
+        raise exception 'agent_config.tools must be a JSON array';
+    end if;
+    if jsonb_typeof(coalesce(payload->'runtime_settings', '{}'::jsonb)) <> 'object' then
+        raise exception 'agent_config.runtime_settings must be a JSON object';
+    end if;
+    if jsonb_typeof(coalesce(payload->'compact', '{}'::jsonb)) <> 'object' then
+        raise exception 'agent_config.compact must be a JSON object';
+    end if;
+    if jsonb_typeof(coalesce(payload->'meta', '{}'::jsonb)) <> 'object' then
+        raise exception 'agent_config.meta must be a JSON object';
     end if;
     if jsonb_typeof(coalesce(payload->'skills', '[]'::jsonb)) <> 'array' then
         raise exception 'agent_config.skills must be a JSON array';
@@ -271,6 +339,30 @@ begin
         where btrim(coalesce(mcp_item.value->>'name', '')) = ''
     ) then
         raise exception 'agent_config.mcp_servers child.name is required';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'sub_agents', '[]'::jsonb)) as sub_agent_item(value)
+        where sub_agent_item.value ? 'tools'
+          and jsonb_typeof(sub_agent_item.value->'tools') <> 'array'
+    ) then
+        raise exception 'agent_config.sub_agents child.tools must be a JSON array';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'mcp_servers', '[]'::jsonb)) as mcp_item(value)
+        where mcp_item.value ? 'args'
+          and jsonb_typeof(mcp_item.value->'args') <> 'array'
+    ) then
+        raise exception 'agent_config.mcp_servers child.args must be a JSON array';
+    end if;
+    if exists (
+        select 1
+        from jsonb_array_elements(coalesce(payload->'mcp_servers', '[]'::jsonb)) as mcp_item(value)
+        where mcp_item.value ? 'env'
+          and jsonb_typeof(mcp_item.value->'env') <> 'object'
+    ) then
+        raise exception 'agent_config.mcp_servers child.env must be a JSON object';
     end if;
     if exists (
         select 1

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1033,6 +1033,66 @@ def test_agent_config_patch_rejects_mcp_enabled_string() -> None:
     assert saved_configs == []
 
 
+def test_agent_config_patch_rejects_mcp_args_object() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(mcp_servers=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="MCP server patch item args must be a JSON array"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"mcpServers": [{"name": "demo-mcp", "transport": "stdio", "command": "uv", "args": {"root": "."}}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="owner-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+        )
+
+    assert saved_configs == []
+
+
+def test_agent_config_patch_rejects_mcp_env_array() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(mcp_servers=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="MCP server patch item env must be a JSON object"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"mcpServers": [{"name": "demo-mcp", "transport": "stdio", "command": "uv", "env": ["A=B"]}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="owner-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_duplicate_mcp_server_names() -> None:
     saved_configs: list[AgentConfig] = []
 
@@ -1207,6 +1267,37 @@ def test_agent_config_patch_rejects_sub_agent_tool_enabled_string() -> None:
         agent_user_service.update_agent_user_config(
             "agent-1",
             {"subAgents": [{"name": "Scout", "tools": [{"name": "Read", "enabled": "false"}]}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=_MemorySkillRepo(),
+        )
+
+    assert saved_configs == []
+
+
+def test_agent_config_patch_rejects_sub_agent_tools_object() -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config()
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="SubAgent patch item tools must be a JSON array"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"subAgents": [{"name": "Scout", "tools": {"Read": True}}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -44,13 +44,21 @@ def test_agent_config_schema_rejects_duplicate_child_names_inside_rpc() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 
     assert "agent_config.name is required" in sql
+    assert "agent_config.tools must be a JSON array" in sql
+    assert "agent_config.runtime_settings must be a JSON object" in sql
+    assert "agent_config.compact must be a JSON object" in sql
+    assert "agent_config.meta must be a JSON object" in sql
     assert "agent_config.skills must be a JSON array" in sql
     assert "agent_config.rules must be a JSON array" in sql
     assert "agent_config.sub_agents must be a JSON array" in sql
+    assert "agent_config.mcp_servers must be a JSON array" in sql
     assert "agent_config.skills child.name is required" in sql
     assert "agent_config.rules child.name is required" in sql
     assert "agent_config.sub_agents child.name is required" in sql
     assert "agent_config.mcp_servers child.name is required" in sql
+    assert "agent_config.sub_agents child.tools must be a JSON array" in sql
+    assert "agent_config.mcp_servers child.args must be a JSON array" in sql
+    assert "agent_config.mcp_servers child.env must be a JSON object" in sql
     assert "agent_config.skills contains duplicate name" in sql
     assert "agent_config.rules contains duplicate name" in sql
     assert "agent_config.sub_agents contains duplicate name" in sql
@@ -94,6 +102,14 @@ def test_agent_config_schema_constrains_named_child_tables() -> None:
 def test_agent_config_schema_constrains_root_identity_fields() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 
+    assert "library.skills.source_json must be a JSON object before hard cut" in sql
+    assert "library.skill_packages.manifest_json must be a JSON object before hard cut" in sql
+    assert "library.skill_packages.files_json must be a JSON object before hard cut" in sql
+    assert "library.skill_packages.source_json must be a JSON object before hard cut" in sql
+    assert "agent.agent_configs.tools_json must be a JSON array before hard cut" in sql
+    assert "agent.agent_configs.runtime_json must be a JSON object before hard cut" in sql
+    assert "agent.agent_configs.compact_json must be a JSON object before hard cut" in sql
+    assert "agent.agent_configs.meta_json must be a JSON object before hard cut" in sql
     assert "agent_configs_owner_user_id_required_ck" in sql
     assert "agent_configs_agent_user_id_required_ck" in sql
     assert "agent_configs_name_required_ck" in sql

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -228,9 +228,72 @@ def test_get_agent_config_preserves_empty_tool_list() -> None:
     assert config.tools == []
 
 
+def test_get_agent_config_fails_loudly_when_tools_json_is_not_an_array() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["tools_json"] = {"Read": True}
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="tools_json must be a JSON array"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_runtime_json_is_not_an_object() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["runtime_json"] = []
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="runtime_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_compact_json_is_not_an_object() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["compact_json"] = []
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="compact_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_meta_json_is_not_an_object() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["meta_json"] = []
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="meta_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_skill_source_json_is_not_an_object() -> None:
+    tables = _tables()
+    tables["library.skill_packages"][0]["source_json"] = ["bad"]
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="skill source_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_sub_agent_tools_json_is_not_an_array() -> None:
+    tables = _tables()
+    tables["agent.agent_sub_agents"][0]["tools_json"] = {"Read": True}
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="agent_sub_agents tools_json must be a JSON array"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_fails_loudly_when_mcp_json_is_not_an_array() -> None:
     tables = _tables()
     tables["agent.agent_configs"][0]["mcp_json"] = {"filesystem": {"command": "fs"}}
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="mcp_json must be a JSON array"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_mcp_json_is_empty_object() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["mcp_json"] = {}
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
     with pytest.raises(RuntimeError, match="mcp_json must be a JSON array"):
@@ -252,6 +315,24 @@ def test_get_agent_config_fails_loudly_when_mcp_json_enabled_is_not_boolean() ->
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
     with pytest.raises(RuntimeError, match="mcp_json item enabled must be a boolean"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_mcp_args_is_not_an_array() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "args": {"root": "."}}]
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="mcp_json item args must be a JSON array"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_mcp_env_is_not_an_object() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "env": ["A=B"]}]
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="mcp_json item env must be a JSON object"):
         repo.get_agent_config("cfg-1")
 
 


### PR DESCRIPTION
## Summary
- validate AgentConfig JSON root and child shapes in Supabase reads
- enforce the same shape rules in the AgentConfig hard-cut SQL
- reject object-shaped MCP/SubAgent patch fields instead of interpreting them as lists

## Test Plan
- uv run pytest tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q
- uv run pytest tests/Unit -q
- uv run ruff check . && uv run ruff format --check .
- uv run pyright backend/threads/agent_user_service.py storage/providers/supabase/agent_config_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py