### PR TITLE
Add frontend group join request entry

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -168,6 +168,18 @@ def get_chat(
     return messaging_service.get_chat_detail(chat)
 
 
+@router.get("/{chat_id}/join-target")
+def get_chat_join_target(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_join_request_service: Annotated[Any, Depends(get_chat_join_request_service)],
+):
+    try:
+        return chat_join_request_service.join_target(chat_id, user_id)
+    except Exception as exc:
+        raise _map_chat_join_error(exc) from exc
+
+
 @router.get("/{chat_id}/messages")
 def list_messages(
     chat_id: str,

--- a/frontend/app/src/api/types.ts
+++ b/frontend/app/src/api/types.ts
@@ -365,12 +365,24 @@ export interface ChatJoinRequest {
   id: string;
   chat_id: string;
   requester_user_id: string;
+  requester_name?: string | null;
+  requester_type?: string | null;
   state: "pending" | "approved" | "rejected";
   message?: string | null;
   decided_by_user_id?: string | null;
   decided_at?: number | null;
   created_at: number;
   updated_at: number;
+}
+
+export interface ChatJoinTarget {
+  id: string;
+  type: "group";
+  title: string | null;
+  status: string;
+  created_by_user_id: string;
+  is_member: boolean;
+  current_request: ChatJoinRequest | null;
 }
 
 export interface ChatMessage {

--- a/frontend/app/src/pages/ChatConversationPage.test.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.test.tsx
@@ -193,6 +193,8 @@ describe("ChatConversationPage SSE teardown", () => {
               id: "request-1",
               chat_id: "chat-1",
               requester_user_id: "visitor-1",
+              requester_name: "Visitor",
+              requester_type: "external",
               state: "pending",
               message: "Please add me.",
               created_at: 1,
@@ -227,10 +229,10 @@ describe("ChatConversationPage SSE teardown", () => {
     );
 
     expect(await screen.findByText("入群申请")).toBeTruthy();
-    expect(screen.getByText("visitor-1")).toBeTruthy();
+    expect(screen.getByText("Visitor")).toBeTruthy();
     expect(screen.getByText("Please add me.")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "同意 visitor-1 入群" }));
+    fireEvent.click(screen.getByRole("button", { name: "同意 Visitor 入群" }));
 
     await waitFor(() => {
       expect(authFetchMocks.authFetch).toHaveBeenCalledWith(
@@ -326,5 +328,74 @@ describe("ChatConversationPage SSE teardown", () => {
       expect(screen.getByText("direct room")).toBeTruthy();
     });
     expect(screen.queryByText("入群申请")).toBeNull();
+  });
+
+  it("shows a join request card when the current user is not a group member", async () => {
+    authFetchMocks.authFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/chats/chat-1") {
+        return {
+          ok: false,
+          status: 403,
+          text: async () => "Not a participant of this chat",
+        };
+      }
+      if (url === "/api/chats/chat-1/join-target") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "chat-1",
+            type: "group",
+            title: "public group",
+            status: "active",
+            created_by_user_id: "owner-1",
+            is_member: false,
+            current_request: null,
+          }),
+        };
+      }
+      if (url === "/api/chats/chat-1/join-requests" && init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "request-1",
+            chat_id: "chat-1",
+            requester_user_id: "user-1",
+            requester_name: "tester",
+            requester_type: "human",
+            state: "pending",
+            message: "Please let me in.",
+            created_at: 1,
+            updated_at: 1,
+          }),
+        };
+      }
+      if (url.includes("/messages") || url.endsWith("/read") || url.endsWith("/events")) {
+        throw new Error("non-members should not load member-only chat surfaces");
+      }
+      throw new Error(`Unexpected authFetch url: ${url}`);
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/chat/visit/chat-1"]}>
+        <Routes>
+          <Route path="/chat/visit/:chatId" element={<ChatConversationPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("public group")).toBeTruthy();
+    expect(screen.getByText("申请加入群聊")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("写一句申请理由..."), { target: { value: "Please let me in." } });
+    fireEvent.click(screen.getByRole("button", { name: "发送申请" }));
+
+    await waitFor(() => {
+      expect(authFetchMocks.authFetch).toHaveBeenCalledWith(
+        "/api/chats/chat-1/join-requests",
+        { method: "POST", body: JSON.stringify({ message: "Please let me in." }) },
+      );
+    });
+    expect(await screen.findByText("申请已发送")).toBeTruthy();
+    expect(authFetchMocks.streamChatEvents).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router-dom";
-import { Check, PanelLeft, Send, X } from "lucide-react";
+import { Check, PanelLeft, Send, UserPlus, X } from "lucide-react";
 import { authFetch, useAuthStore } from "../store/auth-store";
 import { parseChatMessageEventData, parseChatTypingUserId, streamChatEvents } from "../api/chat-events";
 import { UserBubble } from "../components/chat-area/UserBubble";
 import { ChatBubble } from "../components/chat-area/ChatBubble";
-import type { ChatMember, ChatMessage, ChatDetail, ChatJoinRequest } from "../api/types";
+import type { ChatMember, ChatMessage, ChatDetail, ChatJoinRequest, ChatJoinTarget } from "../api/types";
 
 // @@@time-gap — only show timestamp when gap >= 5 minutes
 function shouldShowTime(prev: ChatMessage | null, curr: ChatMessage): boolean {
@@ -45,11 +45,15 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
   const myUserId = useAuthStore(s => s.userId);
   const myName = useAuthStore(s => s.user?.name) || "You";
   const [chat, setChat] = useState<ChatDetail | null>(null);
+  const [joinTarget, setJoinTarget] = useState<ChatJoinTarget | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
+  const [joinMessage, setJoinMessage] = useState("");
+  const [joinSubmitting, setJoinSubmitting] = useState(false);
+  const [joinSubmitError, setJoinSubmitError] = useState<string | null>(null);
   const [joinRequests, setJoinRequests] = useState<ChatJoinRequest[]>([]);
   const [joinRequestError, setJoinRequestError] = useState<string | null>(null);
   const [joinRequestBusyId, setJoinRequestBusyId] = useState<string | null>(null);
@@ -104,27 +108,47 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setJoinSubmitError(null);
 
-    Promise.all([
-      authFetch(`/api/chats/${chatId}`).then(r => {
-        if (!r.ok) throw new Error(`Chat not found (${r.status})`);
-        return r.json();
-      }),
-      authFetch(`/api/chats/${chatId}/messages?limit=100`).then(r => {
-        if (!r.ok) throw new Error(`Messages load failed (${r.status})`);
-        return r.json();
-      }),
-    ])
-      .then(([chatData, msgsData]) => {
+    async function load() {
+      const chatRes = await authFetch(`/api/chats/${chatId}`);
+      if (chatRes.status === 403) {
+        const targetRes = await authFetch(`/api/chats/${chatId}/join-target`);
+        if (!targetRes.ok) {
+          const body = await targetRes.text();
+          throw new Error(body || `Join target load failed (${targetRes.status})`);
+        }
+        const targetData: ChatJoinTarget = await targetRes.json();
         if (cancelled) return;
+        if (targetData.is_member) {
+          setError("当前会话状态已变化，请刷新页面");
+          setLoading(false);
+          return;
+        }
+        setChat(null);
+        setMessages([]);
+        setJoinTarget(targetData);
+        setLoading(false);
+        return;
+      }
+      if (!chatRes.ok) throw new Error(`Chat not found (${chatRes.status})`);
+      const chatData: ChatDetail = await chatRes.json();
+      const msgsRes = await authFetch(`/api/chats/${chatId}/messages?limit=100`);
+      if (!msgsRes.ok) throw new Error(`Messages load failed (${msgsRes.status})`);
+      const msgsData: ChatMessage[] = await msgsRes.json();
+      if (!cancelled) {
         setChat(chatData);
+        setJoinTarget(null);
         setMessages(msgsData);
         setLoading(false);
         // Mark read + refresh sidebar
         authFetch(`/api/chats/${chatId}/read`, { method: "POST" })
           .then(() => refreshChatList())
           .catch(err => console.warn("[mark_read] failed:", err));
-      })
+      }
+    }
+
+    load()
       .catch(err => {
         if (cancelled) return;
         setError(err.message);
@@ -143,6 +167,7 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
 
   // SSE for real-time messages
   useEffect(() => {
+    if (!chat) return;
     const ac = new AbortController();
     // @@@pagehide-abort — browser-level navigation can destroy the page before React unmount finishes
     const handlePageHide = () => ac.abort();
@@ -200,7 +225,7 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
       ac.abort();
       refreshChatList(); // refresh sidebar on leave
     };
-  }, [chatId, scrollToBottom, refreshChatList]);
+  }, [chat, chatId, scrollToBottom, refreshChatList]);
 
   // Send message
   const handleSend = useCallback(async () => {
@@ -290,6 +315,30 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
     }
   }, [chatId, refreshChatList]);
 
+  const submitJoinRequest = useCallback(async () => {
+    if (!joinTarget || joinSubmitting || joinTarget.current_request?.state === "pending") return;
+    setJoinSubmitting(true);
+    setJoinSubmitError(null);
+    try {
+      const message = joinMessage.trim();
+      const res = await authFetch(`/api/chats/${chatId}/join-requests`, {
+        method: "POST",
+        body: JSON.stringify({ message: message || null }),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(body || `Join request failed (${res.status})`);
+      }
+      const current_request: ChatJoinRequest = await res.json();
+      setJoinTarget({ ...joinTarget, current_request });
+      setJoinMessage("");
+    } catch (err) {
+      setJoinSubmitError(err instanceof Error ? err.message : "Join request failed");
+    } finally {
+      setJoinSubmitting(false);
+    }
+  }, [chatId, joinMessage, joinSubmitting, joinTarget]);
+
   // Typing indicator display — works for both 1:1 and group
   const typingNames = [...typingUsers]
     .map(id => memberMap.get(id)?.name)
@@ -310,6 +359,8 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
   // Display name for header
   const chatName = chat
     ? chat.title || chat.members.filter(member => member.id !== myUserId).map(member => member.name).join(", ") || "聊天"
+    : joinTarget
+      ? joinTarget.title || "群聊"
     : "聊天";
 
   if (loading) {
@@ -325,6 +376,75 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
       <div className="h-full flex flex-col items-center justify-center gap-2">
         <p className="text-sm text-destructive">{error}</p>
         <Link to="/chat" className="text-xs text-primary hover:underline">返回对话列表</Link>
+      </div>
+    );
+  }
+
+  if (joinTarget) {
+    const pendingRequest = joinTarget.current_request?.state === "pending" ? joinTarget.current_request : null;
+    return (
+      <div className="h-full flex flex-col min-h-0">
+        <header className="h-12 flex items-center justify-between px-4 flex-shrink-0 bg-card border-b border-border">
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              onClick={() => setSidebarCollapsed(v => !v)}
+              className="w-8 h-8 rounded-lg flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <PanelLeft className="w-4 h-4" />
+            </button>
+            <span className="text-sm font-medium text-foreground truncate max-w-[200px]">
+              {chatName}
+            </span>
+            <span className="text-2xs px-1.5 py-0.5 rounded-md font-medium border border-border text-muted-foreground bg-muted">
+              等待入群
+            </span>
+          </div>
+        </header>
+        <div className="flex-1 overflow-y-auto bg-background px-5 py-8">
+          <div className="mx-auto max-w-md rounded-lg border border-border bg-card p-4">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+                <UserPlus className="h-4 w-4" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-semibold text-foreground">申请加入群聊</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  群主批准后，你就能读取新消息并参与对话。
+                </p>
+              </div>
+            </div>
+            {pendingRequest ? (
+              <div className="mt-4 rounded-md border border-border bg-muted/40 px-3 py-2">
+                <p className="text-xs font-medium text-foreground">申请已发送</p>
+                {pendingRequest.message && (
+                  <p className="mt-1 text-xs text-muted-foreground">{pendingRequest.message}</p>
+                )}
+              </div>
+            ) : (
+              <div className="mt-4 space-y-3">
+                <textarea
+                  value={joinMessage}
+                  onChange={e => setJoinMessage(e.target.value)}
+                  placeholder="写一句申请理由..."
+                  rows={3}
+                  className="w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/10"
+                />
+                {joinSubmitError && (
+                  <p className="text-xs text-destructive">{joinSubmitError}</p>
+                )}
+                <button
+                  type="button"
+                  onClick={() => void submitJoinRequest()}
+                  disabled={joinSubmitting}
+                  className="inline-flex h-9 items-center gap-2 rounded-lg bg-foreground px-3 text-sm font-medium text-background hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Send className="h-4 w-4" />
+                  {joinSubmitting ? "发送中..." : "发送申请"}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     );
   }
@@ -365,41 +485,44 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
             {joinRequestError && (
               <p className="text-2xs text-destructive">{joinRequestError}</p>
             )}
-            {pendingJoinRequests.map(request => (
-              <div
-                key={request.id}
-                className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-xs font-medium text-foreground">{request.requester_user_id}</p>
-                  {request.message && (
-                    <p className="mt-0.5 truncate text-2xs text-muted-foreground">{request.message}</p>
-                  )}
+            {pendingJoinRequests.map(request => {
+              const requesterLabel = request.requester_name || request.requester_user_id;
+              return (
+                <div
+                  key={request.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-medium text-foreground">{requesterLabel}</p>
+                    {request.message && (
+                      <p className="mt-0.5 truncate text-2xs text-muted-foreground">{request.message}</p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    <button
+                      type="button"
+                      aria-label={`同意 ${requesterLabel} 入群`}
+                      disabled={joinRequestBusyId === request.id}
+                      onClick={() => void decideJoinRequest(request.id, "approve")}
+                      className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-2xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                      同意
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`拒绝 ${requesterLabel} 入群`}
+                      disabled={joinRequestBusyId === request.id}
+                      onClick={() => void decideJoinRequest(request.id, "reject")}
+                      className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-2xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                      拒绝
+                    </button>
+                  </div>
                 </div>
-                <div className="flex shrink-0 items-center gap-1.5">
-                  <button
-                    type="button"
-                    aria-label={`同意 ${request.requester_user_id} 入群`}
-                    disabled={joinRequestBusyId === request.id}
-                    onClick={() => void decideJoinRequest(request.id, "approve")}
-                    className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-2xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
-                  >
-                    <Check className="h-3.5 w-3.5" />
-                    同意
-                  </button>
-                  <button
-                    type="button"
-                    aria-label={`拒绝 ${request.requester_user_id} 入群`}
-                    disabled={joinRequestBusyId === request.id}
-                    onClick={() => void decideJoinRequest(request.id, "reject")}
-                    className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-2xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                    拒绝
-                  </button>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </section>
       )}

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -30,11 +30,27 @@ class ChatJoinRequestService:
             message_type="notification",
             mentions=[owner_id],
         )
-        return row
+        return self._project_request(row)
+
+    def join_target(self, chat_id: str, viewer_user_id: str) -> dict[str, Any]:
+        chat = self._require_joinable_chat(chat_id)
+        current_request = next(
+            (self._project_request(row) for row in self._requests.list_for_chat(chat_id) if row.get("requester_user_id") == viewer_user_id),
+            None,
+        )
+        return {
+            "id": chat.id,
+            "type": chat.type,
+            "title": chat.title,
+            "status": chat.status,
+            "created_by_user_id": chat.created_by_user_id,
+            "is_member": self._members.is_member(chat_id, viewer_user_id),
+            "current_request": current_request,
+        }
 
     def list_for_chat(self, chat_id: str, viewer_user_id: str) -> list[dict[str, Any]]:
         self._require_chat_owner(chat_id, viewer_user_id)
-        return self._requests.list_for_chat(chat_id)
+        return [self._project_request(row) for row in self._requests.list_for_chat(chat_id)]
 
     def approve(self, chat_id: str, request_id: str, approver_user_id: str) -> dict[str, Any]:
         self._require_chat_owner(chat_id, approver_user_id)
@@ -49,7 +65,7 @@ class ChatJoinRequestService:
             message_type="notification",
             mentions=[requester_user_id],
         )
-        return row
+        return self._project_request(row)
 
     def reject(self, chat_id: str, request_id: str, rejecter_user_id: str) -> dict[str, Any]:
         self._require_chat_owner(chat_id, rejecter_user_id)
@@ -62,7 +78,7 @@ class ChatJoinRequestService:
             f"Rejected chat join request for {requester_user_id}.",
             message_type="notification",
         )
-        return row
+        return self._project_request(row)
 
     def _require_joinable_chat(self, chat_id: str) -> Any:
         chat = self._chats.get_by_id(chat_id)
@@ -92,3 +108,13 @@ class ChatJoinRequestService:
         if message and message.strip():
             return f"{requester_user_id} requested to join this chat: {message.strip()}"
         return f"{requester_user_id} requested to join this chat."
+
+    def _project_request(self, row: dict[str, Any]) -> dict[str, Any]:
+        projected = dict(row)
+        requester_user_id = str(projected.get("requester_user_id") or "")
+        requester = self._messaging.resolve_display_user(requester_user_id) if requester_user_id else None
+        if requester is not None:
+            projected["requester_name"] = requester.display_name
+            requester_type = getattr(requester, "type", None)
+            projected["requester_type"] = requester_type.value if hasattr(requester_type, "value") else str(requester_type)
+        return projected

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -351,6 +351,7 @@ class MessagingService:
     def get_chat_detail(self, chat: Any) -> dict[str, Any]:
         return {
             "id": chat.id,
+            "type": chat.type,
             "title": chat.title,
             "status": chat.status,
             "created_by_user_id": chat.created_by_user_id,

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -17,6 +17,7 @@ def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> N
     assert "/api/chats" in paths
     assert "/api/chats/{chat_id}/messages/unread" in paths
     assert "/api/chats/{chat_id}/join-requests" in paths
+    assert "/api/chats/{chat_id}/join-target" in paths
     assert "/api/chats/{chat_id}/join-requests/{request_id}/approve" in paths
     assert "/api/relationships" in paths
     assert "/api/conversations" in paths

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -17,6 +17,7 @@ from storage.contracts import ContactEdgeRow
 def _chat(chat_id: str) -> SimpleNamespace:
     return SimpleNamespace(
         id=chat_id,
+        type="group",
         title="Chat title",
         status="active",
         created_at="2026-04-07T00:00:00Z",
@@ -173,6 +174,29 @@ def test_request_chat_join_uses_current_token_user() -> None:
     assert result == expected
 
 
+def test_get_chat_join_target_uses_current_token_user() -> None:
+    seen: list[tuple[str, str]] = []
+    expected = {
+        "id": "chat-1",
+        "type": "group",
+        "title": "Group",
+        "status": "active",
+        "created_by_user_id": "owner-1",
+        "is_member": False,
+        "current_request": None,
+    }
+    chat_join_request_service = SimpleNamespace(join_target=lambda chat_id, user_id: seen.append((chat_id, user_id)) or expected)
+
+    result = chats_router.get_chat_join_target(
+        "chat-1",
+        user_id="human-user-2",
+        chat_join_request_service=chat_join_request_service,
+    )
+
+    assert seen == [("chat-1", "human-user-2")]
+    assert result == expected
+
+
 def test_approve_chat_join_uses_current_token_user() -> None:
     seen: list[tuple[str, str, str]] = []
     expected = {
@@ -266,6 +290,7 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
                 messaging_service=SimpleNamespace(
                     get_chat_detail=lambda chat_obj: {
                         "id": chat_obj.id,
+                        "type": chat_obj.type,
                         "title": chat_obj.title,
                         "status": chat_obj.status,
                         "created_at": chat_obj.created_at,
@@ -289,6 +314,7 @@ def test_get_chat_uses_access_helper(monkeypatch: pytest.MonkeyPatch):
 
     assert result == {
         "id": "chat-1",
+        "type": "group",
         "title": "Chat title",
         "status": "active",
         "created_at": "2026-04-07T00:00:00Z",

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -1068,6 +1068,7 @@ def test_messaging_service_chat_detail_fails_on_unknown_member_identity() -> Non
 
     chat = SimpleNamespace(
         id="chat-1",
+        type="group",
         title=None,
         status="active",
         created_by_user_id="human-user-1",
@@ -1719,6 +1720,7 @@ def test_messaging_service_get_chat_detail_exposes_agent_user_participant_id() -
     detail = service.get_chat_detail(
         SimpleNamespace(
             id="chat-1",
+            type="group",
             title="Chat title",
             status="active",
             created_by_user_id="human-user-1",
@@ -1728,6 +1730,7 @@ def test_messaging_service_get_chat_detail_exposes_agent_user_participant_id() -
 
     assert detail == {
         "id": "chat-1",
+        "type": "group",
         "title": "Chat title",
         "status": "active",
         "created_by_user_id": "human-user-1",

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -57,6 +57,11 @@ class _Messaging:
         self.sent.append((chat_id, sender_id, content, message_type, mentions))
         return {"id": "msg-1"}
 
+    def resolve_display_user(self, user_id: str):
+        if user_id == "visitor-1":
+            return SimpleNamespace(id="visitor-1", display_name="Visitor One", type="external")
+        return None
+
 
 def _service() -> tuple[ChatJoinRequestService, _Members, _Requests, _Messaging]:
     members = _Members()
@@ -67,6 +72,7 @@ def _service() -> tuple[ChatJoinRequestService, _Members, _Requests, _Messaging]
             SimpleNamespace(
                 id=chat_id,
                 type="group",
+                title="Group",
                 status="active",
                 created_by_user_id="owner-1",
             )
@@ -103,6 +109,70 @@ def test_chat_join_request_records_pending_row_and_notifies_owner() -> None:
             ["owner-1"],
         )
     ]
+
+
+def test_chat_join_request_list_projects_requester_display_fields() -> None:
+    service, _members, requests, _messaging = _service()
+    requests.rows["chat_join:chat-1:visitor-1"] = {
+        "id": "chat_join:chat-1:visitor-1",
+        "chat_id": "chat-1",
+        "requester_user_id": "visitor-1",
+        "state": "pending",
+        "message": "please add me",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+
+    rows = service.list_for_chat("chat-1", "owner-1")
+
+    assert rows == [
+        {
+            "id": "chat_join:chat-1:visitor-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "visitor-1",
+            "requester_name": "Visitor One",
+            "requester_type": "external",
+            "state": "pending",
+            "message": "please add me",
+            "created_at": 1.0,
+            "updated_at": 1.0,
+        }
+    ]
+
+
+def test_chat_join_target_exposes_minimal_non_member_state() -> None:
+    service, _members, requests, _messaging = _service()
+    requests.rows["chat_join:chat-1:visitor-1"] = {
+        "id": "chat_join:chat-1:visitor-1",
+        "chat_id": "chat-1",
+        "requester_user_id": "visitor-1",
+        "state": "pending",
+        "message": "please add me",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+
+    target = service.join_target("chat-1", "visitor-1")
+
+    assert target == {
+        "id": "chat-1",
+        "type": "group",
+        "title": "Group",
+        "status": "active",
+        "created_by_user_id": "owner-1",
+        "is_member": False,
+        "current_request": {
+            "id": "chat_join:chat-1:visitor-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "visitor-1",
+            "requester_name": "Visitor One",
+            "requester_type": "external",
+            "state": "pending",
+            "message": "please add me",
+            "created_at": 1.0,
+            "updated_at": 1.0,
+        },
+    }
 
 
 def test_chat_join_approve_requires_owner_and_adds_member_before_notification() -> None:


### PR DESCRIPTION
## Summary
- expose a public join-target route for non-member group chat pages
- project requester display fields from backend join request service
- show a frontend join request entry state instead of a dead 403 screen
- keep owner review readable by using projected requester names

## Verification
- uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/messaging/test_chat_join_request_tool_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Integration/test_chat_app_router.py tests/Unit/backend/test_chat_bootstrap.py -q
- uv run ruff check . && uv run ruff format --check .
- npm test -- --run src/pages/ChatConversationPage.test.tsx
- npm run lint && npm run build
- Frontend YATU: backend 8045 + frontend 5178; visitor requested through UI, managed owner approved through real LLM/tool path, visitor reloaded into group. Artifact: /Users/lexicalmathical/share/yatu/frontend-join-request-ui-20260425T183836Z