### PR TITLE
Refactor chat agent wake policy

### DIFF
--- a/backend/threads/chat_adapters/chat_handler.py
+++ b/backend/threads/chat_adapters/chat_handler.py
@@ -28,5 +28,6 @@ class NativeAgentChatDeliveryHandler:
             sender_id=envelope.sender.user_id,
             sender_name=envelope.sender.display_name,
             sender_avatar_url=envelope.sender.avatar_url,
+            wake=envelope.wake,
         )
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=thread_id)

--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -57,6 +57,7 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
             ),
             recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source="mycel", thread_id=thread_id),
             message=AgentRuntimeMessage(content=rendered_content, signal=request.signal),
+            wake=request.wake,
             extensions={
                 "mycel": {
                     "recipient_user_id": recipient_user_id,

--- a/backend/threads/chat_adapters/chat_runtime_services.py
+++ b/backend/threads/chat_adapters/chat_runtime_services.py
@@ -16,6 +16,7 @@ class AgentChatRuntimeServices(Protocol):
         sender_id: str,
         sender_name: str,
         sender_avatar_url: str | None,
+        wake: bool = True,
     ) -> None: ...
 
 
@@ -54,6 +55,7 @@ class AppAgentChatRuntimeServices:
         sender_id: str,
         sender_name: str,
         sender_avatar_url: str | None,
+        wake: bool = True,
     ) -> None:
         self._queue_manager.enqueue(
             content,
@@ -63,4 +65,5 @@ class AppAgentChatRuntimeServices:
             sender_id=sender_id,
             sender_name=sender_name,
             sender_avatar_url=sender_avatar_url,
+            wake=wake,
         )

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -37,6 +37,7 @@ class MessageQueueManager:
         sender_name: str | None = None,
         sender_avatar_url: str | None = None,
         is_steer: bool = False,
+        wake: bool = True,
     ) -> None:
         self._repo.enqueue(
             thread_id,
@@ -46,6 +47,8 @@ class MessageQueueManager:
             sender_id=sender_id,
             sender_name=sender_name,
         )
+        if not wake:
+            return
         with self._wake_lock:
             handler = self._wake_handlers.get(thread_id)
         if handler:

--- a/messaging/delivery/actions.py
+++ b/messaging/delivery/actions.py
@@ -6,6 +6,6 @@ from enum import StrEnum
 
 
 class DeliveryAction(StrEnum):
-    DELIVER = "deliver"  # inject into agent context, wake agent
-    NOTIFY = "notify"  # store + unread count, no delivery
-    DROP = "drop"  # silent: stored but invisible to recipient
+    DELIVER = "deliver"  # runtime delivery is allowed
+    NOTIFY = "notify"  # runtime delivery is allowed without waking
+    DROP = "drop"  # runtime delivery is blocked

--- a/messaging/delivery/contracts.py
+++ b/messaging/delivery/contracts.py
@@ -18,6 +18,7 @@ class ChatDeliveryRequest:
     sender_avatar_url: str | None
     unread_count: int
     signal: str | None
+    wake: bool = True
 
 
 class ChatDeliveryFn(Protocol):

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -9,6 +9,13 @@ from typing import Any
 from messaging.avatars import AvatarUrlBuilder
 from messaging.delivery.actions import DeliveryAction
 from messaging.delivery.contracts import ChatDeliveryFn, ChatDeliveryRequest
+from messaging.delivery.wake_policy import (
+    ReceiverWakePreference,
+    SenderWakeScope,
+    WakeAction,
+    WakeSafety,
+    compose_wake_action,
+)
 from messaging.display_user import resolve_messaging_display_user
 
 logger = logging.getLogger(__name__)
@@ -46,6 +53,7 @@ class ChatDeliveryDispatcher:
         signal: str | None = None,
     ) -> None:
         mention_set = set(mentions)
+        sender_scope = SenderWakeScope.from_mentions(mentions)
         members = self._chat_members_repo.list_members(chat_id)
         sender_user = self._resolve_display_user(sender_id)
         if sender_user is None:
@@ -72,32 +80,23 @@ class ChatDeliveryDispatcher:
             if member_type != "agent":
                 continue
 
+            action = DeliveryAction.DELIVER
             # @@@same-owner-group-delivery - explicit group membership among the same owner
-            # must reach sibling actors even when no relationship row exists yet.
-            if sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id:
-                if self._same_owner_delivery_is_muted(member, uid in mention_set):
-                    logger.info("[messaging] POLICY %s for %s", DeliveryAction.NOTIFY.value, uid[:15])
-                    continue
-                self._deliver(
-                    uid,
-                    recipient,
-                    content,
-                    sender_name,
-                    sender_type,
-                    chat_id,
-                    sender_id,
-                    sender_avatar_url,
-                    unread_count=self._count_unread(chat_id, uid),
-                    signal=signal,
-                )
-                continue
-
-            if self._delivery_resolver:
+            # is already enough access for runtime delivery; resolver policy is only needed
+            # across ownership boundaries.
+            if self._needs_access_resolver(sender_owner_id, recipient) and self._delivery_resolver:
                 is_mentioned = uid in mention_set
                 action = self._delivery_resolver.resolve(uid, chat_id, sender_id, is_mentioned=is_mentioned)
-                if action != DeliveryAction.DELIVER:
-                    logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])
-                    continue
+
+            wake_action = compose_wake_action(
+                safety=self._wake_safety(action),
+                sender_scope=sender_scope,
+                receiver_preference=self._receiver_preference(member, action),
+                recipient_is_mentioned=uid in mention_set,
+            )
+            if wake_action is WakeAction.DROP_RUNTIME:
+                logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])
+                continue
 
             self._deliver(
                 uid,
@@ -110,6 +109,7 @@ class ChatDeliveryDispatcher:
                 sender_avatar_url,
                 unread_count=self._count_unread(chat_id, uid),
                 signal=signal,
+                wake=wake_action is WakeAction.WAKE_NOW,
             )
 
     def _resolve_display_user(self, social_user_id: str) -> Any | None:
@@ -131,6 +131,9 @@ class ChatDeliveryDispatcher:
             raise RuntimeError("Chat delivery avatar URL builder is not configured")
         return self._avatar_url_builder(user_id, has_avatar)
 
+    def _needs_access_resolver(self, sender_owner_id: str | None, recipient: Any) -> bool:
+        return not (sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id)
+
     def _deliver(
         self,
         recipient_id: str,
@@ -144,6 +147,7 @@ class ChatDeliveryDispatcher:
         unread_count: int,
         *,
         signal: str | None,
+        wake: bool,
     ) -> None:
         if not self._delivery_fn:
             raise RuntimeError("Chat delivery function is not configured")
@@ -159,13 +163,16 @@ class ChatDeliveryDispatcher:
                 sender_avatar_url=sender_avatar_url,
                 unread_count=unread_count,
                 signal=signal,
+                wake=wake,
             )
         )
 
-    def _same_owner_delivery_is_muted(self, member: dict[str, Any], is_mentioned: bool) -> bool:
-        # @@@same-owner-attention-control - same-owner group delivery skips
-        # relationship checks, but chat-level mute is still the owner-controlled
-        # attention switch; explicit mentions wake muted agents.
-        if is_mentioned:
-            return False
-        return bool(member.get("muted", False))
+    def _wake_safety(self, action: DeliveryAction) -> WakeSafety:
+        if action is DeliveryAction.DROP:
+            return WakeSafety.BLOCKED
+        return WakeSafety.ALLOWED
+
+    def _receiver_preference(self, member: dict[str, Any], action: DeliveryAction) -> ReceiverWakePreference:
+        if bool(member.get("muted", False)) or action is DeliveryAction.NOTIFY:
+            return ReceiverWakePreference.QUIET
+        return ReceiverWakePreference.DEFAULT

--- a/messaging/delivery/resolver.py
+++ b/messaging/delivery/resolver.py
@@ -1,14 +1,10 @@
-"""HireVisitDeliveryResolver — delivery action based on relationship state.
+"""HireVisitDeliveryResolver — receiver access and quiet policy.
 
 Priority chain (highest wins):
-1. blocked (contact relation) → DROP
-2. HIRE relationship → DELIVER (direct access)
-3. @mention override → DELIVER
-4. muted contact → NOTIFY
-5. muted chat → NOTIFY
-6. VISIT relationship → NOTIFY (queue, not direct)
-7. stranger (no relationship) → NOTIFY (anti-spam default)
-8. Default → DELIVER (same-owner users, known contacts)
+1. blocked contact → DROP
+2. muted contact → NOTIFY
+3. muted chat → NOTIFY
+4. otherwise → DELIVER
 """
 
 from __future__ import annotations
@@ -50,46 +46,23 @@ class HireVisitDeliveryResolver:
         *,
         is_mentioned: bool = False,
     ) -> DeliveryAction:
-        # 1. Contact-level block — always DROP
         contact = self._get_contact(recipient_id, sender_id)
         if self._is_blocked(contact):
             logger.debug("[resolver] DROP: %s blocked %s", recipient_id[:15], sender_id[:15])
             return DeliveryAction.DROP
 
-        # Fetch relationship once for checks 2, 6, 7
         rel = self._relationships.get(recipient_id, sender_id) if self._relationships else None
-        rel_state = self._relationship_state(rel) if rel else "none"
+        if rel:
+            self._relationship_state(rel)
 
-        # 2. HIRE → DELIVER
-        if rel_state == "hire":
-            logger.debug("[resolver] DELIVER: HIRE relationship %s←%s", recipient_id[:15], sender_id[:15])
-            return DeliveryAction.DELIVER
-
-        # 3. @mention override — skip mute checks (not block)
-        if is_mentioned:
-            return DeliveryAction.DELIVER
-
-        # 4. Contact-level mute
         if self._is_muted(contact):
             logger.debug("[resolver] NOTIFY: %s muted %s", recipient_id[:15], sender_id[:15])
             return DeliveryAction.NOTIFY
 
-        # 5. Chat-level mute
         if self._is_chat_muted(recipient_id, chat_id):
             logger.debug("[resolver] NOTIFY: %s muted chat %s", recipient_id[:15], chat_id[:8])
             return DeliveryAction.NOTIFY
 
-        # 6. VISIT → NOTIFY
-        if rel_state == "visit":
-            logger.debug("[resolver] NOTIFY: VISIT relationship %s←%s", recipient_id[:15], sender_id[:15])
-            return DeliveryAction.NOTIFY
-
-        # 7. Stranger (none or no relationship) → NOTIFY (anti-spam)
-        if self._relationships and rel_state == "none":
-            logger.debug("[resolver] NOTIFY: stranger %s←%s", recipient_id[:15], sender_id[:15])
-            return DeliveryAction.NOTIFY
-
-        # 8. Default → DELIVER
         return DeliveryAction.DELIVER
 
     def _relationship_state(self, relationship: dict[str, Any]) -> str:

--- a/messaging/delivery/wake_policy.py
+++ b/messaging/delivery/wake_policy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class WakeSafety(StrEnum):
+    ALLOWED = "allowed"
+    BLOCKED = "blocked"
+
+
+class SenderWakeScope(StrEnum):
+    OPEN = "open"
+    TARGETED = "targeted"
+    QUIET = "quiet"
+
+    @classmethod
+    def from_mentions(cls, mentions: list[str]) -> SenderWakeScope:
+        return cls.TARGETED if mentions else cls.OPEN
+
+
+class ReceiverWakePreference(StrEnum):
+    ALWAYS_WAKE = "always_wake"
+    DEFAULT = "default"
+    QUIET = "quiet"
+
+
+class WakeAction(StrEnum):
+    WAKE_NOW = "wake_now"
+    QUEUE_ONLY = "queue_only"
+    DROP_RUNTIME = "drop_runtime"
+
+
+def compose_wake_action(
+    *,
+    safety: WakeSafety,
+    sender_scope: SenderWakeScope,
+    receiver_preference: ReceiverWakePreference,
+    recipient_is_mentioned: bool,
+) -> WakeAction:
+    if safety is WakeSafety.BLOCKED:
+        return WakeAction.DROP_RUNTIME
+    if receiver_preference is ReceiverWakePreference.QUIET:
+        return WakeAction.QUEUE_ONLY
+    if receiver_preference is ReceiverWakePreference.ALWAYS_WAKE:
+        return WakeAction.WAKE_NOW
+    if sender_scope is SenderWakeScope.QUIET:
+        return WakeAction.QUEUE_ONLY
+    if sender_scope is SenderWakeScope.OPEN:
+        return WakeAction.WAKE_NOW
+    if recipient_is_mentioned:
+        return WakeAction.WAKE_NOW
+    return WakeAction.QUEUE_ONLY

--- a/protocols/agent_runtime.py
+++ b/protocols/agent_runtime.py
@@ -52,6 +52,7 @@ class AgentChatDeliveryEnvelope:
     sender: AgentRuntimeActor
     recipient: AgentChatRecipient
     message: AgentRuntimeMessage
+    wake: bool = True
     transport: AgentRuntimeTransport = AgentRuntimeTransport()
     protocol_version: Literal["agent.chat.delivery.v1"] = "agent.chat.delivery.v1"
     event_type: Literal["chat.message"] = "chat.message"

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -350,9 +350,9 @@ class RelationshipRow(BaseModel):
 
 
 class DeliveryAction(StrEnum):
-    DELIVER = "deliver"  # full delivery: inject into agent context, wake agent
-    NOTIFY = "notify"  # red dot only: message stored, unread counted, no delivery
-    DROP = "drop"  # silent: message stored but invisible to this user
+    DELIVER = "deliver"  # runtime delivery is allowed
+    NOTIFY = "notify"  # runtime delivery is allowed without waking
+    DROP = "drop"  # runtime delivery is blocked
 
 
 ContactRelation = Literal["normal", "blocked", "muted"]

--- a/tests/Unit/backend/test_chat_runtime_services.py
+++ b/tests/Unit/backend/test_chat_runtime_services.py
@@ -6,12 +6,12 @@ from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRunt
 
 def test_chat_runtime_services_use_injected_typing_tracker_and_queue_manager():
     started: list[tuple[str, str, str]] = []
-    enqueued: list[tuple[str, str, str | None, str | None]] = []
+    enqueued: list[tuple[str, str, str | None, str | None, bool | None]] = []
 
     injected_typing_tracker = SimpleNamespace(start_chat=lambda thread_id, chat_id, user_id: started.append((thread_id, chat_id, user_id)))
     injected_queue_manager = SimpleNamespace(
         enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
-            (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
+            (content, thread_id, meta.get("sender_id"), meta.get("sender_name"), meta.get("wake"))
         )
     )
 
@@ -45,7 +45,33 @@ def test_chat_runtime_services_use_injected_typing_tracker_and_queue_manager():
     )
 
     assert started == [("thread-1", "chat-1", "agent-user-1")]
-    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human", True)]
+
+
+def test_chat_runtime_services_can_queue_without_waking():
+    enqueued: list[tuple[str, bool | None]] = []
+    injected_queue_manager = SimpleNamespace(
+        enqueue=lambda content, _thread_id, _notification_type, **meta: enqueued.append((content, meta.get("wake")))
+    )
+    services = AppAgentChatRuntimeServices(
+        SimpleNamespace(state=SimpleNamespace()),
+        typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
+        queue_manager=injected_queue_manager,
+        get_or_create_agent=lambda *_args, **_kwargs: None,
+        resolve_thread_sandbox=lambda *_args, **_kwargs: "local",
+        ensure_thread_handlers=lambda *_args, **_kwargs: None,
+    )
+
+    services.enqueue_chat_message(
+        content="quiet chat notification",
+        thread_id="thread-1",
+        sender_id="human-user-1",
+        sender_name="Human",
+        sender_avatar_url=None,
+        wake=False,
+    )
+
+    assert enqueued == [("quiet chat notification", False)]
 
 
 def test_chat_runtime_services_use_injected_runtime_callables():

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -20,10 +20,10 @@ def _app(
     *,
     threads: list[dict[str, Any]] | None = None,
     pool: dict[str, Any] | None = None,
-) -> tuple[SimpleNamespace, list[tuple[str, str, str]], list[tuple[str, str]], list[tuple[str, str, str | None, str | None]]]:
+) -> tuple[SimpleNamespace, list[tuple[str, str, str]], list[tuple[str, str]], list[tuple[str, str, str | None, str | None, bool | None]]]:
     started: list[tuple[str, str, str]] = []
     unread_calls: list[tuple[str, str]] = []
-    enqueued: list[tuple[str, str, str | None, str | None]] = []
+    enqueued: list[tuple[str, str, str | None, str | None, bool | None]] = []
     thread_rows = threads or [{"id": "thread-1", "agent_user_id": "agent-user-1", "is_main": True, "branch_index": 0}]
     default_thread = next((row for row in thread_rows if row.get("is_main")), thread_rows[0])
 
@@ -37,7 +37,7 @@ def _app(
             agent_pool=pool or {},
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
-                    (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))
+                    (content, thread_id, meta.get("sender_id"), meta.get("sender_name"), meta.get("wake"))
                 )
             ),
             thread_cwd={},
@@ -56,12 +56,14 @@ def _envelope(
     signal: str | None = "ping",
     content: str = "hello",
     thread_id: str | None = "thread-1",
+    wake: bool = True,
 ) -> AgentChatDeliveryEnvelope:
     return AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id=chat_id),
         sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
         recipient=AgentChatRecipient(agent_user_id="agent-user-1", runtime_source="mycel", thread_id=thread_id),
         message=AgentRuntimeMessage(content=content, signal=signal),
+        wake=wake,
     )
 
 
@@ -82,7 +84,24 @@ async def test_gateway_dispatch_chat_enqueues_notification(monkeypatch: pytest.M
     assert result.thread_id == "thread-1"
     assert started == [("thread-1", "chat-1", "agent-user-1")]
     assert unread_calls == []
-    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human", True)]
+
+
+@pytest.mark.asyncio
+async def test_gateway_dispatch_chat_can_queue_without_waking(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_get_or_create_agent(_app, _sandbox_type: str, *, thread_id: str):
+        return SimpleNamespace(id=f"agent-for-{thread_id}")
+
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.get_or_create_agent", _fake_get_or_create_agent)
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", lambda _app, _thread_id: "local")
+    monkeypatch.setattr("backend.threads.chat_adapters.bootstrap._ensure_thread_handlers", lambda *_args, **_kwargs: None)
+    app, _started, _unread_calls, enqueued = _app()
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
+
+    result = await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_chat(_envelope(wake=False))
+
+    assert result.status == "accepted"
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human", False)]
 
 
 @pytest.mark.asyncio
@@ -117,4 +136,4 @@ async def test_gateway_dispatch_chat_uses_explicit_typing_tracker(monkeypatch: p
 
     assert result.status == "accepted"
     assert started == [("thread-1", "chat-1", "agent-user-1")]
-    assert enqueued == [("hello", "thread-1", "human-user-1", "Human")]
+    assert enqueued == [("hello", "thread-1", "human-user-1", "Human", True)]

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -13,6 +13,7 @@ def test_agent_runtime_chat_and_thread_inputs_share_message_protocol_objects() -
     assert chat_fields["sender"] is protocol_module.AgentRuntimeActor
     assert chat_fields["message"] is protocol_module.AgentRuntimeMessage
     assert chat_fields["transport"] is protocol_module.AgentRuntimeTransport
+    assert chat_fields["wake"] is bool
     assert thread_fields["sender"] is protocol_module.AgentRuntimeActor
     assert thread_fields["message"] is protocol_module.AgentRuntimeMessage
     assert thread_fields["transport"] is protocol_module.AgentRuntimeTransport

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -93,6 +93,41 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_delivery_hook_passes_request_wake_to_runtime_envelope() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_chat(self, envelope):
+            self.envelope = envelope
+
+    gateway = RecordingGateway()
+    app = _hook_app(gateway)
+    deliver = owner_chat_inlet.make_chat_delivery_fn(
+        app,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
+        thread_repo=app.state.thread_repo,
+    )
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+        content="hello",
+        sender_name="Human",
+        sender_type="human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        unread_count=3,
+        signal=None,
+        wake=False,
+    )
+
+    await asyncio.to_thread(deliver, request)
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.wake is False
+
+
+@pytest.mark.asyncio
 async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
     class RecordingGateway:
         called = False

--- a/tests/Unit/core/test_message_queue_manager_wake.py
+++ b/tests/Unit/core/test_message_queue_manager_wake.py
@@ -1,0 +1,25 @@
+from core.runtime.middleware.queue.manager import MessageQueueManager
+
+
+def test_queue_manager_can_enqueue_without_waking(tmp_path) -> None:
+    manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
+    seen: list[str] = []
+
+    manager.register_wake("thread-1", lambda item: seen.append(item.content))
+    manager.enqueue("queued only", "thread-1", notification_type="chat", wake=False)
+
+    assert seen == []
+    item = manager.dequeue("thread-1")
+    assert item is not None
+    assert item.content == "queued only"
+    assert item.notification_type == "chat"
+
+
+def test_queue_manager_wakes_by_default(tmp_path) -> None:
+    manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
+    seen: list[str] = []
+
+    manager.register_wake("thread-1", lambda item: seen.append(item.content))
+    manager.enqueue("wake now", "thread-1", notification_type="chat")
+
+    assert seen == ["wake now"]

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2865,6 +2865,69 @@ def test_delivery_resolver_reads_contact_edge_row_objects() -> None:
     assert action is DeliveryAction.DELIVER
 
 
+def test_delivery_resolver_delivers_default_visit_relationship_without_mention() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [
+                {"user_id": "agent-user-1", "muted": False},
+                {"user_id": "human-user-1", "muted": False},
+            ]
+        ),
+        relationship_repo=SimpleNamespace(
+            get=lambda _recipient_id, _sender_id: {
+                "id": "hire_visit:agent-user-1:human-user-1",
+                "user_low": "agent-user-1",
+                "user_high": "human-user-1",
+                "kind": "hire_visit",
+                "state": "visit",
+                "initiator_user_id": "human-user-1",
+                "message": None,
+                "created_at": "2026-04-07T00:00:00Z",
+                "updated_at": "2026-04-07T00:00:01Z",
+            }
+        ),
+    )
+
+    action = resolver.resolve("agent-user-1", "chat-1", "human-user-1")
+
+    assert action is DeliveryAction.DELIVER
+
+
+def test_delivery_resolver_delivers_default_group_member_without_relationship() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [
+                {"user_id": "agent-user-1", "muted": False},
+                {"user_id": "human-user-1", "muted": False},
+            ]
+        ),
+        relationship_repo=SimpleNamespace(get=lambda _recipient_id, _sender_id: None),
+    )
+
+    action = resolver.resolve("agent-user-1", "chat-1", "human-user-1")
+
+    assert action is DeliveryAction.DELIVER
+
+
+def test_delivery_resolver_receiver_mute_wins_over_explicit_mention() -> None:
+    resolver = HireVisitDeliveryResolver(
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [
+                {"user_id": "agent-user-1", "muted": True},
+                {"user_id": "human-user-1", "muted": False},
+            ]
+        ),
+        relationship_repo=None,
+    )
+
+    action = resolver.resolve("agent-user-1", "chat-1", "human-user-1", is_mentioned=True)
+
+    assert action is DeliveryAction.NOTIFY
+
+
 def test_delivery_resolver_propagates_contact_repo_failures() -> None:
     def _raise_get(_owner_id: str, _target_id: str) -> None:
         raise RuntimeError("contact repo unavailable")
@@ -2995,8 +3058,8 @@ def test_same_owner_agent_turn_delivers_to_sibling_user_without_relationship() -
     assert delivered == [("agent-user-2", "agent-user-2")]
 
 
-def test_same_owner_group_delivery_honors_chat_mute_until_mentioned() -> None:
-    delivered: list[tuple[str, str]] = []
+def test_same_owner_group_delivery_queues_muted_recipients_even_when_mentioned() -> None:
+    delivered: list[tuple[str, bool]] = []
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=SimpleNamespace(
             list_members=lambda _chat_id: [
@@ -3018,13 +3081,18 @@ def test_same_owner_group_delivery_honors_chat_mute_until_mentioned() -> None:
         ),
         unread_counter=lambda _chat_id, _user_id: 0,
         delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: DeliveryAction.DELIVER),
-        delivery_fn=lambda request: delivered.append((request.recipient_id, request.recipient_user.id)),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.wake)),
     )
 
     dispatcher.dispatch("chat-1", "human-user-1", "plain update", [])
     dispatcher.dispatch("chat-1", "human-user-1", "explicit mention", ["agent-user-2"])
 
-    assert delivered == [("agent-user-1", "agent-user-1"), ("agent-user-1", "agent-user-1"), ("agent-user-2", "agent-user-2")]
+    assert delivered == [
+        ("agent-user-1", True),
+        ("agent-user-2", False),
+        ("agent-user-1", False),
+        ("agent-user-2", False),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -104,6 +104,36 @@ def test_dispatcher_same_owner_group_delivers_without_relationship() -> None:
     assert delivered == ["agent-user-1", "agent-user-2"]
 
 
+def test_dispatcher_open_sender_scope_wakes_all_default_agents() -> None:
+    delivered: list[tuple[str, bool]] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
+        user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
+        unread_counter=lambda _chat_id, _user_id: 0,
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.wake)),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", [])
+
+    assert delivered == [("agent-user-1", True), ("agent-user-2", True)]
+
+
+def test_dispatcher_explicit_mentions_queue_unmentioned_default_agents() -> None:
+    delivered: list[tuple[str, bool]] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
+        user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
+        unread_counter=lambda _chat_id, _user_id: 0,
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.wake)),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "hello", ["agent-user-2"])
+
+    assert delivered == [("agent-user-1", False), ("agent-user-2", True)]
+
+
 def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
     delivered: list[str] = []
     dispatcher = ChatDeliveryDispatcher(
@@ -138,15 +168,30 @@ def test_dispatcher_does_not_runtime_deliver_to_external_users() -> None:
     assert delivered == []
 
 
-@pytest.mark.parametrize("action", [DeliveryAction.NOTIFY, DeliveryAction.DROP])
-def test_dispatcher_respects_non_deliver_policy(action: DeliveryAction) -> None:
+def test_dispatcher_queues_notify_policy_without_waking() -> None:
+    delivered: list[tuple[str, bool]] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["outside-human-user", "agent-user-1"]),
+        user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
+        unread_counter=lambda _chat_id, _user_id: 0,
+        delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: DeliveryAction.NOTIFY),
+        delivery_fn=lambda request: delivered.append((request.recipient_id, request.wake)),
+    )
+
+    dispatcher.dispatch("chat-1", "outside-human-user", "hello", [])
+
+    assert delivered == [("agent-user-1", False)]
+
+
+def test_dispatcher_respects_drop_policy() -> None:
     delivered: list[str] = []
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["outside-human-user", "agent-user-1"]),
         user_repo=_user_repo(),
         avatar_url_builder=lambda _user_id, _has_avatar: None,
         unread_counter=lambda _chat_id, _user_id: 0,
-        delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: action),
+        delivery_resolver=SimpleNamespace(resolve=lambda *_args, **_kwargs: DeliveryAction.DROP),
         delivery_fn=lambda request: delivered.append(request.recipient_id),
     )
 

--- a/tests/Unit/messaging/test_wake_policy.py
+++ b/tests/Unit/messaging/test_wake_policy.py
@@ -1,0 +1,81 @@
+from messaging.delivery.wake_policy import (
+    ReceiverWakePreference,
+    SenderWakeScope,
+    WakeAction,
+    WakeSafety,
+    compose_wake_action,
+)
+
+
+def test_sender_scope_is_open_without_mentions() -> None:
+    assert SenderWakeScope.from_mentions([]) is SenderWakeScope.OPEN
+
+
+def test_sender_scope_is_targeted_with_mentions() -> None:
+    assert SenderWakeScope.from_mentions(["agent-user-1"]) is SenderWakeScope.TARGETED
+
+
+def test_default_receiver_wakes_for_open_sender_scope() -> None:
+    action = compose_wake_action(
+        safety=WakeSafety.ALLOWED,
+        sender_scope=SenderWakeScope.OPEN,
+        receiver_preference=ReceiverWakePreference.DEFAULT,
+        recipient_is_mentioned=False,
+    )
+
+    assert action is WakeAction.WAKE_NOW
+
+
+def test_default_receiver_queues_when_targeted_but_unmentioned() -> None:
+    action = compose_wake_action(
+        safety=WakeSafety.ALLOWED,
+        sender_scope=SenderWakeScope.TARGETED,
+        receiver_preference=ReceiverWakePreference.DEFAULT,
+        recipient_is_mentioned=False,
+    )
+
+    assert action is WakeAction.QUEUE_ONLY
+
+
+def test_default_receiver_wakes_when_targeted_and_mentioned() -> None:
+    action = compose_wake_action(
+        safety=WakeSafety.ALLOWED,
+        sender_scope=SenderWakeScope.TARGETED,
+        receiver_preference=ReceiverWakePreference.DEFAULT,
+        recipient_is_mentioned=True,
+    )
+
+    assert action is WakeAction.WAKE_NOW
+
+
+def test_quiet_receiver_queues_even_when_mentioned() -> None:
+    action = compose_wake_action(
+        safety=WakeSafety.ALLOWED,
+        sender_scope=SenderWakeScope.TARGETED,
+        receiver_preference=ReceiverWakePreference.QUIET,
+        recipient_is_mentioned=True,
+    )
+
+    assert action is WakeAction.QUEUE_ONLY
+
+
+def test_always_wake_receiver_wakes_even_when_unmentioned() -> None:
+    action = compose_wake_action(
+        safety=WakeSafety.ALLOWED,
+        sender_scope=SenderWakeScope.TARGETED,
+        receiver_preference=ReceiverWakePreference.ALWAYS_WAKE,
+        recipient_is_mentioned=False,
+    )
+
+    assert action is WakeAction.WAKE_NOW
+
+
+def test_blocked_safety_drops_runtime_notification() -> None:
+    action = compose_wake_action(
+        safety=WakeSafety.BLOCKED,
+        sender_scope=SenderWakeScope.OPEN,
+        receiver_preference=ReceiverWakePreference.ALWAYS_WAKE,
+        recipient_is_mentioned=True,
+    )
+
+    assert action is WakeAction.DROP_RUNTIME


### PR DESCRIPTION
## Summary
- separate durable chat delivery from runtime wake decisions
- add queue-only notification support and a pure wake-policy composer
- pass wake intent through chat runtime envelopes/services
- make dispatcher deliver both wake-now and queue-only runtime notifications while keeping hard drops blocked
- simplify relationship delivery resolver so block/mute/access stays separate from sender mention scope

## Verification
- `uv run ruff check messaging/delivery core/runtime/middleware/queue backend/threads/chat_adapters protocols tests/Unit/messaging/test_wake_policy.py tests/Unit/core/test_message_queue_manager_wake.py tests/Unit/backend/test_chat_runtime_services.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run pyright backend/threads/chat_adapters/chat_handler.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_runtime_services.py core/runtime/middleware/queue/manager.py messaging/delivery/actions.py messaging/delivery/contracts.py messaging/delivery/dispatcher.py messaging/delivery/resolver.py messaging/delivery/wake_policy.py protocols/agent_runtime.py storage/contracts.py`
- `uv run pytest tests -q` -> 2068 passed, 8 skipped, 15 warnings

## Notes
- Full-repo pyright still fails on unrelated existing monitor/router/test typing debt; scoped production files for this slice are clean.
- Design doc committed locally in `mycel-db-design`: `program/doc/core/chat-agent-wake-policy-design-2026-04-26.html`.