### PR TITLE
Refactor AgentConfig version boundary

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -12,6 +12,7 @@ from config.loader import AgentLoader
 
 _SYSTEM_AGENTS_DIR = (Path(__file__).resolve().parents[2] / "config" / "defaults" / "agents").resolve()
 _MCP_CONFIG_KEYS = ("transport", "command", "args", "env", "url", "allowed_tools", "instructions")
+INITIAL_AGENT_CONFIG_VERSION = "1.0.0"
 
 
 def _tools_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
@@ -290,7 +291,7 @@ def create_agent_user(
             name=name,
             description=description,
             status="draft",
-            version="0.1.0",
+            version=INITIAL_AGENT_CONFIG_VERSION,
         )
 
     created = get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
@@ -365,7 +366,7 @@ def _save_config_to_repo(
     tools: list[str] | None = None,
     system_prompt: str = "",
     status: str = "draft",
-    version: str = "0.1.0",
+    version: str,
     runtime_settings: dict | None = None,
     mcp_servers: list[McpServerConfig] | None = None,
     meta: dict | None = None,

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -181,7 +181,7 @@ class AgentConfig(AgentConfigSchemaModel):
     tools: list[str] = Field(default_factory=lambda: ["*"])
     system_prompt: str = ""
     status: str = "draft"
-    version: str = "0.1.0"
+    version: str
     runtime_settings: dict[str, Any] = Field(default_factory=dict)
     compact: dict[str, Any] = Field(default_factory=dict)
     skills: list[AgentSkill] = Field(default_factory=list)
@@ -190,7 +190,7 @@ class AgentConfig(AgentConfigSchemaModel):
     mcp_servers: list[McpServerConfig] = Field(default_factory=list)
     meta: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("id", "owner_user_id", "agent_user_id", "name")
+    @field_validator("id", "owner_user_id", "agent_user_id", "name", "version")
     @classmethod
     def _non_blank_identity(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -101,6 +101,8 @@ begin
            or btrim(agent_user_id) = ''
            or name is null
            or btrim(name) = ''
+           or version is null
+           or btrim(version) = ''
     ) then
         raise exception 'agent.agent_configs contains blank root identity before hard cut';
     end if;
@@ -114,7 +116,10 @@ begin
             check (agent_user_id is not null and btrim(agent_user_id) <> ''),
         drop constraint if exists agent_configs_name_required_ck,
         add constraint agent_configs_name_required_ck
-            check (name is not null and btrim(name) <> '');
+            check (name is not null and btrim(name) <> ''),
+        drop constraint if exists agent_configs_version_required_ck,
+        add constraint agent_configs_version_required_ck
+            check (version is not null and btrim(version) <> '');
 
     if exists (
         select 1
@@ -281,6 +286,9 @@ begin
     end if;
     if payload->>'name' is null or btrim(payload->>'name') = '' then
         raise exception 'agent_config.name is required';
+    end if;
+    if payload->>'version' is null or btrim(payload->>'version') = '' then
+        raise exception 'agent_config.version is required';
     end if;
     if jsonb_typeof(coalesce(payload->'tools', '["*"]'::jsonb)) <> 'array' then
         raise exception 'agent_config.tools must be a JSON array';
@@ -463,7 +471,7 @@ begin
         coalesce(payload->'tools', '["*"]'::jsonb),
         coalesce(payload->>'system_prompt', ''),
         coalesce(payload->>'status', 'draft'),
-        coalesce(payload->>'version', '0.1.0'),
+        payload->>'version',
         coalesce(payload->'runtime_settings', '{}'::jsonb),
         coalesce(payload->'compact', '{}'::jsonb),
         coalesce(payload->'meta', '{}'::jsonb),

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -73,6 +73,7 @@ def _config(**overrides: object) -> AgentConfig:
         "owner_user_id": "owner-1",
         "agent_user_id": "agent-1",
         "name": "Researcher",
+        "version": "1.0.0",
         "description": "Research agent",
         "model": "gpt-test",
         "tools": ["read", "shell"],

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -77,8 +77,34 @@ def test_agent_config_model_rejects_unknown_fields() -> None:
                 "owner_user_id": "owner-1",
                 "agent_user_id": "agent-1",
                 "name": "Researcher",
+                "version": "1.0.0",
                 "skill_packages": [],
             }
+        )
+
+
+def test_agent_config_model_requires_version() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        AgentConfig.model_validate(
+            {
+                "id": "cfg-1",
+                "owner_user_id": "owner-1",
+                "agent_user_id": "agent-1",
+                "name": "Researcher",
+            }
+        )
+
+    assert "version" in str(excinfo.value)
+
+
+def test_agent_config_model_rejects_blank_version() -> None:
+    with pytest.raises(ValueError, match="agent_config.version must not be blank"):
+        AgentConfig(
+            id="cfg-1",
+            owner_user_id="owner-1",
+            agent_user_id="agent-1",
+            name="Researcher",
+            version=" ",
         )
 
 

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -10,6 +10,7 @@ def test_snapshot_contains_resolved_agent_config_only():
             owner_user_id="owner-1",
             agent_user_id="agent-1",
             name="Researcher",
+            version="1.0.0",
             skills=[
                 AgentSkill(
                     skill_id="github",

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -22,6 +22,7 @@ class _EmptyAgentConfigRepo:
             owner_user_id="owner-test",
             agent_user_id="agent-user-test",
             name="Test Agent",
+            version="1.0.0",
         )
 
 
@@ -971,6 +972,7 @@ async def test_get_or_create_agent_passes_repo_backed_compact_config_to_runtime(
                 owner_user_id="owner-12",
                 agent_user_id="agent-user-12",
                 name="Compact Agent",
+                version="1.0.0",
                 compact={"trigger_tokens": 80000},
             )
 

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -45,6 +45,8 @@ def test_agent_config_schema_rejects_duplicate_child_names_inside_rpc() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 
     assert "agent_config.name is required" in sql
+    assert "agent_config.version is required" in sql
+    assert "coalesce(payload->>'version', '0.1.0')" not in sql
     assert "agent_config.tools must be a JSON array" in sql
     assert "agent_config.runtime_settings must be a JSON object" in sql
     assert "agent_config.compact must be a JSON object" in sql
@@ -117,7 +119,9 @@ def test_agent_config_schema_constrains_root_identity_fields() -> None:
     assert "agent_configs_owner_user_id_required_ck" in sql
     assert "agent_configs_agent_user_id_required_ck" in sql
     assert "agent_configs_name_required_ck" in sql
+    assert "agent_configs_version_required_ck" in sql
     assert "check (owner_user_id is not null and btrim(owner_user_id) <> '')" in sql
     assert "check (agent_user_id is not null and btrim(agent_user_id) <> '')" in sql
     assert "check (name is not null and btrim(name) <> '')" in sql
+    assert "check (version is not null and btrim(version) <> '')" in sql
     assert "agent.agent_configs contains blank root identity before hard cut" in sql

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -520,6 +520,7 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
             owner_user_id="owner-1",
             agent_user_id="agent-1",
             name="Researcher",
+            version="1.0.0",
             tools=["read"],
             runtime_settings={"shell": {"enabled": False}},
             compact={"trigger_tokens": 1000},
@@ -560,6 +561,7 @@ def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
         owner_user_id="owner-1",
         agent_user_id="agent-1",
         name="Researcher",
+        version="1.0.0",
         skills=[
             AgentSkill(skill_id="github", package_id="package-1", name="github", version="1.0.0"),
             AgentSkill(skill_id="github-two", package_id="package-2", name="github", version="1.0.0"),
@@ -580,6 +582,7 @@ def test_save_agent_config_rejects_duplicate_mcp_server_names_before_rpc() -> No
         owner_user_id="owner-1",
         agent_user_id="agent-1",
         name="Researcher",
+        version="1.0.0",
         mcp_servers=[
             McpServerConfig(name="filesystem", transport="stdio", command="fs-one"),
             McpServerConfig(name="filesystem", transport="stdio", command="fs-two"),
@@ -600,6 +603,7 @@ def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -
         owner_user_id="owner-1",
         agent_user_id="agent-1",
         name="Researcher",
+        version="1.0.0",
         skills=[
             AgentSkill(skill_id="github", package_id="package-1", name="github", version="1.0.0", enabled=False),
             AgentSkill(skill_id="github-two", package_id="package-2", name="github", version="1.0.0", enabled=False),
@@ -624,6 +628,7 @@ def test_save_agent_config_rejects_duplicate_rule_and_sub_agent_names_before_rpc
         owner_user_id="owner-1",
         agent_user_id="agent-1",
         name="Researcher",
+        version="1.0.0",
         rules=[
             AgentRule(name="coding", content="one"),
             AgentRule(name="coding", content="two"),


### PR DESCRIPTION
## Summary
- require AgentConfig.version in the model and reject blank values
- make repo-backed Agent creation write the initial config version explicitly
- require AgentConfig root version in the hard-cut SQL schema and save RPC

## Test Plan
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright config/agent_config_types.py backend/threads/agent_user_service.py storage/providers/supabase/agent_config_repo.py tests/Unit/config/test_agent_config_types.py tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/storage/test_supabase_agent_config_repo.py
- uv run pytest tests/Unit -q