### PR TITLE
Require persisted Skill descriptions

### DIFF
--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -22,13 +22,13 @@ class Skill(AgentConfigSchemaModel):
     id: str
     owner_user_id: str
     name: str
-    description: str = ""
+    description: str
     package_id: str | None = None
     source: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
     updated_at: datetime
 
-    @field_validator("id", "owner_user_id", "name")
+    @field_validator("id", "owner_user_id", "name", "description")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
+from config.skill_document import parse_skill_document
 from config.skill_files import normalize_skill_file_map
 
 
@@ -53,6 +54,12 @@ class SkillPackage(AgentConfigSchemaModel):
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():
             raise ValueError(f"skill_package.{info.field_name} must not be blank")
+        return value
+
+    @field_validator("skill_md")
+    @classmethod
+    def _valid_skill_document(cls, value: str) -> str:
+        parse_skill_document(value, label="skill_package.skill_md", require_description=True)
         return value
 
     @field_validator("files", mode="before")

--- a/storage/providers/supabase/skill_repo.py
+++ b/storage/providers/supabase/skill_repo.py
@@ -97,7 +97,7 @@ def _skill_from_row(row: dict[str, Any]) -> Skill:
         id=row["id"],
         owner_user_id=row["owner_user_id"],
         name=row["name"],
-        description=_text(row, "description", table="library.skills"),
+        description=_required_text(row, "description", table="library.skills"),
         package_id=row.get("package_id"),
         source=_json_object(row, "source_json", table="library.skills"),
         created_at=row["created_at"],
@@ -116,6 +116,13 @@ def _text(row: dict[str, Any], column: str, *, table: str) -> str:
     value = row[column]
     if not isinstance(value, str):
         raise RuntimeError(f"{table}.{column} must be text")
+    return value
+
+
+def _required_text(row: dict[str, Any], column: str, *, table: str) -> str:
+    value = _text(row, column, table=table)
+    if not value.strip():
+        raise RuntimeError(f"{table}.{column} must not be blank")
     return value
 
 

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -10,7 +10,7 @@ create table if not exists library.skills (
     id text not null,
     owner_user_id text not null,
     name text not null,
-    description text not null default '',
+    description text not null,
     package_id text,
     source_json jsonb not null default '{}'::jsonb,
     created_at timestamptz not null default now(),
@@ -41,6 +41,9 @@ alter table library.skills
     add constraint skills_package_fk
         foreign key (package_id)
         references library.skill_packages(id);
+
+alter table if exists library.skills
+    alter column description drop default;
 
 alter table if exists library.skill_packages
     alter column version drop default;
@@ -162,6 +165,20 @@ end $$;
 
 do $$
 begin
+    if exists (
+        select 1
+        from library.skills
+        where description is null
+           or btrim(description) = ''
+    ) then
+        raise exception 'library.skills.description must be present before hard cut';
+    end if;
+
+    alter table library.skills
+        drop constraint if exists skills_description_required_ck,
+        add constraint skills_description_required_ck
+            check (description is not null and btrim(description) <> '');
+
     if exists (
         select 1
         from library.skills

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -278,7 +278,7 @@ def test_resolver_rejects_package_that_does_not_belong_to_selected_skill():
                         skill_id="other-skill",
                         version="1.0.0",
                         hash="sha256:visible",
-                        skill_md="---\nname: Runtime Skill\n---\n\n# Runtime Skill\n",
+                        skill_md="---\nname: Runtime Skill\ndescription: Runtime guidance\n---\n\n# Runtime Skill\n",
                         created_at=datetime(2026, 4, 25, tzinfo=UTC),
                     )
                 }

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, ResolvedSkill, SkillPackage
+from config.agent_config_types import AgentConfig, AgentRule, AgentSkill, AgentSubAgent, McpServerConfig, ResolvedSkill, Skill, SkillPackage
 
 
 def test_resolved_skill_model_normalizes_file_paths() -> None:
@@ -58,8 +58,36 @@ def test_resolved_skill_model_rejects_blank_id() -> None:
         ResolvedSkill(
             id=" ",
             name="query-helper",
+            description="Build precise queries",
             version="1.0.0",
             content="---\nname: query-helper\n---\nUse exact terms.",
+        )
+
+
+def test_skill_model_requires_description() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        Skill.model_validate(
+            {
+                "id": "skill-1",
+                "owner_user_id": "owner-1",
+                "name": "query-helper",
+                "created_at": datetime(2026, 4, 25, tzinfo=UTC),
+                "updated_at": datetime(2026, 4, 25, tzinfo=UTC),
+            }
+        )
+
+    assert "description" in str(excinfo.value)
+
+
+def test_skill_model_rejects_blank_description() -> None:
+    with pytest.raises(ValueError, match="skill.description must not be blank"):
+        Skill(
+            id="skill-1",
+            owner_user_id="owner-1",
+            name="query-helper",
+            description=" ",
+            created_at=datetime(2026, 4, 25, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 25, tzinfo=UTC),
         )
 
 
@@ -207,7 +235,7 @@ def test_skill_package_requires_package_identity_and_skill_md() -> None:
         version="1.0.0",
         hash="sha256:abc",
         manifest={"files": [{"path": "references/query.md", "sha256": "def"}]},
-        skill_md="---\nname: query-helper\n---\nUse exact terms.",
+        skill_md="---\nname: query-helper\ndescription: Build precise queries\n---\nUse exact terms.",
         files={"references\\query.md": "Prefer precise queries."},
         created_at=datetime(2026, 4, 25, tzinfo=UTC),
     )

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -9,6 +9,7 @@ def test_resolved_skill_model_normalizes_file_paths() -> None:
     resolved_skill = ResolvedSkill(
         id="query-helper",
         name="query-helper",
+        description="Build precise queries",
         version="1.0.0",
         content="---\nname: query-helper\n---\nUse exact terms.",
         files={"references\\query.md": "Prefer precise queries."},
@@ -35,6 +36,7 @@ def test_resolved_skill_model_rejects_blank_version() -> None:
         ResolvedSkill(
             id="query-helper",
             name="query-helper",
+            description="Build precise queries",
             version=" ",
             content="---\nname: query-helper\n---\nUse exact terms.",
         )
@@ -45,6 +47,7 @@ def test_resolved_skill_model_requires_id() -> None:
         ResolvedSkill.model_validate(
             {
                 "name": "query-helper",
+                "description": "Build precise queries",
                 "version": "1.0.0",
                 "content": "---\nname: query-helper\n---\nUse exact terms.",
             }

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -259,6 +259,20 @@ def test_skill_package_rejects_blank_skill_md() -> None:
         SkillPackage(skill_md=" ", **common)
 
 
+def test_skill_package_requires_skill_md_description() -> None:
+    with pytest.raises(ValueError, match="skill_package.skill_md frontmatter must include description"):
+        SkillPackage(
+            id="package-1",
+            owner_user_id="owner-1",
+            skill_id="skill-1",
+            version="1.0.0",
+            hash="sha256:abc",
+            manifest={},
+            skill_md="---\nname: query-helper\n---\nUse exact terms.",
+            created_at=datetime(2026, 4, 25, tzinfo=UTC),
+        )
+
+
 @pytest.mark.parametrize(
     ("model_cls", "payload"),
     [
@@ -269,7 +283,7 @@ def test_skill_package_rejects_blank_skill_md() -> None:
                 "owner_user_id": "owner-1",
                 "skill_id": "skill-1",
                 "hash": "sha256:abc",
-                "skill_md": "---\nname: query-helper\n---\nUse exact terms.",
+                "skill_md": "---\nname: query-helper\ndescription: Build precise queries\n---\nUse exact terms.",
                 "created_at": datetime(2026, 4, 25, tzinfo=UTC),
             },
         ),

--- a/tests/Unit/config/test_skill_package.py
+++ b/tests/Unit/config/test_skill_package.py
@@ -5,7 +5,7 @@ from config.skill_package import build_skill_package, build_skill_package_hash, 
 
 def test_build_skill_package_uses_content_hash_as_identity() -> None:
     created_at = datetime(2026, 4, 26, tzinfo=UTC)
-    skill_md = "---\nname: Query Helper\n---\nUse exact terms."
+    skill_md = "---\nname: Query Helper\ndescription: Build precise queries\n---\nUse exact terms."
     files = {"references/query.md": "Prefer precise queries."}
 
     package = build_skill_package(

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -203,7 +203,7 @@ async def test_panel_agent_detail_exposes_library_skill_id_for_round_trip() -> N
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
     agent = UserRow(
         id="agent-1",
@@ -444,7 +444,7 @@ def test_agent_config_patch_saves_library_skill_package_choice() -> None:
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
 
     class _AgentConfigRepo:
@@ -490,7 +490,7 @@ def test_agent_config_patch_keeps_package_source_out_of_agent_skill_binding() ->
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
     skill_repo.upsert(library_skill.model_copy(update={"source": {"source_version": "library-stale"}}))
 
@@ -680,7 +680,7 @@ def test_agent_config_patch_rejects_skill_item_without_library_skill_id() -> Non
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
 
     class _AgentConfigRepo:
@@ -720,7 +720,7 @@ def test_agent_config_patch_rejects_skill_name_and_desc_fields() -> None:
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
 
     class _AgentConfigRepo:
@@ -900,7 +900,7 @@ def test_agent_config_patch_explicit_library_id_uses_library_package_choice() ->
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nLibrary content.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nLibrary content.",
     )
 
     class _AgentConfigRepo:
@@ -949,7 +949,7 @@ def test_select_agent_skill_uses_agent_config_skill_patch_boundary() -> None:
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
 
     class _AgentConfigRepo:
@@ -990,7 +990,7 @@ def test_select_agent_skill_rejects_package_for_another_skill() -> None:
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
     wrong_package = SkillPackage(
         id="wrong-package",
@@ -998,7 +998,7 @@ def test_select_agent_skill_rejects_package_for_another_skill() -> None:
         skill_id="other-skill",
         version="1.0.0",
         hash="sha256:wrong",
-        skill_md="---\nname: Other Skill\n---\nUse it.",
+        skill_md="---\nname: Other Skill\ndescription: Other\n---\nUse it.",
         created_at=datetime(2026, 4, 24, tzinfo=UTC),
     )
     skill_repo.create_package(wrong_package)
@@ -1064,7 +1064,7 @@ def test_library_skill_content_rejects_selected_package_for_another_skill() -> N
         skill_id="loadable-skill",
         name="Loadable Skill",
         description="loadable",
-        content="---\nname: Loadable Skill\n---\nUse it.",
+        content="---\nname: Loadable Skill\ndescription: loadable\n---\nUse it.",
     )
     wrong_package = SkillPackage(
         id="wrong-package",
@@ -1072,7 +1072,7 @@ def test_library_skill_content_rejects_selected_package_for_another_skill() -> N
         skill_id="other-skill",
         version="1.0.0",
         hash="sha256:wrong",
-        skill_md="---\nname: Other Skill\n---\nUse it.",
+        skill_md="---\nname: Other Skill\ndescription: Other\n---\nUse it.",
         created_at=datetime(2026, 4, 24, tzinfo=UTC),
     )
     skill_repo.create_package(wrong_package)
@@ -2776,7 +2776,7 @@ async def test_delete_skill_route_rejects_skill_still_selected_by_agent(monkeypa
         skill_id="skill-1",
         name="api-design-reviewer",
         description="API Design Reviewer",
-        content="---\nname: api-design-reviewer\n---\nBody",
+        content="---\nname: api-design-reviewer\ndescription: API Design Reviewer\n---\nBody",
     )
     agent = _agent_user(user_id="agent-1", owner_user_id="user-1")
     fake_user_repo = SimpleNamespace(list_by_owner_user_id=lambda owner_user_id: [agent] if owner_user_id == "user-1" else [])
@@ -2824,7 +2824,7 @@ async def test_delete_skill_route_allows_skill_after_agent_config_removal(monkey
         skill_id="skill-1",
         name="api-design-reviewer",
         description="API Design Reviewer",
-        content="---\nname: api-design-reviewer\n---\nBody",
+        content="---\nname: api-design-reviewer\ndescription: API Design Reviewer\n---\nBody",
     )
     agent = _agent_user(user_id="agent-1", owner_user_id="user-1")
     fake_user_repo = SimpleNamespace(list_by_owner_user_id=lambda owner_user_id: [agent] if owner_user_id == "user-1" else [])

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2142,45 +2142,6 @@ def test_panel_agents_http_surface_does_not_expose_query_app_param(monkeypatch: 
     assert delete.json() == {"success": True}
 
 
-def test_get_agent_user_preserves_explicit_empty_repo_skill_desc():
-    skill_repo = _MemorySkillRepo()
-    _put_skill(
-        skill_repo,
-        owner_user_id="user-1",
-        skill_id="search",
-        name="Search",
-        description="",
-        content="---\nname: Search\ndescription: Search repos\n---\nBody",
-    )
-    agent = UserRow(
-        id="agent-1",
-        type=UserType.AGENT,
-        display_name="Toad",
-        owner_user_id="user-1",
-        agent_config_id="cfg-1",
-        created_at=1.0,
-    )
-
-    class _AgentConfigRepo:
-        def get_agent_config(self, agent_config_id: str):
-            assert agent_config_id == "cfg-1"
-            return _agent_config(
-                description="probe",
-                model="leon:large",
-                system_prompt="",
-                skills=[AgentSkill(skill_id="search", package_id="search-package")],
-            )
-
-    result = agent_user_service.get_agent_user(
-        "agent-1",
-        user_repo=SimpleNamespace(get_by_id=lambda user_id: agent if user_id == "agent-1" else None),
-        agent_config_repo=_AgentConfigRepo(),
-        skill_repo=skill_repo,
-    )
-
-    assert result["config"]["skills"] == [{"id": "search", "name": "Search", "enabled": True, "desc": ""}]
-
-
 def test_apply_snapshot_saves_one_agent_config_aggregate():
     import backend.hub.snapshot_apply as snapshot_apply
 

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -332,6 +332,7 @@ class TestApplySkill:
             id="same-slug",
             owner_user_id="owner-1",
             name="Original Skill",
+            description="Original desc",
             source={"marketplace_item_id": "item-rename"},
             created_at=datetime(2026, 4, 24, tzinfo=UTC),
             updated_at=datetime(2026, 4, 24, tzinfo=UTC),
@@ -354,6 +355,7 @@ class TestApplySkill:
             id="original-slug",
             owner_user_id="owner-1",
             name="Shared Name",
+            description="Shared desc",
             created_at=datetime(2026, 4, 24, tzinfo=UTC),
             updated_at=datetime(2026, 4, 24, tzinfo=UTC),
         )

--- a/tests/Unit/scripts/test_import_file_skills_to_library.py
+++ b/tests/Unit/scripts/test_import_file_skills_to_library.py
@@ -67,6 +67,7 @@ def test_import_file_skill_reuses_existing_skill_by_name(monkeypatch: pytest.Mon
             id="original-skill",
             owner_user_id="owner-1",
             name="Shared Skill",
+            description="Shared",
             created_at=datetime(2026, 4, 24, tzinfo=UTC),
             updated_at=datetime(2026, 4, 24, tzinfo=UTC),
         )

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -9,6 +9,8 @@ def test_agent_config_schema_uses_library_package_storage() -> None:
     assert "create table if not exists library.skills" in sql
     assert "create table if not exists library.skill_packages" in sql
     assert "create table if not exists agent.skill_bindings" in sql
+    assert "description text not null default ''" not in sql
+    assert "skills_description_required_ck" in sql
     assert "drop table if exists agent.agent_skills cascade" in sql
     assert "drop table if exists agent.skills cascade" in sql
     assert "skill_md text not null" in sql
@@ -106,6 +108,7 @@ def test_agent_config_schema_constrains_root_identity_fields() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 
     assert "library.skills.source_json must be a JSON object before hard cut" in sql
+    assert "library.skills.description must be present before hard cut" in sql
     assert "library.skill_packages.manifest_json must be a JSON object before hard cut" in sql
     assert "library.skill_packages.version must be present before hard cut" in sql
     assert "library.skill_packages.files_json must be a JSON object before hard cut" in sql

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -147,6 +147,16 @@ def test_get_by_id_rejects_null_skill_description() -> None:
         repo.get_by_id("owner-1", "skill-1")
 
 
+def test_get_by_id_rejects_blank_skill_description() -> None:
+    row = _row()
+    row["description"] = " "
+    client = _FakeClient({"library.skills": [row]})
+    repo = SupabaseSkillRepo(client)
+
+    with pytest.raises(RuntimeError, match="library.skills.description must not be blank"):
+        repo.get_by_id("owner-1", "skill-1")
+
+
 def test_upsert_writes_library_skill_metadata_only() -> None:
     client = _FakeClient()
     repo = SupabaseSkillRepo(client)
@@ -157,6 +167,7 @@ def test_upsert_writes_library_skill_metadata_only() -> None:
             id="skill-1",
             owner_user_id="owner-1",
             name="github",
+            description="GitHub helper",
             package_id="package-1",
             source={"source_version": "1.0.0"},
             created_at=timestamp,

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -81,7 +81,7 @@ def _row(skill_id: str = "skill-1") -> dict:
         "name": "github",
         "description": "GitHub guidance",
         "version": "1.0.0",
-        "content": "---\nname: github\n---\n",
+        "content": "---\nname: github\ndescription: GitHub guidance\n---\n",
         "files_json": {"references/query.md": "Prefer precise queries."},
         "source_json": {"source_version": "1.0.0"},
         "created_at": "2026-04-24T00:00:00+00:00",

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -97,7 +97,7 @@ def _package_row(package_id: str = "package-1") -> dict:
         "version": "1.0.0",
         "hash": "sha256:abc",
         "manifest_json": {"files": [{"path": "references/query.md", "sha256": "def"}]},
-        "skill_md": "---\nname: github\n---\n",
+        "skill_md": "---\nname: github\ndescription: GitHub guidance\n---\n",
         "files_json": {"references/query.md": "Prefer precise queries."},
         "source_json": {"source_version": "1.0.0"},
         "created_at": "2026-04-24T00:00:00+00:00",
@@ -188,7 +188,7 @@ def test_create_package_writes_immutable_skill_package() -> None:
             version="1.0.0",
             hash="sha256:abc",
             manifest={"files": [{"path": "references/query.md", "sha256": "def"}]},
-            skill_md="---\nname: github\n---\n",
+            skill_md="---\nname: github\ndescription: GitHub guidance\n---\n",
             files={"references/query.md": "Prefer precise queries."},
             source={"source_version": "1.0.0"},
             created_at=timestamp,
@@ -197,7 +197,7 @@ def test_create_package_writes_immutable_skill_package() -> None:
 
     payload = client.table_queries["library.skill_packages"][0].upsert_payload
     assert payload is not None
-    assert payload["skill_md"] == "---\nname: github\n---\n"
+    assert payload["skill_md"] == "---\nname: github\ndescription: GitHub guidance\n---\n"
     assert payload["files_json"] == {"references/query.md": "Prefer precise queries."}
     assert payload["manifest_json"] == {"files": [{"path": "references/query.md", "sha256": "def"}]}
     assert payload["source_json"] == {"source_version": "1.0.0"}


### PR DESCRIPTION
## Summary
- require non-blank Library Skill descriptions at the model and schema layers
- require SkillPackage.skill_md to be a described SKILL.md document
- reject blank Skill descriptions from Supabase reads and remove empty-description fixtures

## Verification
- uv run pytest tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_skill_package.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/platform/test_marketplace_client.py tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "skill or package or snapshot"
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright config/agent_config_types.py storage/providers/supabase/skill_repo.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_skill_package.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/config/test_agent_config_resolver.py