### PR TITLE
Refactor agent config read boundaries

### DIFF
--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -134,7 +134,7 @@ class SupabaseAgentConfigRepo:
                     package_id=package_id,
                     name=skill["name"],
                     description=skill.get("description") or "",
-                    version=package.get("version") or "0.1.0",
+                    version=package["version"],
                     enabled=_enabled_from_row(row, label="skill_bindings"),
                     source=_required_json_object(package.get("source_json"), label="skill package source_json"),
                 )

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -127,9 +127,6 @@ class SupabaseAgentConfigRepo:
             package_id = row["package_id"]
             skill = self._get_library_skill(owner_user_id, skill_id)
             package = self._get_skill_package(owner_user_id, package_id)
-            source_json = package.get("source_json")
-            if source_json is None or source_json == {}:
-                source_json = skill.get("source_json")
             skills.append(
                 AgentSkill(
                     id=row.get("id"),
@@ -139,7 +136,7 @@ class SupabaseAgentConfigRepo:
                     description=skill.get("description") or "",
                     version=package.get("version") or "0.1.0",
                     enabled=_enabled_from_row(row, label="skill_bindings"),
-                    source=_json_object(source_json, label="skill source_json"),
+                    source=_required_json_object(package.get("source_json"), label="skill package source_json"),
                 )
             )
         return skills

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -203,11 +203,7 @@ class SupabaseAgentConfigRepo:
         rows = q.rows(self._table("agent_configs").select("mcp_json").eq("id", agent_config_id).execute(), _REPO, "_list_mcp_rows")
         if not rows:
             raise RuntimeError(f"Agent config {agent_config_id} disappeared while reading mcp_json")
-        mcp_rows = rows[0].get("mcp_json")
-        if mcp_rows is None:
-            mcp_rows = []
-        if not isinstance(mcp_rows, list):
-            raise RuntimeError(f"Agent config {agent_config_id} mcp_json must be a JSON array")
+        mcp_rows = _required_json_array(rows[0].get("mcp_json"), label=f"Agent config {agent_config_id} mcp_json")
         servers: list[McpServerConfig] = []
         for row in mcp_rows:
             if not isinstance(row, dict):

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -42,6 +42,12 @@ def _json_array(value: Any, *, label: str, default: list[Any] | None = None) -> 
     return list(value)
 
 
+def _required_json_array(value: Any, *, label: str) -> list[Any]:
+    if value is None:
+        raise RuntimeError(f"{label} must be a JSON array")
+    return _json_array(value, label=label)
+
+
 def _json_object(value: Any, *, label: str, default: dict[str, Any] | None = None) -> dict[str, Any]:
     if value is None:
         return dict(default or {})
@@ -79,7 +85,7 @@ class SupabaseAgentConfigRepo:
             name=root["name"],
             description=root.get("description") or "",
             model=root.get("model"),
-            tools=_json_array(root.get("tools_json"), label="tools_json", default=["*"]),
+            tools=_required_json_array(root.get("tools_json"), label="tools_json"),
             system_prompt=root.get("system_prompt") or "",
             status=root.get("status") or "draft",
             version=root.get("version") or "0.1.0",

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -56,6 +56,12 @@ def _json_object(value: Any, *, label: str, default: dict[str, Any] | None = Non
     return dict(value)
 
 
+def _required_json_object(value: Any, *, label: str) -> dict[str, Any]:
+    if value is None:
+        raise RuntimeError(f"{label} must be a JSON object")
+    return _json_object(value, label=label)
+
+
 class SupabaseAgentConfigRepo:
     def __init__(self, client: Any) -> None:
         self._client = q.validate_client(client, _REPO)
@@ -89,9 +95,9 @@ class SupabaseAgentConfigRepo:
             system_prompt=root.get("system_prompt") or "",
             status=root.get("status") or "draft",
             version=root.get("version") or "0.1.0",
-            runtime_settings=_json_object(root.get("runtime_json"), label="runtime_json"),
-            compact=_json_object(root.get("compact_json"), label="compact_json"),
-            meta=_json_object(root.get("meta_json"), label="meta_json"),
+            runtime_settings=_required_json_object(root.get("runtime_json"), label="runtime_json"),
+            compact=_required_json_object(root.get("compact_json"), label="compact_json"),
+            meta=_required_json_object(root.get("meta_json"), label="meta_json"),
             skills=self._list_skill_rows(agent_config_id, root["owner_user_id"]),
             rules=self._list_rule_rows(agent_config_id),
             sub_agents=self._list_sub_agent_rows(agent_config_id),

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -255,6 +255,15 @@ def test_get_agent_config_fails_loudly_when_runtime_json_is_not_an_object() -> N
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_runtime_json_is_null() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["runtime_json"] = None
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="runtime_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_fails_loudly_when_compact_json_is_not_an_object() -> None:
     tables = _tables()
     tables["agent.agent_configs"][0]["compact_json"] = []
@@ -264,9 +273,27 @@ def test_get_agent_config_fails_loudly_when_compact_json_is_not_an_object() -> N
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_compact_json_is_null() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["compact_json"] = None
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="compact_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_fails_loudly_when_meta_json_is_not_an_object() -> None:
     tables = _tables()
     tables["agent.agent_configs"][0]["meta_json"] = []
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="meta_json must be a JSON object"):
+        repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_fails_loudly_when_meta_json_is_null() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["meta_json"] = None
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
     with pytest.raises(RuntimeError, match="meta_json must be a JSON object"):

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -237,6 +237,15 @@ def test_get_agent_config_fails_loudly_when_tools_json_is_not_an_array() -> None
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_tools_json_is_null() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["tools_json"] = None
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="tools_json must be a JSON array"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_fails_loudly_when_runtime_json_is_not_an_object() -> None:
     tables = _tables()
     tables["agent.agent_configs"][0]["runtime_json"] = []

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -305,8 +305,20 @@ def test_get_agent_config_fails_loudly_when_skill_source_json_is_not_an_object()
     tables["library.skill_packages"][0]["source_json"] = ["bad"]
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
-    with pytest.raises(RuntimeError, match="skill source_json must be a JSON object"):
+    with pytest.raises(RuntimeError, match="skill package source_json must be a JSON object"):
         repo.get_agent_config("cfg-1")
+
+
+def test_get_agent_config_reads_agent_skill_source_from_selected_package_only() -> None:
+    tables = _tables()
+    tables["library.skills"][0]["source_json"] = {"source_version": "library"}
+    tables["library.skill_packages"][0]["source_json"] = {}
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    config = repo.get_agent_config("cfg-1")
+
+    assert config is not None
+    assert config.skills[0].source == {}
 
 
 def test_get_agent_config_fails_loudly_when_sub_agent_tools_json_is_not_an_array() -> None:

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -327,6 +327,15 @@ def test_get_agent_config_fails_loudly_when_mcp_json_is_not_an_array() -> None:
         repo.get_agent_config("cfg-1")
 
 
+def test_get_agent_config_fails_loudly_when_mcp_json_is_null() -> None:
+    tables = _tables()
+    tables["agent.agent_configs"][0]["mcp_json"] = None
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="mcp_json must be a JSON array"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_fails_loudly_when_mcp_json_is_empty_object() -> None:
     tables = _tables()
     tables["agent.agent_configs"][0]["mcp_json"] = {}

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -321,6 +321,15 @@ def test_get_agent_config_reads_agent_skill_source_from_selected_package_only() 
     assert config.skills[0].source == {}
 
 
+def test_get_agent_config_fails_loudly_when_skill_package_version_is_null() -> None:
+    tables = _tables()
+    tables["library.skill_packages"][0]["version"] = None
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(ValueError, match="version"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_fails_loudly_when_sub_agent_tools_json_is_not_an_array() -> None:
     tables = _tables()
     tables["agent.agent_sub_agents"][0]["tools_json"] = {"Read": True}


### PR DESCRIPTION
## Summary
- require AgentConfig storage JSON columns to read as explicit arrays/objects
- read Agent Skill source from the selected package only
- require Agent Skill version from the selected package row

## Verification
- `uv run pytest tests/Unit/storage/test_supabase_agent_config_repo.py -q`
- `uv run pytest tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/platform/test_marketplace_client.py tests/Unit/core/test_skills_service.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright storage/providers/supabase/agent_config_repo.py tests/Unit/storage/test_supabase_agent_config_repo.py`
- `uv run pytest tests/Unit -q`