### PR TITLE
Refactor skill file package boundaries

### DIFF
--- a/config/skill_files.py
+++ b/config/skill_files.py
@@ -4,6 +4,14 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 
+def _normalize_skill_file_path(path: str, *, context: str) -> str:
+    normalized_path = path.replace("\\", "/")
+    parts = normalized_path.split("/")
+    if not normalized_path.strip() or any(part == "" for part in parts):
+        raise ValueError(f"{context} path must be a relative file path")
+    return normalized_path
+
+
 def normalize_skill_file_map(files: Mapping[Any, Any], *, context: str) -> dict[str, str]:
     return normalize_skill_file_entries(files.items(), context=context)
 
@@ -13,7 +21,7 @@ def normalize_skill_file_entries(entries: Iterable[tuple[Any, Any]], *, context:
     for path, content in entries:
         if not isinstance(path, str):
             raise ValueError(f"{context} path must be a string")
-        normalized_path = path.replace("\\", "/")
+        normalized_path = _normalize_skill_file_path(path, context=context)
         if normalized_path in result:
             raise ValueError(f"{context} contain duplicate path after normalization: {normalized_path}")
         if not isinstance(content, str):

--- a/config/skill_files.py
+++ b/config/skill_files.py
@@ -11,7 +11,9 @@ def normalize_skill_file_map(files: Mapping[Any, Any], *, context: str) -> dict[
 def normalize_skill_file_entries(entries: Iterable[tuple[Any, Any]], *, context: str) -> dict[str, str]:
     result: dict[str, str] = {}
     for path, content in entries:
-        normalized_path = str(path).replace("\\", "/")
+        if not isinstance(path, str):
+            raise ValueError(f"{context} path must be a string")
+        normalized_path = path.replace("\\", "/")
         if normalized_path in result:
             raise ValueError(f"{context} contain duplicate path after normalization: {normalized_path}")
         if not isinstance(content, str):

--- a/config/skill_files.py
+++ b/config/skill_files.py
@@ -7,6 +7,8 @@ from typing import Any
 def _normalize_skill_file_path(path: str, *, context: str) -> str:
     normalized_path = path.replace("\\", "/")
     parts = normalized_path.split("/")
+    if normalized_path.startswith("/") or any(part in {".", ".."} for part in parts):
+        raise ValueError(f"{context} path must stay inside the Skill package")
     if not normalized_path.strip() or any(part == "" for part in parts):
         raise ValueError(f"{context} path must be a relative file path")
     return normalized_path

--- a/config/skill_files.py
+++ b/config/skill_files.py
@@ -14,5 +14,7 @@ def normalize_skill_file_entries(entries: Iterable[tuple[Any, Any]], *, context:
         normalized_path = str(path).replace("\\", "/")
         if normalized_path in result:
             raise ValueError(f"{context} contain duplicate path after normalization: {normalized_path}")
-        result[normalized_path] = str(content)
+        if not isinstance(content, str):
+            raise ValueError(f"{context} content must be a string: {normalized_path}")
+        result[normalized_path] = content
     return result

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -31,12 +31,12 @@ def _frontmatter(content: str) -> dict[str, Any]:
 
 
 def _read_files(skill_dir: Path) -> dict[str, str]:
-    file_entries: list[tuple[Path, str]] = []
+    file_entries: list[tuple[str, str]] = []
     for path in sorted(skill_dir.rglob("*")):
         if not path.is_file() or path.name == "SKILL.md":
             continue
         try:
-            file_entries.append((path.relative_to(skill_dir), path.read_text(encoding="utf-8")))
+            file_entries.append((path.relative_to(skill_dir).as_posix(), path.read_text(encoding="utf-8")))
         except UnicodeDecodeError as exc:
             raise RuntimeError(f"Skill adjacent file could not be read: {path}") from exc
     return normalize_skill_file_entries(file_entries, context="File Skill files")

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -177,6 +177,29 @@ begin
     end if;
     if exists (
         select 1
+        from library.skill_packages package
+        cross join lateral jsonb_each(package.files_json) as file(path, content)
+        where jsonb_typeof(file.content) <> 'string'
+    ) then
+        raise exception 'library.skill_packages.files_json values must be strings before hard cut';
+    end if;
+    if exists (
+        select 1
+        from library.skill_packages package
+        cross join lateral jsonb_each(package.files_json) as file(path, content)
+        where btrim(file.path) = ''
+           or file.path like '/%'
+           or file.path like '%//%'
+           or file.path like './%'
+           or file.path like '%/./%'
+           or file.path like '../%'
+           or file.path like '%/../%'
+           or position(chr(92) in file.path) > 0
+    ) then
+        raise exception 'library.skill_packages.files_json keys must be package-relative paths before hard cut';
+    end if;
+    if exists (
+        select 1
         from library.skill_packages
         where jsonb_typeof(source_json) <> 'object'
     ) then

--- a/tests/Unit/config/test_skill_files.py
+++ b/tests/Unit/config/test_skill_files.py
@@ -39,3 +39,9 @@ def test_normalize_skill_file_map_rejects_non_string_content() -> None:
 def test_normalize_skill_file_map_rejects_non_string_paths() -> None:
     with pytest.raises(ValueError, match="Skill files path must be a string"):
         normalize_skill_file_map({123: "Use exact queries."}, context="Skill files")
+
+
+@pytest.mark.parametrize("path", ["", " ", "references//query.md"])
+def test_normalize_skill_file_map_rejects_blank_or_empty_segment_paths(path: str) -> None:
+    with pytest.raises(ValueError, match="Skill files path must be a relative file path"):
+        normalize_skill_file_map({path: "Use exact queries."}, context="Skill files")

--- a/tests/Unit/config/test_skill_files.py
+++ b/tests/Unit/config/test_skill_files.py
@@ -34,3 +34,8 @@ def test_normalize_skill_file_entries_rejects_duplicate_paths_after_normalizatio
 def test_normalize_skill_file_map_rejects_non_string_content() -> None:
     with pytest.raises(ValueError, match="Skill files content must be a string: references/query.md"):
         normalize_skill_file_map({"references/query.md": {"text": "Use exact queries."}}, context="Skill files")
+
+
+def test_normalize_skill_file_map_rejects_non_string_paths() -> None:
+    with pytest.raises(ValueError, match="Skill files path must be a string"):
+        normalize_skill_file_map({123: "Use exact queries."}, context="Skill files")

--- a/tests/Unit/config/test_skill_files.py
+++ b/tests/Unit/config/test_skill_files.py
@@ -45,3 +45,9 @@ def test_normalize_skill_file_map_rejects_non_string_paths() -> None:
 def test_normalize_skill_file_map_rejects_blank_or_empty_segment_paths(path: str) -> None:
     with pytest.raises(ValueError, match="Skill files path must be a relative file path"):
         normalize_skill_file_map({path: "Use exact queries."}, context="Skill files")
+
+
+@pytest.mark.parametrize("path", ["/references/query.md", "references/../secret.md", "./references/query.md"])
+def test_normalize_skill_file_map_rejects_paths_outside_package(path: str) -> None:
+    with pytest.raises(ValueError, match="Skill files path must stay inside the Skill package"):
+        normalize_skill_file_map({path: "Use exact queries."}, context="Skill files")

--- a/tests/Unit/config/test_skill_files.py
+++ b/tests/Unit/config/test_skill_files.py
@@ -29,3 +29,8 @@ def test_normalize_skill_file_entries_rejects_duplicate_paths_after_normalizatio
             ],
             context="Local Skill files",
         )
+
+
+def test_normalize_skill_file_map_rejects_non_string_content() -> None:
+    with pytest.raises(ValueError, match="Skill files content must be a string: references/query.md"):
+        normalize_skill_file_map({"references/query.md": {"text": "Use exact queries."}}, context="Skill files")

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -105,6 +105,8 @@ def test_agent_config_schema_constrains_root_identity_fields() -> None:
     assert "library.skills.source_json must be a JSON object before hard cut" in sql
     assert "library.skill_packages.manifest_json must be a JSON object before hard cut" in sql
     assert "library.skill_packages.files_json must be a JSON object before hard cut" in sql
+    assert "library.skill_packages.files_json values must be strings before hard cut" in sql
+    assert "library.skill_packages.files_json keys must be package-relative paths before hard cut" in sql
     assert "library.skill_packages.source_json must be a JSON object before hard cut" in sql
     assert "agent.agent_configs.tools_json must be a JSON array before hard cut" in sql
     assert "agent.agent_configs.runtime_json must be a JSON object before hard cut" in sql


### PR DESCRIPTION
## Summary
- Require Skill adjacent file paths and contents to be explicit strings instead of coercing arbitrary values.
- Reject blank, empty-segment, absolute, traversal, and backslash package file paths.
- Validate existing `library.skill_packages.files_json` key/value shape in the hard-cut SQL.

## Test Plan
- `uv run pytest tests/Unit/config/test_skill_files.py tests/Unit/config/test_agent_config_types.py tests/Unit/core/test_skills_service.py tests/Unit/platform/test_marketplace_client.py tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/storage/test_agent_config_schema_sql.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright config/skill_files.py config/agent_config_types.py backend/hub/client.py scripts/import_file_skills_to_library.py tests/Unit/config/test_skill_files.py tests/Unit/storage/test_agent_config_schema_sql.py`
- `uv run pytest tests/Unit -q`
