### PR TITLE
fix: unblock concurrent group chat replies

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -95,6 +95,57 @@ class ChatToolService:
             raise RuntimeError(f"Chat message sender identity not found: {sender_id}")
         return sender.display_name
 
+    def _display_user_type(self, user: Any, *, user_id: str) -> str:
+        raw_type = getattr(user, "type", None)
+        if hasattr(raw_type, "value"):
+            raw_type = raw_type.value
+        if not isinstance(raw_type, str) or not raw_type:
+            raise RuntimeError(f"Chat user {user_id} is missing user type")
+        return raw_type
+
+    def _chat_member_count(self, chat_id: str) -> int:
+        members = self._messaging.list_chat_members(chat_id)
+        if not isinstance(members, list):
+            raise RuntimeError(f"Chat members collection is invalid for chat {chat_id}")
+        for member in members:
+            if not isinstance(member, dict):
+                raise RuntimeError(f"Chat member row is invalid for chat {chat_id}")
+            member_user_id = member.get("user_id") or member.get("id")
+            if not isinstance(member_user_id, str) or not member_user_id:
+                raise RuntimeError(f"Chat member row is missing user_id for chat {chat_id}")
+        return len(members)
+
+    def _blocking_unread_count(self, chat_id: str, sender_id: str, *, direct_chat: bool) -> int:
+        unread_messages = self._messaging.list_unread(chat_id, sender_id)
+        if not isinstance(unread_messages, list):
+            raise RuntimeError(f"Chat unread messages collection is invalid for chat {chat_id}")
+        if not unread_messages:
+            return 0
+
+        is_direct = direct_chat or self._chat_member_count(chat_id) <= 2
+        blocking = 0
+        for message in unread_messages:
+            if not isinstance(message, dict):
+                raise RuntimeError(f"Chat unread message row is invalid for chat {chat_id}")
+            if is_direct:
+                blocking += 1
+                continue
+            mentioned_ids = message.get("mentioned_ids") or message.get("mentions") or message.get("mentions_json") or []
+            if not isinstance(mentioned_ids, list):
+                raise RuntimeError(f"Chat unread message mentions are invalid for chat {chat_id}")
+            if sender_id in mentioned_ids:
+                blocking += 1
+                continue
+            message_sender_id = message.get("sender_id") or message.get("sender_user_id")
+            if not isinstance(message_sender_id, str) or not message_sender_id:
+                raise RuntimeError(f"Chat unread message is missing sender_id for chat {chat_id}")
+            message_sender = self._resolve_display_user(message_sender_id)
+            if message_sender is None:
+                raise RuntimeError(f"Chat message sender identity not found: {message_sender_id}")
+            if self._display_user_type(message_sender, user_id=message_sender_id) == "human":
+                blocking += 1
+        return blocking
+
     def _register(self, registry: ToolRegistry) -> None:
         self._register_list_chats(registry)
         self._register_create_group_chat(registry)
@@ -361,11 +412,13 @@ class ChatToolService:
         ) -> str | ToolResultEnvelope:
             resolved_chat_id = chat_id
             target_name = "chat"
+            direct_chat = False
 
             if chat_id:
                 if not self._messaging.is_chat_member(chat_id, eid):
                     raise RuntimeError(f"You are not a member of chat {chat_id}")
             elif participant_id:
+                direct_chat = True
                 if participant_id == eid:
                     raise RuntimeError("Cannot send a message to yourself.")
                 target = self._resolve_display_user(participant_id)
@@ -383,10 +436,10 @@ class ChatToolService:
             else:
                 raise RuntimeError("Provide participant_id (for 1:1) or chat_id (for group)")
 
-            # @@@read-before-send-gate - group chats and direct chats share the same
-            # delivery invariant: you must consume unread messages before replying,
-            # otherwise siblings can race on stale history and fork the conversation.
-            unread = self._messaging.count_unread(resolved_chat_id, eid)
+            # @@@attention-read-gate - a group reply must not be serialized behind
+            # unrelated peer replies, but it still cannot skip direct, human, or
+            # explicitly mentioned unread messages that require this identity's attention.
+            unread = self._blocking_unread_count(resolved_chat_id, eid, direct_chat=direct_chat)
             if type(unread) is not int:
                 raise RuntimeError(f"Chat unread count is invalid for chat {resolved_chat_id}")
             if unread > 0:
@@ -406,7 +459,6 @@ class ChatToolService:
                     content,
                     mentions=mentions,
                     signal=effective_signal,
-                    enforce_caught_up=True,
                 )
             except RuntimeError as exc:
                 message = str(exc)

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2076,7 +2076,7 @@ def test_chat_tool_send_accepts_agent_user_target_id() -> None:
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             find_or_create_chat=lambda user_ids: {"id": "chat-1", "user_ids": user_ids},
-            count_unread=lambda _chat_id, _user_id: 0,
+            list_unread=lambda _chat_id, _user_id: [],
             send=lambda chat_id, sender_id, content, **_kwargs: sent.append((chat_id, sender_id, content)),
         ),
     )
@@ -2241,7 +2241,7 @@ def test_chat_tool_send_fails_before_unread_check_when_created_chat_id_is_empty(
     assert sent == []
 
 
-def test_chat_tool_send_fails_before_send_when_unread_count_is_invalid() -> None:
+def test_chat_tool_send_fails_before_send_when_unread_collection_is_invalid() -> None:
     registry = ToolRegistry()
     sent: list[tuple[str, str, str]] = []
     ChatToolService(
@@ -2249,7 +2249,7 @@ def test_chat_tool_send_fails_before_send_when_unread_count_is_invalid() -> None
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             find_or_create_chat=lambda _user_ids: {"id": "chat-1"},
-            count_unread=lambda _chat_id, _user_id: None,
+            list_unread=lambda _chat_id, _user_id: None,
             send=lambda chat_id, sender_id, content, **_kwargs: sent.append((chat_id, sender_id, content)),
         ),
     )
@@ -2260,7 +2260,7 @@ def test_chat_tool_send_fails_before_send_when_unread_count_is_invalid() -> None
     with pytest.raises(RuntimeError) as excinfo:
         send_message.handler(content="hello", participant_id="agent-user-1")
 
-    assert str(excinfo.value) == "Chat unread count is invalid for chat chat-1"
+    assert str(excinfo.value) == "Chat unread messages collection is invalid for chat chat-1"
     assert sent == []
 
 
@@ -2272,7 +2272,7 @@ def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
         chat_identity_id="human-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: True,
-            count_unread=lambda _chat_id, _user_id: 0,
+            list_unread=lambda _chat_id, _user_id: [],
             send=lambda chat_id, sender_id, content, **kwargs: sent.append(
                 {
                     "chat_id": chat_id,
@@ -2295,7 +2295,6 @@ def test_chat_tool_send_appends_yield_signal_to_content_and_payload() -> None:
             "chat_id": "chat-1",
             "sender_id": "human-user-1",
             "content": "done\n[signal: yield]",
-            "enforce_caught_up": True,
             "mentions": None,
             "signal": "yield",
         }
@@ -2319,7 +2318,7 @@ def test_chat_tool_send_checks_group_membership_via_messaging_service_without_me
         send_message.handler(content="hello", chat_id="chat-1")
 
 
-def test_chat_tool_send_requires_group_reply_to_consume_peer_unread() -> None:
+def test_chat_tool_send_requires_group_reply_to_consume_human_unread() -> None:
     registry = ToolRegistry()
     sent: list[dict[str, object]] = []
     ChatToolService(
@@ -2327,7 +2326,9 @@ def test_chat_tool_send_requires_group_reply_to_consume_peer_unread() -> None:
         chat_identity_id="agent-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: True,
-            count_unread=lambda _chat_id, _user_id: 1,
+            list_chat_members=lambda _chat_id: [{"user_id": "agent-user-1"}, {"user_id": "human-user-1"}, {"user_id": "agent-user-2"}],
+            list_unread=lambda _chat_id, _user_id: [{"sender_id": "human-user-1", "mentioned_ids": []}],
+            resolve_display_user=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="human" if uid == "human-user-1" else "agent"),
             send=lambda chat_id, sender_id, content, **kwargs: sent.append(
                 {
                     "chat_id": chat_id,
@@ -2351,6 +2352,149 @@ def test_chat_tool_send_requires_group_reply_to_consume_peer_unread() -> None:
     assert sent == []
 
 
+def test_chat_tool_send_requires_group_reply_to_consume_mentioned_agent_unread() -> None:
+    registry = ToolRegistry()
+    sent: list[dict[str, object]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
+            list_chat_members=lambda _chat_id: [{"user_id": "agent-user-1"}, {"user_id": "agent-user-2"}, {"user_id": "agent-user-3"}],
+            list_unread=lambda _chat_id, _user_id: [{"sender_id": "agent-user-2", "mentioned_ids": ["agent-user-1"]}],
+            resolve_display_user=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="agent"),
+            send=lambda chat_id, sender_id, content, **kwargs: sent.append(
+                {
+                    "chat_id": chat_id,
+                    "sender_id": sender_id,
+                    "content": content,
+                    **kwargs,
+                }
+            ),
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    result = send_message.handler(content="GROUP_READ_OK", chat_id="chat-1")
+
+    assert isinstance(result, ToolResultEnvelope)
+    assert result.kind == "error"
+    assert result.metadata["error_type"] == "chat_not_caught_up"
+    assert result.content == "You have 1 unread message(s). Call read_messages(chat_id='chat-1') first."
+    assert sent == []
+
+
+def test_chat_tool_send_ignores_unmentioned_agent_peer_unread_in_group() -> None:
+    registry = ToolRegistry()
+    sent: list[dict[str, object]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
+            list_chat_members=lambda _chat_id: [{"user_id": "agent-user-1"}, {"user_id": "agent-user-2"}, {"user_id": "agent-user-3"}],
+            list_unread=lambda _chat_id, _user_id: [{"sender_id": "agent-user-2", "mentioned_ids": []}],
+            resolve_display_user=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="agent"),
+            send=lambda chat_id, sender_id, content, **kwargs: sent.append(
+                {
+                    "chat_id": chat_id,
+                    "sender_id": sender_id,
+                    "content": content,
+                    **kwargs,
+                }
+            ),
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    result = send_message.handler(content="vote: agent 01", chat_id="chat-1")
+
+    assert result == "Message sent to chat."
+    assert sent == [
+        {
+            "chat_id": "chat-1",
+            "sender_id": "agent-user-1",
+            "content": "vote: agent 01",
+            "mentions": None,
+            "signal": None,
+        }
+    ]
+
+
+def test_chat_tool_send_requires_direct_reply_to_consume_agent_peer_unread() -> None:
+    registry = ToolRegistry()
+    sent: list[dict[str, object]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
+            list_chat_members=lambda _chat_id: [{"user_id": "agent-user-1"}, {"user_id": "agent-user-2"}],
+            list_unread=lambda _chat_id, _user_id: [{"sender_id": "agent-user-2", "mentioned_ids": []}],
+            resolve_display_user=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="agent"),
+            send=lambda chat_id, sender_id, content, **kwargs: sent.append(
+                {
+                    "chat_id": chat_id,
+                    "sender_id": sender_id,
+                    "content": content,
+                    **kwargs,
+                }
+            ),
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    result = send_message.handler(content="DIRECT_READ_OK", chat_id="chat-1")
+
+    assert isinstance(result, ToolResultEnvelope)
+    assert result.kind == "error"
+    assert result.metadata["error_type"] == "chat_not_caught_up"
+    assert sent == []
+
+
+def test_chat_tool_send_does_not_serialize_concurrent_group_replies_after_read() -> None:
+    registry = ToolRegistry()
+    sent: list[dict[str, object]] = []
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
+            list_unread=lambda _chat_id, _user_id: [],
+            send=lambda chat_id, sender_id, content, **kwargs: sent.append(
+                {
+                    "chat_id": chat_id,
+                    "sender_id": sender_id,
+                    "content": content,
+                    **kwargs,
+                }
+            ),
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    result = send_message.handler(content="vote: agent 01", chat_id="chat-1")
+
+    assert result == "Message sent to chat."
+    assert sent == [
+        {
+            "chat_id": "chat-1",
+            "sender_id": "agent-user-1",
+            "content": "vote: agent 01",
+            "mentions": None,
+            "signal": None,
+        }
+    ]
+
+
 def test_chat_tool_send_returns_tool_error_when_chat_advances_after_read() -> None:
     registry = ToolRegistry()
 
@@ -2362,7 +2506,7 @@ def test_chat_tool_send_returns_tool_error_when_chat_advances_after_read() -> No
         chat_identity_id="agent-user-1",
         messaging_service=SimpleNamespace(
             is_chat_member=lambda _chat_id, _user_id: True,
-            count_unread=lambda _chat_id, _user_id: 0,
+            list_unread=lambda _chat_id, _user_id: [],
             send=_send,
         ),
     )


### PR DESCRIPTION
## Summary
- make agent chat tool read-before-send gate attention-aware for group chats
- keep direct chat, human unread, and explicit mention unread as blocking
- stop serializing concurrent unmentioned managed-agent group replies behind peer replies

## Evidence
- uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
- 16-agent CLI YATU on latest origin/dev backend: /Users/lexicalmathical/share/yatu/debate-tournament-cli-20260426T-fanout-race-fix-v4
- v4 result: 14/14 mentioned voters replied; Agent 01/02 stayed silent; vote split 9/5

## Notes
No SDK/CLI code changed. This is backend tool-runtime behavior; public API shape stays unchanged.