### PR TITLE
Preserve Skill ids in AgentSnapshots

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -11,17 +11,17 @@ from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, Re
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 
 
-def _skill_id_from_name(name: str) -> str:
-    skill_id = name.strip().lower().replace(" ", "-")
-    if "/" in skill_id or "\\" in skill_id or skill_id in {"", ".", ".."}:
-        raise ValueError(f"Invalid Skill name for Library id: {name}")
-    return skill_id
-
-
 def _required_text(value: Any, *, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{label} must be a string")
     return value.strip()
+
+
+def _required_skill_id(skill_id: str) -> str:
+    skill_id = _required_text(skill_id, label="Snapshot Skill id")
+    if "/" in skill_id or "\\" in skill_id or skill_id in {".", ".."}:
+        raise ValueError(f"Invalid Snapshot Skill id: {skill_id}")
+    return skill_id
 
 
 def _materialize_snapshot_skills(
@@ -38,9 +38,13 @@ def _materialize_snapshot_skills(
     if skill_repo is None:
         raise RuntimeError("skill_repo is required to apply snapshot Skills")
 
+    seen_ids: set[str] = set()
     seen_names: set[str] = set()
     for snapshot_skill in skills:
         validate_resolved_skill_content(snapshot_skill)
+        if snapshot_skill.id in seen_ids:
+            raise ValueError(f"Duplicate Skill id in snapshot: {snapshot_skill.id}")
+        seen_ids.add(snapshot_skill.id)
         if snapshot_skill.name in seen_names:
             raise ValueError(f"Duplicate Skill name in snapshot: {snapshot_skill.name}")
         seen_names.add(snapshot_skill.name)
@@ -49,7 +53,7 @@ def _materialize_snapshot_skills(
     timestamp = datetime.now(UTC)
     library_skills = skill_repo.list_for_owner(owner_user_id)
     for snapshot_skill in skills:
-        skill_id = _skill_id_from_name(snapshot_skill.name)
+        skill_id = _required_skill_id(snapshot_skill.id)
         existing = skill_repo.get_by_id(owner_user_id, skill_id)
         if existing is not None and existing.name != snapshot_skill.name:
             raise ValueError("Snapshot Skill frontmatter name must match existing Skill name")

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -60,6 +60,7 @@ def _resolve_skill(owner_user_id: str, skill: Any, skill_repo: Any) -> ResolvedS
     if package.skill_id != skill.skill_id:
         raise RuntimeError(f"Skill package {skill.package_id} does not belong to Skill {skill.skill_id}")
     resolved = ResolvedSkill(
+        id=skill.skill_id,
         name=skill.name,
         description=skill.description,
         version=package.version,

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -85,6 +85,7 @@ class AgentSkill(AgentConfigSchemaModel):
 
 
 class ResolvedSkill(AgentConfigSchemaModel):
+    id: str
     name: str
     description: str = ""
     version: str
@@ -92,7 +93,7 @@ class ResolvedSkill(AgentConfigSchemaModel):
     files: dict[str, str] = Field(default_factory=dict)
     source: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("name", "version", "content")
+    @field_validator("id", "name", "version", "content")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -107,6 +107,7 @@ def test_resolved_config_contains_only_enabled_children():
 
     assert resolved.id == "cfg-1"
     assert resolved.name == "Researcher"
+    assert resolved.skills[0].id == "github"
     assert [skill.name for skill in resolved.skills] == ["github"]
     assert resolved.skills[0].files == {"references/query.md": "Prefer precise queries."}
     assert [rule.name for rule in resolved.rules] == ["Cite"]

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -122,6 +122,40 @@ def test_resolver_names_skill_working_set_as_resolved_skills() -> None:
     assert "resolved_skills" in source
 
 
+def test_resolver_keeps_skill_id_separate_from_display_name() -> None:
+    config = _config(
+        skills=[
+            AgentSkill(
+                skill_id="github-core",
+                package_id="github-core-package",
+                name="GitHub",
+                description="GitHub guidance",
+                version="1.0.0",
+            )
+        ]
+    )
+
+    resolved = resolve_agent_config(
+        config,
+        skill_repo=_SkillRepo(
+            {
+                "github-core-package": SkillPackage(
+                    id="github-core-package",
+                    owner_user_id="owner-1",
+                    skill_id="github-core",
+                    version="1.0.0",
+                    hash="sha256:github-core",
+                    skill_md=_skill_md("GitHub"),
+                    created_at=datetime(2026, 4, 25, tzinfo=UTC),
+                )
+            }
+        ),
+    )
+
+    assert resolved.skills[0].id == "github-core"
+    assert resolved.skills[0].name == "GitHub"
+
+
 def test_resolver_rejects_skill_without_package_id():
     config = _config(skills=[AgentSkill(skill_id="broken", name="broken", version="1.0.0")])
 

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -7,6 +7,7 @@ from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentS
 
 def test_resolved_skill_model_normalizes_file_paths() -> None:
     resolved_skill = ResolvedSkill(
+        id="query-helper",
         name="query-helper",
         version="1.0.0",
         content="---\nname: query-helper\n---\nUse exact terms.",
@@ -26,14 +27,38 @@ def test_resolved_skill_model_rejects_duplicate_file_paths_after_normalization()
     }
 
     with pytest.raises(ValueError, match="Skill files contain duplicate path after normalization: references/query.md"):
-        ResolvedSkill(name="query-helper", **common)
+        ResolvedSkill(id="query-helper", name="query-helper", **common)
 
 
 def test_resolved_skill_model_rejects_blank_version() -> None:
     with pytest.raises(ValueError, match="resolved_skill.version must not be blank"):
         ResolvedSkill(
+            id="query-helper",
             name="query-helper",
             version=" ",
+            content="---\nname: query-helper\n---\nUse exact terms.",
+        )
+
+
+def test_resolved_skill_model_requires_id() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        ResolvedSkill.model_validate(
+            {
+                "name": "query-helper",
+                "version": "1.0.0",
+                "content": "---\nname: query-helper\n---\nUse exact terms.",
+            }
+        )
+
+    assert "id" in str(excinfo.value)
+
+
+def test_resolved_skill_model_rejects_blank_id() -> None:
+    with pytest.raises(ValueError, match="resolved_skill.id must not be blank"):
+        ResolvedSkill(
+            id=" ",
+            name="query-helper",
+            version="1.0.0",
             content="---\nname: query-helper\n---\nUse exact terms.",
         )
 
@@ -183,7 +208,7 @@ def test_skill_package_rejects_blank_skill_md() -> None:
             },
         ),
         (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
-        (ResolvedSkill, {"name": "query-helper", "content": "---\nname: query-helper\n---\nUse exact terms."}),
+        (ResolvedSkill, {"id": "query-helper", "name": "query-helper", "content": "---\nname: query-helper\n---\nUse exact terms."}),
     ],
 )
 def test_skill_package_and_runtime_skill_models_require_version(model_cls, payload) -> None:

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -48,3 +48,43 @@ def test_snapshot_contains_resolved_agent_config_only():
     assert payload["agent"]["skills"][0]["files"] == {"references/query.md": "Prefer precise queries."}
     assert "owner_user_id" not in payload["agent"]
     assert "agent_user_id" not in payload["agent"]
+
+
+def test_snapshot_preserves_skill_id_when_name_changes():
+    resolved = resolve_agent_config(
+        AgentConfig(
+            id="cfg-1",
+            owner_user_id="owner-1",
+            agent_user_id="agent-1",
+            name="Researcher",
+            version="1.0.0",
+            skills=[
+                AgentSkill(
+                    skill_id="github-core",
+                    package_id="github-core-package",
+                    name="GitHub",
+                    version="1.0.0",
+                )
+            ],
+        ),
+        skill_repo=type(
+            "_SkillRepo",
+            (),
+            {
+                "get_package": lambda self, _owner_user_id, package_id: SkillPackage(
+                    id=package_id,
+                    owner_user_id="owner-1",
+                    skill_id="github-core",
+                    version="1.0.0",
+                    hash="sha256:github-core",
+                    skill_md="---\nname: GitHub\n---\n\n# GitHub\n",
+                    created_at="2026-04-25T00:00:00+00:00",
+                )
+            },
+        )(),
+    )
+
+    payload = snapshot_from_resolved_config(resolved).model_dump(mode="json")
+
+    assert payload["agent"]["skills"][0]["id"] == "github-core"
+    assert payload["agent"]["skills"][0]["name"] == "GitHub"

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -43,6 +43,7 @@ def test_snapshot_contains_resolved_agent_config_only():
 
     assert payload["schema_version"] == "agent-snapshot/v1"
     assert payload["agent"]["id"] == "cfg-1"
+    assert payload["agent"]["skills"][0]["id"] == "github"
     assert payload["agent"]["skills"][0]["name"] == "github"
     assert payload["agent"]["skills"][0]["files"] == {"references/query.md": "Prefer precise queries."}
     assert "owner_user_id" not in payload["agent"]

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -13,7 +13,7 @@ def _skill(
     content: str = "---\nname: query-helper\n---\nUse exact terms.",
     files: dict[str, str] | None = None,
 ) -> ResolvedSkill:
-    return ResolvedSkill(name=name, version="1.0.0", content=content, files=files or {})
+    return ResolvedSkill(id=name, name=name, version="1.0.0", content=content, files=files or {})
 
 
 def test_skills_service_has_no_filesystem_skill_index() -> None:

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -387,6 +387,7 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
                     "name": "Snapshot Agent",
                     "skills": [
                         {
+                            "id": "snapshot-core",
                             "name": "Snapshot Skill",
                             "description": "skill desc",
                             "version": "1.2.3",
@@ -419,7 +420,7 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
     saved_config = agent_config_repo.saved[0]
     saved_skill = saved_config.skills[0]
     assert result == {"user_id": saved_config.agent_user_id, "type": "user", "version": "1.2.3"}
-    assert saved_skill.skill_id == "snapshot-skill"
+    assert saved_skill.skill_id == "snapshot-core"
     assert saved_skill.package_id
     package = skill_repo.get_package("owner-1", saved_skill.package_id)
     assert package is not None

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2125,6 +2125,38 @@ def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
     assert skill_repo.list_for_owner("user-1") == []
 
 
+def test_apply_snapshot_rejects_non_library_skill_id_before_library_write():
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Invalid Snapshot Skill id: nested/search"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [
+                        {
+                            "id": "nested/search",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search\n---\nbody",
+                        }
+                    ],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+            skill_repo=skill_repo,
+        )
+    assert skill_repo.list_for_owner("user-1") == []
+
+
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1978,6 +1978,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
                 "system_prompt": "main prompt",
                 "skills": [
                     {
+                        "id": "search-core",
                         "name": "Search",
                         "version": "1.0.0",
                         "content": "---\nname: Search\n---\nbody",
@@ -2000,9 +2001,9 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
     assert user_id == created_users[0].id
     assert saved_configs[0].name == "Repo Agent"
     assert saved_configs[0].skills[0].description == "skill desc"
-    assert saved_configs[0].skills[0].skill_id == "search"
+    assert saved_configs[0].skills[0].skill_id == "search-core"
     assert saved_configs[0].skills[0].package_id
-    assert skill_repo.get_by_id("user-1", "search") is not None
+    assert skill_repo.get_by_id("user-1", "search-core") is not None
     package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id or "")
     assert package is not None
     assert package.skill_md == "---\nname: Search\n---\nbody"
@@ -2012,7 +2013,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
         "source_at": saved_configs[0].skills[0].source["source_at"],
     }
     assert saved_configs[0].skills[0].source == package.source
-    library_skill = skill_repo.get_by_id("user-1", "search")
+    library_skill = skill_repo.get_by_id("user-1", "search-core")
     assert library_skill is not None
     assert library_skill.source == package.source
     assert saved_configs[0].rules[0].content == "rule body"
@@ -2030,7 +2031,7 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
                 "agent": {
                     "id": "cfg-source",
                     "name": "Repo Agent",
-                    "skills": [{"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                    "skills": [{"id": "search", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
                 },
             },
             marketplace_item_id="item-1",
@@ -2059,7 +2060,7 @@ def test_apply_snapshot_requires_source_identity(field: str, value: object, mess
             "agent": {
                 "id": "cfg-source",
                 "name": "Repo Agent",
-                "skills": [{"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                "skills": [{"id": "search", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
             },
         },
         "marketplace_item_id": "item-1",
@@ -2085,6 +2086,45 @@ def test_apply_snapshot_does_not_fill_package_version_from_source_version() -> N
     assert "or source_version" not in source
 
 
+def test_apply_snapshot_does_not_derive_skill_id_from_name() -> None:
+    import inspect
+
+    import backend.hub.snapshot_apply as snapshot_apply
+
+    source = inspect.getsource(snapshot_apply)
+
+    assert "_skill_id_from_name" not in source
+    assert '.lower().replace(" ", "-")' not in source
+
+
+def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Duplicate Skill id in snapshot: search"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [
+                        {"id": "search", "name": "Search One", "version": "1.0.0", "content": "---\nname: Search One\n---\none"},
+                        {"id": "search", "name": "Search Two", "version": "1.0.0", "content": "---\nname: Search Two\n---\ntwo"},
+                    ],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+            skill_repo=skill_repo,
+        )
+    assert skill_repo.list_for_owner("user-1") == []
+
+
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 
@@ -2098,8 +2138,8 @@ def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
                     "id": "cfg-source",
                     "name": "Repo Agent",
                     "skills": [
-                        {"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\none"},
-                        {"name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\ntwo"},
+                        {"id": "search-one", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\none"},
+                        {"id": "search-two", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\ntwo"},
                     ],
                 },
             },


### PR DESCRIPTION
## Summary
- Require resolved Skills to carry their Library Skill id.
- Preserve that id through AgentSnapshot publish artifacts.
- Materialize downloaded AgentSnapshot Skills by snapshot Skill id instead of deriving ids from display names.
- Add guards for id/name separation, duplicate snapshot ids, invalid snapshot ids, and name-derived id residue.

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright backend/hub/snapshot_apply.py config/agent_config_resolver.py config/agent_config_types.py config/agent_snapshot.py
- cd frontend/app && npm test
- cd frontend/app && npm run lint
- cd frontend/app && npm run typecheck
- cd frontend/app && npm run build