### PR TITLE
Require seeded Skill metadata from SKILL.md

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -70,7 +70,7 @@ def _require_skill_repo(skill_repo: SkillRepo | None) -> SkillRepo:
 
 def _skill_document_from_content(content: str, *, require_version: bool = False) -> SkillDocument:
     # @@@skill-name-single-truth - runtime indexes Skills by SKILL.md frontmatter name, so Library name must not drift.
-    return parse_skill_document(content, label="Skill content", require_version=require_version)
+    return parse_skill_document(content, label="Skill content", require_description=True, require_version=require_version)
 
 
 def _now_dt() -> datetime:

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -148,7 +148,7 @@ def build_skill_payload(
         "type": "skill",
         "name": package["name"],
         "description": package["description"],
-        "version": "1.0.0",
+        "version": package["version"],
         "release_notes": "Initial release",
         "tags": package["tags"],
         "visibility": "public",

--- a/scripts/seed_github_skills.py
+++ b/scripts/seed_github_skills.py
@@ -65,9 +65,12 @@ def parse_skill_md(skill_md: Path) -> dict | None:
     if len(content.strip()) < 50:
         return None
 
-    document = parse_skill_document(content, label="SKILL.md")
+    document = parse_skill_document(content, label="SKILL.md", require_description=True, require_version=True)
     name = document.name
     description = document.description
+    version = document.version
+    if version is None:
+        raise RuntimeError("SKILL.md version was not parsed")
     tags = []
     meta = document.frontmatter.get("metadata", {})
     if isinstance(meta, dict):
@@ -78,16 +81,10 @@ def parse_skill_md(skill_md: Path) -> dict | None:
         if isinstance(triggers, str):
             tags.extend([t.strip() for t in triggers.split(",")[:5] if t.strip()])
 
-    if not description:
-        for line in document.body.split("\n"):
-            stripped = line.strip()
-            if stripped and not stripped.startswith("#"):
-                description = stripped[:200]
-                break
-
     return {
         "name": name,
         "description": description,
+        "version": version,
         "tags": sorted({t for t in tags if t})[:10],
         "content": content,
     }

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1129,6 +1129,23 @@ def test_library_skill_create_requires_version_frontmatter() -> None:
     assert skill_repo.packages == {}
 
 
+def test_library_skill_create_requires_description_frontmatter() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="frontmatter must include description"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "Use this skill",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content="---\nname: Loadable Skill\nversion: 1.0.0\n---\n\nUse this skill.",
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
+
+
 def test_library_skill_content_update_requires_version_frontmatter() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
@@ -1145,6 +1162,31 @@ def test_library_skill_content_update_requires_version_frontmatter() -> None:
             "skill",
             created["id"],
             "---\nname: Loadable Skill\ndescription: Use this skill\n---\n\nUse it.",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+        )
+
+    stored = skill_repo.get_by_id("owner-1", created["id"])
+    assert stored is not None and stored.package_id is not None
+    assert skill_repo.get_package("owner-1", stored.package_id).version == "1.0.0"
+
+
+def test_library_skill_content_update_requires_description_frontmatter() -> None:
+    skill_repo = _MemorySkillRepo()
+    created = library_service.create_resource(
+        "skill",
+        "Loadable Skill",
+        "Use this skill",
+        owner_user_id="owner-1",
+        skill_repo=skill_repo,
+        content=_editable_skill_md(),
+    )
+
+    with pytest.raises(ValueError, match="frontmatter must include description"):
+        library_service.update_resource_content(
+            "skill",
+            created["id"],
+            "---\nname: Loadable Skill\nversion: 1.0.1\n---\n\nUse it.",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
         )

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -18,7 +18,7 @@ def test_seed_skill_package_includes_adjacent_files(tmp_path: Path) -> None:
     skill_dir = tmp_path / "repo" / "skills" / "api-design"
     _write_skill(
         skill_dir,
-        "---\nname: API Design\ndescription: Design APIs\nmetadata:\n  domain: backend\n---\nUse REST carefully.",
+        "---\nname: API Design\ndescription: Design APIs\nversion: 1.0.0\nmetadata:\n  domain: backend\n---\nUse REST carefully.",
     )
     (skill_dir / "references").mkdir()
     (skill_dir / "references" / "routing.md").write_text("Prefer explicit routes.", encoding="utf-8")
@@ -28,15 +28,16 @@ def test_seed_skill_package_includes_adjacent_files(tmp_path: Path) -> None:
     assert package == {
         "name": "API Design",
         "description": "Design APIs",
+        "version": "1.0.0",
         "tags": ["backend"],
-        "content": "---\nname: API Design\ndescription: Design APIs\nmetadata:\n  domain: backend\n---\nUse REST carefully.",
+        "content": "---\nname: API Design\ndescription: Design APIs\nversion: 1.0.0\nmetadata:\n  domain: backend\n---\nUse REST carefully.",
         "files": {"references/routing.md": "Prefer explicit routes."},
     }
 
 
 def test_seed_skill_package_normalizes_adjacent_file_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     skill_dir = tmp_path / "repo" / "skills" / "api-design"
-    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\n---\nUse REST carefully.")
+    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\nversion: 1.0.0\n---\nUse REST carefully.")
     refs_dir = skill_dir / "references"
     refs_dir.mkdir()
     (refs_dir / "routing.md").write_text("Prefer explicit routes.", encoding="utf-8")
@@ -77,14 +78,20 @@ def test_seed_skill_parse_requires_skill_frontmatter(tmp_path: Path) -> None:
         seed_github_skills.read_skill_package(skill_dir)
 
 
-def test_seed_skill_description_fallback_reads_body_not_frontmatter(tmp_path: Path) -> None:
+def test_seed_skill_parse_requires_description_frontmatter(tmp_path: Path) -> None:
     skill_dir = tmp_path / "repo" / "skills" / "api-design"
     _write_skill(skill_dir, "---\nname: API Design\nmetadata:\n  domain: backend\n---\nUse REST carefully.")
 
-    package = seed_github_skills.read_skill_package(skill_dir)
+    with pytest.raises(ValueError, match="SKILL.md frontmatter must include description"):
+        seed_github_skills.read_skill_package(skill_dir)
 
-    assert package is not None
-    assert package["description"] == "Use REST carefully."
+
+def test_seed_skill_parse_requires_version_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "repo" / "skills" / "api-design"
+    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\n---\nUse REST carefully.")
+
+    with pytest.raises(ValueError, match="SKILL.md frontmatter must include version"):
+        seed_github_skills.read_skill_package(skill_dir)
 
 
 def test_seed_skill_parse_rejects_unreadable_skill_md(tmp_path: Path) -> None:

--- a/tests/Unit/scripts/test_seed_github_skills.py
+++ b/tests/Unit/scripts/test_seed_github_skills.py
@@ -105,7 +105,7 @@ def test_seed_skill_parse_rejects_unreadable_skill_md(tmp_path: Path) -> None:
 
 def test_seed_skill_payload_publishes_snapshot_files(tmp_path: Path) -> None:
     skill_dir = tmp_path / "repo" / "skills" / "api-design"
-    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\n---\nUse REST carefully.")
+    _write_skill(skill_dir, "---\nname: API Design\ndescription: Design APIs\nversion: 1.2.3\n---\nUse REST carefully.")
     (skill_dir / "references").mkdir()
     (skill_dir / "references" / "routing.md").write_text("Prefer explicit routes.", encoding="utf-8")
     package = seed_github_skills.read_skill_package(skill_dir)
@@ -120,6 +120,7 @@ def test_seed_skill_payload_publishes_snapshot_files(tmp_path: Path) -> None:
 
     assert payload["snapshot"]["content"] == package["content"]
     assert payload["snapshot"]["files"] == {"references/routing.md": "Prefer explicit routes."}
+    assert payload["version"] == "1.2.3"
 
 
 def test_seed_skill_slug_is_hub_item_path_not_library_identity(tmp_path: Path) -> None:
@@ -170,8 +171,9 @@ def test_seed_publish_skill_package_uses_package_payload(monkeypatch: pytest.Mon
         package={
             "name": "API Design",
             "description": "Design APIs",
+            "version": "1.0.0",
             "tags": ["backend"],
-            "content": "---\nname: API Design\n---\nUse REST carefully.",
+            "content": "---\nname: API Design\ndescription: Design APIs\nversion: 1.0.0\n---\nUse REST carefully.",
             "files": {"references/routing.md": "Prefer explicit routes."},
         },
         publisher_user_id="publisher-1",


### PR DESCRIPTION
## Summary
- require GitHub-seeded Skills to declare description and version in SKILL.md
- publish the parsed Skill package version instead of a hard-coded version
- require Library Skill descriptions at the SKILL.md parse boundary on create/update

## Verification
- uv run pytest tests/Unit/scripts/test_seed_github_skills.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "skill"
- uv run pytest tests/Unit/scripts/test_seed_github_skills.py tests/Unit/scripts/test_import_file_skills_to_library.py tests/Unit/config/test_skill_package.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "skill or package or snapshot"
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright backend/library/service.py scripts/seed_github_skills.py tests/Unit/scripts/test_seed_github_skills.py