### PR TITLE
Centralize Skill package construction

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -12,11 +12,11 @@ from fastapi import HTTPException
 import backend.hub.snapshot_apply as _snapshot_apply
 from backend.hub.versioning import BumpType, bump_semver
 from config.agent_config_resolver import resolve_agent_config
-from config.agent_config_types import Skill, SkillPackage
+from config.agent_config_types import Skill
 from config.agent_snapshot import snapshot_from_resolved_config
 from config.skill_document import SkillDocument, parse_skill_document
 from config.skill_files import normalize_skill_file_map
-from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+from config.skill_package import build_skill_package
 from storage.utils import generate_skill_id
 
 HUB_URL = os.environ.get("MYCEL_HUB_URL", "https://hub.mycel.nextmind.space")
@@ -277,15 +277,11 @@ def apply_item(
                 updated_at=timestamp,
             )
         )
-        package_hash = build_skill_package_hash(content, skill_files)
         package = skill_repo.create_package(
-            SkillPackage(
-                id=package_hash.removeprefix("sha256:"),
+            build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
                 version=source_version,
-                hash=package_hash,
-                manifest=build_skill_package_manifest(content, skill_files),
                 skill_md=content,
                 files=skill_files,
                 source=source,

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -7,8 +7,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from config.agent_config_resolver import validate_resolved_skill_content
-from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, ResolvedSkill, Skill, SkillPackage
-from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, ResolvedSkill, Skill
+from config.skill_package import build_skill_package
 from storage.utils import generate_skill_id
 
 SNAPSHOT_SKILL_SOURCE_ID_KEY = "snapshot_skill_id"
@@ -91,15 +91,11 @@ def _materialize_snapshot_skills(
                 updated_at=timestamp,
             )
         )
-        package_hash = build_skill_package_hash(snapshot_skill.content, snapshot_skill.files)
         package = skill_repo.create_package(
-            SkillPackage(
-                id=package_hash.removeprefix("sha256:"),
+            build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
                 version=snapshot_skill.version,
-                hash=package_hash,
-                manifest=build_skill_package_manifest(snapshot_skill.content, snapshot_skill.files),
                 skill_md=snapshot_skill.content,
                 files=snapshot_skill.files,
                 source=source,

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -11,7 +11,7 @@ from backend.sandboxes import provider_availability as sandbox_provider_availabi
 from backend.sandboxes.recipe_bootstrap import seed_default_recipes as seed_builtin_recipes
 from config.agent_config_types import Skill, SkillPackage
 from config.skill_document import parse_skill_document, skill_version
-from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+from config.skill_package import build_skill_package
 from sandbox.recipes import FEATURE_CATALOG, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 from storage.contracts import RecipeRepo, SkillRepo
 from storage.utils import generate_skill_id
@@ -85,10 +85,6 @@ def _dt_millis(value: datetime) -> int:
     return int(value.timestamp() * 1000)
 
 
-def _package_id(package_hash: str) -> str:
-    return package_hash.removeprefix("sha256:")
-
-
 def _selected_skill_package(owner_user_id: str, skill: Skill, skill_repo: SkillRepo) -> SkillPackage | None:
     if not skill.package_id:
         return None
@@ -108,15 +104,11 @@ def _write_skill_package(
     version: str,
     source: dict[str, Any] | None = None,
 ) -> SkillPackage:
-    package_hash = build_skill_package_hash(content, files)
     package = skill_repo.create_package(
-        SkillPackage(
-            id=_package_id(package_hash),
+        build_skill_package(
             owner_user_id=owner_user_id,
             skill_id=skill.id,
             version=version,
-            hash=package_hash,
-            manifest=build_skill_package_manifest(content, files),
             skill_md=content,
             files=files,
             source=source or {},

--- a/config/skill_package.py
+++ b/config/skill_package.py
@@ -2,7 +2,35 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime
 from typing import Any
+
+from config.agent_config_types import SkillPackage
+
+
+def build_skill_package(
+    *,
+    owner_user_id: str,
+    skill_id: str,
+    version: str,
+    skill_md: str,
+    files: dict[str, str],
+    source: dict[str, Any],
+    created_at: datetime,
+) -> SkillPackage:
+    package_hash = build_skill_package_hash(skill_md, files)
+    return SkillPackage(
+        id=package_hash.removeprefix("sha256:"),
+        owner_user_id=owner_user_id,
+        skill_id=skill_id,
+        version=version,
+        hash=package_hash,
+        manifest=build_skill_package_manifest(skill_md, files),
+        skill_md=skill_md,
+        files=files,
+        source=source,
+        created_at=created_at,
+    )
 
 
 def build_skill_package_manifest(skill_md: str, files: dict[str, str]) -> dict[str, Any]:

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -7,10 +7,10 @@ import argparse
 from datetime import UTC, datetime
 from pathlib import Path
 
-from config.agent_config_types import Skill, SkillPackage
+from config.agent_config_types import Skill
 from config.skill_document import SkillDocument, parse_skill_document, skill_description, skill_version
 from config.skill_files import normalize_skill_file_entries
-from config.skill_package import build_skill_package_hash, build_skill_package_manifest
+from config.skill_package import build_skill_package
 from storage.runtime import build_storage_container
 from storage.utils import generate_skill_id
 
@@ -58,7 +58,6 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
             raise RuntimeError("Generated Skill id already exists")
         version = skill_version(document)
         files = _read_files(skill_dir)
-        package_hash = build_skill_package_hash(content, files)
         skill = repo.upsert(
             Skill(
                 id=skill_id,
@@ -71,13 +70,10 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
             )
         )
         package = repo.create_package(
-            SkillPackage(
-                id=package_hash.removeprefix("sha256:"),
+            build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
                 version=version,
-                hash=package_hash,
-                manifest=build_skill_package_manifest(content, files),
                 skill_md=content,
                 files=files,
                 source=dict(FILE_IMPORT_SOURCE),

--- a/tests/Unit/config/test_skill_package.py
+++ b/tests/Unit/config/test_skill_package.py
@@ -1,0 +1,31 @@
+from datetime import UTC, datetime
+
+from config.skill_package import build_skill_package, build_skill_package_hash, build_skill_package_manifest
+
+
+def test_build_skill_package_uses_content_hash_as_identity() -> None:
+    created_at = datetime(2026, 4, 26, tzinfo=UTC)
+    skill_md = "---\nname: Query Helper\n---\nUse exact terms."
+    files = {"references/query.md": "Prefer precise queries."}
+
+    package = build_skill_package(
+        owner_user_id="owner-1",
+        skill_id="skill-1",
+        version="1.0.0",
+        skill_md=skill_md,
+        files=files,
+        source={"kind": "test"},
+        created_at=created_at,
+    )
+
+    expected_hash = build_skill_package_hash(skill_md, files)
+    assert package.id == expected_hash.removeprefix("sha256:")
+    assert package.hash == expected_hash
+    assert package.manifest == build_skill_package_manifest(skill_md, files)
+    assert package.owner_user_id == "owner-1"
+    assert package.skill_id == "skill-1"
+    assert package.version == "1.0.0"
+    assert package.skill_md == skill_md
+    assert package.files == files
+    assert package.source == {"kind": "test"}
+    assert package.created_at == created_at


### PR DESCRIPTION
## Summary
- Add one SkillPackage constructor that owns content hash, package id, and manifest construction
- Route Library Skill writes, Hub Skill install, Hub AgentSnapshot materialization, and file Skill import through that constructor
- Remove repeated package hash/id/manifest assembly from call sites while leaving repo writes and package selection at their existing boundaries

## Verification
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright config/skill_package.py backend/hub/client.py backend/hub/snapshot_apply.py backend/library/service.py scripts/import_file_skills_to_library.py