### PR TITLE
Reject direct Skill descriptions in Library service

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -73,6 +73,11 @@ def _skill_document_from_content(content: str, *, require_version: bool = False)
     return parse_skill_document(content, label="Skill content", require_description=True, require_version=require_version)
 
 
+def _reject_skill_description_argument(desc: str) -> None:
+    if desc != "":
+        raise ValueError("Skill description must be declared in SKILL.md frontmatter")
+
+
 def _now_dt() -> datetime:
     return datetime.now(UTC)
 

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -247,6 +247,7 @@ def create_resource(
     if resource_type == "skill":
         owner_user_id = _require_skill_owner(owner_user_id)
         skill_repo = _require_skill_repo(skill_repo)
+        _reject_skill_description_argument(desc)
         if not content or not content.strip():
             raise ValueError("Skill creation requires SKILL.md content")
         document = _skill_document_from_content(content, require_version=True)

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1318,6 +1318,23 @@ def test_library_skill_create_rejects_blank_separate_description() -> None:
     assert skill_repo.packages == {}
 
 
+def test_library_skill_create_rejects_newline_separate_description() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "\n",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content=_editable_skill_md(description="Frontmatter desc"),
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
+
+
 def test_library_skill_create_rejects_matching_separate_description() -> None:
     skill_repo = _MemorySkillRepo()
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1284,6 +1284,57 @@ def test_library_skill_description_comes_from_skill_md_frontmatter() -> None:
     assert stored.description == "Frontmatter desc"
 
 
+def test_library_skill_create_rejects_separate_description() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "Caller desc",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content=_editable_skill_md(description="Frontmatter desc"),
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
+
+
+def test_library_skill_create_rejects_blank_separate_description() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "   ",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content=_editable_skill_md(description="Frontmatter desc"),
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
+
+
+def test_library_skill_create_rejects_matching_separate_description() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "Frontmatter desc",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content=_editable_skill_md(description="Frontmatter desc"),
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
+
+
 def test_library_skill_content_update_refreshes_description_from_skill_md() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1139,7 +1139,7 @@ def test_library_skill_content_update_rejects_frontmatter_name_drift() -> None:
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Use this skill",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
@@ -1166,7 +1166,7 @@ def test_library_skill_create_requires_version_frontmatter() -> None:
         library_service.create_resource(
             "skill",
             "Loadable Skill",
-            "Use this skill",
+            "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
             content="---\nname: Loadable Skill\ndescription: Use this skill\n---\n\nUse this skill.",
@@ -1183,7 +1183,7 @@ def test_library_skill_create_requires_description_frontmatter() -> None:
         library_service.create_resource(
             "skill",
             "Loadable Skill",
-            "Use this skill",
+            "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
             content="---\nname: Loadable Skill\nversion: 1.0.0\n---\n\nUse this skill.",
@@ -1198,7 +1198,7 @@ def test_library_skill_content_update_requires_version_frontmatter() -> None:
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Use this skill",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
@@ -1223,7 +1223,7 @@ def test_library_skill_content_update_requires_description_frontmatter() -> None
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Use this skill",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
@@ -1248,7 +1248,7 @@ def test_library_skill_name_is_immutable_after_creation() -> None:
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Use this skill",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
@@ -1272,7 +1272,7 @@ def test_library_skill_description_comes_from_skill_md_frontmatter() -> None:
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Caller desc",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(description="Frontmatter desc"),
@@ -1289,7 +1289,7 @@ def test_library_skill_content_update_refreshes_description_from_skill_md() -> N
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Caller desc",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(description="Original desc"),
@@ -1313,7 +1313,7 @@ def test_library_skill_description_cannot_be_updated_without_skill_md() -> None:
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Caller desc",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(description="Frontmatter desc"),
@@ -1336,7 +1336,7 @@ def test_library_skill_create_rejects_duplicate_name_before_write() -> None:
     created = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Use this skill",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
@@ -1346,7 +1346,7 @@ def test_library_skill_create_rejects_duplicate_name_before_write() -> None:
         library_service.create_resource(
             "skill",
             "Loadable Skill",
-            "Duplicate name",
+            "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
             content=_editable_skill_md("Loadable Skill", "Duplicate name"),
@@ -1364,7 +1364,7 @@ def test_library_skill_create_does_not_derive_id_from_name() -> None:
     first = library_service.create_resource(
         "skill",
         "Loadable Skill",
-        "Use this skill",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
@@ -1372,7 +1372,7 @@ def test_library_skill_create_does_not_derive_id_from_name() -> None:
     second = library_service.create_resource(
         "skill",
         "Loadable-Skill",
-        "Different name",
+        "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md("Loadable-Skill", "Different name"),
@@ -1410,7 +1410,7 @@ def test_library_skill_create_fails_when_generated_id_exists(monkeypatch: pytest
         library_service.create_resource(
             "skill",
             "Loadable Skill",
-            "Use this skill",
+            "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
             content=_editable_skill_md(),


### PR DESCRIPTION
## Summary
- require direct Library Skill creates to leave the description argument empty
- keep Skill descriptions sourced from SKILL.md frontmatter only
- add regression tests for caller-supplied, blank, whitespace, and matching description arguments

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "separate_description or library_skill or skill_routes or panel_library_skill or resource"`
- `uv run pytest tests/Unit -q`
- `uv run ruff format --check . && uv run ruff check .`
- `uv run pyright backend/library/service.py`