### PR TITLE
Refactor skill package read boundaries

### DIFF
--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -94,10 +94,17 @@ def _skill_from_row(row: dict[str, Any]) -> Skill:
         name=row["name"],
         description=row.get("description") or "",
         package_id=row.get("package_id"),
-        source=dict(row.get("source_json") or {}),
+        source=_json_object(row, "source_json", table="library.skills"),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
+
+
+def _json_object(row: dict[str, Any], column: str, *, table: str) -> dict[str, Any]:
+    value = row[column]
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{table}.{column} must be a JSON object")
+    return value.copy()
 
 
 def _package_from_row(row: dict[str, Any]) -> SkillPackage:

--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -112,7 +112,7 @@ def _package_from_row(row: dict[str, Any]) -> SkillPackage:
         id=row["id"],
         owner_user_id=row["owner_user_id"],
         skill_id=row["skill_id"],
-        version=row.get("version") or "0.1.0",
+        version=row["version"],
         hash=row["hash"],
         manifest=_json_object(row, "manifest_json", table="library.skill_packages"),
         skill_md=row["skill_md"],

--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -114,7 +114,7 @@ def _package_from_row(row: dict[str, Any]) -> SkillPackage:
         skill_id=row["skill_id"],
         version=row.get("version") or "0.1.0",
         hash=row["hash"],
-        manifest=dict(row.get("manifest_json") or {}),
+        manifest=_json_object(row, "manifest_json", table="library.skill_packages"),
         skill_md=row["skill_md"],
         files=dict(row.get("files_json") or {}),
         source=dict(row.get("source_json") or {}),

--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -116,7 +116,7 @@ def _package_from_row(row: dict[str, Any]) -> SkillPackage:
         hash=row["hash"],
         manifest=_json_object(row, "manifest_json", table="library.skill_packages"),
         skill_md=row["skill_md"],
-        files=dict(row.get("files_json") or {}),
+        files=_json_object(row, "files_json", table="library.skill_packages"),
         source=dict(row.get("source_json") or {}),
         created_at=row["created_at"],
     )

--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -117,6 +117,6 @@ def _package_from_row(row: dict[str, Any]) -> SkillPackage:
         manifest=_json_object(row, "manifest_json", table="library.skill_packages"),
         skill_md=row["skill_md"],
         files=_json_object(row, "files_json", table="library.skill_packages"),
-        source=dict(row.get("source_json") or {}),
+        source=_json_object(row, "source_json", table="library.skill_packages"),
         created_at=row["created_at"],
     )

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -220,6 +220,16 @@ def test_get_package_rejects_non_object_manifest_json() -> None:
         repo.get_package("owner-1", "package-1")
 
 
+def test_get_package_rejects_non_object_files_json() -> None:
+    row = _package_row()
+    row["files_json"] = [["references/query.md", "Prefer precise queries."]]
+    client = _FakeClient({"library.skill_packages": [row]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="library.skill_packages.files_json must be a JSON object"):
+        repo.get_package("owner-1", "package-1")
+
+
 def test_select_package_updates_library_skill_pointer() -> None:
     client = _FakeClient({"library.skills": [_row()]})
     repo = SupabaseSkillRepo(client)

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -210,6 +210,16 @@ def test_get_package_filters_owner_and_package_id() -> None:
     assert ("id", "package-1") in client.table_queries["library.skill_packages"][0].eq_calls
 
 
+def test_get_package_rejects_non_object_manifest_json() -> None:
+    row = _package_row()
+    row["manifest_json"] = []
+    client = _FakeClient({"library.skill_packages": [row]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="library.skill_packages.manifest_json must be a JSON object"):
+        repo.get_package("owner-1", "package-1")
+
+
 def test_select_package_updates_library_skill_pointer() -> None:
     client = _FakeClient({"library.skills": [_row()]})
     repo = SupabaseSkillRepo(client)

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
 
+import pytest
+
 from config.agent_config_types import Skill, SkillPackage
 from storage.container import StorageContainer
 from storage.providers.supabase.skill_repo import SupabaseSkillRepo
@@ -123,6 +125,16 @@ def test_get_by_id_filters_owner_and_skill_id() -> None:
     assert skill.id == "skill-1"
     assert ("owner_user_id", "owner-1") in client.table_queries["library.skills"][0].eq_calls
     assert ("id", "skill-1") in client.table_queries["library.skills"][0].eq_calls
+
+
+def test_get_by_id_rejects_non_object_skill_source_json() -> None:
+    row = _row()
+    row["source_json"] = []
+    client = _FakeClient({"library.skills": [row]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="library.skills.source_json must be a JSON object"):
+        repo.get_by_id("owner-1", "skill-1")
 
 
 def test_upsert_writes_library_skill_metadata_only() -> None:

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -240,6 +240,16 @@ def test_get_package_rejects_non_object_source_json() -> None:
         repo.get_package("owner-1", "package-1")
 
 
+def test_get_package_rejects_null_version() -> None:
+    row = _package_row()
+    row["version"] = None
+    client = _FakeClient({"library.skill_packages": [row]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(ValueError, match="version"):
+        repo.get_package("owner-1", "package-1")
+
+
 def test_select_package_updates_library_skill_pointer() -> None:
     client = _FakeClient({"library.skills": [_row()]})
     repo = SupabaseSkillRepo(client)

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -230,6 +230,16 @@ def test_get_package_rejects_non_object_files_json() -> None:
         repo.get_package("owner-1", "package-1")
 
 
+def test_get_package_rejects_non_object_source_json() -> None:
+    row = _package_row()
+    row["source_json"] = []
+    client = _FakeClient({"library.skill_packages": [row]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="library.skill_packages.source_json must be a JSON object"):
+        repo.get_package("owner-1", "package-1")
+
+
 def test_select_package_updates_library_skill_pointer() -> None:
     client = _FakeClient({"library.skills": [_row()]})
     repo = SupabaseSkillRepo(client)


### PR DESCRIPTION
## Summary
- require Skill repo JSONB columns to read as actual JSON objects
- stop coercing `files_json` array pairs or null source/manifest values into dictionaries
- require Skill package `version` from the storage row instead of synthesizing it on read

## Verification
- `uv run pytest tests/Unit/storage/test_supabase_skill_repo.py -q`
- `uv run pytest tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/core/test_skills_service.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright storage/providers/supabase/skill_repo.py tests/Unit/storage/test_supabase_skill_repo.py`
- `uv run pytest tests/Unit -q`