### PR TITLE
Refactor agent config enabled type boundaries

### DIFF
--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -8,6 +8,12 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from config.skill_files import normalize_skill_file_map
 
 
+def _require_enabled_bool(value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError("enabled must be a boolean")
+    return value
+
+
 class Skill(BaseModel):
     id: str
     owner_user_id: str
@@ -68,6 +74,11 @@ class AgentSkill(BaseModel):
             raise ValueError(f"agent_skill.{info.field_name} must not be blank")
         return value
 
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _enabled_bool(cls, value: Any) -> bool:
+        return _require_enabled_bool(value)
+
 
 class ResolvedSkill(BaseModel):
     name: str
@@ -103,6 +114,11 @@ class AgentRule(BaseModel):
             raise ValueError("agent_rule.name must not be blank")
         return value
 
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _enabled_bool(cls, value: Any) -> bool:
+        return _require_enabled_bool(value)
+
 
 class AgentSubAgent(BaseModel):
     id: str | None = None
@@ -119,6 +135,11 @@ class AgentSubAgent(BaseModel):
         if not value.strip():
             raise ValueError("agent_sub_agent.name must not be blank")
         return value
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _enabled_bool(cls, value: Any) -> bool:
+        return _require_enabled_bool(value)
 
 
 class McpServerConfig(BaseModel):
@@ -139,6 +160,11 @@ class McpServerConfig(BaseModel):
         if not value.strip():
             raise ValueError("mcp_server.name must not be blank")
         return value
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _enabled_bool(cls, value: Any) -> bool:
+        return _require_enabled_bool(value)
 
 
 class AgentConfig(BaseModel):

--- a/config/schema.py
+++ b/config/schema.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, StrictBool, field_validator
 
 # Default model used across the codebase — single source of truth
 DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
@@ -195,7 +195,7 @@ class MCPServerConfig(BaseModel):
 class MCPConfig(BaseModel):
     """MCP (Model Context Protocol) configuration."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     servers: dict[str, MCPServerConfig] = Field(default_factory=dict, description="MCP server configurations")
 
 

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -49,6 +49,20 @@ def test_agent_config_child_models_reject_string_enabled(model_cls, kwargs) -> N
         model_cls(enabled="false", **kwargs)
 
 
+@pytest.mark.parametrize(
+    ("model_cls", "kwargs"),
+    [
+        (AgentSkill, {"name": "query-helper"}),
+        (AgentRule, {"name": "cite", "content": "cite sources"}),
+        (AgentSubAgent, {"name": "worker"}),
+        (McpServerConfig, {"name": "filesystem", "command": "fs"}),
+    ],
+)
+def test_agent_config_child_models_reject_numeric_enabled(model_cls, kwargs) -> None:
+    with pytest.raises(ValueError, match="enabled must be a boolean"):
+        model_cls(enabled=1, **kwargs)
+
+
 def test_skill_package_requires_package_identity_and_skill_md() -> None:
     package = SkillPackage(
         id="package-1",

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from config.agent_config_types import AgentSkill, ResolvedSkill, SkillPackage
+from config.agent_config_types import AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, ResolvedSkill, SkillPackage
 
 
 def test_resolved_skill_model_normalizes_file_paths() -> None:
@@ -33,6 +33,20 @@ def test_agent_skill_model_has_no_resolved_content() -> None:
 
     assert "content" not in agent_skill.model_dump()
     assert "files" not in agent_skill.model_dump()
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "kwargs"),
+    [
+        (AgentSkill, {"name": "query-helper"}),
+        (AgentRule, {"name": "cite", "content": "cite sources"}),
+        (AgentSubAgent, {"name": "worker"}),
+        (McpServerConfig, {"name": "filesystem", "command": "fs"}),
+    ],
+)
+def test_agent_config_child_models_reject_string_enabled(model_cls, kwargs) -> None:
+    with pytest.raises(ValueError, match="enabled must be a boolean"):
+        model_cls(enabled="false", **kwargs)
 
 
 def test_skill_package_requires_package_identity_and_skill_md() -> None:

--- a/tests/Unit/config/test_runtime_schema.py
+++ b/tests/Unit/config/test_runtime_schema.py
@@ -6,3 +6,8 @@ from config.schema import MCPConfig
 def test_mcp_config_rejects_string_enabled() -> None:
     with pytest.raises(ValueError, match="enabled"):
         MCPConfig.model_validate({"enabled": "false", "servers": {}})
+
+
+def test_mcp_config_rejects_numeric_enabled() -> None:
+    with pytest.raises(ValueError, match="enabled"):
+        MCPConfig.model_validate({"enabled": 1, "servers": {}})

--- a/tests/Unit/config/test_runtime_schema.py
+++ b/tests/Unit/config/test_runtime_schema.py
@@ -1,0 +1,8 @@
+import pytest
+
+from config.schema import MCPConfig
+
+
+def test_mcp_config_rejects_string_enabled() -> None:
+    with pytest.raises(ValueError, match="enabled"):
+        MCPConfig.model_validate({"enabled": "false", "servers": {}})


### PR DESCRIPTION
## Summary
- Require `enabled` to be a real boolean on AgentConfig child models: skills, rules, sub-agents, and MCP servers.
- Require runtime MCP config `enabled` to be a strict boolean.
- Add regression coverage for string and numeric `enabled` values so config boundaries fail loudly.

## Test Plan
- `uv run pytest tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_runtime_schema.py tests/Unit/platform/test_mcp_transport.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright config/agent_config_types.py config/schema.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_runtime_schema.py`
- `uv run pytest tests/Unit -q`
