### PR TITLE
Refactor Agent Skill binding patch boundary

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -620,18 +620,8 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
                 package_id=library_package.id,
                 name=library_skill.name,
                 description=description,
-                version=str(
-                    library_package.version
-                    or item.get("version")
-                    or (current_skill.version if current_skill is not None else "")
-                    or "0.1.0"
-                ),
-                source=dict(
-                    library_package.source
-                    or library_skill.source
-                    or item.get("source")
-                    or (current_skill.source if current_skill is not None else {})
-                ),
+                version=library_package.version,
+                source=dict(library_package.source),
                 enabled=enabled,
             )
         )

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -588,6 +588,8 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
             raise RuntimeError("Skill patch item must include name")
         if "content" in item or "files" in item:
             raise RuntimeError("Skill patch item must not include content or files")
+        if "source" in item or "version" in item:
+            raise RuntimeError("Skill patch item must not include source or version")
         if "disabled" in item:
             raise RuntimeError("Skill patch item must use enabled, not disabled")
         _enabled_from_patch_item(item, label="Skill patch item")

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -428,6 +428,56 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
     ]
 
 
+def test_agent_config_patch_uses_selected_package_source_only() -> None:
+    saved_configs: list[AgentConfig] = []
+    skill_repo = _MemorySkillRepo()
+    library_skill = _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="loadable-skill",
+        name="Loadable Skill",
+        description="loadable",
+        content="---\nname: Loadable Skill\n---\nUse it.",
+    )
+    skill_repo.upsert(library_skill.model_copy(update={"source": {"source_version": "library-stale"}}))
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(
+                skills=[
+                    AgentSkill(
+                        id="agent-skill-1",
+                        skill_id="loadable-skill",
+                        package_id=library_skill.package_id,
+                        name="Loadable Skill",
+                        source={"source_version": "current-stale"},
+                    )
+                ]
+            )
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    agent_user_service.update_agent_user_config(
+        "agent-1",
+        {"skills": [{"name": "Loadable Skill", "enabled": True}]},
+        user_repo=SimpleNamespace(
+            get_by_id=lambda _agent_id: UserRow(
+                id="agent-1",
+                type=UserType.AGENT,
+                display_name="Toad",
+                owner_user_id="user-1",
+                agent_config_id="cfg-1",
+                created_at=1,
+            )
+        ),
+        agent_config_repo=_AgentConfigRepo(),
+        skill_repo=skill_repo,
+    )
+
+    assert saved_configs[-1].skills[0].source == {}
+
+
 def test_agent_config_patch_rejects_inline_skill_content() -> None:
     saved_configs: list[AgentConfig] = []
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -478,6 +478,18 @@ def test_agent_config_patch_uses_selected_package_source_only() -> None:
     assert saved_configs[-1].skills[0].source == {}
 
 
+def test_agent_config_patch_does_not_fill_skill_identity_from_patch_or_current_binding() -> None:
+    import inspect
+
+    source = inspect.getsource(agent_user_service._skills_from_patch)
+
+    assert 'item.get("version")' not in source
+    assert "current_skill.version" not in source
+    assert "library_skill.source" not in source
+    assert 'item.get("source")' not in source
+    assert "current_skill.source" not in source
+
+
 def test_agent_config_patch_rejects_inline_skill_content() -> None:
     saved_configs: list[AgentConfig] = []
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -459,6 +459,40 @@ def test_agent_config_patch_rejects_inline_skill_content() -> None:
     assert saved_configs == []
 
 
+@pytest.mark.parametrize("field", ["source", "version"])
+def test_agent_config_patch_rejects_skill_content_identity_fields(field: str) -> None:
+    saved_configs: list[AgentConfig] = []
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(skills=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    patch_item = {"name": "Loadable Skill", "enabled": True, field: {"source_version": "patch"} if field == "source" else "9.9.9"}
+
+    with pytest.raises(RuntimeError, match="Skill patch item must not include source or version"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"skills": [patch_item]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=_MemorySkillRepo(),
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_skill_disabled_flag() -> None:
     saved_configs: list[AgentConfig] = []
 


### PR DESCRIPTION
## Summary
- reject Skill patch source/version identity fields
- save Agent Skill binding version/source from the selected package only
- add source guards against reintroducing patch/current binding identity fill paths

## Verification
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_agent_config_patch_saves_library_skill_package_choice tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_agent_config_patch_rejects_skill_content_identity_fields tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_agent_config_patch_uses_selected_package_source_only tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_agent_config_patch_does_not_fill_skill_identity_from_patch_or_current_binding -q
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/storage/test_supabase_agent_config_repo.py -q
- uv run pyright backend/threads/agent_user_service.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/Unit -q