### PR TITLE
docs(test): add product YATU cards

### DIFF
--- a/tests/yatu/README.md
+++ b/tests/yatu/README.md
@@ -1,0 +1,42 @@
+# Mycel App YATU Tests
+
+YATU means **You As The User**.
+
+These files are product test cards, not automation scripts. A YATU card tells a
+human or code agent how to exercise Mycel through real user surfaces:
+
+- real backend process from the current branch
+- real frontend browser when the card is frontend-facing
+- real `mycel` CLI or SDK when the card is external-agent-facing
+- real Mycel-managed agents with a real LLM when agent behavior matters
+- real read-before-send loops through chat messages
+
+Do not use mocks, DB peeking, internal agent memory transfer, direct helper
+calls, or backend-only shortcuts as proof for these cards.
+
+## Where Results Go
+
+Do not write run results into these cards. Put artifacts under `~/share/yatu`
+with a timestamped folder, and write a short result note outside the repo if a
+run needs explanation.
+
+Good artifact examples:
+
+- `~/share/yatu/mention-wake-postmerge-20260426T031323Z`
+- `~/share/yatu/managed-agent-relationship-cli-20260426T011838`
+- `~/share/yatu/frontend-relationship-join-currentdev-20260426T`
+
+## How To Read A Card
+
+Each card has:
+
+- **User story**: what a real user is trying to do.
+- **Entry surfaces**: product surfaces allowed for the proof.
+- **Setup**: what must exist before the first action.
+- **User loop**: natural actions to perform.
+- **Pass bar**: what a user should be able to observe.
+- **Pitfalls**: known mistakes that invalidate the proof.
+
+If a card is painful to run, do not add private glue to the test. Treat that as
+product/API feedback and improve the underlying surface.
+

--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -1,0 +1,54 @@
+# YATU Catalog
+
+This catalog maps dispersed historical YATU material into durable test-card
+families. Results stay outside the repo; the cards in this directory are the
+maintained prompts.
+
+## Chat And Delivery
+
+- `chat-wake-policy.md`
+- Historical notes:
+  - `$MYCEL_WORKSPACE/notes/2026-04-26-chat-wake-policy-postmerge-yatu.html`
+- Historical artifacts:
+  - `~/share/yatu/mention-wake-postmerge-20260426T031323Z`
+  - `~/share/yatu/latest-dev-smoke-20260425T221808Z`
+  - `~/share/yatu/latest-dev-smoke-20260425T224428Z`
+
+## Relationship And Join
+
+- `relationship-and-chat-join.md`
+- Historical notes:
+  - `$MYCEL_WORKSPACE/notes/2026-04-26-relationship-and-chat-join-design.html`
+  - `$MYCEL_WORKSPACE/notes/2026-04-26-social-relationship-chat-join-current-design.html`
+- Historical artifacts:
+  - `~/share/yatu/managed-agent-relationship-cli-20260426T011838`
+  - `~/share/yatu/frontend-relationship-message-20260426T093212`
+  - `~/share/yatu/frontend-relationship-join-currentdev-20260426T`
+  - `~/share/yatu/chat-join-reject-mention-20260426T0948`
+
+## Frontend
+
+- `frontend-social-flows.md`
+- Historical artifacts:
+  - `~/share/yatu/mycel-relationship-frontend-20260425T214005`
+  - `~/share/yatu/frontend-join-request-ui-20260425T183836Z`
+  - `~/share/yatu/frontend-social-discovery-20260426T0542`
+
+## Managed Agents
+
+- `managed-agent-tools.md`
+- Historical artifacts:
+  - `~/share/yatu/codex-run-two-mycel-agents-20260425T223206Z`
+  - `~/share/yatu/codex-run-cli-managed-agent-20260425T235843Z`
+
+## Multi-Agent Workflows
+
+- `multi-agent-natural-language-workflows.md`
+- Historical notes:
+  - `$MYCEL_WORKSPACE/notes/2026-04-25-natural-language-multi-agent-yatu.html`
+  - `$MYCEL_WORKSPACE/notes/2026-04-25-sdk-yatu-16-agent-debate-tournament-plan.html`
+  - `$MYCEL_WORKSPACE/notes/2026-04-26-16-agent-debate-yatu-findings.html`
+- Historical artifacts:
+  - `~/share/yatu/sdk-guess-average-workflow-20260425T230405Z`
+  - `~/share/yatu/debate-tournament-cli-20260426T0333`
+  - `~/share/yatu/debate-tournament-cli-20260426T200308-mute-control`

--- a/tests/yatu/chat-wake-policy.md
+++ b/tests/yatu/chat-wake-policy.md
@@ -1,0 +1,57 @@
+# YATU: Chat Wake Policy
+
+## User Story
+
+As a group owner, I want a normal group message to wake all default Mycel agents,
+but an explicitly mentioned message should wake only the mentioned default
+agents. Everyone still receives the persisted chat message.
+
+## Entry Surfaces
+
+- Real Mycel backend from the current branch.
+- Installed `mycel` CLI.
+- Real Mycel-managed agents with runtime threads.
+- Chat message list/read/send surfaces only.
+
+## Setup
+
+1. Start the backend from the branch under test.
+2. Use an owner profile with a valid token.
+3. Create or choose three managed-agent users with live runtime threads.
+4. Create one group chat containing the owner and all three agents.
+5. Confirm the owner can run `mycel agent whoami`, `mycel chat read`, and
+   `mycel chat messages list`.
+
+## User Loop
+
+1. Mark the group chat read as the owner.
+2. Send a natural-language message mentioning only Agent 1 and Agent 2 by
+   passing `--mention <agent-1-id>` and `--mention <agent-2-id>`.
+3. Wait long enough for managed-agent runtime replies.
+4. Read the chat transcript as the owner.
+5. Mark the group chat read again.
+6. Send a second natural-language message with no `--mention`.
+7. Wait again and read the transcript.
+
+## Pass Bar
+
+- The first send stores `mentioned_ids` for only Agent 1 and Agent 2.
+- Before the second send, only Agent 1 and Agent 2 reply.
+- Agent 3 remains quiet before the open-scope message.
+- The second send has no mentions.
+- After the second send, Agent 1, Agent 2, and Agent 3 can all reply.
+- Message visibility and read/unread behavior are still normal chat behavior;
+  wake policy only changes runtime interruption.
+
+## Pitfalls
+
+- Typing `@agent-id` in message text is not a mention. Use the CLI/API mention
+  field.
+- Do not inspect runtime queue internals to decide pass/fail.
+- Do not treat duplicate follow-up chatter by already-woken agents as a
+  wake-scope failure unless an unmentioned quiet agent speaks before it should.
+
+## Historical Seeds
+
+- `$MYCEL_WORKSPACE/notes/2026-04-26-chat-wake-policy-postmerge-yatu.html`
+- `~/share/yatu/mention-wake-postmerge-20260426T031323Z`

--- a/tests/yatu/frontend-social-flows.md
+++ b/tests/yatu/frontend-social-flows.md
@@ -1,0 +1,58 @@
+# YATU: Frontend Social Flows
+
+## User Story
+
+As a human user, I should be able to discover people, request a relationship,
+review incoming requests, open chats after approval, and request to join a group
+without knowing backend vocabulary.
+
+## Entry Surfaces
+
+- Real browser via Playwright CLI.
+- Frontend app from the current branch.
+- Real backend from the current branch.
+- Real user sessions and storage state.
+
+## Setup
+
+1. Start backend and frontend on non-overlapping ports.
+2. Create or reuse real users with valid tokens.
+3. Use browser sessions for requester, target, group owner, and visitor.
+4. Keep CLI/API setup only for seeding users or profiles; all observed product
+   proof must be through the browser.
+
+## User Loop
+
+1. Requester opens contact discovery or contacts surface.
+2. Requester sends a relationship request with a natural-language message.
+3. Target opens contacts/detail and sees the pending request message.
+4. Target approves.
+5. Requester opens a direct chat from the UI.
+6. Visitor opens a group link or group URL while not a member.
+7. Visitor submits a group join request.
+8. Group owner opens the group page, sees the pending request, and approves.
+9. Visitor reloads and can read/send as a member.
+
+## Pass Bar
+
+- Product text distinguishes relationship access from group membership.
+- Pending relationship messages are visible in list/detail surfaces.
+- Group join request form is usable from a non-member entry.
+- Owner approval changes the visitor's visible chat state without manual DB
+  changes.
+- Browser screenshots or YAML snapshots show the user-visible state.
+
+## Pitfalls
+
+- Playwright CLI/browser proof is required. Backend responses alone are not
+  frontend YATU.
+- Do not use Playwright MCP as the product proof surface.
+- Do not hide network or console errors when the browser looks visually fine.
+
+## Historical Seeds
+
+- `~/share/yatu/mycel-relationship-frontend-20260425T214005`
+- `~/share/yatu/frontend-relationship-join-currentdev-20260426T`
+- `~/share/yatu/frontend-social-discovery-20260426T0542`
+- `~/share/yatu/frontend-join-request-ui-20260425T183836Z`
+

--- a/tests/yatu/managed-agent-tools.md
+++ b/tests/yatu/managed-agent-tools.md
@@ -1,0 +1,57 @@
+# YATU: Managed-Agent Tools
+
+## User Story
+
+As a Mycel-managed agent, I should be able to participate in real product
+workflows using tools: relationship review, chat join review, chat reading,
+message sending, subagent work, and background command execution.
+
+## Entry Surfaces
+
+- Real managed-agent runtime thread.
+- Real LLM model.
+- Product chat messages and runtime notifications.
+- Agent tool calls exposed by the backend runtime.
+
+## Setup
+
+1. Start backend from the branch under test.
+2. Create a managed-agent user and runtime thread.
+3. Ensure model credentials are live.
+4. Create chats or requests that require the agent to act.
+
+## User Loop
+
+1. Send the managed agent a relationship request from an external profile.
+2. Ask the agent naturally to inspect pending relationships and decide.
+3. Ask the agent to read a chat, summarize unread messages, and reply.
+4. Create a group join request for a group owned by the managed agent.
+5. Ask the agent naturally to inspect join requests and approve or reject.
+6. Ask the agent to run a small background command and report completion.
+7. Ask the agent to delegate one bounded subtask to a subagent and report the
+   result back in chat.
+
+## Pass Bar
+
+- The agent uses tools instead of hallucinating backend state.
+- Relationship and join-request decisions persist in the backend.
+- Background command completion is delivered back through the runtime.
+- Subagent tool usage produces a visible result and does not block the parent
+  indefinitely.
+- All participant-visible information moves through chat or tool outputs, not
+  hidden memory extraction.
+
+## Pitfalls
+
+- Do not replace the LLM with a fake model.
+- Do not call the tool services directly from a test helper.
+- Do not accept prompt echo as proof that a tool ran.
+- If the agent cannot find the right tool, treat that as product/tooling
+  feedback.
+
+## Historical Seeds
+
+- `~/share/yatu/managed-agent-relationship-cli-20260426T011838`
+- `~/share/yatu/latest-dev-smoke-20260425T224428Z`
+- `~/share/yatu/codex-run-two-mycel-agents-20260425T223206Z`
+

--- a/tests/yatu/multi-agent-natural-language-workflows.md
+++ b/tests/yatu/multi-agent-natural-language-workflows.md
@@ -1,0 +1,61 @@
+# YATU: Multi-Agent Natural-Language Workflows
+
+## User Story
+
+As a user orchestrating many agents, I should be able to run complex workflows
+through ordinary chat messages, not by pulling private state out of agents.
+
+## Entry Surfaces
+
+- Real backend and managed-agent runtime.
+- Installed `mycel` CLI or public SDK.
+- Real chat messages and read-before-send loops.
+- Real managed-agent LLM replies.
+
+## Workflow A: Debate Tournament
+
+1. Create or choose 16 managed agents.
+2. Create a tournament chat or per-match chats.
+3. Announce the bracket in natural language.
+4. For each match, ask two agents to debate.
+5. Ask non-debating agents to vote by ordinary chat replies.
+6. Announce winners and advance the bracket.
+7. Continue until one winner remains.
+
+Pass bar:
+
+- Agents see prompts through chat.
+- Votes are visible messages.
+- The organizer can reconstruct winners from chat transcript.
+- No internal memory or DB row is used as participant communication.
+
+## Workflow B: Guess The Average
+
+1. Chair asks every participant to secretly choose a number from 1 to 100 and
+   send it in chat.
+2. Chair computes the average from visible replies.
+3. Chair announces the closest participant and gives a short comment.
+4. Repeat three rounds.
+5. Chair comments on how the group average changed.
+
+Pass bar:
+
+- No structured-output contract is required.
+- All guesses are ordinary chat text.
+- Chair can compute from visible messages only.
+- The workflow remains short enough that SDK/CLI friction is obvious.
+
+## Pitfalls
+
+- Do not mute everyone and then expect mention to wake muted agents. Mute is
+  receiver-side quiet mode.
+- Do not add workflow-specific backend concepts for tournament or average
+  games.
+- If orchestration requires long glue code, improve base chat/SDK primitives.
+
+## Historical Seeds
+
+- `$MYCEL_WORKSPACE/notes/2026-04-25-sdk-yatu-16-agent-debate-tournament-plan.html`
+- `$MYCEL_WORKSPACE/notes/2026-04-26-16-agent-debate-yatu-findings.html`
+- `~/share/yatu/sdk-guess-average-workflow-20260425T230405Z`
+- `~/share/yatu/debate-tournament-cli-20260426T200308-mute-control`

--- a/tests/yatu/relationship-and-chat-join.md
+++ b/tests/yatu/relationship-and-chat-join.md
@@ -1,0 +1,73 @@
+# YATU: Relationship Requests And Chat Join Requests
+
+## User Story
+
+As users and agents, we need two distinct request flows:
+
+- relationship request: user-to-user social access
+- chat join request: user-to-group membership
+
+Approving one must not secretly approve the other.
+
+## Entry Surfaces
+
+- Frontend contacts and chat pages for human-facing proof.
+- Installed `mycel` CLI for external-agent proof.
+- Managed-agent relationship and chat-join tools when the target/owner is a
+  Mycel-managed agent.
+- Public backend APIs through the frontend/SDK/CLI only.
+
+## Setup
+
+1. Start the backend from the current branch.
+2. Prepare an owner or human profile, an external-agent profile, and at least
+   one managed-agent runtime thread.
+3. Prepare one active group chat with a clear owner.
+4. Prepare a non-member visitor profile.
+
+## User Loop
+
+### Relationship Request
+
+1. External user requests a relationship with a managed agent and includes a
+   short natural-language reason.
+2. The managed agent receives the request notification, lists pending
+   relationships through its tool, and approves or rejects.
+3. The external user lists relationships through the CLI and observes the state.
+4. If approved, the external user opens a direct chat and sends a message with
+   an explicit mention to the managed agent.
+
+### Chat Join Request
+
+1. Visitor opens the group entry surface with `join-target` or the frontend
+   group URL.
+2. Visitor submits a natural-language request to join.
+3. Group owner lists pending join requests through the frontend, CLI, or
+   managed-agent tool.
+4. Group owner approves the request.
+5. Visitor reads and sends in the group as a real member.
+
+## Pass Bar
+
+- Relationship requester/approver identities come from token or managed-agent
+  tool identity, not body arguments.
+- Relationship request message is visible to the reviewer.
+- Chat join request approval creates real membership.
+- A rejected managed-agent chat-join requester is notified through runtime
+  delivery even though it is not a group member.
+- Notification delivery never replaces durable request state.
+
+## Pitfalls
+
+- Do not call storage repos or inspect DB rows as the test oracle.
+- Do not approve a relationship and assume the user joined a group.
+- Do not approve a join request and assume the users now have a relationship.
+- Do not use a mock LLM for managed-agent approval behavior.
+
+## Historical Seeds
+
+- `$MYCEL_WORKSPACE/notes/2026-04-26-relationship-and-chat-join-design.html`
+- `$MYCEL_WORKSPACE/notes/2026-04-26-social-relationship-chat-join-current-design.html`
+- `~/share/yatu/managed-agent-relationship-cli-20260426T011838`
+- `~/share/yatu/frontend-relationship-join-currentdev-20260426T`
+- `~/share/yatu/frontend-relationship-message-20260426T093212`


### PR DESCRIPTION
## Summary\n- add tests/yatu Markdown cards as the durable product YATU entry point\n- cover chat wake policy, relationship and chat join flows, frontend social flows, managed-agent tools, and natural-language multi-agent workflows\n- add a catalog mapping historical notes/artifacts while keeping run results outside the repo\n\n## Verification\n- synced from origin/dev at 811b8e18979a0bd9445d6281807ca4d2c4be2874\n- ran content scan: no TODO/TBD/results/auth-token leakage patterns in tests/yatu\n- verified referenced workspace note paths exist under /notes\n