### PR TITLE
Generate ids for Library-created Skills

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -14,6 +14,7 @@ from config.agent_config_types import Skill, SkillPackage
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from sandbox.recipes import FEATURE_CATALOG, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 from storage.contracts import RecipeRepo, SkillRepo
+from storage.utils import generate_skill_id
 
 _SKILL_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _RESOURCE_TYPES = {"skill", "sandbox-template"}
@@ -275,10 +276,13 @@ def create_resource(
         if frontmatter_name != name:
             raise ValueError("Skill content frontmatter name must match Skill name")
         version = _skill_frontmatter_version(content)
-        rid = name.lower().replace(" ", "-")
+        for skill in skill_repo.list_for_owner(owner_user_id):
+            if skill.name == name:
+                raise ValueError("Skill name already exists")
+        rid = generate_skill_id()
         existing = skill_repo.get_by_id(owner_user_id, rid)
-        if existing is not None and existing.name != name:
-            raise ValueError("Skill id already exists with a different Skill name")
+        if existing is not None:
+            raise RuntimeError("Generated Skill id already exists")
         timestamp = _now_dt()
         skill = skill_repo.upsert(
             Skill(

--- a/storage/utils.py
+++ b/storage/utils.py
@@ -10,3 +10,7 @@ def generate_agent_user_id() -> str:
 
 def generate_agent_config_id() -> str:
     return "cfg_" + "".join(secrets.choice(_ID_ALPHABET) for _ in range(12))
+
+
+def generate_skill_id() -> str:
+    return "skill_" + "".join(secrets.choice(_ID_ALPHABET) for _ in range(12))

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -996,13 +996,15 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
             json={"name": "Loadable Skill", "desc": "Use this skill", "content": _editable_skill_md()},
         )
         assert created.status_code == 200
-        assert created.json()["id"] == "loadable-skill"
+        created_id = created.json()["id"]
+        assert created_id != "loadable-skill"
+        assert created_id.startswith("skill_")
 
         listed = client.get("/api/panel/library/skill")
         assert listed.status_code == 200
         assert listed.json()["items"][0]["name"] == "Loadable Skill"
 
-        content = client.get("/api/panel/library/skill/loadable-skill/content")
+        content = client.get(f"/api/panel/library/skill/{created_id}/content")
         assert content.status_code == 200
         assert content.json()["content"] == _editable_skill_md()
 
@@ -1097,7 +1099,7 @@ def test_library_skill_name_is_immutable_after_creation() -> None:
     assert skill_repo.get_by_id("owner-1", created["id"]).name == "Loadable Skill"
 
 
-def test_library_skill_create_rejects_slug_collision_with_different_name() -> None:
+def test_library_skill_create_rejects_duplicate_name_before_write() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
@@ -1108,20 +1110,47 @@ def test_library_skill_create_rejects_slug_collision_with_different_name() -> No
         content=_editable_skill_md(),
     )
 
-    with pytest.raises(ValueError, match="Skill id already exists with a different Skill name"):
+    with pytest.raises(ValueError, match="Skill name already exists"):
         library_service.create_resource(
             "skill",
-            "Loadable-Skill",
-            "Different name, same slug",
+            "Loadable Skill",
+            "Duplicate name",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
-            content=_editable_skill_md("Loadable-Skill", "Different name, same slug"),
+            content=_editable_skill_md("Loadable Skill", "Duplicate name"),
         )
 
     stored = skill_repo.get_by_id("owner-1", created["id"])
     assert stored is not None
     assert stored.name == "Loadable Skill"
     assert stored.description == "Use this skill"
+
+
+def test_library_skill_create_does_not_derive_id_from_name() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    first = library_service.create_resource(
+        "skill",
+        "Loadable Skill",
+        "Use this skill",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md(),
+    )
+    second = library_service.create_resource(
+        "skill",
+        "Loadable-Skill",
+        "Different name",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md("Loadable-Skill", "Different name"),
+    )
+
+    assert first["id"] != "loadable-skill"
+    assert second["id"] != "loadable-skill"
+    assert first["id"] != second["id"]
+    assert skill_repo.get_by_id("owner-1", first["id"]).name == "Loadable Skill"
+    assert skill_repo.get_by_id("owner-1", second["id"]).name == "Loadable-Skill"
 
 
 def test_library_rejects_agent_resource_type() -> None:

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1153,6 +1153,15 @@ def test_library_skill_create_does_not_derive_id_from_name() -> None:
     assert skill_repo.get_by_id("owner-1", second["id"]).name == "Loadable-Skill"
 
 
+def test_library_skill_create_source_does_not_slugify_name() -> None:
+    import inspect
+
+    source = inspect.getsource(library_service.create_resource)
+
+    assert '.lower().replace(" ", "-")' not in source
+    assert "generate_skill_id()" in source
+
+
 def test_library_rejects_agent_resource_type() -> None:
     with pytest.raises(ValueError, match="Unknown resource type: agent"):
         library_service.list_library("agent")

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1162,6 +1162,29 @@ def test_library_skill_create_source_does_not_slugify_name() -> None:
     assert "generate_skill_id()" in source
 
 
+def test_library_skill_create_fails_when_generated_id_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="owner-1",
+        skill_id="skill_existing",
+        name="Existing Skill",
+        description="Existing",
+        content="---\nname: Existing Skill\nversion: 1.0.0\n---\nExisting.",
+    )
+    monkeypatch.setattr(library_service, "generate_skill_id", lambda: "skill_existing")
+
+    with pytest.raises(RuntimeError, match="Generated Skill id already exists"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "Use this skill",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content=_editable_skill_md(),
+        )
+
+
 def test_library_rejects_agent_resource_type() -> None:
     with pytest.raises(ValueError, match="Unknown resource type: agent"):
         library_service.list_library("agent")

--- a/tests/Unit/storage/test_utils.py
+++ b/tests/Unit/storage/test_utils.py
@@ -1,4 +1,4 @@
-from storage.utils import generate_agent_config_id, generate_agent_user_id
+from storage.utils import generate_agent_config_id, generate_agent_user_id, generate_skill_id
 
 
 def test_generate_agent_user_id_uses_agent_user_prefix() -> None:
@@ -13,3 +13,10 @@ def test_generate_agent_config_id_uses_config_prefix() -> None:
 
     assert agent_config_id.startswith("cfg_")
     assert len(agent_config_id) == 16
+
+
+def test_generate_skill_id_uses_skill_prefix() -> None:
+    skill_id = generate_skill_id()
+
+    assert skill_id.startswith("skill_")
+    assert len(skill_id) == 18


### PR DESCRIPTION
## Summary
- Add an opaque Skill id generator for Library-created Skills.
- Stop deriving manual Library Skill ids from display names.
- Reject duplicate Skill names before write, while keeping returned ids as the route/content handle.
- Add guards for name slugification and generated-id collisions.

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright backend/library/service.py storage/utils.py
- cd frontend/app && npm test
- cd frontend/app && npm run lint
- cd frontend/app && npm run typecheck
- cd frontend/app && npm run build