### PR TITLE
Refactor Hub snapshot Skill source boundary

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -51,14 +51,11 @@ def _materialize_snapshot_skills(
             if library_skill.name == snapshot_skill.name and library_skill.id != skill_id:
                 raise ValueError("Snapshot Skill name already exists under a different Library id")
 
-        source = dict(snapshot_skill.source)
-        source.update(
-            {
-                "marketplace_item_id": marketplace_item_id,
-                "source_version": source_version,
-                "source_at": source_at,
-            }
-        )
+        source = {
+            "marketplace_item_id": marketplace_item_id,
+            "source_version": source_version,
+            "source_at": source_at,
+        }
         # @@@snapshot-skill-materialization - AgentConfig stores package bindings; Hub snapshots carry resolved Skill content.
         skill = skill_repo.upsert(
             Skill(

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -18,6 +18,12 @@ def _skill_id_from_name(name: str) -> str:
     return skill_id
 
 
+def _required_text(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a string")
+    return value.strip()
+
+
 def _materialize_snapshot_skills(
     *,
     skills: list[ResolvedSkill],
@@ -114,6 +120,8 @@ def apply_snapshot(
     if user_repo is None or agent_config_repo is None:
         raise RuntimeError("user_repo and agent_config_repo are required to apply marketplace user snapshot")
 
+    marketplace_item_id = _required_text(marketplace_item_id, label="marketplace_item_id")
+    source_version = _required_text(source_version, label="source_version")
     parsed = AgentSnapshot.model_validate(snapshot)
     resolved = parsed.agent
     now = time.time()

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1733,7 +1733,9 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
         "source_at": saved_configs[0].skills[0].source["source_at"],
     }
     assert saved_configs[0].skills[0].source == package.source
-    assert skill_repo.get_by_id("user-1", "search").source == package.source
+    library_skill = skill_repo.get_by_id("user-1", "search")
+    assert library_skill is not None
+    assert library_skill.source == package.source
     assert saved_configs[0].rules[0].content == "rule body"
     assert saved_configs[0].sub_agents[0].name == "Scout"
     assert saved_configs[0].meta["source"]["source_version"] == "1.0.0"

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1759,6 +1759,38 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("marketplace_item_id", " ", "marketplace_item_id must be a string"),
+        ("source_version", " ", "source_version must be a string"),
+    ],
+)
+def test_apply_snapshot_requires_source_identity(field: str, value: str, message: str):
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    kwargs = {
+        "snapshot": {
+            "schema_version": "agent-snapshot/v1",
+            "agent": {
+                "id": "cfg-source",
+                "name": "Repo Agent",
+                "skills": [{"name": "Search", "content": "---\nname: Search\n---\nbody"}],
+            },
+        },
+        "marketplace_item_id": "item-1",
+        "source_version": "1.0.0",
+        "owner_user_id": "user-1",
+        "user_repo": SimpleNamespace(create=lambda _row: None),
+        "agent_config_repo": SimpleNamespace(save_agent_config=lambda _config: None),
+        "skill_repo": _MemorySkillRepo(),
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        apply_snapshot(**kwargs)
+
+
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -1763,10 +1764,12 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
     ("field", "value", "message"),
     [
         ("marketplace_item_id", " ", "marketplace_item_id must be a string"),
+        ("marketplace_item_id", {"id": "item-1"}, "marketplace_item_id must be a string"),
         ("source_version", " ", "source_version must be a string"),
+        ("source_version", ["1.0.0"], "source_version must be a string"),
     ],
 )
-def test_apply_snapshot_requires_source_identity(field: str, value: str, message: str):
+def test_apply_snapshot_requires_source_identity(field: str, value: object, message: str):
     from backend.hub.snapshot_apply import apply_snapshot
 
     kwargs = {
@@ -1788,7 +1791,7 @@ def test_apply_snapshot_requires_source_identity(field: str, value: str, message
     kwargs[field] = value
 
     with pytest.raises(ValueError, match=message):
-        apply_snapshot(**kwargs)
+        apply_snapshot(**cast(Any, kwargs))
 
 
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1697,7 +1697,14 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
                 "model": "leon:large",
                 "tools": ["Read"],
                 "system_prompt": "main prompt",
-                "skills": [{"name": "Search", "content": "---\nname: Search\n---\nbody", "description": "skill desc"}],
+                "skills": [
+                    {
+                        "name": "Search",
+                        "content": "---\nname: Search\n---\nbody",
+                        "description": "skill desc",
+                        "source": {"source_version": "snapshot-stale", "extra": "drop"},
+                    }
+                ],
                 "rules": [{"name": "Rule_Unsafe", "content": "rule body"}],
                 "sub_agents": [{"name": "Scout", "description": "scout desc", "tools": ["Read"], "system_prompt": "scout prompt"}],
             },
@@ -1719,6 +1726,13 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
     package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id or "")
     assert package is not None
     assert package.skill_md == "---\nname: Search\n---\nbody"
+    assert package.source == {
+        "marketplace_item_id": "item-1",
+        "source_version": "1.0.0",
+        "source_at": saved_configs[0].skills[0].source["source_at"],
+    }
+    assert saved_configs[0].skills[0].source == package.source
+    assert skill_repo.get_by_id("user-1", "search").source == package.source
     assert saved_configs[0].rules[0].content == "rule body"
     assert saved_configs[0].sub_agents[0].name == "Scout"
     assert saved_configs[0].meta["source"]["source_version"] == "1.0.0"


### PR DESCRIPTION
## Summary
- materialize Hub snapshot Skill source from the install identity only
- require non-empty Hub source identity before snapshot apply writes rows
- pin Library Skill, Skill package, and Agent Skill binding source to the same materialized object

## Verification
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_apply_snapshot_saves_one_agent_config_aggregate tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_apply_snapshot_requires_source_identity -q
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/platform/test_marketplace_client.py -q
- uv run pyright backend/hub/snapshot_apply.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/Unit -q