### PR TITLE
Harden Skill package schema identity

### DIFF
--- a/config/agent_config_types.py
+++ b/config/agent_config_types.py
@@ -66,6 +66,8 @@ class SkillPackage(AgentConfigSchemaModel):
         document = parse_skill_document(self.skill_md, label="skill_package.skill_md", require_description=True, require_version=True)
         if document.version != self.version:
             raise ValueError("skill_package.version must match SKILL.md frontmatter version")
+        if self.id == self.hash.removeprefix("sha256:"):
+            raise ValueError("skill_package.id must not be the content hash")
         return self
 
 

--- a/config/skill_package.py
+++ b/config/skill_package.py
@@ -21,7 +21,7 @@ def build_skill_package(
     document = parse_skill_document(skill_md, label="SKILL.md", require_description=True, require_version=True)
     package_hash = build_skill_package_hash(skill_md, files)
     return SkillPackage(
-        id=package_hash.removeprefix("sha256:"),
+        id=build_skill_package_id(owner_user_id, skill_id, package_hash),
         owner_user_id=owner_user_id,
         skill_id=skill_id,
         version=cast(str, document.version),
@@ -55,6 +55,16 @@ def build_skill_package_hash(skill_md: str, files: dict[str, str]) -> str:
     }
     encoded = json.dumps(package_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def build_skill_package_id(owner_user_id: str, skill_id: str, package_hash: str) -> str:
+    row_payload = {
+        "owner_user_id": owner_user_id,
+        "skill_id": skill_id,
+        "hash": package_hash,
+    }
+    encoded = json.dumps(row_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"pkg_{hashlib.sha256(encoded).hexdigest()}"
 
 
 def _sha256_text(value: str) -> str:

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -32,15 +32,36 @@ create table if not exists library.skill_packages (
     created_at timestamptz not null default now(),
     unique (owner_user_id, skill_id, hash),
     unique (owner_user_id, skill_id, id),
+    unique (skill_id, id),
     foreign key (owner_user_id, skill_id)
         references library.skills(owner_user_id, id)
         on delete cascade
 );
 
-alter table library.skill_packages
-    drop constraint if exists skill_packages_owner_user_id_skill_id_id_key,
-    add constraint skill_packages_owner_user_id_skill_id_id_key
-        unique (owner_user_id, skill_id, id);
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'skill_packages_owner_user_id_skill_id_id_key'
+          and conrelid = 'library.skill_packages'::regclass
+    ) then
+        alter table library.skill_packages
+            add constraint skill_packages_owner_user_id_skill_id_id_key
+                unique (owner_user_id, skill_id, id);
+    end if;
+
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'skill_packages_skill_id_id_key'
+          and conrelid = 'library.skill_packages'::regclass
+    ) then
+        alter table library.skill_packages
+            add constraint skill_packages_skill_id_id_key
+                unique (skill_id, id);
+    end if;
+end $$;
 
 alter table library.skills
     drop constraint if exists skills_package_fk,
@@ -61,8 +82,7 @@ create table if not exists agent.skill_bindings (
     id uuid primary key default gen_random_uuid(),
     agent_config_id text not null,
     skill_id text not null,
-    package_id text not null
-        references library.skill_packages(id),
+    package_id text not null,
     enabled boolean not null default true,
     created_at timestamptz not null default now(),
     unique (agent_config_id, skill_id)
@@ -100,7 +120,11 @@ alter table if exists agent.agent_sub_agents
 alter table if exists agent.skill_bindings
     drop constraint if exists skill_bindings_agent_config_id_fkey,
     add constraint skill_bindings_agent_config_id_fkey
-        foreign key (agent_config_id) references agent.agent_configs(id) on delete cascade;
+        foreign key (agent_config_id) references agent.agent_configs(id) on delete cascade,
+    drop constraint if exists skill_bindings_package_id_fkey,
+    drop constraint if exists skill_bindings_package_skill_fk,
+    add constraint skill_bindings_package_skill_fk
+        foreign key (skill_id, package_id) references library.skill_packages(skill_id, id);
 
 do $$
 begin

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -31,16 +31,22 @@ create table if not exists library.skill_packages (
     source_json jsonb not null default '{}'::jsonb,
     created_at timestamptz not null default now(),
     unique (owner_user_id, skill_id, hash),
+    unique (owner_user_id, skill_id, id),
     foreign key (owner_user_id, skill_id)
         references library.skills(owner_user_id, id)
         on delete cascade
 );
 
+alter table library.skill_packages
+    drop constraint if exists skill_packages_owner_user_id_skill_id_id_key,
+    add constraint skill_packages_owner_user_id_skill_id_id_key
+        unique (owner_user_id, skill_id, id);
+
 alter table library.skills
     drop constraint if exists skills_package_fk,
     add constraint skills_package_fk
-        foreign key (package_id)
-        references library.skill_packages(id);
+        foreign key (owner_user_id, id, package_id)
+        references library.skill_packages(owner_user_id, skill_id, id);
 
 alter table if exists library.skills
     alter column description drop default;
@@ -205,6 +211,12 @@ begin
         drop constraint if exists skill_packages_version_required_ck,
         add constraint skill_packages_version_required_ck
             check (version is not null and btrim(version) <> ''),
+        drop constraint if exists skill_packages_hash_format_ck,
+        add constraint skill_packages_hash_format_ck
+            check (hash like 'sha256:%'),
+        drop constraint if exists skill_packages_id_not_hash_ck,
+        add constraint skill_packages_id_not_hash_ck
+            check (id <> substring(hash from 8)),
         drop constraint if exists skill_packages_manifest_json_object_ck,
         add constraint skill_packages_manifest_json_object_ck
             check (jsonb_typeof(manifest_json) = 'object'),

--- a/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
+++ b/storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql
@@ -48,6 +48,9 @@ alter table if exists library.skills
 alter table if exists library.skill_packages
     alter column version drop default;
 
+alter table if exists agent.agent_configs
+    alter column mcp_json set default '[]'::jsonb;
+
 create table if not exists agent.skill_bindings (
     id uuid primary key default gen_random_uuid(),
     agent_config_id text not null,
@@ -177,7 +180,10 @@ begin
     alter table library.skills
         drop constraint if exists skills_description_required_ck,
         add constraint skills_description_required_ck
-            check (description is not null and btrim(description) <> '');
+            check (description is not null and btrim(description) <> ''),
+        drop constraint if exists skills_source_json_object_ck,
+        add constraint skills_source_json_object_ck
+            check (jsonb_typeof(source_json) = 'object');
 
     if exists (
         select 1
@@ -198,7 +204,16 @@ begin
     alter table library.skill_packages
         drop constraint if exists skill_packages_version_required_ck,
         add constraint skill_packages_version_required_ck
-            check (version is not null and btrim(version) <> '');
+            check (version is not null and btrim(version) <> ''),
+        drop constraint if exists skill_packages_manifest_json_object_ck,
+        add constraint skill_packages_manifest_json_object_ck
+            check (jsonb_typeof(manifest_json) = 'object'),
+        drop constraint if exists skill_packages_files_json_object_ck,
+        add constraint skill_packages_files_json_object_ck
+            check (jsonb_typeof(files_json) = 'object'),
+        drop constraint if exists skill_packages_source_json_object_ck,
+        add constraint skill_packages_source_json_object_ck
+            check (jsonb_typeof(source_json) = 'object');
 
     if exists (
         select 1
@@ -279,6 +294,23 @@ begin
     ) then
         raise exception 'agent.agent_configs.mcp_json must be a JSON array before hard cut';
     end if;
+
+    alter table agent.agent_configs
+        drop constraint if exists agent_configs_tools_json_array_ck,
+        add constraint agent_configs_tools_json_array_ck
+            check (jsonb_typeof(tools_json) = 'array'),
+        drop constraint if exists agent_configs_runtime_json_object_ck,
+        add constraint agent_configs_runtime_json_object_ck
+            check (jsonb_typeof(runtime_json) = 'object'),
+        drop constraint if exists agent_configs_compact_json_object_ck,
+        add constraint agent_configs_compact_json_object_ck
+            check (jsonb_typeof(compact_json) = 'object'),
+        drop constraint if exists agent_configs_meta_json_object_ck,
+        add constraint agent_configs_meta_json_object_ck
+            check (jsonb_typeof(meta_json) = 'object'),
+        drop constraint if exists agent_configs_mcp_json_array_ck,
+        add constraint agent_configs_mcp_json_array_ck
+            check (jsonb_typeof(mcp_json) = 'array');
 end $$;
 
 create or replace function agent.save_agent_config(payload jsonb)

--- a/tests/Unit/config/test_agent_config_types.py
+++ b/tests/Unit/config/test_agent_config_types.py
@@ -349,6 +349,20 @@ def test_skill_package_requires_skill_md_description() -> None:
         )
 
 
+def test_skill_package_id_must_not_be_content_hash_identity() -> None:
+    with pytest.raises(ValueError, match="skill_package.id must not be the content hash"):
+        SkillPackage(
+            id="abc",
+            owner_user_id="owner-1",
+            skill_id="skill-1",
+            version="1.0.0",
+            hash="sha256:abc",
+            manifest={},
+            skill_md="---\nname: query-helper\ndescription: Build precise queries\nversion: 1.0.0\n---\nUse exact terms.",
+            created_at=datetime(2026, 4, 25, tzinfo=UTC),
+        )
+
+
 @pytest.mark.parametrize(
     ("model_cls", "payload"),
     [

--- a/tests/Unit/config/test_skill_package.py
+++ b/tests/Unit/config/test_skill_package.py
@@ -4,10 +4,10 @@ from datetime import UTC, datetime
 import pytest
 
 from config.agent_config_types import SkillPackage
-from config.skill_package import build_skill_package, build_skill_package_hash, build_skill_package_manifest
+from config.skill_package import build_skill_package, build_skill_package_hash, build_skill_package_id, build_skill_package_manifest
 
 
-def test_build_skill_package_uses_content_hash_as_identity() -> None:
+def test_build_skill_package_separates_row_identity_from_content_hash() -> None:
     created_at = datetime(2026, 4, 26, tzinfo=UTC)
     skill_md = "---\nname: Query Helper\ndescription: Build precise queries\nversion: 1.2.3\n---\nUse exact terms."
     files = {"references/query.md": "Prefer precise queries."}
@@ -22,7 +22,8 @@ def test_build_skill_package_uses_content_hash_as_identity() -> None:
     )
 
     expected_hash = build_skill_package_hash(skill_md, files)
-    assert package.id == expected_hash.removeprefix("sha256:")
+    assert package.id == build_skill_package_id("owner-1", "skill-1", expected_hash)
+    assert package.id != expected_hash.removeprefix("sha256:")
     assert package.hash == expected_hash
     assert package.manifest == build_skill_package_manifest(skill_md, files)
     assert package.owner_user_id == "owner-1"
@@ -32,6 +33,39 @@ def test_build_skill_package_uses_content_hash_as_identity() -> None:
     assert package.files == files
     assert package.source == {"kind": "test"}
     assert package.created_at == created_at
+
+
+def test_build_skill_package_row_identity_is_scoped_to_owner_and_skill() -> None:
+    created_at = datetime(2026, 4, 26, tzinfo=UTC)
+    skill_md = "---\nname: Query Helper\ndescription: Build precise queries\nversion: 1.2.3\n---\nUse exact terms."
+
+    owner_one = build_skill_package(
+        owner_user_id="owner-1",
+        skill_id="skill-1",
+        skill_md=skill_md,
+        files={},
+        source={},
+        created_at=created_at,
+    )
+    owner_two = build_skill_package(
+        owner_user_id="owner-2",
+        skill_id="skill-1",
+        skill_md=skill_md,
+        files={},
+        source={},
+        created_at=created_at,
+    )
+    skill_two = build_skill_package(
+        owner_user_id="owner-1",
+        skill_id="skill-2",
+        skill_md=skill_md,
+        files={},
+        source={},
+        created_at=created_at,
+    )
+
+    assert owner_one.hash == owner_two.hash == skill_two.hash
+    assert len({owner_one.id, owner_two.id, skill_two.id}) == 3
 
 
 def test_build_skill_package_has_no_external_version_argument() -> None:

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -90,6 +90,9 @@ def test_agent_config_schema_does_not_convert_object_mcp_json() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 
     assert "agent.agent_configs.mcp_json must be a JSON array before hard cut" in sql
+    assert "alter column mcp_json set default '[]'::jsonb" in sql
+    assert "agent_configs_mcp_json_array_ck" in sql
+    assert "check (jsonb_typeof(mcp_json) = 'array')" in sql
     assert "jsonb_typeof(mcp_json) not in ('array', 'object')" not in sql
     assert "jsonb_each(c.mcp_json)" not in sql
     assert "(item.value - 'disabled')" not in sql
@@ -115,10 +118,18 @@ def test_agent_config_schema_constrains_root_identity_fields() -> None:
     assert "library.skill_packages.files_json values must be strings before hard cut" in sql
     assert "library.skill_packages.files_json keys must be package-relative paths before hard cut" in sql
     assert "library.skill_packages.source_json must be a JSON object before hard cut" in sql
+    assert "skills_source_json_object_ck" in sql
+    assert "skill_packages_manifest_json_object_ck" in sql
+    assert "skill_packages_files_json_object_ck" in sql
+    assert "skill_packages_source_json_object_ck" in sql
     assert "agent.agent_configs.tools_json must be a JSON array before hard cut" in sql
     assert "agent.agent_configs.runtime_json must be a JSON object before hard cut" in sql
     assert "agent.agent_configs.compact_json must be a JSON object before hard cut" in sql
     assert "agent.agent_configs.meta_json must be a JSON object before hard cut" in sql
+    assert "agent_configs_tools_json_array_ck" in sql
+    assert "agent_configs_runtime_json_object_ck" in sql
+    assert "agent_configs_compact_json_object_ck" in sql
+    assert "agent_configs_meta_json_object_ck" in sql
     assert "agent_configs_owner_user_id_required_ck" in sql
     assert "agent_configs_agent_user_id_required_ck" in sql
     assert "agent_configs_name_required_ck" in sql

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -18,7 +18,6 @@ def test_agent_config_schema_uses_library_package_storage() -> None:
     assert "files_json jsonb not null default '{}'::jsonb" in sql
     assert "manifest_json jsonb not null default '{}'::jsonb" in sql
     assert "artifact_uri" not in sql
-    assert "references library.skill_packages(id)" in sql
     assert "skills_package_fk" in sql
     assert "foreign key (owner_user_id, id, package_id)" in sql
     assert "references library.skill_packages(owner_user_id, skill_id, id)" in sql
@@ -40,6 +39,7 @@ def test_skill_package_schema_separates_row_id_from_content_hash() -> None:
     assert "skill_packages_id_not_hash_ck" in sql
     assert "id <> substring(hash from 8)" in sql
     assert "unique (owner_user_id, skill_id, id)" in sql
+    assert "unique (skill_id, id)" in sql
 
 
 def test_agent_skill_binding_package_fk_does_not_silently_delete_agent_selection() -> None:
@@ -52,7 +52,10 @@ def test_agent_skill_binding_package_fk_does_not_silently_delete_agent_selection
     )
     assert binding_table is not None
     body = binding_table.group("body")
-    assert "references library.skill_packages(id)" in body
+    assert "references library.skill_packages(id)" not in body
+    assert "skill_bindings_package_skill_fk" in sql
+    assert "foreign key (skill_id, package_id)" in sql
+    assert "references library.skill_packages(skill_id, id)" in sql
     assert "on delete cascade" not in body.lower()
 
 

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -42,6 +42,20 @@ def test_skill_package_schema_separates_row_id_from_content_hash() -> None:
     assert "unique (skill_id, id)" in sql
 
 
+def test_skill_package_unique_constraints_are_added_without_breaking_dependents() -> None:
+    sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
+
+    package_backfill = re.search(
+        r"if not exists \(.*?skill_packages_owner_user_id_skill_id_id_key.*?end if;.*?"
+        r"if not exists \(.*?skill_packages_skill_id_id_key.*?end if;",
+        sql,
+        flags=re.DOTALL,
+    )
+    assert package_backfill is not None
+    assert "drop constraint if exists skill_packages_owner_user_id_skill_id_id_key" not in sql
+    assert "drop constraint if exists skill_packages_skill_id_id_key" not in sql
+
+
 def test_agent_skill_binding_package_fk_does_not_silently_delete_agent_selection() -> None:
     sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
 

--- a/tests/Unit/storage/test_agent_config_schema_sql.py
+++ b/tests/Unit/storage/test_agent_config_schema_sql.py
@@ -19,6 +19,9 @@ def test_agent_config_schema_uses_library_package_storage() -> None:
     assert "manifest_json jsonb not null default '{}'::jsonb" in sql
     assert "artifact_uri" not in sql
     assert "references library.skill_packages(id)" in sql
+    assert "skills_package_fk" in sql
+    assert "foreign key (owner_user_id, id, package_id)" in sql
+    assert "references library.skill_packages(owner_user_id, skill_id, id)" in sql
     assert "agent_config.skills child.skill_id is required" in sql
     assert "agent_config.skills child.package_id is required" in sql
     assert "agent_skill.package_id does not belong to owner" in sql
@@ -27,6 +30,16 @@ def test_agent_config_schema_uses_library_package_storage() -> None:
     assert "insert into agent.agent_skills" not in sql
     assert "agent.agent_skills.content" not in sql
     assert "agent.agent_skills.files_json" not in sql
+
+
+def test_skill_package_schema_separates_row_id_from_content_hash() -> None:
+    sql = Path("storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql").read_text(encoding="utf-8")
+
+    assert "skill_packages_hash_format_ck" in sql
+    assert "hash like 'sha256:%'" in sql
+    assert "skill_packages_id_not_hash_ck" in sql
+    assert "id <> substring(hash from 8)" in sql
+    assert "unique (owner_user_id, skill_id, id)" in sql
 
 
 def test_agent_skill_binding_package_fk_does_not_silently_delete_agent_selection() -> None:


### PR DESCRIPTION
## Summary
- split Skill package row identity from content hash
- constrain Library selected packages to the same owner and Skill
- constrain Agent Skill bindings to matching Skill packages
- harden JSON shape constraints and live schema replay idempotence

## Verification
- uv run pytest tests/Unit/config/test_skill_package.py tests/Unit/config/test_agent_config_types.py tests/Unit/config/test_agent_config_resolver.py tests/Unit/storage/test_agent_config_schema_sql.py tests/Unit/storage/test_supabase_agent_config_repo.py tests/Unit/storage/test_supabase_skill_repo.py tests/Unit/platform/test_marketplace_client.py tests/Unit/integration_contracts/test_marketplace_router_user_shell.py -q -k "skill or package or agent_config_schema"
- uv run pytest tests/Unit -q
- uv run ruff format --check . && uv run ruff check .
- uv run pyright config/skill_package.py config/agent_config_types.py storage/providers/supabase/skill_repo.py storage/providers/supabase/agent_config_repo.py
- replayed storage/schema/2026_04_24_agent_config_resolved_config_hardcut.sql on live Supabase with supabase_admin

## Live Supabase checks
- agent.agent_configs.mcp_json default is []
- library Skill package JSON constraints are installed
- library.skills.package_id uses composite package ownership FK
- agent.skill_bindings uses matching Skill/package FK