### PR TITLE
refactor(chat): derive chat creator from auth token

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from backend.chat.api.http.dependencies import (
     get_chat_event_bus,
@@ -24,7 +24,10 @@ router = APIRouter(prefix="/api/chats", tags=["chats"])
 
 
 class CreateChatBody(BaseModel):
-    user_ids: list[str]
+    user_ids: list[str] = Field(
+        min_length=1,
+        description="Other participant user ids. Do not include the authenticated user; the backend adds it from the bearer token.",
+    )
     title: str | None = None
 
 
@@ -97,8 +100,7 @@ def _validate_chat_participant_ids(
     validated: list[str] = []
     for participant_id in participant_ids:
         if participant_id == requester_user_id:
-            validated.append(participant_id)
-            continue
+            raise ValueError("Chat participant ids must not include the authenticated user")
         if thread_repo.get_by_user_id(participant_id) is not None:
             validated.append(participant_id)
             continue
@@ -110,18 +112,16 @@ def _validate_chat_participant_ids(
     return validated
 
 
-def _is_owned_participant(user_repo: Any, participant_id: str, requester_user_id: str) -> bool:
-    participant = user_repo.get_by_id(participant_id)
-    return is_owned_by_viewer(requester_user_id, participant)
-
-
-def _validate_requester_is_participant(user_repo: Any, participant_ids: list[str], requester_user_id: str) -> None:
-    for participant_id in participant_ids:
-        if participant_id == requester_user_id:
-            return
-        if _is_owned_participant(user_repo, participant_id, requester_user_id):
-            return
-    raise ValueError("Chat participants must include the requester or a requester-owned participant")
+def _chat_participant_ids_for_request(
+    user_repo: Any,
+    thread_repo: Any,
+    participant_ids: list[str],
+    requester_user_id: str,
+) -> list[str]:
+    other_participants = _validate_chat_participant_ids(user_repo, thread_repo, participant_ids, requester_user_id)
+    if not other_participants:
+        raise ValueError("Chat must include at least one other participant")
+    return list(dict.fromkeys([requester_user_id, *other_participants]))
 
 
 @router.get("")
@@ -141,8 +141,7 @@ def create_chat(
     thread_repo: Annotated[Any, Depends(get_thread_repo)],
 ):
     try:
-        participant_ids = _validate_chat_participant_ids(user_repo, thread_repo, body.user_ids, user_id)
-        _validate_requester_is_participant(user_repo, participant_ids, user_id)
+        participant_ids = _chat_participant_ids_for_request(user_repo, thread_repo, body.user_ids, user_id)
         if len(participant_ids) >= 3:
             chat = messaging_service.create_group_chat(participant_ids, body.title)
         else:

--- a/frontend/app/src/components/NewChatDialog.test.tsx
+++ b/frontend/app/src/components/NewChatDialog.test.tsx
@@ -144,7 +144,7 @@ describe("NewChatDialog", () => {
         "/api/chats",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ user_ids: ["human-1", "human-2", "agent-2"], title: "Trial group" }),
+          body: JSON.stringify({ user_ids: ["human-2", "agent-2"], title: "Trial group" }),
         }),
       );
     });
@@ -211,7 +211,7 @@ describe("NewChatDialog", () => {
         "/api/chats",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ user_ids: ["human-1", "actor-agent-1", "human-2"] }),
+          body: JSON.stringify({ user_ids: ["actor-agent-1", "human-2"] }),
         }),
       );
     });

--- a/frontend/app/src/components/NewChatDialog.tsx
+++ b/frontend/app/src/components/NewChatDialog.tsx
@@ -102,7 +102,7 @@ export default function NewChatDialog({ open, onOpenChange }: NewChatDialogProps
     setCreating(true);
     setError(null);
     try {
-      const chatId = await createChat([myUserId, ...selectedIds], groupTitle.trim() || null);
+      const chatId = await createChat(selectedIds, groupTitle.trim() || null);
       onOpenChange(false);
       navigate(`/chat/visit/${chatId}`);
     } catch (err) {

--- a/frontend/app/src/pages/contacts/ContactDetailPage.test.tsx
+++ b/frontend/app/src/pages/contacts/ContactDetailPage.test.tsx
@@ -131,7 +131,7 @@ describe("ContactDetailPage", () => {
     await waitFor(() => {
       expect(authFetch).toHaveBeenCalledWith("/api/chats", {
         method: "POST",
-        body: JSON.stringify({ user_ids: ["human-1", "agent-2"] }),
+        body: JSON.stringify({ user_ids: ["agent-2"] }),
       });
     });
     expect(navigate).toHaveBeenCalledWith("/chat/visit/chat-agent-2");
@@ -168,7 +168,7 @@ describe("ContactDetailPage", () => {
     await waitFor(() => {
       expect(authFetch).toHaveBeenCalledWith("/api/chats", {
         method: "POST",
-        body: JSON.stringify({ user_ids: ["human-1", "human-2"] }),
+        body: JSON.stringify({ user_ids: ["human-2"] }),
       });
     });
     expect(navigate).toHaveBeenCalledWith("/chat/visit/chat-human-2");

--- a/frontend/app/src/pages/contacts/ContactDetailPage.tsx
+++ b/frontend/app/src/pages/contacts/ContactDetailPage.tsx
@@ -17,10 +17,10 @@ function errorText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-async function createDirectChat(currentUserId: string, targetUserId: string): Promise<string> {
+async function createDirectChat(targetUserId: string): Promise<string> {
   const response = await authFetch("/api/chats", {
     method: "POST",
-    body: JSON.stringify({ user_ids: [currentUserId, targetUserId] }),
+    body: JSON.stringify({ user_ids: [targetUserId] }),
   });
   if (!response.ok) throw new Error(`API ${response.status}: ${await response.text()}`);
   const payload = await response.json();
@@ -111,7 +111,7 @@ export default function ContactDetailPage() {
     setOpenError(null);
     try {
       if (!myUserId) throw new Error("当前用户未登录");
-      const chatId = await createDirectChat(myUserId, contact.user_id);
+      const chatId = await createDirectChat(contact.user_id);
       navigate(`/chat/visit/${chatId}`);
     } catch (err) {
       setOpenError(errorText(err));

--- a/tests/Integration/test_chat_external_user_contract.py
+++ b/tests/Integration/test_chat_external_user_contract.py
@@ -16,10 +16,10 @@ def test_validate_chat_participant_ids_accepts_external_user() -> None:
         "external-1": UserRow(id="external-1", display_name="Codex External", type=UserType.EXTERNAL, created_at=1.0),
     }
 
-    result = chats_router._validate_chat_participant_ids(
+    result = chats_router._chat_participant_ids_for_request(
         _user_directory(rows),
         SimpleNamespace(get_by_user_id=lambda _user_id: None),
-        participant_ids=["human-1", "external-1"],
+        participant_ids=["external-1"],
         requester_user_id="human-1",
     )
 

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -773,7 +773,7 @@ def test_create_chat_accepts_agent_user_ids_for_group_participants() -> None:
     result = _create_chat(
         app,
         chats_router.CreateChatBody(
-            user_ids=["human-user-1", "agent-user-1", "agent-user-2"],
+            user_ids=["agent-user-1", "agent-user-2"],
             title="agent-group",
         ),
     )
@@ -793,7 +793,7 @@ def test_create_chat_accepts_agent_user_id_for_direct_participant() -> None:
     result = _create_chat(
         app,
         chats_router.CreateChatBody(
-            user_ids=["human-user-1", "agent-user-1"],
+            user_ids=["agent-user-1"],
             title=None,
         ),
     )
@@ -809,7 +809,7 @@ def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_particip
     result = _create_chat(
         app,
         chats_router.CreateChatBody(
-            user_ids=["human-user-1", "thread-user-1", "thread-user-2"],
+            user_ids=["thread-user-1", "thread-user-2"],
             title="good-group",
         ),
     )
@@ -823,33 +823,29 @@ def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_particip
     }
 
 
-def test_create_chat_rejects_participants_unrelated_to_requester() -> None:
-    state, called = _create_chat_route_state(
-        users={
-            "human-user-2": SimpleNamespace(id="human-user-2", owner_user_id=None),
-            "human-user-3": SimpleNamespace(id="human-user-3", owner_user_id=None),
-            "human-user-4": SimpleNamespace(id="human-user-4", owner_user_id=None),
-        },
-        active_contact_pairs={
-            ("human-user-1", "human-user-2"),
-            ("human-user-1", "human-user-3"),
-            ("human-user-1", "human-user-4"),
-        },
-    )
+def test_create_chat_rejects_explicit_authenticated_user_id() -> None:
+    state, called = _create_chat_route_state()
     app = SimpleNamespace(state=state)
 
     with pytest.raises(HTTPException) as exc_info:
         _create_chat(
             app,
             chats_router.CreateChatBody(
-                user_ids=["human-user-2", "human-user-3", "human-user-4"],
-                title="unrelated-group",
+                user_ids=["human-user-1", "human-user-2"],
+                title="legacy-group",
             ),
         )
 
     assert exc_info.value.status_code == 400
-    assert "requester" in str(exc_info.value.detail).lower()
+    assert "authenticated user" in str(exc_info.value.detail).lower()
     assert called == []
+
+
+def test_create_chat_rejects_empty_other_participants() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        chats_router.CreateChatBody(user_ids=[], title="empty-group")
+
+    assert "at least 1 item" in str(exc_info.value)
 
 
 def test_create_group_chat_rejects_external_participant_without_active_relationship() -> None:
@@ -872,7 +868,7 @@ def test_create_group_chat_rejects_external_participant_without_active_relations
         _create_chat(
             app,
             chats_router.CreateChatBody(
-                user_ids=["human-user-1", "owned-agent-1", "human-user-2"],
+                user_ids=["owned-agent-1", "human-user-2"],
                 title="bad-group",
             ),
         )
@@ -897,7 +893,7 @@ def test_create_group_chat_accepts_external_active_contact_without_relationship(
     result = _create_chat(
         app,
         chats_router.CreateChatBody(
-            user_ids=["human-user-1", "owned-agent-1", "human-user-2"],
+            user_ids=["owned-agent-1", "human-user-2"],
             title="contact-group",
         ),
     )
@@ -922,7 +918,7 @@ def test_create_group_chat_accepts_agent_owned_by_external_active_contact() -> N
     result = _create_chat(
         app,
         chats_router.CreateChatBody(
-            user_ids=["human-user-1", "owned-agent-1", "external-agent-1"],
+            user_ids=["owned-agent-1", "external-agent-1"],
             title="owner-contact-agent-group",
         ),
     )
@@ -945,7 +941,7 @@ def test_create_group_chat_accepts_owned_agent_without_relationship() -> None:
     result = _create_chat(
         app,
         chats_router.CreateChatBody(
-            user_ids=["human-user-1", "owned-agent-1", "human-user-2"],
+            user_ids=["owned-agent-1", "human-user-2"],
             title="good-group",
         ),
     )
@@ -962,7 +958,7 @@ def test_create_chat_rejects_unknown_participant_ids_instead_of_falling_to_stora
         _create_chat(
             app,
             chats_router.CreateChatBody(
-                user_ids=["human-user-1", "thread-id-not-a-user", "thread-user-2"],
+                user_ids=["thread-id-not-a-user", "thread-user-2"],
                 title="bad-group",
             ),
         )


### PR DESCRIPTION
## Summary
- derive chat creator membership from the authenticated backend user instead of requiring clients to send their own user id
- update frontend chat creation calls to send only other participants
- tighten route tests around explicit self-injection and empty participant lists

## Verification
- uv run pytest tests/Unit/integration_contracts/test_messaging_router.py -q
- npm test -- --run src/components/NewChatDialog.test.tsx src/pages/contacts/ContactDetailPage.test.tsx
- npm run typecheck
- YATU: /Users/lexicalmathical/share/yatu/chat-create-auth-derived-20260425T233809Z