### PR TITLE
Refactor resolved Skill version boundary

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -80,7 +80,7 @@ def _materialize_snapshot_skills(
                 id=package_hash.removeprefix("sha256:"),
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
-                version=snapshot_skill.version or source_version,
+                version=snapshot_skill.version,
                 hash=package_hash,
                 manifest=build_skill_package_manifest(snapshot_skill.content, snapshot_skill.files),
                 skill_md=snapshot_skill.content,

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -11,7 +11,7 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> ResolvedAgentConfig:
-    enabled_skills = []
+    resolved_skills = []
     seen_skill_names: set[str] = set()
     for skill in config.skills:
         if not skill.enabled:
@@ -19,7 +19,7 @@ def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> Reso
         if skill.name in seen_skill_names:
             raise ValueError(f"Duplicate Skill name in AgentConfig: {skill.name}")
         seen_skill_names.add(skill.name)
-        enabled_skills.append(_resolve_skill(config.owner_user_id, skill, skill_repo))
+        resolved_skills.append(_resolve_skill(config.owner_user_id, skill, skill_repo))
     enabled_mcp_servers = []
     seen_mcp_server_names: set[str] = set()
     for server in config.mcp_servers:
@@ -38,7 +38,7 @@ def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> Reso
         system_prompt=config.system_prompt,
         runtime_settings=dict(config.runtime_settings),
         compact=dict(config.compact),
-        skills=enabled_skills,
+        skills=resolved_skills,
         rules=[rule for rule in config.rules if rule.enabled],
         sub_agents=[agent for agent in config.sub_agents if agent.enabled],
         mcp_servers=enabled_mcp_servers,

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -92,7 +92,7 @@ class ResolvedSkill(AgentConfigSchemaModel):
     files: dict[str, str] = Field(default_factory=dict)
     source: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("name", "content")
+    @field_validator("name", "version", "content")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -113,6 +113,13 @@ def test_resolved_config_contains_only_enabled_children():
     assert [server.name for server in resolved.mcp_servers] == ["filesystem"]
 
 
+def test_resolver_names_skill_working_set_as_resolved_skills() -> None:
+    source = inspect.getsource(resolve_agent_config)
+
+    assert "enabled_skills" not in source
+    assert "resolved_skills" in source
+
+
 def test_resolver_rejects_skill_without_package_id():
     config = _config(skills=[AgentSkill(skill_id="broken", name="broken")])
 

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -28,6 +28,15 @@ def test_resolved_skill_model_rejects_duplicate_file_paths_after_normalization()
         ResolvedSkill(name="query-helper", **common)
 
 
+def test_resolved_skill_model_rejects_blank_version() -> None:
+    with pytest.raises(ValueError, match="resolved_skill.version must not be blank"):
+        ResolvedSkill(
+            name="query-helper",
+            version=" ",
+            content="---\nname: query-helper\n---\nUse exact terms.",
+        )
+
+
 def test_agent_skill_model_has_no_resolved_content() -> None:
     agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper")
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1796,6 +1796,16 @@ def test_apply_snapshot_requires_source_identity(field: str, value: object, mess
         apply_snapshot(**cast(Any, kwargs))
 
 
+def test_apply_snapshot_does_not_fill_package_version_from_source_version() -> None:
+    import inspect
+
+    from backend.hub.snapshot_apply import _materialize_snapshot_skills
+
+    source = inspect.getsource(_materialize_snapshot_skills)
+
+    assert "or source_version" not in source
+
+
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 


### PR DESCRIPTION
## Summary
- require resolved Skill versions to be non-blank
- keep Hub snapshot package version on resolved Skill content instead of source identity
- rename resolver working set to resolved Skills and add source guards for both boundary cuts

## Verification
- uv run pytest tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_apply_snapshot_does_not_fill_package_version_from_source_version tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_apply_snapshot_saves_one_agent_config_aggregate -q
- uv run pyright config/agent_config_types.py config/agent_config_resolver.py backend/hub/snapshot_apply.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_agent_config_resolver.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/Unit -q