### PR TITLE
Refactor Skill intake boundaries

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -68,6 +68,14 @@ def _required_text(value: Any, *, label: str) -> str:
     return value.strip()
 
 
+def _optional_text(value: Any, *, label: str) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    return value.strip()
+
+
 def _skill_metadata_from_content(content: str) -> dict[str, Any]:
     if not content.startswith("---\n"):
         raise ValueError("Skill snapshot must be a SKILL.md document with frontmatter")
@@ -86,6 +94,10 @@ def _skill_metadata_from_content(content: str) -> dict[str, Any]:
         raise ValueError("Skill snapshot frontmatter must include name")
     metadata["name"] = name.strip()
     return metadata
+
+
+def _skill_description_from_metadata(metadata: dict[str, Any]) -> str:
+    return _optional_text(metadata.get("description"), label="Skill snapshot frontmatter description")
 
 
 def _skill_files_from_snapshot(snapshot: dict[str, Any]) -> dict[str, str]:
@@ -251,10 +263,7 @@ def apply_item(
         for skill in skill_repo.list_for_owner(owner_user_id):
             if skill.name == skill_name and skill.id != slug:
                 raise ValueError("Skill name already exists under a different Library id")
-        meta = snapshot.get("meta", {})
-        if not isinstance(meta, dict):
-            raise ValueError("Skill snapshot meta must be an object")
-        skill_description = str(meta.get("desc") or item.get("description", ""))
+        skill_description = _skill_description_from_metadata(skill_metadata)
         publisher = _required_text(item.get("publisher_username"), label="Hub item publisher_username")
         timestamp = datetime.now(UTC)
         source = {

--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -56,6 +56,18 @@ def _hub_error_detail(response: httpx.Response) -> str | None:
     return detail if isinstance(detail, str) and detail else None
 
 
+def _required_object(value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _required_text(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a string")
+    return value.strip()
+
+
 def _skill_metadata_from_content(content: str) -> dict[str, Any]:
     if not content.startswith("---\n"):
         raise ValueError("Skill snapshot must be a SKILL.md document with frontmatter")
@@ -216,22 +228,20 @@ def apply_item(
     or add Agent User.
     """
     result = _hub_api("POST", f"/items/{item_id}/download")
-    snapshot = result["snapshot"]
-    item = result["item"]
-    source_version = result["version"]
-    item_type = item.get("type", "skill")
+    snapshot = _required_object(result.get("snapshot"), label="Hub download snapshot")
+    item = _required_object(result.get("item"), label="Hub download item")
+    source_version = _required_text(result.get("version"), label="Hub download version")
+    item_type = _required_text(item.get("type"), label="Hub item type")
 
     now = int(time.time() * 1000)
 
     if item_type == "skill":
-        content = snapshot.get("content", "")
-        if not isinstance(content, str):
-            raise ValueError("Skill snapshot content must be a string")
+        content = _required_text(snapshot.get("content"), label="Skill snapshot content")
         skill_metadata = _skill_metadata_from_content(content)
         skill_files = _skill_files_from_snapshot(snapshot)
         if skill_repo is None:
             raise RuntimeError("skill_repo is required to save a skill to Library")
-        slug = item.get("slug", item["name"].lower().replace(" ", "-"))
+        slug = _required_text(item.get("slug"), label="Hub item slug")
         if "/" in slug or "\\" in slug or slug in {"", ".", ".."}:
             raise ValueError(f"Invalid slug: {slug}")
         skill_name = str(skill_metadata["name"]).strip()
@@ -245,12 +255,13 @@ def apply_item(
         if not isinstance(meta, dict):
             raise ValueError("Skill snapshot meta must be an object")
         skill_description = str(meta.get("desc") or item.get("description", ""))
+        publisher = _required_text(item.get("publisher_username"), label="Hub item publisher_username")
         timestamp = datetime.now(UTC)
         source = {
             "marketplace_item_id": item_id,
             "source_version": source_version,
             "source_at": now,
-            "publisher": item.get("publisher_username", ""),
+            "publisher": publisher,
         }
         skill = skill_repo.upsert(
             Skill(
@@ -303,7 +314,7 @@ def apply_item(
                     source={
                         "marketplace_item_id": item_id,
                         "source_version": source_version,
-                        "publisher": item.get("publisher_username", ""),
+                        "publisher": publisher,
                     },
                 )
             )

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -15,6 +15,9 @@ from config.skill_files import normalize_skill_file_entries
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from storage.runtime import build_storage_container
 
+FILE_IMPORT_SOURCE = {"kind": "file_import"}
+INITIAL_SKILL_PACKAGE_VERSION = "0.1.0"
+
 
 def _frontmatter(content: str) -> dict[str, Any]:
     if not content.startswith("---"):
@@ -25,9 +28,25 @@ def _frontmatter(content: str) -> dict[str, Any]:
     metadata = yaml.safe_load(parts[1]) or {}
     if not isinstance(metadata, dict):
         raise ValueError("SKILL.md frontmatter must be a mapping")
-    if not str(metadata.get("name") or "").strip():
-        raise ValueError("SKILL.md frontmatter must include name")
+    _frontmatter_text(metadata, "name")
+    _frontmatter_text(metadata, "description")
     return metadata
+
+
+def _frontmatter_text(metadata: dict[str, Any], key: str) -> str:
+    value = metadata.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"SKILL.md frontmatter must include {key}")
+    return value.strip()
+
+
+def _frontmatter_version(metadata: dict[str, Any]) -> str:
+    if "version" not in metadata:
+        return INITIAL_SKILL_PACKAGE_VERSION
+    value = metadata["version"]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("SKILL.md frontmatter version must be a string")
+    return value.strip()
 
 
 def _read_files(skill_dir: Path) -> dict[str, str]:
@@ -67,8 +86,8 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
                 id=skill_dir.name,
                 owner_user_id=owner_user_id,
                 name=skill_name,
-                description=str(metadata.get("description") or ""),
-                source={"file_skill_dir": str(skill_dir)},
+                description=_frontmatter_text(metadata, "description"),
+                source=dict(FILE_IMPORT_SOURCE),
                 created_at=now,
                 updated_at=now,
             )
@@ -78,12 +97,12 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
                 id=package_hash.removeprefix("sha256:"),
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
-                version=str(metadata.get("version") or "0.1.0"),
+                version=_frontmatter_version(metadata),
                 hash=package_hash,
                 manifest=build_skill_package_manifest(content, files),
                 skill_md=content,
                 files=files,
-                source={"file_skill_dir": str(skill_dir)},
+                source=dict(FILE_IMPORT_SOURCE),
                 created_at=now,
             )
         )

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -213,6 +213,82 @@ class TestApplySkill:
         assert saved[0].source["publisher"] == "alice"
         assert packages[0].source["source_version"] == "2.1.0"
 
+    def test_apply_skill_uses_frontmatter_description_as_library_description(self):
+        saved: list[Skill] = []
+        packages: list[SkillPackage] = []
+        hub_resp = _make_hub_response(
+            "skill",
+            "described-skill",
+            content="---\nname: Described Skill\ndescription: Frontmatter description\n---\n# Hello",
+        )
+        hub_resp["item"]["description"] = "Hub card description"
+        hub_resp["snapshot"]["meta"]["desc"] = "Snapshot meta description"
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda skill: saved.append(skill) or skill,
+            create_package=lambda package: packages.append(package) or package,
+            select_package=lambda _owner_user_id, _skill_id, _package_id: None,
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            apply_item("item-described", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert saved[0].description == "Frontmatter description"
+
+    def test_apply_skill_requires_snapshot_version(self):
+        hub_resp = _make_hub_response(
+            "skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody"
+        )
+        del hub_resp["version"]
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save broken Skill")),
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            with pytest.raises(ValueError, match="Hub download version must be a string"):
+                apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
+
+    def test_apply_skill_requires_item_slug(self):
+        hub_resp = _make_hub_response(
+            "skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody"
+        )
+        del hub_resp["item"]["slug"]
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save broken Skill")),
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            with pytest.raises(ValueError, match="Hub item slug must be a string"):
+                apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
+
+    def test_apply_skill_requires_publisher(self):
+        hub_resp = _make_hub_response(
+            "skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody"
+        )
+        del hub_resp["item"]["publisher_username"]
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save broken Skill")),
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            with pytest.raises(ValueError, match="Hub item publisher_username must be a string"):
+                apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
+
     def test_apply_to_library_rejects_name_drift_for_existing_skill_id(self):
         existing = Skill(
             id="same-slug",
@@ -296,20 +372,28 @@ class TestApplySkill:
             with pytest.raises(ValueError, match="Skill snapshot frontmatter must include name"):
                 apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
 
-    def test_apply_to_library_rejects_non_object_skill_snapshot_meta(self):
-        hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\n---\nBody")
+    def test_apply_to_library_does_not_read_skill_snapshot_meta(self):
+        saved: list[Skill] = []
+        packages: list[SkillPackage] = []
+        hub_resp = _make_hub_response(
+            "skill", "meta-free-skill", content="---\nname: Meta Free Skill\ndescription: Frontmatter wins\n---\nBody"
+        )
         hub_resp["snapshot"]["meta"] = []
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
             list_for_owner=lambda _owner_user_id: [],
-            upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save broken Skill")),
+            upsert=lambda skill: saved.append(skill) or skill,
+            create_package=lambda package: packages.append(package) or package,
+            select_package=lambda _owner_user_id, _skill_id, _package_id: None,
         )
 
         with patch("backend.hub.client._hub_api", return_value=hub_resp):
             from backend.hub.client import apply_item
 
-            with pytest.raises(ValueError, match="Skill snapshot meta must be an object"):
-                apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
+            apply_item("item-meta", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert saved[0].description == "Frontmatter wins"
+        assert packages[0].skill_id == "meta-free-skill"
 
     def test_path_traversal_blocked(self):
         hub_resp = _make_hub_response("skill", "../../evil", content="---\nname: Evil\n---\n# Hello")
@@ -373,7 +457,7 @@ class TestApplySkill:
             "agent_user_id": "agent-user-1",
         }
         assert saved_skills[0].name == "FastAPI"
-        assert saved_skills[0].description == "Meta FastAPI description"
+        assert saved_skills[0].description == "Build FastAPI APIs"
         assert packages[0].skill_md == "---\nname: FastAPI\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter."
         assert packages[0].manifest["files"][0]["path"] == "references/routing.md"
         assert selected == [("owner-1", "fastapi", packages[0].id)]
@@ -381,7 +465,7 @@ class TestApplySkill:
         assert [skill.name for skill in saved[0].skills] == ["Existing", "FastAPI"]
         assert saved[0].skills[1].skill_id == "fastapi"
         assert saved[0].skills[1].package_id == packages[0].id
-        assert saved[0].skills[1].description == "Meta FastAPI description"
+        assert saved[0].skills[1].description == "Build FastAPI APIs"
         assert saved[0].skills[1].source == {
             "marketplace_item_id": "skillsmp:fastapi",
             "source_version": "1.2.3",

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -4,6 +4,7 @@ import importlib
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import httpx
@@ -239,9 +240,7 @@ class TestApplySkill:
         assert saved[0].description == "Frontmatter description"
 
     def test_apply_skill_requires_snapshot_version(self):
-        hub_resp = _make_hub_response(
-            "skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody"
-        )
+        hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")
         del hub_resp["version"]
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
@@ -256,9 +255,7 @@ class TestApplySkill:
                 apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
 
     def test_apply_skill_requires_item_slug(self):
-        hub_resp = _make_hub_response(
-            "skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody"
-        )
+        hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")
         del hub_resp["item"]["slug"]
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
@@ -273,9 +270,7 @@ class TestApplySkill:
                 apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
 
     def test_apply_skill_requires_publisher(self):
-        hub_resp = _make_hub_response(
-            "skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody"
-        )
+        hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")
         del hub_resp["item"]["publisher_username"]
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
@@ -732,7 +727,7 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
     import backend.hub.client as marketplace_client
 
     saved: dict[str, AgentConfig] = {}
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, agent_config_id="cfg-1", owner_user_id="owner-1"))
 
@@ -782,7 +777,7 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                 hash="sha256:search",
                 skill_md="---\nname: Search\n---\nskill content",
                 source={"name": "Search", "desc": "Repo Search"},
-                created_at="2026-04-25T00:00:00+00:00",
+                created_at=datetime(2026, 4, 25, tzinfo=UTC),
             )
         ),
     )
@@ -812,7 +807,7 @@ def test_publish_prefers_repo_lineage_even_when_stale_member_dir_exists(tmp_path
     import backend.hub.client as marketplace_client
 
     saved: dict[str, AgentConfig] = {}
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
     members_root = tmp_path / "members"
     member_dir = members_root / "agent-user-1"
     member_dir.mkdir(parents=True)

--- a/tests/Unit/scripts/test_import_file_skills_to_library.py
+++ b/tests/Unit/scripts/test_import_file_skills_to_library.py
@@ -44,7 +44,7 @@ def test_import_file_skill_rejects_name_drift_for_existing_skill_id(monkeypatch:
     library_dir = tmp_path / "library"
     skill_dir = library_dir / "skills" / "same-skill"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: Renamed Skill\n---\nBody", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: Renamed Skill\ndescription: Renamed\n---\nBody", encoding="utf-8")
     repo = _MemorySkillRepo(
         Skill(
             id="same-skill",
@@ -66,7 +66,7 @@ def test_import_file_skill_rejects_same_name_under_different_skill_id(monkeypatc
     library_dir = tmp_path / "library"
     skill_dir = library_dir / "skills" / "new-skill"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: Shared Skill\n---\nBody", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: Shared Skill\ndescription: Shared\n---\nBody", encoding="utf-8")
     repo = _MemorySkillRepo(
         Skill(
             id="original-skill",
@@ -88,7 +88,7 @@ def test_import_file_skill_rejects_unreadable_adjacent_file(monkeypatch: pytest.
     library_dir = tmp_path / "library"
     skill_dir = library_dir / "skills" / "new-skill"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\n---\nBody", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\ndescription: New\n---\nBody", encoding="utf-8")
     (skill_dir / "broken.bin").write_bytes(b"\xff\xfe\xfa")
     repo = _MemorySkillRepo()
     monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
@@ -104,7 +104,7 @@ def test_import_file_skill_stores_adjacent_files_as_posix_paths(monkeypatch: pyt
     skill_dir = library_dir / "skills" / "new-skill"
     refs_dir = skill_dir / "references"
     refs_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\n---\nBody", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\ndescription: New\n---\nBody", encoding="utf-8")
     (refs_dir / "query.md").write_text("Use exact queries.", encoding="utf-8")
     repo = _MemorySkillRepo()
     original_relative_to = Path.relative_to
@@ -120,9 +120,37 @@ def test_import_file_skill_stores_adjacent_files_as_posix_paths(monkeypatch: pyt
 
     assert repo.saved[0].id == "new-skill"
     assert repo.packages[0].skill_id == "new-skill"
-    assert repo.packages[0].skill_md == "---\nname: New Skill\n---\nBody"
+    assert repo.packages[0].skill_md == "---\nname: New Skill\ndescription: New\n---\nBody"
     assert repo.packages[0].manifest["files"][0]["path"] == "references/query.md"
     assert repo.selected == [("owner-1", "new-skill", repo.packages[0].id)]
+
+
+def test_import_file_skill_does_not_store_local_skill_path(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    library_dir = tmp_path / "library"
+    skill_dir = library_dir / "skills" / "new-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\ndescription: Imported skill\n---\nBody", encoding="utf-8")
+    repo = _MemorySkillRepo()
+    monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+
+    import_file_skills_to_library.import_skills("owner-1", library_dir)
+
+    assert repo.saved[0].source == {"kind": "file_import"}
+    assert repo.packages[0].source == {"kind": "file_import"}
+
+
+def test_import_file_skill_requires_description_frontmatter(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    library_dir = tmp_path / "library"
+    skill_dir = library_dir / "skills" / "new-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\n---\nBody", encoding="utf-8")
+    repo = _MemorySkillRepo()
+    monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+
+    with pytest.raises(ValueError, match="SKILL.md frontmatter must include description"):
+        import_file_skills_to_library.import_skills("owner-1", library_dir)
+
+    assert repo.saved == []
 
 
 def test_import_file_skill_rejects_adjacent_file_path_collision(monkeypatch: pytest.MonkeyPatch, tmp_path):
@@ -130,7 +158,7 @@ def test_import_file_skill_rejects_adjacent_file_path_collision(monkeypatch: pyt
     skill_dir = library_dir / "skills" / "new-skill"
     refs_dir = skill_dir / "references"
     refs_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\n---\nBody", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\ndescription: New\n---\nBody", encoding="utf-8")
     (refs_dir / "a.md").write_text("Windows-shaped key.", encoding="utf-8")
     (refs_dir / "b.md").write_text("POSIX-shaped key.", encoding="utf-8")
     repo = _MemorySkillRepo()


### PR DESCRIPTION
## Summary
- stop file Skill import from persisting local host paths; imported Skills become database snapshots with package files
- require file Skill frontmatter description and explicit package version handling
- make Hub Skill downloads require explicit snapshot/item/version/slug/publisher fields
- read Library/Agent Skill description from SKILL.md frontmatter, not Hub snapshot meta/card text
- remove Skill apply dependency on snapshot meta shape and fix publish fixture typing

## Verification
- uv run pytest tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/platform/test_marketplace_client.py -q
- uv run pytest tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/platform/test_marketplace_client.py tests/Unit/core/test_skills_service.py tests/Unit/scripts/test_import_file_skills_to_library.py -q
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright backend/hub/client.py scripts/import_file_skills_to_library.py tests/Unit/platform/test_marketplace_client.py tests/Unit/scripts/test_import_file_skills_to_library.py
- uv run pytest tests/Unit -q