### PR TITLE
Refactor runtime Skill resolution boundary

### DIFF
--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -62,10 +62,10 @@ def _resolve_skill(owner_user_id: str, skill: Any, skill_repo: Any) -> ResolvedS
     resolved = ResolvedSkill(
         name=skill.name,
         description=skill.description,
-        version=package.version or skill.version,
+        version=package.version,
         content=package.skill_md,
         files=dict(package.files),
-        source=dict(package.source or skill.source),
+        source=dict(package.source),
     )
     return validate_resolved_skill_content(resolved)
 

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -1173,15 +1173,11 @@ class LeonAgent:
         resolved_skills = []
         resolved_config = getattr(self, "_resolved_agent_config", None)
         if resolved_config is not None:
-            resolved_skills = [
-                {"name": skill.name, "content": skill.content, "files": skill.files, "meta": skill.source}
-                for skill in resolved_config.skills
-            ]
+            resolved_skills = list(resolved_config.skills)
         if resolved_skills:
             self._skills_service = SkillsService(
                 registry=self._tool_registry,
                 skills=resolved_skills,
-                enabled_skills={skill["name"]: True for skill in resolved_skills},
             )
 
         # Task tools (DEFERRED - discoverable via tool_search)

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from typing import Any
 
 import yaml
 
-from config.skill_files import normalize_skill_file_map
+from config.agent_config_types import ResolvedSkill
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
 
 
@@ -14,30 +13,24 @@ class SkillsService:
     def __init__(
         self,
         registry: ToolRegistry,
-        skills: Sequence[dict[str, Any]] | None = None,
-        enabled_skills: dict[str, bool] | None = None,
+        skills: Sequence[ResolvedSkill] | None = None,
     ):
-        self.enabled_skills = enabled_skills or {}
         self._skills: dict[str, str] = {}
         self._skill_files: dict[str, dict[str, str]] = {}
-        self._load_skills(skills or [])
+        self._load_skills(skills if skills is not None else ())
         self._register(registry)
 
-    def _load_skills(self, skills: Sequence[dict[str, Any]]) -> None:
+    def _load_skills(self, skills: Sequence[ResolvedSkill]) -> None:
         for skill in skills:
-            content = skill.get("content")
-            if not isinstance(content, str):
-                raise ValueError("Skill content must be a string")
-            metadata = self._parse_frontmatter(content)
+            if not isinstance(skill, ResolvedSkill):
+                raise TypeError("SkillsService requires ResolvedSkill items")
+            metadata = self._parse_frontmatter(skill.content)
             if "name" not in metadata:
                 raise ValueError("Skill content must include frontmatter name")
-            skill_name = metadata["name"]
-            self._skills[skill_name] = content
-            files = skill.get("files")
-            if isinstance(files, dict):
-                self._skill_files[skill_name] = normalize_skill_file_map(files, context="Skill files")
-            elif files is not None:
-                raise ValueError("Skill files must be an object")
+            if metadata["name"] != skill.name:
+                raise ValueError("Skill frontmatter name must match ResolvedSkill.name")
+            self._skills[skill.name] = skill.content
+            self._skill_files[skill.name] = skill.files
 
     @staticmethod
     def _parse_frontmatter(content: str) -> dict[str, str]:
@@ -95,11 +88,8 @@ class SkillsService:
             available = ", ".join(sorted(self._skills))
             raise ValueError(f"Skill '{skill_name}' not found. Available skills: {available}")
 
-        if self.enabled_skills and skill_name in self.enabled_skills and not self.enabled_skills[skill_name]:
-            raise ValueError(f"Skill '{skill_name}' is disabled in profile configuration.")
-
         content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", self._skills[skill_name], flags=re.DOTALL)
-        return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._skill_files.get(skill_name, {}))}"
+        return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._skill_files[skill_name])}"
 
     @staticmethod
     def _append_adjacent_files(content: str, files: dict[str, str]) -> str:

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -283,6 +283,23 @@ def test_resolver_rejects_duplicate_enabled_skill_names():
     assert "Duplicate Skill name in AgentConfig: github" in str(excinfo.value)
 
 
+def test_resolver_uses_selected_package_source_not_agent_skill_source():
+    config = _config(
+        skills=[
+            AgentSkill(
+                skill_id="github",
+                package_id="github-package",
+                name="github",
+                source={"source_version": "agent-stale"},
+            )
+        ]
+    )
+
+    resolved = resolve_agent_config(config, skill_repo=_SkillRepo())
+
+    assert resolved.skills[0].source == {}
+
+
 def test_resolver_rejects_duplicate_enabled_mcp_server_names():
     config = _config(
         mcp_servers=[

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -1,4 +1,6 @@
 import inspect
+from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -48,7 +50,7 @@ class _SkillRepo:
                 hash="sha256:github",
                 skill_md=_skill_md("github"),
                 files={"references/query.md": "Prefer precise queries."},
-                created_at="2026-04-25T00:00:00+00:00",
+                created_at=datetime(2026, 4, 25, tzinfo=UTC),
             ),
             "disabled-package": SkillPackage(
                 id="disabled-package",
@@ -57,7 +59,7 @@ class _SkillRepo:
                 version="1.0.0",
                 hash="sha256:disabled",
                 skill_md=_skill_md("disabled"),
-                created_at="2026-04-25T00:00:00+00:00",
+                created_at=datetime(2026, 4, 25, tzinfo=UTC),
             ),
         }
 
@@ -135,7 +137,7 @@ def test_agent_named_children_reject_blank_names():
 
 def test_agent_config_rejects_blank_identity_fields():
     for field_name in ("id", "owner_user_id", "agent_user_id", "name"):
-        data = {
+        data: dict[str, Any] = {
             "id": "cfg-1",
             "owner_user_id": "owner-1",
             "agent_user_id": "agent-1",
@@ -164,7 +166,7 @@ def test_resolver_rejects_skill_without_frontmatter():
                         version="1.0.0",
                         hash="sha256:broken",
                         skill_md="# Missing",
-                        created_at="2026-04-25T00:00:00+00:00",
+                        created_at=datetime(2026, 4, 25, tzinfo=UTC),
                     )
                 }
             ),
@@ -196,7 +198,7 @@ def test_resolver_rejects_skill_frontmatter_without_name():
                         version="1.0.0",
                         hash="sha256:broken",
                         skill_md="---\ndescription: Missing canonical name.\n---\n\n# Broken\n",
-                        created_at="2026-04-25T00:00:00+00:00",
+                        created_at=datetime(2026, 4, 25, tzinfo=UTC),
                     )
                 }
             ),
@@ -228,7 +230,7 @@ def test_resolver_rejects_display_name_without_name():
                         version="1.0.0",
                         hash="sha256:broken",
                         skill_md="---\ndisplay_name: Pretty label only.\n---\n\n# Broken\n",
-                        created_at="2026-04-25T00:00:00+00:00",
+                        created_at=datetime(2026, 4, 25, tzinfo=UTC),
                     )
                 }
             ),
@@ -260,7 +262,7 @@ def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill
                         version="1.0.0",
                         hash="sha256:visible",
                         skill_md="---\nname: Runtime Skill\n---\n\n# Runtime Skill\n",
-                        created_at="2026-04-25T00:00:00+00:00",
+                        created_at=datetime(2026, 4, 25, tzinfo=UTC),
                     )
                 }
             ),

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -82,10 +82,13 @@ def test_skills_service_requires_resolved_skill_items() -> None:
         SkillsService(
             registry=registry,
             skills=[
-                {
-                    "name": "query-helper",
-                    "content": "---\nname: query-helper\n---\nUse exact terms.",
-                }
+                cast(
+                    Any,
+                    {
+                        "name": "query-helper",
+                        "content": "---\nname: query-helper\n---\nUse exact terms.",
+                    },
+                )
             ],
         )
 

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -3,8 +3,17 @@ from typing import cast
 
 import pytest
 
+from config.agent_config_types import ResolvedSkill
 from core.runtime.registry import ToolRegistry
 from core.tools.skills.service import SkillsService
+
+
+def _skill(
+    name: str = "query-helper",
+    content: str = "---\nname: query-helper\n---\nUse exact terms.",
+    files: dict[str, str] | None = None,
+) -> ResolvedSkill:
+    return ResolvedSkill(name=name, content=content, files=files or {})
 
 
 def test_skills_service_has_no_filesystem_skill_index() -> None:
@@ -13,6 +22,7 @@ def test_skills_service_has_no_filesystem_skill_index() -> None:
     assert "skill_paths" not in source
     assert "rglob" not in source
     assert "SKILL.md" not in source
+    assert "enabled_skills" not in source
 
 
 def test_skills_service_does_not_register_without_skills() -> None:
@@ -29,10 +39,7 @@ def test_skill_frontmatter_uses_yaml_parser() -> None:
     SkillsService(
         registry=registry,
         skills=[
-            {
-                "name": "query-helper",
-                "content": '---\nname: "query-helper"\n---\nUse exact terms.',
-            }
+            _skill(content='---\nname: "query-helper"\n---\nUse exact terms.'),
         ],
     )
 
@@ -46,10 +53,7 @@ def test_load_missing_skill_fails_loudly() -> None:
     SkillsService(
         registry=registry,
         skills=[
-            {
-                "name": "query-helper",
-                "content": "---\nname: query-helper\n---\nUse exact terms.",
-            }
+            _skill(),
         ],
     )
 
@@ -66,41 +70,34 @@ def test_skill_without_frontmatter_name_fails_loudly() -> None:
         SkillsService(
             registry=registry,
             skills=[
-                {
-                    "name": "query-helper",
-                    "content": "Use exact terms.",
-                }
+                _skill(content="Use exact terms."),
             ],
         )
 
 
-def test_skill_without_string_content_fails_loudly() -> None:
+def test_skills_service_requires_resolved_skill_items() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(ValueError, match="Skill content must be a string"):
-        SkillsService(
-            registry=registry,
-            skills=[
-                {
-                    "name": "query-helper",
-                    "content": None,
-                }
-            ],
-        )
-
-
-def test_skill_files_must_be_an_object() -> None:
-    registry = ToolRegistry()
-
-    with pytest.raises(ValueError, match="Skill files must be an object"):
+    with pytest.raises(TypeError, match="SkillsService requires ResolvedSkill items"):
         SkillsService(
             registry=registry,
             skills=[
                 {
                     "name": "query-helper",
                     "content": "---\nname: query-helper\n---\nUse exact terms.",
-                    "files": ["references/query.md"],
                 }
+            ],
+        )
+
+
+def test_skill_frontmatter_name_must_match_resolved_skill_name() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(ValueError, match="Skill frontmatter name must match ResolvedSkill.name"):
+        SkillsService(
+            registry=registry,
+            skills=[
+                _skill(name="query-helper", content="---\nname: other-helper\n---\nUse exact terms."),
             ],
         )
 
@@ -110,11 +107,7 @@ def test_load_skill_returns_adjacent_files() -> None:
     SkillsService(
         registry=registry,
         skills=[
-            {
-                "name": "query-helper",
-                "content": "---\nname: query-helper\n---\nUse exact terms.",
-                "files": {"references/query.md": "Prefer precise queries."},
-            }
+            _skill(files={"references/query.md": "Prefer precise queries."}),
         ],
     )
 
@@ -134,11 +127,7 @@ def test_load_skill_normalizes_adjacent_file_paths() -> None:
     SkillsService(
         registry=registry,
         skills=[
-            {
-                "name": "query-helper",
-                "content": "---\nname: query-helper\n---\nUse exact terms.",
-                "files": {"references\\query.md": "Prefer precise queries."},
-            }
+            _skill(files={"references\\query.md": "Prefer precise queries."}),
         ],
     )
 
@@ -158,13 +147,11 @@ def test_skill_rejects_adjacent_file_path_collision() -> None:
         SkillsService(
             registry=registry,
             skills=[
-                {
-                    "name": "query-helper",
-                    "content": "---\nname: query-helper\n---\nUse exact terms.",
-                    "files": {
+                _skill(
+                    files={
                         "references\\query.md": "Windows-shaped key.",
                         "references/query.md": "POSIX-shaped key.",
                     },
-                }
+                )
             ],
         )

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, SystemMessage, ToolMessage
 
-from config.agent_config_types import AgentConfig, AgentSkill, McpServerConfig, SkillPackage
+from config.agent_config_types import AgentConfig, AgentSkill, McpServerConfig, ResolvedSkill, SkillPackage
 
 
 def _mock_model(text="Integration test response"):
@@ -771,6 +771,56 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
             "--- references/routing.md ---\n"
             "Prefer APIRouter over app-level route decorators."
         )
+
+        agent.close()
+
+
+@pytest.mark.asyncio
+@_patch_env_api_key()
+async def test_leon_agent_passes_resolved_skill_models_to_runtime_service(tmp_path):
+    from core.runtime.agent import LeonAgent
+
+    captured: list[ResolvedSkill] = []
+
+    class _Repo:
+        def get_agent_config(self, agent_config_id: str):
+            assert agent_config_id == "cfg-1"
+            return _agent_config(
+                name="Repo Toad",
+                system_prompt="You are Repo Toad.",
+                skills=[
+                    AgentSkill(
+                        skill_id="fastapi",
+                        package_id="fastapi-package",
+                        name="FastAPI",
+                    )
+                ],
+            )
+
+    class _CapturingSkillsService:
+        def __init__(self, *, registry, skills):
+            captured.extend(skills)
+
+    mock_model = _mock_model("Repo skill response")
+
+    with (
+        patch("core.runtime.agent.LeonAgent._create_model", return_value=mock_model),
+        patch("core.runtime.agent.LeonAgent._init_async_components", return_value=(None, [])),
+        patch("core.runtime.agent.LeonAgent._init_checkpointer", new_callable=AsyncMock, return_value=None),
+        patch("core.runtime.agent.LeonAgent._init_mcp_tools", new_callable=AsyncMock, return_value=[]),
+        patch("core.runtime.agent.SkillsService", _CapturingSkillsService),
+    ):
+        agent = LeonAgent(
+            workspace_root=str(tmp_path),
+            agent_config_id="cfg-1",
+            agent_config_repo=_Repo(),
+            skill_repo=_SkillRepo(),
+            api_key="sk-test-integration",
+        )
+        await agent.ainit()
+
+        assert [skill.name for skill in captured] == ["FastAPI"]
+        assert all(isinstance(skill, ResolvedSkill) for skill in captured)
 
         agent.close()
 


### PR DESCRIPTION
## Summary
- make SkillsService consume ResolvedSkill models directly instead of ad-hoc dict envelopes
- remove the secondary enabled_skills map from runtime Skill loading
- pass resolved_config.skills directly from LeonAgent into the runtime Skill service
- use selected SkillPackage version/source as the resolved runtime Skill truth
- type the touched resolver/service fixtures so pyright can check these boundary files

## Verification
- uv run pytest tests/Unit/core/test_skills_service.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/integration_contracts/test_leon_agent.py -q
- uv run pytest tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/platform/test_marketplace_client.py tests/Unit/core/test_skills_service.py tests/Unit/scripts/test_import_file_skills_to_library.py -q
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright core/tools/skills/service.py core/runtime/agent.py config/agent_config_resolver.py tests/Unit/core/test_skills_service.py tests/Unit/config/test_agent_config_resolver.py
- uv run pytest tests/Unit -q