### PR TITLE
Notify agent requesters about relationship decisions

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -6,7 +6,10 @@ from typing import Any
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.chat_inlet import make_chat_delivery_fn
 from backend.threads.chat_adapters.chat_join_inlet import make_chat_join_rejection_notification_fn
-from backend.threads.chat_adapters.relationship_inlet import make_relationship_request_notification_fn
+from backend.threads.chat_adapters.relationship_inlet import (
+    make_relationship_decision_notification_fn,
+    make_relationship_request_notification_fn,
+)
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.join_requests import ChatJoinRequestService
 from messaging.realtime.events import ChatEventBus
@@ -108,6 +111,24 @@ def wire_relationship_request_notifications(
 ) -> None:
     relationship_service.set_relationship_request_notification_fn(
         make_relationship_request_notification_fn(
+            app,
+            activity_reader=activity_reader,
+            thread_repo=thread_repo,
+            user_repo=user_repo,
+        )
+    )
+
+
+def wire_relationship_decision_notifications(
+    app: Any,
+    *,
+    relationship_service: Any,
+    activity_reader: Any,
+    thread_repo: Any,
+    user_repo: Any,
+) -> None:
+    relationship_service.set_relationship_decision_notification_fn(
+        make_relationship_decision_notification_fn(
             app,
             activity_reader=activity_reader,
             thread_repo=thread_repo,

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -6,9 +6,14 @@ from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from messaging.contracts import RelationshipRow
+from messaging.contracts import RelationshipEvent, RelationshipRow
 from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
 from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+
+_DECISION_VERBS: dict[RelationshipEvent, str] = {
+    "approve": "approved",
+    "reject": "rejected",
+}
 
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -59,6 +64,55 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
     return _notify
 
 
+def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
+    if activity_reader is None:
+        raise RuntimeError("Agent runtime thread activity reader is not configured")
+    loop = asyncio.get_running_loop()
+
+    async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
+        requester_id = _requester_id(row)
+        decider_id = _target_id(row, requester_id)
+        requester = _require_user(user_repo, requester_id, "requester")
+        decider = _require_user(user_repo, decider_id, "decider")
+        if _user_type(requester, requester_id) != "agent":
+            return
+
+        thread_id = select_runtime_thread_for_recipient(
+            requester_id,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if thread_id is None:
+            raise RuntimeError(f"Relationship decision requester agent has no runtime thread: {requester_id}")
+
+        await get_agent_runtime_gateway(app).dispatch_thread_input(
+            AgentThreadInputEnvelope(
+                thread_id=thread_id,
+                sender=AgentRuntimeActor(
+                    user_id=decider_id,
+                    user_type=_user_type(decider, decider_id),
+                    display_name=_display_name(decider, decider_id),
+                    avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                    source="relationship",
+                ),
+                message=AgentRuntimeMessage(
+                    content=f"{_display_name(decider, decider_id)} {_decision_verb(event)} your relationship request.",
+                    metadata={
+                        "relationship_id": row.id,
+                        "event": event,
+                        "state": row.state,
+                    },
+                ),
+            )
+        )
+
+    def _notify(row: RelationshipRow, event: RelationshipEvent) -> None:
+        future = asyncio.run_coroutine_threadsafe(notify_runtime(row, event), loop)
+        future.result()
+
+    return _notify
+
+
 def _requester_id(row: RelationshipRow) -> str:
     if row.initiator_user_id is None:
         raise RuntimeError(f"Relationship request row is missing initiator: {row.id}")
@@ -99,3 +153,10 @@ def _notification_content(requester_name: str, message: str | None) -> str:
     if message and message.strip():
         base = f"{base} Message: {message.strip()}"
     return f"{base} Review the pending relationship request in Mycel, then approve or reject it."
+
+
+def _decision_verb(event: RelationshipEvent) -> str:
+    try:
+        return _DECISION_VERBS[event]
+    except KeyError as exc:
+        raise RuntimeError(f"Relationship decision notification does not support event: {event}") from exc

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -61,6 +61,7 @@ async def lifespan(app: FastAPI):
         attach_chat_runtime,
         wire_chat_delivery,
         wire_chat_join_request_notifications,
+        wire_relationship_decision_notifications,
         wire_relationship_request_notifications,
     )
     from backend.threads.bootstrap import attach_threads_runtime
@@ -93,6 +94,13 @@ async def lifespan(app: FastAPI):
         thread_repo=app.state.thread_repo,
     )
     wire_relationship_request_notifications(
+        app,
+        relationship_service=chat_runtime.relationship_service,
+        activity_reader=threads_runtime.activity_reader,
+        thread_repo=app.state.thread_repo,
+        user_repo=app.state.user_repo,
+    )
+    wire_relationship_decision_notifications(
         app,
         relationship_service=chat_runtime.relationship_service,
         activity_reader=threads_runtime.activity_reader,

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -20,12 +20,17 @@ class RelationshipService:
         relationship_repo: Any,
         *,
         on_relationship_requested: Callable[[RelationshipRow], None] | None = None,
+        on_relationship_decided: Callable[[RelationshipRow, RelationshipEvent], None] | None = None,
     ) -> None:
         self._repo = relationship_repo
         self._on_relationship_requested = on_relationship_requested
+        self._on_relationship_decided = on_relationship_decided
 
     def set_relationship_request_notification_fn(self, fn: Callable[[RelationshipRow], None]) -> None:
         self._on_relationship_requested = fn
+
+    def set_relationship_decision_notification_fn(self, fn: Callable[[RelationshipRow, RelationshipEvent], None]) -> None:
+        self._on_relationship_decided = fn
 
     def apply_event(
         self,
@@ -80,10 +85,16 @@ class RelationshipService:
         return row
 
     def approve(self, approver_id: str, requester_id: str) -> RelationshipRow:
-        return self.apply_event(approver_id, requester_id, "approve")
+        row = self.apply_event(approver_id, requester_id, "approve")
+        if self._on_relationship_decided is not None:
+            self._on_relationship_decided(row, "approve")
+        return row
 
     def reject(self, approver_id: str, requester_id: str) -> RelationshipRow:
-        return self.apply_event(approver_id, requester_id, "reject")
+        row = self.apply_event(approver_id, requester_id, "reject")
+        if self._on_relationship_decided is not None:
+            self._on_relationship_decided(row, "reject")
+        return row
 
     def upgrade(self, owner_id: str, agent_id: str) -> RelationshipRow:
         return self.apply_event(owner_id, agent_id, "upgrade")

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -162,6 +162,37 @@ def test_wire_relationship_request_notifications_binds_notification_fn(monkeypat
     assert relationship_service.notification_fn is notification_fn
 
 
+def test_wire_relationship_decision_notifications_binds_notification_fn(monkeypatch):
+    notification_fn = object()
+    relationship_service = SimpleNamespace(notification_fn=None)
+    activity_reader = object()
+    thread_repo = object()
+    user_repo = object()
+
+    def _set_notification_fn(value):
+        relationship_service.notification_fn = value
+
+    relationship_service.set_relationship_decision_notification_fn = _set_notification_fn
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    monkeypatch.setattr(
+        chat_bootstrap,
+        "make_relationship_decision_notification_fn",
+        lambda target_app, *, activity_reader, thread_repo, user_repo: notification_fn,
+    )
+
+    chat_bootstrap.wire_relationship_decision_notifications(
+        app,
+        relationship_service=relationship_service,
+        activity_reader=activity_reader,
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+    )
+
+    assert relationship_service.notification_fn is notification_fn
+
+
 def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(monkeypatch):
     notification_fn = object()
     chat_join_request_service = SimpleNamespace(notification_fn=None)

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -24,6 +24,7 @@ def _patch_lifespan_runtime_contract(
     attach_threads_runtime,
     wire_chat_delivery,
     wire_relationship_request_notifications,
+    wire_relationship_decision_notifications=lambda *_args, **_kwargs: None,
     wire_chat_join_request_notifications=lambda *_args, **_kwargs: None,
 ):
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
@@ -74,6 +75,7 @@ def _patch_lifespan_runtime_contract(
     monkeypatch.setattr("backend.chat.bootstrap.attach_chat_runtime", attach_chat_runtime)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", wire_chat_delivery)
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", wire_relationship_request_notifications)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_decision_notifications", wire_relationship_decision_notifications)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_join_request_notifications", wire_chat_join_request_notifications)
     monkeypatch.setattr("backend.threads.bootstrap.attach_threads_runtime", attach_threads_runtime)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
@@ -182,6 +184,11 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert relationship_service is returned_relationship_service
         assert activity_reader is returned_activity_reader
 
+    def _wire_relationship_decision_notifications(_app, *, relationship_service, activity_reader, thread_repo, user_repo):
+        call_log.append("wire-relationship-decision")
+        assert relationship_service is returned_relationship_service
+        assert activity_reader is returned_activity_reader
+
     def _wire_chat_join_request_notifications(_app, *, chat_join_request_service, activity_reader, thread_repo, user_repo):
         call_log.append("wire-chat-join")
         assert chat_join_request_service is returned_chat_join_request_service
@@ -194,13 +201,22 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         attach_threads_runtime=_attach_threads_runtime,
         wire_chat_delivery=_wire_chat_delivery,
         wire_relationship_request_notifications=_wire_relationship_request_notifications,
+        wire_relationship_decision_notifications=_wire_relationship_decision_notifications,
         wire_chat_join_request_notifications=_wire_chat_join_request_notifications,
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     async with web_lifespan.lifespan(app):
-        assert call_log == ["chat", "auth", "threads", "wire-chat", "wire-relationship", "wire-chat-join"]
+        assert call_log == [
+            "chat",
+            "auth",
+            "threads",
+            "wire-chat",
+            "wire-relationship",
+            "wire-relationship-decision",
+            "wire-chat-join",
+        ]
 
 
 @pytest.mark.asyncio
@@ -266,6 +282,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     )
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_delivery", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_decision_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_join_request_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from backend.threads.chat_adapters import relationship_inlet
-from messaging.contracts import RelationshipRow
+from messaging.contracts import RelationshipRow, RelationshipState
 from protocols.agent_runtime import AgentThreadInputResult
 
 
@@ -17,6 +17,7 @@ def _relationship_row(
     user_high: str = "human-user-1",
     initiator_user_id: str = "human-user-1",
     message: str | None = None,
+    state: RelationshipState = "pending",
 ) -> RelationshipRow:
     now = datetime(2026, 4, 26, tzinfo=UTC)
     return RelationshipRow(
@@ -24,7 +25,7 @@ def _relationship_row(
         user_low=user_low,
         user_high=user_high,
         kind="hire_visit",
-        state="pending",
+        state=state,
         initiator_user_id=initiator_user_id,
         message=message,
         created_at=now,
@@ -144,5 +145,84 @@ async def test_relationship_request_notification_fails_when_agent_target_has_no_
 
     with pytest.raises(RuntimeError, match="Relationship request target agent has no runtime thread: agent-user-1"):
         await asyncio.to_thread(notify, _relationship_row())
+
+    assert gateway.called is False
+
+
+@pytest.mark.asyncio
+async def test_relationship_decision_notification_dispatches_to_agent_requester() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_thread_input(self, envelope):
+            self.envelope = envelope
+            return AgentThreadInputResult(status="injected", routing="steer", thread_id=envelope.thread_id)
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_decision_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=_thread_repo(),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _relationship_row(
+            user_low="agent-user-1",
+            user_high="human-user-1",
+            initiator_user_id="agent-user-1",
+            state="visit",
+        ),
+        "approve",
+    )
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.thread_id == "thread-main"
+    assert gateway.envelope.sender.user_id == "human-user-1"
+    assert gateway.envelope.sender.user_type == "human"
+    assert gateway.envelope.sender.display_name == "Human"
+    assert gateway.envelope.sender.source == "relationship"
+    assert "Human approved your relationship request." in gateway.envelope.message.content
+    assert gateway.envelope.message.metadata == {
+        "relationship_id": "hire_visit:agent-user-1:human-user-1",
+        "event": "approve",
+        "state": "visit",
+    }
+
+
+@pytest.mark.asyncio
+async def test_relationship_decision_notification_ignores_non_agent_requester() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+            "human-user-2": SimpleNamespace(id="human-user-2", type="human", display_name="Other", avatar=None),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_decision_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _relationship_row(user_low="human-user-1", user_high="human-user-2", initiator_user_id="human-user-1"),
+        "reject",
+    )
 
     assert gateway.called is False

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -186,6 +186,31 @@ def test_relationship_request_notifies_after_persisting_pending_row() -> None:
     assert notifications[0].initiator_user_id == "human-user-1"
 
 
+def test_relationship_approve_notifies_original_requester_after_persisting_decision() -> None:
+    repo = _FakeRelationshipRepo()
+    repo._existing[("agent-user-1", "human-user-1")]["state"] = "pending"
+    notifications = []
+    service = RelationshipService(repo, on_relationship_decided=lambda row, event: notifications.append((row, event)))
+
+    row = service.approve("agent-user-1", "human-user-1")
+
+    assert row.state == "visit"
+    assert notifications == [(row, "approve")]
+
+
+def test_relationship_reject_notifies_original_requester_after_persisting_decision() -> None:
+    repo = _FakeRelationshipRepo()
+    repo._existing[("agent-user-1", "human-user-1")]["state"] = "pending"
+    notifications = []
+    service = RelationshipService(repo, on_relationship_decided=lambda row, event: notifications.append((row, event)))
+
+    row = service.reject("agent-user-1", "human-user-1")
+
+    assert row.state == "none"
+    assert row.initiator_user_id == "human-user-1"
+    assert notifications == [(row, "reject")]
+
+
 def test_relationship_list_for_user_fails_on_invalid_row() -> None:
     service = RelationshipService(
         SimpleNamespace(


### PR DESCRIPTION
## Summary
- emit relationship approve/reject decision notifications after persistence
- route managed-agent requesters through the backend relationship runtime inlet
- wire the notification port during web lifespan startup

## Verification
- uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_approve_notifies_original_requester_after_persisting_decision tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_relationship_reject_notifies_original_requester_after_persisting_decision tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py -q
- uv run ruff check messaging/relationships/service.py backend/threads/chat_adapters/relationship_inlet.py backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run ruff format --check messaging/relationships/service.py backend/threads/chat_adapters/relationship_inlet.py backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- git diff --check
- uv run pytest tests -q