### PR TITLE
Generate local Skill ids for AgentSnapshot apply

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -9,6 +9,7 @@ from typing import Any
 from config.agent_config_resolver import validate_resolved_skill_content
 from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, ResolvedSkill, Skill, SkillPackage
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+from storage.utils import generate_skill_id
 
 
 def _required_text(value: Any, *, label: str) -> str:
@@ -17,11 +18,11 @@ def _required_text(value: Any, *, label: str) -> str:
     return value.strip()
 
 
-def _required_skill_id(skill_id: str) -> str:
-    skill_id = _required_text(skill_id, label="Snapshot Skill id")
-    if "/" in skill_id or "\\" in skill_id or skill_id in {".", ".."}:
-        raise ValueError(f"Invalid Snapshot Skill id: {skill_id}")
-    return skill_id
+def _snapshot_source_skill(skills: list[Skill], marketplace_item_id: str, snapshot_skill_id: str) -> Skill | None:
+    for skill in skills:
+        if skill.source.get("marketplace_item_id") == marketplace_item_id and skill.source.get("snapshot_skill_id") == snapshot_skill_id:
+            return skill
+    return None
 
 
 def _materialize_snapshot_skills(
@@ -53,16 +54,23 @@ def _materialize_snapshot_skills(
     timestamp = datetime.now(UTC)
     library_skills = skill_repo.list_for_owner(owner_user_id)
     for snapshot_skill in skills:
-        skill_id = _required_skill_id(snapshot_skill.id)
-        existing = skill_repo.get_by_id(owner_user_id, skill_id)
+        snapshot_skill_id = _required_text(snapshot_skill.id, label="Snapshot Skill id")
+        existing = _snapshot_source_skill(library_skills, marketplace_item_id, snapshot_skill_id)
         if existing is not None and existing.name != snapshot_skill.name:
             raise ValueError("Snapshot Skill frontmatter name must match existing Skill name")
-        for library_skill in library_skills:
-            if library_skill.name == snapshot_skill.name and library_skill.id != skill_id:
-                raise ValueError("Snapshot Skill name already exists under a different Library id")
+        if existing is None:
+            skill_id = generate_skill_id()
+            if skill_repo.get_by_id(owner_user_id, skill_id) is not None:
+                raise RuntimeError("Generated Skill id already exists")
+            for library_skill in library_skills:
+                if library_skill.name == snapshot_skill.name:
+                    raise ValueError("Snapshot Skill name already exists under a different Library id")
+        else:
+            skill_id = existing.id
 
         source = {
             "marketplace_item_id": marketplace_item_id,
+            "snapshot_skill_id": snapshot_skill_id,
             "source_version": source_version,
             "source_at": source_at,
         }

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -11,6 +11,8 @@ from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, Re
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from storage.utils import generate_skill_id
 
+SNAPSHOT_SKILL_SOURCE_ID_KEY = "snapshot_skill_id"
+
 
 def _required_text(value: Any, *, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -20,7 +22,10 @@ def _required_text(value: Any, *, label: str) -> str:
 
 def _snapshot_source_skill(skills: list[Skill], marketplace_item_id: str, snapshot_skill_id: str) -> Skill | None:
     for skill in skills:
-        if skill.source.get("marketplace_item_id") == marketplace_item_id and skill.source.get("snapshot_skill_id") == snapshot_skill_id:
+        if (
+            skill.source.get("marketplace_item_id") == marketplace_item_id
+            and skill.source.get(SNAPSHOT_SKILL_SOURCE_ID_KEY) == snapshot_skill_id
+        ):
             return skill
     return None
 
@@ -70,7 +75,7 @@ def _materialize_snapshot_skills(
 
         source = {
             "marketplace_item_id": marketplace_item_id,
-            "snapshot_skill_id": snapshot_skill_id,
+            SNAPSHOT_SKILL_SOURCE_ID_KEY: snapshot_skill_id,
             "source_version": source_version,
             "source_at": source_at,
         }

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -402,6 +402,7 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
         }
 
     monkeypatch.setattr(marketplace_router.marketplace_client, "_hub_api", hub_response)
+    monkeypatch.setattr(marketplace_router.marketplace_client._snapshot_apply, "generate_skill_id", lambda: "skill_generated123")
     skill_repo = _SkillRepo()
     agent_config_repo = _AgentConfigRepo()
     request = SimpleNamespace(
@@ -422,11 +423,12 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
     saved_config = agent_config_repo.saved[0]
     saved_skill = saved_config.skills[0]
     assert result == {"user_id": saved_config.agent_user_id, "type": "user", "version": "1.2.3"}
-    assert saved_skill.skill_id == "snapshot-core"
+    assert saved_skill.skill_id == "skill_generated123"
     assert saved_skill.package_id
     package = skill_repo.get_package("owner-1", saved_skill.package_id)
     assert package is not None
     assert getattr(package, "files") == {"references/routing.md": "route narrowly"}
+    assert getattr(package, "source")["snapshot_skill_id"] == "snapshot-core"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2162,6 +2162,19 @@ def test_apply_snapshot_generates_library_skill_id() -> None:
     assert "existing = skill_repo.get_by_id(owner_user_id, skill_id)" not in source
 
 
+def test_apply_snapshot_source_keeps_snapshot_skill_id_out_of_library_identity() -> None:
+    import inspect
+
+    from backend.hub.snapshot_apply import _materialize_snapshot_skills
+
+    source = inspect.getsource(_materialize_snapshot_skills)
+
+    assert "snapshot_skill_id = _required_text(snapshot_skill.id" in source
+    assert "skill_id = generate_skill_id()" in source
+    assert "skill_id = snapshot_skill_id" not in source
+    assert "id=snapshot_skill_id" not in source
+
+
 def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2272,6 +2272,39 @@ def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: py
     assert saved_configs[0].skills[0].source["snapshot_skill_id"] == "search-core"
 
 
+def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest.MonkeyPatch):
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="skill_existing123",
+        name="Existing",
+        description="existing",
+        content="---\nname: Existing\n---\nbody",
+    )
+    monkeypatch.setattr("backend.hub.snapshot_apply.generate_skill_id", lambda: "skill_existing123")
+
+    with pytest.raises(RuntimeError, match="Generated Skill id already exists"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [{"id": "search-core", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+            skill_repo=skill_repo,
+        )
+
+
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2318,6 +2318,39 @@ def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest
         )
 
 
+def test_apply_snapshot_rejects_existing_same_name_without_snapshot_source(monkeypatch: pytest.MonkeyPatch):
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="skill_existing123",
+        name="Search",
+        description="existing",
+        content="---\nname: Search\n---\nbody",
+    )
+    monkeypatch.setattr("backend.hub.snapshot_apply.generate_skill_id", lambda: "skill_generated123")
+
+    with pytest.raises(ValueError, match="Snapshot Skill name already exists under a different Library id"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [{"id": "search-core", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+            skill_repo=skill_repo,
+        )
+
+
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
     from backend.hub.snapshot_apply import apply_snapshot
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2013,7 +2013,7 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
 
 
 def test_apply_snapshot_saves_one_agent_config_aggregate():
-    from backend.hub.snapshot_apply import apply_snapshot
+    import backend.hub.snapshot_apply as snapshot_apply
 
     created_users: list[UserRow] = []
     saved_configs: list[AgentConfig] = []
@@ -2027,7 +2027,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    user_id = apply_snapshot(
+    user_id = snapshot_apply.apply_snapshot(
         snapshot={
             "schema_version": "agent-snapshot/v1",
             "agent": {
@@ -2062,19 +2062,21 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
     assert user_id == created_users[0].id
     assert saved_configs[0].name == "Repo Agent"
     assert saved_configs[0].skills[0].description == "skill desc"
-    assert saved_configs[0].skills[0].skill_id == "search-core"
+    assert saved_configs[0].skills[0].skill_id.startswith("skill_")
+    assert saved_configs[0].skills[0].skill_id != "search-core"
     assert saved_configs[0].skills[0].package_id
-    assert skill_repo.get_by_id("user-1", "search-core") is not None
+    assert skill_repo.get_by_id("user-1", "search-core") is None
     package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id or "")
     assert package is not None
     assert package.skill_md == "---\nname: Search\n---\nbody"
     assert package.source == {
         "marketplace_item_id": "item-1",
+        "snapshot_skill_id": "search-core",
         "source_version": "1.0.0",
         "source_at": saved_configs[0].skills[0].source["source_at"],
     }
     assert saved_configs[0].skills[0].source == package.source
-    library_skill = skill_repo.get_by_id("user-1", "search-core")
+    library_skill = skill_repo.get_by_id("user-1", saved_configs[0].skills[0].skill_id)
     assert library_skill is not None
     assert library_skill.source == package.source
     assert saved_configs[0].rules[0].content == "rule body"
@@ -2147,7 +2149,7 @@ def test_apply_snapshot_does_not_fill_package_version_from_source_version() -> N
     assert "or source_version" not in source
 
 
-def test_apply_snapshot_does_not_derive_skill_id_from_name() -> None:
+def test_apply_snapshot_generates_library_skill_id() -> None:
     import inspect
 
     import backend.hub.snapshot_apply as snapshot_apply
@@ -2156,6 +2158,8 @@ def test_apply_snapshot_does_not_derive_skill_id_from_name() -> None:
 
     assert "_skill_id_from_name" not in source
     assert '.lower().replace(" ", "-")' not in source
+    assert "generate_skill_id()" in source
+    assert "existing = skill_repo.get_by_id(owner_user_id, skill_id)" not in source
 
 
 def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
@@ -2186,36 +2190,86 @@ def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
     assert skill_repo.list_for_owner("user-1") == []
 
 
-def test_apply_snapshot_rejects_non_library_skill_id_before_library_write():
+def test_apply_snapshot_treats_snapshot_skill_id_as_source_metadata(monkeypatch: pytest.MonkeyPatch):
     from backend.hub.snapshot_apply import apply_snapshot
 
     skill_repo = _MemorySkillRepo()
+    monkeypatch.setattr("backend.hub.snapshot_apply.generate_skill_id", lambda: "skill_generated123")
 
-    with pytest.raises(ValueError, match="Invalid Snapshot Skill id: nested/search"):
-        apply_snapshot(
-            snapshot={
-                "schema_version": "agent-snapshot/v1",
-                "agent": {
-                    "id": "cfg-source",
-                    "name": "Repo Agent",
-                    "skills": [
-                        {
-                            "id": "nested/search",
-                            "name": "Search",
-                            "version": "1.0.0",
-                            "content": "---\nname: Search\n---\nbody",
-                        }
-                    ],
-                },
+    saved_configs: list[AgentConfig] = []
+
+    apply_snapshot(
+        snapshot={
+            "schema_version": "agent-snapshot/v1",
+            "agent": {
+                "id": "cfg-source",
+                "name": "Repo Agent",
+                "skills": [
+                    {
+                        "id": "nested/search",
+                        "name": "Search",
+                        "version": "1.0.0",
+                        "content": "---\nname: Search\n---\nbody",
+                    }
+                ],
             },
-            marketplace_item_id="item-1",
-            source_version="1.0.0",
+        },
+        marketplace_item_id="item-1",
+        source_version="1.0.0",
+        owner_user_id="user-1",
+        user_repo=SimpleNamespace(create=lambda _row: None),
+        agent_config_repo=SimpleNamespace(save_agent_config=lambda config: saved_configs.append(config)),
+        skill_repo=skill_repo,
+    )
+
+    assert saved_configs[0].skills[0].skill_id == "skill_generated123"
+    assert skill_repo.get_by_id("user-1", "nested/search") is None
+    assert skill_repo.get_by_id("user-1", "skill_generated123") is not None
+    assert saved_configs[0].skills[0].source["snapshot_skill_id"] == "nested/search"
+
+
+def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: pytest.MonkeyPatch):
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    skill_repo = _MemorySkillRepo()
+    timestamp = datetime(2026, 4, 24, tzinfo=UTC)
+    skill_repo.upsert(
+        Skill(
+            id="skill_existing123",
             owner_user_id="user-1",
-            user_repo=SimpleNamespace(create=lambda _row: None),
-            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
-            skill_repo=skill_repo,
+            name="Search",
+            description="old",
+            source={"marketplace_item_id": "item-1", "snapshot_skill_id": "search-core"},
+            created_at=timestamp,
+            updated_at=timestamp,
         )
-    assert skill_repo.list_for_owner("user-1") == []
+    )
+    monkeypatch.setattr(
+        "backend.hub.snapshot_apply.generate_skill_id",
+        lambda: (_ for _ in ()).throw(AssertionError("must reuse the source Skill")),
+    )
+    saved_configs: list[AgentConfig] = []
+
+    apply_snapshot(
+        snapshot={
+            "schema_version": "agent-snapshot/v1",
+            "agent": {
+                "id": "cfg-source",
+                "name": "Repo Agent",
+                "skills": [{"id": "search-core", "name": "Search", "version": "1.0.1", "content": "---\nname: Search\n---\nnew"}],
+            },
+        },
+        marketplace_item_id="item-1",
+        source_version="1.0.1",
+        owner_user_id="user-1",
+        user_repo=SimpleNamespace(create=lambda _row: None),
+        agent_config_repo=SimpleNamespace(save_agent_config=lambda config: saved_configs.append(config)),
+        skill_repo=skill_repo,
+    )
+
+    assert saved_configs[0].skills[0].skill_id == "skill_existing123"
+    assert skill_repo.get_by_id("user-1", "skill_existing123").description == ""
+    assert saved_configs[0].skills[0].source["snapshot_skill_id"] == "search-core"
 
 
 def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():


### PR DESCRIPTION
## Summary
- materialize AgentSnapshot Skills with owner-local Library Skill ids
- store the snapshot child id as source.snapshot_skill_id and reuse by marketplace item + snapshot child id
- keep unrelated same-name Library Skills protected from snapshot mutation

## Verification
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "apply_snapshot"
- uv run pytest tests/Unit/integration_contracts/test_marketplace_router_user_shell.py::test_apply_member_snapshot_materializes_skill_through_router -q
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/platform/test_marketplace_client.py -q
- uv run pytest tests/Unit -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright backend/hub/snapshot_apply.py
- npm test
- npm run lint
- npm run typecheck
- npm run build