### PR TITLE
Hard-cut Skill config API to Library Skill ids

### DIFF
--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -38,6 +38,7 @@ def _skills_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
     for skill in config.skills:
         skills_list.append(
             {
+                "id": skill.skill_id,
                 "name": skill.name,
                 "enabled": skill.enabled,
                 "desc": skill.description,
@@ -549,13 +550,6 @@ def _sub_agents_from_patch(current_config: AgentConfig, config_patch: dict[str, 
     return sub_agents
 
 
-def _library_skill_by_name(owner_user_id: str, name: str, skill_repo: Any) -> Any | None:
-    for skill in skill_repo.list_for_owner(owner_user_id):
-        if skill.name == name:
-            return skill
-    return None
-
-
 def _selected_library_package(owner_user_id: str, library_skill: Any, skill_repo: Any) -> Any:
     package_id = getattr(library_skill, "package_id", None)
     if not package_id:
@@ -566,11 +560,9 @@ def _selected_library_package(owner_user_id: str, library_skill: Any, skill_repo
     return package
 
 
-def _current_skill_by_name_or_id(config: AgentConfig, name: str, skill_id: str | None) -> AgentSkill | None:
+def _current_skill_by_id(config: AgentConfig, skill_id: str) -> AgentSkill | None:
     for skill in config.skills:
-        if skill.name == name:
-            return skill
-        if skill_id is not None and (skill.skill_id == skill_id or skill.id == skill_id):
+        if skill.skill_id == skill_id:
             return skill
     return None
 
@@ -594,6 +586,8 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
         if "disabled" in item:
             raise RuntimeError("Skill patch item must use enabled, not disabled")
         _enabled_from_patch_item(item, label="Skill patch item")
+        if not (item.get("id") or item.get("skill_id")):
+            raise RuntimeError("Skill patch item must include id")
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate Skill name in patch: {name}")
@@ -602,15 +596,11 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
         name = str(item["name"])
         enabled = _enabled_from_patch_item(item, label="Skill patch item")
         explicit_skill_id = item.get("id") or item.get("skill_id")
-        explicit_skill_id_str = str(explicit_skill_id) if explicit_skill_id else None
-        current_skill = _current_skill_by_name_or_id(current_config, name, explicit_skill_id_str)
-        library_skill = (
-            skill_repo.get_by_id(owner_user_id, explicit_skill_id_str) if explicit_skill_id_str else None
-        ) or _library_skill_by_name(owner_user_id, name, skill_repo)
-        if explicit_skill_id_str and library_skill is None:
-            raise RuntimeError(f"Library skill not found: {explicit_skill_id_str}")
+        explicit_skill_id_str = str(explicit_skill_id)
+        current_skill = _current_skill_by_id(current_config, explicit_skill_id_str)
+        library_skill = skill_repo.get_by_id(owner_user_id, explicit_skill_id_str)
         if library_skill is None:
-            raise RuntimeError(f"Library skill not found: {name}")
+            raise RuntimeError(f"Library skill not found: {explicit_skill_id_str}")
         library_package = _selected_library_package(owner_user_id, library_skill, skill_repo)
         description = library_skill.description
         agent_skill_id = item.get("agent_skill_id") or item.get("row_id") or (current_skill.id if current_skill is not None else None)

--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -38,6 +38,11 @@ function errorText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function skillId(item: CrudItem): string {
+  if (!item.id) throw new Error(`Agent Skill is missing id: ${item.name}`);
+  return item.id;
+}
+
 // ==================== Main Component ====================
 
 export default function AgentDetail() {
@@ -118,15 +123,14 @@ export default function AgentDetail() {
     } catch (err) { toast.error(`更新失败：${errorText(err)}`); }
   };
 
-  const handleAssign = async (type: "skill", names: string[]) => {
+  const handleAssign = async (type: "skill", items: ResourceItem[]) => {
     if (!agent) return;
     try {
       if (type === "skill") {
-        const existing = new Set(agent.config.skills.map(s => s.name));
-        const newSkills = names.filter(n => !existing.has(n)).map(n => {
-          const lib = librarySkills.find(s => s.name === n);
-          return { name: n, desc: lib?.desc || "", enabled: true };
-        });
+        const existing = new Set(agent.config.skills.map(skillId));
+        const newSkills = items
+          .filter(item => !existing.has(item.id))
+          .map(item => ({ id: item.id, name: item.name, desc: item.desc || "", enabled: true }));
         if (newSkills.length) await updateAgentConfig(agent.id, { skills: [...agent.config.skills, ...newSkills] });
       }
       toast.success("已添加");
@@ -283,8 +287,8 @@ export default function AgentDetail() {
           <ResourcePicker
             type={pickerType}
             library={librarySkills}
-            assigned={agent.config.skills.map(s => s.name)}
-            onConfirm={(names) => { handleAssign(pickerType, names); setPickerType(null); }}
+            assigned={agent.config.skills.map(skillId)}
+            onConfirm={(items) => { handleAssign(pickerType, items); setPickerType(null); }}
             onClose={() => setPickerType(null)}
           />
         );
@@ -827,7 +831,7 @@ function ResourcePicker({ type, library, assigned, onConfirm, onClose }: {
   type: "skill";
   library: ResourceItem[];
   assigned: string[];
-  onConfirm: (names: string[]) => void;
+  onConfirm: (items: ResourceItem[]) => void;
   onClose: () => void;
 }) {
   const labels = { skill: "Skill" };
@@ -836,14 +840,14 @@ function ResourcePicker({ type, library, assigned, onConfirm, onClose }: {
   const assignedSet = useMemo(() => new Set(assigned), [assigned]);
 
   const available = useMemo(() =>
-    library.filter(item => !assignedSet.has(item.name) && (!filter || item.name.toLowerCase().includes(filter.toLowerCase()))),
+    library.filter(item => !assignedSet.has(item.id) && (!filter || item.name.toLowerCase().includes(filter.toLowerCase()))),
     [library, assignedSet, filter]
   );
 
-  const toggle = (name: string) => {
+  const toggle = (id: string) => {
     setSelected(prev => {
       const next = new Set(prev);
-      if (next.has(name)) next.delete(name); else next.add(name);
+      if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
   };
@@ -867,15 +871,15 @@ function ResourcePicker({ type, library, assigned, onConfirm, onClose }: {
           ) : available.map(item => (
             <button
               key={item.id}
-              onClick={() => toggle(item.name)}
+              onClick={() => toggle(item.id)}
               className={`w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors duration-fast ${
-                selected.has(item.name) ? "bg-primary/10 text-primary" : "hover:bg-muted"
+                selected.has(item.id) ? "bg-primary/10 text-primary" : "hover:bg-muted"
               }`}
             >
               <div className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${
-                selected.has(item.name) ? "bg-primary border-primary" : "border-muted-foreground/30"
+                selected.has(item.id) ? "bg-primary border-primary" : "border-muted-foreground/30"
               }`}>
-                {selected.has(item.name) && <Check className="h-3 w-3 text-primary-foreground" />}
+                {selected.has(item.id) && <Check className="h-3 w-3 text-primary-foreground" />}
               </div>
               <div className="min-w-0 flex-1">
                 <p className="font-medium truncate">{item.name}</p>
@@ -886,7 +890,7 @@ function ResourcePicker({ type, library, assigned, onConfirm, onClose }: {
         </div>
         <DialogFooter>
           <Button variant="outline" size="sm" onClick={onClose}>取消</Button>
-          <Button size="sm" disabled={selected.size === 0} onClick={() => onConfirm([...selected])}>
+          <Button size="sm" disabled={selected.size === 0} onClick={() => onConfirm(library.filter(item => selected.has(item.id)))}>
             添加 {selected.size > 0 && `(${selected.size})`}
           </Button>
         </DialogFooter>

--- a/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
@@ -7,12 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AgentDetailPage from "./AgentDetailPage";
 import { toast } from "sonner";
 
-const { getAgentById, fetchAgent, updateAgent, updateAgentConfig, ensureLibrary } = vi.hoisted(() => ({
+const { getAgentById, fetchAgent, updateAgent, updateAgentConfig, ensureLibrary, librarySkills } = vi.hoisted(() => ({
   getAgentById: vi.fn(),
   fetchAgent: vi.fn(),
   updateAgent: vi.fn(),
   updateAgentConfig: vi.fn(),
   ensureLibrary: vi.fn(),
+  librarySkills: [] as Array<{ id: string; name: string; desc: string; type: string; created_at: number; updated_at: number }>,
 }));
 
 const { navigateMock } = vi.hoisted(() => ({
@@ -53,7 +54,7 @@ vi.mock("@/store/app-store", () => ({
       updateAgentConfig,
       ensureLibrary,
       loadAll: vi.fn(),
-      librarySkills: [],
+      librarySkills,
     }),
 }));
 
@@ -75,6 +76,7 @@ afterEach(() => {
 
 describe("AgentDetailPage wording contract", () => {
   beforeEach(() => {
+    librarySkills.splice(0);
     getAgentById.mockReturnValue(agentFixture);
     fetchAgent.mockResolvedValue(agentFixture);
     ensureLibrary.mockResolvedValue(undefined);
@@ -223,6 +225,43 @@ describe("AgentDetailPage wording contract", () => {
 
     expect(screen.getByText("暂无MCP 服务器")).toBeTruthy();
     expect(ensureLibrary).not.toHaveBeenCalled();
+  });
+
+  it("adds a Skill from Library with the Library Skill id", async () => {
+    librarySkills.push({
+      id: "loadable-skill",
+      name: "Loadable Skill",
+      desc: "loadable",
+      type: "skill",
+      created_at: 0,
+      updated_at: 0,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
+        <Routes>
+          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^技能/ }));
+    fireEvent.click(screen.getByText("点击 + 从 Library 添加 技能"));
+    fireEvent.click(await screen.findByText("Loadable Skill"));
+    fireEvent.click(screen.getByRole("button", { name: /添加 \(1\)/ }));
+
+    await waitFor(() => {
+      expect(updateAgentConfig).toHaveBeenCalledWith("agent-1", {
+        skills: [
+          {
+            id: "loadable-skill",
+            name: "Loadable Skill",
+            desc: "loadable",
+            enabled: true,
+          },
+        ],
+      });
+    });
   });
 
   it("toggles MCP servers with enabled config", async () => {

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -172,14 +172,24 @@ def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch:
         beta_apply = client.post("/api/marketplace/apply", json={"item_id": "skillsmp:beta"})
         library_after_apply = client.get("/api/panel/library/skill")
         agent_after_apply = client.get("/api/panel/agents/agent-1")
+        library_by_name = {item["name"]: item for item in library_after_apply.json()["items"]}
+        assigned_by_name = {item["name"]: item for item in agent_after_apply.json()["config"]["skills"]}
 
         assign_both = client.put(
             "/api/panel/agents/agent-1/config",
-            json={"skills": [{"name": "Alpha Skill", "enabled": True}, {"name": "Beta Skill", "enabled": True}]},
+            json={
+                "skills": [
+                    {"id": assigned_by_name["Alpha Skill"]["id"], "name": "Alpha Skill", "enabled": True},
+                    {"id": library_by_name["Beta Skill"]["id"], "name": "Beta Skill", "enabled": True},
+                ]
+            },
         )
         blocked_alpha_delete = client.delete("/api/panel/library/skill/alpha-skill")
 
-        keep_beta = client.put("/api/panel/agents/agent-1/config", json={"skills": [{"name": "Beta Skill", "enabled": True}]})
+        keep_beta = client.put(
+            "/api/panel/agents/agent-1/config",
+            json={"skills": [{"id": library_by_name["Beta Skill"]["id"], "name": "Beta Skill", "enabled": True}]},
+        )
         deleted_alpha = client.delete("/api/panel/library/skill/alpha-skill")
         blocked_beta_delete = client.delete("/api/panel/library/skill/beta-skill")
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -195,6 +195,50 @@ async def test_panel_agent_detail_keeps_full_config_for_owner_scope(monkeypatch:
 
 
 @pytest.mark.asyncio
+async def test_panel_agent_detail_exposes_library_skill_id_for_round_trip() -> None:
+    agent = UserRow(
+        id="agent-1",
+        type=UserType.AGENT,
+        display_name="Toad",
+        owner_user_id="user-1",
+        agent_config_id="cfg-1",
+        created_at=1.0,
+    )
+    fake_repo = SimpleNamespace(
+        get_by_id=lambda agent_id: agent if agent_id == "agent-1" else None,
+    )
+    fake_agent_config_repo = SimpleNamespace(
+        get_agent_config=lambda agent_config_id: _agent_config(
+            id=agent_config_id,
+            skills=[
+                AgentSkill(
+                    id="agent-skill-1",
+                    skill_id="loadable-skill",
+                    package_id="loadable-skill-package",
+                    name="Loadable Skill",
+                    description="loadable",
+                    version="1.0.0",
+                    enabled=True,
+                )
+            ],
+        ),
+    )
+
+    result = await panel_router.get_agent(
+        "agent-1",
+        user_id="user-1",
+        request=SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(user_repo=fake_repo, runtime_storage_state=_runtime_storage_state(fake_agent_config_repo))
+            )
+        ),
+    )
+
+    assert result["config"]["skills"][0]["id"] == "loadable-skill"
+    assert result["config"]["skills"][0]["name"] == "Loadable Skill"
+
+
+@pytest.mark.asyncio
 async def test_update_agent_route_returns_404_for_missing_agent(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(agent_user_service, "get_agent_user", lambda _agent_user_id: None)
 
@@ -404,7 +448,7 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
 
     result = agent_user_service.update_agent_user_config(
         "agent-1",
-        {"skills": [{"name": "Loadable Skill", "desc": "loadable", "enabled": True}]},
+        {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "desc": "loadable", "enabled": True}]},
         user_repo=SimpleNamespace(
             get_by_id=lambda _agent_id: UserRow(
                 id="agent-1",
@@ -465,7 +509,7 @@ def test_agent_config_patch_uses_selected_package_source_only() -> None:
 
     agent_user_service.update_agent_user_config(
         "agent-1",
-        {"skills": [{"name": "Loadable Skill", "enabled": True}]},
+        {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "enabled": True}]},
         user_repo=SimpleNamespace(
             get_by_id=lambda _agent_id: UserRow(
                 id="agent-1",
@@ -622,6 +666,46 @@ def test_agent_config_patch_rejects_skill_enabled_string() -> None:
     assert saved_configs == []
 
 
+def test_agent_config_patch_rejects_skill_item_without_library_skill_id() -> None:
+    saved_configs: list[AgentConfig] = []
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="loadable-skill",
+        name="Loadable Skill",
+        description="loadable",
+        content="---\nname: Loadable Skill\n---\nUse it.",
+    )
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(skills=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    with pytest.raises(RuntimeError, match="Skill patch item must include id"):
+        agent_user_service.update_agent_user_config(
+            "agent-1",
+            {"skills": [{"name": "Loadable Skill", "enabled": True}]},
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=skill_repo,
+        )
+
+    assert saved_configs == []
+
+
 def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
@@ -641,7 +725,7 @@ def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Library skill not found: loadable-skill"):
+    with pytest.raises(RuntimeError, match="Skill patch item must include id"):
         agent_user_service.update_agent_user_config(
             "agent-1",
             {"skills": [{"name": "loadable-skill", "desc": "loadable", "enabled": True}]},
@@ -708,8 +792,8 @@ def test_agent_config_patch_rejects_duplicate_skill_names() -> None:
             "agent-1",
             {
                 "skills": [
-                    {"name": "Loadable Skill"},
-                    {"name": "Loadable Skill"},
+                    {"id": "loadable-skill", "name": "Loadable Skill"},
+                    {"id": "loadable-skill-copy", "name": "Loadable Skill"},
                 ]
             },
             user_repo=SimpleNamespace(
@@ -748,10 +832,10 @@ def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Library skill not found: Loadable Skill"):
+    with pytest.raises(RuntimeError, match="Library skill not found: loadable-skill"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"name": "Loadable Skill", "desc": "loadable", "enabled": False}]},
+            {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "desc": "loadable", "enabled": False}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -1645,7 +1729,7 @@ def test_get_agent_user_uses_repo_skill_desc():
         agent_config_repo=_AgentConfigRepo(),
     )
 
-    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "repo desc"}]
+    assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": "repo desc"}]
 
 
 def test_get_agent_user_ignores_runtime_skill_desc_override():
@@ -1677,7 +1761,7 @@ def test_get_agent_user_ignores_runtime_skill_desc_override():
         agent_config_repo=_AgentConfigRepo(),
     )
 
-    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": "repo desc"}]
+    assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": "repo desc"}]
 
 
 @pytest.mark.asyncio
@@ -1822,7 +1906,7 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
         agent_config_repo=_AgentConfigRepo(),
     )
 
-    assert result["config"]["skills"] == [{"name": "Search", "enabled": True, "desc": ""}]
+    assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": ""}]
 
 
 def test_apply_snapshot_saves_one_agent_config_aggregate():


### PR DESCRIPTION
## Summary
- expose selected Agent Skill Library ids in Agent detail config payloads
- require Agent config Skill patch items to carry Library Skill ids and remove Library name lookup writes
- update Agent detail UI picker to select Library Skill items by id
- update backend YATU to assign multiple Hub-downloaded Skills by ids read from real Library / Agent detail responses

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright backend/threads/agent_user_service.py
- npm test
- npm run lint
- npm run typecheck
- npm run build
