### PR TITLE
feat(chat): expose message seq cursor

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -96,6 +96,7 @@ class MessagingService:
             "content": message["content"],
             "message_type": message.get("message_type", "human"),
             "mentioned_ids": message.get("mentioned_ids") or [],
+            "seq": message.get("seq"),
             "signal": message.get("signal"),
             "retracted_at": message.get("retracted_at"),
             "created_at": message.get("created_at"),

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -864,6 +864,7 @@ def test_messaging_service_list_message_responses_projects_sender_name_from_agen
                     "sender_user_id": "agent-user-1",
                     "content": "hello",
                     "message_type": "human",
+                    "seq": 42,
                     "created_at": "2026-04-07T00:00:00Z",
                 }
             ]
@@ -884,6 +885,7 @@ def test_messaging_service_list_message_responses_projects_sender_name_from_agen
             "content": "hello",
             "message_type": "human",
             "mentioned_ids": [],
+            "seq": 42,
             "signal": None,
             "retracted_at": None,
             "created_at": "2026-04-07T00:00:00Z",


### PR DESCRIPTION
## Summary
- expose chat-local message `seq` in public message responses
- keep the existing backend `before` cursor semantics visible to generated SDK/CLI consumers

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_list_message_responses_projects_sender_name_from_agent_user_id tests/Unit/integration_contracts/test_messaging_router.py::test_list_messages_resolves_thread_user_sender_name_via_thread_repo tests/Unit/integration_contracts/test_messaging_router.py::test_list_messages_route_resolves_sender_name_via_messaging_service -q`
- real CLI smoke on port 8042: `mycel chat messages list 6c1d02ff-0635-4a11-b08b-8d60ef284110 --limit 220` returned 205 messages with `seq` 1..205 and backend served two message pages (`limit=200`, then `limit=20&before=6`).

## Notes
This is the backend contract slice needed by mycel-sdk long-history pagination.