### PR TITLE
Make ResolvedSkill the runtime Skill boundary

### DIFF
--- a/backend/hub/snapshot_apply.py
+++ b/backend/hub/snapshot_apply.py
@@ -6,7 +6,6 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
-from config.agent_config_resolver import validate_resolved_skill_content
 from config.agent_config_types import AgentConfig, AgentSkill, AgentSnapshot, ResolvedSkill, Skill
 from config.skill_package import build_skill_package
 from storage.utils import generate_skill_id
@@ -46,10 +45,7 @@ def _materialize_snapshot_skills(
 
     seen_ids: set[str] = set()
     seen_names: set[str] = set()
-    validated_skills: list[ResolvedSkill] = []
     for snapshot_skill in skills:
-        snapshot_skill = validate_resolved_skill_content(snapshot_skill)
-        validated_skills.append(snapshot_skill)
         if snapshot_skill.id in seen_ids:
             raise ValueError(f"Duplicate Skill id in snapshot: {snapshot_skill.id}")
         seen_ids.add(snapshot_skill.id)
@@ -60,7 +56,7 @@ def _materialize_snapshot_skills(
     result: list[AgentSkill] = []
     timestamp = datetime.now(UTC)
     library_skills = skill_repo.list_for_owner(owner_user_id)
-    for snapshot_skill in validated_skills:
+    for snapshot_skill in skills:
         snapshot_skill_id = _required_text(snapshot_skill.id, label="Snapshot Skill id")
         existing = _snapshot_source_skill(library_skills, marketplace_item_id, snapshot_skill_id)
         if existing is not None and existing.name != snapshot_skill.name:

--- a/config/agent_config_resolver.py
+++ b/config/agent_config_resolver.py
@@ -58,7 +58,7 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
         require_description=True,
         require_version=True,
     )
-    resolved = ResolvedSkill(
+    return ResolvedSkill(
         id=skill.skill_id,
         name=document.name,
         description=document.description,
@@ -67,18 +67,3 @@ def _resolve_skill(owner_user_id: str, skill: AgentSkill, skill_repo: Any) -> Re
         files=dict(package.files),
         source=dict(package.source),
     )
-    return validate_resolved_skill_content(resolved)
-
-
-def validate_resolved_skill_content(skill: ResolvedSkill) -> ResolvedSkill:
-    document = parse_skill_document(
-        skill.content,
-        label=f"Skill {skill.name!r} on Agent config",
-        require_description=True,
-        require_version=True,
-    )
-    if document.name != skill.name:
-        raise ValueError(f"Skill {skill.name!r} on Agent config frontmatter name must match ResolvedSkill.name")
-    if document.version != skill.version:
-        raise ValueError("ResolvedSkill.version must match SKILL.md frontmatter version")
-    return skill.model_copy(update={"description": document.description})

--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -91,13 +91,13 @@ class AgentSkill(AgentConfigSchemaModel):
 class ResolvedSkill(AgentConfigSchemaModel):
     id: str
     name: str
-    description: str = ""
+    description: str
     version: str
     content: str
     files: dict[str, str] = Field(default_factory=dict)
     source: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("id", "name", "version", "content")
+    @field_validator("id", "name", "description", "version", "content")
     @classmethod
     def _non_blank(cls, value: str, info: ValidationInfo) -> str:
         if not value.strip():
@@ -108,6 +108,18 @@ class ResolvedSkill(AgentConfigSchemaModel):
     @classmethod
     def _normalize_files(cls, value: Any) -> Any:
         return normalize_skill_file_map(value, context="Skill files") if isinstance(value, dict) else value
+
+    @model_validator(mode="after")
+    def _content_frontmatter_matches_fields(self) -> ResolvedSkill:
+        # @@@resolved-skill-boundary - runtime Skill fields are derived from and pinned to SKILL.md.
+        document = parse_skill_document(self.content, label="resolved_skill.content", require_description=True, require_version=True)
+        if document.name != self.name:
+            raise ValueError("resolved_skill.content frontmatter name must match resolved_skill.name")
+        if document.description != self.description:
+            raise ValueError("resolved_skill.content frontmatter description must match resolved_skill.description")
+        if document.version != self.version:
+            raise ValueError("resolved_skill.content frontmatter version must match resolved_skill.version")
+        return self
 
 
 class AgentRule(AgentConfigSchemaModel):

--- a/core/tools/skills/service.py
+++ b/core/tools/skills/service.py
@@ -24,10 +24,6 @@ class SkillsService:
             if not isinstance(skill, ResolvedSkill):
                 raise TypeError("SkillsService requires ResolvedSkill items")
             document = parse_skill_document(skill.content, label="Skill content", require_description=True, require_version=True)
-            if document.name != skill.name:
-                raise ValueError("Skill frontmatter name must match ResolvedSkill.name")
-            if document.version != skill.version:
-                raise ValueError("Skill frontmatter version must match ResolvedSkill.version")
             self._skill_bodies[skill.name] = document.body
             self._skill_descriptions[skill.name] = document.description
             self._skill_files[skill.name] = skill.files

--- a/tests/Unit/config/test_agent_config_resolver.py
+++ b/tests/Unit/config/test_agent_config_resolver.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from config.agent_config_resolver import resolve_agent_config, validate_resolved_skill_content
+from config.agent_config_resolver import resolve_agent_config
 from config.agent_config_types import (
     AgentConfig,
     AgentRule,
@@ -135,20 +135,6 @@ def test_resolver_names_skill_working_set_as_resolved_skills() -> None:
 
     assert "enabled_skills" not in source
     assert "resolved_skills" in source
-
-
-def test_resolved_skill_content_requires_version_frontmatter() -> None:
-    skill = _resolved_skill(
-        content_version="1.0.0",
-    ).model_copy(update={"content": "---\nname: github\ndescription: Use gh.\n---\n# GitHub\n"})
-
-    with pytest.raises(ValueError, match="Skill 'github' on Agent config frontmatter must include version"):
-        validate_resolved_skill_content(skill)
-
-
-def test_resolved_skill_version_matches_skill_md_frontmatter() -> None:
-    with pytest.raises(ValueError, match="ResolvedSkill.version must match SKILL.md frontmatter version"):
-        validate_resolved_skill_content(_resolved_skill(version="2.0.0", content_version="1.0.0"))
 
 
 def test_resolver_keeps_skill_id_separate_from_display_name() -> None:

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -11,7 +11,7 @@ def test_resolved_skill_model_normalizes_file_paths() -> None:
         name="query-helper",
         description="Build precise queries",
         version="1.0.0",
-        content="---\nname: query-helper\n---\nUse exact terms.",
+        content="---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
         files={"references\\query.md": "Prefer precise queries."},
     )
 
@@ -20,7 +20,9 @@ def test_resolved_skill_model_normalizes_file_paths() -> None:
 
 def test_resolved_skill_model_rejects_duplicate_file_paths_after_normalization() -> None:
     common = {
-        "content": "---\nname: query-helper\n---\nUse exact terms.",
+        "content": "---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
+        "description": "Build precise queries",
+        "version": "1.0.0",
         "files": {
             "references\\query.md": "Windows-shaped key.",
             "references/query.md": "POSIX-shaped key.",
@@ -38,7 +40,78 @@ def test_resolved_skill_model_rejects_blank_version() -> None:
             name="query-helper",
             description="Build precise queries",
             version=" ",
-            content="---\nname: query-helper\n---\nUse exact terms.",
+            content="---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
+        )
+
+
+def test_resolved_skill_model_rejects_blank_description() -> None:
+    with pytest.raises(ValueError, match="resolved_skill.description must not be blank"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description=" ",
+            version="1.0.0",
+            content="---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
+        )
+
+
+def test_resolved_skill_model_requires_skill_md_frontmatter() -> None:
+    with pytest.raises(ValueError, match="resolved_skill.content must be a SKILL.md document with frontmatter"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description="Build precise queries",
+            version="1.0.0",
+            content="Use exact terms.",
+        )
+
+
+def test_resolved_skill_model_requires_content_description_and_version() -> None:
+    with pytest.raises(ValueError, match="resolved_skill.content frontmatter must include description"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description="Build precise queries",
+            version="1.0.0",
+            content="---\nname: query-helper\nversion: 1.0.0\n---\nUse exact terms.",
+        )
+
+    with pytest.raises(ValueError, match="resolved_skill.content frontmatter must include version"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description="Build precise queries",
+            version="1.0.0",
+            content="---\nname: query-helper\ndescription: Build precise queries\n---\nUse exact terms.",
+        )
+
+
+def test_resolved_skill_model_requires_content_identity_to_match_fields() -> None:
+    with pytest.raises(ValueError, match="resolved_skill.content frontmatter name must match resolved_skill.name"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description="Build precise queries",
+            version="1.0.0",
+            content="---\nname: other-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
+        )
+
+    with pytest.raises(ValueError, match="resolved_skill.content frontmatter description must match resolved_skill.description"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description="Build precise queries",
+            version="1.0.0",
+            content="---\nname: query-helper\ndescription: Different text\nversion: 1.0.0\n---\nUse exact terms.",
+        )
+
+    with pytest.raises(ValueError, match="resolved_skill.content frontmatter version must match resolved_skill.version"):
+        ResolvedSkill(
+            id="query-helper",
+            name="query-helper",
+            description="Build precise queries",
+            version="1.0.0",
+            content="---\nname: query-helper\ndescription: Build precise queries\nversion: 2.0.0\n---\nUse exact terms.",
         )
 
 
@@ -63,7 +136,7 @@ def test_resolved_skill_model_rejects_blank_id() -> None:
             name="query-helper",
             description="Build precise queries",
             version="1.0.0",
-            content="---\nname: query-helper\n---\nUse exact terms.",
+            content="---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
         )
 
 

--- a/tests/Unit/core/test_skills_service.py
+++ b/tests/Unit/core/test_skills_service.py
@@ -70,42 +70,6 @@ def test_load_missing_skill_fails_loudly() -> None:
         entry.handler("missing")
 
 
-def test_skill_without_frontmatter_name_fails_loudly() -> None:
-    registry = ToolRegistry()
-
-    with pytest.raises(ValueError, match="Skill content must be a SKILL.md document with frontmatter"):
-        SkillsService(
-            registry=registry,
-            skills=[
-                _skill(content="Use exact terms."),
-            ],
-        )
-
-
-def test_skill_without_frontmatter_description_fails_loudly() -> None:
-    registry = ToolRegistry()
-
-    with pytest.raises(ValueError, match="Skill content frontmatter must include description"):
-        SkillsService(
-            registry=registry,
-            skills=[
-                _skill(content="---\nname: query-helper\n---\nUse exact terms."),
-            ],
-        )
-
-
-def test_skill_version_must_match_resolved_skill_version() -> None:
-    registry = ToolRegistry()
-
-    with pytest.raises(ValueError, match="Skill frontmatter version must match ResolvedSkill.version"):
-        SkillsService(
-            registry=registry,
-            skills=[
-                _skill(content="---\nname: query-helper\ndescription: Build precise search queries\nversion: 2.0.0\n---\nUse exact terms."),
-            ],
-        )
-
-
 def test_load_skill_schema_lists_skill_descriptions() -> None:
     registry = ToolRegistry()
     SkillsService(
@@ -137,21 +101,6 @@ def test_skills_service_requires_resolved_skill_items() -> None:
                         "content": "---\nname: query-helper\ndescription: Build precise search queries\nversion: 1.0.0\n---\nUse exact terms.",
                     },
                 )
-            ],
-        )
-
-
-def test_skill_frontmatter_name_must_match_resolved_skill_name() -> None:
-    registry = ToolRegistry()
-
-    with pytest.raises(ValueError, match="Skill frontmatter name must match ResolvedSkill.name"):
-        SkillsService(
-            registry=registry,
-            skills=[
-                _skill(
-                    name="query-helper",
-                    content="---\nname: other-helper\ndescription: Build precise search queries\nversion: 1.0.0\n---\nUse exact terms.",
-                ),
             ],
         )
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2387,6 +2387,7 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
                         {
                             "id": "search",
                             "name": "Search",
+                            "description": "Search repos",
                             "version": "1.0.0",
                             "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         }
@@ -2404,7 +2405,7 @@ def test_apply_snapshot_with_skills_requires_skill_repo():
 def test_apply_snapshot_skill_requires_frontmatter_description() -> None:
     from backend.hub.snapshot_apply import apply_snapshot
 
-    with pytest.raises(ValueError, match="Skill 'Search' on Agent config frontmatter must include description"):
+    with pytest.raises(ValueError, match="resolved_skill.content frontmatter must include description"):
         apply_snapshot(
             snapshot={
                 "schema_version": "agent-snapshot/v1",
@@ -2453,6 +2454,7 @@ def test_apply_snapshot_requires_source_identity(field: str, value: object, mess
                     {
                         "id": "search",
                         "name": "Search",
+                        "description": "Search repos",
                         "version": "1.0.0",
                         "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                     }
@@ -2524,12 +2526,14 @@ def test_apply_snapshot_rejects_duplicate_skill_ids_before_library_write():
                         {
                             "id": "search",
                             "name": "Search One",
+                            "description": "Search one",
                             "version": "1.0.0",
                             "content": "---\nname: Search One\ndescription: Search one\nversion: 1.0.0\n---\none",
                         },
                         {
                             "id": "search",
                             "name": "Search Two",
+                            "description": "Search two",
                             "version": "1.0.0",
                             "content": "---\nname: Search Two\ndescription: Search two\nversion: 1.0.0\n---\ntwo",
                         },
@@ -2564,6 +2568,7 @@ def test_apply_snapshot_treats_snapshot_skill_id_as_source_metadata(monkeypatch:
                     {
                         "id": "nested/search",
                         "name": "Search",
+                        "description": "Search repos",
                         "version": "1.0.0",
                         "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                     }
@@ -2618,6 +2623,7 @@ def test_apply_snapshot_reuses_existing_skill_by_snapshot_source(monkeypatch: py
                     {
                         "id": "search-core",
                         "name": "Search",
+                        "description": "Search repos",
                         "version": "1.0.1",
                         "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.1\n---\nnew",
                     }
@@ -2664,6 +2670,7 @@ def test_apply_snapshot_fails_when_generated_skill_id_exists(monkeypatch: pytest
                         {
                             "id": "search-core",
                             "name": "Search",
+                            "description": "Search repos",
                             "version": "1.0.0",
                             "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         }
@@ -2704,6 +2711,7 @@ def test_apply_snapshot_rejects_existing_same_name_without_snapshot_source(monke
                         {
                             "id": "search-core",
                             "name": "Search",
+                            "description": "Search repos",
                             "version": "1.0.0",
                             "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\nbody",
                         }
@@ -2735,12 +2743,14 @@ def test_apply_snapshot_rejects_duplicate_skill_names_before_library_write():
                         {
                             "id": "search-one",
                             "name": "Search",
+                            "description": "Search repos",
                             "version": "1.0.0",
                             "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\none",
                         },
                         {
                             "id": "search-two",
                             "name": "Search",
+                            "description": "Search repos",
                             "version": "1.0.0",
                             "content": "---\nname: Search\ndescription: Search repos\nversion: 1.0.0\n---\ntwo",
                         },


### PR DESCRIPTION
## Summary
- require ResolvedSkill descriptions and pin name/description/version to SKILL.md frontmatter
- remove the separate resolved Skill validation helper from resolver and Hub snapshot apply
- simplify SkillsService so it only loads parsed Skill bodies/descriptions for load_skill
- update snapshot fixtures to carry complete resolved Skill fields

## Verification
- uv run pytest tests/Unit/config/test_skill_package.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/config/test_agent_snapshot.py tests/Unit/core/test_skills_service.py tests/Unit/core/test_agent_pool.py tests/Unit/integration_contracts/test_leon_agent.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q -k "skill or package or snapshot or resolved" == 143 passed, 133 deselected
- uv run pytest tests/Unit -q == 1976 passed, 3 skipped, 15 warnings
- uv run ruff format --check . && uv run ruff check . == 654 files already formatted; All checks passed
- uv run pyright config/agent_config_types.py config/agent_config_resolver.py core/tools/skills/service.py backend/hub/snapshot_apply.py == 0 errors, 0 warnings, 0 informations