### PR TITLE
Route Hub skill adds through AgentConfig selection

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException
 import backend.hub.snapshot_apply as _snapshot_apply
 from backend.hub.versioning import BumpType, bump_semver
 from config.agent_config_resolver import resolve_agent_config
-from config.agent_config_types import AgentSkill, Skill, SkillPackage
+from config.agent_config_types import Skill, SkillPackage
 from config.agent_snapshot import snapshot_from_resolved_config
 from config.skill_files import normalize_skill_file_map
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
@@ -232,7 +232,6 @@ def apply_item(
     user_repo: Any = None,
     agent_config_repo: Any = None,
     skill_repo: Any = None,
-    agent_user_id: str | None = None,
 ) -> dict:
     """Apply a Hub item into the owner account.
 
@@ -300,37 +299,6 @@ def apply_item(
         )
         skill_repo.select_package(owner_user_id, skill.id, package.id)
 
-        if agent_user_id is not None:
-            if user_repo is None or agent_config_repo is None:
-                raise RuntimeError("user_repo and agent_config_repo are required to add a skill to an agent")
-            user = user_repo.get_by_id(agent_user_id)
-            if user is None or user.owner_user_id != owner_user_id:
-                raise RuntimeError(f"Agent user not found for owner: {agent_user_id}")
-            if not getattr(user, "agent_config_id", None):
-                raise RuntimeError(f"Agent user has no agent_config_id: {agent_user_id}")
-
-            config = agent_config_repo.get_agent_config(user.agent_config_id)
-            if config is None:
-                raise RuntimeError(f"Agent config not found for agent user: {agent_user_id}")
-            next_skills = [skill for skill in config.skills if skill.name != skill_name]
-            next_skills.append(
-                AgentSkill(
-                    skill_id=slug,
-                    package_id=package.id,
-                    name=skill_name,
-                    description=skill_description,
-                    version=package.version,
-                    source=dict(package.source),
-                )
-            )
-            agent_config_repo.save_agent_config(config.model_copy(update={"skills": next_skills}))
-            return {
-                "resource_id": slug,
-                "package_id": package.id,
-                "type": "skill",
-                "version": source_version,
-                "agent_user_id": agent_user_id,
-            }
         return {"resource_id": slug, "package_id": package.id, "type": "skill", "version": source_version}
 
     if item_type == "agent":

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -352,6 +352,34 @@ def update_agent_user_config(
     return _sync_agent_config_patch_to_repo(agent_user_id, config_patch, user_repo, agent_config_repo, skill_repo)
 
 
+def select_agent_skill(
+    agent_user_id: str,
+    skill_id: str,
+    user_repo: Any = None,
+    agent_config_repo: Any = None,
+    skill_repo: Any = None,
+) -> dict[str, Any] | None:
+    if skill_repo is None:
+        raise RuntimeError("skill_repo is required for agent config skill writes")
+    user, current_config = _resolve_repo_backed_agent(agent_user_id, user_repo, agent_config_repo)
+    if user is None or current_config is None:
+        return None
+    if user.owner_user_id != current_config.owner_user_id:
+        raise RuntimeError(f"Agent user owner does not match Agent config owner: {agent_user_id}")
+    library_skill = skill_repo.get_by_id(current_config.owner_user_id, skill_id)
+    if library_skill is None:
+        raise RuntimeError(f"Library skill not found: {skill_id}")
+    current_items = [item for item in _skills_from_repo(current_config) if item["id"] != library_skill.id]
+    current_items.append({"id": library_skill.id, "name": library_skill.name, "enabled": True})
+    return _sync_agent_config_patch_to_repo(
+        agent_user_id,
+        {"skills": current_items},
+        user_repo,
+        agent_config_repo,
+        skill_repo,
+    )
+
+
 # ── Agent config repo helpers ──
 
 

--- a/backend/web/routers/marketplace.py
+++ b/backend/web/routers/marketplace.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.hub import client as marketplace_client
 from backend.identity.profile import get_profile
+from backend.threads import agent_user_service
 from backend.web.core.dependencies import get_current_user_id
 from backend.web.models.marketplace import (
     ApplyFromMarketplaceRequest,
@@ -122,15 +123,27 @@ async def apply_marketplace_item(
     if req.agent_user_id is not None:
         await _verify_user_ownership(req.agent_user_id, user_id, user_repo)
     try:
-        return await asyncio.to_thread(
+        result = await asyncio.to_thread(
             marketplace_client.apply_item,
             item_id=req.item_id,
             owner_user_id=user_id,
             user_repo=user_repo,
             agent_config_repo=agent_config_repo,
             skill_repo=skill_repo,
-            agent_user_id=req.agent_user_id,
         )
+        if req.agent_user_id is not None:
+            if result.get("type") != "skill" or not isinstance(result.get("resource_id"), str):
+                raise HTTPException(400, "agent_user_id can only select Skill items")
+            await asyncio.to_thread(
+                agent_user_service.select_agent_skill,
+                agent_user_id=req.agent_user_id,
+                skill_id=result["resource_id"],
+                user_repo=user_repo,
+                agent_config_repo=agent_config_repo,
+                skill_repo=skill_repo,
+            )
+            result = {**result, "agent_user_id": req.agent_user_id}
+        return result
     except ValueError as error:
         raise HTTPException(400, str(error)) from error
 

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -291,8 +291,18 @@ async def test_upgrade_from_marketplace_uses_user_repo_not_member_repo(monkeypat
 @pytest.mark.asyncio
 async def test_apply_marketplace_item_uses_user_and_agent_config_repos(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
+    selected: dict[str, object] = {}
 
-    monkeypatch.setattr(marketplace_router.marketplace_client, "apply_item", lambda **kwargs: seen.update(kwargs) or {"ok": True})
+    monkeypatch.setattr(
+        marketplace_router.marketplace_client,
+        "apply_item",
+        lambda **kwargs: seen.update(kwargs) or {"resource_id": "skill-1", "type": "skill", "version": "1.0.0"},
+    )
+    monkeypatch.setattr(
+        marketplace_router.agent_user_service,
+        "select_agent_skill",
+        lambda **kwargs: selected.update(kwargs) or {"id": "agent-1"},
+    )
 
     owner_agent = SimpleNamespace(id="agent-1", owner_user_id="owner-1")
     request = SimpleNamespace(
@@ -307,13 +317,18 @@ async def test_apply_marketplace_item_uses_user_and_agent_config_repos(monkeypat
 
     result = await marketplace_router.apply_marketplace_item(req=req, user_id="owner-1", request=cast(Any, request))
 
-    assert result == {"ok": True}
+    assert result == {"resource_id": "skill-1", "type": "skill", "version": "1.0.0", "agent_user_id": "agent-1"}
     assert seen["item_id"] == "item-1"
     assert seen["owner_user_id"] == "owner-1"
     assert seen["user_repo"] is request.app.state.user_repo
     assert seen["agent_config_repo"] is request.app.state.runtime_storage_state.storage_container.agent_config_repo()
     assert seen["skill_repo"] is request.app.state.runtime_storage_state.storage_container.skill_repo()
-    assert seen["agent_user_id"] == "agent-1"
+    assert "agent_user_id" not in seen
+    assert selected["agent_user_id"] == "agent-1"
+    assert selected["skill_id"] == "skill-1"
+    assert selected["user_repo"] is request.app.state.user_repo
+    assert selected["agent_config_repo"] is request.app.state.runtime_storage_state.storage_container.agent_config_repo()
+    assert selected["skill_repo"] is request.app.state.runtime_storage_state.storage_container.skill_repo()
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -941,6 +941,48 @@ def test_agent_config_patch_explicit_library_id_uses_library_package_choice() ->
     assert "content" not in saved_configs[-1].skills[0].model_dump()
 
 
+def test_select_agent_skill_uses_agent_config_skill_patch_boundary() -> None:
+    saved_configs: list[AgentConfig] = []
+    skill_repo = _MemorySkillRepo()
+    library_skill = _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="loadable-skill",
+        name="Loadable Skill",
+        description="loadable",
+        content="---\nname: Loadable Skill\n---\nUse it.",
+    )
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(skills=[])
+
+        def save_agent_config(self, config: AgentConfig) -> None:
+            saved_configs.append(config)
+
+    result = agent_user_service.select_agent_skill(
+        "agent-1",
+        "loadable-skill",
+        user_repo=SimpleNamespace(
+            get_by_id=lambda _agent_id: UserRow(
+                id="agent-1",
+                type=UserType.AGENT,
+                display_name="Toad",
+                owner_user_id="user-1",
+                agent_config_id="cfg-1",
+                created_at=1,
+            )
+        ),
+        agent_config_repo=_AgentConfigRepo(),
+        skill_repo=skill_repo,
+    )
+
+    assert result is not None
+    assert saved_configs[-1].skills[0].skill_id == "loadable-skill"
+    assert saved_configs[-1].skills[0].package_id == library_skill.package_id
+    assert saved_configs[-1].skills[0].description == "loadable"
+
+
 def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None:
     app = FastAPI()
     app.include_router(panel_router.router)

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -400,7 +400,7 @@ class TestApplySkill:
             with pytest.raises(ValueError, match="Invalid slug"):
                 apply_item("item-evil", owner_user_id="owner-1", skill_repo=skill_repo)
 
-    def test_apply_with_agent_user_id_selects_skill_package_for_agent_config(self):
+    def test_apply_skill_saves_library_package_without_agent_config_write(self):
         import backend.hub.client as marketplace_client
 
         saved: list[AgentConfig] = []
@@ -443,7 +443,6 @@ class TestApplySkill:
                 user_repo=user_repo,
                 agent_config_repo=_AgentConfigRepo(),
                 skill_repo=skill_repo,
-                agent_user_id="agent-user-1",
             )
 
         assert result == {
@@ -451,22 +450,15 @@ class TestApplySkill:
             "package_id": packages[0].id,
             "type": "skill",
             "version": "1.2.3",
-            "agent_user_id": "agent-user-1",
         }
         assert saved_skills[0].name == "FastAPI"
         assert saved_skills[0].description == "Build FastAPI APIs"
         assert packages[0].skill_md == "---\nname: FastAPI\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter."
         assert packages[0].manifest["files"][0]["path"] == "references/routing.md"
         assert selected == [("owner-1", "fastapi", packages[0].id)]
-        assert saved[0].id == "cfg-1"
-        assert [skill.name for skill in saved[0].skills] == ["Existing", "FastAPI"]
-        assert saved[0].skills[1].skill_id == "fastapi"
-        assert saved[0].skills[1].package_id == packages[0].id
-        assert saved[0].skills[1].description == "Build FastAPI APIs"
-        assert saved[0].skills[1].source == packages[0].source
-        assert "source_at" in saved[0].skills[1].source
+        assert saved == []
 
-    def test_saves_skill_to_library_when_agent_user_id_is_provided(self):
+    def test_saves_skill_to_library_without_agent_config_repo(self):
         import backend.hub.client as marketplace_client
 
         saved_configs: list[AgentConfig] = []
@@ -503,7 +495,6 @@ class TestApplySkill:
                 user_repo=user_repo,
                 agent_config_repo=_AgentConfigRepo(),
                 skill_repo=skill_repo,
-                agent_user_id="agent-user-1",
             )
 
         assert saved_skills[0].id == "fastapi"
@@ -513,13 +504,10 @@ class TestApplySkill:
             "package_id": packages[0].id,
             "type": "skill",
             "version": "1.2.3",
-            "agent_user_id": "agent-user-1",
         }
-        assert saved_configs[0].skills[0].name == "FastAPI"
-        assert saved_configs[0].skills[0].skill_id == "fastapi"
-        assert saved_configs[0].skills[0].package_id == packages[0].id
+        assert saved_configs == []
 
-    def test_apply_with_agent_user_id_selects_trimmed_frontmatter_name(self):
+    def test_apply_skill_uses_trimmed_frontmatter_name(self):
         import backend.hub.client as marketplace_client
 
         saved: list[AgentConfig] = []
@@ -555,13 +543,12 @@ class TestApplySkill:
                 user_repo=user_repo,
                 agent_config_repo=_AgentConfigRepo(),
                 skill_repo=skill_repo,
-                agent_user_id="agent-user-1",
             )
 
         assert result["resource_id"] == "fastapi"
         assert result["package_id"] == packages[0].id
         assert saved_skills[0].name == "FastAPI"
-        assert saved[0].skills[0].name == "FastAPI"
+        assert saved == []
 
 
 def test_apply_skill_to_agent_does_not_handwrite_binding_source() -> None:
@@ -572,6 +559,18 @@ def test_apply_skill_to_agent_does_not_handwrite_binding_source() -> None:
     source = inspect.getsource(marketplace_client.apply_item)
 
     assert 'source={\n                        "marketplace_item_id": item_id' not in source
+
+
+def test_apply_skill_does_not_write_agent_config() -> None:
+    import inspect
+
+    import backend.hub.client as marketplace_client
+
+    source = inspect.getsource(marketplace_client.apply_item)
+
+    assert "AgentSkill(" not in source
+    assert "save_agent_config" not in source
+    assert "agent_user_id" not in inspect.signature(marketplace_client.apply_item).parameters
 
 
 def test_apply_skill_to_agent_does_not_use_source_version_for_binding_version() -> None:


### PR DESCRIPTION
## Summary
- keep Hub skill apply limited to Library Skill + SkillPackage writes
- remove Hub client agent_user_id handling and inline AgentSkill construction
- add AgentConfig service selection by Library Skill id
- compose Hub -> Library -> AgentConfig.skills in the Marketplace router
- update backend YATU and Hub client contracts for the single Skill add path

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright backend/hub/client.py backend/web/routers/marketplace.py backend/threads/agent_user_service.py
