### PR TITLE
Derive Library Skill names from SKILL.md

### DIFF
--- a/backend/library/service.py
+++ b/backend/library/service.py
@@ -78,6 +78,11 @@ def _reject_skill_description_argument(desc: str) -> None:
         raise ValueError("Skill description must be declared in SKILL.md frontmatter")
 
 
+def _reject_skill_name_argument(name: str) -> None:
+    if name != "":
+        raise ValueError("Skill name must be declared in SKILL.md frontmatter")
+
+
 def _now_dt() -> datetime:
     return datetime.now(UTC)
 
@@ -245,14 +250,13 @@ def create_resource(
     if resource_type == "skill":
         owner_user_id = _require_skill_owner(owner_user_id)
         skill_repo = _require_skill_repo(skill_repo)
+        _reject_skill_name_argument(name)
         _reject_skill_description_argument(desc)
         if not content or not content.strip():
             raise ValueError("Skill creation requires SKILL.md content")
         document = _skill_document_from_content(content, require_version=True)
-        if document.name != name:
-            raise ValueError("Skill content frontmatter name must match Skill name")
         for skill in skill_repo.list_for_owner(owner_user_id):
-            if skill.name == name:
+            if skill.name == document.name:
                 raise ValueError("Skill name already exists")
         rid = generate_skill_id()
         existing = skill_repo.get_by_id(owner_user_id, rid)
@@ -263,7 +267,7 @@ def create_resource(
             Skill(
                 id=rid,
                 owner_user_id=owner_user_id,
-                name=name,
+                name=document.name,
                 description=document.description,
                 created_at=timestamp,
                 updated_at=timestamp,
@@ -321,8 +325,8 @@ def update_resource(
         current = skill_repo.get_by_id(owner_user_id, resource_id)
         if current is None:
             return None
-        if name is not None and name != current.name:
-            raise ValueError("Skill name is immutable; create a new Skill for a new name")
+        if name is not None:
+            raise ValueError("Skill name must be declared in SKILL.md frontmatter")
         if desc is not None and desc != current.description:
             raise ValueError("Skill description comes from SKILL.md content")
         updated = skill_repo.upsert(

--- a/backend/web/models/panel.py
+++ b/backend/web/models/panel.py
@@ -34,7 +34,7 @@ class PublishAgentRequest(BaseModel):
 
 
 class CreateResourceRequest(BaseModel):
-    name: str
+    name: str = ""
     desc: str = ""
     content: str | None = None
     provider_name: str | None = None

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -301,7 +301,7 @@ async def create_resource(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
-    _reject_skill_request_fields(resource_type, req, {"desc", "features", "provider_name", "provider_type"})
+    _reject_skill_request_fields(resource_type, req, {"name", "desc", "features", "provider_name", "provider_type"})
     category = req.provider_type or ""
     try:
         return await asyncio.to_thread(
@@ -329,7 +329,7 @@ async def update_resource(
     request: Request,
     user_id: CurrentUserId,
 ) -> dict[str, Any]:
-    _reject_skill_request_fields(resource_type, req, {"desc", "features"})
+    _reject_skill_request_fields(resource_type, req, {"name", "desc", "features"})
     try:
         item = await asyncio.to_thread(
             library_service.update_resource,

--- a/tests/Unit/backend/web/test_panel_models.py
+++ b/tests/Unit/backend/web/test_panel_models.py
@@ -1,0 +1,8 @@
+from backend.web.models.panel import CreateResourceRequest
+
+
+def test_create_resource_request_allows_skill_content_without_name() -> None:
+    request = CreateResourceRequest.model_validate({"content": "---\nname: Skill\n---\nBody"})
+
+    assert request.name == ""
+    assert request.content == "---\nname: Skill\n---\nBody"

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -1042,7 +1042,7 @@ def test_panel_library_skill_routes_use_skill_repo_without_recipe_repo() -> None
     with TestClient(app) as client:
         created = client.post(
             "/api/panel/library/skill",
-            json={"name": "Loadable Skill", "content": _editable_skill_md()},
+            json={"content": _editable_skill_md()},
         )
         assert created.status_code == 200
         created_id = created.json()["id"]
@@ -1077,7 +1077,24 @@ def test_panel_library_skill_create_rejects_non_skill_fields() -> None:
         )
 
     assert created.status_code == 400
-    assert created.json()["detail"] == "Skill Library requests must not include desc, features, provider_name"
+    assert created.json()["detail"] == "Skill Library requests must not include desc, features, name, provider_name"
+
+
+def test_library_skill_create_rejects_separate_name() -> None:
+    skill_repo = _MemorySkillRepo()
+
+    with pytest.raises(ValueError, match="Skill name must be declared in SKILL.md frontmatter"):
+        library_service.create_resource(
+            "skill",
+            "Loadable Skill",
+            "",
+            owner_user_id="owner-1",
+            skill_repo=skill_repo,
+            content=_editable_skill_md(),
+        )
+
+    assert skill_repo.skills == {}
+    assert skill_repo.packages == {}
 
 
 def test_panel_library_skill_update_rejects_non_skill_fields() -> None:
@@ -1103,6 +1120,31 @@ def test_panel_library_skill_update_rejects_non_skill_fields() -> None:
 
     assert updated.status_code == 400
     assert updated.json()["detail"] == "Skill Library requests must not include desc, features"
+
+
+def test_panel_library_skill_update_rejects_name_field() -> None:
+    app = FastAPI()
+    app.include_router(panel_router.router)
+    app.dependency_overrides[panel_router.get_current_user_id] = lambda: "owner-1"
+    skill_repo = _MemorySkillRepo()
+    skill = _put_skill(
+        skill_repo,
+        owner_user_id="owner-1",
+        skill_id="skill-1",
+        name="Loadable Skill",
+        description="Loadable",
+        content=_editable_skill_md(),
+    )
+    app.state.runtime_storage_state = _runtime_storage_state(SimpleNamespace(), skill_repo=skill_repo)
+
+    with TestClient(app) as client:
+        updated = client.put(
+            f"/api/panel/library/skill/{skill.id}",
+            json={"name": "Renamed Skill"},
+        )
+
+    assert updated.status_code == 400
+    assert updated.json()["detail"] == "Skill Library requests must not include name"
 
 
 def test_library_skill_content_rejects_selected_package_for_another_skill() -> None:
@@ -1140,7 +1182,7 @@ def test_library_skill_content_update_rejects_frontmatter_name_drift() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1167,7 +1209,7 @@ def test_library_skill_create_requires_version_frontmatter() -> None:
     with pytest.raises(ValueError, match="frontmatter must include version"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1184,7 +1226,7 @@ def test_library_skill_create_requires_description_frontmatter() -> None:
     with pytest.raises(ValueError, match="frontmatter must include description"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1199,7 +1241,7 @@ def test_library_skill_content_update_requires_version_frontmatter() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1224,7 +1266,7 @@ def test_library_skill_content_update_requires_description_frontmatter() -> None
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1245,18 +1287,18 @@ def test_library_skill_content_update_requires_description_frontmatter() -> None
     assert skill_repo.get_package("owner-1", stored.package_id).version == "1.0.0"
 
 
-def test_library_skill_name_is_immutable_after_creation() -> None:
+def test_library_skill_name_cannot_be_updated_without_skill_md() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
         content=_editable_skill_md(),
     )
 
-    with pytest.raises(ValueError, match="Skill name is immutable"):
+    with pytest.raises(ValueError, match="Skill name must be declared in SKILL.md frontmatter"):
         library_service.update_resource(
             "skill",
             created["id"],
@@ -1273,7 +1315,7 @@ def test_library_skill_description_comes_from_skill_md_frontmatter() -> None:
 
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1292,7 +1334,7 @@ def test_library_skill_create_rejects_separate_description() -> None:
     with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "Caller desc",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1309,7 +1351,7 @@ def test_library_skill_create_rejects_blank_separate_description() -> None:
     with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "   ",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1326,7 +1368,7 @@ def test_library_skill_create_rejects_newline_separate_description() -> None:
     with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "\n",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1343,7 +1385,7 @@ def test_library_skill_create_rejects_matching_separate_description() -> None:
     with pytest.raises(ValueError, match="Skill description must be declared in SKILL.md frontmatter"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "Frontmatter desc",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1358,7 +1400,7 @@ def test_library_skill_content_update_refreshes_description_from_skill_md() -> N
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1382,7 +1424,7 @@ def test_library_skill_description_cannot_be_updated_without_skill_md() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1405,7 +1447,7 @@ def test_library_skill_create_rejects_duplicate_name_before_write() -> None:
     skill_repo = _MemorySkillRepo()
     created = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1415,7 +1457,7 @@ def test_library_skill_create_rejects_duplicate_name_before_write() -> None:
     with pytest.raises(ValueError, match="Skill name already exists"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,
@@ -1433,7 +1475,7 @@ def test_library_skill_create_does_not_derive_id_from_name() -> None:
 
     first = library_service.create_resource(
         "skill",
-        "Loadable Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1441,7 +1483,7 @@ def test_library_skill_create_does_not_derive_id_from_name() -> None:
     )
     second = library_service.create_resource(
         "skill",
-        "Loadable-Skill",
+        "",
         "",
         owner_user_id="owner-1",
         skill_repo=skill_repo,
@@ -1464,6 +1506,25 @@ def test_library_skill_create_source_does_not_slugify_name() -> None:
     assert "generate_skill_id()" in source
 
 
+def test_library_skill_create_source_uses_skill_md_name() -> None:
+    import inspect
+
+    source = inspect.getsource(library_service.create_resource)
+
+    assert "document.name != name" not in source
+    assert "name=document.name" in source
+
+
+def test_panel_skill_routes_reject_name_field_source() -> None:
+    import inspect
+
+    create_source = inspect.getsource(panel_router.create_resource)
+    update_source = inspect.getsource(panel_router.update_resource)
+
+    assert '{"name", "desc", "features", "provider_name", "provider_type"}' in create_source
+    assert '{"name", "desc", "features"}' in update_source
+
+
 def test_library_skill_create_fails_when_generated_id_exists(monkeypatch: pytest.MonkeyPatch) -> None:
     skill_repo = _MemorySkillRepo()
     _put_skill(
@@ -1479,7 +1540,7 @@ def test_library_skill_create_fails_when_generated_id_exists(monkeypatch: pytest
     with pytest.raises(RuntimeError, match="Generated Skill id already exists"):
         library_service.create_resource(
             "skill",
-            "Loadable Skill",
+            "",
             "",
             owner_user_id="owner-1",
             skill_repo=skill_repo,


### PR DESCRIPTION
## Summary
- allow Panel Skill create requests to omit name and reject name on Skill create/update requests
- reject direct Library Skill create calls that pass a separate name
- create Library Skill rows from SKILL.md frontmatter name and keep duplicate checks on that parsed name
- add model/panel/library tests for the Skill-name boundary

## Verification
- uv run pytest tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py tests/Unit/backend/web/test_panel_models.py -q -k "library_skill or panel_library_skill or create_resource_request" == 30 passed, 76 deselected
- uv run pytest tests/Unit -q == 1986 passed, 3 skipped, 15 warnings
- uv run ruff format --check . && uv run ruff check . == 657 files already formatted; All checks passed
- uv run pyright backend/library/service.py backend/web/routers/panel.py backend/web/models/panel.py == 0 errors, 0 warnings, 0 informations