### PR TITLE
Centralize Skill document metadata

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -69,14 +69,6 @@ def _required_text(value: Any, *, label: str) -> str:
     return value.strip()
 
 
-def _optional_text(value: Any, *, label: str) -> str:
-    if value is None:
-        return ""
-    if not isinstance(value, str):
-        raise ValueError(f"{label} must be a string")
-    return value.strip()
-
-
 def _skill_document_from_content(content: str) -> SkillDocument:
     return parse_skill_document(content, label="Skill snapshot")
 
@@ -254,7 +246,6 @@ def apply_item(
                     raise ValueError("Skill name already exists under a different Library id")
         else:
             skill_id = existing_skill.id
-        skill_description = _optional_text(skill_document.frontmatter.get("description"), label="Skill snapshot frontmatter description")
         publisher = _required_text(item.get("publisher_username"), label="Hub item publisher_username")
         timestamp = datetime.now(UTC)
         source = {
@@ -271,7 +262,7 @@ def apply_item(
                 id=skill_id,
                 owner_user_id=owner_user_id,
                 name=skill_name,
-                description=skill_description,
+                description=skill_document.description,
                 source=source,
                 created_at=timestamp,
                 updated_at=timestamp,

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -10,7 +10,7 @@ import yaml
 from backend.sandboxes import provider_availability as sandbox_provider_availability
 from backend.sandboxes.recipe_bootstrap import seed_default_recipes as seed_builtin_recipes
 from config.agent_config_types import Skill, SkillPackage
-from config.skill_document import parse_skill_document, skill_version
+from config.skill_document import SkillDocument, parse_skill_document
 from config.skill_package import build_skill_package
 from sandbox.recipes import FEATURE_CATALOG, default_recipe_snapshot, normalize_recipe_snapshot, provider_type_from_name
 from storage.contracts import RecipeRepo, SkillRepo
@@ -68,13 +68,9 @@ def _require_skill_repo(skill_repo: SkillRepo | None) -> SkillRepo:
     return skill_repo
 
 
-def _skill_name_from_content(content: str) -> str:
+def _skill_document_from_content(content: str, *, require_version: bool = False) -> SkillDocument:
     # @@@skill-name-single-truth - runtime indexes Skills by SKILL.md frontmatter name, so Library name must not drift.
-    return parse_skill_document(content, label="Skill content").name
-
-
-def _skill_version_from_content(content: str) -> str:
-    return skill_version(parse_skill_document(content, label="Skill content"))
+    return parse_skill_document(content, label="Skill content", require_version=require_version)
 
 
 def _now_dt() -> datetime:
@@ -248,10 +244,11 @@ def create_resource(
         skill_repo = _require_skill_repo(skill_repo)
         if not content or not content.strip():
             raise ValueError("Skill creation requires SKILL.md content")
-        frontmatter_name = _skill_name_from_content(content)
-        if frontmatter_name != name:
+        document = _skill_document_from_content(content, require_version=True)
+        if document.name != name:
             raise ValueError("Skill content frontmatter name must match Skill name")
-        version = _skill_version_from_content(content)
+        if document.version is None:
+            raise RuntimeError("Skill content version was not parsed")
         for skill in skill_repo.list_for_owner(owner_user_id):
             if skill.name == name:
                 raise ValueError("Skill name already exists")
@@ -270,7 +267,7 @@ def create_resource(
                 updated_at=timestamp,
             )
         )
-        _write_skill_package(owner_user_id, skill, content, {}, skill_repo, version=version)
+        _write_skill_package(owner_user_id, skill, content, {}, skill_repo, version=document.version)
         return _library_resource_item(
             "skill",
             skill.id,
@@ -482,13 +479,14 @@ def update_resource_content(
         current = skill_repo.get_by_id(owner_user_id, resource_id)
         if current is None:
             return False
-        frontmatter_name = _skill_name_from_content(content)
-        if frontmatter_name != current.name:
+        document = _skill_document_from_content(content, require_version=True)
+        if document.name != current.name:
             raise ValueError("Skill content frontmatter name must match Skill name")
-        version = _skill_version_from_content(content)
+        if document.version is None:
+            raise RuntimeError("Skill content version was not parsed")
         current_package = _selected_skill_package(owner_user_id, current, skill_repo)
         files = current_package.files if current_package is not None else {}
         updated = skill_repo.upsert(current.model_copy(update={"updated_at": _now_dt()}))
-        _write_skill_package(owner_user_id, updated, content, files, skill_repo, version=version)
+        _write_skill_package(owner_user_id, updated, content, files, skill_repo, version=document.version)
         return True
     return False

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -53,14 +53,10 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
     if package.skill_id != skill.skill_id:
         raise RuntimeError(f"Skill package {skill.package_id} does not belong to Skill {skill.skill_id}")
     document = parse_skill_document(package.skill_md, label=f"Skill {skill.skill_id!r} on Agent config")
-    name = document.name
-    description = document.frontmatter.get("description", "")
-    if not isinstance(description, str):
-        description = ""
     resolved = ResolvedSkill(
         id=skill.skill_id,
-        name=name,
-        description=description,
+        name=document.name,
+        description=document.description,
         version=package.version,
         content=package.skill_md,
         files=dict(package.files),

--- a/config/skill_document.py
+++ b/config/skill_document.py
@@ -58,22 +58,6 @@ def _frontmatter_text(frontmatter: dict[str, Any], key: str, *, label: str) -> s
     return value.strip()
 
 
-def skill_description(document: SkillDocument, *, required: bool = False) -> str:
-    if required and not document.description:
-        raise ValueError("SKILL.md frontmatter must include description")
-    return document.description
-
-
-def skill_version(document: SkillDocument) -> str:
-    if document.version is None:
-        raise ValueError("SKILL.md frontmatter must include version")
-    return document.version
-
-
-def strip_skill_frontmatter(content: str) -> str:
-    return parse_skill_document(content).body
-
-
 def _optional_frontmatter_text(frontmatter: dict[str, Any], key: str, *, label: str, required: bool) -> str | None:
     value = frontmatter.get(key)
     if value is None and not required:

--- a/config/skill_document.py
+++ b/config/skill_document.py
@@ -14,9 +14,17 @@ class SkillDocument:
     frontmatter: dict[str, Any]
     body: str
     name: str
+    description: str
+    version: str | None
 
 
-def parse_skill_document(content: str, *, label: str = "Skill document") -> SkillDocument:
+def parse_skill_document(
+    content: str,
+    *,
+    label: str = "Skill document",
+    require_description: bool = False,
+    require_version: bool = False,
+) -> SkillDocument:
     match = _FRONTMATTER_RE.match(content)
     if match is None:
         raise ValueError(f"{label} must be a SKILL.md document with frontmatter")
@@ -27,31 +35,51 @@ def parse_skill_document(content: str, *, label: str = "Skill document") -> Skil
     if not isinstance(frontmatter, dict):
         raise ValueError(f"{label} frontmatter must be a mapping")
     name = _frontmatter_text(frontmatter, "name", label=label)
-    return SkillDocument(frontmatter=frontmatter, body=content[match.end() :], name=name)
-
-
-def skill_description(document: SkillDocument, *, required: bool = False) -> str:
-    value = document.frontmatter.get("description")
-    if value is None and not required:
-        return ""
-    return _frontmatter_text(document.frontmatter, "description", label="SKILL.md")
-
-
-def skill_version(document: SkillDocument) -> str:
-    if "version" not in document.frontmatter:
-        raise ValueError("SKILL.md frontmatter must include version")
-    value = document.frontmatter["version"]
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError("SKILL.md frontmatter version must be a string")
-    return value.strip()
-
-
-def strip_skill_frontmatter(content: str) -> str:
-    return parse_skill_document(content).body
+    description = _optional_frontmatter_text(
+        frontmatter,
+        "description",
+        label=label,
+        required=require_description,
+    )
+    version = _optional_frontmatter_text(frontmatter, "version", label=label, required=require_version)
+    return SkillDocument(
+        frontmatter=frontmatter,
+        body=content[match.end() :],
+        name=name,
+        description=description or "",
+        version=version,
+    )
 
 
 def _frontmatter_text(frontmatter: dict[str, Any], key: str, *, label: str) -> str:
     value = frontmatter.get(key)
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{label} frontmatter must include {key}")
+    return value.strip()
+
+
+def skill_description(document: SkillDocument, *, required: bool = False) -> str:
+    if required and not document.description:
+        raise ValueError("SKILL.md frontmatter must include description")
+    return document.description
+
+
+def skill_version(document: SkillDocument) -> str:
+    if document.version is None:
+        raise ValueError("SKILL.md frontmatter must include version")
+    return document.version
+
+
+def strip_skill_frontmatter(content: str) -> str:
+    return parse_skill_document(content).body
+
+
+def _optional_frontmatter_text(frontmatter: dict[str, Any], key: str, *, label: str, required: bool) -> str | None:
+    value = frontmatter.get(key)
+    if value is None and not required:
+        return None
+    if value is None:
+        raise ValueError(f"{label} frontmatter must include {key}")
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} frontmatter {key} must be a string")
     return value.strip()

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -13,7 +13,7 @@ class SkillsService:
         registry: ToolRegistry,
         skills: Sequence[ResolvedSkill] | None = None,
     ):
-        self._skills: dict[str, str] = {}
+        self._skill_bodies: dict[str, str] = {}
         self._skill_files: dict[str, dict[str, str]] = {}
         self._load_skills(skills if skills is not None else ())
         self._register(registry)
@@ -25,11 +25,11 @@ class SkillsService:
             document = parse_skill_document(skill.content, label="Skill content")
             if document.name != skill.name:
                 raise ValueError("Skill frontmatter name must match ResolvedSkill.name")
-            self._skills[skill.name] = skill.content
+            self._skill_bodies[skill.name] = document.body
             self._skill_files[skill.name] = skill.files
 
     def _register(self, registry: ToolRegistry) -> None:
-        if not self._skills:
+        if not self._skill_bodies:
             return
 
         registry.register(
@@ -45,7 +45,7 @@ class SkillsService:
         )
 
     def _get_schema(self) -> dict:
-        available_skills = sorted(self._skills)
+        available_skills = sorted(self._skill_bodies)
         skills_list = "\n".join(f"- {name}" for name in available_skills)
 
         return make_tool_schema(
@@ -66,11 +66,11 @@ class SkillsService:
         )
 
     def _load_skill(self, skill_name: str) -> str:
-        if skill_name not in self._skills:
-            available = ", ".join(sorted(self._skills))
+        if skill_name not in self._skill_bodies:
+            available = ", ".join(sorted(self._skill_bodies))
             raise ValueError(f"Skill '{skill_name}' not found. Available skills: {available}")
 
-        content = parse_skill_document(self._skills[skill_name], label="Skill content").body
+        content = self._skill_bodies[skill_name]
         return f"Loaded skill: {skill_name}\n\n{self._append_adjacent_files(content, self._skill_files[skill_name])}"
 
     @staticmethod

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from config.agent_config_types import Skill
-from config.skill_document import SkillDocument, parse_skill_document, skill_description, skill_version
+from config.skill_document import SkillDocument, parse_skill_document
 from config.skill_files import normalize_skill_file_entries
 from config.skill_package import build_skill_package
 from storage.runtime import build_storage_container
@@ -18,10 +18,7 @@ FILE_IMPORT_SOURCE = {"kind": "file_import"}
 
 
 def _skill_document(content: str) -> SkillDocument:
-    document = parse_skill_document(content, label="SKILL.md")
-    skill_description(document, required=True)
-    skill_version(document)
-    return document
+    return parse_skill_document(content, label="SKILL.md", require_description=True, require_version=True)
 
 
 def _read_files(skill_dir: Path) -> dict[str, str]:
@@ -56,14 +53,15 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
         skill_id = existing.id if existing is not None else generate_skill_id()
         if existing is None and repo.get_by_id(owner_user_id, skill_id) is not None:
             raise RuntimeError("Generated Skill id already exists")
-        version = skill_version(document)
+        if document.version is None:
+            raise RuntimeError("SKILL.md version was not parsed")
         files = _read_files(skill_dir)
         skill = repo.upsert(
             Skill(
                 id=skill_id,
                 owner_user_id=owner_user_id,
                 name=skill_name,
-                description=skill_description(document, required=True),
+                description=document.description,
                 source=dict(FILE_IMPORT_SOURCE),
                 created_at=getattr(existing, "created_at", now),
                 updated_at=now,
@@ -73,7 +71,7 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
             build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
-                version=version,
+                version=document.version,
                 skill_md=content,
                 files=files,
                 source=dict(FILE_IMPORT_SOURCE),

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -67,15 +67,8 @@ def parse_skill_md(skill_md: Path) -> dict | None:
 
     document = parse_skill_document(content, label="SKILL.md")
     name = document.name
-    description = ""
+    description = document.description
     tags = []
-    raw_description = document.frontmatter.get("description", "")
-    if raw_description is None:
-        description = ""
-    elif isinstance(raw_description, str):
-        description = raw_description.strip()
-    else:
-        raise ValueError("SKILL.md frontmatter description must be a string")
     meta = document.frontmatter.get("metadata", {})
     if isinstance(meta, dict):
         for key in ("domain", "role", "category"):

--- a/tests/Unit/config/test_skill_document.py
+++ b/tests/Unit/config/test_skill_document.py
@@ -1,19 +1,18 @@
 import pytest
 
-from config.skill_document import parse_skill_document, skill_description, skill_version, strip_skill_frontmatter
+from config.skill_document import parse_skill_document
 
 
-def test_parse_skill_document_reads_frontmatter_and_body() -> None:
+def test_parse_skill_document_reads_frontmatter_fields_and_body() -> None:
     document = parse_skill_document(
         "---\nname: Query Helper\ndescription: Use precise query terms\nversion: 1.2.3\n---\nBody\n",
         label="Test Skill",
     )
 
     assert document.name == "Query Helper"
-    assert document.frontmatter["description"] == "Use precise query terms"
+    assert document.description == "Use precise query terms"
+    assert document.version == "1.2.3"
     assert document.body == "Body\n"
-    assert skill_description(document, required=True) == "Use precise query terms"
-    assert skill_version(document) == "1.2.3"
 
 
 def test_parse_skill_document_requires_frontmatter_name() -> None:
@@ -21,5 +20,11 @@ def test_parse_skill_document_requires_frontmatter_name() -> None:
         parse_skill_document("---\ndescription: Missing\n---\nBody", label="Test Skill")
 
 
-def test_strip_skill_frontmatter_returns_body() -> None:
-    assert strip_skill_frontmatter("---\nname: Query Helper\n---\nUse exact terms.") == "Use exact terms."
+def test_parse_skill_document_can_require_description() -> None:
+    with pytest.raises(ValueError, match="Test Skill frontmatter must include description"):
+        parse_skill_document("---\nname: Query Helper\n---\nBody", label="Test Skill", require_description=True)
+
+
+def test_parse_skill_document_can_require_version() -> None:
+    with pytest.raises(ValueError, match="Test Skill frontmatter must include version"):
+        parse_skill_document("---\nname: Query Helper\n---\nBody", label="Test Skill", require_version=True)


### PR DESCRIPTION
## Summary
- make parse_skill_document return parsed Skill name, description, version, and body
- move Library/import/Hub/seed/resolver/runtime callers to read the parsed document once
- remove stray skill_description, skill_version, and strip_skill_frontmatter helpers

## Verification
- uv run pytest tests/Unit/config/test_skill_document.py tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/platform/test_marketplace_client.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/core/test_tool_registry_runner.py tests/Unit/scripts/test_seed_github_skills.py -q
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright config/skill_document.py backend/library/service.py backend/hub/client.py config/agent_config_resolver.py core/tools/skills/service.py scripts/import_file_skills_to_library.py scripts/seed_github_skills.py