### PR TITLE
Derive Skill package versions from SKILL.md

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -272,7 +272,6 @@ def apply_item(
             build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
-                version=source_version,
                 skill_md=content,
                 files=skill_files,
                 source=source,
@@ -281,7 +280,7 @@ def apply_item(
         )
         skill_repo.select_package(owner_user_id, skill.id, package.id)
 
-        return {"resource_id": skill.id, "package_id": package.id, "type": "skill", "version": source_version}
+        return {"resource_id": skill.id, "package_id": package.id, "type": "skill", "version": package.version}
 
     if item_type == "agent":
         raise ValueError("Marketplace agent items are not supported; apply Agent user items instead")

--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -97,7 +97,6 @@ def _materialize_snapshot_skills(
             build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
-                version=snapshot_skill.version,
                 skill_md=snapshot_skill.content,
                 files=snapshot_skill.files,
                 source=source,

--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -102,14 +102,12 @@ def _write_skill_package(
     files: dict[str, str],
     skill_repo: SkillRepo,
     *,
-    version: str,
     source: dict[str, Any] | None = None,
 ) -> SkillPackage:
     package = skill_repo.create_package(
         build_skill_package(
             owner_user_id=owner_user_id,
             skill_id=skill.id,
-            version=version,
             skill_md=content,
             files=files,
             source=source or {},
@@ -253,8 +251,6 @@ def create_resource(
         document = _skill_document_from_content(content, require_version=True)
         if document.name != name:
             raise ValueError("Skill content frontmatter name must match Skill name")
-        if document.version is None:
-            raise RuntimeError("Skill content version was not parsed")
         for skill in skill_repo.list_for_owner(owner_user_id):
             if skill.name == name:
                 raise ValueError("Skill name already exists")
@@ -273,7 +269,7 @@ def create_resource(
                 updated_at=timestamp,
             )
         )
-        _write_skill_package(owner_user_id, skill, content, {}, skill_repo, version=document.version)
+        _write_skill_package(owner_user_id, skill, content, {}, skill_repo)
         return _library_resource_item(
             "skill",
             skill.id,
@@ -490,11 +486,9 @@ def update_resource_content(
         document = _skill_document_from_content(content, require_version=True)
         if document.name != current.name:
             raise ValueError("Skill content frontmatter name must match Skill name")
-        if document.version is None:
-            raise RuntimeError("Skill content version was not parsed")
         current_package = _selected_skill_package(owner_user_id, current, skill_repo)
         files = current_package.files if current_package is not None else {}
         updated = skill_repo.upsert(current.model_copy(update={"description": document.description, "updated_at": _now_dt()}))
-        _write_skill_package(owner_user_id, updated, content, files, skill_repo, version=document.version)
+        _write_skill_package(owner_user_id, updated, content, files, skill_repo)
         return True
     return False

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -56,6 +56,7 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
         package.skill_md,
         label=f"Skill {skill.skill_id!r} on Agent config",
         require_description=True,
+        require_version=True,
     )
     resolved = ResolvedSkill(
         id=skill.skill_id,
@@ -70,7 +71,14 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
 
 
 def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
-    document = parse_skill_document(skill.content, label=f"Skill {skill.name!r} on Agent config", require_description=True)
+    document = parse_skill_document(
+        skill.content,
+        label=f"Skill {skill.name!r} on Agent config",
+        require_description=True,
+        require_version=True,
+    )
     if document.name != skill.name:
         raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter name must match ResolvedSkill.name")
+    if document.version != skill.version:
+        raise ValueError("ResolvedSkill.version must match SKILL.md frontmatter version")
     return skill.model_copy(update={"description": document.description})

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from config.skill_document import parse_skill_document
 from config.skill_files import normalize_skill_file_map
@@ -56,16 +56,17 @@ class SkillPackage(AgentConfigSchemaModel):
             raise ValueError(f"skill_package.{info.field_name} must not be blank")
         return value
 
-    @field_validator("skill_md")
-    @classmethod
-    def _valid_skill_document(cls, value: str) -> str:
-        parse_skill_document(value, label="skill_package.skill_md", require_description=True)
-        return value
-
     @field_validator("files", mode="before")
     @classmethod
     def _normalize_files(cls, value: Any) -> Any:
         return normalize_skill_file_map(value, context="Skill package files") if isinstance(value, dict) else value
+
+    @model_validator(mode="after")
+    def _version_matches_skill_document(self) -> SkillPackage:
+        document = parse_skill_document(self.skill_md, label="skill_package.skill_md", require_description=True, require_version=True)
+        if document.version != self.version:
+            raise ValueError("skill_package.version must match SKILL.md frontmatter version")
+        return self
 
 
 class AgentSkill(AgentConfigSchemaModel):

--- a/config/skill_package.py
+++ b/config/skill_package.py
@@ -3,27 +3,28 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from config.agent_config_types import SkillPackage
+from config.skill_document import parse_skill_document
 
 
 def build_skill_package(
     *,
     owner_user_id: str,
     skill_id: str,
-    version: str,
     skill_md: str,
     files: dict[str, str],
     source: dict[str, Any],
     created_at: datetime,
 ) -> SkillPackage:
+    document = parse_skill_document(skill_md, label="SKILL.md", require_description=True, require_version=True)
     package_hash = build_skill_package_hash(skill_md, files)
     return SkillPackage(
         id=package_hash.removeprefix("sha256:"),
         owner_user_id=owner_user_id,
         skill_id=skill_id,
-        version=version,
+        version=cast(str, document.version),
         hash=package_hash,
         manifest=build_skill_package_manifest(skill_md, files),
         skill_md=skill_md,

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -23,9 +23,11 @@ class SkillsService:
         for skill in skills:
             if not isinstance(skill, ResolvedSkill):
                 raise TypeError("SkillsService requires ResolvedSkill items")
-            document = parse_skill_document(skill.content, label="Skill content", require_description=True)
+            document = parse_skill_document(skill.content, label="Skill content", require_description=True, require_version=True)
             if document.name != skill.name:
                 raise ValueError("Skill frontmatter name must match ResolvedSkill.name")
+            if document.version != skill.version:
+                raise ValueError("Skill frontmatter version must match ResolvedSkill.version")
             self._skill_bodies[skill.name] = document.body
             self._skill_descriptions[skill.name] = document.description
             self._skill_files[skill.name] = skill.files

--- a/scripts/import_file_skills_to_library.py
+++ b/scripts/import_file_skills_to_library.py
@@ -53,8 +53,6 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
         skill_id = existing.id if existing is not None else generate_skill_id()
         if existing is None and repo.get_by_id(owner_user_id, skill_id) is not None:
             raise RuntimeError("Generated Skill id already exists")
-        if document.version is None:
-            raise RuntimeError("SKILL.md version was not parsed")
         files = _read_files(skill_dir)
         skill = repo.upsert(
             Skill(
@@ -71,7 +69,6 @@ def import_skills(owner_user_id: str, library_dir: Path) -> int:
             build_skill_package(
                 owner_user_id=owner_user_id,
                 skill_id=skill.id,
-                version=document.version,
                 skill_md=content,
                 files=files,
                 source=dict(FILE_IMPORT_SOURCE),

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -4,13 +4,14 @@ from typing import Any
 
 import pytest
 
-from config.agent_config_resolver import resolve_agent_config
+from config.agent_config_resolver import resolve_agent_config, validate_resolved_skill_content
 from config.agent_config_types import (
     AgentConfig,
     AgentRule,
     AgentSkill,
     AgentSubAgent,
     McpServerConfig,
+    ResolvedSkill,
     SkillPackage,
 )
 
@@ -27,12 +28,30 @@ def _skill_md(name: str = "github") -> str:
     return f"""---
 name: {name}
 description: Use gh.
+version: 1.0.0
 ---
 
 # GitHub
 
 Use gh with explicit repositories.
 """
+
+
+def _resolved_skill(*, version: str = "1.0.0", content_version: str = "1.0.0") -> ResolvedSkill:
+    return ResolvedSkill(
+        id="github",
+        name="github",
+        description="Use gh.",
+        version=version,
+        content=f"""---
+name: github
+description: Use gh.
+version: {content_version}
+---
+
+# GitHub
+""",
+    )
 
 
 class _SkillRepo:
@@ -116,6 +135,20 @@ def test_resolver_names_skill_working_set_as_resolved_skills() -> None:
 
     assert "enabled_skills" not in source
     assert "resolved_skills" in source
+
+
+def test_resolved_skill_content_requires_version_frontmatter() -> None:
+    skill = _resolved_skill(
+        content_version="1.0.0",
+    ).model_copy(update={"content": "---\nname: github\ndescription: Use gh.\n---\n# GitHub\n"})
+
+    with pytest.raises(ValueError, match="Skill 'github' on Agent config frontmatter must include version"):
+        validate_resolved_skill_content(skill)
+
+
+def test_resolved_skill_version_matches_skill_md_frontmatter() -> None:
+    with pytest.raises(ValueError, match="ResolvedSkill.version must match SKILL.md frontmatter version"):
+        validate_resolved_skill_content(_resolved_skill(version="2.0.0", content_version="1.0.0"))
 
 
 def test_resolver_keeps_skill_id_separate_from_display_name() -> None:
@@ -278,7 +311,7 @@ def test_resolver_rejects_package_that_does_not_belong_to_selected_skill():
                         skill_id="other-skill",
                         version="1.0.0",
                         hash="sha256:visible",
-                        skill_md="---\nname: Runtime Skill\ndescription: Runtime guidance\n---\n\n# Runtime Skill\n",
+                        skill_md="---\nname: Runtime Skill\ndescription: Runtime guidance\nversion: 1.0.0\n---\n\n# Runtime Skill\n",
                         created_at=datetime(2026, 4, 25, tzinfo=UTC),
                     )
                 }

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -238,7 +238,7 @@ def test_skill_package_requires_package_identity_and_skill_md() -> None:
         version="1.0.0",
         hash="sha256:abc",
         manifest={"files": [{"path": "references/query.md", "sha256": "def"}]},
-        skill_md="---\nname: query-helper\ndescription: Build precise queries\n---\nUse exact terms.",
+        skill_md="---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
         files={"references\\query.md": "Prefer precise queries."},
         created_at=datetime(2026, 4, 25, tzinfo=UTC),
     )
@@ -271,7 +271,7 @@ def test_skill_package_requires_skill_md_description() -> None:
             version="1.0.0",
             hash="sha256:abc",
             manifest={},
-            skill_md="---\nname: query-helper\n---\nUse exact terms.",
+            skill_md="---\nname: query-helper\nversion: 1.0.0\n---\nUse exact terms.",
             created_at=datetime(2026, 4, 25, tzinfo=UTC),
         )
 

--- a/tests/Unit/config/test_agent_snapshot.py
+++ b/tests/Unit/config/test_agent_snapshot.py
@@ -30,7 +30,7 @@ def test_snapshot_contains_resolved_agent_config_only():
                     skill_id="github",
                     version="1.0.0",
                     hash="sha256:github",
-                    skill_md="---\nname: github\ndescription: Query GitHub precisely\n---\n\n# GitHub\n",
+                    skill_md="---\nname: github\ndescription: Query GitHub precisely\nversion: 1.0.0\n---\n\n# GitHub\n",
                     files={"references/query.md": "Prefer precise queries."},
                     created_at=datetime.fromisoformat("2026-04-25T00:00:00+00:00"),
                 )
@@ -75,7 +75,7 @@ def test_snapshot_preserves_skill_id_when_name_changes():
                     skill_id="github-core",
                     version="1.0.0",
                     hash="sha256:github-core",
-                    skill_md="---\nname: GitHub\ndescription: Query GitHub precisely\n---\n\n# GitHub\n",
+                    skill_md="---\nname: GitHub\ndescription: Query GitHub precisely\nversion: 1.0.0\n---\n\n# GitHub\n",
                     created_at=datetime.fromisoformat("2026-04-25T00:00:00+00:00"),
                 )
             },

--- a/tests/Unit/config/test_skill_package.py
+++ b/tests/Unit/config/test_skill_package.py
@@ -1,17 +1,20 @@
+import inspect
 from datetime import UTC, datetime
 
+import pytest
+
+from config.agent_config_types import SkillPackage
 from config.skill_package import build_skill_package, build_skill_package_hash, build_skill_package_manifest
 
 
 def test_build_skill_package_uses_content_hash_as_identity() -> None:
     created_at = datetime(2026, 4, 26, tzinfo=UTC)
-    skill_md = "---\nname: Query Helper\ndescription: Build precise queries\n---\nUse exact terms."
+    skill_md = "---\nname: Query Helper\ndescription: Build precise queries\nversion: 1.2.3\n---\nUse exact terms."
     files = {"references/query.md": "Prefer precise queries."}
 
     package = build_skill_package(
         owner_user_id="owner-1",
         skill_id="skill-1",
-        version="1.0.0",
         skill_md=skill_md,
         files=files,
         source={"kind": "test"},
@@ -24,8 +27,38 @@ def test_build_skill_package_uses_content_hash_as_identity() -> None:
     assert package.manifest == build_skill_package_manifest(skill_md, files)
     assert package.owner_user_id == "owner-1"
     assert package.skill_id == "skill-1"
-    assert package.version == "1.0.0"
+    assert package.version == "1.2.3"
     assert package.skill_md == skill_md
     assert package.files == files
     assert package.source == {"kind": "test"}
     assert package.created_at == created_at
+
+
+def test_build_skill_package_has_no_external_version_argument() -> None:
+    assert "version" not in inspect.signature(build_skill_package).parameters
+
+
+def test_skill_package_requires_skill_md_version_frontmatter() -> None:
+    with pytest.raises(ValueError, match="skill_package.skill_md frontmatter must include version"):
+        SkillPackage(
+            id="package-1",
+            owner_user_id="owner-1",
+            skill_id="skill-1",
+            version="1.0.0",
+            hash="sha256:package-1",
+            skill_md="---\nname: Query Helper\ndescription: Build precise queries\n---\nUse exact terms.",
+            created_at=datetime(2026, 4, 26, tzinfo=UTC),
+        )
+
+
+def test_skill_package_version_matches_skill_md_frontmatter() -> None:
+    with pytest.raises(ValueError, match="skill_package.version must match SKILL.md frontmatter version"):
+        SkillPackage(
+            id="package-1",
+            owner_user_id="owner-1",
+            skill_id="skill-1",
+            version="2.0.0",
+            hash="sha256:package-1",
+            skill_md=("---\nname: Query Helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms."),
+            created_at=datetime(2026, 4, 26, tzinfo=UTC),
+        )

--- a/tests/Unit/core/test_agent_pool.py
+++ b/tests/Unit/core/test_agent_pool.py
@@ -595,7 +595,7 @@ async def test_get_or_create_agent_resolves_skill_packages_before_runtime_startu
                 skill_id="fastapi",
                 version="1.0.0",
                 hash="sha256:fastapi",
-                skill_md="---\nname: FastAPI\ndescription: Build FastAPI routes\n---\nUse APIRouter.",
+                skill_md="---\nname: FastAPI\ndescription: Build FastAPI routes\nversion: 1.0.0\n---\nUse APIRouter.",
                 created_at=datetime.fromisoformat("2026-04-26T00:00:00+00:00"),
             )
 

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -10,7 +10,7 @@ from core.tools.skills.service import SkillsService
 
 def _skill(
     name: str = "query-helper",
-    content: str = "---\nname: query-helper\ndescription: Build precise search queries\n---\nUse exact terms.",
+    content: str = "---\nname: query-helper\ndescription: Build precise search queries\nversion: 1.0.0\n---\nUse exact terms.",
     files: dict[str, str] | None = None,
 ) -> ResolvedSkill:
     return ResolvedSkill(
@@ -46,7 +46,7 @@ def test_skill_frontmatter_uses_yaml_parser() -> None:
     SkillsService(
         registry=registry,
         skills=[
-            _skill(content='---\nname: "query-helper"\ndescription: Build precise search queries\n---\nUse exact terms.'),
+            _skill(content='---\nname: "query-helper"\ndescription: Build precise search queries\nversion: 1.0.0\n---\nUse exact terms.'),
         ],
     )
 
@@ -94,6 +94,18 @@ def test_skill_without_frontmatter_description_fails_loudly() -> None:
         )
 
 
+def test_skill_version_must_match_resolved_skill_version() -> None:
+    registry = ToolRegistry()
+
+    with pytest.raises(ValueError, match="Skill frontmatter version must match ResolvedSkill.version"):
+        SkillsService(
+            registry=registry,
+            skills=[
+                _skill(content="---\nname: query-helper\ndescription: Build precise search queries\nversion: 2.0.0\n---\nUse exact terms."),
+            ],
+        )
+
+
 def test_load_skill_schema_lists_skill_descriptions() -> None:
     registry = ToolRegistry()
     SkillsService(
@@ -122,7 +134,7 @@ def test_skills_service_requires_resolved_skill_items() -> None:
                     Any,
                     {
                         "name": "query-helper",
-                        "content": "---\nname: query-helper\ndescription: Build precise search queries\n---\nUse exact terms.",
+                        "content": "---\nname: query-helper\ndescription: Build precise search queries\nversion: 1.0.0\n---\nUse exact terms.",
                     },
                 )
             ],
@@ -137,7 +149,8 @@ def test_skill_frontmatter_name_must_match_resolved_skill_name() -> None:
             registry=registry,
             skills=[
                 _skill(
-                    name="query-helper", content="---\nname: other-helper\ndescription: Build precise search queries\n---\nUse exact terms."
+                    name="query-helper",
+                    content="---\nname: other-helper\ndescription: Build precise search queries\nversion: 1.0.0\n---\nUse exact terms.",
                 ),
             ],
         )

--- a/tests/Unit/integration_contracts/test_leon_agent.py
+++ b/tests/Unit/integration_contracts/test_leon_agent.py
@@ -78,7 +78,7 @@ class _SkillRepo:
             skill_id="fastapi",
             version="1.0.0",
             hash="sha256:fastapi",
-            skill_md="---\nname: FastAPI\ndescription: Build FastAPI services\n---\nAlways use APIRouter.",
+            skill_md="---\nname: FastAPI\ndescription: Build FastAPI services\nversion: 1.0.0\n---\nAlways use APIRouter.",
             files=self.files,
             created_at=datetime.fromisoformat("2026-04-25T00:00:00+00:00"),
         )
@@ -88,7 +88,7 @@ def _write_file_skill_dir(tmp_path, *, name: str, body: str, description: str = 
     skill_dir = tmp_path / "file-skills" / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {name}\ndescription: {description}\n---\n{body}",
+        f"---\nname: {name}\ndescription: {description}\nversion: 1.0.0\n---\n{body}",
         encoding="utf-8",
     )
 

--- a/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_marketplace_router_user_shell.py
@@ -148,7 +148,7 @@ def test_skill_marketplace_to_agent_library_delete_backend_api_yatu(monkeypatch:
             },
             "version": "1.0.0",
             "snapshot": {
-                "content": f"---\nname: {row['name']}\ndescription: {row['description']}\n---\n{row['body']}",
+                "content": f"---\nname: {row['name']}\ndescription: {row['description']}\nversion: 1.0.0\n---\n{row['body']}",
                 "meta": {"desc": row["description"]},
                 "files": {"references/routing.md": row["body"]},
             },
@@ -393,7 +393,7 @@ async def test_apply_member_snapshot_materializes_skill_through_router(monkeypat
                             "name": "Snapshot Skill",
                             "description": "skill desc",
                             "version": "1.2.3",
-                            "content": "---\nname: Snapshot Skill\ndescription: skill desc\n---\nbody",
+                            "content": "---\nname: Snapshot Skill\ndescription: skill desc\nversion: 1.2.3\n---\nbody",
                             "files": {"references/routing.md": "route narrowly"},
                         }
                     ],

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -93,6 +93,8 @@ def _put_skill(
     files: dict[str, str] | None = None,
     version: str = "1.0.0",
 ) -> Skill:
+    if "\nversion:" not in content and "\ndescription:" in content:
+        content = content.replace("\n---", f"\nversion: {version}\n---", 1)
     timestamp = datetime(2026, 4, 24, tzinfo=UTC)
     skill = skill_repo.upsert(
         Skill(
@@ -998,7 +1000,7 @@ def test_select_agent_skill_rejects_package_for_another_skill() -> None:
         skill_id="other-skill",
         version="1.0.0",
         hash="sha256:wrong",
-        skill_md="---\nname: Other Skill\ndescription: Other\n---\nUse it.",
+        skill_md="---\nname: Other Skill\ndescription: Other\nversion: 1.0.0\n---\nUse it.",
         created_at=datetime(2026, 4, 24, tzinfo=UTC),
     )
     skill_repo.create_package(wrong_package)
@@ -1119,7 +1121,7 @@ def test_library_skill_content_rejects_selected_package_for_another_skill() -> N
         skill_id="other-skill",
         version="1.0.0",
         hash="sha256:wrong",
-        skill_md="---\nname: Other Skill\ndescription: Other\n---\nUse it.",
+        skill_md="---\nname: Other Skill\ndescription: Other\nversion: 1.0.0\n---\nUse it.",
         created_at=datetime(2026, 4, 24, tzinfo=UTC),
     )
     skill_repo.create_package(wrong_package)
@@ -2329,7 +2331,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
                         "id": "search-core",
                         "name": "Search",
                         "version": "1.0.0",
-                        "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         "description": "Search repos",
                         "source": {"source_version": "snapshot-stale", "extra": "drop"},
                     }
@@ -2355,7 +2357,7 @@ def test_apply_snapshot_saves_one_agent_config_aggregate():
     assert skill_repo.get_by_id("user-1", "search-core") is None
     package = skill_repo.get_package("user-1", saved_configs[0].skills[0].package_id or "")
     assert package is not None
-    assert package.skill_md == "---\nname: Search\ndescription: Search repos\n---\nbody"
+    assert package.skill_md == "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody"
     assert package.source == {
         "marketplace_item_id": "item-1",
         "snapshot_skill_id": "search-core",
@@ -2386,7 +2388,7 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
                             "id": "search",
                             "name": "Search",
                             "version": "1.0.0",
-                            "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                            "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         }
                     ],
                 },
@@ -2415,7 +2417,7 @@ def test_apply_snapshot_skill_requires_frontmatter_description() -> None:
                             "name": "Search",
                             "version": "1.0.0",
                             "description": "Snapshot desc",
-                            "content": "---\nname: Search\n---\nbody",
+                            "content": "---\nname: Search\nversion: 1.0.0\n---\nbody",
                         }
                     ],
                 },
@@ -2452,7 +2454,7 @@ def test_apply_snapshot_requires_source_identity(field: str, value: object, mess
                         "id": "search",
                         "name": "Search",
                         "version": "1.0.0",
-                        "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                     }
                 ],
             },
@@ -2523,13 +2525,13 @@ def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
                             "id": "search",
                             "name": "Search One",
                             "version": "1.0.0",
-                            "content": "---\nname: Search One\ndescription: Search one\n---\none",
+                            "content": "---\nname: Search One\ndescription: Search one\nversion: 1.0.0\n---\none",
                         },
                         {
                             "id": "search",
                             "name": "Search Two",
                             "version": "1.0.0",
-                            "content": "---\nname: Search Two\ndescription: Search two\n---\ntwo",
+                            "content": "---\nname: Search Two\ndescription: Search two\nversion: 1.0.0\n---\ntwo",
                         },
                     ],
                 },
@@ -2563,7 +2565,7 @@ def test_apply_snapshot_treats_snapshot_skill_id_as_source_metadata(monkeypatch:
                         "id": "nested/search",
                         "name": "Search",
                         "version": "1.0.0",
-                        "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                        "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                     }
                 ],
             },
@@ -2617,7 +2619,7 @@ def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: py
                         "id": "search-core",
                         "name": "Search",
                         "version": "1.0.1",
-                        "content": "---\nname: Search\ndescription: Search repos\n---\nnew",
+                        "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.1\n---\nnew",
                     }
                 ],
             },
@@ -2663,7 +2665,7 @@ def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest
                             "id": "search-core",
                             "name": "Search",
                             "version": "1.0.0",
-                            "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                            "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         }
                     ],
                 },
@@ -2703,7 +2705,7 @@ def test_apply_snapshot_rejects_existing_same_name_without_snapshot_source(monke
                             "id": "search-core",
                             "name": "Search",
                             "version": "1.0.0",
-                            "content": "---\nname: Search\ndescription: Search repos\n---\nbody",
+                            "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         }
                     ],
                 },
@@ -2734,13 +2736,13 @@ def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
                             "id": "search-one",
                             "name": "Search",
                             "version": "1.0.0",
-                            "content": "---\nname: Search\ndescription: Search repos\n---\none",
+                            "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\none",
                         },
                         {
                             "id": "search-two",
                             "name": "Search",
                             "version": "1.0.0",
-                            "content": "---\nname: Search\ndescription: Search repos\n---\ntwo",
+                            "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\ntwo",
                         },
                     ],
                 },

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -75,8 +75,16 @@ def test_hub_api_preserves_hub_bad_request_detail(monkeypatch):
 # ── Helpers ──
 
 
+def _skill_content_with_version(content: str, version: str) -> str:
+    if "\nversion:" in content or "\ndescription:" not in content:
+        return content
+    return content.replace("\n---", f"\nversion: {version}\n---", 1)
+
+
 def _make_hub_response(item_type: str, slug: str, content: str = "# Hello", version: str = "1.0.0", publisher: str = "tester") -> dict:
     """Build a fake Hub /download response."""
+    if item_type == "skill":
+        content = _skill_content_with_version(content, version)
     return {
         "item": {
             "name": slug.replace("-", " ").title(),
@@ -146,7 +154,7 @@ class TestApplySkill:
         assert saved[0].name == "My Skill"
         assert not hasattr(saved[0], "content")
         assert packages[0].skill_id == "skill_generated123"
-        assert packages[0].skill_md == "---\nname: My Skill\ndescription: My Skill desc\n---\n# My Skill\nDo stuff"
+        assert packages[0].skill_md == "---\nname: My Skill\ndescription: My Skill desc\nversion: 1.0.0\n---\n# My Skill\nDo stuff"
         assert packages[0].manifest["files"][0]["path"] == "references/usage.md"
         assert selected == [("owner-1", "skill_generated123", packages[0].id)]
         assert result["package_id"] == packages[0].id
@@ -509,7 +517,7 @@ class TestApplySkill:
         }
         assert saved_skills[0].name == "FastAPI"
         assert saved_skills[0].description == "Build FastAPI APIs"
-        assert packages[0].skill_md == "---\nname: FastAPI\ndescription: Build FastAPI APIs\n---\nAlways use APIRouter."
+        assert packages[0].skill_md == "---\nname: FastAPI\ndescription: Build FastAPI APIs\nversion: 1.2.3\n---\nAlways use APIRouter."
         assert packages[0].manifest["files"][0]["path"] == "references/routing.md"
         assert selected == [("owner-1", saved_skills[0].id, packages[0].id)]
         assert saved == []
@@ -732,8 +740,8 @@ class TestApplyIdempotency:
         assert result["package_id"] == packages[1].id
         assert list(saved) == ["skill_idem123"]
         assert saved["skill_idem123"].source["source_version"] == "1.0.1"
-        assert packages[0].skill_md == "---\nname: Idem Skill\ndescription: Idempotent\n---\nV1"
-        assert packages[1].skill_md == "---\nname: Idem Skill\ndescription: Idempotent\n---\nV2"
+        assert packages[0].skill_md == "---\nname: Idem Skill\ndescription: Idempotent\nversion: 1.0.0\n---\nV1"
+        assert packages[1].skill_md == "---\nname: Idem Skill\ndescription: Idempotent\nversion: 1.0.1\n---\nV2"
         assert selected[-1] == ("owner-1", "skill_idem123", packages[1].id)
 
 
@@ -849,7 +857,7 @@ def test_publish_uses_repo_material_when_member_dir_is_absent(tmp_path, monkeypa
                 skill_id="search",
                 version="1.0.0",
                 hash="sha256:search",
-                skill_md="---\nname: Search\ndescription: Search repos\n---\nskill content",
+                skill_md="---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nskill content",
                 source={"name": "Search", "desc": "Repo Search"},
                 created_at=datetime(2026, 4, 25, tzinfo=UTC),
             )

--- a/tests/Unit/storage/test_supabase_skill_repo.py
+++ b/tests/Unit/storage/test_supabase_skill_repo.py
@@ -81,7 +81,7 @@ def _row(skill_id: str = "skill-1") -> dict:
         "name": "github",
         "description": "GitHub guidance",
         "version": "1.0.0",
-        "content": "---\nname: github\ndescription: GitHub guidance\n---\n",
+        "content": "---\nname: github\ndescription: GitHub guidance\nversion: 1.0.0\n---\n",
         "files_json": {"references/query.md": "Prefer precise queries."},
         "source_json": {"source_version": "1.0.0"},
         "created_at": "2026-04-24T00:00:00+00:00",
@@ -97,7 +97,7 @@ def _package_row(package_id: str = "package-1") -> dict:
         "version": "1.0.0",
         "hash": "sha256:abc",
         "manifest_json": {"files": [{"path": "references/query.md", "sha256": "def"}]},
-        "skill_md": "---\nname: github\ndescription: GitHub guidance\n---\n",
+        "skill_md": "---\nname: github\ndescription: GitHub guidance\nversion: 1.0.0\n---\n",
         "files_json": {"references/query.md": "Prefer precise queries."},
         "source_json": {"source_version": "1.0.0"},
         "created_at": "2026-04-24T00:00:00+00:00",
@@ -199,7 +199,7 @@ def test_create_package_writes_immutable_skill_package() -> None:
             version="1.0.0",
             hash="sha256:abc",
             manifest={"files": [{"path": "references/query.md", "sha256": "def"}]},
-            skill_md="---\nname: github\ndescription: GitHub guidance\n---\n",
+            skill_md="---\nname: github\ndescription: GitHub guidance\nversion: 1.0.0\n---\n",
             files={"references/query.md": "Prefer precise queries."},
             source={"source_version": "1.0.0"},
             created_at=timestamp,
@@ -208,7 +208,7 @@ def test_create_package_writes_immutable_skill_package() -> None:
 
     payload = client.table_queries["library.skill_packages"][0].upsert_payload
     assert payload is not None
-    assert payload["skill_md"] == "---\nname: github\ndescription: GitHub guidance\n---\n"
+    assert payload["skill_md"] == "---\nname: github\ndescription: GitHub guidance\nversion: 1.0.0\n---\n"
     assert payload["files_json"] == {"references/query.md": "Prefer precise queries."}
     assert payload["manifest_json"] == {"files": [{"path": "references/query.md", "sha256": "def"}]}
     assert payload["source_json"] == {"source_version": "1.0.0"}


### PR DESCRIPTION
## Summary
- remove external version input from Skill package construction
- require SkillPackage and ResolvedSkill versions to match SKILL.md frontmatter
- update Hub, snapshot, Library, and file import paths to package Skill content from the document itself

## Verification
- `uv run pytest tests/Unit/config/test_skill_package.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/core/test_skills_service.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "skill or package or snapshot or version"`
- `uv run pytest tests/Unit -q`
- `uv run ruff format --check . && uv run ruff check .`
- `uv run pyright config/agent_config_resolver.py core/tools/skills/service.py config/agent_config_types.py config/skill_package.py backend/library/service.py backend/hub/client.py backend/hub/snapshot_apply.py scripts/import_file_skills_to_library.py`