### PR TITLE
Hard cut file Skill import identity

### DIFF
--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -14,6 +14,7 @@ from config.agent_config_types import Skill, SkillPackage
 from config.skill_files import normalize_skill_file_entries
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from storage.runtime import build_storage_container
+from storage.utils import generate_skill_id
 
 FILE_IMPORT_SOURCE = {"kind": "file_import"}
 
@@ -60,6 +61,10 @@ def _read_files(skill_dir: Path) -> dict[str, str]:
     return normalize_skill_file_entries(file_entries, context="File Skill files")
 
 
+def _find_skill_by_name(skills: list[Skill], skill_name: str) -> Skill | None:
+    return next((skill for skill in skills if skill.name == skill_name), None)
+
+
 def import_skills(owner_user_id: str, library_dir: Path) -> int:
     repo = build_storage_container().skill_repo()
     skills_root = library_dir / "skills"
@@ -71,24 +76,22 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
         content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
         metadata = _frontmatter(content)
         skill_name = str(metadata["name"]).strip()
-        existing = repo.get_by_id(owner_user_id, skill_dir.name)
-        if existing is not None and existing.name != skill_name:
-            raise ValueError("SKILL.md frontmatter name must match existing Skill name")
-        for skill in repo.list_for_owner(owner_user_id):
-            if skill.name == skill_name and skill.id != skill_dir.name:
-                raise ValueError("Skill name already exists under a different Library id")
+        existing = _find_skill_by_name(repo.list_for_owner(owner_user_id), skill_name)
         now = datetime.now(UTC)
+        skill_id = existing.id if existing is not None else generate_skill_id()
+        if existing is None and repo.get_by_id(owner_user_id, skill_id) is not None:
+            raise RuntimeError("Generated Skill id already exists")
         version = _frontmatter_version(metadata)
         files = _read_files(skill_dir)
         package_hash = build_skill_package_hash(content, files)
         skill = repo.upsert(
             Skill(
-                id=skill_dir.name,
+                id=skill_id,
                 owner_user_id=owner_user_id,
                 name=skill_name,
                 description=_frontmatter_text(metadata, "description"),
                 source=dict(FILE_IMPORT_SOURCE),
-                created_at=now,
+                created_at=getattr(existing, "created_at", now),
                 updated_at=now,
             )
         )

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -205,6 +205,22 @@ def upload(payload: dict) -> bool:
     return False
 
 
+def publish_skill_package(
+    *,
+    slug: str,
+    package: dict,
+    publisher_user_id: str,
+    publisher_username: str,
+) -> bool:
+    payload = build_skill_payload(
+        slug=slug,
+        package=package,
+        publisher_user_id=publisher_user_id,
+        publisher_username=publisher_username,
+    )
+    return upload(payload)
+
+
 def main():
     # Register all publishers
     for key, (uid, uname, dname) in PUBLISHERS.items():
@@ -248,15 +264,13 @@ def main():
                 total_skip += 1
                 continue
 
-            payload = build_skill_payload(
+            print(f"  Upload: {slug} ...", end=" ")
+            if publish_skill_package(
                 slug=slug,
                 package=package,
                 publisher_user_id=uid,
                 publisher_username=uname,
-            )
-
-            print(f"  Upload: {slug} ...", end=" ")
-            if upload(payload):
+            ):
                 print("OK")
                 total_ok += 1
             else:

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import httpx
 import yaml
 
+from config.skill_files import normalize_skill_file_entries
+
 HUB_URL = "http://localhost:8090"
 
 # Publisher mapping: repo_key -> (user_id, username, display_name)
@@ -40,23 +42,20 @@ SKIP_DIRS = {
 
 
 def register_publisher(user_id: str, username: str, display_name: str) -> None:
-    try:
-        httpx.post(
-            f"{HUB_URL}/api/v1/publishers/register",
-            json={
-                "user_id": user_id,
-                "username": username,
-                "display_name": display_name,
-            },
-            timeout=10.0,
-        ).raise_for_status()
-    except Exception as e:
-        print(f"  Publisher {username}: {e}")
+    httpx.post(
+        f"{HUB_URL}/api/v1/publishers/register",
+        json={
+            "user_id": user_id,
+            "username": username,
+            "display_name": display_name,
+        },
+        timeout=10.0,
+    ).raise_for_status()
 
 
 def parse_skill_md(skill_md: Path) -> dict | None:
     """Parse a SKILL.md into name/description/tags."""
-    content = skill_md.read_text(encoding="utf-8", errors="replace")
+    content = skill_md.read_text(encoding="utf-8")
     if len(content.strip()) < 50:
         return None
 
@@ -67,21 +66,28 @@ def parse_skill_md(skill_md: Path) -> dict | None:
     if content.startswith("---"):
         parts = content.split("---", 2)
         if len(parts) >= 3:
-            try:
-                fm = yaml.safe_load(parts[1])
-                if fm and isinstance(fm, dict):
-                    name = fm.get("name", name)
-                    description = fm.get("description", "")
-                    meta = fm.get("metadata", {})
-                    if isinstance(meta, dict):
-                        for key in ("domain", "role", "category"):
-                            if meta.get(key):
-                                tags.append(str(meta[key]))
-                        triggers = meta.get("triggers", "")
-                        if isinstance(triggers, str):
-                            tags.extend([t.strip() for t in triggers.split(",")[:5] if t.strip()])
-            except Exception:
-                pass
+            fm = yaml.safe_load(parts[1]) or {}
+            if not isinstance(fm, dict):
+                raise ValueError("SKILL.md frontmatter must be a mapping")
+            raw_name = fm.get("name", name)
+            if not isinstance(raw_name, str) or not raw_name.strip():
+                raise ValueError("SKILL.md frontmatter name must be a string")
+            name = raw_name.strip()
+            raw_description = fm.get("description", "")
+            if raw_description is None:
+                description = ""
+            elif isinstance(raw_description, str):
+                description = raw_description.strip()
+            else:
+                raise ValueError("SKILL.md frontmatter description must be a string")
+            meta = fm.get("metadata", {})
+            if isinstance(meta, dict):
+                for key in ("domain", "role", "category"):
+                    if meta.get(key):
+                        tags.append(str(meta[key]))
+                triggers = meta.get("triggers", "")
+                if isinstance(triggers, str):
+                    tags.extend([t.strip() for t in triggers.split(",")[:5] if t.strip()])
 
     if not description:
         for line in content.split("\n"):
@@ -93,9 +99,29 @@ def parse_skill_md(skill_md: Path) -> dict | None:
     return {
         "name": name,
         "description": description,
-        "tags": list(set(t for t in tags if t))[:10],
+        "tags": sorted({t for t in tags if t})[:10],
         "content": content,
     }
+
+
+def _read_adjacent_files(skill_dir: Path) -> dict[str, str]:
+    file_entries: list[tuple[str, str]] = []
+    for path in sorted(skill_dir.rglob("*")):
+        if not path.is_file() or path.name == "SKILL.md":
+            continue
+        try:
+            file_entries.append((path.relative_to(skill_dir).as_posix(), path.read_text(encoding="utf-8")))
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(f"Skill adjacent file could not be read: {path}") from exc
+    return normalize_skill_file_entries(file_entries, context="Seed Skill files")
+
+
+def read_skill_package(skill_dir: Path) -> dict | None:
+    parsed = parse_skill_md(skill_dir / "SKILL.md")
+    if parsed is None:
+        return None
+    parsed["files"] = _read_adjacent_files(skill_dir)
+    return parsed
 
 
 def find_skill_dirs(repo_root: Path, skill_roots: list[Path] | None) -> list[Path]:
@@ -118,6 +144,34 @@ def find_skill_dirs(repo_root: Path, skill_roots: list[Path] | None) -> list[Pat
     return sorted(set(results))
 
 
+def build_skill_payload(
+    *,
+    slug: str,
+    package: dict,
+    publisher_user_id: str,
+    publisher_username: str,
+) -> dict:
+    return {
+        "slug": slug,
+        "type": "skill",
+        "name": package["name"],
+        "description": package["description"],
+        "version": "1.0.0",
+        "release_notes": "Initial release",
+        "tags": package["tags"],
+        "visibility": "public",
+        "snapshot": {
+            "meta": {"name": package["name"], "desc": package["description"]},
+            "content": package["content"],
+            "files": package["files"],
+        },
+        "parent_item_id": None,
+        "parent_version": None,
+        "publisher_user_id": publisher_user_id,
+        "publisher_username": publisher_username,
+    }
+
+
 def upload(payload: dict) -> bool:
     import time
 
@@ -126,10 +180,13 @@ def upload(payload: dict) -> bool:
             resp = httpx.post(f"{HUB_URL}/api/v1/publish", json=payload, timeout=30.0)
             resp.raise_for_status()
             return True
-        except Exception as e:
-            if attempt < 2 and ("Connection reset" in str(e) or "timed out" in str(e)):
+        except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.TimeoutException) as e:
+            if attempt < 2:
                 time.sleep(1 + attempt)
                 continue
+            print(f"  FAIL: {e}")
+            return False
+        except httpx.HTTPStatusError as e:
             print(f"  FAIL: {e}")
             return False
     return False
@@ -142,12 +199,11 @@ def main():
         print(f"Publisher registered: {uname}")
 
     # Check existing items to avoid duplicates
-    try:
-        existing = httpx.get(f"{HUB_URL}/api/v1/items?page_size=2000", timeout=30.0).json()
-        existing_slugs = {(item["publisher_username"], item["slug"]) for item in existing.get("items", [])}
-        print(f"\nExisting items in Hub: {len(existing_slugs)}")
-    except Exception:
-        existing_slugs = set()
+    existing_response = httpx.get(f"{HUB_URL}/api/v1/items?page_size=2000", timeout=30.0)
+    existing_response.raise_for_status()
+    existing = existing_response.json()
+    existing_slugs = {(item["publisher_username"], item["slug"]) for item in existing.get("items", [])}
+    print(f"\nExisting items in Hub: {len(existing_slugs)}")
 
     total_ok = 0
     total_fail = 0
@@ -178,30 +234,18 @@ def main():
                 total_skip += 1
                 continue
 
-            parsed = parse_skill_md(skill_md)
-            if not parsed:
+            package = read_skill_package(skill_dir)
+            if not package:
                 print(f"  SKIP: {slug} (too short)")
                 total_skip += 1
                 continue
 
-            payload = {
-                "slug": slug,
-                "type": "skill",
-                "name": parsed["name"],
-                "description": parsed["description"],
-                "version": "1.0.0",
-                "release_notes": "Initial release",
-                "tags": parsed["tags"],
-                "visibility": "public",
-                "snapshot": {
-                    "meta": {"name": parsed["name"], "desc": parsed["description"]},
-                    "content": parsed["content"],
-                },
-                "parent_item_id": None,
-                "parent_version": None,
-                "publisher_user_id": uid,
-                "publisher_username": uname,
-            }
+            payload = build_skill_payload(
+                slug=slug,
+                package=package,
+                publisher_user_id=uid,
+                publisher_username=uname,
+            )
 
             print(f"  Upload: {slug} ...", end=" ")
             if upload(payload):

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -144,6 +144,12 @@ def find_skill_dirs(repo_root: Path, skill_roots: list[Path] | None) -> list[Pat
     return sorted(set(results))
 
 
+def build_skill_slug(repo_root: Path, skill_dir: Path) -> str:
+    rel = skill_dir.relative_to(repo_root)
+    parts = [part for part in rel.parts if part not in SKIP_DIRS]
+    return "--".join(parts) if len(parts) > 1 else skill_dir.name
+
+
 def build_skill_payload(
     *,
     slug: str,
@@ -219,10 +225,8 @@ def main():
         print(f"\n=== {repo_key} ({len(skill_dirs)} skills found) ===")
 
         for skill_dir in skill_dirs:
-            # Use relative path as slug to avoid collisions in nested repos
-            rel = skill_dir.relative_to(repo_root)
-            parts = [p for p in rel.parts if p not in SKIP_DIRS]
-            slug = "--".join(parts) if len(parts) > 1 else skill_dir.name
+            # Hub item slug is marketplace address only; Library Skill id is generated downstream.
+            slug = build_skill_slug(repo_root, skill_dir)
 
             # Skip if already exists
             if (uname, slug) in existing_slugs:

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -53,6 +53,12 @@ def register_publisher(user_id: str, username: str, display_name: str) -> None:
     ).raise_for_status()
 
 
+def register_all_publishers() -> None:
+    for _key, (uid, uname, dname) in PUBLISHERS.items():
+        register_publisher(uid, uname, dname)
+        print(f"Publisher registered: {uname}")
+
+
 def parse_skill_md(skill_md: Path) -> dict | None:
     """Parse a SKILL.md into name/description/tags."""
     content = skill_md.read_text(encoding="utf-8")
@@ -222,10 +228,7 @@ def publish_skill_package(
 
 
 def main():
-    # Register all publishers
-    for key, (uid, uname, dname) in PUBLISHERS.items():
-        register_publisher(uid, uname, dname)
-        print(f"Publisher registered: {uname}")
+    register_all_publishers()
 
     # Check existing items to avoid duplicates
     existing_slugs = read_existing_hub_slugs()

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -178,6 +178,13 @@ def build_skill_payload(
     }
 
 
+def read_existing_hub_slugs() -> set[tuple[str, str]]:
+    response = httpx.get(f"{HUB_URL}/api/v1/items?page_size=2000", timeout=30.0)
+    response.raise_for_status()
+    existing = response.json()
+    return {(item["publisher_username"], item["slug"]) for item in existing.get("items", [])}
+
+
 def upload(payload: dict) -> bool:
     import time
 
@@ -205,10 +212,7 @@ def main():
         print(f"Publisher registered: {uname}")
 
     # Check existing items to avoid duplicates
-    existing_response = httpx.get(f"{HUB_URL}/api/v1/items?page_size=2000", timeout=30.0)
-    existing_response.raise_for_status()
-    existing = existing_response.json()
-    existing_slugs = {(item["publisher_username"], item["slug"]) for item in existing.get("items", [])}
+    existing_slugs = read_existing_hub_slugs()
     print(f"\nExisting items in Hub: {len(existing_slugs)}")
 
     total_ok = 0

--- a/tests/Unit/scripts/test_import_file_skills_to_library.py
+++ b/tests/Unit/scripts/test_import_file_skills_to_library.py
@@ -41,31 +41,25 @@ class _MemorySkillRepo:
         self.selected.append((owner_user_id, skill_id, package_id))
 
 
-def test_import_file_skill_rejects_name_drift_for_existing_skill_id(monkeypatch: pytest.MonkeyPatch, tmp_path):
+def test_import_file_skill_generates_library_skill_id(monkeypatch: pytest.MonkeyPatch, tmp_path):
     library_dir = tmp_path / "library"
-    skill_dir = library_dir / "skills" / "same-skill"
+    skill_dir = library_dir / "skills" / "folder-name"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: Renamed Skill\ndescription: Renamed\nversion: 1.0.0\n---\nBody", encoding="utf-8")
-    repo = _MemorySkillRepo(
-        Skill(
-            id="same-skill",
-            owner_user_id="owner-1",
-            name="Original Skill",
-            created_at=datetime(2026, 4, 24, tzinfo=UTC),
-            updated_at=datetime(2026, 4, 24, tzinfo=UTC),
-        )
-    )
+    (skill_dir / "SKILL.md").write_text("---\nname: New Skill\ndescription: New\nversion: 1.0.0\n---\nBody", encoding="utf-8")
+    repo = _MemorySkillRepo()
     monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+    monkeypatch.setattr(import_file_skills_to_library, "generate_skill_id", lambda: "skill_generated123")
 
-    with pytest.raises(ValueError, match="frontmatter name must match existing Skill name"):
-        import_file_skills_to_library.import_skills("owner-1", library_dir)
+    import_file_skills_to_library.import_skills("owner-1", library_dir)
 
-    assert repo.saved == []
+    assert repo.saved[0].id == "skill_generated123"
+    assert repo.packages[0].skill_id == "skill_generated123"
+    assert repo.selected == [("owner-1", "skill_generated123", repo.packages[0].id)]
 
 
-def test_import_file_skill_rejects_same_name_under_different_skill_id(monkeypatch: pytest.MonkeyPatch, tmp_path):
+def test_import_file_skill_reuses_existing_skill_by_name(monkeypatch: pytest.MonkeyPatch, tmp_path):
     library_dir = tmp_path / "library"
-    skill_dir = library_dir / "skills" / "new-skill"
+    skill_dir = library_dir / "skills" / "folder-name"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: Shared Skill\ndescription: Shared\nversion: 1.0.0\n---\nBody", encoding="utf-8")
     repo = _MemorySkillRepo(
@@ -78,11 +72,17 @@ def test_import_file_skill_rejects_same_name_under_different_skill_id(monkeypatc
         )
     )
     monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+    monkeypatch.setattr(
+        import_file_skills_to_library,
+        "generate_skill_id",
+        lambda: (_ for _ in ()).throw(AssertionError("must reuse the existing Library Skill")),
+    )
 
-    with pytest.raises(ValueError, match="Skill name already exists under a different Library id"):
-        import_file_skills_to_library.import_skills("owner-1", library_dir)
+    import_file_skills_to_library.import_skills("owner-1", library_dir)
 
-    assert repo.saved == []
+    assert repo.saved[0].id == "original-skill"
+    assert repo.packages[0].skill_id == "original-skill"
+    assert repo.selected == [("owner-1", "original-skill", repo.packages[0].id)]
 
 
 def test_import_file_skill_rejects_unreadable_adjacent_file(monkeypatch: pytest.MonkeyPatch, tmp_path):
@@ -116,15 +116,16 @@ def test_import_file_skill_stores_adjacent_files_as_posix_paths(monkeypatch: pyt
 
     monkeypatch.setattr(Path, "relative_to", windows_relative_to)
     monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+    monkeypatch.setattr(import_file_skills_to_library, "generate_skill_id", lambda: "skill_generated123")
 
     import_file_skills_to_library.import_skills("owner-1", library_dir)
 
-    assert repo.saved[0].id == "new-skill"
-    assert repo.packages[0].skill_id == "new-skill"
+    assert repo.saved[0].id == "skill_generated123"
+    assert repo.packages[0].skill_id == "skill_generated123"
     assert repo.packages[0].version == "1.0.0"
     assert repo.packages[0].skill_md == "---\nname: New Skill\ndescription: New\nversion: 1.0.0\n---\nBody"
     assert repo.packages[0].manifest["files"][0]["path"] == "references/query.md"
-    assert repo.selected == [("owner-1", "new-skill", repo.packages[0].id)]
+    assert repo.selected == [("owner-1", "skill_generated123", repo.packages[0].id)]
 
 
 def test_import_file_skill_does_not_store_local_skill_path(monkeypatch: pytest.MonkeyPatch, tmp_path):
@@ -134,6 +135,7 @@ def test_import_file_skill_does_not_store_local_skill_path(monkeypatch: pytest.M
     (skill_dir / "SKILL.md").write_text("---\nname: New Skill\ndescription: Imported skill\nversion: 1.0.0\n---\nBody", encoding="utf-8")
     repo = _MemorySkillRepo()
     monkeypatch.setattr(import_file_skills_to_library, "build_storage_container", lambda: SimpleNamespace(skill_repo=lambda: repo))
+    monkeypatch.setattr(import_file_skills_to_library, "generate_skill_id", lambda: "skill_generated123")
 
     import_file_skills_to_library.import_skills("owner-1", library_dir)
 
@@ -174,6 +176,15 @@ def test_import_file_skill_has_no_default_package_version() -> None:
 
     assert "INITIAL_SKILL_PACKAGE_VERSION" not in source
     assert 'return "0.1.0"' not in source
+
+
+def test_import_file_skill_source_does_not_use_directory_name_as_library_identity() -> None:
+    source = inspect.getsource(import_file_skills_to_library)
+
+    assert "generate_skill_id()" in source
+    assert "get_by_id(owner_user_id, skill_dir.name)" not in source
+    assert "skill.id != skill_dir.name" not in source
+    assert "id=skill_dir.name" not in source
 
 
 @pytest.mark.parametrize(

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path, PureWindowsPath
+
+import pytest
+import yaml
+
+from scripts import seed_github_skills
+
+
+def _write_skill(skill_dir: Path, content: str) -> None:
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+
+def test_seed_skill_package_includes_adjacent_files(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "api-design"
+    _write_skill(
+        skill_dir,
+        "---\nname: API Design\ndescription: Design APIs\nmetadata:\n  domain: backend\n---\nUse REST carefully.",
+    )
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "routing.md").write_text("Prefer explicit routes.", encoding="utf-8")
+
+    package = seed_github_skills.read_skill_package(skill_dir)
+
+    assert package == {
+        "name": "API Design",
+        "description": "Design APIs",
+        "tags": ["backend"],
+        "content": "---\nname: API Design\ndescription: Design APIs\nmetadata:\n  domain: backend\n---\nUse REST carefully.",
+        "files": {"references/routing.md": "Prefer explicit routes."},
+    }
+
+
+def test_seed_skill_package_normalizes_adjacent_file_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "api-design"
+    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\n---\nUse REST carefully.")
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir()
+    (refs_dir / "routing.md").write_text("Prefer explicit routes.", encoding="utf-8")
+    original_relative_to = Path.relative_to
+
+    def windows_relative_to(self: Path, *other: str | Path) -> PureWindowsPath:
+        return PureWindowsPath(*original_relative_to(self, *other).parts)
+
+    monkeypatch.setattr(Path, "relative_to", windows_relative_to)
+
+    package = seed_github_skills.read_skill_package(skill_dir)
+
+    assert package is not None
+    assert package["files"] == {"references/routing.md": "Prefer explicit routes."}
+
+
+def test_seed_skill_parse_fails_loudly_on_invalid_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "broken"
+    _write_skill(skill_dir, "---\nname: [broken\n---\nBody long enough to avoid the tiny file skip path.")
+
+    with pytest.raises(yaml.YAMLError):
+        seed_github_skills.read_skill_package(skill_dir)
+
+
+def test_seed_skill_parse_rejects_non_text_frontmatter_name(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "broken"
+    _write_skill(skill_dir, "---\nname: 123\ndescription: Broken\n---\nBody long enough to parse.")
+
+    with pytest.raises(ValueError, match="SKILL.md frontmatter name must be a string"):
+        seed_github_skills.read_skill_package(skill_dir)
+
+
+def test_seed_skill_parse_rejects_unreadable_skill_md(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "broken"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(b"\xff\xfe\xfa")
+
+    with pytest.raises(UnicodeDecodeError):
+        seed_github_skills.read_skill_package(skill_dir)
+
+
+def test_seed_skill_payload_publishes_snapshot_files(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "api-design"
+    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\n---\nUse REST carefully.")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "routing.md").write_text("Prefer explicit routes.", encoding="utf-8")
+    package = seed_github_skills.read_skill_package(skill_dir)
+    assert package is not None
+
+    payload = seed_github_skills.build_skill_payload(
+        slug="skills--api-design",
+        package=package,
+        publisher_user_id="publisher-1",
+        publisher_username="publisher",
+    )
+
+    assert payload["snapshot"]["content"] == package["content"]
+    assert payload["snapshot"]["files"] == {"references/routing.md": "Prefer explicit routes."}
+
+
+def test_seed_skill_parser_does_not_swallow_parse_errors() -> None:
+    source = inspect.getsource(seed_github_skills.parse_skill_md)
+
+    assert "except Exception" not in source
+    assert "pass" not in source
+
+
+def test_seed_script_does_not_catch_broad_exceptions() -> None:
+    source = inspect.getsource(seed_github_skills)
+
+    assert "except Exception" not in source

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path, PureWindowsPath
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -105,6 +106,30 @@ def test_seed_skill_slug_is_hub_item_path_not_library_identity(tmp_path: Path) -
     slug = seed_github_skills.build_skill_slug(repo_root, skill_dir)
 
     assert slug == "skills--backend--api-design"
+
+
+def test_seed_existing_hub_slugs_require_successful_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_get(url: str, timeout: float):
+        seen["url"] = url
+        seen["timeout"] = str(timeout)
+        return SimpleNamespace(
+            raise_for_status=lambda: seen.setdefault("raised", "yes"),
+            json=lambda: {
+                "items": [
+                    {"publisher_username": "anthropics", "slug": "skills--planner"},
+                    {"publisher_username": "mycel", "slug": "skills--reviewer"},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(seed_github_skills.httpx, "get", fake_get)
+
+    slugs = seed_github_skills.read_existing_hub_slugs()
+
+    assert seen == {"url": "http://localhost:8090/api/v1/items?page_size=2000", "timeout": "30.0", "raised": "yes"}
+    assert slugs == {("anthropics", "skills--planner"), ("mycel", "skills--reviewer")}
 
 
 def test_seed_skill_parser_does_not_swallow_parse_errors() -> None:

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -97,6 +97,16 @@ def test_seed_skill_payload_publishes_snapshot_files(tmp_path: Path) -> None:
     assert payload["snapshot"]["files"] == {"references/routing.md": "Prefer explicit routes."}
 
 
+def test_seed_skill_slug_is_hub_item_path_not_library_identity(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skill_dir = repo_root / "skills" / "backend" / "api-design"
+    skill_dir.mkdir(parents=True)
+
+    slug = seed_github_skills.build_skill_slug(repo_root, skill_dir)
+
+    assert slug == "skills--backend--api-design"
+
+
 def test_seed_skill_parser_does_not_swallow_parse_errors() -> None:
     source = inspect.getsource(seed_github_skills.parse_skill_md)
 

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -132,6 +132,33 @@ def test_seed_existing_hub_slugs_require_successful_response(monkeypatch: pytest
     assert slugs == {("anthropics", "skills--planner"), ("mycel", "skills--reviewer")}
 
 
+def test_seed_publish_skill_package_uses_package_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, dict] = {}
+
+    def fake_upload(payload: dict) -> bool:
+        seen["payload"] = payload
+        return True
+
+    monkeypatch.setattr(seed_github_skills, "upload", fake_upload)
+
+    ok = seed_github_skills.publish_skill_package(
+        slug="skills--api-design",
+        package={
+            "name": "API Design",
+            "description": "Design APIs",
+            "tags": ["backend"],
+            "content": "---\nname: API Design\n---\nUse REST carefully.",
+            "files": {"references/routing.md": "Prefer explicit routes."},
+        },
+        publisher_user_id="publisher-1",
+        publisher_username="publisher",
+    )
+
+    assert ok is True
+    assert seen["payload"]["snapshot"]["files"] == {"references/routing.md": "Prefer explicit routes."}
+    assert seen["payload"]["publisher_username"] == "publisher"
+
+
 def test_seed_skill_parser_does_not_swallow_parse_errors() -> None:
     source = inspect.getsource(seed_github_skills.parse_skill_md)
 

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -159,6 +159,23 @@ def test_seed_publish_skill_package_uses_package_payload(monkeypatch: pytest.Mon
     assert seen["payload"]["publisher_username"] == "publisher"
 
 
+def test_seed_register_all_publishers_uses_declared_publishers(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        seed_github_skills,
+        "PUBLISHERS",
+        {
+            "one": ("uid-1", "user-1", "User One"),
+            "two": ("uid-2", "user-2", "User Two"),
+        },
+    )
+    monkeypatch.setattr(seed_github_skills, "register_publisher", lambda uid, uname, dname: calls.append((uid, uname, dname)))
+
+    seed_github_skills.register_all_publishers()
+
+    assert calls == [("uid-1", "user-1", "User One"), ("uid-2", "user-2", "User Two")]
+
+
 def test_seed_skill_parser_does_not_swallow_parse_errors() -> None:
     source = inspect.getsource(seed_github_skills.parse_skill_md)
 


### PR DESCRIPTION
## Summary
- generate Library-owned ids for file-imported Skills and reuse existing Library rows by Skill name
- seed GitHub Skill packages into Hub with adjacent files under snapshot.files
- make seed script parse and Hub inventory failures loud, with explicit slug/inventory/publish/register boundaries

## Verification
- uv run pytest tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/scripts/test_seed_github_skills.py -q
- uv run pytest tests/Unit/integration_contracts/test_marketplace_router_user_shell.py::test_skill_marketplace_to_agent_library_delete_backend_api_yatu -q
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright scripts/import_file_skills_to_library.py scripts/seed_github_skills.py tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/scripts/test_seed_github_skills.py
- npm test
- npm run lint
- npm run typecheck
- npm run build