### PR TITLE
Refactor Skill package version boundary

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -68,7 +68,7 @@ def _require_skill_repo(skill_repo: SkillRepo | None) -> SkillRepo:
     return skill_repo
 
 
-def _skill_frontmatter_name(content: str) -> str:
+def _skill_frontmatter_metadata(content: str) -> dict[str, Any]:
     # @@@skill-name-single-truth - runtime indexes Skills by SKILL.md frontmatter name, so Library name must not drift.
     match = _SKILL_FRONTMATTER_RE.search(content)
     if match is None:
@@ -76,10 +76,23 @@ def _skill_frontmatter_name(content: str) -> str:
     metadata = yaml.safe_load(match.group(1)) or {}
     if not isinstance(metadata, dict):
         raise ValueError("Skill content frontmatter must be a mapping")
+    return metadata
+
+
+def _skill_frontmatter_name(content: str) -> str:
+    metadata = _skill_frontmatter_metadata(content)
     name = metadata.get("name")
     if not isinstance(name, str) or not name.strip():
         raise ValueError("Skill content frontmatter name is required")
     return name.strip()
+
+
+def _skill_frontmatter_version(content: str) -> str:
+    metadata = _skill_frontmatter_metadata(content)
+    version = metadata.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("Skill content frontmatter version is required")
+    return version.strip()
 
 
 def _now_dt() -> datetime:
@@ -107,7 +120,7 @@ def _write_skill_package(
     files: dict[str, str],
     skill_repo: SkillRepo,
     *,
-    version: str = "0.1.0",
+    version: str,
     source: dict[str, Any] | None = None,
 ) -> SkillPackage:
     package_hash = build_skill_package_hash(content, files)
@@ -220,6 +233,8 @@ def create_resource(
     owner_user_id: str | None = None,
     recipe_repo: RecipeRepo | None = None,
     skill_repo: SkillRepo | None = None,
+    *,
+    content: str | None = None,
 ) -> dict[str, Any]:
     now = int(time.time() * 1000)
     if resource_type == "sandbox-template":
@@ -254,12 +269,17 @@ def create_resource(
     if resource_type == "skill":
         owner_user_id = _require_skill_owner(owner_user_id)
         skill_repo = _require_skill_repo(skill_repo)
+        if not content or not content.strip():
+            raise ValueError("Skill creation requires SKILL.md content")
+        frontmatter_name = _skill_frontmatter_name(content)
+        if frontmatter_name != name:
+            raise ValueError("Skill content frontmatter name must match Skill name")
+        version = _skill_frontmatter_version(content)
         rid = name.lower().replace(" ", "-")
         existing = skill_repo.get_by_id(owner_user_id, rid)
         if existing is not None and existing.name != name:
             raise ValueError("Skill id already exists with a different Skill name")
         timestamp = _now_dt()
-        content = f"---\nname: {name}\ndescription: {desc}\n---\n\n{desc}\n"
         skill = skill_repo.upsert(
             Skill(
                 id=rid,
@@ -270,7 +290,7 @@ def create_resource(
                 updated_at=timestamp,
             )
         )
-        _write_skill_package(owner_user_id, skill, content, {}, skill_repo)
+        _write_skill_package(owner_user_id, skill, content, {}, skill_repo, version=version)
         return _library_resource_item(
             "skill",
             skill.id,
@@ -485,9 +505,10 @@ def update_resource_content(
         frontmatter_name = _skill_frontmatter_name(content)
         if frontmatter_name != current.name:
             raise ValueError("Skill content frontmatter name must match Skill name")
+        version = _skill_frontmatter_version(content)
         current_package = _selected_skill_package(owner_user_id, current, skill_repo)
         files = current_package.files if current_package is not None else {}
         updated = skill_repo.upsert(current.model_copy(update={"updated_at": _now_dt()}))
-        _write_skill_package(owner_user_id, updated, content, files, skill_repo)
+        _write_skill_package(owner_user_id, updated, content, files, skill_repo, version=version)
         return True
     return False

--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -36,6 +36,7 @@ class PublishAgentRequest(BaseModel):
 class CreateResourceRequest(BaseModel):
     name: str
     desc: str = ""
+    content: str | None = None
     provider_name: str | None = None
     provider_type: str | None = None
     features: dict[str, bool] | None = None

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -290,6 +290,7 @@ async def create_resource(
             user_id,
             _recipe_repo_for(resource_type, request),
             _skill_repo_for(resource_type, request),
+            content=req.content,
         )
     except ValueError as error:
         raise HTTPException(400, str(error)) from error
@@ -332,6 +333,8 @@ async def delete_resource(
     recipe_repo = _recipe_repo_for(resource_type, request)
     skill_repo = _skill_repo_for(resource_type, request)
     if resource_type == "skill":
+        if skill_repo is None:
+            raise HTTPException(500, "skill_repo is required for panel library routes")
         skill = await asyncio.to_thread(skill_repo.get_by_id, user_id, resource_id)
         if skill is not None:
             used_by = await asyncio.to_thread(

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -40,7 +40,7 @@ class SkillPackage(AgentConfigSchemaModel):
     id: str
     owner_user_id: str
     skill_id: str
-    version: str = "0.1.0"
+    version: str
     hash: str
     manifest: dict[str, Any] = Field(default_factory=dict)
     skill_md: str
@@ -67,7 +67,7 @@ class AgentSkill(AgentConfigSchemaModel):
     package_id: str | None = None
     name: str
     description: str = ""
-    version: str = "0.1.0"
+    version: str
     enabled: bool = True
     source: dict[str, Any] = Field(default_factory=dict)
 
@@ -87,7 +87,7 @@ class AgentSkill(AgentConfigSchemaModel):
 class ResolvedSkill(AgentConfigSchemaModel):
     name: str
     description: str = ""
-    version: str = "0.1.0"
+    version: str
     content: str
     files: dict[str, str] = Field(default_factory=dict)
     source: dict[str, Any] = Field(default_factory=dict)

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -23,7 +23,7 @@ create table if not exists library.skill_packages (
     id text primary key,
     owner_user_id text not null,
     skill_id text not null,
-    version text not null default '0.1.0',
+    version text not null,
     hash text not null,
     manifest_json jsonb not null default '{}'::jsonb,
     skill_md text not null,
@@ -41,6 +41,9 @@ alter table library.skills
     add constraint skills_package_fk
         foreign key (package_id)
         references library.skill_packages(id);
+
+alter table if exists library.skill_packages
+    alter column version drop default;
 
 create table if not exists agent.skill_bindings (
     id uuid primary key default gen_random_uuid(),
@@ -161,6 +164,20 @@ begin
     ) then
         raise exception 'library.skills.source_json must be a JSON object before hard cut';
     end if;
+    if exists (
+        select 1
+        from library.skill_packages
+        where version is null
+           or btrim(version) = ''
+    ) then
+        raise exception 'library.skill_packages.version must be present before hard cut';
+    end if;
+
+    alter table library.skill_packages
+        drop constraint if exists skill_packages_version_required_ck,
+        add constraint skill_packages_version_required_ck
+            check (version is not null and btrim(version) <> '');
+
     if exists (
         select 1
         from library.skill_packages

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -121,7 +121,7 @@ def test_resolver_names_skill_working_set_as_resolved_skills() -> None:
 
 
 def test_resolver_rejects_skill_without_package_id():
-    config = _config(skills=[AgentSkill(skill_id="broken", name="broken")])
+    config = _config(skills=[AgentSkill(skill_id="broken", name="broken", version="1.0.0")])
 
     with pytest.raises(ValueError) as excinfo:
         resolve_agent_config(config, skill_repo=_SkillRepo())
@@ -159,7 +159,7 @@ def test_agent_config_rejects_blank_identity_fields():
 
 
 def test_resolver_rejects_skill_without_frontmatter():
-    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package", name="broken")])
+    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package", name="broken", version="1.0.0")])
 
     with pytest.raises(ValueError) as excinfo:
         resolve_agent_config(
@@ -189,6 +189,7 @@ def test_resolver_rejects_skill_frontmatter_without_name():
                 skill_id="broken",
                 package_id="broken-package",
                 name="broken",
+                version="1.0.0",
             )
         ]
     )
@@ -221,6 +222,7 @@ def test_resolver_rejects_display_name_without_name():
                 skill_id="broken",
                 package_id="broken-package",
                 name="broken",
+                version="1.0.0",
             )
         ]
     )
@@ -253,6 +255,7 @@ def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill
                 skill_id="visible-skill",
                 package_id="visible-package",
                 name="Visible Skill",
+                version="1.0.0",
             )
         ]
     )
@@ -299,6 +302,7 @@ def test_resolver_uses_selected_package_source_not_agent_skill_source():
                 skill_id="github",
                 package_id="github-package",
                 name="github",
+                version="1.0.0",
                 source={"source_version": "agent-stale"},
             )
         ]

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -8,6 +8,7 @@ from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentS
 def test_resolved_skill_model_normalizes_file_paths() -> None:
     resolved_skill = ResolvedSkill(
         name="query-helper",
+        version="1.0.0",
         content="---\nname: query-helper\n---\nUse exact terms.",
         files={"references\\query.md": "Prefer precise queries."},
     )
@@ -38,7 +39,7 @@ def test_resolved_skill_model_rejects_blank_version() -> None:
 
 
 def test_agent_skill_model_has_no_resolved_content() -> None:
-    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper")
+    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper", version="1.0.0")
 
     assert "content" not in agent_skill.model_dump()
     assert "files" not in agent_skill.model_dump()
@@ -46,7 +47,15 @@ def test_agent_skill_model_has_no_resolved_content() -> None:
 
 def test_agent_skill_model_rejects_resolved_content_fields() -> None:
     with pytest.raises(ValueError, match="content"):
-        AgentSkill.model_validate({"name": "query-helper", "skill_id": "skill-1", "package_id": "package-1", "content": "Use exact terms."})
+        AgentSkill.model_validate(
+            {
+                "name": "query-helper",
+                "skill_id": "skill-1",
+                "package_id": "package-1",
+                "version": "1.0.0",
+                "content": "Use exact terms.",
+            }
+        )
 
     with pytest.raises(ValueError, match="files"):
         AgentSkill.model_validate(
@@ -54,6 +63,7 @@ def test_agent_skill_model_rejects_resolved_content_fields() -> None:
                 "name": "query-helper",
                 "skill_id": "skill-1",
                 "package_id": "package-1",
+                "version": "1.0.0",
                 "files": {"references/query.md": "Use exact terms."},
             }
         )
@@ -75,7 +85,7 @@ def test_agent_config_model_rejects_unknown_fields() -> None:
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"name": "query-helper"}),
+        (AgentSkill, {"name": "query-helper", "version": "1.0.0"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),
@@ -89,7 +99,7 @@ def test_agent_config_child_models_reject_string_enabled(model_cls, kwargs) -> N
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"name": "query-helper"}),
+        (AgentSkill, {"name": "query-helper", "version": "1.0.0"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),
@@ -130,3 +140,28 @@ def test_skill_package_rejects_blank_skill_md() -> None:
 
     with pytest.raises(ValueError, match="skill_package.skill_md must not be blank"):
         SkillPackage(skill_md=" ", **common)
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "payload"),
+    [
+        (
+            SkillPackage,
+            {
+                "id": "package-1",
+                "owner_user_id": "owner-1",
+                "skill_id": "skill-1",
+                "hash": "sha256:abc",
+                "skill_md": "---\nname: query-helper\n---\nUse exact terms.",
+                "created_at": datetime(2026, 4, 25, tzinfo=UTC),
+            },
+        ),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
+        (ResolvedSkill, {"name": "query-helper", "content": "---\nname: query-helper\n---\nUse exact terms."}),
+    ],
+)
+def test_skill_package_and_runtime_skill_models_require_version(model_cls, payload) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        model_cls.model_validate(payload)
+
+    assert "version" in str(excinfo.value)

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -15,6 +15,7 @@ def test_snapshot_contains_resolved_agent_config_only():
                     skill_id="github",
                     package_id="github-package",
                     name="github",
+                    version="1.0.0",
                 )
             ],
         ),

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -13,7 +13,7 @@ def _skill(
     content: str = "---\nname: query-helper\n---\nUse exact terms.",
     files: dict[str, str] | None = None,
 ) -> ResolvedSkill:
-    return ResolvedSkill(name=name, content=content, files=files or {})
+    return ResolvedSkill(name=name, version="1.0.0", content=content, files=files or {})
 
 
 def test_skills_service_has_no_filesystem_skill_index() -> None:

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -739,6 +739,7 @@ async def test_leon_agent_agent_config_id_registers_repo_backed_skills(tmp_path)
                         skill_id="fastapi",
                         package_id="fastapi-package",
                         name="FastAPI",
+                        version="1.0.0",
                         source={"desc": "Build FastAPI services"},
                     )
                 ],
@@ -793,6 +794,7 @@ async def test_leon_agent_passes_resolved_skill_models_to_runtime_service(tmp_pa
                         skill_id="fastapi",
                         package_id="fastapi-package",
                         name="FastAPI",
+                        version="1.0.0",
                     )
                 ],
             )
@@ -848,6 +850,7 @@ async def test_leon_agent_agent_config_id_does_not_register_host_file_skills(tmp
                         skill_id="fastapi",
                         package_id="fastapi-package",
                         name="FastAPI",
+                        version="1.0.0",
                     )
                 ],
             )
@@ -1000,6 +1003,7 @@ async def test_leon_agent_agent_config_id_does_not_read_stale_runtime_skill_togg
                         skill_id="fastapi",
                         package_id="fastapi-package",
                         name="FastAPI",
+                        version="1.0.0",
                     )
                 ],
             )

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -364,6 +364,7 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
                         {
                             "name": "Snapshot Skill",
                             "description": "skill desc",
+                            "version": "1.2.3",
                             "content": "---\nname: Snapshot Skill\n---\nbody",
                             "files": {"references/routing.md": "route narrowly"},
                         }

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -121,6 +121,10 @@ def _put_skill(
     return skill_repo.get_by_id(owner_user_id, skill_id) or skill
 
 
+def _editable_skill_md(name: str = "Loadable Skill", description: str = "Use this skill", version: str = "1.0.0") -> str:
+    return f"---\nname: {name}\ndescription: {description}\nversion: {version}\n---\n\n{description}\n"
+
+
 @pytest.mark.asyncio
 async def test_panel_agents_uses_injected_user_repo_for_owner_scope(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     agent = UserRow(
@@ -450,6 +454,7 @@ def test_agent_config_patch_uses_selected_package_source_only() -> None:
                         skill_id="loadable-skill",
                         package_id=library_skill.package_id,
                         name="Loadable Skill",
+                        version="1.0.0",
                         source={"source_version": "current-stale"},
                     )
                 ]
@@ -732,6 +737,7 @@ def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
         package_id="loadable-package",
         name="Loadable Skill",
         description="loadable",
+        version="1.0.0",
         source={"source_version": "1.0.0"},
     )
 
@@ -859,7 +865,10 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
     app.state.runtime_storage_state = _runtime_storage_state(SimpleNamespace(), skill_repo=skill_repo)
 
     with TestClient(app) as client:
-        created = client.post("/api/panel/library/skill", json={"name": "Loadable Skill", "desc": "Use this skill"})
+        created = client.post(
+            "/api/panel/library/skill",
+            json={"name": "Loadable Skill", "desc": "Use this skill", "content": _editable_skill_md()},
+        )
         assert created.status_code == 200
         assert created.json()["id"] == "loadable-skill"
 
@@ -869,7 +878,7 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
 
         content = client.get("/api/panel/library/skill/loadable-skill/content")
         assert content.status_code == 200
-        assert content.json()["content"] == "---\nname: Loadable Skill\ndescription: Use this skill\n---\n\nUse this skill\n"
+        assert content.json()["content"] == _editable_skill_md()
 
 
 def test_library_skill_content_update_rejects_frontmatter_name_drift() -> None:
@@ -880,23 +889,63 @@ def test_library_skill_content_update_rejects_frontmatter_name_drift() -> None:
         "Use this skill",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
+        content=_editable_skill_md(),
     )
 
     with pytest.raises(ValueError, match="frontmatter name must match Skill name"):
         library_service.update_resource_content(
             "skill",
             created["id"],
-            "---\nname: Runtime Skill\n---\n\nUse it.",
+            "---\nname: Runtime Skill\ndescription: Use it.\nversion: 1.0.1\n---\n\nUse it.",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
         )
 
     stored = skill_repo.get_by_id("owner-1", created["id"])
     assert stored is not None and stored.package_id is not None
-    assert (
-        skill_repo.get_package("owner-1", stored.package_id).skill_md
-        == "---\nname: Loadable Skill\ndescription: Use this skill\n---\n\nUse this skill\n"
+    assert skill_repo.get_package("owner-1", stored.package_id).skill_md == _editable_skill_md()
+
+
+def test_library_skill_create_requires_version_frontmatter() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="frontmatter version is required"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "Use this skill",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content="---\nname: Loadable Skill\ndescription: Use this skill\n---\n\nUse this skill.",
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
+
+
+def test_library_skill_content_update_requires_version_frontmatter() -> None:
+    skill_repo = _MemorySkillRepo()
+    created = library_service.create_resource(
+        "skill",
+        "Loadable Skill",
+        "Use this skill",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md(),
     )
+
+    with pytest.raises(ValueError, match="frontmatter version is required"):
+        library_service.update_resource_content(
+            "skill",
+            created["id"],
+            "---\nname: Loadable Skill\ndescription: Use this skill\n---\n\nUse it.",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+        )
+
+    stored = skill_repo.get_by_id("owner-1", created["id"])
+    assert stored is not None and stored.package_id is not None
+    assert skill_repo.get_package("owner-1", stored.package_id).version == "1.0.0"
 
 
 def test_library_skill_name_is_immutable_after_creation() -> None:
@@ -907,6 +956,7 @@ def test_library_skill_name_is_immutable_after_creation() -> None:
         "Use this skill",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
+        content=_editable_skill_md(),
     )
 
     with pytest.raises(ValueError, match="Skill name is immutable"):
@@ -929,6 +979,7 @@ def test_library_skill_create_rejects_slug_collision_with_different_name() -> No
         "Use this skill",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
+        content=_editable_skill_md(),
     )
 
     with pytest.raises(ValueError, match="Skill id already exists with a different Skill name"):
@@ -938,6 +989,7 @@ def test_library_skill_create_rejects_slug_collision_with_different_name() -> No
             "Different name, same slug",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
+            content=_editable_skill_md("Loadable-Skill", "Different name, same slug"),
         )
 
     stored = skill_repo.get_by_id("owner-1", created["id"])
@@ -1582,7 +1634,9 @@ def test_get_agent_user_uses_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
+                skills=[
+                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc", version="1.0.0")
+                ],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1612,7 +1666,9 @@ def test_get_agent_user_ignores_runtime_skill_desc_override():
                 model="leon:large",
                 system_prompt="",
                 runtime_settings={"skills:Search": {"desc": "runtime desc", "enabled": False}},
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
+                skills=[
+                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc", version="1.0.0")
+                ],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1757,7 +1813,7 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="", version="1.0.0")],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1797,6 +1853,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
                 "skills": [
                     {
                         "name": "Search",
+                        "version": "1.0.0",
                         "content": "---\nname: Search\n---\nbody",
                         "description": "skill desc",
                         "source": {"source_version": "snapshot-stale", "extra": "drop"},
@@ -1847,7 +1904,7 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
                 "agent": {
                     "id": "cfg-source",
                     "name": "Repo Agent",
-                    "skills": [{"name": "Search", "content": "---\nname: Search\n---\nbody"}],
+                    "skills": [{"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
                 },
             },
             marketplace_item_id="item-1",
@@ -1876,7 +1933,7 @@ def test_apply_snapshot_requires_source_identity(field: str, value: object, mess
             "agent": {
                 "id": "cfg-source",
                 "name": "Repo Agent",
-                "skills": [{"name": "Search", "content": "---\nname: Search\n---\nbody"}],
+                "skills": [{"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
             },
         },
         "marketplace_item_id": "item-1",
@@ -1915,8 +1972,8 @@ def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
                     "id": "cfg-source",
                     "name": "Repo Agent",
                     "skills": [
-                        {"name": "Search", "content": "---\nname: Search\n---\none"},
-                        {"name": "Search", "content": "---\nname: Search\n---\ntwo"},
+                        {"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\none"},
+                        {"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\ntwo"},
                     ],
                 },
             },
@@ -2046,6 +2103,7 @@ def test_library_used_by_reads_agent_configs_without_display_projection(monkeypa
                     skill_id="skill-1",
                     package_id="skill-1-package",
                     name="api-design-reviewer",
+                    version="1.0.0",
                     enabled=True,
                 )
             ],
@@ -2081,6 +2139,7 @@ async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypa
                     skill_id="skill-1",
                     package_id="skill-1-package",
                     name="api-design-reviewer",
+                    version="1.0.0",
                     enabled=True,
                 )
             ],

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -419,7 +419,9 @@ class TestApplySkill:
         class _AgentConfigRepo:
             def get_agent_config(self, agent_config_id: str) -> AgentConfig | None:
                 assert agent_config_id == "cfg-1"
-                return _agent_config(skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing")])
+                return _agent_config(
+                    skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing", version="1.0.0")]
+                )
 
             def save_agent_config(self, config: AgentConfig) -> None:
                 saved.append(config)
@@ -760,6 +762,7 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                         skill_id="search",
                         package_id="search-package",
                         name="Search",
+                        version="1.0.0",
                         source={"name": "Search", "desc": "Repo Search"},
                     )
                 ],

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -12,6 +12,7 @@ def test_agent_config_schema_uses_library_package_storage() -> None:
     assert "drop table if exists agent.agent_skills cascade" in sql
     assert "drop table if exists agent.skills cascade" in sql
     assert "skill_md text not null" in sql
+    assert "version text not null default" not in sql
     assert "files_json jsonb not null default '{}'::jsonb" in sql
     assert "manifest_json jsonb not null default '{}'::jsonb" in sql
     assert "artifact_uri" not in sql
@@ -104,6 +105,7 @@ def test_agent_config_schema_constrains_root_identity_fields() -> None:
 
     assert "library.skills.source_json must be a JSON object before hard cut" in sql
     assert "library.skill_packages.manifest_json must be a JSON object before hard cut" in sql
+    assert "library.skill_packages.version must be present before hard cut" in sql
     assert "library.skill_packages.files_json must be a JSON object before hard cut" in sql
     assert "library.skill_packages.files_json values must be strings before hard cut" in sql
     assert "library.skill_packages.files_json keys must be package-relative paths before hard cut" in sql

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -529,6 +529,7 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
                     skill_id="skill-1",
                     package_id="package-1",
                     name="github",
+                    version="1.0.0",
                 )
             ],
             rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -560,8 +561,8 @@ def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
         agent_user_id="agent-1",
         name="Researcher",
         skills=[
-            AgentSkill(skill_id="github", package_id="package-1", name="github"),
-            AgentSkill(skill_id="github-two", package_id="package-2", name="github"),
+            AgentSkill(skill_id="github", package_id="package-1", name="github", version="1.0.0"),
+            AgentSkill(skill_id="github-two", package_id="package-2", name="github", version="1.0.0"),
         ],
     )
 
@@ -600,8 +601,8 @@ def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -
         agent_user_id="agent-1",
         name="Researcher",
         skills=[
-            AgentSkill(skill_id="github", package_id="package-1", name="github", enabled=False),
-            AgentSkill(skill_id="github-two", package_id="package-2", name="github", enabled=False),
+            AgentSkill(skill_id="github", package_id="package-1", name="github", version="1.0.0", enabled=False),
+            AgentSkill(skill_id="github-two", package_id="package-2", name="github", version="1.0.0", enabled=False),
         ],
         mcp_servers=[
             McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),


### PR DESCRIPTION
## Summary
- require SkillPackage, AgentSkill, and ResolvedSkill to carry explicit versions
- require Library Skill creation/update to read package version from SKILL.md frontmatter
- remove the SQL default for library.skill_packages.version and add a hard-cut version constraint

## Test Plan
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright config/agent_config_types.py backend/library/service.py backend/web/models/panel.py backend/web/routers/panel.py tests/Unit/config/test_agent_config_types.py tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/platform/test_marketplace_client.py
- uv run pytest tests/Unit -q