### PR TITLE
Require Skill descriptions from SKILL.md

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -70,7 +70,7 @@ def _required_text(value: Any, *, label: str) -> str:
 
 
 def _skill_document_from_content(content: str) -> SkillDocument:
-    return parse_skill_document(content, label="Skill snapshot")
+    return parse_skill_document(content, label="Skill snapshot", require_description=True)
 
 
 def _skill_files_from_snapshot(snapshot: dict[str, Any]) -> dict[str, str]:

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -46,8 +46,10 @@ def _materialize_snapshot_skills(
 
     seen_ids: set[str] = set()
     seen_names: set[str] = set()
+    validated_skills: list[ResolvedSkill] = []
     for snapshot_skill in skills:
-        validate_resolved_skill_content(snapshot_skill)
+        snapshot_skill = validate_resolved_skill_content(snapshot_skill)
+        validated_skills.append(snapshot_skill)
         if snapshot_skill.id in seen_ids:
             raise ValueError(f"Duplicate Skill id in snapshot: {snapshot_skill.id}")
         seen_ids.add(snapshot_skill.id)
@@ -58,7 +60,7 @@ def _materialize_snapshot_skills(
     result: list[AgentSkill] = []
     timestamp = datetime.now(UTC)
     library_skills = skill_repo.list_for_owner(owner_user_id)
-    for snapshot_skill in skills:
+    for snapshot_skill in validated_skills:
         snapshot_skill_id = _required_text(snapshot_skill.id, label="Snapshot Skill id")
         existing = _snapshot_source_skill(library_skills, marketplace_item_id, snapshot_skill_id)
         if existing is not None and existing.name != snapshot_skill.name:

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -262,7 +262,7 @@ def create_resource(
                 id=rid,
                 owner_user_id=owner_user_id,
                 name=name,
-                description=desc,
+                description=document.description,
                 created_at=timestamp,
                 updated_at=timestamp,
             )
@@ -321,11 +321,13 @@ def update_resource(
             return None
         if name is not None and name != current.name:
             raise ValueError("Skill name is immutable; create a new Skill for a new name")
+        if desc is not None and desc != current.description:
+            raise ValueError("Skill description comes from SKILL.md content")
         updated = skill_repo.upsert(
             current.model_copy(
                 update={
                     "name": current.name,
-                    "description": desc if desc is not None else current.description,
+                    "description": current.description,
                     "updated_at": _now_dt(),
                 }
             )
@@ -486,7 +488,7 @@ def update_resource_content(
             raise RuntimeError("Skill content version was not parsed")
         current_package = _selected_skill_package(owner_user_id, current, skill_repo)
         files = current_package.files if current_package is not None else {}
-        updated = skill_repo.upsert(current.model_copy(update={"updated_at": _now_dt()}))
+        updated = skill_repo.upsert(current.model_copy(update={"description": document.description, "updated_at": _now_dt()}))
         _write_skill_package(owner_user_id, updated, content, files, skill_repo, version=document.version)
         return True
     return False

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -52,7 +52,11 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
         raise RuntimeError(f"Skill package not found while resolving AgentConfig: {skill.package_id}")
     if package.skill_id != skill.skill_id:
         raise RuntimeError(f"Skill package {skill.package_id} does not belong to Skill {skill.skill_id}")
-    document = parse_skill_document(package.skill_md, label=f"Skill {skill.skill_id!r} on Agent config")
+    document = parse_skill_document(
+        package.skill_md,
+        label=f"Skill {skill.skill_id!r} on Agent config",
+        require_description=True,
+    )
     resolved = ResolvedSkill(
         id=skill.skill_id,
         name=document.name,
@@ -66,7 +70,7 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
 
 
 def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
-    document = parse_skill_document(skill.content, label=f"Skill {skill.name!r} on Agent config")
+    document = parse_skill_document(skill.content, label=f"Skill {skill.name!r} on Agent config", require_description=True)
     if document.name != skill.name:
         raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter name must match ResolvedSkill.name")
-    return skill
+    return skill.model_copy(update={"description": document.description})

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -14,6 +14,7 @@ class SkillsService:
         skills: Sequence[ResolvedSkill] | None = None,
     ):
         self._skill_bodies: dict[str, str] = {}
+        self._skill_descriptions: dict[str, str] = {}
         self._skill_files: dict[str, dict[str, str]] = {}
         self._load_skills(skills if skills is not None else ())
         self._register(registry)
@@ -22,10 +23,11 @@ class SkillsService:
         for skill in skills:
             if not isinstance(skill, ResolvedSkill):
                 raise TypeError("SkillsService requires ResolvedSkill items")
-            document = parse_skill_document(skill.content, label="Skill content")
+            document = parse_skill_document(skill.content, label="Skill content", require_description=True)
             if document.name != skill.name:
                 raise ValueError("Skill frontmatter name must match ResolvedSkill.name")
             self._skill_bodies[skill.name] = document.body
+            self._skill_descriptions[skill.name] = document.description
             self._skill_files[skill.name] = skill.files
 
     def _register(self, registry: ToolRegistry) -> None:
@@ -46,7 +48,8 @@ class SkillsService:
 
     def _get_schema(self) -> dict:
         available_skills = sorted(self._skill_bodies)
-        skills_list = "\n".join(f"- {name}" for name in available_skills)
+        skills_list = "\n".join(f"- {name}: {self._skill_descriptions[name]}" for name in available_skills)
+        skill_options = "; ".join(f"{name} - {self._skill_descriptions[name]}" for name in available_skills)
 
         return make_tool_schema(
             name="load_skill",
@@ -59,7 +62,7 @@ class SkillsService:
             properties={
                 "skill_name": {
                     "type": "string",
-                    "description": f"Name of the skill to load. Available: {', '.join(available_skills)}",
+                    "description": f"Name of the skill to load. Available: {skill_options}",
                 },
             },
             required=["skill_name"],

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from config.agent_config_resolver import resolve_agent_config
 from config.agent_config_types import AgentConfig, AgentSkill, SkillPackage
 from config.agent_snapshot import snapshot_from_resolved_config
@@ -28,9 +30,9 @@ def test_snapshot_contains_resolved_agent_config_only():
                     skill_id="github",
                     version="1.0.0",
                     hash="sha256:github",
-                    skill_md="---\nname: github\n---\n\n# GitHub\n",
+                    skill_md="---\nname: github\ndescription: Query GitHub precisely\n---\n\n# GitHub\n",
                     files={"references/query.md": "Prefer precise queries."},
-                    created_at="2026-04-25T00:00:00+00:00",
+                    created_at=datetime.fromisoformat("2026-04-25T00:00:00+00:00"),
                 )
             },
         )(),
@@ -73,8 +75,8 @@ def test_snapshot_preserves_skill_id_when_name_changes():
                     skill_id="github-core",
                     version="1.0.0",
                     hash="sha256:github-core",
-                    skill_md="---\nname: GitHub\n---\n\n# GitHub\n",
-                    created_at="2026-04-25T00:00:00+00:00",
+                    skill_md="---\nname: GitHub\ndescription: Query GitHub precisely\n---\n\n# GitHub\n",
+                    created_at=datetime.fromisoformat("2026-04-25T00:00:00+00:00"),
                 )
             },
         )(),

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -595,7 +595,7 @@ async def test_get_or_create_agent_resolves_skill_packages_before_runtime_startu
                 skill_id="fastapi",
                 version="1.0.0",
                 hash="sha256:fastapi",
-                skill_md="---\nname: FastAPI\n---\nUse APIRouter.",
+                skill_md="---\nname: FastAPI\ndescription: Build FastAPI routes\n---\nUse APIRouter.",
                 created_at=datetime.fromisoformat("2026-04-26T00:00:00+00:00"),
             )
 

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -10,10 +10,17 @@ from core.tools.skills.service import SkillsService
 
 def _skill(
     name: str = "query-helper",
-    content: str = "---\nname: query-helper\n---\nUse exact terms.",
+    content: str = "---\nname: query-helper\ndescription: Build precise search queries\n---\nUse exact terms.",
     files: dict[str, str] | None = None,
 ) -> ResolvedSkill:
-    return ResolvedSkill(id=name, name=name, version="1.0.0", content=content, files=files or {})
+    return ResolvedSkill(
+        id=name,
+        name=name,
+        description="Build precise search queries",
+        version="1.0.0",
+        content=content,
+        files=files or {},
+    )
 
 
 def test_skills_service_has_no_filesystem_skill_index() -> None:
@@ -39,7 +46,7 @@ def test_skill_frontmatter_uses_yaml_parser() -> None:
     SkillsService(
         registry=registry,
         skills=[
-            _skill(content='---\nname: "query-helper"\n---\nUse exact terms.'),
+            _skill(content='---\nname: "query-helper"\ndescription: Build precise search queries\n---\nUse exact terms.'),
         ],
     )
 
@@ -75,6 +82,35 @@ def test_skill_without_frontmatter_name_fails_loudly() -> None:
         )
 
 
+def test_skill_without_frontmatter_description_fails_loudly() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(ValueError, match="Skill content frontmatter must include description"):
+        SkillsService(
+            registry=registry,
+            skills=[
+                _skill(content="---\nname: query-helper\n---\nUse exact terms."),
+            ],
+        )
+
+
+def test_load_skill_schema_lists_skill_descriptions() -> None:
+    registry = ToolRegistry()
+    SkillsService(
+        registry=registry,
+        skills=[
+            _skill(),
+        ],
+    )
+
+    entry = registry.get("load_skill")
+    assert entry is not None
+    schema = entry.get_schema()
+
+    assert "- query-helper: Build precise search queries" in schema["description"]
+    assert "query-helper - Build precise search queries" in schema["parameters"]["properties"]["skill_name"]["description"]
+
+
 def test_skills_service_requires_resolved_skill_items() -> None:
     registry = ToolRegistry()
 
@@ -86,7 +122,7 @@ def test_skills_service_requires_resolved_skill_items() -> None:
                     Any,
                     {
                         "name": "query-helper",
-                        "content": "---\nname: query-helper\n---\nUse exact terms.",
+                        "content": "---\nname: query-helper\ndescription: Build precise search queries\n---\nUse exact terms.",
                     },
                 )
             ],
@@ -100,7 +136,9 @@ def test_skill_frontmatter_name_must_match_resolved_skill_name() -> None:
         SkillsService(
             registry=registry,
             skills=[
-                _skill(name="query-helper", content="---\nname: other-helper\n---\nUse exact terms."),
+                _skill(
+                    name="query-helper", content="---\nname: other-helper\ndescription: Build precise search queries\n---\nUse exact terms."
+                ),
             ],
         )
 

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -148,7 +148,7 @@ def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch:
             },
             "version": "1.0.0",
             "snapshot": {
-                "content": f"---\nname: {row['name']}\n---\n{row['body']}",
+                "content": f"---\nname: {row['name']}\ndescription: {row['description']}\n---\n{row['body']}",
                 "meta": {"desc": row["description"]},
                 "files": {"references/routing.md": row["body"]},
             },
@@ -393,7 +393,7 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
                             "name": "Snapshot Skill",
                             "description": "skill desc",
                             "version": "1.2.3",
-                            "content": "---\nname: Snapshot Skill\n---\nbody",
+                            "content": "---\nname: Snapshot Skill\ndescription: skill desc\n---\nbody",
                             "files": {"references/routing.md": "route narrowly"},
                         }
                     ],

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2211,8 +2211,8 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
                         "id": "search-core",
                         "name": "Search",
                         "version": "1.0.0",
-                        "content": "---\nname: Search\n---\nbody",
-                        "description": "skill desc",
+                        "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        "description": "Search repos",
                         "source": {"source_version": "snapshot-stale", "extra": "drop"},
                     }
                 ],
@@ -2237,7 +2237,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
     assert skill_repo.get_by_id("user-1", "search-core") is None
     package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id or "")
     assert package is not None
-    assert package.skill_md == "---\nname: Search\n---\nbody"
+    assert package.skill_md == "---\nname: Search\ndescription: Search repos\n---\nbody"
     assert package.source == {
         "marketplace_item_id": "item-1",
         "snapshot_skill_id": "search-core",
@@ -2263,7 +2263,14 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
                 "agent": {
                     "id": "cfg-source",
                     "name": "Repo Agent",
-                    "skills": [{"id": "search", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                    "skills": [
+                        {
+                            "id": "search",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        }
+                    ],
                 },
             },
             marketplace_item_id="item-1",
@@ -2271,6 +2278,36 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
             owner_user_id="user-1",
             user_repo=SimpleNamespace(create=lambda _row: None),
             agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+        )
+
+
+def test_apply_snapshot_skill_requires_frontmatter_description() -> None:
+    from backend.hub.snapshot_apply import apply_snapshot
+
+    with pytest.raises(ValueError, match="Skill 'Search' on Agent config frontmatter must include description"):
+        apply_snapshot(
+            snapshot={
+                "schema_version": "agent-snapshot/v1",
+                "agent": {
+                    "id": "cfg-source",
+                    "name": "Repo Agent",
+                    "skills": [
+                        {
+                            "id": "search",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "description": "Snapshot desc",
+                            "content": "---\nname: Search\n---\nbody",
+                        }
+                    ],
+                },
+            },
+            marketplace_item_id="item-1",
+            source_version="1.0.0",
+            owner_user_id="user-1",
+            user_repo=SimpleNamespace(create=lambda _row: None),
+            agent_config_repo=SimpleNamespace(save_agent_config=lambda _config: None),
+            skill_repo=_MemorySkillRepo(),
         )
 
 
@@ -2292,7 +2329,14 @@ def test_apply_snapshot_requires_source_identity(field: str, value: object, mess
             "agent": {
                 "id": "cfg-source",
                 "name": "Repo Agent",
-                "skills": [{"id": "search", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                "skills": [
+                    {
+                        "id": "search",
+                        "name": "Search",
+                        "version": "1.0.0",
+                        "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                    }
+                ],
             },
         },
         "marketplace_item_id": "item-1",
@@ -2357,8 +2401,18 @@ def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
                     "id": "cfg-source",
                     "name": "Repo Agent",
                     "skills": [
-                        {"id": "search", "name": "Search One", "version": "1.0.0", "content": "---\nname: Search One\n---\none"},
-                        {"id": "search", "name": "Search Two", "version": "1.0.0", "content": "---\nname: Search Two\n---\ntwo"},
+                        {
+                            "id": "search",
+                            "name": "Search One",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search One\ndescription: Search one\n---\none",
+                        },
+                        {
+                            "id": "search",
+                            "name": "Search Two",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search Two\ndescription: Search two\n---\ntwo",
+                        },
                     ],
                 },
             },
@@ -2391,7 +2445,7 @@ def test_apply_snapshot_treats_snapshot_skill_id_as_source_metadata(monkeypatch:
                         "id": "nested/search",
                         "name": "Search",
                         "version": "1.0.0",
-                        "content": "---\nname: Search\n---\nbody",
+                        "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
                     }
                 ],
             },
@@ -2440,7 +2494,14 @@ def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: py
             "agent": {
                 "id": "cfg-source",
                 "name": "Repo Agent",
-                "skills": [{"id": "search-core", "name": "Search", "version": "1.0.1", "content": "---\nname: Search\n---\nnew"}],
+                "skills": [
+                    {
+                        "id": "search-core",
+                        "name": "Search",
+                        "version": "1.0.1",
+                        "content": "---\nname: Search\ndescription: Search repos\n---\nnew",
+                    }
+                ],
             },
         },
         marketplace_item_id="item-1",
@@ -2452,7 +2513,7 @@ def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: py
     )
 
     assert saved_configs[0].skills[0].skill_id == "skill_existing123"
-    assert skill_repo.get_by_id("user-1", "skill_existing123").description == ""
+    assert skill_repo.get_by_id("user-1", "skill_existing123").description == "Search repos"
     package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id)
     assert package is not None
     assert package.source["snapshot_skill_id"] == "search-core"
@@ -2468,7 +2529,7 @@ def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest
         skill_id="skill_existing123",
         name="Existing",
         description="existing",
-        content="---\nname: Existing\n---\nbody",
+        content="---\nname: Existing\ndescription: Existing desc\n---\nbody",
     )
     monkeypatch.setattr("backend.hub.snapshot_apply.generate_skill_id", lambda: "skill_existing123")
 
@@ -2479,7 +2540,14 @@ def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest
                 "agent": {
                     "id": "cfg-source",
                     "name": "Repo Agent",
-                    "skills": [{"id": "search-core", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                    "skills": [
+                        {
+                            "id": "search-core",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        }
+                    ],
                 },
             },
             marketplace_item_id="item-1",
@@ -2501,7 +2569,7 @@ def test_apply_snapshot_rejects_existing_same_name_without_snapshot_source(monke
         skill_id="skill_existing123",
         name="Search",
         description="existing",
-        content="---\nname: Search\n---\nbody",
+        content="---\nname: Search\ndescription: Search repos\n---\nbody",
     )
     monkeypatch.setattr("backend.hub.snapshot_apply.generate_skill_id", lambda: "skill_generated123")
 
@@ -2512,7 +2580,14 @@ def test_apply_snapshot_rejects_existing_same_name_without_snapshot_source(monke
                 "agent": {
                     "id": "cfg-source",
                     "name": "Repo Agent",
-                    "skills": [{"id": "search-core", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\nbody"}],
+                    "skills": [
+                        {
+                            "id": "search-core",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        }
+                    ],
                 },
             },
             marketplace_item_id="item-1",
@@ -2537,8 +2612,18 @@ def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
                     "id": "cfg-source",
                     "name": "Repo Agent",
                     "skills": [
-                        {"id": "search-one", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\none"},
-                        {"id": "search-two", "name": "Search", "version": "1.0.0", "content": "---\nname: Search\n---\ntwo"},
+                        {
+                            "id": "search-one",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search\ndescription: Search repos\n---\none",
+                        },
+                        {
+                            "id": "search-two",
+                            "name": "Search",
+                            "version": "1.0.0",
+                            "content": "---\nname: Search\ndescription: Search repos\n---\ntwo",
+                        },
                     ],
                 },
             },

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1177,6 +1177,71 @@ def test_library_skill_name_is_immutable_after_creation() -> None:
     assert skill_repo.get_by_id("owner-1", created["id"]).name == "Loadable Skill"
 
 
+def test_library_skill_description_comes_from_skill_md_frontmatter() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    created = library_service.create_resource(
+        "skill",
+        "Loadable Skill",
+        "Caller desc",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md(description="Frontmatter desc"),
+    )
+
+    stored = skill_repo.get_by_id("owner-1", created["id"])
+    assert stored is not None
+    assert created["desc"] == "Frontmatter desc"
+    assert stored.description == "Frontmatter desc"
+
+
+def test_library_skill_content_update_refreshes_description_from_skill_md() -> None:
+    skill_repo = _MemorySkillRepo()
+    created = library_service.create_resource(
+        "skill",
+        "Loadable Skill",
+        "Caller desc",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md(description="Original desc"),
+    )
+
+    assert library_service.update_resource_content(
+        "skill",
+        created["id"],
+        _editable_skill_md(description="Updated desc", version="1.0.1"),
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+    )
+
+    stored = skill_repo.get_by_id("owner-1", created["id"])
+    assert stored is not None
+    assert stored.description == "Updated desc"
+
+
+def test_library_skill_description_cannot_be_updated_without_skill_md() -> None:
+    skill_repo = _MemorySkillRepo()
+    created = library_service.create_resource(
+        "skill",
+        "Loadable Skill",
+        "Caller desc",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md(description="Frontmatter desc"),
+    )
+
+    with pytest.raises(ValueError, match="Skill description comes from SKILL.md"):
+        library_service.update_resource(
+            "skill",
+            created["id"],
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            desc="Separate desc",
+        )
+
+    assert skill_repo.get_by_id("owner-1", created["id"]).description == "Frontmatter desc"
+
+
 def test_library_skill_create_rejects_duplicate_name_before_write() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
@@ -1248,7 +1313,7 @@ def test_library_skill_create_fails_when_generated_id_exists(monkeypatch: pytest
         skill_id="skill_existing",
         name="Existing Skill",
         description="Existing",
-        content="---\nname: Existing Skill\nversion: 1.0.0\n---\nExisting.",
+        content="---\nname: Existing Skill\ndescription: Existing desc\nversion: 1.0.0\n---\nExisting.",
     )
     monkeypatch.setattr(library_service, "generate_skill_id", lambda: "skill_existing")
 
@@ -1890,7 +1955,7 @@ def test_get_agent_user_uses_repo_skill_desc():
         skill_id="search",
         name="Search",
         description="repo desc",
-        content="---\nname: Search\n---\nBody",
+        content="---\nname: Search\ndescription: Search repos\n---\nBody",
     )
     agent = UserRow(
         id="agent-1",
@@ -1929,7 +1994,7 @@ def test_get_agent_user_ignores_runtime_skill_desc_override():
         skill_id="search",
         name="Search",
         description="repo desc",
-        content="---\nname: Search\n---\nBody",
+        content="---\nname: Search\ndescription: Search repos\n---\nBody",
     )
     agent = UserRow(
         id="agent-1",
@@ -2085,7 +2150,7 @@ def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
         skill_id="search",
         name="Search",
         description="",
-        content="---\nname: Search\n---\nBody",
+        content="---\nname: Search\ndescription: Search repos\n---\nBody",
     )
     agent = UserRow(
         id="agent-1",

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -122,7 +122,9 @@ class TestApplySkill:
         saved: list[Skill] = []
         packages: list[SkillPackage] = []
         selected: list[tuple[str, str, str]] = []
-        hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
+        hub_resp = _make_hub_response(
+            "skill", "my-skill", content="---\nname: My Skill\ndescription: My Skill desc\n---\n# My Skill\nDo stuff"
+        )
         hub_resp["snapshot"]["files"] = {"references/usage.md": "Use carefully"}
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
@@ -144,7 +146,7 @@ class TestApplySkill:
         assert saved[0].name == "My Skill"
         assert not hasattr(saved[0], "content")
         assert packages[0].skill_id == "skill_generated123"
-        assert packages[0].skill_md == "---\nname: My Skill\n---\n# My Skill\nDo stuff"
+        assert packages[0].skill_md == "---\nname: My Skill\ndescription: My Skill desc\n---\n# My Skill\nDo stuff"
         assert packages[0].manifest["files"][0]["path"] == "references/usage.md"
         assert selected == [("owner-1", "skill_generated123", packages[0].id)]
         assert result["package_id"] == packages[0].id
@@ -163,7 +165,9 @@ class TestApplySkill:
         monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_posix123")
         saved: list[Skill] = []
         packages: list[SkillPackage] = []
-        hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
+        hub_resp = _make_hub_response(
+            "skill", "my-skill", content="---\nname: My Skill\ndescription: My Skill desc\n---\n# My Skill\nDo stuff"
+        )
         hub_resp["snapshot"]["files"] = {"references\\usage.md": "Use carefully"}
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
@@ -183,7 +187,9 @@ class TestApplySkill:
 
     def test_apply_rejects_hub_skill_file_path_collision(self):
         saved: list[Skill] = []
-        hub_resp = _make_hub_response("skill", "my-skill", content="---\nname: My Skill\n---\n# My Skill\nDo stuff")
+        hub_resp = _make_hub_response(
+            "skill", "my-skill", content="---\nname: My Skill\ndescription: My Skill desc\n---\n# My Skill\nDo stuff"
+        )
         hub_resp["snapshot"]["files"] = {
             "references\\usage.md": "Windows-shaped key.",
             "references/usage.md": "POSIX-shaped key.",
@@ -206,7 +212,11 @@ class TestApplySkill:
         saved: list[Skill] = []
         packages: list[SkillPackage] = []
         hub_resp = _make_hub_response(
-            "skill", "tracked-skill", content="---\nname: Tracked Skill\n---\n# Hello", version="2.1.0", publisher="alice"
+            "skill",
+            "tracked-skill",
+            content="---\nname: Tracked Skill\ndescription: Track source\n---\n# Hello",
+            version="2.1.0",
+            publisher="alice",
         )
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
@@ -250,6 +260,20 @@ class TestApplySkill:
             apply_item("item-described", owner_user_id="owner-1", skill_repo=skill_repo)
 
         assert saved[0].description == "Frontmatter description"
+
+    def test_apply_skill_requires_frontmatter_description(self):
+        hub_resp = _make_hub_response("skill", "missing-description", content="---\nname: Missing Description\n---\n# Hello")
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda _skill: (_ for _ in ()).throw(AssertionError("must not save invalid Skill")),
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            with pytest.raises(ValueError, match="Skill snapshot frontmatter must include description"):
+                apply_item("item-missing-description", owner_user_id="owner-1", skill_repo=skill_repo)
 
     def test_apply_skill_requires_snapshot_version(self):
         hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")
@@ -312,7 +336,7 @@ class TestApplySkill:
             created_at=datetime(2026, 4, 24, tzinfo=UTC),
             updated_at=datetime(2026, 4, 24, tzinfo=UTC),
         )
-        hub_resp = _make_hub_response("skill", "same-slug", content="---\nname: Renamed Skill\n---\nBody")
+        hub_resp = _make_hub_response("skill", "same-slug", content="---\nname: Renamed Skill\ndescription: Renamed\n---\nBody")
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
             list_for_owner=lambda _owner_user_id: [existing],
@@ -333,7 +357,7 @@ class TestApplySkill:
             created_at=datetime(2026, 4, 24, tzinfo=UTC),
             updated_at=datetime(2026, 4, 24, tzinfo=UTC),
         )
-        hub_resp = _make_hub_response("skill", "new-slug", content="---\nname: Shared Name\n---\nBody")
+        hub_resp = _make_hub_response("skill", "new-slug", content="---\nname: Shared Name\ndescription: Shared\n---\nBody")
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, _skill_id: None,
             list_for_owner=lambda _owner_user_id: [existing],
@@ -413,7 +437,7 @@ class TestApplySkill:
 
     def test_slug_path_shape_does_not_affect_library_id(self, monkeypatch):
         monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_evilSafe1")
-        hub_resp = _make_hub_response("skill", "../../evil", content="---\nname: Evil\n---\n# Hello")
+        hub_resp = _make_hub_response("skill", "../../evil", content="---\nname: Evil\ndescription: Safe id probe\n---\n# Hello")
         saved: list[Skill] = []
         packages: list[SkillPackage] = []
         skill_repo = SimpleNamespace(
@@ -563,7 +587,7 @@ class TestApplySkill:
             "skill",
             "fastapi",
             version="1.2.3",
-            content='---\nname: " FastAPI "\n---\nAlways use APIRouter.',
+            content='---\nname: " FastAPI "\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter.',
         )
 
         with patch("backend.hub.client._hub_api", return_value=hub_resp):
@@ -684,8 +708,8 @@ class TestApplyIdempotency:
         saved: dict[str, Skill] = {}
         packages: list[SkillPackage] = []
         selected: list[tuple[str, str, str]] = []
-        v1 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\n---\nV1", version="1.0.0")
-        v2 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\n---\nV2", version="1.0.1")
+        v1 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\ndescription: Idempotent\n---\nV1", version="1.0.0")
+        v2 = _make_hub_response("skill", "idem-skill", content="---\nname: Idem Skill\ndescription: Idempotent\n---\nV2", version="1.0.1")
         skill_repo = SimpleNamespace(
             get_by_id=lambda _owner_user_id, skill_id: saved.get(skill_id),
             list_for_owner=lambda _owner_user_id: list(saved.values()),
@@ -706,8 +730,8 @@ class TestApplyIdempotency:
         assert result["package_id"] == packages[1].id
         assert list(saved) == ["skill_idem123"]
         assert saved["skill_idem123"].source["source_version"] == "1.0.1"
-        assert packages[0].skill_md == "---\nname: Idem Skill\n---\nV1"
-        assert packages[1].skill_md == "---\nname: Idem Skill\n---\nV2"
+        assert packages[0].skill_md == "---\nname: Idem Skill\ndescription: Idempotent\n---\nV1"
+        assert packages[1].skill_md == "---\nname: Idem Skill\ndescription: Idempotent\n---\nV2"
         assert selected[-1] == ("owner-1", "skill_idem123", packages[1].id)
 
 
@@ -823,7 +847,7 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                 skill_id="search",
                 version="1.0.0",
                 hash="sha256:search",
-                skill_md="---\nname: Search\n---\nskill content",
+                skill_md="---\nname: Search\ndescription: Search repos\n---\nskill content",
                 source={"name": "Search", "desc": "Repo Search"},
                 created_at=datetime(2026, 4, 25, tzinfo=UTC),
             )


### PR DESCRIPTION
## Summary
- require Skill descriptions at AgentConfig resolve, Hub install, snapshot materialization, and runtime load_skill
- derive Library Skill descriptions from SKILL.md instead of a parallel caller field
- expose Skill descriptions in the load_skill schema so runtime selection has useful metadata

## Verification
- uv run pytest tests/Unit/core/test_skills_service.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/config/test_agent_snapshot.py tests/Unit/core/test_agent_pool.py::test_get_or_create_agent_resolves_skill_packages_before_runtime_startup tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py -q
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright core/tools/skills/service.py config/agent_config_resolver.py backend/hub/client.py backend/hub/snapshot_apply.py backend/library/service.py tests/Unit/config/test_agent_snapshot.py tests/Unit/core/test_agent_pool.py