### PR TITLE
Notify requester on chat join rejection

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.chat_inlet import make_chat_delivery_fn
+from backend.threads.chat_adapters.chat_join_inlet import make_chat_join_rejection_notification_fn
 from backend.threads.chat_adapters.relationship_inlet import make_relationship_request_notification_fn
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.join_requests import ChatJoinRequestService
@@ -107,6 +108,24 @@ def wire_relationship_request_notifications(
 ) -> None:
     relationship_service.set_relationship_request_notification_fn(
         make_relationship_request_notification_fn(
+            app,
+            activity_reader=activity_reader,
+            thread_repo=thread_repo,
+            user_repo=user_repo,
+        )
+    )
+
+
+def wire_chat_join_request_notifications(
+    app: Any,
+    *,
+    chat_join_request_service: Any,
+    activity_reader: Any,
+    thread_repo: Any,
+    user_repo: Any,
+) -> None:
+    chat_join_request_service.set_join_request_rejected_notification_fn(
+        make_chat_join_rejection_notification_fn(
             app,
             activity_reader=activity_reader,
             thread_repo=thread_repo,

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from enum import Enum
+from typing import Any
+
+from backend.identity.avatar.urls import avatar_url
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
+from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+
+
+def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
+    if activity_reader is None:
+        raise RuntimeError("Agent runtime thread activity reader is not configured")
+    loop = asyncio.get_running_loop()
+
+    async def notify_runtime(row: dict[str, Any]) -> None:
+        requester_id = _required_str(row, "requester_user_id")
+        decider_id = _required_str(row, "decided_by_user_id")
+        chat_id = _required_str(row, "chat_id")
+        requester = _require_user(user_repo, requester_id, "requester")
+        decider = _require_user(user_repo, decider_id, "decider")
+        if _user_type(requester, requester_id) != "agent":
+            return
+
+        thread_id = select_runtime_thread_for_recipient(
+            requester_id,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if thread_id is None:
+            raise RuntimeError(f"Chat join request requester agent has no runtime thread: {requester_id}")
+
+        await get_agent_runtime_gateway(app).dispatch_thread_input(
+            AgentThreadInputEnvelope(
+                thread_id=thread_id,
+                sender=AgentRuntimeActor(
+                    user_id=decider_id,
+                    user_type=_user_type(decider, decider_id),
+                    display_name=_display_name(decider, decider_id),
+                    avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                    source="chat_join",
+                ),
+                message=AgentRuntimeMessage(
+                    content=f"{_display_name(decider, decider_id)} rejected your request to join chat {chat_id}.",
+                    metadata={
+                        "chat_join_request_id": _required_str(row, "id"),
+                        "chat_id": chat_id,
+                        "state": "rejected",
+                    },
+                ),
+            )
+        )
+
+    def _notify(row: dict[str, Any]) -> None:
+        future = asyncio.run_coroutine_threadsafe(notify_runtime(row), loop)
+        future.result()
+
+    return _notify
+
+
+def _required_str(row: dict[str, Any], key: str) -> str:
+    value = row.get(key)
+    if not value:
+        raise RuntimeError(f"Chat join rejection row is missing {key}: {row.get('id') or '<missing>'}")
+    return str(value)
+
+
+def _require_user(user_repo: Any, user_id: str, role: str) -> Any:
+    user = user_repo.get_by_id(user_id)
+    if user is None:
+        raise RuntimeError(f"Chat join rejection {role} user not found: {user_id}")
+    return user
+
+
+def _user_type(user: Any, user_id: str) -> str:
+    raw_type = getattr(user, "type", None)
+    if raw_type is None:
+        raise RuntimeError(f"Chat join rejection user is missing type: {user_id}")
+    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
+
+
+def _display_name(user: Any, user_id: str) -> str:
+    display_name = getattr(user, "display_name", None)
+    if display_name is None:
+        raise RuntimeError(f"Chat join rejection user is missing display name: {user_id}")
+    return str(display_name)

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -57,7 +57,12 @@ async def lifespan(app: FastAPI):
     app.state.sandbox_runtime_repo = storage_container.sandbox_runtime_repo()
     app.state.workspace_repo = storage_container.workspace_repo()
     app.state.sandbox_repo = storage_container.sandbox_repo()
-    from backend.chat.bootstrap import attach_chat_runtime, wire_chat_delivery, wire_relationship_request_notifications
+    from backend.chat.bootstrap import (
+        attach_chat_runtime,
+        wire_chat_delivery,
+        wire_chat_join_request_notifications,
+        wire_relationship_request_notifications,
+    )
     from backend.threads.bootstrap import attach_threads_runtime
 
     # @@@web-chat-before-threads - threads bootstrap now constructs the agent
@@ -90,6 +95,13 @@ async def lifespan(app: FastAPI):
     wire_relationship_request_notifications(
         app,
         relationship_service=chat_runtime.relationship_service,
+        activity_reader=threads_runtime.activity_reader,
+        thread_repo=app.state.thread_repo,
+        user_repo=app.state.user_repo,
+    )
+    wire_chat_join_request_notifications(
+        app,
+        chat_join_request_service=chat_runtime.chat_join_request_service,
         activity_reader=threads_runtime.activity_reader,
         thread_repo=app.state.thread_repo,
         user_repo=app.state.user_repo,

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -11,11 +11,16 @@ class ChatJoinRequestService:
         chat_member_repo: Any,
         chat_join_request_repo: Any,
         messaging_service: Any,
+        on_join_request_rejected: Any | None = None,
     ) -> None:
         self._chats = chat_repo
         self._members = chat_member_repo
         self._requests = chat_join_request_repo
         self._messaging = messaging_service
+        self._on_join_request_rejected = on_join_request_rejected
+
+    def set_join_request_rejected_notification_fn(self, fn: Any) -> None:
+        self._on_join_request_rejected = fn
 
     def request(self, chat_id: str, requester_user_id: str, message: str | None = None) -> dict[str, Any]:
         chat = self._require_joinable_chat(chat_id)
@@ -77,7 +82,10 @@ class ChatJoinRequestService:
             rejecter_user_id,
             f"Rejected chat join request for {requester_user_id}.",
             message_type="notification",
+            mentions=[requester_user_id],
         )
+        if self._on_join_request_rejected is not None:
+            self._on_join_request_rejected(row)
         return self._project_request(row)
 
     def _require_joinable_chat(self, chat_id: str) -> Any:

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -160,3 +160,34 @@ def test_wire_relationship_request_notifications_binds_notification_fn(monkeypat
     )
 
     assert relationship_service.notification_fn is notification_fn
+
+
+def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(monkeypatch):
+    notification_fn = object()
+    chat_join_request_service = SimpleNamespace(notification_fn=None)
+    activity_reader = object()
+    thread_repo = object()
+    user_repo = object()
+
+    def _set_notification_fn(value):
+        chat_join_request_service.notification_fn = value
+
+    chat_join_request_service.set_join_request_rejected_notification_fn = _set_notification_fn
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    monkeypatch.setattr(
+        chat_bootstrap,
+        "make_chat_join_rejection_notification_fn",
+        lambda target_app, *, activity_reader, thread_repo, user_repo: notification_fn,
+    )
+
+    chat_bootstrap.wire_chat_join_request_notifications(
+        app,
+        chat_join_request_service=chat_join_request_service,
+        activity_reader=activity_reader,
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+    )
+
+    assert chat_join_request_service.notification_fn is notification_fn

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -24,6 +24,7 @@ def _patch_lifespan_runtime_contract(
     attach_threads_runtime,
     wire_chat_delivery,
     wire_relationship_request_notifications,
+    wire_chat_join_request_notifications=lambda *_args, **_kwargs: None,
 ):
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
     monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
@@ -73,6 +74,7 @@ def _patch_lifespan_runtime_contract(
     monkeypatch.setattr("backend.chat.bootstrap.attach_chat_runtime", attach_chat_runtime)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", wire_chat_delivery)
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", wire_relationship_request_notifications)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_chat_join_request_notifications", wire_chat_join_request_notifications)
     monkeypatch.setattr("backend.threads.bootstrap.attach_threads_runtime", attach_threads_runtime)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
@@ -180,6 +182,11 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert relationship_service is returned_relationship_service
         assert activity_reader is returned_activity_reader
 
+    def _wire_chat_join_request_notifications(_app, *, chat_join_request_service, activity_reader, thread_repo, user_repo):
+        call_log.append("wire-chat-join")
+        assert chat_join_request_service is returned_chat_join_request_service
+        assert activity_reader is returned_activity_reader
+
     _patch_lifespan_runtime_contract(
         monkeypatch,
         attach_chat_runtime=_attach_chat_runtime,
@@ -187,12 +194,13 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=_wire_chat_delivery,
         wire_relationship_request_notifications=_wire_relationship_request_notifications,
+        wire_chat_join_request_notifications=_wire_chat_join_request_notifications,
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     async with web_lifespan.lifespan(app):
-        assert call_log == ["chat", "auth", "threads", "wire-chat", "wire-relationship"]
+        assert call_log == ["chat", "auth", "threads", "wire-chat", "wire-relationship", "wire-chat-join"]
 
 
 @pytest.mark.asyncio
@@ -258,6 +266,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     )
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_chat_join_request_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
     monkeypatch.setattr("backend.threads.pool.idle_reaper.idle_reaper_loop", lambda _app: _never())

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from backend.threads.chat_adapters import chat_join_inlet
+from protocols.agent_runtime import AgentThreadInputResult
+
+
+def _hook_app(gateway: object) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+
+def _thread_repo() -> SimpleNamespace:
+    default_thread = {"id": "thread-main", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}
+    return SimpleNamespace(
+        get_by_user_id=lambda uid: default_thread if uid == "agent-user-1" else None,
+        list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_join_rejection_notification_dispatches_to_agent_requester() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_thread_input(self, envelope):
+            self.envelope = envelope
+            return AgentThreadInputResult(status="injected", routing="steer", thread_id=envelope.thread_id)
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
+        }.get(uid)
+    )
+    notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=_thread_repo(),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        {
+            "id": "chat_join:chat-1:agent-user-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "agent-user-1",
+            "state": "rejected",
+            "decided_by_user_id": "owner-1",
+        },
+    )
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.thread_id == "thread-main"
+    assert gateway.envelope.sender.user_id == "owner-1"
+    assert gateway.envelope.sender.user_type == "human"
+    assert gateway.envelope.sender.display_name == "Owner"
+    assert gateway.envelope.sender.source == "chat_join"
+    assert "Owner rejected your request to join chat chat-1." in gateway.envelope.message.content
+    assert gateway.envelope.message.metadata == {
+        "chat_join_request_id": "chat_join:chat-1:agent-user-1",
+        "chat_id": "chat-1",
+        "state": "rejected",
+    }
+
+
+@pytest.mark.asyncio
+async def test_chat_join_rejection_notification_ignores_non_agent_requester() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+            "human-1": SimpleNamespace(id="human-1", type="human", display_name="Human", avatar=None),
+        }.get(uid)
+    )
+    notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        {
+            "id": "chat_join:chat-1:human-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "human-1",
+            "state": "rejected",
+            "decided_by_user_id": "owner-1",
+        },
+    )
+
+    assert gateway.called is False

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -63,7 +63,10 @@ class _Messaging:
         return None
 
 
-def _service() -> tuple[ChatJoinRequestService, _Members, _Requests, _Messaging]:
+def _service(
+    *,
+    on_join_request_rejected=None,
+) -> tuple[ChatJoinRequestService, _Members, _Requests, _Messaging]:
     members = _Members()
     requests = _Requests()
     messaging = _Messaging()
@@ -86,6 +89,7 @@ def _service() -> tuple[ChatJoinRequestService, _Members, _Requests, _Messaging]
             chat_member_repo=members,
             chat_join_request_repo=requests,
             messaging_service=messaging,
+            on_join_request_rejected=on_join_request_rejected,
         ),
         members,
         requests,
@@ -190,6 +194,45 @@ def test_chat_join_approve_requires_owner_and_adds_member_before_notification() 
         "notification",
         ["visitor-1"],
     )
+
+
+def test_chat_join_reject_mentions_requester_in_notification() -> None:
+    service, _members, _requests, messaging = _service()
+    pending = service.request("chat-1", "visitor-1", "please add me")
+
+    row = service.reject("chat-1", pending["id"], "owner-1")
+
+    assert row["state"] == "rejected"
+    assert messaging.sent[-1] == (
+        "chat-1",
+        "owner-1",
+        "Rejected chat join request for visitor-1.",
+        "notification",
+        ["visitor-1"],
+    )
+
+
+def test_chat_join_reject_notifies_requester_outside_chat_membership() -> None:
+    notified: list[dict] = []
+    service, members, _requests, _messaging = _service(on_join_request_rejected=notified.append)
+    pending = service.request("chat-1", "visitor-1", "please add me")
+
+    row = service.reject("chat-1", pending["id"], "owner-1")
+
+    assert row["state"] == "rejected"
+    assert ("chat-1", "visitor-1") not in members.members
+    assert notified == [
+        {
+            "id": "chat_join:chat-1:visitor-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "visitor-1",
+            "state": "rejected",
+            "message": "please add me",
+            "created_at": 1.0,
+            "updated_at": 2.0,
+            "decided_by_user_id": "owner-1",
+        }
+    ]
 
 
 def test_chat_join_approve_rejects_non_owner() -> None:


### PR DESCRIPTION
## Summary
- keep the durable group rejection notification row and requester mention
- add a requester-side runtime notification port for rejected managed-agent requesters, because rejected requesters are not chat members
- wire the chat-join rejection notification after thread runtime startup

## YATU
- real CLI run against branch backend: `/Users/lexicalmathical/share/yatu/chat-join-reject-mention-20260426T0948`
- proof verifies the stored rejection row and visible requester mention; code tests cover the managed-agent runtime input path that cannot be reached by member-scoped chat delivery

## Tests
- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/messaging/test_chat_join_request_tool_service.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Integration/test_chat_app_router.py -q`
- `uv run ruff check messaging/join_requests.py backend/chat/bootstrap.py backend/web/core/lifespan.py backend/threads/chat_adapters/chat_join_inlet.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py`
- `uv run ruff format --check messaging/join_requests.py backend/chat/bootstrap.py backend/web/core/lifespan.py backend/threads/chat_adapters/chat_join_inlet.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py`
- `git diff --check`