### PR TITLE
feat: let agents manage relationship requests

### DIFF
--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -20,4 +20,9 @@ async def get_or_create_agent(*args, **kwargs):
         messaging_service = getattr(runtime_state, "messaging_service", None)
         if messaging_service is not None:
             kwargs["messaging_service"] = messaging_service
+    if "relationship_service" not in kwargs and app is not None:
+        runtime_state = getattr(app.state, "threads_runtime_state", None)
+        relationship_service = getattr(runtime_state, "relationship_service", None)
+        if relationship_service is not None:
+            kwargs["relationship_service"] = relationship_service
     return await _registry.get_or_create_agent(*args, **kwargs)

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -14,6 +14,7 @@ class ThreadsRuntimeState:
     agent_runtime_gateway: Any
     activity_reader: Any
     messaging_service: Any | None = None
+    relationship_service: Any | None = None
     typing_tracker: Any | None = None
     display_builder: Any | None = None
     event_loop: Any | None = None
@@ -26,6 +27,7 @@ def attach_threads_runtime(
     *,
     typing_tracker: Any,
     messaging_service: Any,
+    relationship_service: Any,
 ) -> ThreadsRuntimeState:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.agent_pool = {}
@@ -50,6 +52,7 @@ def attach_threads_runtime(
         agent_runtime_gateway=runtime_state.gateway,
         activity_reader=runtime_state.activity_reader,
         messaging_service=messaging_service,
+        relationship_service=relationship_service,
         typing_tracker=typing_tracker,
     )
     app.state.threads_runtime_state = state

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -30,6 +30,7 @@ async def get_or_create_agent(
     agent: str | None = None,
     *,
     messaging_service: Any | None = None,
+    relationship_service: Any | None = None,
 ) -> Any:
     if thread_id:
         set_current_thread_id(thread_id)
@@ -134,6 +135,7 @@ async def get_or_create_agent(
                 "owner_id": owner_id,
                 "user_repo": user_repo,
                 "messaging_service": messaging_service,
+                "relationship_service": relationship_service,
                 "agent_config_repo": agent_config_repo,
             }
 

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -78,6 +78,7 @@ async def lifespan(app: FastAPI):
         storage_container,
         typing_tracker=chat_runtime.typing_tracker,
         messaging_service=chat_runtime.messaging_service,
+        relationship_service=chat_runtime.relationship_service,
     )
     wire_chat_delivery(
         app,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1228,6 +1228,15 @@ class LeonAgent:
                     chat_identity_id=chat_identity_id,
                     messaging_service=repos.get("messaging_service"),
                 )
+                relationship_service = repos.get("relationship_service")
+                if relationship_service is not None:
+                    from messaging.tools.relationship_tool_service import RelationshipToolService
+
+                    self._relationship_tool_service = RelationshipToolService(
+                        registry=self._tool_registry,
+                        relationship_identity_id=chat_identity_id,
+                        relationship_service=relationship_service,
+                    )
 
         # LSP tools — DEFERRED, always registered, multilspy checked at call time
         self._lsp_service = None

--- a/messaging/tools/relationship_tool_service.py
+++ b/messaging/tools/relationship_tool_service.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
+
+
+class RelationshipToolService:
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        relationship_identity_id: str,
+        relationship_service: Any,
+    ) -> None:
+        if not relationship_identity_id:
+            raise ValueError("RelationshipToolService requires relationship_identity_id")
+        if relationship_service is None:
+            raise ValueError("RelationshipToolService requires relationship_service")
+        self._identity_id = relationship_identity_id
+        self._relationships = relationship_service
+        self._register(registry)
+
+    def _register(self, registry: ToolRegistry) -> None:
+        self._register_list_relationships(registry)
+        self._register_request_relationship(registry)
+        self._register_approve_relationship(registry)
+        self._register_reject_relationship(registry)
+
+    def _register_list_relationships(self, registry: ToolRegistry) -> None:
+        def handle() -> str:
+            rows = self._relationships.list_for_user(self._identity_id)
+            if not rows:
+                return "No relationships found."
+            return "\n".join(self._format_row(row) for row in rows)
+
+        registry.register(
+            ToolEntry(
+                name="list_relationships",
+                mode=ToolMode.INLINE,
+                schema=make_tool_schema(
+                    name="list_relationships",
+                    description=(
+                        "List relationship requests and active relationships for your current Mycel user identity. "
+                        "Use this before approving or rejecting a pending request."
+                    ),
+                    properties={},
+                ),
+                handler=handle,
+                source="relationship",
+                is_read_only=True,
+                is_concurrency_safe=True,
+            )
+        )
+
+    def _register_request_relationship(self, registry: ToolRegistry) -> None:
+        def handle(target_user_id: str) -> str:
+            row = self._relationships.request(self._identity_id, target_user_id)
+            return f"Requested relationship with {target_user_id}. {self._format_row(row)}"
+
+        registry.register(
+            ToolEntry(
+                name="request_relationship",
+                mode=ToolMode.INLINE,
+                schema=make_tool_schema(
+                    name="request_relationship",
+                    description="Create a pending relationship request from your current Mycel user to another user.",
+                    properties={
+                        "target_user_id": {
+                            "type": "string",
+                            "description": "Target Mycel user id to request a relationship with.",
+                            "minLength": 1,
+                        }
+                    },
+                    required=["target_user_id"],
+                ),
+                handler=handle,
+                source="relationship",
+            )
+        )
+
+    def _register_approve_relationship(self, registry: ToolRegistry) -> None:
+        def handle(relationship_id: str) -> str:
+            existing, error = self._pending_decision_relationship(relationship_id)
+            if error is not None:
+                return error
+            requester_id = existing["initiator_user_id"]
+            row = self._relationships.approve(self._identity_id, requester_id)
+            return f"Relationship approved. {self._format_row(row)}"
+
+        registry.register(
+            ToolEntry(
+                name="approve_relationship",
+                mode=ToolMode.INLINE,
+                schema=self._decision_schema("approve_relationship", "Approve a pending relationship request sent to your user."),
+                handler=handle,
+                source="relationship",
+            )
+        )
+
+    def _register_reject_relationship(self, registry: ToolRegistry) -> None:
+        def handle(relationship_id: str) -> str:
+            existing, error = self._pending_decision_relationship(relationship_id)
+            if error is not None:
+                return error
+            requester_id = existing["initiator_user_id"]
+            row = self._relationships.reject(self._identity_id, requester_id)
+            return f"Relationship rejected. {self._format_row(row)}"
+
+        registry.register(
+            ToolEntry(
+                name="reject_relationship",
+                mode=ToolMode.INLINE,
+                schema=self._decision_schema("reject_relationship", "Reject a pending relationship request sent to your user."),
+                handler=handle,
+                source="relationship",
+            )
+        )
+
+    def _decision_schema(self, name: str, description: str) -> dict[str, Any]:
+        return make_tool_schema(
+            name=name,
+            description=description,
+            properties={
+                "relationship_id": {
+                    "type": "string",
+                    "description": "Relationship id from list_relationships.",
+                    "minLength": 1,
+                }
+            },
+            required=["relationship_id"],
+        )
+
+    def _pending_decision_relationship(self, relationship_id: str) -> tuple[dict[str, Any], None] | tuple[None, str]:
+        existing = self._relationships.get_by_id(relationship_id)
+        if existing is None or self._identity_id not in (existing.get("user_low"), existing.get("user_high")):
+            return None, "Relationship not found for your user."
+        if existing.get("state") != "pending":
+            return None, "Relationship is not pending."
+        requester_id = existing.get("initiator_user_id")
+        if not requester_id:
+            return None, "Relationship request is missing requester."
+        if requester_id == self._identity_id:
+            return None, "You cannot approve or reject your own relationship request."
+        return existing, None
+
+    def _format_row(self, row: Any) -> str:
+        relationship_id = self._field(row, "id")
+        user_low = self._field(row, "user_low")
+        user_high = self._field(row, "user_high")
+        state = self._field(row, "state")
+        initiator_user_id = self._field(row, "initiator_user_id")
+        if self._identity_id == user_low:
+            other_user_id = user_high
+        elif self._identity_id == user_high:
+            other_user_id = user_low
+        else:
+            raise RuntimeError(f"Relationship row does not include current user: {relationship_id}")
+        direction = ""
+        if state == "pending":
+            direction = "incoming pending request" if initiator_user_id != self._identity_id else "outgoing pending request"
+        else:
+            direction = f"{state} relationship"
+        return f"- {direction}; relationship_id: {relationship_id}; other_user_id: {other_user_id}; state: {state}"
+
+    def _field(self, row: Any, field: str) -> Any:
+        if isinstance(row, dict):
+            return row[field]
+        return getattr(row, field)

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -13,6 +13,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     activity_reader = object()
     typing_tracker = object()
     messaging_service = object()
+    relationship_service = object()
     seen: list[tuple[str, object]] = []
 
     storage_container = SimpleNamespace(queue_repo=lambda: queue_repo)
@@ -38,6 +39,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
         storage_container,
         typing_tracker=typing_tracker,
         messaging_service=messaging_service,
+        relationship_service=relationship_service,
     )
 
     assert app.state.queue_manager is queue_manager
@@ -53,6 +55,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
     assert state.messaging_service is messaging_service
+    assert state.relationship_service is relationship_service
     assert state.typing_tracker is typing_tracker
     assert state.display_builder is None
     assert state.event_loop is None

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -95,9 +95,10 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
             relationship_service=returned_relationship_service,
         )
 
-    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service):
+    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service, relationship_service):
         assert typing_tracker is returned_typing_tracker
         assert messaging_service is returned_messaging_service
+        assert relationship_service is returned_relationship_service
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=object())
 
@@ -139,10 +140,11 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert contact_repo is returned_contact_repo
         return object()
 
-    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service):
+    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service, relationship_service):
         call_log.append("threads")
         assert typing_tracker is returned_typing_tracker
         assert messaging_service is returned_messaging_service
+        assert relationship_service is returned_relationship_service
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=returned_activity_reader)
 

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -138,6 +138,60 @@ async def test_registry_get_or_create_agent_uses_explicit_messaging_service(
 
 
 @pytest.mark.asyncio
+async def test_registry_get_or_create_agent_uses_explicit_relationship_service(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+    messaging_service = object()
+    relationship_service = object()
+
+    def _fake_create_agent_sync(**kwargs) -> object:
+        captured["chat_repos"] = kwargs.get("chat_repos")
+        return SimpleNamespace()
+
+    class _ThreadRepo:
+        def get_by_id(self, thread_id: str):
+            return {
+                "id": thread_id,
+                "agent_user_id": "agent-user-explicit",
+                "cwd": None,
+                "model": "leon:large",
+            }
+
+    class _UserRepo:
+        def get_by_id(self, user_id: str):
+            return SimpleNamespace(id=user_id, owner_user_id="owner-explicit", agent_config_id="cfg-explicit")
+
+    monkeypatch.setattr(agent_pool._registry, "create_agent_sync", _fake_create_agent_sync)
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-explicit")
+    monkeypatch.setattr(
+        agent_pool._registry, "get_file_channel_binding", lambda _thread_id: (_ for _ in ()).throw(ValueError()), raising=False
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_ThreadRepo(),
+            user_repo=_UserRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    await agent_pool._registry.get_or_create_agent(
+        cast(Any, app),
+        "local",
+        thread_id="thread-explicit",
+        messaging_service=messaging_service,
+        relationship_service=relationship_service,
+    )
+
+    chat_repos = cast(dict[str, object], captured["chat_repos"])
+    assert chat_repos["relationship_service"] is relationship_service
+
+
+@pytest.mark.asyncio
 async def test_registry_get_or_create_agent_requires_explicit_messaging_service_for_chat_repos(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -49,6 +49,25 @@ async def test_get_or_create_agent_borrows_messaging_service_for_registry(monkey
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_agent_borrows_relationship_service_for_registry(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+    relationship_service = object()
+
+    async def _fake_registry_get_or_create_agent(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(relationship_service=relationship_service)))
+
+    await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-borrowed")
+
+    kwargs = cast(dict[str, object], captured["kwargs"])
+    assert kwargs["relationship_service"] is relationship_service
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_skips_borrow_when_chat_bootstrap_missing(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -1377,6 +1377,63 @@ def test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies(monkey
     assert "thread_repo" not in captured
 
 
+def test_leon_agent_registers_relationship_tools_from_runtime_relationship_service(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from core.runtime.agent import LeonAgent
+    from core.runtime.registry import ToolRegistry
+
+    captured: dict[str, Any] = {}
+
+    class _NoopService:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeRelationshipToolService:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.mcp_gateway.register_resource_tools", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
+    monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _NoopService)
+    monkeypatch.setattr("messaging.tools.relationship_tool_service.RelationshipToolService", _FakeRelationshipToolService)
+
+    relationship_service = object()
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(name="local", fs=lambda: None, shell=lambda: None)
+    agent._tool_registry = ToolRegistry()
+    agent.workspace_root = str(tmp_path)
+    agent.model_name = "test-model"
+    agent._thread_repo = SimpleNamespace()
+    agent._user_repo = SimpleNamespace()
+    agent.queue_manager = SimpleNamespace()
+    agent._web_app = None
+    agent.allowed_file_extensions = []
+    agent.extra_allowed_paths = []
+    agent.enable_audit_log = False
+    agent.block_dangerous_commands = False
+    agent.block_network_commands = False
+    agent._get_mcp_server_configs = lambda: {}
+    agent._chat_repos = {
+        "chat_identity_id": "thread-user-9",
+        "messaging_service": SimpleNamespace(),
+        "relationship_service": relationship_service,
+    }
+    cast(Any, agent).config = SimpleNamespace(
+        tools=SimpleNamespace(
+            filesystem=SimpleNamespace(enabled=False),
+            search=SimpleNamespace(enabled=False),
+            web=SimpleNamespace(enabled=False),
+            command=SimpleNamespace(enabled=False),
+        ),
+    )
+
+    LeonAgent._init_services(agent)
+
+    assert captured["relationship_identity_id"] == "thread-user-9"
+    assert captured["relationship_service"] is relationship_service
+
+
 def test_leon_agent_init_services_passes_child_thread_live_runner(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     from core.runtime.agent import LeonAgent
     from core.runtime.registry import ToolRegistry

--- a/tests/Unit/messaging/test_relationship_tool_service.py
+++ b/tests/Unit/messaging/test_relationship_tool_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from core.runtime.registry import ToolRegistry
+from messaging.tools.relationship_tool_service import RelationshipToolService
+
+
+def _row(
+    *,
+    relationship_id: str = "hire_visit:agent-user-1:human-user-1",
+    user_low: str = "agent-user-1",
+    user_high: str = "human-user-1",
+    state: str = "pending",
+    initiator_user_id: str | None = "human-user-1",
+):
+    now = datetime(2026, 4, 26, tzinfo=UTC)
+    return SimpleNamespace(
+        id=relationship_id,
+        user_low=user_low,
+        user_high=user_high,
+        state=state,
+        initiator_user_id=initiator_user_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_relationship_tool_service_registers_user_level_tools_without_identity_arguments() -> None:
+    registry = ToolRegistry()
+    RelationshipToolService(
+        registry=registry,
+        relationship_identity_id="agent-user-1",
+        relationship_service=SimpleNamespace(list_for_user=lambda _user_id: []),
+    )
+
+    for tool_name in ("list_relationships", "request_relationship", "approve_relationship", "reject_relationship"):
+        tool = registry.get(tool_name)
+        assert tool is not None
+        assert "user_id" not in tool.get_schema()["parameters"]["properties"]
+
+
+def test_list_relationships_renders_pending_direction_and_relationship_id() -> None:
+    registry = ToolRegistry()
+    RelationshipToolService(
+        registry=registry,
+        relationship_identity_id="agent-user-1",
+        relationship_service=SimpleNamespace(list_for_user=lambda _user_id: [_row()]),
+    )
+
+    result = registry.get("list_relationships").handler()
+
+    assert "incoming pending request" in result
+    assert "relationship_id: hire_visit:agent-user-1:human-user-1" in result
+    assert "other_user_id: human-user-1" in result
+
+
+def test_approve_relationship_uses_current_identity_and_request_initiator() -> None:
+    seen: list[tuple[str, str]] = []
+    relationship = {
+        "id": "hire_visit:agent-user-1:human-user-1",
+        "user_low": "agent-user-1",
+        "user_high": "human-user-1",
+        "state": "pending",
+        "initiator_user_id": "human-user-1",
+    }
+    service = SimpleNamespace(
+        get_by_id=lambda relationship_id: relationship if relationship_id == relationship["id"] else None,
+        approve=lambda approver_id, requester_id: seen.append((approver_id, requester_id)) or _row(state="visit"),
+    )
+    registry = ToolRegistry()
+    RelationshipToolService(
+        registry=registry,
+        relationship_identity_id="agent-user-1",
+        relationship_service=service,
+    )
+
+    result = registry.get("approve_relationship").handler("hire_visit:agent-user-1:human-user-1")
+
+    assert seen == [("agent-user-1", "human-user-1")]
+    assert "approved" in result
+    assert "state: visit" in result
+
+
+def test_reject_relationship_refuses_to_decide_unrelated_relationship() -> None:
+    registry = ToolRegistry()
+    RelationshipToolService(
+        registry=registry,
+        relationship_identity_id="agent-user-1",
+        relationship_service=SimpleNamespace(
+            get_by_id=lambda _relationship_id: {
+                "id": "hire_visit:human-user-1:human-user-2",
+                "user_low": "human-user-1",
+                "user_high": "human-user-2",
+                "state": "pending",
+                "initiator_user_id": "human-user-1",
+            }
+        ),
+    )
+
+    result = registry.get("reject_relationship").handler("hire_visit:human-user-1:human-user-2")
+
+    assert result == "Relationship not found for your user."


### PR DESCRIPTION
## Summary
- add backend-owned relationship tools for managed agent users: list/request/approve/reject
- register those tools from LeonAgent when the thread runtime has a relationship service
- carry relationship_service through threads runtime and agent startup without SDK/CLI concepts

## Verification
- uv run pytest tests/Unit/messaging/test_relationship_tool_service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_chat_tool_registry_exposes_final_contract_only tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/core/test_agent_pool.py tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_chat_tool_wiring_does_not_pass_dead_repo_dependencies tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_registers_relationship_tools_from_runtime_relationship_service tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Integration/test_relationship_router.py -q
- uv run ruff check . && uv run ruff format --check .