### PR TITLE
Fix Hub Skill apply partial writes

### DIFF
--- a/backend/hub/client.py
+++ b/backend/hub/client.py
@@ -257,6 +257,14 @@ def apply_item(
         item_slug = item.get("slug")
         if isinstance(item_slug, str) and item_slug.strip():
             source["marketplace_slug"] = item_slug.strip()
+        package = build_skill_package(
+            owner_user_id=owner_user_id,
+            skill_id=skill_id,
+            skill_md=content,
+            files=skill_files,
+            source=source,
+            created_at=timestamp,
+        )
         skill = skill_repo.upsert(
             Skill(
                 id=skill_id,
@@ -268,16 +276,7 @@ def apply_item(
                 updated_at=timestamp,
             )
         )
-        package = skill_repo.create_package(
-            build_skill_package(
-                owner_user_id=owner_user_id,
-                skill_id=skill.id,
-                skill_md=content,
-                files=skill_files,
-                source=source,
-                created_at=timestamp,
-            )
-        )
+        package = skill_repo.create_package(package)
         skill_repo.select_package(owner_user_id, skill.id, package.id)
 
         return {"resource_id": skill.id, "package_id": package.id, "type": "skill", "version": package.version}

--- a/frontend/app/src/components/marketplace/MarketplaceActionDialog.wording.test.tsx
+++ b/frontend/app/src/components/marketplace/MarketplaceActionDialog.wording.test.tsx
@@ -4,6 +4,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { MarketplaceItemDetail } from "@/store/marketplace-store";
+
 import MarketplaceActionDialog from "./MarketplaceActionDialog";
 
 const mocks = vi.hoisted(() => ({
@@ -49,6 +51,41 @@ vi.mock("sonner", () => ({
   },
 }));
 
+function marketItem(overrides: Partial<MarketplaceItemDetail> = {}): MarketplaceItemDetail {
+  return {
+    id: "pkg-1",
+    slug: "pack-one",
+    description: "desc",
+    avatar_url: null,
+    publisher_user_id: "user-1",
+    name: "Pack One",
+    type: "member",
+    publisher_username: "tester",
+    parent_id: null,
+    download_count: 0,
+    visibility: "public",
+    tags: [],
+    created_at: "2026-04-08T00:00:00Z",
+    updated_at: "2026-04-08T00:00:00Z",
+    versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
+    parent: null,
+    ...overrides,
+  };
+}
+
+function skillItem(): MarketplaceItemDetail {
+  return marketItem({
+    id: "skill-1",
+    slug: "fastapi",
+    name: "FastAPI",
+    type: "skill",
+  });
+}
+
+function renderDialog(item: MarketplaceItemDetail = marketItem()) {
+  return render(<MarketplaceActionDialog open onOpenChange={vi.fn()} item={item} />);
+}
+
 afterEach(() => {
   mocks.applyItem.mockReset();
   mocks.applying = false;
@@ -63,30 +100,7 @@ afterEach(() => {
 
 describe("MarketplaceActionDialog wording contract", () => {
   it("uses Agent wording for Hub agent-user actions", () => {
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "pkg-1",
-          slug: "pack-one",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "Pack One",
-          type: "member",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
+    renderDialog();
 
     expect(document.body.textContent).toContain("添加 Pack One");
     expect(screen.getByText("这将把该 Agent 添加到你的 Agent 列表。")).toBeTruthy();
@@ -101,30 +115,7 @@ describe("MarketplaceActionDialog wording contract", () => {
       version: "1.0.0",
     });
 
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "pkg-1",
-          slug: "pack-one",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "Pack One",
-          type: "member",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
+    renderDialog();
 
     fireEvent.click(screen.getByText("添加 Agent"));
 
@@ -139,30 +130,7 @@ describe("MarketplaceActionDialog wording contract", () => {
   it("uses add wording while a Hub agent-user action is in progress", () => {
     mocks.applying = true;
 
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "pkg-1",
-          slug: "pack-one",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "Pack One",
-          type: "member",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
+    renderDialog();
 
     expect(screen.getByText("添加中...")).toBeTruthy();
   });
@@ -170,31 +138,7 @@ describe("MarketplaceActionDialog wording contract", () => {
   it("uses add failure wording for Hub agent-user errors", async () => {
     mocks.applyItem.mockRejectedValue(new Error("boom"));
 
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "pkg-1",
-          slug: "pack-one",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "Pack One",
-          type: "member",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
-
+    renderDialog();
     fireEvent.click(screen.getByText("添加 Agent"));
 
     await waitFor(() => {
@@ -203,30 +147,7 @@ describe("MarketplaceActionDialog wording contract", () => {
   });
 
   it("defaults Skill saves to Library and keeps Agent assignment optional", () => {
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "skill-1",
-          slug: "fastapi",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "FastAPI",
-          type: "skill",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
+    renderDialog(skillItem());
 
     expect(screen.getByText("这将把该 Skill 保存到 Library，之后可以在 Agent 配置页中添加使用。")).toBeTruthy();
     expect(document.body.textContent).toContain("保存 FastAPI");
@@ -248,31 +169,7 @@ describe("MarketplaceActionDialog wording contract", () => {
       version: "1.0.0",
     });
 
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "skill-1",
-          slug: "fastapi",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "FastAPI",
-          type: "skill",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
-
+    renderDialog(skillItem());
     fireEvent.click(screen.getByText("保存到 Library"));
 
     await waitFor(() => {
@@ -290,31 +187,7 @@ describe("MarketplaceActionDialog wording contract", () => {
       agent_user_id: "agent-1",
     });
 
-    render(
-      <MarketplaceActionDialog
-        open
-        onOpenChange={vi.fn()}
-        item={{
-          id: "skill-1",
-          slug: "fastapi",
-          description: "desc",
-          avatar_url: null,
-          publisher_user_id: "user-1",
-          name: "FastAPI",
-          type: "skill",
-          publisher_username: "tester",
-          parent_id: null,
-          download_count: 0,
-          visibility: "public",
-          tags: [],
-          created_at: "2026-04-08T00:00:00Z",
-          updated_at: "2026-04-08T00:00:00Z",
-          versions: [{ id: "ver-1", version: "1.0.0", release_notes: null, created_at: "2026-04-08T00:00:00Z" }],
-          parent: null,
-        }}
-      />,
-    );
-
+    renderDialog(skillItem());
     fireEvent.click(screen.getByLabelText("保存到 Library 后赋给 Agent"));
     fireEvent.click(screen.getByText("保存到 Library 并赋给 Agent"));
 

--- a/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
+++ b/frontend/app/src/pages/AgentDetailPage.wording.test.tsx
@@ -45,6 +45,16 @@ const agentFixture = {
   },
 };
 
+function renderAgentDetail() {
+  return render(
+    <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
+      <Routes>
+        <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 vi.mock("@/store/app-store", () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
@@ -84,13 +94,7 @@ describe("AgentDetailPage wording contract", () => {
   });
 
   it("uses the contacts page as the back target for direct-open agent detail", async () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     expect(await screen.findByText("Agent One")).toBeTruthy();
     fireEvent.click(screen.getAllByRole("button")[0]);
@@ -99,37 +103,19 @@ describe("AgentDetailPage wording contract", () => {
   });
 
   it("uses Agent wording for the subagent module label", () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     expect(screen.getByRole("button", { name: /子 Agent/ })).toBeTruthy();
   });
 
   it("does not expose the old fake local test panel", () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     expect(screen.queryByRole("button", { name: /^测试$/ })).toBeNull();
   });
 
   it("keeps MCP out of the primary agent config modules", () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     expect(screen.getByRole("button", { name: /^技能/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^子 Agent/ })).toBeTruthy();
@@ -147,13 +133,7 @@ describe("AgentDetailPage wording contract", () => {
       config: { prompt: "", rules: [], tools: [], mcpServers: [], skills: [], subAgents: [] },
     });
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     await waitFor(() => {
       expect(fetchAgent).toHaveBeenCalledWith("agent-1");
@@ -163,13 +143,7 @@ describe("AgentDetailPage wording contract", () => {
   it("shows the concrete rename failure", async () => {
     updateAgent.mockRejectedValue(new Error("name already exists"));
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.doubleClick(screen.getByText("Agent One"));
     fireEvent.change(screen.getByDisplayValue("Agent One"), { target: { value: "Morel" } });
@@ -189,13 +163,7 @@ describe("AgentDetailPage wording contract", () => {
       },
     });
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     const input = screen.getByLabelText("压缩触发 Token");
     expect((input as HTMLInputElement).value).toBe("80000");
@@ -211,13 +179,7 @@ describe("AgentDetailPage wording contract", () => {
   });
 
   it("keeps MCP advanced config outside the Library picker path", async () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     expect(ensureLibrary).not.toHaveBeenCalled();
 
@@ -237,13 +199,7 @@ describe("AgentDetailPage wording contract", () => {
       updated_at: 0,
     });
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.click(screen.getByRole("button", { name: /^技能/ }));
     fireEvent.click(screen.getByText("点击 + 从 Library 添加 技能"));
@@ -279,13 +235,7 @@ describe("AgentDetailPage wording contract", () => {
       },
     });
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.click(screen.getByRole("button", { name: /^MCP 高级/ }));
     fireEvent.click(screen.getByRole("switch"));
@@ -306,13 +256,7 @@ describe("AgentDetailPage wording contract", () => {
   });
 
   it("does not expose a Library picker for subagents", async () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.click(screen.getByRole("button", { name: /^子 Agent/ }));
 
@@ -330,13 +274,7 @@ describe("AgentDetailPage wording contract", () => {
       },
     });
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.click(screen.getByRole("button", { name: /^子 Agent/ }));
 
@@ -345,13 +283,7 @@ describe("AgentDetailPage wording contract", () => {
   });
 
   it("uses subagent wording for the empty subagent detail prompt", () => {
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.click(screen.getByRole("button", { name: /^子 Agent/ }));
 
@@ -367,13 +299,7 @@ describe("AgentDetailPage wording contract", () => {
       },
     });
 
-    render(
-      <MemoryRouter initialEntries={["/contacts/agents/agent-1"]}>
-        <Routes>
-          <Route path="/contacts/agents/:id" element={<AgentDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAgentDetail();
 
     fireEvent.click(screen.getByRole("button", { name: /^子 Agent/ }));
 

--- a/frontend/app/src/pages/MarketplacePage.wording.test.tsx
+++ b/frontend/app/src/pages/MarketplacePage.wording.test.tsx
@@ -11,6 +11,16 @@ function LocationProbe() {
   return <output aria-label="location">{location.pathname + location.search}</output>;
 }
 
+function renderMarketplace(initialEntry = "/marketplace", element = <MarketplacePage />) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/marketplace" element={element} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 let fetchItemsMock: ReturnType<typeof vi.fn>;
 let marketplaceState: Record<string, unknown>;
 
@@ -112,13 +122,7 @@ describe("MarketplacePage wording contract", () => {
   });
 
   it("uses Agent wording for the library agent tab", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent-user"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=agent-user");
 
     expect(screen.getAllByRole("button", { name: /Agent/ }).length).toBeGreaterThan(0);
     expect(screen.getByText("暂无 Agent")).toBeTruthy();
@@ -126,13 +130,7 @@ describe("MarketplacePage wording contract", () => {
   });
 
   it("uses agent-user as the library Agent tab URL key", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library"]}>
-        <Routes>
-          <Route path="/marketplace" element={<><MarketplacePage /><LocationProbe /></>} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library", <><MarketplacePage /><LocationProbe /></>);
 
     fireEvent.click(screen.getAllByRole("button", { name: /Agent/ })[0]);
 
@@ -141,49 +139,25 @@ describe("MarketplacePage wording contract", () => {
   });
 
   it("shows 检查更新 only on the library Agent tab", () => {
-    const { unmount } = render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent-user"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    const { unmount } = renderMarketplace("/marketplace?tab=library&sub=agent-user");
 
     expect(screen.getByRole("button", { name: "检查更新" })).toBeTruthy();
 
     unmount();
 
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=skill"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=skill");
 
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
   });
 
   it("does not show 检查更新 on the library Sandbox tab", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=sandbox-template"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=sandbox-template");
 
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
   });
 
   it("uses Skill wording for the library Skill tab", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=skill"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=skill");
 
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
     expect(screen.getByText("暂无 Skill")).toBeTruthy();
@@ -203,13 +177,7 @@ describe("MarketplacePage wording contract", () => {
       }],
     };
 
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=skill"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=skill");
 
     fireEvent.click(screen.getByTitle("删除"));
 
@@ -219,13 +187,7 @@ describe("MarketplacePage wording contract", () => {
   });
 
   it("uses Sandbox wording for the library Sandbox tab", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=sandbox-template"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=sandbox-template");
 
     expect(screen.queryByRole("button", { name: "检查更新" })).toBeNull();
   });
@@ -246,13 +208,7 @@ describe("MarketplacePage wording contract", () => {
       }],
     };
 
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent-user"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=agent-user");
 
     expect(screen.getByRole("button", { name: "检查更新" }).hasAttribute("disabled")).toBe(true);
   });
@@ -283,50 +239,26 @@ describe("MarketplacePage wording contract", () => {
       }],
     };
 
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent-user"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=agent-user");
 
     expect(screen.getByText("更新到 v1.1.0")).toBeTruthy();
   });
 
   it("normalizes the removed library agent tab to Agent users", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=agent"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=agent");
 
     expect(screen.queryByRole("button", { name: /Subagent/ })).toBeNull();
     expect(screen.getByText("暂无 Agent")).toBeTruthy();
   });
 
   it("does not bootstrap marketplace libraries because RootLayout owns panel loading", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=skill"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=skill");
 
     expect(appStoreFetchLibrary).not.toHaveBeenCalled();
   });
 
   it("shows sandbox recipes as the sandbox library tab", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=sandbox-template"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=sandbox-template");
 
     expect(screen.getAllByRole("button", { name: /Sandbox/ }).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Recipe/ })).toBeNull();
@@ -341,26 +273,14 @@ describe("MarketplacePage wording contract", () => {
       librariesLoaded: { skill: true, "sandbox-template": false },
     };
 
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=sandbox-template"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=sandbox-template");
 
     expect(screen.queryByText("暂无 Sandbox")).toBeNull();
     expect(screen.getByText("正在加载库内容...")).toBeTruthy();
   });
 
   it("creates sandbox recipes with concrete provider_name from backend-loaded recipes", async () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=library&sub=sandbox-template"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=library&sub=sandbox-template");
 
     fireEvent.click(screen.getByRole("button", { name: "新建 Sandbox" }));
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Selfhost Custom" } });
@@ -376,26 +296,14 @@ describe("MarketplacePage wording contract", () => {
   });
 
   it("uses Agent wording for the Hub agent-user item type", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace();
 
     expect(screen.getByRole("button", { name: "Agent" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Member" })).toBeNull();
   });
 
   it("falls back to explore for invalid tab params", () => {
-    render(
-      <MemoryRouter initialEntries={["/marketplace?tab=unknown&sub=ghost"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderMarketplace("/marketplace?tab=unknown&sub=ghost");
 
     expect(screen.getByRole("heading", { name: "Explore" })).toBeTruthy();
   });
@@ -407,13 +315,7 @@ describe("MarketplacePage wording contract", () => {
       return Promise.resolve();
     });
 
-    const { unmount } = render(
-      <MemoryRouter initialEntries={["/marketplace"]}>
-        <Routes>
-          <Route path="/marketplace" element={<MarketplacePage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    const { unmount } = renderMarketplace();
 
     expect(fetchItemsMock).toHaveBeenCalledOnce();
     expect(seenSignals).toHaveLength(1);

--- a/tests/Unit/platform/test_marketplace_client.py
+++ b/tests/Unit/platform/test_marketplace_client.py
@@ -298,6 +298,33 @@ class TestApplySkill:
             with pytest.raises(ValueError, match="Hub download version must be a string"):
                 apply_item("item-broken", owner_user_id="owner-1", skill_repo=skill_repo)
 
+    def test_apply_skill_rejects_unversioned_skill_md_before_library_write(self, monkeypatch):
+        monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_unversioned123")
+        hub_resp = _make_hub_response(
+            "skill",
+            "unversioned-skill",
+            content="---\nname: Unversioned Skill\ndescription: Missing package version\n---\nBody",
+        )
+        hub_resp["snapshot"]["content"] = "---\nname: Unversioned Skill\ndescription: Missing package version\n---\nBody"
+        saved: list[Skill] = []
+        packages: list[SkillPackage] = []
+        skill_repo = SimpleNamespace(
+            get_by_id=lambda _owner_user_id, _skill_id: None,
+            list_for_owner=lambda _owner_user_id: [],
+            upsert=lambda skill: saved.append(skill) or skill,
+            create_package=lambda package: packages.append(package) or package,
+            select_package=lambda _owner_user_id, _skill_id, _package_id: None,
+        )
+
+        with patch("backend.hub.client._hub_api", return_value=hub_resp):
+            from backend.hub.client import apply_item
+
+            with pytest.raises(ValueError, match="SKILL.md frontmatter must include version"):
+                apply_item("item-unversioned", owner_user_id="owner-1", skill_repo=skill_repo)
+
+        assert saved == []
+        assert packages == []
+
     def test_apply_skill_does_not_require_item_slug(self, monkeypatch):
         monkeypatch.setattr("backend.hub.client.generate_skill_id", lambda: "skill_noSlug123")
         hub_resp = _make_hub_response("skill", "broken-skill", content="---\nname: Broken Skill\ndescription: Broken\n---\nBody")

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -224,111 +224,64 @@ def test_get_agent_config_preserves_empty_tool_list() -> None:
     assert config.tools == []
 
 
-def test_get_agent_config_fails_loudly_when_description_is_null() -> None:
+@pytest.mark.parametrize(
+    ("table_name", "field", "value", "message"),
+    [
+        ("agent.agent_configs", "description", None, "agent_configs description must be text"),
+        ("agent.agent_configs", "system_prompt", None, "agent_configs system_prompt must be text"),
+        ("agent.agent_configs", "status", None, "agent_configs status must be text"),
+        ("agent.agent_configs", "version", None, "agent_configs version must be text"),
+        ("agent.agent_configs", "tools_json", {"Read": True}, "tools_json must be a JSON array"),
+        ("agent.agent_configs", "tools_json", None, "tools_json must be a JSON array"),
+        ("agent.agent_configs", "runtime_json", [], "runtime_json must be a JSON object"),
+        ("agent.agent_configs", "runtime_json", None, "runtime_json must be a JSON object"),
+        ("agent.agent_configs", "compact_json", [], "compact_json must be a JSON object"),
+        ("agent.agent_configs", "compact_json", None, "compact_json must be a JSON object"),
+        ("agent.agent_configs", "meta_json", [], "meta_json must be a JSON object"),
+        ("agent.agent_configs", "meta_json", None, "meta_json must be a JSON object"),
+        ("agent.agent_configs", "mcp_json", {"filesystem": {"command": "fs"}}, "mcp_json must be a JSON array"),
+        ("agent.agent_configs", "mcp_json", None, "mcp_json must be a JSON array"),
+        ("agent.agent_configs", "mcp_json", {}, "mcp_json must be a JSON array"),
+        (
+            "agent.agent_configs",
+            "mcp_json",
+            [{"name": "filesystem", "transport": "stdio", "command": "fs", "disabled": False}],
+            "mcp_json items must use enabled",
+        ),
+        (
+            "agent.agent_configs",
+            "mcp_json",
+            [{"name": "filesystem", "transport": "stdio", "command": "fs", "enabled": "false"}],
+            "mcp_json item enabled must be a boolean",
+        ),
+        (
+            "agent.agent_configs",
+            "mcp_json",
+            [{"name": "filesystem", "transport": "stdio", "command": "fs", "args": {"root": "."}}],
+            "mcp_json item args must be a JSON array",
+        ),
+        (
+            "agent.agent_configs",
+            "mcp_json",
+            [{"name": "filesystem", "transport": "stdio", "command": "fs", "env": ["A=B"]}],
+            "mcp_json item env must be a JSON object",
+        ),
+        ("agent.skill_bindings", "enabled", "false", "skill_bindings enabled must be a boolean"),
+        ("agent.agent_rules", "name", None, "agent_rules name must be text"),
+        ("agent.agent_rules", "content", None, "agent_rules content must be text"),
+        ("agent.agent_rules", "enabled", "false", "agent_rules enabled must be a boolean"),
+        ("agent.agent_sub_agents", "tools_json", {"Read": True}, "agent_sub_agents tools_json must be a JSON array"),
+        ("agent.agent_sub_agents", "description", None, "agent_sub_agents description must be text"),
+        ("agent.agent_sub_agents", "system_prompt", None, "agent_sub_agents system_prompt must be text"),
+        ("agent.agent_sub_agents", "enabled", "false", "agent_sub_agents enabled must be a boolean"),
+    ],
+)
+def test_get_agent_config_fails_loudly_for_invalid_table_values(table_name: str, field: str, value: object, message: str) -> None:
     tables = _tables()
-    tables["agent.agent_configs"][0]["description"] = None
+    tables[table_name][0][field] = value
     repo = SupabaseAgentConfigRepo(_FakeClient(tables))
 
-    with pytest.raises(RuntimeError, match="agent_configs description must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_system_prompt_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["system_prompt"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_configs system_prompt must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_status_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["status"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_configs status must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_version_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["version"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_configs version must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_tools_json_is_not_an_array() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["tools_json"] = {"Read": True}
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="tools_json must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_tools_json_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["tools_json"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="tools_json must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_runtime_json_is_not_an_object() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["runtime_json"] = []
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="runtime_json must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_runtime_json_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["runtime_json"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="runtime_json must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_compact_json_is_not_an_object() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["compact_json"] = []
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="compact_json must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_compact_json_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["compact_json"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="compact_json must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_meta_json_is_not_an_object() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["meta_json"] = []
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="meta_json must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_meta_json_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["meta_json"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="meta_json must be a JSON object"):
+    with pytest.raises(RuntimeError, match=message):
         repo.get_agent_config("cfg-1")
 
 
@@ -384,141 +337,6 @@ def test_get_agent_config_does_not_read_skill_description() -> None:
 
     assert config is not None
     assert "description" not in config.skills[0].model_dump()
-
-
-def test_get_agent_config_fails_loudly_when_sub_agent_tools_json_is_not_an_array() -> None:
-    tables = _tables()
-    tables["agent.agent_sub_agents"][0]["tools_json"] = {"Read": True}
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_sub_agents tools_json must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_sub_agent_description_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_sub_agents"][0]["description"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_sub_agents description must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_sub_agent_system_prompt_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_sub_agents"][0]["system_prompt"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_sub_agents system_prompt must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_rule_name_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_rules"][0]["name"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_rules name must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_rule_content_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_rules"][0]["content"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_rules content must be text"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_json_is_not_an_array() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = {"filesystem": {"command": "fs"}}
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_json_is_null() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = None
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_json_is_empty_object() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = {}
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_json_uses_reverse_state() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "disabled": False}]
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json items must use enabled"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_json_enabled_is_not_boolean() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "enabled": "false"}]
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json item enabled must be a boolean"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_args_is_not_an_array() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "args": {"root": "."}}]
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json item args must be a JSON array"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_mcp_env_is_not_an_object() -> None:
-    tables = _tables()
-    tables["agent.agent_configs"][0]["mcp_json"] = [{"name": "filesystem", "transport": "stdio", "command": "fs", "env": ["A=B"]}]
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="mcp_json item env must be a JSON object"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_skill_binding_enabled_is_not_boolean() -> None:
-    tables = _tables()
-    tables["agent.skill_bindings"][0]["enabled"] = "false"
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="skill_bindings enabled must be a boolean"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_rule_enabled_is_not_boolean() -> None:
-    tables = _tables()
-    tables["agent.agent_rules"][0]["enabled"] = "false"
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_rules enabled must be a boolean"):
-        repo.get_agent_config("cfg-1")
-
-
-def test_get_agent_config_fails_loudly_when_sub_agent_enabled_is_not_boolean() -> None:
-    tables = _tables()
-    tables["agent.agent_sub_agents"][0]["enabled"] = "false"
-    repo = SupabaseAgentConfigRepo(_FakeClient(tables))
-
-    with pytest.raises(RuntimeError, match="agent_sub_agents enabled must be a boolean"):
-        repo.get_agent_config("cfg-1")
 
 
 def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:

--- a/tests/Unit/storage/test_supabase_agent_config_repo.py
+++ b/tests/Unit/storage/test_supabase_agent_config_repo.py
@@ -380,93 +380,80 @@ def test_save_agent_config_calls_single_rpc_with_full_payload() -> None:
     assert "runtime_" + "settings_json" not in payload
 
 
-def test_save_agent_config_rejects_duplicate_skill_ids_before_rpc() -> None:
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (
+            AgentConfig(
+                id="cfg-1",
+                owner_user_id="owner-1",
+                agent_user_id="agent-1",
+                name="Researcher",
+                version="1.0.0",
+                skills=[
+                    AgentSkill(skill_id="github", package_id="package-1"),
+                    AgentSkill(skill_id="github", package_id="package-2"),
+                ],
+            ),
+            "Duplicate Skill id in AgentConfig: github",
+        ),
+        (
+            AgentConfig(
+                id="cfg-1",
+                owner_user_id="owner-1",
+                agent_user_id="agent-1",
+                name="Researcher",
+                version="1.0.0",
+                mcp_servers=[
+                    McpServerConfig(name="filesystem", transport="stdio", command="fs-one"),
+                    McpServerConfig(name="filesystem", transport="stdio", command="fs-two"),
+                ],
+            ),
+            "Duplicate MCP server name in AgentConfig: filesystem",
+        ),
+        (
+            AgentConfig(
+                id="cfg-1",
+                owner_user_id="owner-1",
+                agent_user_id="agent-1",
+                name="Researcher",
+                version="1.0.0",
+                skills=[
+                    AgentSkill(skill_id="github", package_id="package-1", enabled=False),
+                    AgentSkill(skill_id="github", package_id="package-2", enabled=False),
+                ],
+                mcp_servers=[
+                    McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),
+                    McpServerConfig(name="filesystem", transport="stdio", command="fs-two", enabled=False),
+                ],
+            ),
+            "Duplicate Skill id in AgentConfig: github",
+        ),
+        (
+            AgentConfig(
+                id="cfg-1",
+                owner_user_id="owner-1",
+                agent_user_id="agent-1",
+                name="Researcher",
+                version="1.0.0",
+                rules=[
+                    AgentRule(name="coding", content="one"),
+                    AgentRule(name="coding", content="two"),
+                ],
+                sub_agents=[
+                    AgentSubAgent(name="Scout"),
+                    AgentSubAgent(name="Scout"),
+                ],
+            ),
+            "Duplicate Rule name in AgentConfig: coding",
+        ),
+    ],
+)
+def test_save_agent_config_rejects_duplicate_child_names_before_rpc(config: AgentConfig, message: str) -> None:
     client = _FakeClient()
     repo = SupabaseAgentConfigRepo(client)
-    config = AgentConfig(
-        id="cfg-1",
-        owner_user_id="owner-1",
-        agent_user_id="agent-1",
-        name="Researcher",
-        version="1.0.0",
-        skills=[
-            AgentSkill(skill_id="github", package_id="package-1"),
-            AgentSkill(skill_id="github", package_id="package-2"),
-        ],
-    )
 
-    with pytest.raises(ValueError, match="Duplicate Skill id in AgentConfig: github"):
-        repo.save_agent_config(config)
-
-    assert client.rpc_calls == []
-
-
-def test_save_agent_config_rejects_duplicate_mcp_server_names_before_rpc() -> None:
-    client = _FakeClient()
-    repo = SupabaseAgentConfigRepo(client)
-    config = AgentConfig(
-        id="cfg-1",
-        owner_user_id="owner-1",
-        agent_user_id="agent-1",
-        name="Researcher",
-        version="1.0.0",
-        mcp_servers=[
-            McpServerConfig(name="filesystem", transport="stdio", command="fs-one"),
-            McpServerConfig(name="filesystem", transport="stdio", command="fs-two"),
-        ],
-    )
-
-    with pytest.raises(ValueError, match="Duplicate MCP server name in AgentConfig: filesystem"):
-        repo.save_agent_config(config)
-
-    assert client.rpc_calls == []
-
-
-def test_save_agent_config_rejects_duplicate_inactive_child_names_before_rpc() -> None:
-    client = _FakeClient()
-    repo = SupabaseAgentConfigRepo(client)
-    config = AgentConfig(
-        id="cfg-1",
-        owner_user_id="owner-1",
-        agent_user_id="agent-1",
-        name="Researcher",
-        version="1.0.0",
-        skills=[
-            AgentSkill(skill_id="github", package_id="package-1", enabled=False),
-            AgentSkill(skill_id="github", package_id="package-2", enabled=False),
-        ],
-        mcp_servers=[
-            McpServerConfig(name="filesystem", transport="stdio", command="fs-one", enabled=False),
-            McpServerConfig(name="filesystem", transport="stdio", command="fs-two", enabled=False),
-        ],
-    )
-
-    with pytest.raises(ValueError, match="Duplicate Skill id in AgentConfig: github"):
-        repo.save_agent_config(config)
-
-    assert client.rpc_calls == []
-
-
-def test_save_agent_config_rejects_duplicate_rule_and_sub_agent_names_before_rpc() -> None:
-    client = _FakeClient()
-    repo = SupabaseAgentConfigRepo(client)
-    config = AgentConfig(
-        id="cfg-1",
-        owner_user_id="owner-1",
-        agent_user_id="agent-1",
-        name="Researcher",
-        version="1.0.0",
-        rules=[
-            AgentRule(name="coding", content="one"),
-            AgentRule(name="coding", content="two"),
-        ],
-        sub_agents=[
-            AgentSubAgent(name="Scout"),
-            AgentSubAgent(name="Scout"),
-        ],
-    )
-
-    with pytest.raises(ValueError, match="Duplicate Rule name in AgentConfig: coding"):
+    with pytest.raises(ValueError, match=message):
         repo.save_agent_config(config)
 
     assert client.rpc_calls == []


### PR DESCRIPTION
## Summary
- Build Hub Skill packages before writing Library Skill rows, so invalid SKILL.md content cannot leave package-less Library Skills.
- Add regression coverage for unversioned Hub Skill content failing before Library writes.
- Reduce repeated test harness code in Skill/Marketplace wording and AgentConfig storage guard tests after the Skill reset PR-size audit.

## Verification
- uv run pytest tests/Unit/platform/test_marketplace_client.py tests/Unit/storage/test_supabase_agent_config_repo.py -q
- uv run pyright backend/hub/client.py
- npm run test -- MarketplaceActionDialog.wording.test.tsx AgentDetailPage.wording.test.tsx MarketplacePage.wording.test.tsx
- npm run lint -- src/components/marketplace/MarketplaceActionDialog.wording.test.tsx src/pages/AgentDetailPage.wording.test.tsx src/pages/MarketplacePage.wording.test.tsx
- uv run pytest tests/Unit -q

## Notes
- Five reviewable commits, net negative line count.
- Backend YATU evidence is recorded in the Skill-first checkpoint ledger.