### PR TITLE
feat: carry relationship request messages

### DIFF
--- a/backend/chat/api/http/relationships_router.py
+++ b/backend/chat/api/http/relationships_router.py
@@ -22,6 +22,7 @@ class RelationshipRequestBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     target_user_id: str
+    message: str | None = None
 
 
 class RelationshipActionBody(BaseModel):
@@ -52,6 +53,7 @@ def _row_to_dict(row: RelationshipRow, viewer_id: str) -> dict:
         "other_user_id": other_id,
         "state": row.state,
         "is_requester": is_requester,
+        "message": row.message,
         "created_at": row.created_at.isoformat(),
         "updated_at": row.updated_at.isoformat(),
     }
@@ -75,7 +77,7 @@ def request_relationship(
     if user_id == body.target_user_id:
         raise HTTPException(400, "Cannot request relationship with yourself")
     try:
-        row = relationship_service.request(user_id, body.target_user_id)
+        row = relationship_service.request(user_id, body.target_user_id, body.message)
         return _row_to_dict(row, user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -43,9 +43,9 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
                     source="relationship",
                 ),
                 message=AgentRuntimeMessage(
-                    content=(
-                        f"{_display_name(requester, requester_id)} requested a relationship with you. "
-                        "Review the pending relationship request in Mycel, then approve or reject it."
+                    content=_notification_content(
+                        _display_name(requester, requester_id),
+                        row.message,
                     ),
                     metadata={"relationship_id": row.id},
                 ),
@@ -92,3 +92,10 @@ def _display_name(user: Any, user_id: str) -> str:
     if display_name is None:
         raise RuntimeError(f"Relationship request user is missing display name: {user_id}")
     return str(display_name)
+
+
+def _notification_content(requester_name: str, message: str | None) -> str:
+    base = f"{requester_name} requested a relationship with you."
+    if message and message.strip():
+        base = f"{base} Message: {message.strip()}"
+    return f"{base} Review the pending relationship request in Mycel, then approve or reject it."

--- a/messaging/contracts.py
+++ b/messaging/contracts.py
@@ -142,6 +142,7 @@ class RelationshipRow(BaseModel):
     kind: str = "hire_visit"
     state: RelationshipState = "none"
     initiator_user_id: str | None = None
+    message: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -32,6 +32,8 @@ class RelationshipService:
         requester_id: str,
         target_id: str,
         event: RelationshipEvent,
+        *,
+        message: str | None = None,
     ) -> RelationshipRow:
         """Apply an event to the relationship between requester and target.
 
@@ -62,11 +64,17 @@ class RelationshipService:
             event,
         )
 
-        row = self._repo.upsert(requester_id, target_id, state=new_state, initiator_user_id=initiator_user_id)
+        row = self._repo.upsert(
+            requester_id,
+            target_id,
+            state=new_state,
+            initiator_user_id=initiator_user_id,
+            message=message,
+        )
         return RelationshipRow.model_validate(row)
 
-    def request(self, requester_id: str, target_id: str) -> RelationshipRow:
-        row = self.apply_event(requester_id, target_id, "request")
+    def request(self, requester_id: str, target_id: str, message: str | None = None) -> RelationshipRow:
+        row = self.apply_event(requester_id, target_id, "request", message=message)
         if self._on_relationship_requested is not None:
             self._on_relationship_requested(row)
         return row

--- a/messaging/tools/relationship_tool_service.py
+++ b/messaging/tools/relationship_tool_service.py
@@ -54,8 +54,8 @@ class RelationshipToolService:
         )
 
     def _register_request_relationship(self, registry: ToolRegistry) -> None:
-        def handle(target_user_id: str) -> str:
-            row = self._relationships.request(self._identity_id, target_user_id)
+        def handle(target_user_id: str, message: str | None = None) -> str:
+            row = self._relationships.request(self._identity_id, target_user_id, message)
             return f"Requested relationship with {target_user_id}. {self._format_row(row)}"
 
         registry.register(
@@ -70,7 +70,11 @@ class RelationshipToolService:
                             "type": "string",
                             "description": "Target Mycel user id to request a relationship with.",
                             "minLength": 1,
-                        }
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Optional natural-language reason for the relationship request.",
+                        },
                     },
                     required=["target_user_id"],
                 ),
@@ -161,9 +165,15 @@ class RelationshipToolService:
             direction = "incoming pending request" if initiator_user_id != self._identity_id else "outgoing pending request"
         else:
             direction = f"{state} relationship"
-        return f"- {direction}; relationship_id: {relationship_id}; other_user_id: {other_user_id}; state: {state}"
+        message = self._field(row, "message", default=None)
+        suffix = f"; message: {message}" if message else ""
+        return f"- {direction}; relationship_id: {relationship_id}; other_user_id: {other_user_id}; state: {state}{suffix}"
 
-    def _field(self, row: Any, field: str) -> Any:
+    def _field(self, row: Any, field: str, *, default: Any = ...) -> Any:
         if isinstance(row, dict):
-            return row[field]
-        return getattr(row, field)
+            if default is ...:
+                return row[field]
+            return row.get(field, default)
+        if default is ...:
+            return getattr(row, field)
+        return getattr(row, field, default)

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -325,6 +325,7 @@ class RelationshipRow(BaseModel):
     kind: str
     state: str = "pending"
     initiator_user_id: str
+    message: str | None = None
     version: int = 0
     created_at: float
     updated_at: float | None = None

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -352,12 +352,14 @@ class SupabaseRelationshipRepo:
         *,
         state: RelationshipState,
         initiator_user_id: str | None,
+        message: str | None = None,
     ) -> dict[str, Any]:
         user_low, user_high = self._ordered(user_a, user_b)
         existing = self.get(user_a, user_b)
         now = time.time()
+        message_update = {"message": message} if message is not None else {}
         if existing:
-            relationship_updates = {"state": state, "initiator_user_id": initiator_user_id}
+            relationship_updates = {"state": state, "initiator_user_id": initiator_user_id, **message_update}
             if state == "none":
                 (self._t().delete().eq("user_low", user_low).eq("user_high", user_high).eq("kind", "hire_visit").execute())
                 return self._normalize({**existing, "updated_at": now, **relationship_updates})
@@ -379,6 +381,7 @@ class SupabaseRelationshipRepo:
             "updated_at": now,
             "state": state,
             "initiator_user_id": initiator_user_id,
+            "message": message,
         }
         res = self._t().insert(row).execute()
         return self._normalize(res.data[0] if res.data else row)

--- a/storage/schema/2026_04_26_relationship_request_message.sql
+++ b/storage/schema/2026_04_26_relationship_request_message.sql
@@ -1,0 +1,4 @@
+alter table chat.relationships
+    add column if not exists message text;
+
+notify pgrst, 'reload schema';

--- a/tests/Integration/test_relationship_router.py
+++ b/tests/Integration/test_relationship_router.py
@@ -18,6 +18,7 @@ def _row(
     initiator_user_id: str = "requester-user-1",
     user_low: str = "agent-user-1",
     user_high: str = "requester-user-1",
+    message: str | None = None,
 ) -> RelationshipRow:
     now = datetime(2026, 4, 8, tzinfo=UTC)
     return RelationshipRow(
@@ -27,6 +28,7 @@ def _row(
         kind="hire_visit",
         state=state,
         initiator_user_id=initiator_user_id,
+        message=message,
         created_at=now,
         updated_at=now,
     )
@@ -40,7 +42,7 @@ def test_relationship_public_openapi_uses_token_identity_only() -> None:
     request_properties = schemas["RelationshipRequestBody"]["properties"]
     action_properties = schemas["RelationshipActionBody"]["properties"]
 
-    assert list(request_properties) == ["target_user_id"]
+    assert list(request_properties) == ["target_user_id", "message"]
     assert action_properties == {}
 
 
@@ -48,28 +50,33 @@ def test_relationship_request_route_is_sync_for_runtime_notification_delivery() 
     assert inspect.iscoroutinefunction(owner_relationship_router.request_relationship) is False
 
 
-def test_request_relationship_uses_current_token_user() -> None:
-    seen: list[tuple[str, str]] = []
+def test_request_relationship_uses_current_token_user_and_message() -> None:
+    seen: list[tuple[str, str, str | None]] = []
     relationship_service = SimpleNamespace(
-        request=lambda requester_id, target_id: (
-            seen.append((requester_id, target_id))
+        request=lambda requester_id, target_id, message=None: (
+            seen.append((requester_id, target_id, message))
             or _row(
                 initiator_user_id=requester_id,
                 user_low=requester_id,
                 user_high=target_id,
+                message=message,
             )
         )
     )
 
     result = owner_relationship_router.request_relationship(
-        owner_relationship_router.RelationshipRequestBody(target_user_id="requester-user-1"),
+        owner_relationship_router.RelationshipRequestBody(
+            target_user_id="requester-user-1",
+            message="I want to coordinate on the YATU group.",
+        ),
         user_id="owner-user-1",
         relationship_service=relationship_service,
     )
 
-    assert seen == [("owner-user-1", "requester-user-1")]
+    assert seen == [("owner-user-1", "requester-user-1", "I want to coordinate on the YATU group.")]
     assert result["other_user_id"] == "requester-user-1"
     assert result["is_requester"] is True
+    assert result["message"] == "I want to coordinate on the YATU group."
 
 
 def test_approve_relationship_uses_current_token_user() -> None:

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -16,6 +16,7 @@ def _relationship_row(
     user_low: str = "agent-user-1",
     user_high: str = "human-user-1",
     initiator_user_id: str = "human-user-1",
+    message: str | None = None,
 ) -> RelationshipRow:
     now = datetime(2026, 4, 26, tzinfo=UTC)
     return RelationshipRow(
@@ -25,6 +26,7 @@ def _relationship_row(
         kind="hire_visit",
         state="pending",
         initiator_user_id=initiator_user_id,
+        message=message,
         created_at=now,
         updated_at=now,
     )
@@ -75,7 +77,7 @@ async def test_relationship_request_notification_dispatches_thread_input_to_agen
         user_repo=user_repo,
     )
 
-    await asyncio.to_thread(notify, _relationship_row())
+    await asyncio.to_thread(notify, _relationship_row(message="Please add me to the planning chat."))
 
     assert gateway.envelope is not None
     assert gateway.envelope.thread_id == "thread-main"
@@ -84,6 +86,7 @@ async def test_relationship_request_notification_dispatches_thread_input_to_agen
     assert gateway.envelope.sender.display_name == "Human"
     assert gateway.envelope.sender.source == "relationship"
     assert "Human requested a relationship with you." in gateway.envelope.message.content
+    assert "Please add me to the planning chat." in gateway.envelope.message.content
     assert gateway.envelope.message.metadata == {"relationship_id": "hire_visit:agent-user-1:human-user-1"}
 
 

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -47,6 +47,7 @@ class _FakeRelationshipRepo:
                 "kind": "hire_visit",
                 "state": "hire",
                 "initiator_user_id": "human-user-1",
+                "message": None,
                 "created_at": "2026-04-07T00:00:00Z",
                 "updated_at": "2026-04-07T00:00:00Z",
             }
@@ -56,10 +57,20 @@ class _FakeRelationshipRepo:
         key = cast(tuple[str, str], tuple(sorted((requester_id, target_id))))
         return self._existing.get(key)
 
-    def upsert(self, requester_id: str, target_id: str, *, state: str, initiator_user_id: str | None):
+    def upsert(
+        self,
+        requester_id: str,
+        target_id: str,
+        *,
+        state: str,
+        initiator_user_id: str | None,
+        message: str | None = None,
+    ):
         key = cast(tuple[str, str], tuple(sorted((requester_id, target_id))))
         row = dict(self._existing[key])
         row.update({"state": state, "initiator_user_id": initiator_user_id})
+        if message is not None:
+            row["message"] = message
         row["updated_at"] = "2026-04-07T00:01:00Z"
         self._existing[key] = row
         return row

--- a/tests/Unit/messaging/test_relationship_tool_service.py
+++ b/tests/Unit/messaging/test_relationship_tool_service.py
@@ -14,6 +14,7 @@ def _row(
     user_high: str = "human-user-1",
     state: str = "pending",
     initiator_user_id: str | None = "human-user-1",
+    message: str | None = None,
 ):
     now = datetime(2026, 4, 26, tzinfo=UTC)
     return SimpleNamespace(
@@ -22,6 +23,7 @@ def _row(
         user_high=user_high,
         state=state,
         initiator_user_id=initiator_user_id,
+        message=message,
         created_at=now,
         updated_at=now,
     )
@@ -54,6 +56,34 @@ def test_list_relationships_renders_pending_direction_and_relationship_id() -> N
     assert "incoming pending request" in result
     assert "relationship_id: hire_visit:agent-user-1:human-user-1" in result
     assert "other_user_id: human-user-1" in result
+
+
+def test_request_relationship_tool_accepts_natural_language_message() -> None:
+    seen: list[tuple[str, str, str | None]] = []
+    registry = ToolRegistry()
+    RelationshipToolService(
+        registry=registry,
+        relationship_identity_id="agent-user-1",
+        relationship_service=SimpleNamespace(
+            request=lambda requester_id, target_user_id, message=None: (
+                seen.append((requester_id, target_user_id, message))
+                or _row(
+                    user_low=requester_id,
+                    user_high=target_user_id,
+                    initiator_user_id=requester_id,
+                    message=message,
+                )
+            )
+        ),
+    )
+
+    result = registry.get("request_relationship").handler(
+        "human-user-1",
+        "I want to join the planning group.",
+    )
+
+    assert seen == [("agent-user-1", "human-user-1", "I want to join the planning group.")]
+    assert "message: I want to join the planning group." in result
 
 
 def test_approve_relationship_uses_current_identity_and_request_initiator() -> None:

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -77,11 +77,13 @@ def test_supabase_contact_and_relationship_repos_use_chat_schema() -> None:
         "user-2",
         state="pending",
         initiator_user_id="user-1",
+        message="Please connect for the YATU run.",
     )
 
     assert tables["chat.contacts"][0]["source_user_id"] == "user-1"
     assert relationship["id"] == "hire_visit:user-1:user-2"
     assert tables["chat.relationships"][0]["initiator_user_id"] == "user-1"
+    assert tables["chat.relationships"][0]["message"] == "Please connect for the YATU run."
     assert "contacts" not in tables
     assert "relationships" not in tables
 


### PR DESCRIPTION
## Summary
- add an optional backend relationship request message field through schema, storage, service, public API, and managed-agent notification
- expose request messages in the managed-agent relationship tool output
- keep identity token-derived; SDK/CLI remain thin wrappers in the follow-up repo

## Verification
- uv run pytest tests/Integration/test_relationship_router.py tests/Unit/messaging/test_relationship_tool_service.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py -q
- uv run ruff format --check backend/chat/api/http/relationships_router.py backend/threads/chat_adapters/relationship_inlet.py messaging/contracts.py messaging/relationships/service.py messaging/tools/relationship_tool_service.py storage/contracts.py storage/providers/supabase/messaging_repo.py tests/Integration/test_relationship_router.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/messaging/test_relationship_tool_service.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
- uv run ruff check backend/chat/api/http/relationships_router.py backend/threads/chat_adapters/relationship_inlet.py messaging/contracts.py messaging/relationships/service.py messaging/tools/relationship_tool_service.py storage/contracts.py storage/providers/supabase/messaging_repo.py tests/Integration/test_relationship_router.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/messaging/test_relationship_tool_service.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
- real CLI YATU on http://127.0.0.1:8044: external Codex sent mycel relationship request --message to managed agent m_kTAo5RTFR7S9, managed agent approved to visit, then replied REQUEST-MESSAGE-YATU-005353 in direct chat

## Artifact
- /Users/lexicalmathical/share/yatu/relationship-request-message-20260426T005353Z