### PR TITLE
Centralize Skill document parsing

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime
 from typing import Any
 
 import httpx
-import yaml
 from fastapi import HTTPException
 
 import backend.hub.snapshot_apply as _snapshot_apply
@@ -15,6 +14,7 @@ from backend.hub.versioning import BumpType, bump_semver
 from config.agent_config_resolver import resolve_agent_config
 from config.agent_config_types import Skill, SkillPackage
 from config.agent_snapshot import snapshot_from_resolved_config
+from config.skill_document import SkillDocument, parse_skill_document
 from config.skill_files import normalize_skill_file_map
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from storage.utils import generate_skill_id
@@ -77,28 +77,8 @@ def _optional_text(value: Any, *, label: str) -> str:
     return value.strip()
 
 
-def _skill_metadata_from_content(content: str) -> dict[str, Any]:
-    if not content.startswith("---\n"):
-        raise ValueError("Skill snapshot must be a SKILL.md document with frontmatter")
-    try:
-        _, frontmatter, _body = content.split("---", 2)
-    except ValueError as exc:
-        raise ValueError("Skill snapshot must be a SKILL.md document with frontmatter") from exc
-    try:
-        metadata = yaml.safe_load(frontmatter) or {}
-    except yaml.YAMLError as exc:
-        raise ValueError("Skill snapshot frontmatter must be valid YAML") from exc
-    if not isinstance(metadata, dict):
-        raise ValueError("Skill snapshot frontmatter must include name")
-    name = metadata.get("name")
-    if not isinstance(name, str) or not name.strip():
-        raise ValueError("Skill snapshot frontmatter must include name")
-    metadata["name"] = name.strip()
-    return metadata
-
-
-def _skill_description_from_metadata(metadata: dict[str, Any]) -> str:
-    return _optional_text(metadata.get("description"), label="Skill snapshot frontmatter description")
+def _skill_document_from_content(content: str) -> SkillDocument:
+    return parse_skill_document(content, label="Skill snapshot")
 
 
 def _skill_files_from_snapshot(snapshot: dict[str, Any]) -> dict[str, str]:
@@ -256,11 +236,11 @@ def apply_item(
 
     if item_type == "skill":
         content = _required_text(snapshot.get("content"), label="Skill snapshot content")
-        skill_metadata = _skill_metadata_from_content(content)
+        skill_document = _skill_document_from_content(content)
         skill_files = _skill_files_from_snapshot(snapshot)
         if skill_repo is None:
             raise RuntimeError("skill_repo is required to save a skill to Library")
-        skill_name = str(skill_metadata["name"]).strip()
+        skill_name = skill_document.name
         owner_skills = skill_repo.list_for_owner(owner_user_id)
         existing_skill = _hub_source_skill(owner_skills, item_id)
         if existing_skill is not None and existing_skill.name != skill_name:
@@ -274,7 +254,7 @@ def apply_item(
                     raise ValueError("Skill name already exists under a different Library id")
         else:
             skill_id = existing_skill.id
-        skill_description = _skill_description_from_metadata(skill_metadata)
+        skill_description = _optional_text(skill_document.frontmatter.get("description"), label="Skill snapshot frontmatter description")
         publisher = _required_text(item.get("publisher_username"), label="Hub item publisher_username")
         timestamp = datetime.now(UTC)
         source = {

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -1,6 +1,5 @@
 """Library CRUD for Skills and sandbox templates."""
 
-import re
 import time
 import uuid
 from datetime import UTC, datetime
@@ -11,12 +10,12 @@ import yaml
 from backend.sandboxes import provider_availability as sandbox_provider_availability
 from backend.sandboxes.recipe_bootstrap import seed_default_recipes as seed_builtin_recipes
 from config.agent_config_types import Skill, SkillPackage
+from config.skill_document import parse_skill_document, skill_version
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from sandbox.recipes import FEATURE_CATALOG, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 from storage.contracts import RecipeRepo, SkillRepo
 from storage.utils import generate_skill_id
 
-_SKILL_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _RESOURCE_TYPES = {"skill", "sandbox-template"}
 
 
@@ -69,31 +68,13 @@ def _require_skill_repo(skill_repo: SkillRepo | None) -> SkillRepo:
     return skill_repo
 
 
-def _skill_frontmatter_metadata(content: str) -> dict[str, Any]:
+def _skill_name_from_content(content: str) -> str:
     # @@@skill-name-single-truth - runtime indexes Skills by SKILL.md frontmatter name, so Library name must not drift.
-    match = _SKILL_FRONTMATTER_RE.search(content)
-    if match is None:
-        raise ValueError("Skill content must be a SKILL.md document with frontmatter")
-    metadata = yaml.safe_load(match.group(1)) or {}
-    if not isinstance(metadata, dict):
-        raise ValueError("Skill content frontmatter must be a mapping")
-    return metadata
+    return parse_skill_document(content, label="Skill content").name
 
 
-def _skill_frontmatter_name(content: str) -> str:
-    metadata = _skill_frontmatter_metadata(content)
-    name = metadata.get("name")
-    if not isinstance(name, str) or not name.strip():
-        raise ValueError("Skill content frontmatter name is required")
-    return name.strip()
-
-
-def _skill_frontmatter_version(content: str) -> str:
-    metadata = _skill_frontmatter_metadata(content)
-    version = metadata.get("version")
-    if not isinstance(version, str) or not version.strip():
-        raise ValueError("Skill content frontmatter version is required")
-    return version.strip()
+def _skill_version_from_content(content: str) -> str:
+    return skill_version(parse_skill_document(content, label="Skill content"))
 
 
 def _now_dt() -> datetime:
@@ -275,10 +256,10 @@ def create_resource(
         skill_repo = _require_skill_repo(skill_repo)
         if not content or not content.strip():
             raise ValueError("Skill creation requires SKILL.md content")
-        frontmatter_name = _skill_frontmatter_name(content)
+        frontmatter_name = _skill_name_from_content(content)
         if frontmatter_name != name:
             raise ValueError("Skill content frontmatter name must match Skill name")
-        version = _skill_frontmatter_version(content)
+        version = _skill_version_from_content(content)
         for skill in skill_repo.list_for_owner(owner_user_id):
             if skill.name == name:
                 raise ValueError("Skill name already exists")
@@ -509,10 +490,10 @@ def update_resource_content(
         current = skill_repo.get_by_id(owner_user_id, resource_id)
         if current is None:
             return False
-        frontmatter_name = _skill_frontmatter_name(content)
+        frontmatter_name = _skill_name_from_content(content)
         if frontmatter_name != current.name:
             raise ValueError("Skill content frontmatter name must match Skill name")
-        version = _skill_frontmatter_version(content)
+        version = _skill_version_from_content(content)
         current_package = _selected_skill_package(owner_user_id, current, skill_repo)
         files = current_package.files if current_package is not None else {}
         updated = skill_repo.upsert(current.model_copy(update={"updated_at": _now_dt()}))

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import re
 from typing import Any
 
-import yaml
-
 from config.agent_config_types import AgentConfig, AgentSkill, ResolvedAgentConfig, ResolvedSkill
-
-_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+from config.skill_document import parse_skill_document
 
 
 def resolve_agent_config(config: AgentConfig, *, skill_repo: Any = None) -> ResolvedAgentConfig:
@@ -56,9 +52,9 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
         raise RuntimeError(f"Skill package not found while resolving AgentConfig: {skill.package_id}")
     if package.skill_id != skill.skill_id:
         raise RuntimeError(f"Skill package {skill.package_id} does not belong to Skill {skill.skill_id}")
-    frontmatter = _skill_frontmatter(package.skill_md, skill_label=skill.skill_id)
-    name = frontmatter["name"].strip()
-    description = frontmatter.get("description", "")
+    document = parse_skill_document(package.skill_md, label=f"Skill {skill.skill_id!r} on Agent config")
+    name = document.name
+    description = document.frontmatter.get("description", "")
     if not isinstance(description, str):
         description = ""
     resolved = ResolvedSkill(
@@ -73,24 +69,8 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
     return validate_resolved_skill_content(resolved)
 
 
-def _skill_frontmatter(content: str, *, skill_label: str) -> dict[str, Any]:
-    if not content.strip():
-        raise ValueError(f"Skill {skill_label!r} on Agent config has blank content")
-    frontmatter_result = _FRONTMATTER_RE.search(content)
-    if frontmatter_result is None:
-        raise ValueError(f"Skill {skill_label!r} on Agent config is missing SKILL.md frontmatter")
-    frontmatter = yaml.safe_load(frontmatter_result.group(1)) or {}
-    if not isinstance(frontmatter, dict):
-        raise ValueError(f"Skill {skill_label!r} on Agent config frontmatter must be a mapping")
-    frontmatter_name = frontmatter.get("name")
-    if not isinstance(frontmatter_name, str) or not frontmatter_name.strip():
-        raise ValueError(f"Skill {skill_label!r} on Agent config frontmatter is missing name")
-    return frontmatter
-
-
 def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
-    frontmatter = _skill_frontmatter(skill.content, skill_label=skill.name)
-    frontmatter_name = frontmatter["name"]
-    if frontmatter_name.strip() != skill.name:
+    document = parse_skill_document(skill.content, label=f"Skill {skill.name!r} on Agent config")
+    if document.name != skill.name:
         raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter name must match ResolvedSkill.name")
     return skill

--- a/config/skill_document.py
+++ b/config/skill_document.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class SkillDocument:
+    frontmatter: dict[str, Any]
+    body: str
+    name: str
+
+
+def parse_skill_document(content: str, *, label: str = "Skill document") -> SkillDocument:
+    match = _FRONTMATTER_RE.match(content)
+    if match is None:
+        raise ValueError(f"{label} must be a SKILL.md document with frontmatter")
+    try:
+        frontmatter = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{label} frontmatter must be valid YAML") from exc
+    if not isinstance(frontmatter, dict):
+        raise ValueError(f"{label} frontmatter must be a mapping")
+    name = _frontmatter_text(frontmatter, "name", label=label)
+    return SkillDocument(frontmatter=frontmatter, body=content[match.end() :], name=name)
+
+
+def skill_description(document: SkillDocument, *, required: bool = False) -> str:
+    value = document.frontmatter.get("description")
+    if value is None and not required:
+        return ""
+    return _frontmatter_text(document.frontmatter, "description", label="SKILL.md")
+
+
+def skill_version(document: SkillDocument) -> str:
+    if "version" not in document.frontmatter:
+        raise ValueError("SKILL.md frontmatter must include version")
+    value = document.frontmatter["version"]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("SKILL.md frontmatter version must be a string")
+    return value.strip()
+
+
+def strip_skill_frontmatter(content: str) -> str:
+    return parse_skill_document(content).body
+
+
+def _frontmatter_text(frontmatter: dict[str, Any], key: str, *, label: str) -> str:
+    value = frontmatter.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} frontmatter must include {key}")
+    return value.strip()

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import re
 from collections.abc import Sequence
 
-import yaml
-
 from config.agent_config_types import ResolvedSkill
+from config.skill_document import parse_skill_document
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
 
 
@@ -24,27 +22,11 @@ class SkillsService:
         for skill in skills:
             if not isinstance(skill, ResolvedSkill):
                 raise TypeError("SkillsService requires ResolvedSkill items")
-            metadata = self._parse_frontmatter(skill.content)
-            if "name" not in metadata:
-                raise ValueError("Skill content must include frontmatter name")
-            if metadata["name"] != skill.name:
+            document = parse_skill_document(skill.content, label="Skill content")
+            if document.name != skill.name:
                 raise ValueError("Skill frontmatter name must match ResolvedSkill.name")
             self._skills[skill.name] = skill.content
             self._skill_files[skill.name] = skill.files
-
-    @staticmethod
-    def _parse_frontmatter(content: str) -> dict[str, str]:
-        match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
-        if not match:
-            return {}
-        metadata = yaml.safe_load(match.group(1)) or {}
-        if not isinstance(metadata, dict):
-            raise ValueError("Skill frontmatter must be a mapping")
-        result: dict[str, str] = {}
-        for key, value in metadata.items():
-            if isinstance(key, str) and isinstance(value, str):
-                result[key.strip()] = value.strip()
-        return result
 
     def _register(self, registry: ToolRegistry) -> None:
         if not self._skills:
@@ -88,7 +70,7 @@ class SkillsService:
             available = ", ".join(sorted(self._skills))
             raise ValueError(f"Skill '{skill_name}' not found. Available skills: {available}")
 
-        content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", self._skills[skill_name], flags=re.DOTALL)
+        content = parse_skill_document(self._skills[skill_name], label="Skill content").body
         return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._skill_files[skill_name])}"
 
     @staticmethod

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -6,11 +6,9 @@ from __future__ import annotations
 import argparse
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
-
-import yaml
 
 from config.agent_config_types import Skill, SkillPackage
+from config.skill_document import SkillDocument, parse_skill_document, skill_description, skill_version
 from config.skill_files import normalize_skill_file_entries
 from config.skill_package import build_skill_package_hash, build_skill_package_manifest
 from storage.runtime import build_storage_container
@@ -19,34 +17,11 @@ from storage.utils import generate_skill_id
 FILE_IMPORT_SOURCE = {"kind": "file_import"}
 
 
-def _frontmatter(content: str) -> dict[str, Any]:
-    if not content.startswith("---"):
-        raise ValueError("SKILL.md must start with YAML frontmatter")
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        raise ValueError("SKILL.md frontmatter is not closed")
-    metadata = yaml.safe_load(parts[1]) or {}
-    if not isinstance(metadata, dict):
-        raise ValueError("SKILL.md frontmatter must be a mapping")
-    _frontmatter_text(metadata, "name")
-    _frontmatter_text(metadata, "description")
-    return metadata
-
-
-def _frontmatter_text(metadata: dict[str, Any], key: str) -> str:
-    value = metadata.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"SKILL.md frontmatter must include {key}")
-    return value.strip()
-
-
-def _frontmatter_version(metadata: dict[str, Any]) -> str:
-    if "version" not in metadata:
-        raise ValueError("SKILL.md frontmatter must include version")
-    value = metadata["version"]
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError("SKILL.md frontmatter version must be a string")
-    return value.strip()
+def _skill_document(content: str) -> SkillDocument:
+    document = parse_skill_document(content, label="SKILL.md")
+    skill_description(document, required=True)
+    skill_version(document)
+    return document
 
 
 def _read_files(skill_dir: Path) -> dict[str, str]:
@@ -74,14 +49,14 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
     count = 0
     for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
         content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
-        metadata = _frontmatter(content)
-        skill_name = str(metadata["name"]).strip()
+        document = _skill_document(content)
+        skill_name = document.name
         existing = _find_skill_by_name(repo.list_for_owner(owner_user_id), skill_name)
         now = datetime.now(UTC)
         skill_id = existing.id if existing is not None else generate_skill_id()
         if existing is None and repo.get_by_id(owner_user_id, skill_id) is not None:
             raise RuntimeError("Generated Skill id already exists")
-        version = _frontmatter_version(metadata)
+        version = skill_version(document)
         files = _read_files(skill_dir)
         package_hash = build_skill_package_hash(content, files)
         skill = repo.upsert(
@@ -89,7 +64,7 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
                 id=skill_id,
                 owner_user_id=owner_user_id,
                 name=skill_name,
-                description=_frontmatter_text(metadata, "description"),
+                description=skill_description(document, required=True),
                 source=dict(FILE_IMPORT_SOURCE),
                 created_at=getattr(existing, "created_at", now),
                 updated_at=now,

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 
 import httpx
-import yaml
 
+from config.skill_document import parse_skill_document
 from config.skill_files import normalize_skill_file_entries
 
 HUB_URL = "http://localhost:8090"
@@ -65,40 +65,30 @@ def parse_skill_md(skill_md: Path) -> dict | None:
     if len(content.strip()) < 50:
         return None
 
-    name = skill_md.parent.name
+    document = parse_skill_document(content, label="SKILL.md")
+    name = document.name
     description = ""
     tags = []
-
-    if content.startswith("---"):
-        parts = content.split("---", 2)
-        if len(parts) >= 3:
-            fm = yaml.safe_load(parts[1]) or {}
-            if not isinstance(fm, dict):
-                raise ValueError("SKILL.md frontmatter must be a mapping")
-            raw_name = fm.get("name", name)
-            if not isinstance(raw_name, str) or not raw_name.strip():
-                raise ValueError("SKILL.md frontmatter name must be a string")
-            name = raw_name.strip()
-            raw_description = fm.get("description", "")
-            if raw_description is None:
-                description = ""
-            elif isinstance(raw_description, str):
-                description = raw_description.strip()
-            else:
-                raise ValueError("SKILL.md frontmatter description must be a string")
-            meta = fm.get("metadata", {})
-            if isinstance(meta, dict):
-                for key in ("domain", "role", "category"):
-                    if meta.get(key):
-                        tags.append(str(meta[key]))
-                triggers = meta.get("triggers", "")
-                if isinstance(triggers, str):
-                    tags.extend([t.strip() for t in triggers.split(",")[:5] if t.strip()])
+    raw_description = document.frontmatter.get("description", "")
+    if raw_description is None:
+        description = ""
+    elif isinstance(raw_description, str):
+        description = raw_description.strip()
+    else:
+        raise ValueError("SKILL.md frontmatter description must be a string")
+    meta = document.frontmatter.get("metadata", {})
+    if isinstance(meta, dict):
+        for key in ("domain", "role", "category"):
+            if meta.get(key):
+                tags.append(str(meta[key]))
+        triggers = meta.get("triggers", "")
+        if isinstance(triggers, str):
+            tags.extend([t.strip() for t in triggers.split(",")[:5] if t.strip()])
 
     if not description:
-        for line in content.split("\n"):
+        for line in document.body.split("\n"):
             stripped = line.strip()
-            if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
+            if stripped and not stripped.startswith("#"):
                 description = stripped[:200]
                 break
 

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -199,7 +199,7 @@ def test_resolver_rejects_skill_without_frontmatter():
             ),
         )
 
-    assert "missing SKILL.md frontmatter" in str(excinfo.value)
+    assert "must be a SKILL.md document with frontmatter" in str(excinfo.value)
 
 
 def test_resolver_rejects_skill_frontmatter_without_name():
@@ -230,7 +230,7 @@ def test_resolver_rejects_skill_frontmatter_without_name():
             ),
         )
 
-    assert "frontmatter is missing name" in str(excinfo.value)
+    assert "frontmatter must include name" in str(excinfo.value)
 
 
 def test_resolver_rejects_display_name_without_name():
@@ -261,7 +261,7 @@ def test_resolver_rejects_display_name_without_name():
             ),
         )
 
-    assert "frontmatter is missing name" in str(excinfo.value)
+    assert "frontmatter must include name" in str(excinfo.value)
 
 
 def test_resolver_rejects_package_that_does_not_belong_to_selected_skill():

--- a/tests/Unit/config/test_skill_document.py
+++ b/tests/Unit/config/test_skill_document.py
@@ -1,0 +1,25 @@
+import pytest
+
+from config.skill_document import parse_skill_document, skill_description, skill_version, strip_skill_frontmatter
+
+
+def test_parse_skill_document_reads_frontmatter_and_body() -> None:
+    document = parse_skill_document(
+        "---\nname: Query Helper\ndescription: Use precise query terms\nversion: 1.2.3\n---\nBody\n",
+        label="Test Skill",
+    )
+
+    assert document.name == "Query Helper"
+    assert document.frontmatter["description"] == "Use precise query terms"
+    assert document.body == "Body\n"
+    assert skill_description(document, required=True) == "Use precise query terms"
+    assert skill_version(document) == "1.2.3"
+
+
+def test_parse_skill_document_requires_frontmatter_name() -> None:
+    with pytest.raises(ValueError, match="Test Skill frontmatter must include name"):
+        parse_skill_document("---\ndescription: Missing\n---\nBody", label="Test Skill")
+
+
+def test_strip_skill_frontmatter_returns_body() -> None:
+    assert strip_skill_frontmatter("---\nname: Query Helper\n---\nUse exact terms.") == "Use exact terms."

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -66,7 +66,7 @@ def test_load_missing_skill_fails_loudly() -> None:
 def test_skill_without_frontmatter_name_fails_loudly() -> None:
     registry = ToolRegistry()
 
-    with pytest.raises(ValueError, match="Skill content must include frontmatter name"):
+    with pytest.raises(ValueError, match="Skill content must be a SKILL.md document with frontmatter"):
         SkillsService(
             registry=registry,
             skills=[

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1115,7 +1115,7 @@ def test_library_skill_content_update_rejects_frontmatter_name_drift() -> None:
 def test_library_skill_create_requires_version_frontmatter() -> None:
     skill_repo = _MemorySkillRepo()
 
-    with pytest.raises(ValueError, match="frontmatter version is required"):
+    with pytest.raises(ValueError, match="frontmatter must include version"):
         library_service.create_resource(
             "skill",
             "Loadable Skill",
@@ -1140,7 +1140,7 @@ def test_library_skill_content_update_requires_version_frontmatter() -> None:
         content=_editable_skill_md(),
     )
 
-    with pytest.raises(ValueError, match="frontmatter version is required"):
+    with pytest.raises(ValueError, match="frontmatter must include version"):
         library_service.update_resource_content(
             "skill",
             created["id"],

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -5,7 +5,6 @@ from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
-import yaml
 
 from scripts import seed_github_skills
 
@@ -58,7 +57,7 @@ def test_seed_skill_parse_fails_loudly_on_invalid_frontmatter(tmp_path: Path) ->
     skill_dir = tmp_path / "repo" / "skills" / "broken"
     _write_skill(skill_dir, "---\nname: [broken\n---\nBody long enough to avoid the tiny file skip path.")
 
-    with pytest.raises(yaml.YAMLError):
+    with pytest.raises(ValueError, match="SKILL.md frontmatter must be valid YAML"):
         seed_github_skills.read_skill_package(skill_dir)
 
 
@@ -66,8 +65,26 @@ def test_seed_skill_parse_rejects_non_text_frontmatter_name(tmp_path: Path) -> N
     skill_dir = tmp_path / "repo" / "skills" / "broken"
     _write_skill(skill_dir, "---\nname: 123\ndescription: Broken\n---\nBody long enough to parse.")
 
-    with pytest.raises(ValueError, match="SKILL.md frontmatter name must be a string"):
+    with pytest.raises(ValueError, match="SKILL.md frontmatter must include name"):
         seed_github_skills.read_skill_package(skill_dir)
+
+
+def test_seed_skill_parse_requires_skill_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "broken"
+    _write_skill(skill_dir, "Body long enough to avoid the tiny file skip path.")
+
+    with pytest.raises(ValueError, match="must be a SKILL.md document with frontmatter"):
+        seed_github_skills.read_skill_package(skill_dir)
+
+
+def test_seed_skill_description_fallback_reads_body_not_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "api-design"
+    _write_skill(skill_dir, "---\nname: API Design\nmetadata:\n  domain: backend\n---\nUse REST carefully.")
+
+    package = seed_github_skills.read_skill_package(skill_dir)
+
+    assert package is not None
+    assert package["description"] == "Use REST carefully."
 
 
 def test_seed_skill_parse_rejects_unreadable_skill_md(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a single Skill document parser for SKILL.md frontmatter, body, name, description, and version reads
- Route AgentConfig resolve, runtime load_skill, Library Skill writes, Hub skill apply, and GitHub Skill seeding through that parser
- Remove duplicated ad hoc SKILL.md parsing from Skill-facing paths and make Hub seed uploads require real Skill documents

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright config/skill_document.py backend/hub/client.py backend/library/service.py config/agent_config_resolver.py core/tools/skills/service.py scripts/import_file_skills_to_library.py scripts/seed_github_skills.py