### PR TITLE
feat: notify agents of relationship requests

### DIFF
--- a/backend/chat/api/http/relationships_router.py
+++ b/backend/chat/api/http/relationships_router.py
@@ -58,7 +58,7 @@ def _row_to_dict(row: RelationshipRow, viewer_id: str) -> dict:
 
 
 @router.get("")
-async def list_relationships(
+def list_relationships(
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
 ):
@@ -67,7 +67,7 @@ async def list_relationships(
 
 
 @router.post("/request")
-async def request_relationship(
+def request_relationship(
     body: RelationshipRequestBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     relationship_service: Annotated[Any, Depends(get_relationship_service)],
@@ -82,7 +82,7 @@ async def request_relationship(
 
 
 @router.post("/{relationship_id}/approve")
-async def approve_relationship(
+def approve_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
@@ -99,7 +99,7 @@ async def approve_relationship(
 
 
 @router.post("/{relationship_id}/reject")
-async def reject_relationship(
+def reject_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
@@ -116,7 +116,7 @@ async def reject_relationship(
 
 
 @router.post("/{relationship_id}/upgrade")
-async def upgrade_relationship(
+def upgrade_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
@@ -131,7 +131,7 @@ async def upgrade_relationship(
 
 
 @router.post("/{relationship_id}/revoke")
-async def revoke_relationship(
+def revoke_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
@@ -146,7 +146,7 @@ async def revoke_relationship(
 
 
 @router.post("/{relationship_id}/downgrade")
-async def downgrade_relationship(
+def downgrade_relationship(
     relationship_id: str,
     body: RelationshipActionBody,
     user_id: Annotated[str, Depends(get_current_user_id)],

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.chat_inlet import make_chat_delivery_fn
+from backend.threads.chat_adapters.relationship_inlet import make_relationship_request_notification_fn
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.join_requests import ChatJoinRequestService
 from messaging.realtime.events import ChatEventBus
@@ -90,5 +91,23 @@ def wire_chat_delivery(app: Any, *, messaging_service: Any, activity_reader: Any
             app,
             activity_reader=activity_reader,
             thread_repo=thread_repo,
+        )
+    )
+
+
+def wire_relationship_request_notifications(
+    app: Any,
+    *,
+    relationship_service: Any,
+    activity_reader: Any,
+    thread_repo: Any,
+    user_repo: Any,
+) -> None:
+    relationship_service.set_relationship_request_notification_fn(
+        make_relationship_request_notification_fn(
+            app,
+            activity_reader=activity_reader,
+            thread_repo=thread_repo,
+            user_repo=user_repo,
         )
     )

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+from enum import Enum
+from typing import Any
+
+from backend.identity.avatar.urls import avatar_url
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from messaging.contracts import RelationshipRow
+from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
+from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+
+
+def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
+    if activity_reader is None:
+        raise RuntimeError("Agent runtime thread activity reader is not configured")
+    loop = asyncio.get_running_loop()
+
+    async def notify_runtime(row: RelationshipRow) -> None:
+        requester_id = _requester_id(row)
+        target_id = _target_id(row, requester_id)
+        requester = _require_user(user_repo, requester_id, "requester")
+        target = _require_user(user_repo, target_id, "target")
+        if _user_type(target, target_id) != "agent":
+            return
+
+        thread_id = select_runtime_thread_for_recipient(
+            target_id,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if thread_id is None:
+            raise RuntimeError(f"Relationship request target agent has no runtime thread: {target_id}")
+
+        await get_agent_runtime_gateway(app).dispatch_thread_input(
+            AgentThreadInputEnvelope(
+                thread_id=thread_id,
+                sender=AgentRuntimeActor(
+                    user_id=requester_id,
+                    user_type=_user_type(requester, requester_id),
+                    display_name=_display_name(requester, requester_id),
+                    avatar_url=avatar_url(requester_id, bool(getattr(requester, "avatar", None))),
+                    source="relationship",
+                ),
+                message=AgentRuntimeMessage(
+                    content=(
+                        f"{_display_name(requester, requester_id)} requested a relationship with you. "
+                        "Review the pending relationship request in Mycel, then approve or reject it."
+                    ),
+                    metadata={"relationship_id": row.id},
+                ),
+            )
+        )
+
+    def _notify(row: RelationshipRow) -> None:
+        future = asyncio.run_coroutine_threadsafe(notify_runtime(row), loop)
+        future.result()
+
+    return _notify
+
+
+def _requester_id(row: RelationshipRow) -> str:
+    if row.initiator_user_id is None:
+        raise RuntimeError(f"Relationship request row is missing initiator: {row.id}")
+    return row.initiator_user_id
+
+
+def _target_id(row: RelationshipRow, requester_id: str) -> str:
+    if requester_id == row.user_low:
+        return row.user_high
+    if requester_id == row.user_high:
+        return row.user_low
+    raise RuntimeError(f"Relationship request initiator is not a party: {row.id}")
+
+
+def _require_user(user_repo: Any, user_id: str, role: str) -> Any:
+    user = user_repo.get_by_id(user_id)
+    if user is None:
+        raise RuntimeError(f"Relationship request {role} user not found: {user_id}")
+    return user
+
+
+def _user_type(user: Any, user_id: str) -> str:
+    raw_type = getattr(user, "type", None)
+    if raw_type is None:
+        raise RuntimeError(f"Relationship request user is missing type: {user_id}")
+    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
+
+
+def _display_name(user: Any, user_id: str) -> str:
+    display_name = getattr(user, "display_name", None)
+    if display_name is None:
+        raise RuntimeError(f"Relationship request user is missing display name: {user_id}")
+    return str(display_name)

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
     app.state.sandbox_runtime_repo = storage_container.sandbox_runtime_repo()
     app.state.workspace_repo = storage_container.workspace_repo()
     app.state.sandbox_repo = storage_container.sandbox_repo()
-    from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery
+    from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery, wire_relationship_request_notifications
     from backend.threads.bootstrap import attach_threads_runtime
 
     # @@@web-chat-before-threads - threads bootstrap now constructs the agent
@@ -84,6 +84,13 @@ async def lifespan(app: FastAPI):
         messaging_service=chat_runtime.messaging_service,
         activity_reader=threads_runtime.activity_reader,
         thread_repo=app.state.thread_repo,
+    )
+    wire_relationship_request_notifications(
+        app,
+        relationship_service=chat_runtime.relationship_service,
+        activity_reader=threads_runtime.activity_reader,
+        thread_repo=app.state.thread_repo,
+        user_repo=app.state.user_repo,
     )
 
     # ---- Existing state ----

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from messaging.contracts import RelationshipEvent, RelationshipRow, RelationshipState
@@ -14,8 +15,17 @@ logger = logging.getLogger(__name__)
 class RelationshipService:
     """Manages Hire/Visit relationships between users."""
 
-    def __init__(self, relationship_repo: Any) -> None:
+    def __init__(
+        self,
+        relationship_repo: Any,
+        *,
+        on_relationship_requested: Callable[[RelationshipRow], None] | None = None,
+    ) -> None:
         self._repo = relationship_repo
+        self._on_relationship_requested = on_relationship_requested
+
+    def set_relationship_request_notification_fn(self, fn: Callable[[RelationshipRow], None]) -> None:
+        self._on_relationship_requested = fn
 
     def apply_event(
         self,
@@ -56,7 +66,10 @@ class RelationshipService:
         return RelationshipRow.model_validate(row)
 
     def request(self, requester_id: str, target_id: str) -> RelationshipRow:
-        return self.apply_event(requester_id, target_id, "request")
+        row = self.apply_event(requester_id, target_id, "request")
+        if self._on_relationship_requested is not None:
+            self._on_relationship_requested(row)
+        return row
 
     def approve(self, approver_id: str, requester_id: str) -> RelationshipRow:
         return self.apply_event(approver_id, requester_id, "approve")

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -43,8 +44,11 @@ def test_relationship_public_openapi_uses_token_identity_only() -> None:
     assert action_properties == {}
 
 
-@pytest.mark.asyncio
-async def test_request_relationship_uses_current_token_user() -> None:
+def test_relationship_request_route_is_sync_for_runtime_notification_delivery() -> None:
+    assert inspect.iscoroutinefunction(owner_relationship_router.request_relationship) is False
+
+
+def test_request_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     relationship_service = SimpleNamespace(
         request=lambda requester_id, target_id: (
@@ -57,7 +61,7 @@ async def test_request_relationship_uses_current_token_user() -> None:
         )
     )
 
-    result = await owner_relationship_router.request_relationship(
+    result = owner_relationship_router.request_relationship(
         owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1"),
         user_id="owner-user-1",
         relationship_service=relationship_service,
@@ -68,8 +72,7 @@ async def test_request_relationship_uses_current_token_user() -> None:
     assert result["is_requester"] is True
 
 
-@pytest.mark.asyncio
-async def test_approve_relationship_uses_current_token_user() -> None:
+def test_approve_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     existing = {
         "id": "hire_visit:agent-user-1:requester-user-1",
@@ -85,7 +88,7 @@ async def test_approve_relationship_uses_current_token_user() -> None:
         ),
     )
 
-    result = await owner_relationship_router.approve_relationship(
+    result = owner_relationship_router.approve_relationship(
         existing["id"],
         owner_relationship_router.RelationshipActionBody(),
         user_id="agent-user-1",
@@ -97,8 +100,7 @@ async def test_approve_relationship_uses_current_token_user() -> None:
     assert result["state"] == "visit"
 
 
-@pytest.mark.asyncio
-async def test_reject_relationship_uses_current_token_user() -> None:
+def test_reject_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     existing = {
         "id": "hire_visit:agent-user-1:requester-user-1",
@@ -114,7 +116,7 @@ async def test_reject_relationship_uses_current_token_user() -> None:
         ),
     )
 
-    result = await owner_relationship_router.reject_relationship(
+    result = owner_relationship_router.reject_relationship(
         existing["id"],
         owner_relationship_router.RelationshipActionBody(),
         user_id="agent-user-1",
@@ -126,8 +128,7 @@ async def test_reject_relationship_uses_current_token_user() -> None:
     assert result["state"] == "none"
 
 
-@pytest.mark.asyncio
-async def test_downgrade_relationship_uses_current_token_user() -> None:
+def test_downgrade_relationship_uses_current_token_user() -> None:
     seen: list[tuple[str, str]] = []
     existing = {
         "id": "hire_visit:agent-user-1:requester-user-1",
@@ -143,7 +144,7 @@ async def test_downgrade_relationship_uses_current_token_user() -> None:
         ),
     )
 
-    result = await owner_relationship_router.downgrade_relationship(
+    result = owner_relationship_router.downgrade_relationship(
         existing["id"],
         owner_relationship_router.RelationshipActionBody(),
         user_id="agent-user-1",

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -129,3 +129,34 @@ def test_wire_chat_delivery_binds_delivery_fn(monkeypatch):
     )
 
     assert messaging_service.delivery_fn is delivery_fn
+
+
+def test_wire_relationship_request_notifications_binds_notification_fn(monkeypatch):
+    notification_fn = object()
+    relationship_service = SimpleNamespace(notification_fn=None)
+    activity_reader = object()
+    thread_repo = object()
+    user_repo = object()
+
+    def _set_notification_fn(value):
+        relationship_service.notification_fn = value
+
+    relationship_service.set_relationship_request_notification_fn = _set_notification_fn
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    monkeypatch.setattr(
+        chat_bootstrap,
+        "make_relationship_request_notification_fn",
+        lambda target_app, *, activity_reader, thread_repo, user_repo: notification_fn,
+    )
+
+    chat_bootstrap.wire_relationship_request_notifications(
+        app,
+        relationship_service=relationship_service,
+        activity_reader=activity_reader,
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+    )
+
+    assert relationship_service.notification_fn is notification_fn

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -23,6 +23,7 @@ def _patch_lifespan_runtime_contract(
     attach_auth_runtime,
     attach_threads_runtime,
     wire_chat_delivery,
+    wire_relationship_request_notifications,
 ):
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
     monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
@@ -71,6 +72,7 @@ def _patch_lifespan_runtime_contract(
     )
     monkeypatch.setattr("backend.chat.bootstrap.attach_chat_runtime", attach_chat_runtime)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", wire_chat_delivery)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", wire_relationship_request_notifications)
     monkeypatch.setattr("backend.threads.bootstrap.attach_threads_runtime", attach_threads_runtime)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
@@ -82,6 +84,7 @@ def _patch_lifespan_runtime_contract(
 async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeypatch):
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+    returned_relationship_service = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         contact_repo = object()
@@ -89,6 +92,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
             contact_repo=contact_repo,
             typing_tracker=returned_typing_tracker,
             messaging_service=returned_messaging_service,
+            relationship_service=returned_relationship_service,
         )
 
     def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service):
@@ -103,6 +107,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
         attach_auth_runtime=lambda *_args, **_kwargs: object(),
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=lambda *_args, **_kwargs: None,
+        wire_relationship_request_notifications=lambda *_args, **_kwargs: None,
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
@@ -116,6 +121,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     call_log: list[str] = []
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+    returned_relationship_service = object()
     returned_contact_repo = object()
     returned_activity_reader = object()
 
@@ -125,6 +131,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
             contact_repo=returned_contact_repo,
             typing_tracker=returned_typing_tracker,
             messaging_service=returned_messaging_service,
+            relationship_service=returned_relationship_service,
         )
 
     def _attach_auth_runtime(_app, *, storage_state, contact_repo):
@@ -140,8 +147,13 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         return SimpleNamespace(activity_reader=returned_activity_reader)
 
     def _wire_chat_delivery(_app, *, messaging_service, activity_reader, thread_repo):
-        call_log.append("wire")
+        call_log.append("wire-chat")
         assert messaging_service is returned_messaging_service
+        assert activity_reader is returned_activity_reader
+
+    def _wire_relationship_request_notifications(_app, *, relationship_service, activity_reader, thread_repo, user_repo):
+        call_log.append("wire-relationship")
+        assert relationship_service is returned_relationship_service
         assert activity_reader is returned_activity_reader
 
     _patch_lifespan_runtime_contract(
@@ -150,12 +162,13 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         attach_auth_runtime=_attach_auth_runtime,
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=_wire_chat_delivery,
+        wire_relationship_request_notifications=_wire_relationship_request_notifications,
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     async with web_lifespan.lifespan(app):
-        assert call_log == ["chat", "auth", "threads", "wire"]
+        assert call_log == ["chat", "auth", "threads", "wire-chat", "wire-relationship"]
 
 
 @pytest.mark.asyncio
@@ -211,6 +224,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
             contact_repo=contact_repo,
             typing_tracker=object(),
             messaging_service=SimpleNamespace(set_delivery_fn=lambda _fn: None),
+            relationship_service=object(),
         ),
     )
     monkeypatch.setattr(
@@ -218,6 +232,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
         lambda app, *_args, **_kwargs: setattr(app.state, "agent_pool", {}) or SimpleNamespace(activity_reader=object()),
     )
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
     monkeypatch.setattr("backend.threads.pool.idle_reaper.idle_reaper_loop", lambda _app: _never())

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from backend.threads.chat_adapters import relationship_inlet
+from messaging.contracts import RelationshipRow
+from protocols.agent_runtime import AgentThreadInputResult
+
+
+def _relationship_row(
+    *,
+    user_low: str = "agent-user-1",
+    user_high: str = "human-user-1",
+    initiator_user_id: str = "human-user-1",
+) -> RelationshipRow:
+    now = datetime(2026, 4, 26, tzinfo=UTC)
+    return RelationshipRow(
+        id=f"hire_visit:{user_low}:{user_high}",
+        user_low=user_low,
+        user_high=user_high,
+        kind="hire_visit",
+        state="pending",
+        initiator_user_id=initiator_user_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _hook_app(gateway: object) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+
+def _thread_repo() -> SimpleNamespace:
+    default_thread = {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
+    return SimpleNamespace(
+        get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
+        list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_relationship_request_notification_dispatches_thread_input_to_agent_target() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_thread_input(self, envelope):
+            self.envelope = envelope
+            return AgentThreadInputResult(status="injected", routing="steer", thread_id=envelope.thread_id)
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(
+                id="human-user-1",
+                type="human",
+                display_name="Human",
+                avatar=None,
+            ),
+            "agent-user-1": SimpleNamespace(
+                id="agent-user-1",
+                type="agent",
+                display_name="Toad",
+                avatar=None,
+            ),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_request_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=_thread_repo(),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(notify, _relationship_row())
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.thread_id == "thread-main"
+    assert gateway.envelope.sender.user_id == "human-user-1"
+    assert gateway.envelope.sender.user_type == "human"
+    assert gateway.envelope.sender.display_name == "Human"
+    assert gateway.envelope.sender.source == "relationship"
+    assert "Human requested a relationship with you." in gateway.envelope.message.content
+    assert gateway.envelope.message.metadata == {"relationship_id": "hire_visit:agent-user-1:human-user-1"}
+
+
+@pytest.mark.asyncio
+async def test_relationship_request_notification_does_not_dispatch_to_non_agent_target() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+            "human-user-2": SimpleNamespace(id="human-user-2", type="human", display_name="Other", avatar=None),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_request_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _relationship_row(user_low="human-user-1", user_high="human-user-2", initiator_user_id="human-user-1"),
+    )
+
+    assert gateway.called is False
+
+
+@pytest.mark.asyncio
+async def test_relationship_request_notification_fails_when_agent_target_has_no_runtime_thread() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_request_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    with pytest.raises(RuntimeError, match="Relationship request target agent has no runtime thread: agent-user-1"):
+        await asyncio.to_thread(notify, _relationship_row())
+
+    assert gateway.called is False

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -143,6 +143,38 @@ def test_relationship_request_uses_single_pending_state_and_initiator() -> None:
     assert row.initiator_user_id == "human-user-1"
 
 
+def test_relationship_request_notifies_after_persisting_pending_row() -> None:
+    class _RequestRepo:
+        def __init__(self) -> None:
+            self.persisted = False
+
+        def get(self, _requester_id: str, _target_id: str):
+            return None
+
+        def upsert(self, _requester_id: str, _target_id: str, **fields: Any):
+            self.persisted = True
+            return {
+                "id": "hire_visit:agent-user-1:human-user-1",
+                "user_low": "agent-user-1",
+                "user_high": "human-user-1",
+                "kind": "hire_visit",
+                "created_at": "2026-04-07T00:00:00Z",
+                "updated_at": "2026-04-07T00:00:01Z",
+                **fields,
+            }
+
+    repo = _RequestRepo()
+    notifications = []
+    service = RelationshipService(repo, on_relationship_requested=notifications.append)
+
+    row = service.request("human-user-1", "agent-user-1")
+
+    assert repo.persisted is True
+    assert notifications == [row]
+    assert notifications[0].state == "pending"
+    assert notifications[0].initiator_user_id == "human-user-1"
+
+
 def test_relationship_list_for_user_fails_on_invalid_row() -> None:
     service = RelationshipService(
         SimpleNamespace(


### PR DESCRIPTION
## Summary
- add a backend relationship request notification port on RelationshipService
- deliver relationship requests to managed agent runtime threads through a dedicated relationship inlet
- wire the notification after threads runtime startup and run relationship routes synchronously for blocking runtime delivery

## Verification
- uv run pytest tests/Integration/test_relationship_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_revoke_deletes_hire_without_snapshot_side_channel tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_request_uses_single_pending_state_and_initiator tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_request_notifies_after_persisting_pending_row tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_list_for_user_fails_on_invalid_row tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_get_state_fails_on_invalid_existing_row tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q
- uv run ruff check . && uv run ruff format --check .