### PR TITLE
fix: honor chat member mute for same-owner delivery

### DIFF
--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -75,6 +75,9 @@ class ChatDeliveryDispatcher:
             # @@@same-owner-group-delivery - explicit group membership among the same owner
             # must reach sibling actors even when no relationship row exists yet.
             if sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id:
+                if self._same_owner_delivery_is_muted(member, uid in mention_set):
+                    logger.info("[messaging] POLICY %s for %s", DeliveryAction.NOTIFY.value, uid[:15])
+                    continue
                 self._deliver(
                     uid,
                     recipient,
@@ -158,3 +161,11 @@ class ChatDeliveryDispatcher:
                 signal=signal,
             )
         )
+
+    def _same_owner_delivery_is_muted(self, member: dict[str, Any], is_mentioned: bool) -> bool:
+        # @@@same-owner-attention-control - same-owner group delivery skips
+        # relationship checks, but chat-level mute is still the owner-controlled
+        # attention switch; explicit mentions wake muted agents.
+        if is_mentioned:
+            return False
+        return bool(member.get("muted", False))

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -71,7 +71,7 @@ class SupabaseChatMemberRepo:
         return int(member_res.data[0].get("last_read_seq") or 0)
 
     def update_mute(self, chat_id: str, user_id: str, muted: bool, mute_until: str | None = None) -> None:
-        self._t().update({"muted": muted, "mute_until": mute_until}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
+        self._t().update({"muted": int(muted), "mute_until": mute_until}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
 
     def _t(self) -> Any:
         return q.schema_table(self._client, _SCHEMA, "chat_members", "chat member repo")

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2813,6 +2813,38 @@ def test_same_owner_agent_turn_delivers_to_sibling_user_without_relationship() -
     assert delivered == [("agent-user-2", "agent-user-2")]
 
 
+def test_same_owner_group_delivery_honors_chat_mute_until_mentioned() -> None:
+    delivered: list[tuple[str, str]] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [
+                {"user_id": "human-user-1", "muted": False},
+                {"user_id": "agent-user-1", "muted": False},
+                {"user_id": "agent-user-2", "muted": True},
+            ]
+        ),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None, owner_user_id=None)
+                if uid == "human-user-1"
+                else SimpleNamespace(id=uid, display_name="Morel", type="agent", avatar=None, owner_user_id="human-user-1")
+                if uid == "agent-user-1"
+                else SimpleNamespace(id=uid, display_name="Toad", type="agent", avatar=None, owner_user_id="human-user-1")
+                if uid == "agent-user-2"
+                else None
+            )
+        ),
+        unread_counter=lambda _chat_id, _user_id: 0,
+        delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: DeliveryAction.DELIVER),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "plain update", [])
+    dispatcher.dispatch("chat-1", "human-user-1", "explicit mention", ["agent-user-2"])
+
+    assert delivered == [("agent-user-1", "agent-user-1"), ("agent-user-1", "agent-user-1"), ("agent-user-2", "agent-user-2")]
+
+
 @pytest.mark.asyncio
 async def test_agent_runtime_gateway_uses_recipient_social_user_id_for_thread_lookup_and_passes_through_envelope_content(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -282,6 +282,20 @@ def test_supabase_chat_member_repo_updates_last_read_seq() -> None:
     assert ("user_id", "user-1") in table.eq_calls
 
 
+def test_supabase_chat_member_repo_updates_mute_as_database_integer() -> None:
+    client = _FakeClient()
+    repo = SupabaseChatMemberRepo(client)
+
+    repo.update_mute("chat-1", "user-1", True, "2026-04-26T20:00:00+00:00")
+
+    table = client.tables["chat.chat_members"]
+    assert table.update_payload["muted"] == 1
+    assert type(table.update_payload["muted"]) is int
+    assert table.update_payload["mute_until"] == "2026-04-26T20:00:00+00:00"
+    assert ("chat_id", "chat-1") in table.eq_calls
+    assert ("user_id", "user-1") in table.eq_calls
+
+
 def test_supabase_chat_member_repo_add_member_persists_numeric_joined_at() -> None:
     client = _FakeClient()
     repo = SupabaseChatMemberRepo(client)


### PR DESCRIPTION
## Summary
- make same-owner chat delivery honor member mute unless explicitly mentioned
- persist Supabase chat member mute using the live integer column shape
- add focused dispatcher and Supabase contract coverage

## Verification
- `uv run pytest tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q`
- Real CLI YATU artifact: `/Users/lexicalmathical/share/yatu/debate-tournament-cli-20260426T200308-mute-control`
