### PR TITLE
docs(test): index current merged yatu artifacts

### DIFF
--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -17,6 +17,9 @@ maintained prompts.
 ## Relationship And Join
 
 - `relationship-and-chat-join.md`
+- Latest current-merged proof:
+  - `~/share/yatu/current-merged-relationship-join-cli-20260426T1235/summary.md`
+  - `~/share/yatu/current-merged-frontend-social-20260426T1240/summary.md`
 - Historical notes:
   - `$MYCEL_WORKSPACE/notes/2026-04-26-relationship-and-chat-join-design.html`
   - `$MYCEL_WORKSPACE/notes/2026-04-26-social-relationship-chat-join-current-design.html`
@@ -29,6 +32,8 @@ maintained prompts.
 ## Frontend
 
 - `frontend-social-flows.md`
+- Latest current-merged proof:
+  - `~/share/yatu/current-merged-frontend-social-20260426T1240/summary.md`
 - Historical artifacts:
   - `~/share/yatu/mycel-relationship-frontend-20260425T214005`
   - `~/share/yatu/frontend-join-request-ui-20260425T183836Z`

--- a/tests/yatu/frontend-social-flows.md
+++ b/tests/yatu/frontend-social-flows.md
@@ -51,8 +51,8 @@ without knowing backend vocabulary.
 
 ## Historical Seeds
 
+- `~/share/yatu/current-merged-frontend-social-20260426T1240`
 - `~/share/yatu/mycel-relationship-frontend-20260425T214005`
 - `~/share/yatu/frontend-relationship-join-currentdev-20260426T`
 - `~/share/yatu/frontend-social-discovery-20260426T0542`
 - `~/share/yatu/frontend-join-request-ui-20260425T183836Z`
-

--- a/tests/yatu/relationship-and-chat-join.md
+++ b/tests/yatu/relationship-and-chat-join.md
@@ -66,6 +66,8 @@ Approving one must not secretly approve the other.
 
 ## Historical Seeds
 
+- `~/share/yatu/current-merged-relationship-join-cli-20260426T1235`
+- `~/share/yatu/current-merged-frontend-social-20260426T1240`
 - `$MYCEL_WORKSPACE/notes/2026-04-26-relationship-and-chat-join-design.html`
 - `$MYCEL_WORKSPACE/notes/2026-04-26-social-relationship-chat-join-current-design.html`
 - `~/share/yatu/managed-agent-relationship-cli-20260426T011838`


### PR DESCRIPTION
## Summary
- point app YATU catalog/cards at the latest current-merged relationship/join and frontend social artifacts
- keep test cards as prompts only; no result blobs committed

## Verification
- git diff --check