### PR TITLE
Refactor agent skill binding contracts

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -113,7 +113,6 @@ def _materialize_snapshot_skills(
                 package_id=package.id,
                 name=snapshot_skill.name,
                 description=snapshot_skill.description,
-                version=package.version,
             )
         )
     return result

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -114,7 +114,6 @@ def _materialize_snapshot_skills(
                 name=snapshot_skill.name,
                 description=snapshot_skill.description,
                 version=package.version,
-                source=source,
             )
         )
     return result

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -595,6 +595,13 @@ def _current_skill_by_id(config: AgentConfig, skill_id: str) -> AgentSkill | Non
     return None
 
 
+def _patch_library_skill_id(item: dict[str, Any]) -> str:
+    value = item.get("id")
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError("Skill patch item must include id")
+    return value
+
+
 def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any], owner_user_id: str, skill_repo: Any) -> list[AgentSkill]:
     if "skills" not in config_patch or config_patch["skills"] is None:
         return list(current_config.skills)
@@ -614,27 +621,23 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
         if "disabled" in item:
             raise RuntimeError("Skill patch item must use enabled, not disabled")
         _enabled_from_patch_item(item, label="Skill patch item")
-        if not (item.get("id") or item.get("skill_id")):
-            raise RuntimeError("Skill patch item must include id")
+        _patch_library_skill_id(item)
         name = str(item["name"])
         if name in seen_names:
             raise RuntimeError(f"Duplicate Skill name in patch: {name}")
         seen_names.add(name)
     for item in skill_items:
-        name = str(item["name"])
         enabled = _enabled_from_patch_item(item, label="Skill patch item")
-        explicit_skill_id = item.get("id") or item.get("skill_id")
-        explicit_skill_id_str = str(explicit_skill_id)
-        current_skill = _current_skill_by_id(current_config, explicit_skill_id_str)
-        library_skill = skill_repo.get_by_id(owner_user_id, explicit_skill_id_str)
+        library_skill_id = _patch_library_skill_id(item)
+        current_skill = _current_skill_by_id(current_config, library_skill_id)
+        library_skill = skill_repo.get_by_id(owner_user_id, library_skill_id)
         if library_skill is None:
-            raise RuntimeError(f"Library skill not found: {explicit_skill_id_str}")
+            raise RuntimeError(f"Library skill not found: {library_skill_id}")
         library_package = _selected_library_package(owner_user_id, library_skill, skill_repo)
         description = library_skill.description
-        agent_skill_id = item.get("agent_skill_id") or item.get("row_id") or (current_skill.id if current_skill is not None else None)
         skills.append(
             AgentSkill(
-                id=str(agent_skill_id) if agent_skill_id else None,
+                id=current_skill.id if current_skill is not None else None,
                 skill_id=library_skill.id,
                 package_id=library_package.id,
                 name=library_skill.name,

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -642,7 +642,6 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
                 package_id=library_package.id,
                 name=library_skill.name,
                 description=description,
-                version=library_package.version,
                 enabled=enabled,
             )
         )

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -369,8 +369,12 @@ def select_agent_skill(
     library_skill = skill_repo.get_by_id(current_config.owner_user_id, skill_id)
     if library_skill is None:
         raise RuntimeError(f"Library skill not found: {skill_id}")
-    current_items = [item for item in _skills_from_repo(current_config) if item["id"] != library_skill.id]
-    current_items.append({"id": library_skill.id, "name": library_skill.name, "enabled": True})
+    current_items = [
+        {"id": skill.skill_id, "enabled": skill.enabled}
+        for skill in current_config.skills
+        if skill.skill_id != library_skill.id
+    ]
+    current_items.append({"id": library_skill.id, "enabled": True})
     return _sync_agent_config_patch_to_repo(
         agent_user_id,
         {"skills": current_items},
@@ -610,22 +614,26 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
 
     skills: list[AgentSkill] = []
     seen_names: set[str] = set()
+    seen_skill_ids: set[str] = set()
     skill_items = config_patch["skills"]
     for item in skill_items:
-        if not (isinstance(item, dict) and item.get("name")):
-            raise RuntimeError("Skill patch item must include name")
+        if not isinstance(item, dict):
+            raise RuntimeError("Skill patch item must be an object")
+        if "name" in item or "desc" in item:
+            raise RuntimeError("Skill patch item must not include name or desc")
         if "content" in item or "files" in item:
             raise RuntimeError("Skill patch item must not include content or files")
         if "source" in item or "version" in item:
             raise RuntimeError("Skill patch item must not include source or version")
+        if "skill_id" in item:
+            raise RuntimeError("Skill patch item must use id")
         if "disabled" in item:
             raise RuntimeError("Skill patch item must use enabled, not disabled")
         _enabled_from_patch_item(item, label="Skill patch item")
-        _patch_library_skill_id(item)
-        name = str(item["name"])
-        if name in seen_names:
-            raise RuntimeError(f"Duplicate Skill name in patch: {name}")
-        seen_names.add(name)
+        library_skill_id = _patch_library_skill_id(item)
+        if library_skill_id in seen_skill_ids:
+            raise RuntimeError(f"Duplicate Skill id in patch: {library_skill_id}")
+        seen_skill_ids.add(library_skill_id)
     for item in skill_items:
         enabled = _enabled_from_patch_item(item, label="Skill patch item")
         library_skill_id = _patch_library_skill_id(item)
@@ -633,6 +641,9 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
         library_skill = skill_repo.get_by_id(owner_user_id, library_skill_id)
         if library_skill is None:
             raise RuntimeError(f"Library skill not found: {library_skill_id}")
+        if library_skill.name in seen_names:
+            raise RuntimeError(f"Duplicate Skill name in patch: {library_skill.name}")
+        seen_names.add(library_skill.name)
         library_package = _selected_library_package(owner_user_id, library_skill, skill_repo)
         description = library_skill.description
         skills.append(

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -643,7 +643,6 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
                 name=library_skill.name,
                 description=description,
                 version=library_package.version,
-                source=dict(library_package.source),
                 enabled=enabled,
             )
         )

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -370,9 +370,7 @@ def select_agent_skill(
     if library_skill is None:
         raise RuntimeError(f"Library skill not found: {skill_id}")
     current_items = [
-        {"id": skill.skill_id, "enabled": skill.enabled}
-        for skill in current_config.skills
-        if skill.skill_id != library_skill.id
+        {"id": skill.skill_id, "enabled": skill.enabled} for skill in current_config.skills if skill.skill_id != library_skill.id
     ]
     current_items.append({"id": library_skill.id, "enabled": True})
     return _sync_agent_config_patch_to_repo(

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import yaml
 
-from config.agent_config_types import AgentConfig, ResolvedAgentConfig, ResolvedSkill
+from config.agent_config_types import AgentConfig, AgentSkill, ResolvedAgentConfig, ResolvedSkill
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
@@ -46,13 +46,9 @@ def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> Reso
     )
 
 
-def _resolve_skill(owner_user_id: str, skill: Any, skill_repo: Any) -> ResolvedSkill:
+def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> ResolvedSkill:
     if skill_repo is None:
         raise RuntimeError("skill_repo is required to resolve AgentConfig Skills")
-    if not skill.skill_id:
-        raise ValueError(f"AgentConfig Skill {skill.name!r} is missing skill_id")
-    if not skill.package_id:
-        raise ValueError(f"AgentConfig Skill {skill.name!r} is missing package_id")
 
     package = skill_repo.get_package(owner_user_id, skill.package_id)
     if package is None:

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -69,7 +69,6 @@ class AgentSkill(AgentConfigSchemaModel):
     description: str = ""
     version: str
     enabled: bool = True
-    source: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("skill_id", "package_id", "name")
     @classmethod

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -67,7 +67,6 @@ class AgentSkill(AgentConfigSchemaModel):
     package_id: str
     name: str
     description: str = ""
-    version: str
     enabled: bool = True
 
     @field_validator("skill_id", "package_id", "name")

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -63,15 +63,15 @@ class SkillPackage(AgentConfigSchemaModel):
 
 class AgentSkill(AgentConfigSchemaModel):
     id: str | None = None
-    skill_id: str | None = None
-    package_id: str | None = None
+    skill_id: str
+    package_id: str
     name: str
     description: str = ""
     version: str
     enabled: bool = True
     source: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("name")
+    @field_validator("skill_id", "package_id", "name")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():

--- a/frontend/app/src/pages/AgentDetailPage.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.tsx
@@ -43,6 +43,10 @@ function skillId(item: CrudItem): string {
   return item.id;
 }
 
+function skillPatch(items: CrudItem[]): Array<{ id: string; enabled: boolean }> {
+  return items.map(item => ({ id: skillId(item), enabled: item.enabled }));
+}
+
 // ==================== Main Component ====================
 
 export default function AgentDetail() {
@@ -118,7 +122,7 @@ export default function AgentDetail() {
       } else if (mod === "mcp") {
         await updateAgentConfig(agent.id, { mcpServers: agent.config.mcpServers.map(i => i.name === itemName ? { ...i, enabled } : i) });
       } else if (mod === "skills") {
-        await updateAgentConfig(agent.id, { skills: agent.config.skills.map(i => i.name === itemName ? { ...i, enabled } : i) });
+        await updateAgentConfig(agent.id, { skills: skillPatch(agent.config.skills.map(i => i.name === itemName ? { ...i, enabled } : i)) });
       }
     } catch (err) { toast.error(`更新失败：${errorText(err)}`); }
   };
@@ -130,8 +134,8 @@ export default function AgentDetail() {
         const existing = new Set(agent.config.skills.map(skillId));
         const newSkills = items
           .filter(item => !existing.has(item.id))
-          .map(item => ({ id: item.id, name: item.name, desc: item.desc || "", enabled: true }));
-        if (newSkills.length) await updateAgentConfig(agent.id, { skills: [...agent.config.skills, ...newSkills] });
+          .map(item => ({ id: item.id, enabled: true }));
+        if (newSkills.length) await updateAgentConfig(agent.id, { skills: [...skillPatch(agent.config.skills), ...newSkills] });
       }
       toast.success("已添加");
     } catch (err) { toast.error(`添加失败：${errorText(err)}`); }
@@ -141,7 +145,7 @@ export default function AgentDetail() {
     if (!agent) return;
     try {
       if (mod === "mcp") await updateAgentConfig(agent.id, { mcpServers: agent.config.mcpServers.filter(i => i.name !== itemName) });
-      else if (mod === "skills") await updateAgentConfig(agent.id, { skills: agent.config.skills.filter(i => i.name !== itemName) });
+      else if (mod === "skills") await updateAgentConfig(agent.id, { skills: skillPatch(agent.config.skills.filter(i => i.name !== itemName)) });
       else if (mod === "subagents") await updateAgentConfig(agent.id, { subAgents: agent.config.subAgents.filter(i => i.name !== itemName) });
       else if (mod === "rules") await updateAgentConfig(agent.id, { rules: agent.config.rules.filter(i => i.name !== itemName) });
       toast.success("已移除");

--- a/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
@@ -255,8 +255,6 @@ describe("AgentDetailPage wording contract", () => {
         skills: [
           {
             id: "loadable-skill",
-            name: "Loadable Skill",
-            desc: "loadable",
             enabled: true,
           },
         ],

--- a/frontend/app/src/store/app-store.ts
+++ b/frontend/app/src/store/app-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { Agent, AgentConfig, ResourceItem, UserProfile } from "./types";
+import type { Agent, AgentConfigPatch, ResourceItem, UserProfile } from "./types";
 import { useAuthStore } from "./auth-store";
 
 const API = "/api/panel";
@@ -29,7 +29,7 @@ interface AppState {
   fetchAgent: (id: string) => Promise<Agent>;
   addAgent: (name: string, description?: string) => Promise<Agent>;
   updateAgent: (id: string, fields: Partial<Agent>) => Promise<void>;
-  updateAgentConfig: (id: string, patch: Partial<AgentConfig>) => Promise<void>;
+  updateAgentConfig: (id: string, patch: AgentConfigPatch) => Promise<void>;
   publishAgent: (id: string, bumpType: string) => Promise<Agent>;
   deleteAgent: (id: string) => Promise<void>;
   getAgentById: (id: string) => Agent | undefined;

--- a/frontend/app/src/store/types.ts
+++ b/frontend/app/src/store/types.ts
@@ -41,6 +41,15 @@ export interface AgentConfig {
   };
 }
 
+export interface SkillPatchItem {
+  id: string;
+  enabled?: boolean;
+}
+
+export type AgentConfigPatch = Partial<Omit<AgentConfig, "skills">> & {
+  skills?: SkillPatchItem[];
+};
+
 export interface Agent {
   id: string;
   name: string;

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -12,19 +12,19 @@ _SCHEMA = "agent"
 _LIBRARY_SCHEMA = "library"
 
 
-def _reject_duplicate_names(label: str, names: list[str]) -> None:
+def _reject_duplicate_values(label: str, values: list[str]) -> None:
     seen: set[str] = set()
-    for name in names:
-        if name in seen:
-            raise ValueError(f"Duplicate {label} name in AgentConfig: {name}")
-        seen.add(name)
+    for value in values:
+        if value in seen:
+            raise ValueError(f"Duplicate {label} in AgentConfig: {value}")
+        seen.add(value)
 
 
 def _reject_duplicate_child_names(config: AgentConfig) -> None:
-    _reject_duplicate_names("Skill", [skill.name for skill in config.skills])
-    _reject_duplicate_names("Rule", [rule.name for rule in config.rules])
-    _reject_duplicate_names("SubAgent", [agent.name for agent in config.sub_agents])
-    _reject_duplicate_names("MCP server", [server.name for server in config.mcp_servers])
+    _reject_duplicate_values("Skill id", [skill.skill_id for skill in config.skills])
+    _reject_duplicate_values("Rule name", [rule.name for rule in config.rules])
+    _reject_duplicate_values("SubAgent name", [agent.name for agent in config.sub_agents])
+    _reject_duplicate_values("MCP server name", [server.name for server in config.mcp_servers])
 
 
 def _enabled_from_row(row: dict[str, Any], *, label: str) -> bool:
@@ -133,7 +133,7 @@ class SupabaseAgentConfigRepo:
             skill_id = row["skill_id"]
             package_id = row["package_id"]
             skill = self._get_library_skill(owner_user_id, skill_id)
-            package = self._get_skill_package(owner_user_id, package_id)
+            self._get_skill_package(owner_user_id, package_id)
             skills.append(
                 AgentSkill(
                     id=row.get("id"),

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -143,7 +143,6 @@ class SupabaseAgentConfigRepo:
                     description=_required_text(skill, "description", label="library.skills description"),
                     version=package["version"],
                     enabled=_enabled_from_row(row, label="skill_bindings"),
-                    source=_required_json_object(package.get("source_json"), label="skill package source_json"),
                 )
             )
         return skills

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -141,7 +141,6 @@ class SupabaseAgentConfigRepo:
                     package_id=package_id,
                     name=skill["name"],
                     description=_required_text(skill, "description", label="library.skills description"),
-                    version=package["version"],
                     enabled=_enabled_from_row(row, label="skill_bindings"),
                 )
             )

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -362,13 +362,6 @@ begin
     end if;
     if exists (
         select 1
-        from jsonb_array_elements(coalesce(payload->'skills', '[]'::jsonb)) as skill_item(value)
-        where btrim(coalesce(skill_item.value->>'name', '')) = ''
-    ) then
-        raise exception 'agent_config.skills child.name is required';
-    end if;
-    if exists (
-        select 1
         from jsonb_array_elements(coalesce(payload->'rules', '[]'::jsonb)) as rule_item(value)
         where btrim(coalesce(rule_item.value->>'name', '')) = ''
     ) then
@@ -411,14 +404,6 @@ begin
           and jsonb_typeof(mcp_item.value->'env') <> 'object'
     ) then
         raise exception 'agent_config.mcp_servers child.env must be a JSON object';
-    end if;
-    if exists (
-        select 1
-        from jsonb_array_elements(coalesce(payload->'skills', '[]'::jsonb)) as skill_item(value)
-        group by skill_item.value->>'name'
-        having count(*) > 1
-    ) then
-        raise exception 'agent_config.skills contains duplicate name';
     end if;
     if exists (
         select 1

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -23,7 +23,6 @@ def _skill(name: str = "github", *, enabled: bool = True) -> AgentSkill:
         description="GitHub guidance",
         version="1.0.0",
         enabled=enabled,
-        source={"marketplace_item_id": "skill-github", "source_version": "1.0.0"},
     )
 
 
@@ -322,7 +321,7 @@ def test_resolver_rejects_duplicate_enabled_skill_names():
     assert "Duplicate Skill name in AgentConfig: github" in str(excinfo.value)
 
 
-def test_resolver_uses_selected_package_source_not_agent_skill_source():
+def test_resolver_uses_selected_package_source():
     config = _config(
         skills=[
             AgentSkill(
@@ -330,7 +329,6 @@ def test_resolver_uses_selected_package_source_not_agent_skill_source():
                 package_id="github-package",
                 name="github",
                 version="1.0.0",
-                source={"source_version": "agent-stale"},
             )
         ]
     )

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -21,7 +21,6 @@ def _skill(name: str = "github", *, enabled: bool = True) -> AgentSkill:
         package_id=f"{name}-package",
         name=name,
         description="GitHub guidance",
-        version="1.0.0",
         enabled=enabled,
     )
 
@@ -129,7 +128,6 @@ def test_resolver_keeps_skill_id_separate_from_display_name() -> None:
                 package_id="github-core-package",
                 name="GitHub",
                 description="GitHub guidance",
-                version="1.0.0",
             )
         ]
     )
@@ -185,7 +183,7 @@ def test_agent_config_rejects_blank_identity_fields():
 
 
 def test_resolver_rejects_skill_without_frontmatter():
-    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package", name="broken", version="1.0.0")])
+    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package", name="broken")])
 
     with pytest.raises(ValueError) as excinfo:
         resolve_agent_config(
@@ -215,7 +213,6 @@ def test_resolver_rejects_skill_frontmatter_without_name():
                 skill_id="broken",
                 package_id="broken-package",
                 name="broken",
-                version="1.0.0",
             )
         ]
     )
@@ -248,7 +245,6 @@ def test_resolver_rejects_display_name_without_name():
                 skill_id="broken",
                 package_id="broken-package",
                 name="broken",
-                version="1.0.0",
             )
         ]
     )
@@ -281,7 +277,6 @@ def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill
                 skill_id="visible-skill",
                 package_id="visible-package",
                 name="Visible Skill",
-                version="1.0.0",
             )
         ]
     )
@@ -328,7 +323,6 @@ def test_resolver_uses_selected_package_source():
                 skill_id="github",
                 package_id="github-package",
                 name="github",
-                version="1.0.0",
             )
         ]
     )

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -156,15 +156,6 @@ def test_resolver_keeps_skill_id_separate_from_display_name() -> None:
     assert resolved.skills[0].name == "GitHub"
 
 
-def test_resolver_rejects_skill_without_package_id():
-    config = _config(skills=[AgentSkill(skill_id="broken", name="broken", version="1.0.0")])
-
-    with pytest.raises(ValueError) as excinfo:
-        resolve_agent_config(config, skill_repo=_SkillRepo())
-
-    assert "missing package_id" in str(excinfo.value)
-
-
 def test_agent_named_children_reject_blank_names():
     with pytest.raises(ValueError) as rule_excinfo:
         AgentRule(name=" ", content="body")

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -111,6 +111,19 @@ def test_agent_skill_model_rejects_resolved_content_fields() -> None:
         )
 
 
+def test_agent_skill_model_rejects_package_source() -> None:
+    with pytest.raises(ValueError, match="source"):
+        AgentSkill.model_validate(
+            {
+                "skill_id": "skill-1",
+                "package_id": "package-1",
+                "name": "query-helper",
+                "version": "1.0.0",
+                "source": {"source_version": "1.0.0"},
+            }
+        )
+
+
 def test_agent_config_model_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="skill_packages"):
         AgentConfig.model_validate(

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -70,6 +70,23 @@ def test_agent_skill_model_has_no_resolved_content() -> None:
     assert "files" not in agent_skill.model_dump()
 
 
+def test_agent_skill_model_requires_library_skill_and_package_identity() -> None:
+    with pytest.raises(ValueError) as missing_skill_excinfo:
+        AgentSkill.model_validate({"package_id": "package-1", "name": "query-helper", "version": "1.0.0"})
+    with pytest.raises(ValueError) as missing_package_excinfo:
+        AgentSkill.model_validate({"skill_id": "query-helper", "name": "query-helper", "version": "1.0.0"})
+
+    assert "skill_id" in str(missing_skill_excinfo.value)
+    assert "package_id" in str(missing_package_excinfo.value)
+
+
+def test_agent_skill_model_rejects_blank_library_skill_and_package_identity() -> None:
+    with pytest.raises(ValueError, match="agent_skill.skill_id must not be blank"):
+        AgentSkill(skill_id=" ", package_id="package-1", name="query-helper", version="1.0.0")
+    with pytest.raises(ValueError, match="agent_skill.package_id must not be blank"):
+        AgentSkill(skill_id="query-helper", package_id=" ", name="query-helper", version="1.0.0")
+
+
 def test_agent_skill_model_rejects_resolved_content_fields() -> None:
     with pytest.raises(ValueError, match="content"):
         AgentSkill.model_validate(
@@ -136,7 +153,7 @@ def test_agent_config_model_rejects_blank_version() -> None:
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"name": "query-helper", "version": "1.0.0"}),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper", "version": "1.0.0"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),
@@ -150,7 +167,7 @@ def test_agent_config_child_models_reject_string_enabled(model_cls, kwargs) -> N
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"name": "query-helper", "version": "1.0.0"}),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper", "version": "1.0.0"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -64,7 +64,7 @@ def test_resolved_skill_model_rejects_blank_id() -> None:
 
 
 def test_agent_skill_model_has_no_resolved_content() -> None:
-    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper", version="1.0.0")
+    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper")
 
     assert "content" not in agent_skill.model_dump()
     assert "files" not in agent_skill.model_dump()
@@ -72,9 +72,9 @@ def test_agent_skill_model_has_no_resolved_content() -> None:
 
 def test_agent_skill_model_requires_library_skill_and_package_identity() -> None:
     with pytest.raises(ValueError) as missing_skill_excinfo:
-        AgentSkill.model_validate({"package_id": "package-1", "name": "query-helper", "version": "1.0.0"})
+        AgentSkill.model_validate({"package_id": "package-1", "name": "query-helper"})
     with pytest.raises(ValueError) as missing_package_excinfo:
-        AgentSkill.model_validate({"skill_id": "query-helper", "name": "query-helper", "version": "1.0.0"})
+        AgentSkill.model_validate({"skill_id": "query-helper", "name": "query-helper"})
 
     assert "skill_id" in str(missing_skill_excinfo.value)
     assert "package_id" in str(missing_package_excinfo.value)
@@ -82,9 +82,9 @@ def test_agent_skill_model_requires_library_skill_and_package_identity() -> None
 
 def test_agent_skill_model_rejects_blank_library_skill_and_package_identity() -> None:
     with pytest.raises(ValueError, match="agent_skill.skill_id must not be blank"):
-        AgentSkill(skill_id=" ", package_id="package-1", name="query-helper", version="1.0.0")
+        AgentSkill(skill_id=" ", package_id="package-1", name="query-helper")
     with pytest.raises(ValueError, match="agent_skill.package_id must not be blank"):
-        AgentSkill(skill_id="query-helper", package_id=" ", name="query-helper", version="1.0.0")
+        AgentSkill(skill_id="query-helper", package_id=" ", name="query-helper")
 
 
 def test_agent_skill_model_rejects_resolved_content_fields() -> None:
@@ -94,7 +94,6 @@ def test_agent_skill_model_rejects_resolved_content_fields() -> None:
                 "name": "query-helper",
                 "skill_id": "skill-1",
                 "package_id": "package-1",
-                "version": "1.0.0",
                 "content": "Use exact terms.",
             }
         )
@@ -105,8 +104,19 @@ def test_agent_skill_model_rejects_resolved_content_fields() -> None:
                 "name": "query-helper",
                 "skill_id": "skill-1",
                 "package_id": "package-1",
-                "version": "1.0.0",
                 "files": {"references/query.md": "Use exact terms."},
+            }
+        )
+
+
+def test_agent_skill_model_rejects_package_version() -> None:
+    with pytest.raises(ValueError, match="version"):
+        AgentSkill.model_validate(
+            {
+                "skill_id": "skill-1",
+                "package_id": "package-1",
+                "name": "query-helper",
+                "version": "1.0.0",
             }
         )
 
@@ -118,7 +128,6 @@ def test_agent_skill_model_rejects_package_source() -> None:
                 "skill_id": "skill-1",
                 "package_id": "package-1",
                 "name": "query-helper",
-                "version": "1.0.0",
                 "source": {"source_version": "1.0.0"},
             }
         )
@@ -166,7 +175,7 @@ def test_agent_config_model_rejects_blank_version() -> None:
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper", "version": "1.0.0"}),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),
@@ -180,7 +189,7 @@ def test_agent_config_child_models_reject_string_enabled(model_cls, kwargs) -> N
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper", "version": "1.0.0"}),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),
@@ -237,7 +246,6 @@ def test_skill_package_rejects_blank_skill_md() -> None:
                 "created_at": datetime(2026, 4, 25, tzinfo=UTC),
             },
         ),
-        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
         (ResolvedSkill, {"id": "query-helper", "name": "query-helper", "content": "---\nname: query-helper\n---\nUse exact terms."}),
     ],
 )

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -16,7 +16,6 @@ def test_snapshot_contains_resolved_agent_config_only():
                     skill_id="github",
                     package_id="github-package",
                     name="github",
-                    version="1.0.0",
                 )
             ],
         ),
@@ -63,7 +62,6 @@ def test_snapshot_preserves_skill_id_when_name_changes():
                     skill_id="github-core",
                     package_id="github-core-package",
                     name="GitHub",
-                    version="1.0.0",
                 )
             ],
         ),

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -582,7 +582,7 @@ async def test_get_or_create_agent_resolves_skill_packages_before_runtime_startu
                 agent_user_id="agent-user-skill",
                 name="Skill Agent",
                 version="1.0.0",
-                skills=[AgentSkill(skill_id="fastapi", package_id="pkg-fastapi", name="FastAPI", version="1.0.0")],
+                skills=[AgentSkill(skill_id="fastapi", package_id="pkg-fastapi", name="FastAPI")],
             )
 
     class _SkillRepo:

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -739,7 +739,6 @@ async def test_leon_agent_resolved_config_registers_skills(tmp_path):
                 skill_id="fastapi",
                 package_id="fastapi-package",
                 name="FastAPI",
-                version="1.0.0",
             )
         ],
     )
@@ -786,7 +785,6 @@ async def test_leon_agent_passes_resolved_skill_models_to_runtime_service(tmp_pa
                 skill_id="fastapi",
                 package_id="fastapi-package",
                 name="FastAPI",
-                version="1.0.0",
             )
         ],
     )
@@ -839,7 +837,6 @@ async def test_leon_agent_resolved_config_does_not_register_host_file_skills(tmp
                 skill_id="fastapi",
                 package_id="fastapi-package",
                 name="FastAPI",
-                version="1.0.0",
             )
         ],
     )
@@ -982,7 +979,6 @@ async def test_leon_agent_resolved_config_does_not_read_stale_runtime_skill_togg
                 skill_id="fastapi",
                 package_id="fastapi-package",
                 name="FastAPI",
-                version="1.0.0",
             )
         ],
     )

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -740,7 +740,6 @@ async def test_leon_agent_resolved_config_registers_skills(tmp_path):
                 package_id="fastapi-package",
                 name="FastAPI",
                 version="1.0.0",
-                source={"desc": "Build FastAPI services"},
             )
         ],
     )

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -179,8 +179,8 @@ def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch:
             "/api/panel/agents/agent-1/config",
             json={
                 "skills": [
-                    {"id": assigned_by_name["Alpha Skill"]["id"], "name": "Alpha Skill", "enabled": True},
-                    {"id": library_by_name["Beta Skill"]["id"], "name": "Beta Skill", "enabled": True},
+                    {"id": assigned_by_name["Alpha Skill"]["id"], "enabled": True},
+                    {"id": library_by_name["Beta Skill"]["id"], "enabled": True},
                 ]
             },
         )
@@ -190,7 +190,7 @@ def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch:
 
         keep_beta = client.put(
             "/api/panel/agents/agent-1/config",
-            json={"skills": [{"id": library_by_name["Beta Skill"]["id"], "name": "Beta Skill", "enabled": True}]},
+            json={"skills": [{"id": library_by_name["Beta Skill"]["id"], "enabled": True}]},
         )
         deleted_alpha = client.delete(f"/api/panel/library/skill/{alpha_skill_id}")
         blocked_beta_delete = client.delete(f"/api/panel/library/skill/{beta_skill_id}")

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -532,6 +532,9 @@ def test_agent_config_patch_does_not_fill_skill_identity_from_patch_or_current_b
 
     source = inspect.getsource(agent_user_service._skills_from_patch)
 
+    assert 'item.get("skill_id")' not in source
+    assert "agent_skill_id" not in source
+    assert "row_id" not in source
     assert 'item.get("version")' not in source
     assert "current_skill.version" not in source
     assert "library_skill.source" not in source
@@ -863,7 +866,7 @@ def test_agent_config_patch_rejects_missing_explicit_library_skill_id() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Library skill not found: missing-skill"):
+    with pytest.raises(RuntimeError, match="Skill patch item must include id"):
         agent_user_service.update_agent_user_config(
             "agent-1",
             {
@@ -915,7 +918,7 @@ def test_agent_config_patch_explicit_library_id_uses_library_package_choice() ->
         {
             "skills": [
                 {
-                    "skill_id": "loadable-skill",
+                    "id": "loadable-skill",
                     "name": "Loadable Skill",
                     "enabled": True,
                 }

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1816,9 +1816,7 @@ def test_get_agent_user_uses_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[
-                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")
-                ],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
             )
 
     result = agent_user_service.get_agent_user(
@@ -1848,9 +1846,7 @@ def test_get_agent_user_ignores_runtime_skill_desc_override():
                 model="leon:large",
                 system_prompt="",
                 runtime_settings={"skills:Search": {"desc": "runtime desc", "enabled": False}},
-                skills=[
-                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")
-                ],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
             )
 
     result = agent_user_service.get_agent_user(

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -217,7 +217,6 @@ async def test_panel_agent_detail_exposes_library_skill_id_for_round_trip() -> N
                     package_id="loadable-skill-package",
                     name="Loadable Skill",
                     description="loadable",
-                    version="1.0.0",
                     enabled=True,
                 )
             ],
@@ -471,7 +470,6 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
             package_id=library_skill.package_id,
             name="Loadable Skill",
             description="loadable",
-            version="1.0.0",
         )
     ]
 
@@ -498,7 +496,6 @@ def test_agent_config_patch_keeps_package_source_out_of_agent_skill_binding() ->
                         skill_id="loadable-skill",
                         package_id=library_skill.package_id,
                         name="Loadable Skill",
-                        version="1.0.0",
                     )
                 ]
             )
@@ -823,7 +820,6 @@ def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
         package_id="loadable-package",
         name="Loadable Skill",
         description="loadable",
-        version="1.0.0",
     )
 
     class _AgentConfigRepo:
@@ -1823,7 +1819,7 @@ def test_get_agent_user_uses_repo_skill_desc():
                 model="leon:large",
                 system_prompt="",
                 skills=[
-                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc", version="1.0.0")
+                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")
                 ],
             )
 
@@ -1855,7 +1851,7 @@ def test_get_agent_user_ignores_runtime_skill_desc_override():
                 system_prompt="",
                 runtime_settings={"skills:Search": {"desc": "runtime desc", "enabled": False}},
                 skills=[
-                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc", version="1.0.0")
+                    AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")
                 ],
             )
 
@@ -2001,7 +1997,7 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="", version="1.0.0")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="")],
             )
 
     result = agent_user_service.get_agent_user(
@@ -2500,7 +2496,6 @@ def test_library_used_by_reads_agent_configs_without_display_projection(monkeypa
                     skill_id="skill-1",
                     package_id="skill-1-package",
                     name="api-design-reviewer",
-                    version="1.0.0",
                     enabled=True,
                 )
             ],
@@ -2536,7 +2531,6 @@ async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypa
                     skill_id="skill-1",
                     package_id="skill-1-package",
                     name="api-design-reviewer",
-                    version="1.0.0",
                     enabled=True,
                 )
             ],

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -476,7 +476,7 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
     ]
 
 
-def test_agent_config_patch_uses_selected_package_source_only() -> None:
+def test_agent_config_patch_keeps_package_source_out_of_agent_skill_binding() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
     library_skill = _put_skill(
@@ -499,7 +499,6 @@ def test_agent_config_patch_uses_selected_package_source_only() -> None:
                         package_id=library_skill.package_id,
                         name="Loadable Skill",
                         version="1.0.0",
-                        source={"source_version": "current-stale"},
                     )
                 ]
             )
@@ -524,7 +523,7 @@ def test_agent_config_patch_uses_selected_package_source_only() -> None:
         skill_repo=skill_repo,
     )
 
-    assert saved_configs[-1].skills[0].source == {}
+    assert "source" not in saved_configs[-1].skills[0].model_dump()
 
 
 def test_agent_config_patch_does_not_fill_skill_identity_from_patch_or_current_binding() -> None:
@@ -825,7 +824,6 @@ def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
         name="Loadable Skill",
         description="loadable",
         version="1.0.0",
-        source={"source_version": "1.0.0"},
     )
 
     class _AgentConfigRepo:
@@ -2076,9 +2074,9 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
         "marketplace_item_id": "item-1",
         "snapshot_skill_id": "search-core",
         "source_version": "1.0.0",
-        "source_at": saved_configs[0].skills[0].source["source_at"],
+        "source_at": package.source["source_at"],
     }
-    assert saved_configs[0].skills[0].source == package.source
+    assert "source" not in saved_configs[0].skills[0].model_dump()
     library_skill = skill_repo.get_by_id("user-1", saved_configs[0].skills[0].skill_id)
     assert library_skill is not None
     assert library_skill.source == package.source
@@ -2241,7 +2239,9 @@ def test_apply_snapshot_treats_snapshot_skill_id_as_source_metadata(monkeypatch:
     assert saved_configs[0].skills[0].skill_id == "skill_generated123"
     assert skill_repo.get_by_id("user-1", "nested/search") is None
     assert skill_repo.get_by_id("user-1", "skill_generated123") is not None
-    assert saved_configs[0].skills[0].source["snapshot_skill_id"] == "nested/search"
+    package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id)
+    assert package is not None
+    assert package.source["snapshot_skill_id"] == "nested/search"
 
 
 def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: pytest.MonkeyPatch):
@@ -2285,7 +2285,9 @@ def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: py
 
     assert saved_configs[0].skills[0].skill_id == "skill_existing123"
     assert skill_repo.get_by_id("user-1", "skill_existing123").description == ""
-    assert saved_configs[0].skills[0].source["snapshot_skill_id"] == "search-core"
+    package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id)
+    assert package is not None
+    assert package.source["snapshot_skill_id"] == "search-core"
 
 
 def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -447,7 +447,7 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
 
     result = agent_user_service.update_agent_user_config(
         "agent-1",
-        {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "desc": "loadable", "enabled": True}]},
+        {"skills": [{"id": "loadable-skill", "enabled": True}]},
         user_repo=SimpleNamespace(
             get_by_id=lambda _agent_id: UserRow(
                 id="agent-1",
@@ -505,7 +505,7 @@ def test_agent_config_patch_keeps_package_source_out_of_agent_skill_binding() ->
 
     agent_user_service.update_agent_user_config(
         "agent-1",
-        {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "enabled": True}]},
+        {"skills": [{"id": "loadable-skill", "enabled": True}]},
         user_repo=SimpleNamespace(
             get_by_id=lambda _agent_id: UserRow(
                 id="agent-1",
@@ -551,7 +551,7 @@ def test_agent_config_patch_rejects_inline_skill_content() -> None:
     with pytest.raises(RuntimeError, match="Skill patch item must not include content or files"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"name": "Inline Skill", "content": "---\nname: Inline Skill\n---\nUse it.", "enabled": True}]},
+            {"skills": [{"id": "loadable-skill", "content": "---\nname: Inline Skill\n---\nUse it.", "enabled": True}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -580,7 +580,7 @@ def test_agent_config_patch_rejects_skill_content_identity_fields(field: str) ->
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    patch_item = {"name": "Loadable Skill", "enabled": True, field: {"source_version": "patch"} if field == "source" else "9.9.9"}
+    patch_item = {"id": "loadable-skill", "enabled": True, field: {"source_version": "patch"} if field == "source" else "9.9.9"}
 
     with pytest.raises(RuntimeError, match="Skill patch item must not include source or version"):
         agent_user_service.update_agent_user_config(
@@ -616,7 +616,7 @@ def test_agent_config_patch_rejects_skill_disabled_flag() -> None:
     with pytest.raises(RuntimeError, match="Skill patch item must use enabled, not disabled"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"name": "Loadable Skill", "disabled": False}]},
+            {"skills": [{"id": "loadable-skill", "disabled": False}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -647,7 +647,7 @@ def test_agent_config_patch_rejects_skill_enabled_string() -> None:
     with pytest.raises(RuntimeError, match="Skill patch item enabled must be a boolean"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"name": "Loadable Skill", "enabled": "false"}]},
+            {"skills": [{"id": "loadable-skill", "enabled": "false"}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -687,7 +687,7 @@ def test_agent_config_patch_rejects_skill_item_without_library_skill_id() -> Non
     with pytest.raises(RuntimeError, match="Skill patch item must include id"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"name": "Loadable Skill", "enabled": True}]},
+            {"skills": [{"enabled": True}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -705,7 +705,7 @@ def test_agent_config_patch_rejects_skill_item_without_library_skill_id() -> Non
     assert saved_configs == []
 
 
-def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
+def test_agent_config_patch_rejects_skill_name_and_desc_fields() -> None:
     saved_configs: list[AgentConfig] = []
     skill_repo = _MemorySkillRepo()
     _put_skill(
@@ -724,10 +724,10 @@ def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Skill patch item must include id"):
+    with pytest.raises(RuntimeError, match="Skill patch item must not include name or desc"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"name": "loadable-skill", "desc": "loadable", "enabled": True}]},
+            {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "desc": "loadable", "enabled": True}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -745,7 +745,7 @@ def test_agent_config_patch_rejects_library_id_in_skill_name_field() -> None:
     assert saved_configs == []
 
 
-def test_agent_config_patch_rejects_skill_item_without_name() -> None:
+def test_agent_config_patch_rejects_non_object_skill_item() -> None:
     saved_configs: list[AgentConfig] = []
 
     class _AgentConfigRepo:
@@ -755,10 +755,10 @@ def test_agent_config_patch_rejects_skill_item_without_name() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Skill patch item must include name"):
+    with pytest.raises(RuntimeError, match="Skill patch item must be an object"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"enabled": True}]},
+            {"skills": ["loadable-skill"]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -776,7 +776,7 @@ def test_agent_config_patch_rejects_skill_item_without_name() -> None:
     assert saved_configs == []
 
 
-def test_agent_config_patch_rejects_duplicate_skill_names() -> None:
+def test_agent_config_patch_rejects_duplicate_skill_ids() -> None:
     saved_configs: list[AgentConfig] = []
 
     class _AgentConfigRepo:
@@ -786,13 +786,13 @@ def test_agent_config_patch_rejects_duplicate_skill_names() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Duplicate Skill name in patch: Loadable Skill"):
+    with pytest.raises(RuntimeError, match="Duplicate Skill id in patch: loadable-skill"):
         agent_user_service.update_agent_user_config(
             "agent-1",
             {
                 "skills": [
-                    {"id": "loadable-skill", "name": "Loadable Skill"},
-                    {"id": "loadable-skill-copy", "name": "Loadable Skill"},
+                    {"id": "loadable-skill"},
+                    {"id": "loadable-skill"},
                 ]
             },
             user_repo=SimpleNamespace(
@@ -832,7 +832,7 @@ def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
     with pytest.raises(RuntimeError, match="Library skill not found: loadable-skill"):
         agent_user_service.update_agent_user_config(
             "agent-1",
-            {"skills": [{"id": "loadable-skill", "name": "Loadable Skill", "desc": "loadable", "enabled": False}]},
+            {"skills": [{"id": "loadable-skill", "enabled": False}]},
             user_repo=SimpleNamespace(
                 get_by_id=lambda _agent_id: UserRow(
                     id="agent-1",
@@ -860,14 +860,13 @@ def test_agent_config_patch_rejects_missing_explicit_library_skill_id() -> None:
         def save_agent_config(self, config: AgentConfig) -> None:
             saved_configs.append(config)
 
-    with pytest.raises(RuntimeError, match="Skill patch item must include id"):
+    with pytest.raises(RuntimeError, match="Skill patch item must use id"):
         agent_user_service.update_agent_user_config(
             "agent-1",
             {
                 "skills": [
                     {
                         "skill_id": "missing-skill",
-                        "name": "Inline Skill",
                     }
                 ]
             },
@@ -913,7 +912,6 @@ def test_agent_config_patch_explicit_library_id_uses_library_package_choice() ->
             "skills": [
                 {
                     "id": "loadable-skill",
-                    "name": "Loadable Skill",
                     "enabled": True,
                 }
             ]

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -452,7 +452,7 @@ class TestApplySkill:
             def get_agent_config(self, agent_config_id: str) -> AgentConfig | None:
                 assert agent_config_id == "cfg-1"
                 return _agent_config(
-                    skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing", version="1.0.0")]
+                    skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing")]
                 )
 
             def save_agent_config(self, config: AgentConfig) -> None:
@@ -795,7 +795,6 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                         skill_id="search",
                         package_id="search-package",
                         name="Search",
-                        version="1.0.0",
                     )
                 ],
             )

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -796,7 +796,6 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                         package_id="search-package",
                         name="Search",
                         version="1.0.0",
-                        source={"name": "Search", "desc": "Repo Search"},
                     )
                 ],
             )

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -451,9 +451,7 @@ class TestApplySkill:
         class _AgentConfigRepo:
             def get_agent_config(self, agent_config_id: str) -> AgentConfig | None:
                 assert agent_config_id == "cfg-1"
-                return _agent_config(
-                    skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing")]
-                )
+                return _agent_config(skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing")])
 
             def save_agent_config(self, config: AgentConfig) -> None:
                 saved.append(config)

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -55,14 +55,14 @@ def test_agent_config_schema_rejects_duplicate_child_names_inside_rpc() -> None:
     assert "agent_config.rules must be a JSON array" in sql
     assert "agent_config.sub_agents must be a JSON array" in sql
     assert "agent_config.mcp_servers must be a JSON array" in sql
-    assert "agent_config.skills child.name is required" in sql
+    assert "agent_config.skills child.name is required" not in sql
     assert "agent_config.rules child.name is required" in sql
     assert "agent_config.sub_agents child.name is required" in sql
     assert "agent_config.mcp_servers child.name is required" in sql
     assert "agent_config.sub_agents child.tools must be a JSON array" in sql
     assert "agent_config.mcp_servers child.args must be a JSON array" in sql
     assert "agent_config.mcp_servers child.env must be a JSON object" in sql
-    assert "agent_config.skills contains duplicate name" in sql
+    assert "agent_config.skills contains duplicate name" not in sql
     assert "agent_config.rules contains duplicate name" in sql
     assert "agent_config.sub_agents contains duplicate name" in sql
     assert "agent_config.mcp_servers contains duplicate name" in sql

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -554,7 +554,7 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
     assert "runtime_" + "settings_json" not in payload
 
 
-def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
+def test_save_agent_config_rejects_duplicate_skill_ids_before_rpc() -> None:
     client = _FakeClient()
     repo = SupabaseAgentConfigRepo(client)
     config = AgentConfig(
@@ -565,11 +565,11 @@ def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
         version="1.0.0",
         skills=[
             AgentSkill(skill_id="github", package_id="package-1", name="github"),
-            AgentSkill(skill_id="github-two", package_id="package-2", name="github"),
+            AgentSkill(skill_id="github", package_id="package-2", name="github"),
         ],
     )
 
-    with pytest.raises(ValueError, match="Duplicate Skill name in AgentConfig: github"):
+    with pytest.raises(ValueError, match="Duplicate Skill id in AgentConfig: github"):
         repo.save_agent_config(config)
 
     assert client.rpc_calls == []
@@ -607,7 +607,7 @@ def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -
         version="1.0.0",
         skills=[
             AgentSkill(skill_id="github", package_id="package-1", name="github", enabled=False),
-            AgentSkill(skill_id="github-two", package_id="package-2", name="github", enabled=False),
+            AgentSkill(skill_id="github", package_id="package-2", name="github", enabled=False),
         ],
         mcp_servers=[
             McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),
@@ -615,7 +615,7 @@ def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -
         ],
     )
 
-    with pytest.raises(ValueError, match="Duplicate Skill name in AgentConfig: github"):
+    with pytest.raises(ValueError, match="Duplicate Skill id in AgentConfig: github"):
         repo.save_agent_config(config)
 
     assert client.rpc_calls == []

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -180,7 +180,6 @@ def test_get_agent_config_reads_full_aggregate_from_final_tables() -> None:
                 package_id="package-1",
                 name="github",
                 description="GitHub guidance",
-                version="1.0.0",
             )
         ],
         rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -358,13 +357,15 @@ def test_get_agent_config_keeps_package_source_out_of_agent_skill_binding() -> N
     assert "source" not in config.skills[0].model_dump()
 
 
-def test_get_agent_config_fails_loudly_when_skill_package_version_is_null() -> None:
+def test_get_agent_config_does_not_read_skill_package_version() -> None:
     tables = _tables()
     tables["library.skill_packages"][0]["version"] = None
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
-    with pytest.raises(ValueError, match="version"):
-        repo.get_agent_config("cfg-1")
+    config = repo.get_agent_config("cfg-1")
+
+    assert config is not None
+    assert "version" not in config.skills[0].model_dump()
 
 
 def test_get_agent_config_fails_loudly_when_skill_description_is_null() -> None:
@@ -531,7 +532,6 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
                     skill_id="skill-1",
                     package_id="package-1",
                     name="github",
-                    version="1.0.0",
                 )
             ],
             rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -564,8 +564,8 @@ def test_save_agent_config_rejects_duplicate_skill_names_before_rpc() -> None:
         name="Researcher",
         version="1.0.0",
         skills=[
-            AgentSkill(skill_id="github", package_id="package-1", name="github", version="1.0.0"),
-            AgentSkill(skill_id="github-two", package_id="package-2", name="github", version="1.0.0"),
+            AgentSkill(skill_id="github", package_id="package-1", name="github"),
+            AgentSkill(skill_id="github-two", package_id="package-2", name="github"),
         ],
     )
 
@@ -606,8 +606,8 @@ def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -
         name="Researcher",
         version="1.0.0",
         skills=[
-            AgentSkill(skill_id="github", package_id="package-1", name="github", version="1.0.0", enabled=False),
-            AgentSkill(skill_id="github-two", package_id="package-2", name="github", version="1.0.0", enabled=False),
+            AgentSkill(skill_id="github", package_id="package-1", name="github", enabled=False),
+            AgentSkill(skill_id="github-two", package_id="package-2", name="github", enabled=False),
         ],
         mcp_servers=[
             McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -181,7 +181,6 @@ def test_get_agent_config_reads_full_aggregate_from_final_tables() -> None:
                 name="github",
                 description="GitHub guidance",
                 version="1.0.0",
-                source={"source_version": "1.0.0"},
             )
         ],
         rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -336,25 +335,27 @@ def test_get_agent_config_fails_loudly_when_meta_json_is_null() -> None:
         repo.get_agent_config("cfg-1")
 
 
-def test_get_agent_config_fails_loudly_when_skill_source_json_is_not_an_object() -> None:
+def test_get_agent_config_does_not_read_skill_package_source_json() -> None:
     tables = _tables()
     tables["library.skill_packages"][0]["source_json"] = ["bad"]
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="skill package source_json must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_reads_agent_skill_source_from_selected_package_only() -> None:
-    tables = _tables()
-    tables["library.skills"][0]["source_json"] = {"source_version": "library"}
-    tables["library.skill_packages"][0]["source_json"] = {}
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
     config = repo.get_agent_config("cfg-1")
 
     assert config is not None
-    assert config.skills[0].source == {}
+    assert "source" not in config.skills[0].model_dump()
+
+
+def test_get_agent_config_keeps_package_source_out_of_agent_skill_binding() -> None:
+    tables = _tables()
+    tables["library.skills"][0]["source_json"] = {"source_version": "library"}
+    tables["library.skill_packages"][0]["source_json"] = {"source_version": "package"}
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    config = repo.get_agent_config("cfg-1")
+
+    assert config is not None
+    assert "source" not in config.skills[0].model_dump()
 
 
 def test_get_agent_config_fails_loudly_when_skill_package_version_is_null() -> None:


### PR DESCRIPTION
## Summary
- Make AgentSkill binding identity explicit: skill_id and package_id are required, while package source/version stay on SkillPackage/ResolvedSkill.
- Make Agent Skill config patches id-only (`id` + optional `enabled`) so UI/API writes do not smuggle display fields into binding state.
- Tighten Supabase AgentConfig save checks around Skill bindings by `skill_id` instead of child name.

## Verification
- `uv run pytest tests/Unit -q`
- `uv run ruff format --check . && uv run ruff check .`
- `uv run pyright config/agent_config_types.py config/agent_config_resolver.py backend/threads/agent_user_service.py backend/hub/snapshot_apply.py storage/providers/supabase/agent_config_repo.py`
- `cd frontend/app && npm test && npm run lint && npm run typecheck && npm run build`

Note: frontend build still reports the existing chunk-size warning.