### PR TITLE
Make Agent Skill bindings reference-only

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -111,8 +111,6 @@ def _materialize_snapshot_skills(
             AgentSkill(
                 skill_id=skill.id,
                 package_id=package.id,
-                name=snapshot_skill.name,
-                description=snapshot_skill.description,
             )
         )
     return result

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -435,7 +435,7 @@ def list_library_names(
 
 def get_resource_used_by(
     resource_type: str,
-    resource_name: str,
+    resource_id: str,
     owner_user_id: str,
     *,
     user_repo: Any = None,
@@ -456,7 +456,7 @@ def get_resource_used_by(
         config = agent_config_repo.get_agent_config(agent_config_id)
         if config is None:
             raise RuntimeError(f"Agent config {agent_config_id} is missing for {getattr(agent, 'id', 'unknown')}")
-        if any(getattr(item, "name", None) == resource_name for item in getattr(config, config_attr)):
+        if any(getattr(item, "skill_id", None) == resource_id for item in getattr(config, config_attr)):
             names.append(str(getattr(config, "name", None) or getattr(agent, "display_name", None) or getattr(agent, "id", "unknown")))
     return names
 

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -33,15 +33,20 @@ def _tools_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
     return tools_list
 
 
-def _skills_from_repo(config: AgentConfig) -> list[dict[str, Any]]:
+def _skills_from_repo(config: AgentConfig, skill_repo: Any = None) -> list[dict[str, Any]]:
+    if config.skills and skill_repo is None:
+        raise RuntimeError("skill_repo is required for Agent Skill display projection")
     skills_list = []
     for skill in config.skills:
+        library_skill = skill_repo.get_by_id(config.owner_user_id, skill.skill_id)
+        if library_skill is None:
+            raise RuntimeError(f"Library skill not found for Agent Skill display projection: {skill.skill_id}")
         skills_list.append(
             {
                 "id": skill.skill_id,
-                "name": skill.name,
+                "name": library_skill.name,
                 "enabled": skill.enabled,
-                "desc": skill.description,
+                "desc": library_skill.description,
             }
         )
     return skills_list
@@ -102,7 +107,7 @@ def _source_from_repo(config: AgentConfig) -> dict[str, Any] | None:
     return dict(source)
 
 
-def _agent_user_from_repos(user: Any, agent_config_repo: Any) -> dict[str, Any]:
+def _agent_user_from_repos(user: Any, agent_config_repo: Any, skill_repo: Any = None) -> dict[str, Any]:
     if user.agent_config_id is None:
         raise RuntimeError(f"Agent user {user.id} is missing agent_config_id")
     config = agent_config_repo.get_agent_config(user.agent_config_id)
@@ -121,7 +126,7 @@ def _agent_user_from_repos(user: Any, agent_config_repo: Any) -> dict[str, Any]:
             "rules": _rules_from_repo(config),
             "tools": _tools_from_repo(config),
             "mcpServers": _mcp_servers_from_repo(config),
-            "skills": _skills_from_repo(config),
+            "skills": _skills_from_repo(config, skill_repo),
             "subAgents": _sub_agents_from_repo(config),
             "compact": _compact_from_repo(config),
         },
@@ -206,7 +211,12 @@ def _load_builtin_agents(catalog: dict[str, ToolDef]) -> list[dict[str, Any]]:
 # ── CRUD operations ──
 
 
-def list_agent_users(owner_user_id: str | None = None, user_repo: Any = None, agent_config_repo: Any = None) -> list[dict[str, Any]]:
+def list_agent_users(
+    owner_user_id: str | None = None,
+    user_repo: Any = None,
+    agent_config_repo: Any = None,
+    skill_repo: Any = None,
+) -> list[dict[str, Any]]:
     """List agent users. If owner_user_id given, only that user's agents (no builtin Leon).
 
     Args:
@@ -218,7 +228,7 @@ def list_agent_users(owner_user_id: str | None = None, user_repo: Any = None, ag
         if user_repo is None or agent_config_repo is None:
             raise RuntimeError("user_repo and agent_config_repo are required when owner_user_id is provided")
         agents = user_repo.list_by_owner_user_id(owner_user_id)
-        return [_agent_user_from_repos(agent, agent_config_repo) for agent in agents]
+        return [_agent_user_from_repos(agent, agent_config_repo, skill_repo) for agent in agents]
 
     # Unscoped path is builtin-only. Owner-scoped callers must use repos.
     return [_leon_builtin()]
@@ -237,7 +247,13 @@ def list_agent_user_summaries(
     return [_leon_builtin()]
 
 
-def get_agent_user(agent_user_id: str, *, user_repo: Any = None, agent_config_repo: Any = None) -> dict[str, Any] | None:
+def get_agent_user(
+    agent_user_id: str,
+    *,
+    user_repo: Any = None,
+    agent_config_repo: Any = None,
+    skill_repo: Any = None,
+) -> dict[str, Any] | None:
     if agent_user_id == "__leon__":
         return _leon_builtin()
     if user_repo is None or agent_config_repo is None:
@@ -245,7 +261,7 @@ def get_agent_user(agent_user_id: str, *, user_repo: Any = None, agent_config_re
     user = user_repo.get_by_id(agent_user_id)
     if user is None:
         return None
-    return _agent_user_from_repos(user, agent_config_repo)
+    return _agent_user_from_repos(user, agent_config_repo, skill_repo)
 
 
 def create_agent_user(
@@ -312,6 +328,7 @@ def update_agent_user(
     agent_user_id: str,
     user_repo: Any = None,
     agent_config_repo: Any = None,
+    skill_repo: Any = None,
     *,
     name: str | None = None,
     description: str | None = None,
@@ -324,7 +341,7 @@ def update_agent_user(
         return None
     updates = {key: value for key, value in {"name": name, "description": description, "status": status}.items() if value is not None}
     if not updates:
-        return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
+        return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo, skill_repo=skill_repo)
     if "name" in updates:
         user_repo.update(agent_user_id, display_name=updates["name"])
     agent_config_repo.save_agent_config(
@@ -337,7 +354,7 @@ def update_agent_user(
         )
     )
 
-    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
+    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo, skill_repo=skill_repo)
 
 
 def update_agent_user_config(
@@ -643,14 +660,11 @@ def _skills_from_patch(current_config: AgentConfig, config_patch: dict[str, Any]
             raise RuntimeError(f"Duplicate Skill name in patch: {library_skill.name}")
         seen_names.add(library_skill.name)
         library_package = _selected_library_package(owner_user_id, library_skill, skill_repo)
-        description = library_skill.description
         skills.append(
             AgentSkill(
                 id=current_skill.id if current_skill is not None else None,
                 skill_id=library_skill.id,
                 package_id=library_package.id,
-                name=library_skill.name,
-                description=description,
                 enabled=enabled,
             )
         )
@@ -683,7 +697,7 @@ def _sync_agent_config_patch_to_repo(
         }
     )
     agent_config_repo.save_agent_config(updated_config)
-    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
+    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo, skill_repo=skill_repo)
 
 
 # ── Publish / Delete ──
@@ -694,6 +708,7 @@ def publish_agent_user(
     bump_type: BumpType = "patch",
     user_repo: Any = None,
     agent_config_repo: Any = None,
+    skill_repo: Any = None,
 ) -> dict[str, Any] | None:
     user, config = _resolve_repo_backed_agent(agent_user_id, user_repo, agent_config_repo)
     if user is None or config is None:
@@ -702,7 +717,7 @@ def publish_agent_user(
 
     agent_config_repo.save_agent_config(config.model_copy(update={"version": next_version, "status": "active"}))
 
-    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
+    return get_agent_user(agent_user_id, user_repo=user_repo, agent_config_repo=agent_config_repo, skill_repo=skill_repo)
 
 
 def _resolve_repo_backed_agent(

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -33,9 +33,15 @@ def _require_owned_agent_user(agent_id: str, user_id: str, user_repo: Any) -> An
     return user
 
 
-def _get_owned_agent_or_404_with_config(agent_id: str, user_id: str, user_repo: Any, agent_config_repo: Any) -> dict[str, Any]:
+def _get_owned_agent_or_404_with_config(
+    agent_id: str,
+    user_id: str,
+    user_repo: Any,
+    agent_config_repo: Any,
+    skill_repo: Any,
+) -> dict[str, Any]:
     _require_owned_agent_user(agent_id, user_id, user_repo)
-    item = agent_user_service.get_agent_user(agent_id, user_repo=user_repo, agent_config_repo=agent_config_repo)
+    item = agent_user_service.get_agent_user(agent_id, user_repo=user_repo, agent_config_repo=agent_config_repo, skill_repo=skill_repo)
     if not item:
         raise HTTPException(404, "Agent not found")
     return item
@@ -76,6 +82,13 @@ def _skill_repo(request: Request) -> Any:
     if repo is None:
         raise RuntimeError("skill_repo is required for panel library routes")
     return repo
+
+
+def _skill_repo_or_none(request: Request) -> Any | None:
+    runtime_storage = getattr(request.app.state, "runtime_storage_state", None)
+    storage_container = getattr(runtime_storage, "storage_container", None)
+    repo_factory = getattr(storage_container, "skill_repo", None)
+    return repo_factory() if callable(repo_factory) else None
 
 
 def _skill_repo_for(resource_type: str, request: Request) -> Any | None:
@@ -122,6 +135,7 @@ async def get_agent(
         user_id,
         request.app.state.user_repo,
         _agent_config_repo(request),
+        _skill_repo_or_none(request),
     )
 
 
@@ -164,6 +178,7 @@ async def update_agent(
         agent_id,
         user_repo=user_repo,
         agent_config_repo=agent_config_repo,
+        skill_repo=_skill_repo_or_none(request),
         name=req.name,
         description=req.description,
         status=req.status,
@@ -214,6 +229,7 @@ async def publish_agent(
         req.bump_type,
         user_repo=user_repo,
         agent_config_repo=agent_config_repo,
+        skill_repo=_skill_repo_or_none(request),
     )
     if not item:
         raise HTTPException(404, "Agent not found")
@@ -340,7 +356,7 @@ async def delete_resource(
             used_by = await asyncio.to_thread(
                 library_service.get_resource_used_by,
                 "skill",
-                skill.name,
+                resource_id,
                 user_id,
                 user_repo=request.app.state.user_repo,
                 agent_config_repo=_agent_config_repo(request),

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -16,10 +16,11 @@ def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> Reso
     for skill in config.skills:
         if not skill.enabled:
             continue
-        if skill.name in seen_skill_names:
-            raise ValueError(f"Duplicate Skill name in AgentConfig: {skill.name}")
-        seen_skill_names.add(skill.name)
-        resolved_skills.append(_resolve_skill(config.owner_user_id, skill, skill_repo))
+        resolved_skill = _resolve_skill(config.owner_user_id, skill, skill_repo)
+        if resolved_skill.name in seen_skill_names:
+            raise ValueError(f"Duplicate Skill name in AgentConfig: {resolved_skill.name}")
+        seen_skill_names.add(resolved_skill.name)
+        resolved_skills.append(resolved_skill)
     enabled_mcp_servers = []
     seen_mcp_server_names: set[str] = set()
     for server in config.mcp_servers:
@@ -55,10 +56,15 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
         raise RuntimeError(f"Skill package not found while resolving AgentConfig: {skill.package_id}")
     if package.skill_id != skill.skill_id:
         raise RuntimeError(f"Skill package {skill.package_id} does not belong to Skill {skill.skill_id}")
+    frontmatter = _skill_frontmatter(package.skill_md, skill_label=skill.skill_id)
+    name = frontmatter["name"].strip()
+    description = frontmatter.get("description", "")
+    if not isinstance(description, str):
+        description = ""
     resolved = ResolvedSkill(
         id=skill.skill_id,
-        name=skill.name,
-        description=skill.description,
+        name=name,
+        description=description,
         version=package.version,
         content=package.skill_md,
         files=dict(package.files),
@@ -67,18 +73,24 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
     return validate_resolved_skill_content(resolved)
 
 
-def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
-    if not skill.content.strip():
-        raise ValueError(f"Skill {skill.name!r} on Agent config has blank content")
-    frontmatter_result = _FRONTMATTER_RE.search(skill.content)
+def _skill_frontmatter(content: str, *, skill_label: str) -> dict[str, Any]:
+    if not content.strip():
+        raise ValueError(f"Skill {skill_label!r} on Agent config has blank content")
+    frontmatter_result = _FRONTMATTER_RE.search(content)
     if frontmatter_result is None:
-        raise ValueError(f"Skill {skill.name!r} on Agent config is missing SKILL.md frontmatter")
+        raise ValueError(f"Skill {skill_label!r} on Agent config is missing SKILL.md frontmatter")
     frontmatter = yaml.safe_load(frontmatter_result.group(1)) or {}
     if not isinstance(frontmatter, dict):
-        raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter must be a mapping")
+        raise ValueError(f"Skill {skill_label!r} on Agent config frontmatter must be a mapping")
     frontmatter_name = frontmatter.get("name")
     if not isinstance(frontmatter_name, str) or not frontmatter_name.strip():
-        raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter is missing name")
+        raise ValueError(f"Skill {skill_label!r} on Agent config frontmatter is missing name")
+    return frontmatter
+
+
+def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
+    frontmatter = _skill_frontmatter(skill.content, skill_label=skill.name)
+    frontmatter_name = frontmatter["name"]
     if frontmatter_name.strip() != skill.name:
-        raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter name must match AgentSkill.name")
+        raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter name must match ResolvedSkill.name")
     return skill

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -65,11 +65,9 @@ class AgentSkill(AgentConfigSchemaModel):
     id: str | None = None
     skill_id: str
     package_id: str
-    name: str
-    description: str = ""
     enabled: bool = True
 
-    @field_validator("skill_id", "package_id", "name")
+    @field_validator("skill_id", "package_id")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -132,15 +132,13 @@ class SupabaseAgentConfigRepo:
         for row in binding_rows:
             skill_id = row["skill_id"]
             package_id = row["package_id"]
-            skill = self._get_library_skill(owner_user_id, skill_id)
+            self._get_library_skill(owner_user_id, skill_id)
             self._get_skill_package(owner_user_id, package_id)
             skills.append(
                 AgentSkill(
                     id=row.get("id"),
                     skill_id=skill_id,
                     package_id=package_id,
-                    name=skill["name"],
-                    description=_required_text(skill, "description", label="library.skills description"),
                     enabled=_enabled_from_row(row, label="skill_bindings"),
                 )
             )

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -19,8 +19,6 @@ def _skill(name: str = "github", *, enabled: bool = True) -> AgentSkill:
     return AgentSkill(
         skill_id=name,
         package_id=f"{name}-package",
-        name=name,
-        description="GitHub guidance",
         enabled=enabled,
     )
 
@@ -126,8 +124,6 @@ def test_resolver_keeps_skill_id_separate_from_display_name() -> None:
             AgentSkill(
                 skill_id="github-core",
                 package_id="github-core-package",
-                name="GitHub",
-                description="GitHub guidance",
             )
         ]
     )
@@ -183,7 +179,7 @@ def test_agent_config_rejects_blank_identity_fields():
 
 
 def test_resolver_rejects_skill_without_frontmatter():
-    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package", name="broken")])
+    config = _config(skills=[AgentSkill(skill_id="broken", package_id="broken-package")])
 
     with pytest.raises(ValueError) as excinfo:
         resolve_agent_config(
@@ -212,7 +208,6 @@ def test_resolver_rejects_skill_frontmatter_without_name():
             AgentSkill(
                 skill_id="broken",
                 package_id="broken-package",
-                name="broken",
             )
         ]
     )
@@ -244,7 +239,6 @@ def test_resolver_rejects_display_name_without_name():
             AgentSkill(
                 skill_id="broken",
                 package_id="broken-package",
-                name="broken",
             )
         ]
     )
@@ -270,18 +264,10 @@ def test_resolver_rejects_display_name_without_name():
     assert "frontmatter is missing name" in str(excinfo.value)
 
 
-def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill_name():
-    config = _config(
-        skills=[
-            AgentSkill(
-                skill_id="visible-skill",
-                package_id="visible-package",
-                name="Visible Skill",
-            )
-        ]
-    )
+def test_resolver_rejects_package_that_does_not_belong_to_selected_skill():
+    config = _config(skills=[AgentSkill(skill_id="visible-skill", package_id="visible-package")])
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         resolve_agent_config(
             config,
             skill_repo=_SkillRepo(
@@ -289,7 +275,7 @@ def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill
                     "visible-package": SkillPackage(
                         id="visible-package",
                         owner_user_id="owner-1",
-                        skill_id="visible-skill",
+                        skill_id="other-skill",
                         version="1.0.0",
                         hash="sha256:visible",
                         skill_md="---\nname: Runtime Skill\n---\n\n# Runtime Skill\n",
@@ -299,7 +285,7 @@ def test_resolver_rejects_skill_frontmatter_name_that_does_not_match_agent_skill
             ),
         )
 
-    assert "frontmatter name must match AgentSkill.name" in str(excinfo.value)
+    assert "Skill package visible-package does not belong to Skill visible-skill" in str(excinfo.value)
 
 
 def test_resolver_rejects_duplicate_enabled_skill_names():
@@ -322,7 +308,6 @@ def test_resolver_uses_selected_package_source():
             AgentSkill(
                 skill_id="github",
                 package_id="github-package",
-                name="github",
             )
         ]
     )

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -64,17 +64,19 @@ def test_resolved_skill_model_rejects_blank_id() -> None:
 
 
 def test_agent_skill_model_has_no_resolved_content() -> None:
-    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1", name="query-helper")
+    agent_skill = AgentSkill(skill_id="query-helper", package_id="package-1")
 
+    assert "name" not in agent_skill.model_dump()
+    assert "description" not in agent_skill.model_dump()
     assert "content" not in agent_skill.model_dump()
     assert "files" not in agent_skill.model_dump()
 
 
 def test_agent_skill_model_requires_library_skill_and_package_identity() -> None:
     with pytest.raises(ValueError) as missing_skill_excinfo:
-        AgentSkill.model_validate({"package_id": "package-1", "name": "query-helper"})
+        AgentSkill.model_validate({"package_id": "package-1"})
     with pytest.raises(ValueError) as missing_package_excinfo:
-        AgentSkill.model_validate({"skill_id": "query-helper", "name": "query-helper"})
+        AgentSkill.model_validate({"skill_id": "query-helper"})
 
     assert "skill_id" in str(missing_skill_excinfo.value)
     assert "package_id" in str(missing_package_excinfo.value)
@@ -82,16 +84,15 @@ def test_agent_skill_model_requires_library_skill_and_package_identity() -> None
 
 def test_agent_skill_model_rejects_blank_library_skill_and_package_identity() -> None:
     with pytest.raises(ValueError, match="agent_skill.skill_id must not be blank"):
-        AgentSkill(skill_id=" ", package_id="package-1", name="query-helper")
+        AgentSkill(skill_id=" ", package_id="package-1")
     with pytest.raises(ValueError, match="agent_skill.package_id must not be blank"):
-        AgentSkill(skill_id="query-helper", package_id=" ", name="query-helper")
+        AgentSkill(skill_id="query-helper", package_id=" ")
 
 
 def test_agent_skill_model_rejects_resolved_content_fields() -> None:
     with pytest.raises(ValueError, match="content"):
         AgentSkill.model_validate(
             {
-                "name": "query-helper",
                 "skill_id": "skill-1",
                 "package_id": "package-1",
                 "content": "Use exact terms.",
@@ -101,7 +102,6 @@ def test_agent_skill_model_rejects_resolved_content_fields() -> None:
     with pytest.raises(ValueError, match="files"):
         AgentSkill.model_validate(
             {
-                "name": "query-helper",
                 "skill_id": "skill-1",
                 "package_id": "package-1",
                 "files": {"references/query.md": "Use exact terms."},
@@ -115,7 +115,6 @@ def test_agent_skill_model_rejects_package_version() -> None:
             {
                 "skill_id": "skill-1",
                 "package_id": "package-1",
-                "name": "query-helper",
                 "version": "1.0.0",
             }
         )
@@ -175,7 +174,7 @@ def test_agent_config_model_rejects_blank_version() -> None:
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),
@@ -189,7 +188,7 @@ def test_agent_config_child_models_reject_string_enabled(model_cls, kwargs) -> N
 @pytest.mark.parametrize(
     ("model_cls", "kwargs"),
     [
-        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1", "name": "query-helper"}),
+        (AgentSkill, {"skill_id": "query-helper", "package_id": "package-1"}),
         (AgentRule, {"name": "cite", "content": "cite sources"}),
         (AgentSubAgent, {"name": "worker"}),
         (McpServerConfig, {"name": "filesystem", "command": "fs"}),

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -15,7 +15,6 @@ def test_snapshot_contains_resolved_agent_config_only():
                 AgentSkill(
                     skill_id="github",
                     package_id="github-package",
-                    name="github",
                 )
             ],
         ),
@@ -61,7 +60,6 @@ def test_snapshot_preserves_skill_id_when_name_changes():
                 AgentSkill(
                     skill_id="github-core",
                     package_id="github-core-package",
-                    name="GitHub",
                 )
             ],
         ),

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -582,7 +582,7 @@ async def test_get_or_create_agent_resolves_skill_packages_before_runtime_startu
                 agent_user_id="agent-user-skill",
                 name="Skill Agent",
                 version="1.0.0",
-                skills=[AgentSkill(skill_id="fastapi", package_id="pkg-fastapi", name="FastAPI")],
+                skills=[AgentSkill(skill_id="fastapi", package_id="pkg-fastapi")],
             )
 
     class _SkillRepo:

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -738,7 +738,6 @@ async def test_leon_agent_resolved_config_registers_skills(tmp_path):
             AgentSkill(
                 skill_id="fastapi",
                 package_id="fastapi-package",
-                name="FastAPI",
             )
         ],
     )
@@ -784,7 +783,6 @@ async def test_leon_agent_passes_resolved_skill_models_to_runtime_service(tmp_pa
             AgentSkill(
                 skill_id="fastapi",
                 package_id="fastapi-package",
-                name="FastAPI",
             )
         ],
     )
@@ -836,7 +834,6 @@ async def test_leon_agent_resolved_config_does_not_register_host_file_skills(tmp
             AgentSkill(
                 skill_id="fastapi",
                 package_id="fastapi-package",
-                name="FastAPI",
             )
         ],
     )
@@ -978,7 +975,6 @@ async def test_leon_agent_resolved_config_does_not_read_stale_runtime_skill_togg
             AgentSkill(
                 skill_id="fastapi",
                 package_id="fastapi-package",
-                name="FastAPI",
             )
         ],
     )

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -196,6 +196,15 @@ async def test_panel_agent_detail_keeps_full_config_for_owner_scope(monkeypatch:
 
 @pytest.mark.asyncio
 async def test_panel_agent_detail_exposes_library_skill_id_for_round_trip() -> None:
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="loadable-skill",
+        name="Loadable Skill",
+        description="loadable",
+        content="---\nname: Loadable Skill\n---\nUse it.",
+    )
     agent = UserRow(
         id="agent-1",
         type=UserType.AGENT,
@@ -215,8 +224,6 @@ async def test_panel_agent_detail_exposes_library_skill_id_for_round_trip() -> N
                     id="agent-skill-1",
                     skill_id="loadable-skill",
                     package_id="loadable-skill-package",
-                    name="Loadable Skill",
-                    description="loadable",
                     enabled=True,
                 )
             ],
@@ -228,7 +235,9 @@ async def test_panel_agent_detail_exposes_library_skill_id_for_round_trip() -> N
         user_id="user-1",
         request=SimpleNamespace(
             app=SimpleNamespace(
-                state=SimpleNamespace(user_repo=fake_repo, runtime_storage_state=_runtime_storage_state(fake_agent_config_repo))
+                state=SimpleNamespace(
+                    user_repo=fake_repo, runtime_storage_state=_runtime_storage_state(fake_agent_config_repo, skill_repo=skill_repo)
+                )
             )
         ),
     )
@@ -468,8 +477,6 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
             id=None,
             skill_id="loadable-skill",
             package_id=library_skill.package_id,
-            name="Loadable Skill",
-            description="loadable",
         )
     ]
 
@@ -495,7 +502,6 @@ def test_agent_config_patch_keeps_package_source_out_of_agent_skill_binding() ->
                         id="agent-skill-1",
                         skill_id="loadable-skill",
                         package_id=library_skill.package_id,
-                        name="Loadable Skill",
                     )
                 ]
             )
@@ -818,8 +824,6 @@ def test_agent_config_patch_rejects_skill_after_library_delete() -> None:
         id="agent-skill-1",
         skill_id="loadable-skill",
         package_id="loadable-package",
-        name="Loadable Skill",
-        description="loadable",
     )
 
     class _AgentConfigRepo:
@@ -975,7 +979,7 @@ def test_select_agent_skill_uses_agent_config_skill_patch_boundary() -> None:
     assert result is not None
     assert saved_configs[-1].skills[0].skill_id == "loadable-skill"
     assert saved_configs[-1].skills[0].package_id == library_skill.package_id
-    assert saved_configs[-1].skills[0].description == "loadable"
+    assert "description" not in saved_configs[-1].skills[0].model_dump()
 
 
 def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None:
@@ -1800,6 +1804,15 @@ def test_agent_config_patch_rejects_tool_enabled_string() -> None:
 
 
 def test_get_agent_user_uses_repo_skill_desc():
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="search",
+        name="Search",
+        description="repo desc",
+        content="---\nname: Search\n---\nBody",
+    )
     agent = UserRow(
         id="agent-1",
         type=UserType.AGENT,
@@ -1816,19 +1829,29 @@ def test_get_agent_user_uses_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package")],
             )
 
     result = agent_user_service.get_agent_user(
         "agent-1",
         user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
         agent_config_repo=_AgentConfigRepo(),
+        skill_repo=skill_repo,
     )
 
     assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": "repo desc"}]
 
 
 def test_get_agent_user_ignores_runtime_skill_desc_override():
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="search",
+        name="Search",
+        description="repo desc",
+        content="---\nname: Search\n---\nBody",
+    )
     agent = UserRow(
         id="agent-1",
         type=UserType.AGENT,
@@ -1846,13 +1869,14 @@ def test_get_agent_user_ignores_runtime_skill_desc_override():
                 model="leon:large",
                 system_prompt="",
                 runtime_settings={"skills:Search": {"desc": "runtime desc", "enabled": False}},
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="repo desc")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package")],
             )
 
     result = agent_user_service.get_agent_user(
         "agent-1",
         user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
         agent_config_repo=_AgentConfigRepo(),
+        skill_repo=skill_repo,
     )
 
     assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": "repo desc"}]
@@ -1975,6 +1999,15 @@ def test_panel_agents_http_surface_does_not_expose_query_app_param(monkeypatch: 
 
 
 def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
+    skill_repo = _MemorySkillRepo()
+    _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="search",
+        name="Search",
+        description="",
+        content="---\nname: Search\n---\nBody",
+    )
     agent = UserRow(
         id="agent-1",
         type=UserType.AGENT,
@@ -1991,13 +2024,14 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
                 description="probe",
                 model="leon:large",
                 system_prompt="",
-                skills=[AgentSkill(skill_id="search", package_id="search-package", name="Search", description="")],
+                skills=[AgentSkill(skill_id="search", package_id="search-package")],
             )
 
     result = agent_user_service.get_agent_user(
         "agent-1",
         user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
         agent_config_repo=_AgentConfigRepo(),
+        skill_repo=skill_repo,
     )
 
     assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": ""}]
@@ -2052,7 +2086,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
 
     assert user_id == created_users[0].id
     assert saved_configs[0].name == "Repo Agent"
-    assert saved_configs[0].skills[0].description == "skill desc"
+    assert "description" not in saved_configs[0].skills[0].model_dump()
     assert saved_configs[0].skills[0].skill_id.startswith("skill_")
     assert saved_configs[0].skills[0].skill_id != "search-core"
     assert saved_configs[0].skills[0].package_id
@@ -2489,7 +2523,6 @@ def test_library_used_by_reads_agent_configs_without_display_projection(monkeypa
                 AgentSkill(
                     skill_id="skill-1",
                     package_id="skill-1-package",
-                    name="api-design-reviewer",
                     enabled=True,
                 )
             ],
@@ -2498,7 +2531,7 @@ def test_library_used_by_reads_agent_configs_without_display_projection(monkeypa
 
     assert library_service.get_resource_used_by(
         "skill",
-        "api-design-reviewer",
+        "skill-1",
         "user-1",
         user_repo=fake_user_repo,
         agent_config_repo=fake_agent_config_repo,
@@ -2524,7 +2557,6 @@ async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypa
                 AgentSkill(
                     skill_id="skill-1",
                     package_id="skill-1-package",
-                    name="api-design-reviewer",
                     enabled=True,
                 )
             ],

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -451,7 +451,7 @@ class TestApplySkill:
         class _AgentConfigRepo:
             def get_agent_config(self, agent_config_id: str) -> AgentConfig | None:
                 assert agent_config_id == "cfg-1"
-                return _agent_config(skills=[AgentSkill(skill_id="existing", package_id="existing-package", name="Existing")])
+                return _agent_config(skills=[AgentSkill(skill_id="existing", package_id="existing-package")])
 
             def save_agent_config(self, config: AgentConfig) -> None:
                 saved.append(config)
@@ -792,7 +792,6 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                     AgentSkill(
                         skill_id="search",
                         package_id="search-package",
-                        name="Search",
                     )
                 ],
             )

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -178,8 +178,6 @@ def test_get_agent_config_reads_full_aggregate_from_final_tables() -> None:
                 id="agent-skill-1",
                 skill_id="skill-1",
                 package_id="package-1",
-                name="github",
-                description="GitHub guidance",
             )
         ],
         rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -368,13 +366,15 @@ def test_get_agent_config_does_not_read_skill_package_version() -> None:
     assert "version" not in config.skills[0].model_dump()
 
 
-def test_get_agent_config_fails_loudly_when_skill_description_is_null() -> None:
+def test_get_agent_config_does_not_read_skill_description() -> None:
     tables = _tables()
     tables["library.skills"][0]["description"] = None
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
-    with pytest.raises(RuntimeError, match="library.skills description must be text"):
-        repo.get_agent_config("cfg-1")
+    config = repo.get_agent_config("cfg-1")
+
+    assert config is not None
+    assert "description" not in config.skills[0].model_dump()
 
 
 def test_get_agent_config_fails_loudly_when_sub_agent_tools_json_is_not_an_array() -> None:
@@ -531,7 +531,6 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
                     id="agent-skill-1",
                     skill_id="skill-1",
                     package_id="package-1",
-                    name="github",
                 )
             ],
             rules=[AgentRule(id="rule-1", name="Cite", content="Always cite.")],
@@ -564,8 +563,8 @@ def test_save_agent_config_rejects_duplicate_skill_ids_before_rpc() -> None:
         name="Researcher",
         version="1.0.0",
         skills=[
-            AgentSkill(skill_id="github", package_id="package-1", name="github"),
-            AgentSkill(skill_id="github", package_id="package-2", name="github"),
+            AgentSkill(skill_id="github", package_id="package-1"),
+            AgentSkill(skill_id="github", package_id="package-2"),
         ],
     )
 
@@ -606,8 +605,8 @@ def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -
         name="Researcher",
         version="1.0.0",
         skills=[
-            AgentSkill(skill_id="github", package_id="package-1", name="github", enabled=False),
-            AgentSkill(skill_id="github", package_id="package-2", name="github", enabled=False),
+            AgentSkill(skill_id="github", package_id="package-1", enabled=False),
+            AgentSkill(skill_id="github", package_id="package-2", enabled=False),
         ],
         mcp_servers=[
             McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),


### PR DESCRIPTION
## Summary
- remove Skill name/description from AgentConfig Skill bindings
- resolve runtime Skill name/description from selected SkillPackage SKILL.md frontmatter
- project panel Agent Skill display from Library Skill rows
- check Library Skill usage by skill_id instead of display name

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright config/agent_config_types.py config/agent_config_resolver.py backend/threads/agent_user_service.py backend/web/routers/panel.py backend/library/service.py backend/hub/snapshot_apply.py storage/providers/supabase/agent_config_repo.py
