### PR TITLE
Refactor Hub direct Skill binding source

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -319,7 +319,7 @@ def apply_item(
                     package_id=package.id,
                     name=skill_name,
                     description=skill_description,
-                    version=source_version,
+                    version=package.version,
                     source={
                         "marketplace_item_id": item_id,
                         "source_version": source_version,

--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -320,11 +320,7 @@ def apply_item(
                     name=skill_name,
                     description=skill_description,
                     version=package.version,
-                    source={
-                        "marketplace_item_id": item_id,
-                        "source_version": source_version,
-                        "publisher": publisher,
-                    },
+                    source=dict(package.source),
                 )
             )
             agent_config_repo.save_agent_config(config.model_copy(update={"skills": next_skills}))

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -562,6 +562,26 @@ class TestApplySkill:
         assert saved[0].skills[0].name == "FastAPI"
 
 
+def test_apply_skill_to_agent_does_not_handwrite_binding_source() -> None:
+    import inspect
+
+    import backend.hub.client as marketplace_client
+
+    source = inspect.getsource(marketplace_client.apply_item)
+
+    assert 'source={\n                        "marketplace_item_id": item_id' not in source
+
+
+def test_apply_skill_to_agent_does_not_use_source_version_for_binding_version() -> None:
+    import inspect
+
+    import backend.hub.client as marketplace_client
+
+    source = inspect.getsource(marketplace_client.apply_item)
+
+    assert "version=source_version,\n                    source=" not in source
+
+
 # ── Apply — agent ──
 
 

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -461,11 +461,7 @@ class TestApplySkill:
         assert saved[0].skills[1].skill_id == "fastapi"
         assert saved[0].skills[1].package_id == packages[0].id
         assert saved[0].skills[1].description == "Build FastAPI APIs"
-        assert saved[0].skills[1].source == {
-            "marketplace_item_id": "skillsmp:fastapi",
-            "source_version": "1.2.3",
-            "publisher": "skillsmp",
-        }
+        assert saved[0].skills[1].source == packages[0].source
 
     def test_saves_skill_to_library_when_agent_user_id_is_provided(self):
         import backend.hub.client as marketplace_client

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -462,6 +462,7 @@ class TestApplySkill:
         assert saved[0].skills[1].package_id == packages[0].id
         assert saved[0].skills[1].description == "Build FastAPI APIs"
         assert saved[0].skills[1].source == packages[0].source
+        assert "source_at" in saved[0].skills[1].source
 
     def test_saves_skill_to_library_when_agent_user_id_is_provided(self):
         import backend.hub.client as marketplace_client


### PR DESCRIPTION
## Summary
- bind Hub direct-install AgentSkill version/source from the created package
- require direct binding source to include the package source timestamp
- add source guards against hand-built direct binding source/version paths

## Verification
- uv run pytest tests/Unit/platform/test_marketplace_client.py::TestApplySkill -q
- uv run pytest tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py::test_agent_config_patch_saves_library_skill_package_choice tests/Unit/config/test_agent_config_resolver.py -q
- uv run pyright backend/hub/client.py tests/Unit/platform/test_marketplace_client.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/Unit -q