### PR TITLE
Hard cut runtime MCP config source

### DIFF
--- a/config/defaults/runtime.json
+++ b/config/defaults/runtime.json
@@ -61,9 +61,5 @@
     "command": {
       "enabled": true
     }
-  },
-  "mcp": {
-    "enabled": true,
-    "servers": {}
   }
 }

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,7 +1,7 @@
 """Core runtime configuration schema for Mycel using Pydantic.
 
 This module defines the runtime configuration structure with:
-- Nested config groups (Memory, Tools, Skills, MCP)
+- Nested config groups (Memory, Tools)
 - Runtime behavior parameters (temperature, max_tokens, context_limit, etc.)
 - Field validators for paths, extensions
 
@@ -178,32 +178,6 @@ class ToolsConfig(RuntimeSchemaModel):
 
 
 # ============================================================================
-# MCP Configuration
-# ============================================================================
-
-
-class MCPServerConfig(RuntimeSchemaModel):
-    """Configuration for a single MCP server."""
-
-    transport: str | None = Field(
-        None,
-        description="MCP transport type: stdio | streamable_http | sse | websocket",
-    )
-    command: str | None = Field(None, description="Command to run the MCP server")
-    args: list[str] = Field(default_factory=list, description="Command arguments")
-    env: dict[str, str] = Field(default_factory=dict, description="Environment variables")
-    url: str | None = Field(None, description="URL for streamable HTTP transport")
-    allowed_tools: list[str] | None = Field(None, description="Allowed tool names (None = all)")
-
-
-class MCPConfig(RuntimeSchemaModel):
-    """MCP (Model Context Protocol) configuration."""
-
-    enabled: StrictBool = True
-    servers: dict[str, MCPServerConfig] = Field(default_factory=dict, description="MCP server configurations")
-
-
-# ============================================================================
 # Main Settings
 # ============================================================================
 
@@ -211,7 +185,7 @@ class MCPConfig(RuntimeSchemaModel):
 class LeonSettings(RuntimeSchemaModel):
     """Main Mycel runtime configuration.
 
-    Contains non-model runtime settings: memory, tools, mcp, and behavior params.
+    Contains non-model runtime settings: memory, tools, and behavior params.
     Model identity (model name, provider, API keys) lives in ModelsConfig.
 
     Configuration priority (highest to lowest):
@@ -225,7 +199,6 @@ class LeonSettings(RuntimeSchemaModel):
     # Core configuration groups
     memory: MemoryConfig = Field(default_factory=lambda: MemoryConfig(), description="Memory management")
     tools: ToolsConfig = Field(default_factory=lambda: ToolsConfig(), description="Tools configuration")
-    mcp: MCPConfig = Field(default_factory=lambda: MCPConfig(), description="MCP configuration")
 
     # Agent configuration
     system_prompt: str | None = Field(None, description="Custom system prompt")

--- a/core/runtime/agent.py
+++ b/core/runtime/agent.py
@@ -453,13 +453,13 @@ class LeonAgent:
         resolved_config = getattr(self, "_resolved_agent_config", None)
         if resolved_config is not None:
             return {server.name: server for server in resolved_config.mcp_servers if server.enabled}
-        return self.config.mcp.servers
+        return {}
 
     def _mcp_enabled(self) -> bool:
         resolved_config = getattr(self, "_resolved_agent_config", None)
         if resolved_config is not None:
             return bool(self._get_mcp_server_configs())
-        return bool(self.config.mcp.enabled)
+        return False
 
     def _get_integration_instruction_blocks(self) -> dict[str, str]:
         return mcp_gateway.instruction_blocks(self._get_mcp_server_configs())

--- a/tests/Unit/config/test_runtime_schema.py
+++ b/tests/Unit/config/test_runtime_schema.py
@@ -3,17 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from config.schema import LeonSettings, MCPConfig
+from config.schema import LeonSettings
 
 
-def test_mcp_config_rejects_string_enabled() -> None:
-    with pytest.raises(ValueError, match="enabled"):
-        MCPConfig.model_validate({"enabled": "false", "servers": {}})
-
-
-def test_mcp_config_rejects_numeric_enabled() -> None:
-    with pytest.raises(ValueError, match="enabled"):
-        MCPConfig.model_validate({"enabled": 1, "servers": {}})
+def test_runtime_schema_has_no_top_level_mcp_config() -> None:
+    assert not hasattr(LeonSettings(), "mcp")
+    with pytest.raises(ValueError, match="mcp"):
+        LeonSettings.model_validate({"mcp": {"enabled": True, "servers": {}}})
 
 
 def test_runtime_fields_must_live_under_runtime_object() -> None:
@@ -26,6 +22,7 @@ def test_default_runtime_config_uses_runtime_object() -> None:
     payload = json.loads(defaults_path.read_text(encoding="utf-8"))
 
     assert "runtime" in payload
+    assert "mcp" not in payload
     assert "context_limit" not in payload
     assert "block_network_commands" not in payload
 

--- a/tests/Unit/config/test_runtime_schema.py
+++ b/tests/Unit/config/test_runtime_schema.py
@@ -8,7 +8,7 @@ from config.schema import LeonSettings
 
 
 def test_runtime_schema_has_no_top_level_mcp_config() -> None:
-    assert not hasattr(LeonSettings(), "mcp")
+    assert not hasattr(LeonSettings.model_validate({}), "mcp")
     assert not hasattr(runtime_schema, "MCPConfig")
     assert not hasattr(runtime_schema, "MCPServerConfig")
     with pytest.raises(ValueError, match="mcp"):

--- a/tests/Unit/config/test_runtime_schema.py
+++ b/tests/Unit/config/test_runtime_schema.py
@@ -3,11 +3,14 @@ from pathlib import Path
 
 import pytest
 
+import config.schema as runtime_schema
 from config.schema import LeonSettings
 
 
 def test_runtime_schema_has_no_top_level_mcp_config() -> None:
     assert not hasattr(LeonSettings(), "mcp")
+    assert not hasattr(runtime_schema, "MCPConfig")
+    assert not hasattr(runtime_schema, "MCPServerConfig")
     with pytest.raises(ValueError, match="mcp"):
         LeonSettings.model_validate({"mcp": {"enabled": True, "servers": {}}})
 

--- a/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
+++ b/tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
@@ -33,6 +33,13 @@ def test_runtime_skill_registration_reads_resolved_config_only() -> None:
     assert "resolved_skills" in source
 
 
+def test_runtime_mcp_registration_reads_resolved_config_only() -> None:
+    source = inspect.getsource(LeonAgent._get_mcp_server_configs) + inspect.getsource(LeonAgent._mcp_enabled)
+
+    assert "self.config.mcp" not in source
+    assert "resolved_config.mcp_servers" in source
+
+
 def test_config_loading_does_not_create_skill_directories() -> None:
     loader_source = inspect.getsource(AgentLoader.load)
 

--- a/tests/Unit/platform/test_mcp_transport.py
+++ b/tests/Unit/platform/test_mcp_transport.py
@@ -2,10 +2,22 @@ from __future__ import annotations
 
 import pytest
 
-from config.agent_config_types import McpServerConfig as AgentMcpServerConfig
+from config.agent_config_types import McpServerConfig
 from config.agent_config_types import ResolvedAgentConfig
-from config.schema import LeonSettings, MCPConfig, MCPServerConfig
+from config.schema import LeonSettings
 from core.runtime.agent import LeonAgent
+
+
+def _agent_with_mcp(*servers: McpServerConfig) -> LeonAgent:
+    agent = LeonAgent.__new__(LeonAgent)
+    agent.config = LeonSettings()
+    agent._resolved_agent_config = ResolvedAgentConfig(
+        id="cfg-1",
+        name="Agent",
+        mcp_servers=list(servers),
+    )
+    agent._mcp_client = None
+    return agent
 
 
 @pytest.mark.asyncio
@@ -22,25 +34,13 @@ async def test_init_mcp_tools_respects_explicit_websocket_transport(monkeypatch)
         async def close(self):
             return None
 
-    agent = LeonAgent.__new__(LeonAgent)
-    agent.config = LeonSettings.model_validate(
-        {
-            "mcp": MCPConfig.model_validate(
-                {
-                    "enabled": True,
-                    "servers": {
-                        "wsdemo": MCPServerConfig.model_validate(
-                            {
-                                "transport": "websocket",
-                                "url": "ws://example.test/mcp",
-                            }
-                        )
-                    },
-                }
-            )
-        }
+    agent = _agent_with_mcp(
+        McpServerConfig(
+            name="wsdemo",
+            transport="websocket",
+            url="ws://example.test/mcp",
+        )
     )
-    agent._mcp_client = None
 
     mcp_client_path = ".".join(["langchain_mcp_" + "adap" + "ters", "client", "MultiServerMCPClient"])
     monkeypatch.setattr(mcp_client_path, FakeClient)
@@ -64,18 +64,12 @@ async def test_resolved_agent_config_controls_mcp_enablement(monkeypatch):
         captured["server_configs"] = server_configs
         return None, []
 
-    agent = LeonAgent.__new__(LeonAgent)
-    agent.config = LeonSettings.model_validate({"mcp": MCPConfig.model_validate({"enabled": False, "servers": {}})})
-    agent._resolved_agent_config = ResolvedAgentConfig(
-        id="cfg-1",
-        name="Agent",
-        mcp_servers=[
-            AgentMcpServerConfig(
-                name="agent-mcp",
-                transport="websocket",
-                url="ws://example.test/mcp",
-            )
-        ],
+    agent = _agent_with_mcp(
+        McpServerConfig(
+            name="agent-mcp",
+            transport="websocket",
+            url="ws://example.test/mcp",
+        )
     )
 
     monkeypatch.setattr("core.runtime.agent.mcp_gateway.init_client_tools", fake_init_client_tools)
@@ -97,25 +91,7 @@ async def test_resolved_agent_config_without_mcp_disables_mcp(monkeypatch):
         captured["server_configs"] = server_configs
         return None, []
 
-    agent = LeonAgent.__new__(LeonAgent)
-    agent.config = LeonSettings.model_validate(
-        {
-            "mcp": MCPConfig.model_validate(
-                {
-                    "enabled": True,
-                    "servers": {
-                        "runtime-mcp": MCPServerConfig.model_validate(
-                            {
-                                "transport": "websocket",
-                                "url": "ws://runtime.example.test/mcp",
-                            }
-                        )
-                    },
-                }
-            )
-        }
-    )
-    agent._resolved_agent_config = ResolvedAgentConfig(id="cfg-1", name="Agent", mcp_servers=[])
+    agent = _agent_with_mcp()
 
     monkeypatch.setattr("core.runtime.agent.mcp_gateway.init_client_tools", fake_init_client_tools)
 

--- a/tests/Unit/platform/test_mcp_transport.py
+++ b/tests/Unit/platform/test_mcp_transport.py
@@ -99,3 +99,23 @@ async def test_resolved_agent_config_without_mcp_disables_mcp(monkeypatch):
 
     assert captured["enabled"] is False
     assert captured["server_configs"] == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_resolved_agent_config_disables_mcp(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_init_client_tools(*, enabled: bool, server_configs: dict[str, object]):
+        captured["enabled"] = enabled
+        captured["server_configs"] = server_configs
+        return None, []
+
+    agent = LeonAgent.__new__(LeonAgent)
+    agent.config = LeonSettings()
+
+    monkeypatch.setattr("core.runtime.agent.mcp_gateway.init_client_tools", fake_init_client_tools)
+
+    await LeonAgent._init_mcp_tools(agent)
+
+    assert captured["enabled"] is False
+    assert captured["server_configs"] == {}

--- a/tests/Unit/platform/test_mcp_transport.py
+++ b/tests/Unit/platform/test_mcp_transport.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 import pytest
 
-from config.agent_config_types import McpServerConfig
-from config.agent_config_types import ResolvedAgentConfig
+from config.agent_config_types import McpServerConfig, ResolvedAgentConfig
 from config.schema import LeonSettings
 from core.runtime.agent import LeonAgent
 
 
 def _agent_with_mcp(*servers: McpServerConfig) -> LeonAgent:
     agent = LeonAgent.__new__(LeonAgent)
-    agent.config = LeonSettings()
+    agent.config = LeonSettings.model_validate({})
     agent._resolved_agent_config = ResolvedAgentConfig(
         id="cfg-1",
         name="Agent",
@@ -111,7 +110,7 @@ async def test_missing_resolved_agent_config_disables_mcp(monkeypatch):
         return None, []
 
     agent = LeonAgent.__new__(LeonAgent)
-    agent.config = LeonSettings()
+    agent.config = LeonSettings.model_validate({})
 
     monkeypatch.setattr("core.runtime.agent.mcp_gateway.init_client_tools", fake_init_client_tools)
 


### PR DESCRIPTION
## Summary
- remove top-level runtime MCP settings from LeonSettings and runtime defaults
- route LeonAgent MCP server config only through ResolvedAgentConfig.mcp_servers
- update MCP transport/schema/source-boundary tests to guard the source split

## Verification
- uv run pytest tests/Unit/config/test_runtime_schema.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py::test_runtime_mcp_registration_reads_resolved_config_only tests/Unit/platform/test_mcp_transport.py -q
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright config/schema.py core/runtime/agent.py tests/Unit/platform/test_mcp_transport.py tests/Unit/config/test_runtime_schema.py tests/Unit/integration_contracts/test_agent_config_runtime_source_boundary.py
- npm test (frontend/app)
- npm run lint (frontend/app)
- npm run typecheck (frontend/app)
- npm run build (frontend/app; existing chunk-size warning only)