### PR TITLE
Reject non-Skill fields on Panel Skill routes

### DIFF
--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -301,6 +301,7 @@ async def create_resource(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
+    _reject_skill_request_fields(resource_type, req, {"desc", "features", "provider_name", "provider_type"})
     category = req.provider_type or ""
     try:
         return await asyncio.to_thread(

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -329,6 +329,7 @@ async def update_resource(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
+    _reject_skill_request_fields(resource_type, req, {"desc", "features"})
     try:
         item = await asyncio.to_thread(
             library_service.update_resource,

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -97,6 +97,14 @@ def _skill_repo_for(resource_type: str, request: Request) -> Any | None:
     return _skill_repo(request)
 
 
+def _reject_skill_request_fields(resource_type: str, req: Any, fields: set[str]) -> None:
+    if resource_type != "skill":
+        return
+    sent = sorted(fields.intersection(req.model_fields_set))
+    if sent:
+        raise HTTPException(400, f"Skill Library requests must not include {', '.join(sent)}")
+
+
 def _panel_contact_repo(request: Request) -> Any:
     try:
         return get_contact_repo(request.app)

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1040,7 +1040,7 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
     with TestClient(app) as client:
         created = client.post(
             "/api/panel/library/skill",
-            json={"name": "Loadable Skill", "desc": "Use this skill", "content": _editable_skill_md()},
+            json={"name": "Loadable Skill", "content": _editable_skill_md()},
         )
         assert created.status_code == 200
         created_id = created.json()["id"]

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1056,6 +1056,53 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
         assert content.json()["content"] == _editable_skill_md()
 
 
+def test_panel_library_skill_create_rejects_non_skill_fields() -> None:
+    app = FastAPI()
+    app.include_router(panel_router.router)
+    app.dependency_overrides[panel_router.get_current_user_id] = lambda: "owner-1"
+    app.state.runtime_storage_state = _runtime_storage_state(SimpleNamespace(), skill_repo=_MemorySkillRepo())
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/panel/library/skill",
+            json={
+                "name": "Loadable Skill",
+                "desc": "Use this skill",
+                "provider_name": "daytona",
+                "features": {"lark_cli": True},
+                "content": _editable_skill_md(),
+            },
+        )
+
+    assert created.status_code == 400
+    assert created.json()["detail"] == "Skill Library requests must not include desc, features, provider_name"
+
+
+def test_panel_library_skill_update_rejects_non_skill_fields() -> None:
+    app = FastAPI()
+    app.include_router(panel_router.router)
+    app.dependency_overrides[panel_router.get_current_user_id] = lambda: "owner-1"
+    skill_repo = _MemorySkillRepo()
+    skill = _put_skill(
+        skill_repo,
+        owner_user_id="owner-1",
+        skill_id="skill-1",
+        name="Loadable Skill",
+        description="Loadable",
+        content=_editable_skill_md(),
+    )
+    app.state.runtime_storage_state = _runtime_storage_state(SimpleNamespace(), skill_repo=skill_repo)
+
+    with TestClient(app) as client:
+        updated = client.put(
+            f"/api/panel/library/skill/{skill.id}",
+            json={"desc": "Separate desc", "features": {"lark_cli": True}},
+        )
+
+    assert updated.status_code == 400
+    assert updated.json()["detail"] == "Skill Library requests must not include desc, features"
+
+
 def test_library_skill_content_rejects_selected_package_for_another_skill() -> None:
     skill_repo = _MemorySkillRepo()
     skill = _put_skill(


### PR DESCRIPTION
## Summary
- create Skills from SKILL.md content without sending a separate desc field
- reject sandbox/template-only fields on Panel Skill create requests
- reject non-Skill fields on Panel Skill update requests before service dispatch

## Verification
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "library_skill or skill_routes or panel_library_skill or resource"
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright backend/web/routers/panel.py backend/web/models/panel.py