### PR TITLE
Install Hub skills with Library-owned ids

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -260,9 +260,6 @@ def apply_item(
         skill_files = _skill_files_from_snapshot(snapshot)
         if skill_repo is None:
             raise RuntimeError("skill_repo is required to save a skill to Library")
-        slug = _required_text(item.get("slug"), label="Hub item slug")
-        if "/" in slug or "\\" in slug or slug in {"", ".", ".."}:
-            raise ValueError(f"Invalid slug: {slug}")
         skill_name = str(skill_metadata["name"]).strip()
         owner_skills = skill_repo.list_for_owner(owner_user_id)
         existing_skill = _hub_source_skill(owner_skills, item_id)
@@ -286,6 +283,9 @@ def apply_item(
             "source_at": now,
             "publisher": publisher,
         }
+        item_slug = item.get("slug")
+        if isinstance(item_slug, str) and item_slug.strip():
+            source["marketplace_slug"] = item_slug.strip()
         skill = skill_repo.upsert(
             Skill(
                 id=skill_id,

--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -17,6 +17,7 @@ from config.agent_config_types import Skill, SkillPackage
 from config.agent_snapshot import snapshot_from_resolved_config
 from config.skill_files import normalize_skill_file_map
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+from storage.utils import generate_skill_id
 
 HUB_URL = os.environ.get("MYCEL_HUB_URL", "https://hub.mycel.nextmind.space")
 # @@@hub-agent-user-item-type - Hub still names published Agent users "member";
@@ -256,11 +257,11 @@ def apply_item(
         if "/" in slug or "\\" in slug or slug in {"", ".", ".."}:
             raise ValueError(f"Invalid slug: {slug}")
         skill_name = str(skill_metadata["name"]).strip()
-        existing_skill = skill_repo.get_by_id(owner_user_id, slug)
-        if existing_skill is not None and existing_skill.name != skill_name:
-            raise ValueError("Skill snapshot frontmatter name must match existing Skill name")
+        skill_id = generate_skill_id()
+        if skill_repo.get_by_id(owner_user_id, skill_id) is not None:
+            raise RuntimeError("Generated Skill id already exists")
         for skill in skill_repo.list_for_owner(owner_user_id):
-            if skill.name == skill_name and skill.id != slug:
+            if skill.name == skill_name:
                 raise ValueError("Skill name already exists under a different Library id")
         skill_description = _skill_description_from_metadata(skill_metadata)
         publisher = _required_text(item.get("publisher_username"), label="Hub item publisher_username")
@@ -273,7 +274,7 @@ def apply_item(
         }
         skill = skill_repo.upsert(
             Skill(
-                id=slug,
+                id=skill_id,
                 owner_user_id=owner_user_id,
                 name=skill_name,
                 description=skill_description,
@@ -299,7 +300,7 @@ def apply_item(
         )
         skill_repo.select_package(owner_user_id, skill.id, package.id)
 
-        return {"resource_id": slug, "package_id": package.id, "type": "skill", "version": source_version}
+        return {"resource_id": skill.id, "package_id": package.id, "type": "skill", "version": source_version}
 
     if item_type == "agent":
         raise ValueError("Marketplace agent items are not supported; apply Agent user items instead")

--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -110,6 +110,13 @@ def _skill_files_from_snapshot(snapshot: dict[str, Any]) -> dict[str, str]:
     return normalize_skill_file_map(files, context="Skill snapshot files")
 
 
+def _hub_source_skill(skills: list[Skill], item_id: str) -> Skill | None:
+    for skill in skills:
+        if skill.source.get("marketplace_item_id") == item_id:
+            return skill
+    return None
+
+
 def list_items(
     *,
     type: str | None = None,
@@ -257,12 +264,19 @@ def apply_item(
         if "/" in slug or "\\" in slug or slug in {"", ".", ".."}:
             raise ValueError(f"Invalid slug: {slug}")
         skill_name = str(skill_metadata["name"]).strip()
-        skill_id = generate_skill_id()
-        if skill_repo.get_by_id(owner_user_id, skill_id) is not None:
-            raise RuntimeError("Generated Skill id already exists")
-        for skill in skill_repo.list_for_owner(owner_user_id):
-            if skill.name == skill_name:
-                raise ValueError("Skill name already exists under a different Library id")
+        owner_skills = skill_repo.list_for_owner(owner_user_id)
+        existing_skill = _hub_source_skill(owner_skills, item_id)
+        if existing_skill is not None and existing_skill.name != skill_name:
+            raise ValueError("Skill snapshot frontmatter name must match existing Skill name")
+        if existing_skill is None:
+            skill_id = generate_skill_id()
+            if skill_repo.get_by_id(owner_user_id, skill_id) is not None:
+                raise RuntimeError("Generated Skill id already exists")
+            for skill in owner_skills:
+                if skill.name == skill_name:
+                    raise ValueError("Skill name already exists under a different Library id")
+        else:
+            skill_id = existing_skill.id
         skill_description = _skill_description_from_metadata(skill_metadata)
         publisher = _required_text(item.get("publisher_username"), label="Hub item publisher_username")
         timestamp = datetime.now(UTC)

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -184,17 +184,19 @@ def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch:
                 ]
             },
         )
-        blocked_alpha_delete = client.delete("/api/panel/library/skill/alpha-skill")
+        alpha_skill_id = library_by_name["Alpha Skill"]["id"]
+        beta_skill_id = library_by_name["Beta Skill"]["id"]
+        blocked_alpha_delete = client.delete(f"/api/panel/library/skill/{alpha_skill_id}")
 
         keep_beta = client.put(
             "/api/panel/agents/agent-1/config",
             json={"skills": [{"id": library_by_name["Beta Skill"]["id"], "name": "Beta Skill", "enabled": True}]},
         )
-        deleted_alpha = client.delete("/api/panel/library/skill/alpha-skill")
-        blocked_beta_delete = client.delete("/api/panel/library/skill/beta-skill")
+        deleted_alpha = client.delete(f"/api/panel/library/skill/{alpha_skill_id}")
+        blocked_beta_delete = client.delete(f"/api/panel/library/skill/{beta_skill_id}")
 
         clear_skills = client.put("/api/panel/agents/agent-1/config", json={"skills": []})
-        deleted_beta = client.delete("/api/panel/library/skill/beta-skill")
+        deleted_beta = client.delete(f"/api/panel/library/skill/{beta_skill_id}")
         library_after_delete = client.get("/api/panel/library/skill")
 
     assert alpha_apply.status_code == 200

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -159,7 +159,8 @@ class TestApplySkill:
         assert "id=slug" not in source
         assert "get_by_id(owner_user_id, slug)" not in source
 
-    def test_writes_hub_skill_files_as_posix_paths(self):
+    def test_writes_hub_skill_files_as_posix_paths(self, monkeypatch):
+        monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_posix123")
         saved: list[Skill] = []
         packages: list[SkillPackage] = []
         hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
@@ -177,7 +178,7 @@ class TestApplySkill:
 
             apply_item("item-123", owner_user_id="owner-1", skill_repo=skill_repo)
 
-        assert saved[0].id == "my-skill"
+        assert saved[0].id == "skill_posix123"
         assert packages[0].manifest["files"][0]["path"] == "references/usage.md"
 
     def test_apply_rejects_hub_skill_file_path_collision(self):
@@ -307,12 +308,14 @@ class TestApplySkill:
             id="same-slug",
             owner_user_id="owner-1",
             name="Original Skill",
+            source={"marketplace_item_id": "item-rename"},
             created_at=datetime(2026, 4, 24, tzinfo=UTC),
             updated_at=datetime(2026, 4, 24, tzinfo=UTC),
         )
         hub_resp = _make_hub_response("skill", "same-slug", content="---\nname: Renamed Skill\n---\nBody")
         skill_repo = SimpleNamespace(
-            get_by_id=lambda owner_user_id, skill_id: existing if (owner_user_id, skill_id) == ("owner-1", "same-slug") else None,
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [existing],
             upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not rename existing Skill")),
         )
 
@@ -406,7 +409,7 @@ class TestApplySkill:
             apply_item("item-meta", owner_user_id="owner-1", skill_repo=skill_repo)
 
         assert saved[0].description == "Frontmatter wins"
-        assert packages[0].skill_id == "meta-free-skill"
+        assert packages[0].skill_id == saved[0].id
 
     def test_slug_path_shape_does_not_affect_library_id(self, monkeypatch):
         monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_evilSafe1")
@@ -475,7 +478,7 @@ class TestApplySkill:
             )
 
         assert result == {
-            "resource_id": "fastapi",
+            "resource_id": saved_skills[0].id,
             "package_id": packages[0].id,
             "type": "skill",
             "version": "1.2.3",
@@ -484,7 +487,7 @@ class TestApplySkill:
         assert saved_skills[0].description == "Build FastAPI APIs"
         assert packages[0].skill_md == "---\nname: FastAPI\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter."
         assert packages[0].manifest["files"][0]["path"] == "references/routing.md"
-        assert selected == [("owner-1", "fastapi", packages[0].id)]
+        assert selected == [("owner-1", saved_skills[0].id, packages[0].id)]
         assert saved == []
 
     def test_saves_skill_to_library_without_agent_config_repo(self):
@@ -526,10 +529,10 @@ class TestApplySkill:
                 skill_repo=skill_repo,
             )
 
-        assert saved_skills[0].id == "fastapi"
+        assert saved_skills[0].id.startswith("skill_")
         assert saved_skills[0].name == "FastAPI"
         assert result == {
-            "resource_id": "fastapi",
+            "resource_id": saved_skills[0].id,
             "package_id": packages[0].id,
             "type": "skill",
             "version": "1.2.3",
@@ -574,7 +577,7 @@ class TestApplySkill:
                 skill_repo=skill_repo,
             )
 
-        assert result["resource_id"] == "fastapi"
+        assert result["resource_id"] == saved_skills[0].id
         assert result["package_id"] == packages[0].id
         assert saved_skills[0].name == "FastAPI"
         assert saved == []

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -117,7 +117,8 @@ def _agent_config(**overrides: object) -> AgentConfig:
 
 
 class TestApplySkill:
-    def test_writes_skill_to_skill_repo(self):
+    def test_writes_skill_to_skill_repo(self, monkeypatch):
+        monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_generated123")
         saved: list[Skill] = []
         packages: list[SkillPackage] = []
         selected: list[tuple[str, str, str]] = []
@@ -137,16 +138,26 @@ class TestApplySkill:
             result = apply_item("item-123", owner_user_id="owner-1", skill_repo=skill_repo)
 
         assert result["type"] == "skill"
-        assert result["resource_id"] == "my-skill"
-        assert saved[0].id == "my-skill"
+        assert result["resource_id"] == "skill_generated123"
+        assert saved[0].id == "skill_generated123"
         assert saved[0].owner_user_id == "owner-1"
         assert saved[0].name == "My Skill"
         assert not hasattr(saved[0], "content")
-        assert packages[0].skill_id == "my-skill"
+        assert packages[0].skill_id == "skill_generated123"
         assert packages[0].skill_md == "---\nname: My Skill\n---\n# My Skill\nDo stuff"
         assert packages[0].manifest["files"][0]["path"] == "references/usage.md"
-        assert selected == [("owner-1", "my-skill", packages[0].id)]
+        assert selected == [("owner-1", "skill_generated123", packages[0].id)]
         assert result["package_id"] == packages[0].id
+
+    def test_apply_skill_does_not_use_hub_slug_as_library_id(self) -> None:
+        import inspect
+
+        import backend.hub.client as marketplace_client
+
+        source = inspect.getsource(marketplace_client.apply_item)
+
+        assert "id=slug" not in source
+        assert "get_by_id(owner_user_id, slug)" not in source
 
     def test_writes_hub_skill_files_as_posix_paths(self):
         saved: list[Skill] = []

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -659,7 +659,9 @@ class TestApplyUnsupportedType:
 
 
 class TestApplyIdempotency:
-    def test_apply_twice_upserts_same_skill_id(self):
+    def test_apply_twice_upserts_same_skill_id(self, monkeypatch):
+        generated_ids = iter(["skill_idem123", "skill_mustNotUse"])
+        monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: next(generated_ids))
         saved: dict[str, Skill] = {}
         packages: list[SkillPackage] = []
         selected: list[tuple[str, str, str]] = []
@@ -683,11 +685,11 @@ class TestApplyIdempotency:
 
         assert result["version"] == "1.0.1"
         assert result["package_id"] == packages[1].id
-        assert list(saved) == ["idem-skill"]
-        assert saved["idem-skill"].source["source_version"] == "1.0.1"
+        assert list(saved) == ["skill_idem123"]
+        assert saved["skill_idem123"].source["source_version"] == "1.0.1"
         assert packages[0].skill_md == "---\nname: Idem Skill\n---\nV1"
         assert packages[1].skill_md == "---\nname: Idem Skill\n---\nV2"
-        assert selected[-1] == ("owner-1", "idem-skill", packages[1].id)
+        assert selected[-1] == ("owner-1", "skill_idem123", packages[1].id)
 
 
 def test_upgrade_returns_user_id_contract(monkeypatch):

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -265,20 +265,27 @@ class TestApplySkill:
             with pytest.raises(ValueError, match="Hub download version must be a string"):
                 apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
 
-    def test_apply_skill_requires_item_slug(self):
+    def test_apply_skill_does_not_require_item_slug(self, monkeypatch):
+        monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_noSlug123")
         hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")
         del hub_resp["item"]["slug"]
+        saved: list[Skill] = []
+        packages: list[SkillPackage] = []
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
             list_for_owner=lambda _owner_user_id: [],
-            upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save broken Skill")),
+            upsert=lambda skill: saved.append(skill) or skill,
+            create_package=lambda package: packages.append(package) or package,
+            select_package=lambda _owner_user_id, _skill_id, _package_id: None,
         )
 
         with patch("backend.hub.client._hub_api", return_value=hub_resp):
             from backend.hub.client import apply_item
 
-            with pytest.raises(ValueError, match="Hub item slug must be a string"):
-                apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
+            result = apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert result["resource_id"] == "skill_noSlug123"
+        assert saved[0].id == "skill_noSlug123"
 
     def test_apply_skill_requires_publisher(self):
         hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")
@@ -401,15 +408,26 @@ class TestApplySkill:
         assert saved[0].description == "Frontmatter wins"
         assert packages[0].skill_id == "meta-free-skill"
 
-    def test_path_traversal_blocked(self):
+    def test_slug_path_shape_does_not_affect_library_id(self, monkeypatch):
+        monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_evilSafe1")
         hub_resp = _make_hub_response("skill", "../../evil", content="---\nname: Evil\n---\n# Hello")
-        skill_repo = SimpleNamespace(upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save invalid slug")))
+        saved: list[Skill] = []
+        packages: list[SkillPackage] = []
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda skill: saved.append(skill) or skill,
+            create_package=lambda package: packages.append(package) or package,
+            select_package=lambda _owner_user_id, _skill_id, _package_id: None,
+        )
 
         with patch("backend.hub.client._hub_api", return_value=hub_resp):
             from backend.hub.client import apply_item
 
-            with pytest.raises(ValueError, match="Invalid slug"):
-                apply_item("item-evil", owner_user_id="owner-1", skill_repo=skill_repo)
+            result = apply_item("item-evil", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert result["resource_id"] == "skill_evilSafe1"
+        assert saved[0].id == "skill_evilSafe1"
 
     def test_apply_skill_saves_library_package_without_agent_config_write(self):
         import backend.hub.client as marketplace_client


### PR DESCRIPTION
## Summary
- generate local Library Skill ids for Hub-downloaded Skills instead of using Hub slug
- locate reinstalled Hub Skills by source marketplace item id
- treat Hub slug as optional source metadata and update backend YATU deletion to use Library ids

## Verification
- uv run pytest tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py -q
- uv run pytest tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "skill or marketplace"
- rg -n 'id=slug|get_by_id\(owner_user_id, slug\)|resource_id": "fastapi|/library/skill/(alpha-skill|beta-skill)|Hub item slug must' backend tests frontend/app/src -S
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright backend/hub/client.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
- npm test (frontend/app)
- npm run lint (frontend/app)
- npm run typecheck (frontend/app)
- npm run build (frontend/app; existing chunk-size warning only)