### PR TITLE
Validate Skill package ownership at reference boundaries

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -111,7 +111,10 @@ def _package_id(package_hash: str) -> str:
 def _selected_skill_package(owner_user_id: str, skill: Skill, skill_repo: SkillRepo) -> SkillPackage | None:
     if not skill.package_id:
         return None
-    return skill_repo.get_package(owner_user_id, skill.package_id)
+    package = skill_repo.get_package(owner_user_id, skill.package_id)
+    if package is not None and package.skill_id != skill.id:
+        raise RuntimeError(f"Library skill selected package does not belong to Skill: {skill.package_id}")
+    return package
 
 
 def _write_skill_package(

--- a/backend/threads/agent_user_service.py
+++ b/backend/threads/agent_user_service.py
@@ -604,6 +604,8 @@ def _selected_library_package(owner_user_id: str, library_skill: Any, skill_repo
     package = skill_repo.get_package(owner_user_id, package_id)
     if package is None:
         raise RuntimeError(f"Library skill selected package not found: {package_id}")
+    if getattr(package, "skill_id", None) != library_skill.id:
+        raise RuntimeError(f"Library skill selected package does not belong to Skill: {package_id}")
     return package
 
 

--- a/storage/providers/supabase/agent_config_repo.py
+++ b/storage/providers/supabase/agent_config_repo.py
@@ -133,7 +133,9 @@ class SupabaseAgentConfigRepo:
             skill_id = row["skill_id"]
             package_id = row["package_id"]
             self._get_library_skill(owner_user_id, skill_id)
-            self._get_skill_package(owner_user_id, package_id)
+            package = self._get_skill_package(owner_user_id, package_id)
+            if package.get("skill_id") != skill_id:
+                raise RuntimeError(f"AgentConfig Skill binding package does not belong to Skill: {package_id}")
             skills.append(
                 AgentSkill(
                     id=row.get("id"),

--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -81,6 +81,11 @@ class SupabaseSkillRepo:
         return _package_from_row(rows[0])
 
     def select_package(self, owner_user_id: str, skill_id: str, package_id: str) -> None:
+        package = self.get_package(owner_user_id, package_id)
+        if package is None:
+            raise RuntimeError(f"Skill package not found: {package_id}")
+        if package.skill_id != skill_id:
+            raise RuntimeError(f"Skill package {package_id} does not belong to Skill {skill_id}")
         self._skills_table().update({"package_id": package_id}).eq("owner_user_id", owner_user_id).eq("id", skill_id).execute()
 
     def delete(self, owner_user_id: str, skill_id: str) -> None:

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -982,6 +982,54 @@ def test_select_agent_skill_uses_agent_config_skill_patch_boundary() -> None:
     assert "description" not in saved_configs[-1].skills[0].model_dump()
 
 
+def test_select_agent_skill_rejects_package_for_another_skill() -> None:
+    skill_repo = _MemorySkillRepo()
+    library_skill = _put_skill(
+        skill_repo,
+        owner_user_id="user-1",
+        skill_id="loadable-skill",
+        name="Loadable Skill",
+        description="loadable",
+        content="---\nname: Loadable Skill\n---\nUse it.",
+    )
+    wrong_package = SkillPackage(
+        id="wrong-package",
+        owner_user_id="user-1",
+        skill_id="other-skill",
+        version="1.0.0",
+        hash="sha256:wrong",
+        skill_md="---\nname: Other Skill\n---\nUse it.",
+        created_at=datetime(2026, 4, 24, tzinfo=UTC),
+    )
+    skill_repo.create_package(wrong_package)
+    skill_repo.select_package("user-1", library_skill.id, wrong_package.id)
+
+    class _AgentConfigRepo:
+        def get_agent_config(self, _agent_config_id: str):
+            return _agent_config(skills=[])
+
+        def save_agent_config(self, _config: AgentConfig) -> None:
+            raise AssertionError("invalid package reference must fail before saving AgentConfig")
+
+    with pytest.raises(RuntimeError, match="Library skill selected package does not belong to Skill: wrong-package"):
+        agent_user_service.select_agent_skill(
+            "agent-1",
+            "loadable-skill",
+            user_repo=SimpleNamespace(
+                get_by_id=lambda _agent_id: UserRow(
+                    id="agent-1",
+                    type=UserType.AGENT,
+                    display_name="Toad",
+                    owner_user_id="user-1",
+                    agent_config_id="cfg-1",
+                    created_at=1,
+                )
+            ),
+            agent_config_repo=_AgentConfigRepo(),
+            skill_repo=skill_repo,
+        )
+
+
 def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None:
     app = FastAPI()
     app.include_router(panel_router.router)
@@ -1006,6 +1054,37 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
         content = client.get(f"/api/panel/library/skill/{created_id}/content")
         assert content.status_code == 200
         assert content.json()["content"] == _editable_skill_md()
+
+
+def test_library_skill_content_rejects_selected_package_for_another_skill() -> None:
+    skill_repo = _MemorySkillRepo()
+    skill = _put_skill(
+        skill_repo,
+        owner_user_id="owner-1",
+        skill_id="loadable-skill",
+        name="Loadable Skill",
+        description="loadable",
+        content="---\nname: Loadable Skill\n---\nUse it.",
+    )
+    wrong_package = SkillPackage(
+        id="wrong-package",
+        owner_user_id="owner-1",
+        skill_id="other-skill",
+        version="1.0.0",
+        hash="sha256:wrong",
+        skill_md="---\nname: Other Skill\n---\nUse it.",
+        created_at=datetime(2026, 4, 24, tzinfo=UTC),
+    )
+    skill_repo.create_package(wrong_package)
+    skill_repo.select_package("owner-1", skill.id, wrong_package.id)
+
+    with pytest.raises(RuntimeError, match="Library skill selected package does not belong to Skill: wrong-package"):
+        library_service.get_resource_content(
+            "skill",
+            "loadable-skill",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+        )
 
 
 def test_library_skill_content_update_rejects_frontmatter_name_drift() -> None:

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -366,6 +366,15 @@ def test_get_agent_config_does_not_read_skill_package_version() -> None:
     assert "version" not in config.skills[0].model_dump()
 
 
+def test_get_agent_config_rejects_skill_binding_package_for_another_skill() -> None:
+    tables = _tables()
+    tables["library.skill_packages"][0]["skill_id"] = "other-skill"
+    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
+
+    with pytest.raises(RuntimeError, match="AgentConfig Skill binding package does not belong to Skill: package-1"):
+        repo.get_agent_config("cfg-1")
+
+
 def test_get_agent_config_does_not_read_skill_description() -> None:
     tables = _tables()
     tables["library.skills"][0]["description"] = None

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -261,7 +261,7 @@ def test_get_package_rejects_null_version() -> None:
 
 
 def test_select_package_updates_library_skill_pointer() -> None:
-    client = _FakeClient({"library.skills": [_row()]})
+    client = _FakeClient({"library.skills": [_row()], "library.skill_packages": [_package_row()]})
     repo = SupabaseSkillRepo(client)
 
     repo.select_package("owner-1", "skill-1", "package-1")
@@ -270,6 +270,24 @@ def test_select_package_updates_library_skill_pointer() -> None:
     assert query.update_payload == {"package_id": "package-1"}
     assert ("owner_user_id", "owner-1") in query.eq_calls
     assert ("id", "skill-1") in query.eq_calls
+
+
+def test_select_package_rejects_missing_package() -> None:
+    client = _FakeClient({"library.skills": [_row()], "library.skill_packages": []})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="Skill package not found: package-1"):
+        repo.select_package("owner-1", "skill-1", "package-1")
+
+
+def test_select_package_rejects_package_for_another_skill() -> None:
+    package = _package_row()
+    package["skill_id"] = "other-skill"
+    client = _FakeClient({"library.skills": [_row()], "library.skill_packages": [package]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="Skill package package-1 does not belong to Skill skill-1"):
+        repo.select_package("owner-1", "skill-1", "package-1")
 
 
 def test_delete_filters_owner_and_skill_id() -> None:


### PR DESCRIPTION
## Summary
- reject Agent Skill bindings whose package belongs to a different Skill
- reject Library selected packages that do not belong to the selected Skill
- reject Agent config Skill selection when the Library Skill points at another Skill package
- validate Supabase SkillRepo package selection before updating library.skills.package_id

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright storage/providers/supabase/agent_config_repo.py storage/providers/supabase/skill_repo.py backend/threads/agent_user_service.py backend/library/service.py
