### PR TITLE
Refactor runtime config boundary cleanup

### DIFF
--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from config.skill_files import normalize_skill_file_map
 
@@ -14,7 +14,11 @@ def _require_enabled_bool(value: Any) -> bool:
     return value
 
 
-class Skill(BaseModel):
+class AgentConfigSchemaModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class Skill(AgentConfigSchemaModel):
     id: str
     owner_user_id: str
     name: str
@@ -32,7 +36,7 @@ class Skill(BaseModel):
         return value
 
 
-class SkillPackage(BaseModel):
+class SkillPackage(AgentConfigSchemaModel):
     id: str
     owner_user_id: str
     skill_id: str
@@ -57,7 +61,7 @@ class SkillPackage(BaseModel):
         return normalize_skill_file_map(value, context="Skill package files") if isinstance(value, dict) else value
 
 
-class AgentSkill(BaseModel):
+class AgentSkill(AgentConfigSchemaModel):
     id: str | None = None
     skill_id: str | None = None
     package_id: str | None = None
@@ -80,7 +84,7 @@ class AgentSkill(BaseModel):
         return _require_enabled_bool(value)
 
 
-class ResolvedSkill(BaseModel):
+class ResolvedSkill(AgentConfigSchemaModel):
     name: str
     description: str = ""
     version: str = "0.1.0"
@@ -101,7 +105,7 @@ class ResolvedSkill(BaseModel):
         return normalize_skill_file_map(value, context="Skill files") if isinstance(value, dict) else value
 
 
-class AgentRule(BaseModel):
+class AgentRule(AgentConfigSchemaModel):
     id: str | None = None
     name: str
     content: str
@@ -120,7 +124,7 @@ class AgentRule(BaseModel):
         return _require_enabled_bool(value)
 
 
-class AgentSubAgent(BaseModel):
+class AgentSubAgent(AgentConfigSchemaModel):
     id: str | None = None
     name: str
     description: str = ""
@@ -142,7 +146,7 @@ class AgentSubAgent(BaseModel):
         return _require_enabled_bool(value)
 
 
-class McpServerConfig(BaseModel):
+class McpServerConfig(AgentConfigSchemaModel):
     id: str | None = None
     name: str
     transport: Literal["stdio", "streamable_http", "sse", "websocket"] | None = None
@@ -167,7 +171,7 @@ class McpServerConfig(BaseModel):
         return _require_enabled_bool(value)
 
 
-class AgentConfig(BaseModel):
+class AgentConfig(AgentConfigSchemaModel):
     id: str
     owner_user_id: str
     agent_user_id: str  # @@@aggregate-owner - DB column is not null; aggregate saves must persist it.
@@ -194,7 +198,7 @@ class AgentConfig(BaseModel):
         return value
 
 
-class ResolvedAgentConfig(BaseModel):
+class ResolvedAgentConfig(AgentConfigSchemaModel):
     id: str
     name: str
     description: str = ""
@@ -210,6 +214,6 @@ class ResolvedAgentConfig(BaseModel):
     meta: dict[str, Any] = Field(default_factory=dict)
 
 
-class AgentSnapshot(BaseModel):
+class AgentSnapshot(AgentConfigSchemaModel):
     schema_version: Literal["agent-snapshot/v1"] = "agent-snapshot/v1"
     agent: ResolvedAgentConfig

--- a/config/defaults/runtime.json
+++ b/config/defaults/runtime.json
@@ -1,12 +1,14 @@
 {
-  "context_limit": 0,
-  "enable_audit_log": true,
-  "allowed_extensions": null,
-  "block_dangerous_commands": true,
-  "block_network_commands": false,
-  "temperature": null,
-  "max_tokens": null,
-  "model_kwargs": {},
+  "runtime": {
+    "context_limit": 0,
+    "enable_audit_log": true,
+    "allowed_extensions": null,
+    "block_dangerous_commands": true,
+    "block_network_commands": false,
+    "temperature": null,
+    "max_tokens": null,
+    "model_kwargs": {}
+  },
   "memory": {
     "pruning": {
       "enabled": true,
@@ -31,7 +33,6 @@
     },
     "search": {
       "enabled": true,
-      "max_results": 50,
       "tools": {
         "grep": {
           "enabled": true,

--- a/config/loader.py
+++ b/config/loader.py
@@ -28,8 +28,7 @@ logger = logging.getLogger(__name__)
 class AgentLoader:
     """Unified loader for runtime config and runtime agent definitions."""
 
-    def __init__(self, workspace_root: str | Path | None = None):
-        self.workspace_root = Path(workspace_root).resolve() if workspace_root else None
+    def __init__(self):
         self._system_defaults_dir = Path(__file__).parent / "defaults"
         self._agents: dict[str, RuntimeAgentDefinition] = {}
 
@@ -192,9 +191,6 @@ class AgentLoader:
         return obj
 
 
-def load_config(
-    workspace_root: str | None = None,
-    cli_overrides: dict[str, Any] | None = None,
-) -> LeonSettings:
+def load_config(cli_overrides: dict[str, Any] | None = None) -> LeonSettings:
     """Convenience function to load runtime configuration."""
-    return AgentLoader(workspace_root=workspace_root).load(cli_overrides=cli_overrides)
+    return AgentLoader().load(cli_overrides=cli_overrides)

--- a/config/loader.py
+++ b/config/loader.py
@@ -159,13 +159,6 @@ class AgentLoader:
                     result[key] = value
         return result
 
-    def _lookup_merge(self, key: str, *configs: dict[str, Any]) -> Any:
-        """Lookup strategy: first found wins."""
-        for config in configs:
-            if key in config and config[key] is not None:
-                return config[key]
-        return {}
-
     @staticmethod
     def _reject_removed_runtime_key(key: str, *configs: dict[str, Any]) -> None:
         for config in configs:

--- a/config/schema.py
+++ b/config/schema.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, StrictBool, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
 
 # Default model used across the codebase — single source of truth
 DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
@@ -23,7 +23,11 @@ DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 # ============================================================================
 
 
-class RuntimeConfig(BaseModel):
+class RuntimeSchemaModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class RuntimeConfig(RuntimeSchemaModel):
     """Runtime behavior configuration (non-model identity)."""
 
     temperature: Annotated[float | None, Field(ge=0.0, le=2.0, description="Temperature")] = None
@@ -32,10 +36,10 @@ class RuntimeConfig(BaseModel):
         default_factory=dict
     )
     context_limit: Annotated[int, Field(ge=0, description="Context window limit in tokens (0 = auto-detect from model)")] = 0
-    enable_audit_log: Annotated[bool, Field(description="Enable audit logging")] = True
+    enable_audit_log: Annotated[StrictBool, Field(description="Enable audit logging")] = True
     allowed_extensions: Annotated[list[str] | None, Field(description="Allowed extensions (None = all)")] = None
-    block_dangerous_commands: Annotated[bool, Field(description="Block dangerous commands")] = True
-    block_network_commands: Annotated[bool, Field(description="Block network commands")] = False
+    block_dangerous_commands: Annotated[StrictBool, Field(description="Block dangerous commands")] = True
+    block_network_commands: Annotated[StrictBool, Field(description="Block network commands")] = False
 
 
 # ============================================================================
@@ -43,33 +47,33 @@ class RuntimeConfig(BaseModel):
 # ============================================================================
 
 
-class PruningConfig(BaseModel):
+class PruningConfig(RuntimeSchemaModel):
     """Configuration for message pruning.
 
     Field names match SessionPruner constructor for direct passthrough.
     """
 
-    enabled: Annotated[bool, Field(description="Enable message pruning")] = True
+    enabled: Annotated[StrictBool, Field(description="Enable message pruning")] = True
     soft_trim_chars: Annotated[int, Field(gt=0, description="Soft-trim tool results longer than this")] = 3000
     hard_clear_threshold: Annotated[int, Field(gt=0, description="Hard-clear tool results longer than this")] = 10000
     protect_recent: Annotated[int, Field(gt=0, description="Keep last N tool messages untrimmed")] = 3
-    trim_tool_results: Annotated[bool, Field(description="Trim large tool results")] = True
+    trim_tool_results: Annotated[StrictBool, Field(description="Trim large tool results")] = True
 
 
-class CompactionConfig(BaseModel):
+class CompactionConfig(RuntimeSchemaModel):
     """Configuration for context compaction.
 
     Field names match ContextCompactor constructor for direct passthrough.
     """
 
-    enabled: Annotated[bool, Field(description="Enable context compaction")] = True
+    enabled: Annotated[StrictBool, Field(description="Enable context compaction")] = True
     reserve_tokens: Annotated[int, Field(gt=0, description="Reserve space for new messages")] = 16384
     keep_recent_tokens: Annotated[int, Field(gt=0, description="Keep recent messages verbatim")] = 20000
     min_messages: Annotated[int, Field(gt=0, description="Minimum messages before compaction")] = 20
     trigger_tokens: Annotated[int | None, Field(gt=0, description="Absolute token count that triggers compaction")] = None
 
 
-class MemoryConfig(BaseModel):
+class MemoryConfig(RuntimeSchemaModel):
     """Memory management configuration."""
 
     pruning: PruningConfig = Field(default_factory=lambda: PruningConfig())
@@ -81,76 +85,76 @@ class MemoryConfig(BaseModel):
 # ============================================================================
 
 
-class FileSystemConfig(BaseModel):
+class FileSystemConfig(RuntimeSchemaModel):
     """Configuration for filesystem tools."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     max_file_size: Annotated[int, Field(gt=0, description="Max file size in bytes (10MB)")] = 10485760
 
 
-class GrepConfig(BaseModel):
+class GrepConfig(RuntimeSchemaModel):
     """Configuration for Grep tool."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     max_file_size: Annotated[int, Field(gt=0, description="Max file size in bytes (10MB)")] = 10485760
 
 
-class SearchToolsConfig(BaseModel):
+class SearchToolsConfig(RuntimeSchemaModel):
     """Configuration for search tools."""
 
     grep: GrepConfig = Field(default_factory=lambda: GrepConfig())
-    glob: bool = True
+    glob: StrictBool = True
 
 
-class SearchConfig(BaseModel):
+class SearchConfig(RuntimeSchemaModel):
     """Configuration for search tools."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     tools: SearchToolsConfig = Field(default_factory=lambda: SearchToolsConfig())
 
 
-class WebSearchConfig(BaseModel):
+class WebSearchConfig(RuntimeSchemaModel):
     """Configuration for the WebSearch tool."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     max_results: Annotated[int, Field(gt=0, description="Max search results")] = 5
     tavily_api_key: Annotated[str | None, Field(description="Tavily API key")] = None
     exa_api_key: Annotated[str | None, Field(description="Exa API key")] = None
     firecrawl_api_key: Annotated[str | None, Field(description="Firecrawl API key")] = None
 
 
-class WebFetchConfig(BaseModel):
+class WebFetchConfig(RuntimeSchemaModel):
     """Configuration for the WebFetch tool."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     jina_api_key: Annotated[str | None, Field(description="Jina AI API key")] = None
 
 
-class WebToolsConfig(BaseModel):
+class WebToolsConfig(RuntimeSchemaModel):
     """Configuration for web tools."""
 
     web_search: WebSearchConfig = Field(default_factory=lambda: WebSearchConfig())
     web_fetch: WebFetchConfig = Field(default_factory=lambda: WebFetchConfig())
 
 
-class WebConfig(BaseModel):
+class WebConfig(RuntimeSchemaModel):
     """Configuration for web tools."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     timeout: Annotated[int, Field(gt=0, description="Request timeout in seconds")] = 15
     tools: WebToolsConfig = Field(default_factory=lambda: WebToolsConfig())
 
 
-class CommandConfig(BaseModel):
+class CommandConfig(RuntimeSchemaModel):
     """Configuration for command tools."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
 
 
-class SpillBufferConfig(BaseModel):
+class SpillBufferConfig(RuntimeSchemaModel):
     """Configuration for SpillBuffer middleware."""
 
-    enabled: bool = True
+    enabled: StrictBool = True
     default_threshold: Annotated[int, Field(gt=0, description="Default spill threshold in bytes")] = 50_000
     thresholds: dict[str, int] = Field(
         default_factory=lambda: {
@@ -163,7 +167,7 @@ class SpillBufferConfig(BaseModel):
     )
 
 
-class ToolsConfig(BaseModel):
+class ToolsConfig(RuntimeSchemaModel):
     """Tools configuration."""
 
     filesystem: FileSystemConfig = Field(default_factory=lambda: FileSystemConfig())
@@ -178,7 +182,7 @@ class ToolsConfig(BaseModel):
 # ============================================================================
 
 
-class MCPServerConfig(BaseModel):
+class MCPServerConfig(RuntimeSchemaModel):
     """Configuration for a single MCP server."""
 
     transport: str | None = Field(
@@ -192,7 +196,7 @@ class MCPServerConfig(BaseModel):
     allowed_tools: list[str] | None = Field(None, description="Allowed tool names (None = all)")
 
 
-class MCPConfig(BaseModel):
+class MCPConfig(RuntimeSchemaModel):
     """MCP (Model Context Protocol) configuration."""
 
     enabled: StrictBool = True
@@ -204,7 +208,7 @@ class MCPConfig(BaseModel):
 # ============================================================================
 
 
-class LeonSettings(BaseModel):
+class LeonSettings(RuntimeSchemaModel):
     """Main Mycel runtime configuration.
 
     Contains non-model runtime settings: memory, tools, mcp, and behavior params.

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -524,7 +524,7 @@ class LeonAgent:
             cli_overrides.setdefault("tools", {}).setdefault("web", {})["enabled"] = enable_web_tools
 
         # Load runtime config
-        loader = AgentLoader(workspace_root=workspace_root)
+        loader = AgentLoader()
         config = loader.load(cli_overrides=cli_overrides or None)
         if memory_config_override is not None:
             config = self._with_memory_config_override(config, memory_config_override)
@@ -771,7 +771,7 @@ class LeonAgent:
         # Reload runtime config if tool overrides provided
         if tool_overrides:
             cli_overrides = {"tools": tool_overrides}
-            loader = AgentLoader(workspace_root=self.workspace_root)
+            loader = AgentLoader()
             self.config = loader.load(cli_overrides=cli_overrides)
 
         # Reload models config (picks up new API keys + model changes from disk)

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -80,35 +80,6 @@ class TestAgentLoader:
         result = loader._deep_merge(dict1, dict2, dict3)
         assert result == {"a": 1, "b": {"x": 1, "y": 2, "z": 3}, "c": 3, "d": 4}
 
-    def test_lookup_merge(self):
-        loader = AgentLoader()
-
-        config1 = {"mcp": {"servers": {"server1": {}}}}
-        config2 = {"mcp": {"servers": {"server2": {}}}}
-        config3 = {"mcp": {"servers": {"server3": {}}}}
-
-        result = loader._lookup_merge("mcp", config1, config2, config3)
-        assert "server1" in result["servers"]
-        assert "server2" not in result["servers"]
-
-    def test_lookup_merge_skip_none(self):
-        loader = AgentLoader()
-
-        config1 = {"mcp": None}
-        config2 = {"mcp": {"servers": {"server1": {}}}}
-
-        result = loader._lookup_merge("mcp", config1, config2)
-        assert "server1" in result["servers"]
-
-    def test_lookup_merge_missing_key(self):
-        loader = AgentLoader()
-
-        config1 = {"api": {}}
-        config2 = {"tools": {}}
-
-        result = loader._lookup_merge("mcp", config1, config2)
-        assert result == {}
-
     def test_expand_env_vars_string(self):
         loader = AgentLoader()
 

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import inspect
 from pathlib import Path
 
 import pytest
@@ -9,13 +10,12 @@ from config.schema import LeonSettings
 
 
 class TestAgentLoader:
-    def test_init(self, tmp_path):
-        loader = AgentLoader(workspace_root=str(tmp_path))
-        assert loader.workspace_root == tmp_path
-
-    def test_init_no_workspace(self):
+    def test_init(self):
         loader = AgentLoader()
-        assert loader.workspace_root is None
+        assert "_agents" in vars(loader)
+
+    def test_init_has_no_workspace_root_input(self):
+        assert "workspace_root" not in inspect.signature(AgentLoader).parameters
 
     def test_load_system_defaults_missing(self, tmp_path):
         loader = AgentLoader()
@@ -29,7 +29,7 @@ class TestAgentLoader:
         (project_dir / ".leon").mkdir(parents=True)
         (project_dir / ".leon" / "runtime.json").write_text("{bad json", encoding="utf-8")
 
-        loader = AgentLoader(workspace_root=str(project_dir))
+        loader = AgentLoader()
 
         assert isinstance(loader.load(), LeonSettings)
 
@@ -155,13 +155,13 @@ class TestAgentLoader:
 
 
 class TestLoadConfigFunction:
-    def test_load_config_with_workspace(self, tmp_path, monkeypatch):
+    def test_load_config(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
 
         project_dir = tmp_path / "project"
         project_dir.mkdir()
 
-        settings = load_config(workspace_root=str(project_dir))
+        settings = load_config()
         assert isinstance(settings, LeonSettings)
 
 
@@ -173,7 +173,7 @@ def test_project_agent_file_does_not_override_builtin_runtime_agent(tmp_path: Pa
         encoding="utf-8",
     )
 
-    agent = AgentLoader(workspace_root=tmp_path).load_runtime_agents()["explore"]
+    agent = AgentLoader().load_runtime_agents()["explore"]
 
     assert agent.model is None
     assert agent.system_prompt != "project prompt"
@@ -188,7 +188,7 @@ def test_user_agent_file_does_not_enter_runtime_agent_discovery(tmp_path: Path):
         encoding="utf-8",
     )
 
-    assert "custom" not in AgentLoader(workspace_root=tmp_path).load_runtime_agents()
+    assert "custom" not in AgentLoader().load_runtime_agents()
 
 
 def test_runtime_agent_discovery_excludes_member_dirs(tmp_path: Path):
@@ -200,4 +200,4 @@ def test_runtime_agent_discovery_excludes_member_dirs(tmp_path: Path):
         encoding="utf-8",
     )
 
-    assert "alice" not in AgentLoader(workspace_root=tmp_path).load_runtime_agents()
+    assert "alice" not in AgentLoader().load_runtime_agents()

--- a/tests/Config/test_loader.py
+++ b/tests/Config/test_loader.py
@@ -1,6 +1,7 @@
+import inspect
+import json
 import os
 import sys
-import inspect
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,36 @@ class TestAgentLoader:
         loader = AgentLoader()
 
         assert isinstance(loader.load(), LeonSettings)
+
+    def test_load_applies_nested_runtime_defaults(self, tmp_path):
+        (tmp_path / "runtime.json").write_text(
+            json.dumps(
+                {
+                    "runtime": {
+                        "context_limit": 12345,
+                        "block_network_commands": True,
+                    },
+                    "tools": {"web": {"enabled": False}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        loader = AgentLoader()
+        loader._system_defaults_dir = tmp_path
+
+        settings = loader.load()
+
+        assert settings.runtime.context_limit == 12345
+        assert settings.runtime.block_network_commands is True
+        assert settings.tools.web.enabled is False
+
+    def test_load_rejects_flat_runtime_defaults(self, tmp_path):
+        (tmp_path / "runtime.json").write_text(json.dumps({"context_limit": 12345}), encoding="utf-8")
+        loader = AgentLoader()
+        loader._system_defaults_dir = tmp_path
+
+        with pytest.raises(ValueError, match="context_limit"):
+            loader.load()
 
     def test_deep_merge_simple(self):
         loader = AgentLoader()

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -37,20 +37,29 @@ def test_agent_skill_model_has_no_resolved_content() -> None:
 
 def test_agent_skill_model_rejects_resolved_content_fields() -> None:
     with pytest.raises(ValueError, match="content"):
-        AgentSkill(name="query-helper", skill_id="skill-1", package_id="package-1", content="Use exact terms.")
+        AgentSkill.model_validate({"name": "query-helper", "skill_id": "skill-1", "package_id": "package-1", "content": "Use exact terms."})
 
     with pytest.raises(ValueError, match="files"):
-        AgentSkill(name="query-helper", skill_id="skill-1", package_id="package-1", files={"references/query.md": "Use exact terms."})
+        AgentSkill.model_validate(
+            {
+                "name": "query-helper",
+                "skill_id": "skill-1",
+                "package_id": "package-1",
+                "files": {"references/query.md": "Use exact terms."},
+            }
+        )
 
 
 def test_agent_config_model_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="skill_packages"):
-        AgentConfig(
-            id="cfg-1",
-            owner_user_id="owner-1",
-            agent_user_id="agent-1",
-            name="Researcher",
-            skill_packages=[],
+        AgentConfig.model_validate(
+            {
+                "id": "cfg-1",
+                "owner_user_id": "owner-1",
+                "agent_user_id": "agent-1",
+                "name": "Researcher",
+                "skill_packages": [],
+            }
         )
 
 

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from config.agent_config_types import AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, ResolvedSkill, SkillPackage
+from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, ResolvedSkill, SkillPackage
 
 
 def test_resolved_skill_model_normalizes_file_paths() -> None:
@@ -33,6 +33,25 @@ def test_agent_skill_model_has_no_resolved_content() -> None:
 
     assert "content" not in agent_skill.model_dump()
     assert "files" not in agent_skill.model_dump()
+
+
+def test_agent_skill_model_rejects_resolved_content_fields() -> None:
+    with pytest.raises(ValueError, match="content"):
+        AgentSkill(name="query-helper", skill_id="skill-1", package_id="package-1", content="Use exact terms.")
+
+    with pytest.raises(ValueError, match="files"):
+        AgentSkill(name="query-helper", skill_id="skill-1", package_id="package-1", files={"references/query.md": "Use exact terms."})
+
+
+def test_agent_config_model_rejects_unknown_fields() -> None:
+    with pytest.raises(ValueError, match="skill_packages"):
+        AgentConfig(
+            id="cfg-1",
+            owner_user_id="owner-1",
+            agent_user_id="agent-1",
+            name="Researcher",
+            skill_packages=[],
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/Unit/config/test_runtime_schema.py
+++ b/tests/Unit/config/test_runtime_schema.py
@@ -1,6 +1,9 @@
+import json
+from pathlib import Path
+
 import pytest
 
-from config.schema import MCPConfig
+from config.schema import LeonSettings, MCPConfig
 
 
 def test_mcp_config_rejects_string_enabled() -> None:
@@ -11,3 +14,42 @@ def test_mcp_config_rejects_string_enabled() -> None:
 def test_mcp_config_rejects_numeric_enabled() -> None:
     with pytest.raises(ValueError, match="enabled"):
         MCPConfig.model_validate({"enabled": 1, "servers": {}})
+
+
+def test_runtime_fields_must_live_under_runtime_object() -> None:
+    with pytest.raises(ValueError, match="context_limit"):
+        LeonSettings.model_validate({"context_limit": 12345})
+
+
+def test_default_runtime_config_uses_runtime_object() -> None:
+    defaults_path = Path(__file__).parents[3] / "config" / "defaults" / "runtime.json"
+    payload = json.loads(defaults_path.read_text(encoding="utf-8"))
+
+    assert "runtime" in payload
+    assert "context_limit" not in payload
+    assert "block_network_commands" not in payload
+
+
+def test_runtime_schema_rejects_unknown_nested_fields() -> None:
+    with pytest.raises(ValueError, match="max_results"):
+        LeonSettings.model_validate({"tools": {"search": {"max_results": 50}}})
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("runtime.enable_audit_log", {"runtime": {"enable_audit_log": "false"}}),
+        ("runtime.block_network_commands", {"runtime": {"block_network_commands": 1}}),
+        ("memory.pruning.enabled", {"memory": {"pruning": {"enabled": "false"}}}),
+        ("memory.pruning.trim_tool_results", {"memory": {"pruning": {"trim_tool_results": 1}}}),
+        ("memory.compaction.enabled", {"memory": {"compaction": {"enabled": "false"}}}),
+        ("tools.filesystem.enabled", {"tools": {"filesystem": {"enabled": 1}}}),
+        ("tools.search.tools.glob", {"tools": {"search": {"tools": {"glob": "false"}}}}),
+        ("tools.web.enabled", {"tools": {"web": {"enabled": "false"}}}),
+        ("tools.command.enabled", {"tools": {"command": {"enabled": 1}}}),
+        ("tools.spill_buffer.enabled", {"tools": {"spill_buffer": {"enabled": "false"}}}),
+    ],
+)
+def test_runtime_schema_rejects_coerced_booleans(path: str, payload: dict) -> None:
+    with pytest.raises(ValueError, match=path.split(".")[-1]):
+        LeonSettings.model_validate(payload)


### PR DESCRIPTION
## Summary
- Require runtime config JSON to use the `runtime` object and reject extra fields instead of silently dropping them.
- Require runtime booleans and AgentConfig models to reject coerced or extra fields, including AgentSkill `content/files` payload drift.
- Remove dead AgentLoader local workspace input and unused lookup-merge path.

## Test Plan
- `uv run pytest tests/Unit/config/test_runtime_schema.py tests/Unit/config/test_agent_config_types.py tests/Config/test_loader.py tests/Config/test_loader_skill_dir_boundary.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/platform/test_mcp_transport.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright config/schema.py config/loader.py config/agent_config_types.py core/runtime/agent.py tests/Unit/config/test_runtime_schema.py tests/Unit/config/test_agent_config_types.py tests/Config/test_loader.py`
- `uv run pytest tests/Unit -q`
