### PR TITLE
feat(frontend): surface social discovery actions

### DIFF
--- a/frontend/app/src/pages/ChatConversationPage.test.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.test.tsx
@@ -285,6 +285,28 @@ describe("ChatConversationPage SSE teardown", () => {
     expect(screen.queryByText("入群申请")).toBeNull();
   });
 
+  it("lets group members copy the current group link for join discovery", async () => {
+    const writeText = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <MemoryRouter initialEntries={["/chat/visit/chat-1"]}>
+        <Routes>
+          <Route path="/chat/visit/:chatId" element={<ChatConversationPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("chat title")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "复制群链接" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("http://localhost:3000/chat/visit/chat-1");
+    });
+    expect(await screen.findByText("已复制")).toBeTruthy();
+  });
+
   it("does not fetch group join requests for a direct chat owner", async () => {
     authFetchMocks.authFetch.mockImplementation(async (url: string) => {
       if (url === "/api/chats/chat-1") {

--- a/frontend/app/src/pages/ChatConversationPage.tsx
+++ b/frontend/app/src/pages/ChatConversationPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router-dom";
-import { Check, PanelLeft, Send, UserPlus, X } from "lucide-react";
+import { Check, Clipboard, PanelLeft, Send, UserPlus, X } from "lucide-react";
 import { authFetch, useAuthStore } from "../store/auth-store";
 import { parseChatMessageEventData, parseChatTypingUserId, streamChatEvents } from "../api/chat-events";
 import { UserBubble } from "../components/chat-area/UserBubble";
@@ -57,6 +57,7 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
   const [joinRequests, setJoinRequests] = useState<ChatJoinRequest[]>([]);
   const [joinRequestError, setJoinRequestError] = useState<string | null>(null);
   const [joinRequestBusyId, setJoinRequestBusyId] = useState<string | null>(null);
+  const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [typingUsers, setTypingUsers] = useState<Set<string>>(new Set());
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -339,6 +340,18 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
     }
   }, [chatId, joinMessage, joinSubmitting, joinTarget]);
 
+  const copyGroupLink = useCallback(async () => {
+    setShareStatus(null);
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error("Clipboard API unavailable");
+      await navigator.clipboard.writeText(`${window.location.origin}/chat/visit/${chatId}`);
+      setShareStatus("已复制");
+    } catch (err) {
+      console.error("[ChatShare] copy failed:", err);
+      setShareStatus("复制失败");
+    }
+  }, [chatId]);
+
   // Typing indicator display — works for both 1:1 and group
   const typingNames = [...typingUsers]
     .map(id => memberMap.get(id)?.name)
@@ -469,6 +482,22 @@ function ChatConversationInner({ chatId }: { chatId: string }) {
             </span>
           )}
         </div>
+        {chat?.type === "group" && (
+          <div className="flex shrink-0 items-center gap-2">
+            {shareStatus && (
+              <span className="text-2xs text-muted-foreground">{shareStatus}</span>
+            )}
+            <button
+              type="button"
+              aria-label="复制群链接"
+              onClick={() => void copyGroupLink()}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2 text-2xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Clipboard className="h-3.5 w-3.5" />
+              复制群链接
+            </button>
+          </div>
+        )}
       </header>
 
       {isGroupOwner && (pendingJoinRequests.length > 0 || joinRequestError) && (

--- a/frontend/app/src/pages/contacts/ContactList.test.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.test.tsx
@@ -132,6 +132,8 @@ describe("ContactList", () => {
         owner_name: null,
         is_owned: false,
         relationship_state: "pending",
+        relationship_id: "hire_visit:human-1:human-3",
+        relationship_is_requester: false,
         can_chat: false,
       },
     ]));
@@ -158,9 +160,43 @@ describe("ContactList", () => {
     expect(screen.queryByText("none")).toBeNull();
     expect(screen.queryByText("联系人功能即将上线")).toBeNull();
     expect(screen.queryByText("Morel")).toBeNull();
-    expect(screen.queryByText("Pending")).toBeNull();
+    expect(screen.getByText("Pending")).toBeTruthy();
+    expect(screen.getByText("待处理")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("link", { name: /Ada/ }));
+
+    expect(await screen.findByText("contact detail route")).toBeTruthy();
+  });
+
+  it("keeps outgoing relationship requests reachable from contacts", async () => {
+    authFetch.mockResolvedValueOnce(okJson([
+      {
+        user_id: "human-5",
+        name: "Waiting",
+        type: "human",
+        avatar_url: null,
+        owner_name: null,
+        is_owned: false,
+        relationship_state: "pending",
+        relationship_id: "hire_visit:human-1:human-5",
+        relationship_is_requester: true,
+        can_chat: false,
+      },
+    ]));
+
+    render(
+      <MemoryRouter initialEntries={["/contacts/users"]}>
+        <Routes>
+          <Route path="/contacts/users" element={<ContactList />} />
+          <Route path="/contacts/users/:userId" element={<div>contact detail route</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Waiting")).toBeTruthy();
+    expect(screen.getByText("已申请")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("link", { name: /Waiting/ }));
 
     expect(await screen.findByText("contact detail route")).toBeTruthy();
   });

--- a/frontend/app/src/pages/contacts/ContactList.tsx
+++ b/frontend/app/src/pages/contacts/ContactList.tsx
@@ -16,11 +16,19 @@ const statusDot: Record<string, string> = {
 };
 
 function contactStatusLabel(contact: UserChatCandidate): string {
+  if (contact.relationship_state === "pending") {
+    return contact.relationship_is_requester ? "已申请" : "待处理";
+  }
   if (contact.relationship_state === "visit" || contact.relationship_state === "hire") {
     return contact.relationship_state;
   }
   if (contact.can_chat) return "联系人";
   return contact.relationship_state;
+}
+
+function isVisibleContact(candidate: UserChatCandidate, myUserId: string | null): boolean {
+  if (candidate.user_id === myUserId || candidate.is_owned) return false;
+  return candidate.can_chat || candidate.relationship_state === "pending";
 }
 
 export default function ContactList() {
@@ -47,7 +55,7 @@ export default function ContactList() {
   const contacts = useMemo(() => {
     const query = search.trim().toLowerCase();
     return chatCandidates
-      .filter((candidate) => candidate.user_id !== myUserId && !candidate.is_owned && candidate.can_chat)
+      .filter((candidate) => isVisibleContact(candidate, myUserId))
       .filter((item) => {
         if (!query) return true;
         return [item.name, item.owner_name ?? "", item.type, item.relationship_state].join(" ").toLowerCase().includes(query);


### PR DESCRIPTION
## Summary
- show pending relationship rows in contacts so incoming/outgoing requests are reachable without manually constructing profile URLs
- add a group chat header action to copy the existing /chat/visit/:chat_id URL for join discovery
- keep both changes frontend-only over existing backend relationship/chat state

## Verification
- npm test -- ContactList.test.tsx
- npm test -- ChatConversationPage.test.tsx
- npm run typecheck
- npm run build
- npm run lint
- Playwright CLI YATU: /Users/lexicalmathical/share/yatu/frontend-social-discovery-20260426T0542
