### PR TITLE
docs(test): index multi-agent yatu summaries

### DIFF
--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -49,11 +49,13 @@ maintained prompts.
 ## Multi-Agent Workflows
 
 - `multi-agent-natural-language-workflows.md`
+- Latest controlled-attention proof:
+  - `~/share/yatu/debate-tournament-cli-20260426T-fanout-race-fix-v4/summary.md`
 - Historical notes:
   - `$MYCEL_WORKSPACE/notes/2026-04-25-natural-language-multi-agent-yatu.html`
   - `$MYCEL_WORKSPACE/notes/2026-04-25-sdk-yatu-16-agent-debate-tournament-plan.html`
   - `$MYCEL_WORKSPACE/notes/2026-04-26-16-agent-debate-yatu-findings.html`
 - Historical artifacts:
-  - `~/share/yatu/sdk-guess-average-workflow-20260425T230405Z`
-  - `~/share/yatu/debate-tournament-cli-20260426T0333`
-  - `~/share/yatu/debate-tournament-cli-20260426T200308-mute-control`
+  - `~/share/yatu/sdk-guess-average-workflow-20260425T230405Z/summary.md`
+  - `~/share/yatu/debate-tournament-cli-20260426T0333/summary.md`
+  - `~/share/yatu/debate-tournament-cli-20260426T200308-mute-control/summary.md`

--- a/tests/yatu/multi-agent-natural-language-workflows.md
+++ b/tests/yatu/multi-agent-natural-language-workflows.md
@@ -55,7 +55,9 @@ Pass bar:
 
 ## Historical Seeds
 
+- `~/share/yatu/debate-tournament-cli-20260426T-fanout-race-fix-v4/summary.md`
 - `$MYCEL_WORKSPACE/notes/2026-04-25-sdk-yatu-16-agent-debate-tournament-plan.html`
 - `$MYCEL_WORKSPACE/notes/2026-04-26-16-agent-debate-yatu-findings.html`
-- `~/share/yatu/sdk-guess-average-workflow-20260425T230405Z`
-- `~/share/yatu/debate-tournament-cli-20260426T200308-mute-control`
+- `~/share/yatu/sdk-guess-average-workflow-20260425T230405Z/summary.md`
+- `~/share/yatu/debate-tournament-cli-20260426T0333/summary.md`
+- `~/share/yatu/debate-tournament-cli-20260426T200308-mute-control/summary.md`


### PR DESCRIPTION
## Summary
- point multi-agent YATU cards at summary.md files for guess-average, debate initial, mute-control, and fanout race v4
- clarify the latest controlled-attention proof is v4, not the earlier partial vote run

## Verification
- git diff --check