### PR TITLE
feat: expose chat join request tools to agents

### DIFF
--- a/backend/threads/activity_pool_service.py
+++ b/backend/threads/activity_pool_service.py
@@ -25,4 +25,9 @@ async def get_or_create_agent(*args, **kwargs):
         relationship_service = getattr(runtime_state, "relationship_service", None)
         if relationship_service is not None:
             kwargs["relationship_service"] = relationship_service
+    if "chat_join_request_service" not in kwargs and app is not None:
+        runtime_state = getattr(app.state, "threads_runtime_state", None)
+        chat_join_request_service = getattr(runtime_state, "chat_join_request_service", None)
+        if chat_join_request_service is not None:
+            kwargs["chat_join_request_service"] = chat_join_request_service
     return await _registry.get_or_create_agent(*args, **kwargs)

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -15,6 +15,7 @@ class ThreadsRuntimeState:
     activity_reader: Any
     messaging_service: Any | None = None
     relationship_service: Any | None = None
+    chat_join_request_service: Any | None = None
     typing_tracker: Any | None = None
     display_builder: Any | None = None
     event_loop: Any | None = None
@@ -28,6 +29,7 @@ def attach_threads_runtime(
     typing_tracker: Any,
     messaging_service: Any,
     relationship_service: Any,
+    chat_join_request_service: Any,
 ) -> ThreadsRuntimeState:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.agent_pool = {}
@@ -53,6 +55,7 @@ def attach_threads_runtime(
         activity_reader=runtime_state.activity_reader,
         messaging_service=messaging_service,
         relationship_service=relationship_service,
+        chat_join_request_service=chat_join_request_service,
         typing_tracker=typing_tracker,
     )
     app.state.threads_runtime_state = state

--- a/backend/threads/pool/registry.py
+++ b/backend/threads/pool/registry.py
@@ -31,6 +31,7 @@ async def get_or_create_agent(
     *,
     messaging_service: Any | None = None,
     relationship_service: Any | None = None,
+    chat_join_request_service: Any | None = None,
 ) -> Any:
     if thread_id:
         set_current_thread_id(thread_id)
@@ -136,6 +137,7 @@ async def get_or_create_agent(
                 "user_repo": user_repo,
                 "messaging_service": messaging_service,
                 "relationship_service": relationship_service,
+                "chat_join_request_service": chat_join_request_service,
                 "agent_config_repo": agent_config_repo,
             }
 

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -79,6 +79,7 @@ async def lifespan(app: FastAPI):
         typing_tracker=chat_runtime.typing_tracker,
         messaging_service=chat_runtime.messaging_service,
         relationship_service=chat_runtime.relationship_service,
+        chat_join_request_service=chat_runtime.chat_join_request_service,
     )
     wire_chat_delivery(
         app,

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1237,6 +1237,15 @@ class LeonAgent:
                         relationship_identity_id=chat_identity_id,
                         relationship_service=relationship_service,
                     )
+                chat_join_request_service = repos.get("chat_join_request_service")
+                if chat_join_request_service is not None:
+                    from messaging.tools.chat_join_request_tool_service import ChatJoinRequestToolService
+
+                    self._chat_join_request_tool_service = ChatJoinRequestToolService(
+                        registry=self._tool_registry,
+                        chat_join_identity_id=chat_identity_id,
+                        chat_join_request_service=chat_join_request_service,
+                    )
 
         # LSP tools — DEFERRED, always registered, multilspy checked at call time
         self._lsp_service = None

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -68,8 +68,8 @@ class ChatDeliveryDispatcher:
             if not recipient:
                 raise RuntimeError(f"Chat delivery recipient identity not found: {uid}")
             member_raw_type = getattr(recipient, "type", None)
-            member_type = member_raw_type.value if isinstance(member_raw_type, Enum) else member_raw_type
-            if member_type == "human":
+            member_type = member_raw_type.value if isinstance(member_raw_type, Enum) else str(member_raw_type)
+            if member_type != "agent":
                 continue
 
             # @@@same-owner-group-delivery - explicit group membership among the same owner

--- a/messaging/tools/chat_join_request_tool_service.py
+++ b/messaging/tools/chat_join_request_tool_service.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
+
+
+class ChatJoinRequestToolService:
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        chat_join_identity_id: str,
+        chat_join_request_service: Any,
+    ) -> None:
+        if not chat_join_identity_id:
+            raise ValueError("ChatJoinRequestToolService requires chat_join_identity_id")
+        if chat_join_request_service is None:
+            raise ValueError("ChatJoinRequestToolService requires chat_join_request_service")
+        self._identity_id = chat_join_identity_id
+        self._join_requests = chat_join_request_service
+        self._register(registry)
+
+    def _register(self, registry: ToolRegistry) -> None:
+        self._register_list(registry)
+        self._register_approve(registry)
+        self._register_reject(registry)
+
+    def _register_list(self, registry: ToolRegistry) -> None:
+        def handle(chat_id: str) -> str:
+            rows = self._join_requests.list_for_chat(chat_id, self._identity_id)
+            if not rows:
+                return "No chat join requests found."
+            return "\n".join(self._format_row(row) for row in rows)
+
+        registry.register(
+            ToolEntry(
+                name="list_chat_join_requests",
+                mode=ToolMode.INLINE,
+                schema=make_tool_schema(
+                    name="list_chat_join_requests",
+                    description=(
+                        "List join requests for a group chat you own. Use the chat_id from the join request "
+                        "notification or chat message before approving or rejecting a request."
+                    ),
+                    properties={
+                        "chat_id": {
+                            "type": "string",
+                            "description": "Group chat id to inspect.",
+                            "minLength": 1,
+                        }
+                    },
+                    required=["chat_id"],
+                ),
+                handler=handle,
+                source="chat_join_request",
+                is_read_only=True,
+                is_concurrency_safe=True,
+            )
+        )
+
+    def _register_approve(self, registry: ToolRegistry) -> None:
+        def handle(chat_id: str, request_id: str) -> str:
+            row = self._join_requests.approve(chat_id, request_id, self._identity_id)
+            return f"Chat join request approved. {self._format_row(row)}"
+
+        registry.register(
+            ToolEntry(
+                name="approve_chat_join_request",
+                mode=ToolMode.INLINE,
+                schema=self._decision_schema("approve_chat_join_request", "Approve a pending join request for a group chat you own."),
+                handler=handle,
+                source="chat_join_request",
+            )
+        )
+
+    def _register_reject(self, registry: ToolRegistry) -> None:
+        def handle(chat_id: str, request_id: str) -> str:
+            row = self._join_requests.reject(chat_id, request_id, self._identity_id)
+            return f"Chat join request rejected. {self._format_row(row)}"
+
+        registry.register(
+            ToolEntry(
+                name="reject_chat_join_request",
+                mode=ToolMode.INLINE,
+                schema=self._decision_schema("reject_chat_join_request", "Reject a pending join request for a group chat you own."),
+                handler=handle,
+                source="chat_join_request",
+            )
+        )
+
+    def _decision_schema(self, name: str, description: str) -> dict[str, Any]:
+        return make_tool_schema(
+            name=name,
+            description=description,
+            properties={
+                "chat_id": {
+                    "type": "string",
+                    "description": "Group chat id containing the join request.",
+                    "minLength": 1,
+                },
+                "request_id": {
+                    "type": "string",
+                    "description": "Join request id from list_chat_join_requests.",
+                    "minLength": 1,
+                },
+            },
+            required=["chat_id", "request_id"],
+        )
+
+    def _format_row(self, row: Any) -> str:
+        request_id = self._field(row, "id")
+        chat_id = self._field(row, "chat_id")
+        requester_user_id = self._field(row, "requester_user_id")
+        state = self._field(row, "state")
+        message = self._field(row, "message", default=None)
+        suffix = f"; message: {message}" if message else ""
+        return f"- request_id: {request_id}; chat_id: {chat_id}; requester_user_id: {requester_user_id}; state: {state}{suffix}"
+
+    def _field(self, row: Any, field: str, *, default: Any = ...) -> Any:
+        if isinstance(row, dict):
+            if default is ...:
+                return row[field]
+            return row.get(field, default)
+        if default is ...:
+            return getattr(row, field)
+        return getattr(row, field, default)

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -14,6 +14,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     typing_tracker = object()
     messaging_service = object()
     relationship_service = object()
+    chat_join_request_service = object()
     seen: list[tuple[str, object]] = []
 
     storage_container = SimpleNamespace(queue_repo=lambda: queue_repo)
@@ -40,6 +41,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
         typing_tracker=typing_tracker,
         messaging_service=messaging_service,
         relationship_service=relationship_service,
+        chat_join_request_service=chat_join_request_service,
     )
 
     assert app.state.queue_manager is queue_manager
@@ -56,6 +58,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.activity_reader is activity_reader
     assert state.messaging_service is messaging_service
     assert state.relationship_service is relationship_service
+    assert state.chat_join_request_service is chat_join_request_service
     assert state.typing_tracker is typing_tracker
     assert state.display_builder is None
     assert state.event_loop is None

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -85,6 +85,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_relationship_service = object()
+    returned_chat_join_request_service = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         contact_repo = object()
@@ -93,12 +94,22 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
             typing_tracker=returned_typing_tracker,
             messaging_service=returned_messaging_service,
             relationship_service=returned_relationship_service,
+            chat_join_request_service=returned_chat_join_request_service,
         )
 
-    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service, relationship_service):
+    def _attach_threads_runtime(
+        app,
+        _storage_container,
+        *,
+        typing_tracker,
+        messaging_service,
+        relationship_service,
+        chat_join_request_service,
+    ):
         assert typing_tracker is returned_typing_tracker
         assert messaging_service is returned_messaging_service
         assert relationship_service is returned_relationship_service
+        assert chat_join_request_service is returned_chat_join_request_service
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=object())
 
@@ -123,6 +134,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     returned_typing_tracker = object()
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_relationship_service = object()
+    returned_chat_join_request_service = object()
     returned_contact_repo = object()
     returned_activity_reader = object()
 
@@ -133,6 +145,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
             typing_tracker=returned_typing_tracker,
             messaging_service=returned_messaging_service,
             relationship_service=returned_relationship_service,
+            chat_join_request_service=returned_chat_join_request_service,
         )
 
     def _attach_auth_runtime(_app, *, storage_state, contact_repo):
@@ -140,11 +153,20 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert contact_repo is returned_contact_repo
         return object()
 
-    def _attach_threads_runtime(app, _storage_container, *, typing_tracker, messaging_service, relationship_service):
+    def _attach_threads_runtime(
+        app,
+        _storage_container,
+        *,
+        typing_tracker,
+        messaging_service,
+        relationship_service,
+        chat_join_request_service,
+    ):
         call_log.append("threads")
         assert typing_tracker is returned_typing_tracker
         assert messaging_service is returned_messaging_service
         assert relationship_service is returned_relationship_service
+        assert chat_join_request_service is returned_chat_join_request_service
         app.state.agent_pool = {}
         return SimpleNamespace(activity_reader=returned_activity_reader)
 
@@ -227,6 +249,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
             typing_tracker=object(),
             messaging_service=SimpleNamespace(set_delivery_fn=lambda _fn: None),
             relationship_service=object(),
+            chat_join_request_service=object(),
         ),
     )
     monkeypatch.setattr(

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -68,6 +68,25 @@ async def test_get_or_create_agent_borrows_relationship_service_for_registry(mon
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_agent_borrows_chat_join_request_service_for_registry(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+    chat_join_request_service = object()
+
+    async def _fake_registry_get_or_create_agent(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent", _fake_registry_get_or_create_agent)
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(chat_join_request_service=chat_join_request_service)))
+
+    await agent_pool.get_or_create_agent(cast(Any, app), "local", thread_id="thread-borrowed")
+
+    kwargs = cast(dict[str, object], captured["kwargs"])
+    assert kwargs["chat_join_request_service"] is chat_join_request_service
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_agent_skips_borrow_when_chat_bootstrap_missing(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 
@@ -189,6 +208,60 @@ async def test_registry_get_or_create_agent_uses_explicit_relationship_service(
 
     chat_repos = cast(dict[str, object], captured["chat_repos"])
     assert chat_repos["relationship_service"] is relationship_service
+
+
+@pytest.mark.asyncio
+async def test_registry_get_or_create_agent_uses_explicit_chat_join_request_service(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+    messaging_service = object()
+    chat_join_request_service = object()
+
+    def _fake_create_agent_sync(**kwargs) -> object:
+        captured["chat_repos"] = kwargs.get("chat_repos")
+        return SimpleNamespace()
+
+    class _ThreadRepo:
+        def get_by_id(self, thread_id: str):
+            return {
+                "id": thread_id,
+                "agent_user_id": "agent-user-explicit",
+                "cwd": None,
+                "model": "leon:large",
+            }
+
+    class _UserRepo:
+        def get_by_id(self, user_id: str):
+            return SimpleNamespace(id=user_id, owner_user_id="owner-explicit", agent_config_id="cfg-explicit")
+
+    monkeypatch.setattr(agent_pool._registry, "create_agent_sync", _fake_create_agent_sync)
+    monkeypatch.setattr(agent_pool._registry, "get_or_create_agent_id", lambda **_: "agent-explicit")
+    monkeypatch.setattr(
+        agent_pool._registry, "get_file_channel_binding", lambda _thread_id: (_ for _ in ()).throw(ValueError()), raising=False
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            agent_pool={},
+            thread_repo=_ThreadRepo(),
+            user_repo=_UserRepo(),
+            runtime_storage_state=_runtime_storage_state(_EmptyAgentConfigRepo()),
+            thread_cwd={},
+            thread_sandbox={},
+        )
+    )
+
+    await agent_pool._registry.get_or_create_agent(
+        cast(Any, app),
+        "local",
+        thread_id="thread-explicit",
+        messaging_service=messaging_service,
+        chat_join_request_service=chat_join_request_service,
+    )
+
+    chat_repos = cast(dict[str, object], captured["chat_repos"])
+    assert chat_repos["chat_join_request_service"] is chat_join_request_service
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -1434,6 +1434,63 @@ def test_leon_agent_registers_relationship_tools_from_runtime_relationship_servi
     assert captured["relationship_service"] is relationship_service
 
 
+def test_leon_agent_registers_chat_join_request_tools_from_runtime_service(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from core.runtime.agent import LeonAgent
+    from core.runtime.registry import ToolRegistry
+
+    captured: dict[str, Any] = {}
+
+    class _NoopService:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeChatJoinRequestToolService:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("core.runtime.agent.TaskService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.mcp_gateway.register_resource_tools", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.ToolSearchService", _NoopService)
+    monkeypatch.setattr("core.runtime.agent.AgentService", _NoopService)
+    monkeypatch.setattr("messaging.tools.chat_tool_service.ChatToolService", _NoopService)
+    monkeypatch.setattr("messaging.tools.chat_join_request_tool_service.ChatJoinRequestToolService", _FakeChatJoinRequestToolService)
+
+    chat_join_request_service = object()
+    agent = object.__new__(LeonAgent)
+    agent._sandbox = SimpleNamespace(name="local", fs=lambda: None, shell=lambda: None)
+    agent._tool_registry = ToolRegistry()
+    agent.workspace_root = str(tmp_path)
+    agent.model_name = "test-model"
+    agent._thread_repo = SimpleNamespace()
+    agent._user_repo = SimpleNamespace()
+    agent.queue_manager = SimpleNamespace()
+    agent._web_app = None
+    agent.allowed_file_extensions = []
+    agent.extra_allowed_paths = []
+    agent.enable_audit_log = False
+    agent.block_dangerous_commands = False
+    agent.block_network_commands = False
+    agent._get_mcp_server_configs = lambda: {}
+    agent._chat_repos = {
+        "chat_identity_id": "thread-user-9",
+        "messaging_service": SimpleNamespace(),
+        "chat_join_request_service": chat_join_request_service,
+    }
+    cast(Any, agent).config = SimpleNamespace(
+        tools=SimpleNamespace(
+            filesystem=SimpleNamespace(enabled=False),
+            search=SimpleNamespace(enabled=False),
+            web=SimpleNamespace(enabled=False),
+            command=SimpleNamespace(enabled=False),
+        ),
+    )
+
+    LeonAgent._init_services(agent)
+
+    assert captured["chat_join_identity_id"] == "thread-user-9"
+    assert captured["chat_join_request_service"] is chat_join_request_service
+
+
 def test_leon_agent_init_services_passes_child_thread_live_runner(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     from core.runtime.agent import LeonAgent
     from core.runtime.registry import ToolRegistry

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -26,6 +26,13 @@ def _user_repo() -> SimpleNamespace:
                 avatar=None,
                 owner_user_id=None,
             ),
+            "external-user-1": SimpleNamespace(
+                id="external-user-1",
+                display_name="External",
+                type="external",
+                avatar=None,
+                owner_user_id=None,
+            ),
             "agent-user-1": SimpleNamespace(
                 id="agent-user-1",
                 display_name="Morel",
@@ -113,6 +120,22 @@ def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
     dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])
 
     assert delivered == ["agent-user-2"]
+
+
+def test_dispatcher_does_not_runtime_deliver_to_external_users() -> None:
+    delivered: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["agent-user-1", "external-user-1"]),
+        user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
+        unread_counter=lambda _chat_id, _user_id: 0,
+        delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: DeliveryAction.DELIVER),
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])
+
+    assert delivered == []
 
 
 @pytest.mark.parametrize("action", [DeliveryAction.NOTIFY, DeliveryAction.DROP])

--- a/tests/Unit/messaging/test_chat_join_request_tool_service.py
+++ b/tests/Unit/messaging/test_chat_join_request_tool_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.runtime.registry import ToolRegistry
+from messaging.tools.chat_join_request_tool_service import ChatJoinRequestToolService
+
+
+def _request_row(
+    *,
+    request_id: str = "chat_join:chat-1:visitor-1",
+    chat_id: str = "chat-1",
+    requester_user_id: str = "visitor-1",
+    state: str = "pending",
+    message: str | None = "please add me",
+):
+    return {
+        "id": request_id,
+        "chat_id": chat_id,
+        "requester_user_id": requester_user_id,
+        "state": state,
+        "message": message,
+    }
+
+
+def test_chat_join_request_tool_service_registers_owner_tools_without_identity_arguments() -> None:
+    registry = ToolRegistry()
+    ChatJoinRequestToolService(
+        registry=registry,
+        chat_join_identity_id="agent-owner-1",
+        chat_join_request_service=SimpleNamespace(list_for_chat=lambda _chat_id, _owner_id: []),
+    )
+
+    for tool_name in ("list_chat_join_requests", "approve_chat_join_request", "reject_chat_join_request"):
+        tool = registry.get(tool_name)
+        assert tool is not None
+        assert "user_id" not in tool.get_schema()["parameters"]["properties"]
+        assert "owner_id" not in tool.get_schema()["parameters"]["properties"]
+
+
+def test_list_chat_join_requests_renders_request_ids_and_messages() -> None:
+    registry = ToolRegistry()
+    ChatJoinRequestToolService(
+        registry=registry,
+        chat_join_identity_id="agent-owner-1",
+        chat_join_request_service=SimpleNamespace(list_for_chat=lambda chat_id, owner_id: [_request_row(chat_id=chat_id)]),
+    )
+
+    result = registry.get("list_chat_join_requests").handler("chat-1")
+
+    assert "request_id: chat_join:chat-1:visitor-1" in result
+    assert "requester_user_id: visitor-1" in result
+    assert "state: pending" in result
+    assert "message: please add me" in result
+
+
+def test_approve_chat_join_request_uses_current_identity() -> None:
+    seen: list[tuple[str, str, str]] = []
+    registry = ToolRegistry()
+    ChatJoinRequestToolService(
+        registry=registry,
+        chat_join_identity_id="agent-owner-1",
+        chat_join_request_service=SimpleNamespace(
+            approve=lambda chat_id, request_id, owner_id: seen.append((chat_id, request_id, owner_id)) or _request_row(state="approved")
+        ),
+    )
+
+    result = registry.get("approve_chat_join_request").handler("chat-1", "chat_join:chat-1:visitor-1")
+
+    assert seen == [("chat-1", "chat_join:chat-1:visitor-1", "agent-owner-1")]
+    assert "approved" in result
+
+
+def test_reject_chat_join_request_uses_current_identity() -> None:
+    seen: list[tuple[str, str, str]] = []
+    registry = ToolRegistry()
+    ChatJoinRequestToolService(
+        registry=registry,
+        chat_join_identity_id="agent-owner-1",
+        chat_join_request_service=SimpleNamespace(
+            reject=lambda chat_id, request_id, owner_id: seen.append((chat_id, request_id, owner_id)) or _request_row(state="rejected")
+        ),
+    )
+
+    result = registry.get("reject_chat_join_request").handler("chat-1", "chat_join:chat-1:visitor-1")
+
+    assert seen == [("chat-1", "chat_join:chat-1:visitor-1", "agent-owner-1")]
+    assert "rejected" in result


### PR DESCRIPTION
## Summary
- limit runtime chat delivery to managed agent recipients so human/external users stay durable-chat recipients instead of runtime delivery targets
- add managed-agent chat join request tools: list_chat_join_requests, approve_chat_join_request, reject_chat_join_request
- carry chat_join_request_service from chat bootstrap through threads runtime into agent chat repos

## Verification
- uv run pytest tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/messaging/test_chat_join_request_tool_service.py tests/Unit/messaging/test_relationship_tool_service.py tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_registers_relationship_tools_from_runtime_relationship_service tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_registers_chat_join_request_tools_from_runtime_service tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/core/test_agent_pool.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Integration/test_relationship_router.py -q
- uv run ruff check . && uv run ruff format --check .

## YATU background
- This follows the managed-agent relationship CLI YATU artifact at /Users/lexicalmathical/share/yatu/managed-agent-relationship-cli-20260426T011838. That run exposed the runtime-recipient boundary bug when a managed agent replied to an external user.