### PR TITLE
feat: let agents create owned group chats

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -12,15 +12,12 @@ from backend.chat.api.http.dependencies import (
     get_chat_event_bus,
     get_chat_join_request_service,
     get_chat_repo,
-    get_contact_repo,
     get_current_user_id,
     get_messaging_service,
-    get_relationship_service,
     get_thread_repo,
     get_user_repo,
 )
 from messaging.errors import ChatNotCaughtUpError
-from messaging.social_access import can_group_chat_with_participant
 from messaging.user_ownership import is_owned_by_viewer
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -127,31 +124,6 @@ def _validate_requester_is_participant(user_repo: Any, participant_ids: list[str
     raise ValueError("Chat participants must include the requester or a requester-owned participant")
 
 
-def _validate_group_chat_relationships(
-    relationship_service: Any,
-    contact_repo: Any,
-    user_repo: Any,
-    participant_ids: list[str],
-    requester_user_id: str,
-) -> None:
-    for participant_id in dict.fromkeys(participant_ids):
-        if participant_id == requester_user_id or _is_owned_participant(user_repo, participant_id, requester_user_id):
-            continue
-        try:
-            participant_user = user_repo.get_by_id(participant_id)
-            if can_group_chat_with_participant(
-                viewer_user_id=requester_user_id,
-                participant_user_id=participant_id,
-                participant_user=participant_user,
-                contact_repo=contact_repo,
-                relationship_service=relationship_service,
-            ):
-                continue
-        except RuntimeError as exc:
-            raise ValueError(str(exc)) from exc
-        raise ValueError(f"Active relationship required for group chat participant: {participant_id}")
-
-
 @router.get("")
 def list_chats(
     user_id: Annotated[str, Depends(get_current_user_id)],
@@ -167,20 +139,11 @@ def create_chat(
     messaging_service: Annotated[Any, Depends(get_messaging_service)],
     user_repo: Annotated[Any, Depends(get_user_repo)],
     thread_repo: Annotated[Any, Depends(get_thread_repo)],
-    contact_repo: Annotated[Any, Depends(get_contact_repo)],
-    relationship_service: Annotated[Any, Depends(get_relationship_service)],
 ):
     try:
         participant_ids = _validate_chat_participant_ids(user_repo, thread_repo, body.user_ids, user_id)
         _validate_requester_is_participant(user_repo, participant_ids, user_id)
         if len(participant_ids) >= 3:
-            _validate_group_chat_relationships(
-                relationship_service,
-                contact_repo,
-                user_repo,
-                participant_ids,
-                user_id,
-            )
             chat = messaging_service.create_group_chat(participant_ids, body.title)
         else:
             chat = messaging_service.find_or_create_chat(participant_ids, body.title)

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -54,6 +54,8 @@ def attach_chat_runtime(
         messages_repo=messages_repo,
         user_repo=user_repo,
         thread_repo=thread_repo,
+        contact_repo=contact_repo,
+        relationship_service=relationship_service,
         event_bus=chat_event_bus,
         delivery_resolver=delivery_resolver,
         avatar_url_builder=avatar_url,

--- a/config/defaults/tool_catalog.py
+++ b/config/defaults/tool_catalog.py
@@ -65,6 +65,7 @@ TOOLS: list[ToolDef] = [
     ToolDef(name="SendMessage", desc="向运行中的 Agent 发送排队消息", group=ToolGroup.AGENT),
     # chat
     ToolDef(name="list_chats", desc="列出当前实体可访问的聊天会话", group=ToolGroup.CHAT),
+    ToolDef(name="create_group_chat", desc="创建由当前实体拥有的群聊", group=ToolGroup.CHAT),
     ToolDef(name="read_messages", desc="读取聊天消息并标记为已读", group=ToolGroup.CHAT),
     ToolDef(name="send_message", desc="向聊天对象发送消息", group=ToolGroup.CHAT),
     ToolDef(name="search_messages", desc="搜索历史聊天消息", group=ToolGroup.CHAT),

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -21,6 +21,8 @@ from messaging.contracts import ContentType, MessageType
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
 from messaging.display_user import resolve_messaging_display_user
 from messaging.errors import ChatNotCaughtUpError
+from messaging.social_access import can_group_chat_with_participant
+from messaging.user_ownership import is_owned_by_viewer
 from storage.errors import StorageConflictError
 
 logger = logging.getLogger(__name__)
@@ -42,6 +44,8 @@ class MessagingService:
         messages_repo: Any,
         user_repo: Any,
         thread_repo: Any | None = None,
+        contact_repo: Any | None = None,
+        relationship_service: Any | None = None,
         delivery_resolver: Any | None = None,
         delivery_fn: ChatDeliveryFn | None = None,
         delivery_dispatcher: ChatDeliveryDispatcher | None = None,
@@ -53,6 +57,9 @@ class MessagingService:
         self._chat_members_repo = chat_member_repo
         self._messages = messages_repo
         self._user_repo = user_repo
+        self._thread_repo = thread_repo
+        self._contact_repo = contact_repo
+        self._relationship_service = relationship_service
         self._avatar_url_builder = avatar_url_builder
         self._delivery_dispatcher = delivery_dispatcher or ChatDeliveryDispatcher(
             chat_member_repo=chat_member_repo,
@@ -147,6 +154,7 @@ class MessagingService:
         if len(user_ids) < 3:
             raise ValueError("Group chat requires 3+ users")
         self._require_resolvable_chat_users(user_ids)
+        self._require_group_chat_access(user_ids)
         return self._create_chat(user_ids, chat_type="group", title=title)
 
     def _require_resolvable_chat_users(self, user_ids: list[str]) -> None:
@@ -156,6 +164,28 @@ class MessagingService:
             social_user_id = str(uid or "")
             if not social_user_id or self._resolve_display_user(social_user_id) is None:
                 raise ValueError(f"Chat participant {social_user_id or '<missing>'} is not a resolvable user row")
+
+    def _require_group_chat_access(self, user_ids: list[str]) -> None:
+        requester_user_id = user_ids[0]
+        if self._contact_repo is None:
+            raise RuntimeError("contact_repo is required for social access checks")
+        if self._relationship_service is None:
+            raise RuntimeError("relationship_service is required for social access checks")
+        for participant_id in dict.fromkeys(user_ids):
+            if participant_id == requester_user_id:
+                continue
+            participant_user = self._resolve_display_user(participant_id)
+            if is_owned_by_viewer(requester_user_id, participant_user):
+                continue
+            if can_group_chat_with_participant(
+                viewer_user_id=requester_user_id,
+                participant_user_id=participant_id,
+                participant_user=participant_user,
+                contact_repo=self._contact_repo,
+                relationship_service=self._relationship_service,
+            ):
+                continue
+            raise ValueError(f"Active relationship required for group chat participant: {participant_id}")
 
     def _create_chat(self, user_ids: list[str], *, chat_type: str, title: str | None) -> dict[str, Any]:
         from storage.contracts import ChatRow

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -1,6 +1,6 @@
 """Chat tool service (messaging module version).
 
-Provides 4 tools: list_chats, read_messages, send_message, search_messages.
+Provides 5 tools: list_chats, create_group_chat, read_messages, send_message, search_messages.
 """
 
 from __future__ import annotations
@@ -67,7 +67,7 @@ def _parse_time_endpoint(s: str, now: float) -> float | None:
 
 
 class ChatToolService:
-    """Registers 4 chat tools into ToolRegistry (messaging module version)."""
+    """Registers chat tools into ToolRegistry (messaging module version)."""
 
     def __init__(
         self,
@@ -97,6 +97,7 @@ class ChatToolService:
 
     def _register(self, registry: ToolRegistry) -> None:
         self._register_list_chats(registry)
+        self._register_create_group_chat(registry)
         self._register_chat_read(registry)
         self._register_chat_send(registry)
         self._register_search_messages(registry)
@@ -214,6 +215,53 @@ class ChatToolService:
                             },
                             "limit": {"type": "integer", "description": "Max number of chats to return", "default": 20},
                         },
+                    },
+                },
+                handler=handle,
+                source="chat",
+            )
+        )
+
+    def _register_create_group_chat(self, registry: ToolRegistry) -> None:
+        eid = self._chat_identity_id
+
+        def handle(participant_ids: list[str], title: str | None = None) -> str:
+            if eid in participant_ids:
+                raise RuntimeError("participant_ids must contain only other users")
+            chat = self._messaging.create_group_chat([eid, *participant_ids], title=title)
+            if not isinstance(chat, dict):
+                raise RuntimeError("Created group chat row is invalid")
+            chat_id = chat.get("id")
+            if not isinstance(chat_id, str) or not chat_id:
+                raise RuntimeError("Created group chat has invalid id")
+            chat_title = chat.get("title") or title
+            if chat_title:
+                return f"Group chat created: {chat_title} [chat_id: {chat_id}]"
+            return f"Group chat created. [chat_id: {chat_id}]"
+
+        registry.register(
+            ToolEntry(
+                name="create_group_chat",
+                mode=ToolMode.INLINE,
+                schema={
+                    "name": "create_group_chat",
+                    "description": (
+                        "Create a group chat owned by your current social identity. "
+                        "participant_ids must contain the other users only; your own id is added automatically."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "participant_ids": {
+                                "type": "array",
+                                "items": {"type": "string", "minLength": 1},
+                                "minItems": 2,
+                                "uniqueItems": True,
+                                "description": "Other user ids to include in the group chat.",
+                            },
+                            "title": {"type": "string", "minLength": 1, "description": "Optional group chat title."},
+                        },
+                        "required": ["participant_ids"],
                     },
                 },
                 handler=handle,

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -226,9 +226,8 @@ class ChatToolService:
         eid = self._chat_identity_id
 
         def handle(participant_ids: list[str], title: str | None = None) -> str:
-            if eid in participant_ids:
-                raise RuntimeError("participant_ids must contain only other users")
-            chat = self._messaging.create_group_chat([eid, *participant_ids], title=title)
+            other_ids = [participant_id for participant_id in dict.fromkeys(participant_ids) if participant_id != eid]
+            chat = self._messaging.create_group_chat([eid, *other_ids], title=title)
             if not isinstance(chat, dict):
                 raise RuntimeError("Created group chat row is invalid")
             chat_id = chat.get("id")
@@ -247,7 +246,7 @@ class ChatToolService:
                     "name": "create_group_chat",
                     "description": (
                         "Create a group chat owned by your current social identity. "
-                        "participant_ids must contain the other users only; your own id is added automatically."
+                        "Your own id is added automatically and ignored if participant_ids includes it."
                     ),
                     "parameters": {
                         "type": "object",

--- a/storage/schema/2026_04_25_relationship_pair_constraint.sql
+++ b/storage/schema/2026_04_25_relationship_pair_constraint.sql
@@ -1,0 +1,5 @@
+alter table chat.relationships
+    drop constraint if exists relationships_check;
+
+alter table chat.relationships
+    add constraint relationships_check check (user_low <> user_high);

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -99,8 +99,6 @@ def _create_chat(app: SimpleNamespace, body: chats_router.CreateChatBody, *, use
         messaging_service=app.state.chat_runtime_state.messaging_service,
         user_repo=app.state.user_repo,
         thread_repo=app.state.thread_repo,
-        contact_repo=app.state.chat_runtime_state.contact_repo,
-        relationship_service=app.state.chat_runtime_state.relationship_service,
     )
 
 
@@ -838,6 +836,11 @@ def test_create_group_chat_rejects_external_participant_without_active_relations
         relationship_state="pending",
     )
     app = SimpleNamespace(state=state)
+
+    def _raise_group_policy_error(_user_ids, _title):
+        raise ValueError("Active relationship required for group chat participant: human-user-2")
+
+    app.state.chat_runtime_state.messaging_service = SimpleNamespace(create_group_chat=_raise_group_policy_error)
 
     with pytest.raises(HTTPException) as exc_info:
         _create_chat(

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2126,6 +2126,26 @@ def test_chat_tool_create_group_chat_uses_current_identity_as_group_owner() -> N
     assert created == [(["agent-user-1", "human-user-1", "human-user-2"], "debate room")]
 
 
+def test_chat_tool_create_group_chat_ignores_current_identity_when_agent_includes_it() -> None:
+    registry = ToolRegistry()
+    created: list[tuple[list[str], str | None]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            create_group_chat=lambda user_ids, title=None: created.append((user_ids, title)) or {"id": "chat-1", "title": title}
+        ),
+    )
+
+    create_group_chat = registry.get("create_group_chat")
+    assert create_group_chat is not None
+
+    result = create_group_chat.handler(participant_ids=["agent-user-1", "human-user-1", "human-user-2"], title="debate room")
+
+    assert result == "Group chat created: debate room [chat_id: chat-1]"
+    assert created == [(["agent-user-1", "human-user-1", "human-user-2"], "debate room")]
+
+
 def test_chat_tool_create_group_chat_fails_when_created_chat_has_invalid_id() -> None:
     registry = ToolRegistry()
     ChatToolService(

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -221,7 +221,7 @@ def test_chat_tool_registry_exposes_final_contract_only() -> None:
         messaging_service=_messaging_display_service(),
     )
 
-    for tool_name in ("list_chats", "read_messages", "send_message", "search_messages"):
+    for tool_name in ("list_chats", "create_group_chat", "read_messages", "send_message", "search_messages"):
         assert registry.get(tool_name) is not None
 
 
@@ -1842,6 +1842,70 @@ def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_water
     assert after[0]["unread_count"] == 0
 
 
+def test_messaging_service_group_chat_creation_requires_social_access_collaborators() -> None:
+    created: list[Any] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(create=lambda row: created.append(row)),
+        chat_member_repo=SimpleNamespace(add_member=lambda _chat_id, _user_id: None),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, owner_user_id=None, display_name=uid, type="human", avatar=None)
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        service.create_group_chat(["agent-user-1", "human-user-1", "stranger-user-1"], title="unguarded")
+
+    assert str(excinfo.value) == "contact_repo is required for social access checks"
+    assert created == []
+
+
+def test_messaging_service_group_chat_creation_rejects_participant_without_active_social_access() -> None:
+    created: list[Any] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(create=lambda row: created.append(row)),
+        chat_member_repo=SimpleNamespace(add_member=lambda _chat_id, _user_id: None),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, owner_user_id=None, display_name=uid, type="human", avatar=None)
+        ),
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        relationship_service=SimpleNamespace(get_state=lambda _viewer_id, _target_id: "none"),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        service.create_group_chat(["agent-user-1", "human-user-1", "stranger-user-1"], title="blocked")
+
+    assert str(excinfo.value) == "Active relationship required for group chat participant: human-user-1"
+    assert created == []
+
+
+def test_messaging_service_group_chat_creation_accepts_active_relationships() -> None:
+    created: list[Any] = []
+    members: list[tuple[str, str]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(create=lambda row: created.append(row)),
+        chat_member_repo=SimpleNamespace(add_member=lambda chat_id, user_id: members.append((chat_id, user_id))),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, owner_user_id=None, display_name=uid, type="human", avatar=None)
+        ),
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        relationship_service=SimpleNamespace(get_state=lambda _viewer_id, _target_id: "visit"),
+    )
+
+    chat = service.create_group_chat(["agent-user-1", "human-user-1", "stranger-user-1"], title="guarded")
+
+    assert chat["title"] == "guarded"
+    assert len(created) == 1
+    assert created[0].created_by_user_id == "agent-user-1"
+    assert members == [
+        (chat["id"], "agent-user-1"),
+        (chat["id"], "human-user-1"),
+        (chat["id"], "stranger-user-1"),
+    ]
+
+
 def test_chat_tool_formats_agent_user_id_sender_as_agent_name() -> None:
     registry = ToolRegistry()
     service = ChatToolService(
@@ -2021,6 +2085,62 @@ def test_chat_tool_send_accepts_agent_user_target_id() -> None:
 
     assert result == "Message sent to Toad."
     assert sent == [("chat-1", "human-user-1", "hello")]
+
+
+def test_chat_tool_create_group_chat_registers_without_identity_arguments() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(create_group_chat=lambda _user_ids, title=None: {"id": "chat-1", "title": title}),
+    )
+
+    create_group_chat = registry.get("create_group_chat")
+    assert create_group_chat is not None
+    properties = create_group_chat.schema["parameters"]["properties"]
+
+    assert "participant_ids" in properties
+    assert "title" in properties
+    assert "sender_id" not in properties
+    assert "owner_id" not in properties
+    assert "created_by_user_id" not in properties
+
+
+def test_chat_tool_create_group_chat_uses_current_identity_as_group_owner() -> None:
+    registry = ToolRegistry()
+    created: list[tuple[list[str], str | None]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            create_group_chat=lambda user_ids, title=None: created.append((user_ids, title)) or {"id": "chat-1", "title": title}
+        ),
+    )
+
+    create_group_chat = registry.get("create_group_chat")
+    assert create_group_chat is not None
+
+    result = create_group_chat.handler(participant_ids=["human-user-1", "human-user-2"], title="debate room")
+
+    assert result == "Group chat created: debate room [chat_id: chat-1]"
+    assert created == [(["agent-user-1", "human-user-1", "human-user-2"], "debate room")]
+
+
+def test_chat_tool_create_group_chat_fails_when_created_chat_has_invalid_id() -> None:
+    registry = ToolRegistry()
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(create_group_chat=lambda _user_ids, title=None: {"title": title}),
+    )
+
+    create_group_chat = registry.get("create_group_chat")
+    assert create_group_chat is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        create_group_chat.handler(participant_ids=["human-user-1", "human-user-2"], title="debate room")
+
+    assert str(excinfo.value) == "Created group chat has invalid id"
 
 
 def test_chat_tool_send_fails_before_unread_check_when_created_chat_is_missing_id() -> None:

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1990,7 +1990,7 @@ def test_builtin_agent_surface_exposes_chat_tools():
     agent = agent_user_service._leon_builtin()
     tools = {item["name"]: item for item in agent["config"]["tools"]}
 
-    for tool_name in ("list_chats", "read_messages", "send_message", "search_messages"):
+    for tool_name in ("list_chats", "create_group_chat", "read_messages", "send_message", "search_messages"):
         assert tool_name in tools
         assert tools[tool_name]["enabled"] is True
         assert tools[tool_name]["group"] == "chat"

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from storage.contracts import ChatRow, ContactEdgeRow
@@ -82,6 +84,14 @@ def test_supabase_contact_and_relationship_repos_use_chat_schema() -> None:
     assert tables["chat.relationships"][0]["initiator_user_id"] == "user-1"
     assert "contacts" not in tables
     assert "relationships" not in tables
+
+
+def test_relationship_schema_constraint_does_not_depend_on_database_collation() -> None:
+    sql = Path("storage/schema/2026_04_25_relationship_pair_constraint.sql").read_text()
+
+    assert "drop constraint if exists relationships_check" in sql.lower()
+    assert "user_low <> user_high" in sql.lower()
+    assert "user_low < user_high" not in sql.lower()
 
 
 class _FakeResponse:


### PR DESCRIPTION
## Summary
- add create_group_chat as a managed-agent chat tool; current runtime identity becomes the group owner
- move group-chat social access enforcement into MessagingService.create_group_chat so router and agent tools share one backend rule
- expose the new chat tool in the builtin agent catalog
- align chat.relationships DB constraint with app-owned canonical ordering instead of Postgres locale collation
- make create_group_chat tolerate the agent including its own id, because natural LLM calls often describe the full participant set

## Verification
- uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_builtin_agent_surface_exposes_chat_tools tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_registers_relationship_tools_from_runtime_relationship_service tests/Unit/integration_contracts/test_leon_agent.py::test_leon_agent_registers_chat_join_request_tools_from_runtime_service tests/Unit/core/test_agent_pool.py tests/Unit/backend/test_threads_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/messaging/test_chat_join_request_tool_service.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py -q -> 218 passed
- uv run ruff check . && uv run ruff format --check . -> passed, 650 files already formatted

## Live CLI YATU
Artifact root: /Users/lexicalmathical/share/yatu/managed-agent-group-join-cli-20260425T180410Z
- seeded owner profile, created managed agent m_nIvXmZEVGHQW and thread m_nIvXmZEVGHQW-1
- onboarded external member/seed/visitor users through mycel CLI profiles
- member and seed requested relationships through mycel relationship request; managed agent approved them to visit via relationship tools
- member asked managed agent by chat mention to create an owned group; first attempt exposed the self-id ergonomics issue, after the tool contract fix the agent created group chat 1b4938e4-a6a0-4c48-9b8c-4f736764cc1e and replied with GROUP_CREATE_RETRY_OK_m_nIvXmZEVGHQW
- visitor requested to join the group through mycel chat join-requests request; before approval visitor got 403 on messages, after managed owner approved, visitor could read the group and saw JOIN_APPROVED_OK_m_nIvXmZEVGHQW from the agent
- visitor then sent a group message and member read VISITOR_GROUP_SPEAK_OK_m_nIvXmZEVGHQW through mycel chat messages list