### PR TITLE
auth: persist external user creator

### DIFF
--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -210,6 +210,7 @@ class AuthService:
                 id=external_user_id,
                 type=UserType.EXTERNAL,
                 display_name=external_display_name,
+                created_by_user_id=created_by_user_id,
                 created_at=now,
             )
         )
@@ -225,7 +226,12 @@ class AuthService:
         )
         return {
             "token": token,
-            "user": {"id": external_user_id, "name": external_display_name, "type": "external"},
+            "user": {
+                "id": external_user_id,
+                "name": external_display_name,
+                "type": "external",
+                "created_by_user_id": created_by_user_id,
+            },
         }
 
     def _resolve_email(self, identifier: str) -> str:

--- a/backend/web/routers/users.py
+++ b/backend/web/routers/users.py
@@ -12,6 +12,7 @@ from backend.identity.avatar.paths import avatars_dir
 from backend.identity.avatar.urls import avatar_url
 from backend.web.core.dependencies import get_app, get_current_user_id
 from messaging.social_access import active_contact_target_ids, can_chat_with_owner_scope
+from messaging.user_ownership import is_owned_by_viewer
 from storage.contracts import UserType
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ def _get_owned_avatar_user_or_404(user_id: str, current_user_id: str, user_repo:
     user = user_repo.get_by_id(user_id)
     if not user:
         raise HTTPException(404, "User not found")
-    if user_id == current_user_id or user.owner_user_id == current_user_id:
+    if is_owned_by_viewer(current_user_id, user):
         return user
     raise HTTPException(403, "Not authorized")
 
@@ -172,8 +173,9 @@ async def list_chat_candidates(
     for user in users:
         if user.id == user_id:
             continue
-        is_owned = user.type is UserType.AGENT and user.owner_user_id == user_id
-        if is_owned and thread_repo is None:
+        is_owned = is_owned_by_viewer(user_id, user)
+        is_owned_agent = user.type is UserType.AGENT and user.owner_user_id == user_id
+        if is_owned_agent and thread_repo is None:
             # @@@owned-agent-thread-truth - owned agent candidates expose
             # default_thread_id when available, so this consumer must fail loud
             # when thread_repo is absent instead of silently pretending the
@@ -216,7 +218,7 @@ async def list_chat_candidates(
             )
         else:
             owner = user_map.get(user.owner_user_id) if user.owner_user_id else None
-            default_thread = thread_repo.get_default_thread(user.id) if is_owned and thread_repo is not None else None
+            default_thread = thread_repo.get_default_thread(user.id) if is_owned_agent and thread_repo is not None else None
             item = {
                 "user_id": user.id,
                 "name": user.display_name,
@@ -229,7 +231,7 @@ async def list_chat_candidates(
                 **relationship_fields,
                 "can_chat": can_chat,
             }
-            if is_owned:
+            if is_owned_agent:
                 item["default_thread_id"] = default_thread["id"] if default_thread else None
             items.append(item)
     return items

--- a/messaging/user_ownership.py
+++ b/messaging/user_ownership.py
@@ -7,7 +7,9 @@ from typing import Any
 
 def is_owned_by_viewer(viewer_user_id: str, candidate_user: Any | None) -> bool:
     return candidate_user is not None and (
-        getattr(candidate_user, "id", None) == viewer_user_id or getattr(candidate_user, "owner_user_id", None) == viewer_user_id
+        getattr(candidate_user, "id", None) == viewer_user_id
+        or getattr(candidate_user, "owner_user_id", None) == viewer_user_id
+        or getattr(candidate_user, "created_by_user_id", None) == viewer_user_id
     )
 
 

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -107,6 +107,7 @@ class UserRow(BaseModel):
     avatar: str | None = None
     email: str | None = None
     mycel_id: int | None = None
+    created_by_user_id: str | None = None
     created_at: float
     updated_at: float | None = None
 
@@ -115,18 +116,28 @@ class UserRow(BaseModel):
         # @@@user-row-shape - users are the unified social identity surface, so
         # human/external/agent optional fields must fail loudly instead of drifting
         # into mixed half-valid rows.
-        if self.type in {UserType.HUMAN, UserType.EXTERNAL}:
+        if self.type is UserType.HUMAN:
             if self.owner_user_id is not None:
-                kind = "human" if self.type is UserType.HUMAN else "external"
-                raise ValueError(f"{kind} users must not carry owner_user_id")
+                raise ValueError("human users must not carry owner_user_id")
             if self.agent_config_id is not None:
-                kind = "human" if self.type is UserType.HUMAN else "external"
-                raise ValueError(f"{kind} users must not carry agent_config_id")
+                raise ValueError("human users must not carry agent_config_id")
+            if self.created_by_user_id is not None:
+                raise ValueError("human users must not carry created_by_user_id")
+            return self
+        if self.type is UserType.EXTERNAL:
+            if self.owner_user_id is not None:
+                raise ValueError("external users must not carry owner_user_id")
+            if self.agent_config_id is not None:
+                raise ValueError("external users must not carry agent_config_id")
+            if self.created_by_user_id is None:
+                raise ValueError("external users require created_by_user_id")
             return self
         if self.owner_user_id is None:
             raise ValueError("agent users require owner_user_id")
         if self.agent_config_id is None:
             raise ValueError("agent users require agent_config_id")
+        if self.created_by_user_id is not None:
+            raise ValueError("agent users must not carry created_by_user_id")
         return self
 
 

--- a/storage/providers/supabase/summary_repo.py
+++ b/storage/providers/supabase/summary_repo.py
@@ -16,7 +16,7 @@ class SupabaseSummaryRepo:
         return None
 
     def ensure_tables(self) -> None:
-        """Supabase schema is managed via migrations, not runtime DDL."""
+        """Supabase schema is managed outside request-time DDL."""
 
     def save_summary(
         self,

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -18,6 +18,7 @@ _COLS = (
     "avatar",
     "email",
     "mycel_id",
+    "created_by_user_id",
     "created_at",
     "updated_at",
 )
@@ -42,6 +43,7 @@ class SupabaseUserRepo:
                 "avatar": row.avatar,
                 "email": row.email,
                 "mycel_id": row.mycel_id,
+                "created_by_user_id": row.created_by_user_id,
                 "created_at": row.created_at,
                 "updated_at": row.updated_at,
             }

--- a/tests/Integration/test_chat_external_user_contract.py
+++ b/tests/Integration/test_chat_external_user_contract.py
@@ -13,7 +13,13 @@ def _user_directory(rows: dict[str, UserRow]):
 def test_validate_chat_participant_ids_accepts_external_user() -> None:
     rows = {
         "human-1": UserRow(id="human-1", display_name="Owner", type=UserType.HUMAN, created_at=1.0),
-        "external-1": UserRow(id="external-1", display_name="Codex External", type=UserType.EXTERNAL, created_at=1.0),
+        "external-1": UserRow(
+            id="external-1",
+            display_name="Codex External",
+            type=UserType.EXTERNAL,
+            created_by_user_id="human-1",
+            created_at=1.0,
+        ),
     }
 
     result = chats_router._chat_participant_ids_for_request(

--- a/tests/Integration/test_users_router.py
+++ b/tests/Integration/test_users_router.py
@@ -447,8 +447,14 @@ def test_chat_candidates_route_fails_loud_when_contact_repo_missing() -> None:
 @pytest.mark.asyncio
 async def test_list_chat_candidates_projects_external_user_like_unowned_participant() -> None:
     current_user = _human("u1", "owner")
-    external_user = UserRow(id="ext-1", display_name="Codex External", type=UserType.EXTERNAL, created_at=NOW)
-    app = _users_app([current_user, external_user], relationships={"ext-1": "visit"})
+    external_user = UserRow(
+        id="ext-1",
+        display_name="Codex External",
+        type=UserType.EXTERNAL,
+        created_by_user_id="u1",
+        created_at=NOW,
+    )
+    app = _users_app([current_user, external_user])
 
     result = await _list_chat_candidates(app)
 
@@ -460,9 +466,9 @@ async def test_list_chat_candidates_projects_external_user_like_unowned_particip
             "avatar_url": None,
             "owner_name": None,
             "agent_name": "Codex External",
-            "is_owned": False,
-            "relationship_state": "visit",
-            "relationship_id": "hire_visit:ext-1:u1",
+            "is_owned": True,
+            "relationship_state": "none",
+            "relationship_id": None,
             "relationship_is_requester": False,
             "relationship_message": None,
             "can_chat": True,

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -173,12 +173,19 @@ def test_create_external_user_token_creates_external_user_and_signed_token(monke
     assert created_rows[0].id == "external-codex-1"
     assert created_rows[0].type is UserType.EXTERNAL
     assert created_rows[0].display_name == "Codex Local"
+    assert created_rows[0].owner_user_id is None
+    assert created_rows[0].created_by_user_id == "owner-1"
     decoded = jwt.decode(result["token"], "secret-1", algorithms=["HS256"], options={"verify_aud": False})
     assert decoded["sub"] == "external-codex-1"
     assert decoded["mycel_user_type"] == "external"
     assert decoded["created_by_user_id"] == "owner-1"
     assert _service(user_repo=user_repo).verify_token(result["token"]) == {"user_id": "external-codex-1"}
-    assert result["user"] == {"id": "external-codex-1", "name": "Codex Local", "type": "external"}
+    assert result["user"] == {
+        "id": "external-codex-1",
+        "name": "Codex Local",
+        "type": "external",
+        "created_by_user_id": "owner-1",
+    }
 
 
 def test_create_external_user_token_rejects_existing_user(monkeypatch: pytest.MonkeyPatch):

--- a/tests/Unit/messaging/test_user_ownership.py
+++ b/tests/Unit/messaging/test_user_ownership.py
@@ -17,8 +17,14 @@ def test_is_owned_by_viewer_accepts_owned_agent_user() -> None:
     assert is_owned_by_viewer("viewer-1", user) is True
 
 
+def test_is_owned_by_viewer_accepts_created_external_user() -> None:
+    user = SimpleNamespace(id="external-user-1", owner_user_id=None, created_by_user_id="viewer-1")
+
+    assert is_owned_by_viewer("viewer-1", user) is True
+
+
 def test_is_owned_by_viewer_rejects_stranger() -> None:
-    user = SimpleNamespace(id="agent-user-1", owner_user_id="someone-else")
+    user = SimpleNamespace(id="agent-user-1", owner_user_id="someone-else", created_by_user_id=None)
 
     assert is_owned_by_viewer("viewer-1", user) is False
 

--- a/tests/Unit/storage/test_external_user_type.py
+++ b/tests/Unit/storage/test_external_user_type.py
@@ -5,19 +5,30 @@ import pytest
 from storage.contracts import UserRow, UserType
 
 
-def test_external_user_row_allows_no_owner_and_no_agent_config() -> None:
+def test_external_user_row_requires_creator_and_no_agent_config() -> None:
     row = UserRow(
         id="external-user-1",
         type=UserType.EXTERNAL,
         display_name="Codex External",
-        owner_user_id=None,
         agent_config_id=None,
+        created_by_user_id="owner-1",
         created_at=1.0,
     )
 
     assert row.type is UserType.EXTERNAL
     assert row.owner_user_id is None
     assert row.agent_config_id is None
+    assert row.created_by_user_id == "owner-1"
+
+
+def test_external_user_row_rejects_missing_created_by_user_id() -> None:
+    with pytest.raises(ValueError, match="external users require created_by_user_id"):
+        UserRow(
+            id="external-user-1",
+            type=UserType.EXTERNAL,
+            display_name="Codex External",
+            created_at=1.0,
+        )
 
 
 def test_external_user_row_rejects_owner_user_id() -> None:
@@ -27,6 +38,7 @@ def test_external_user_row_rejects_owner_user_id() -> None:
             type=UserType.EXTERNAL,
             display_name="Codex External",
             owner_user_id="owner-1",
+            created_by_user_id="creator-1",
             created_at=1.0,
         )
 
@@ -37,6 +49,7 @@ def test_external_user_row_rejects_agent_config_id() -> None:
             id="external-user-1",
             type=UserType.EXTERNAL,
             display_name="Codex External",
+            created_by_user_id="owner-1",
             agent_config_id="cfg-1",
             created_at=1.0,
         )

--- a/tests/Unit/storage/test_supabase_user_repo.py
+++ b/tests/Unit/storage/test_supabase_user_repo.py
@@ -84,6 +84,7 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
             avatar="toad.png",
             email="toad@example.com",
             mycel_id=10001,
+            created_by_user_id=None,
             next_thread_seq=3,
             created_at=1.0,
             updated_at=2.0,
@@ -95,7 +96,30 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
     assert client.table_obj.insert_payload["type"] == "agent"
     assert client.table_obj.insert_payload["owner_user_id"] == "owner-1"
     assert client.table_obj.insert_payload["agent_config_id"] == "cfg-1"
+    assert client.table_obj.insert_payload["created_by_user_id"] is None
     assert client.table_obj.insert_payload["next_thread_seq"] == 3
+
+
+def test_supabase_user_repo_create_persists_external_creator() -> None:
+    client = _FakeClient()
+    repo = SupabaseUserRepo(client)
+
+    repo.create(
+        UserRow(
+            id="external-1",
+            type=UserType.EXTERNAL,
+            display_name="Codex External",
+            created_by_user_id="owner-1",
+            created_at=1.0,
+        )
+    )
+
+    assert client.table_name == "identity.users"
+    assert client.table_obj.insert_payload is not None
+    assert client.table_obj.insert_payload["type"] == "external"
+    assert client.table_obj.insert_payload["created_by_user_id"] == "owner-1"
+    assert client.table_obj.insert_payload["owner_user_id"] is None
+    assert client.table_obj.insert_payload["agent_config_id"] is None
 
 
 def test_supabase_user_repo_get_by_id_returns_user_row() -> None:

--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -10,6 +10,7 @@ maintained prompts.
 
 ## Relationship And Join
 
+- `external-user-auth-management.md`
 - `relationship-and-chat-join.md`
 
 ## Frontend

--- a/tests/yatu/external-user-auth-management.md
+++ b/tests/yatu/external-user-auth-management.md
@@ -1,0 +1,52 @@
+# YATU: External User Auth Management
+
+## User Story
+
+As a human Mycel user, I want to create a durable external code-agent user from
+my own account, then let that external user participate in chat as itself.
+
+The human account manages the external user. The external user is still a real
+chat user, not a managed Mycel agent and not an alias for the human.
+
+## Entry Surfaces
+
+- Public backend auth API through the generated SDK or installed `mycel` CLI.
+- Public chat API through the generated SDK or installed `mycel` CLI.
+- Frontend user/chat candidate surfaces when available.
+
+## Setup
+
+1. Start the backend from the current branch.
+2. Log in as a human user and save a local owner profile.
+3. Create one external code-agent user from that owner profile.
+4. Save the returned external token into a separate external profile.
+
+## User Loop
+
+1. As the owner profile, inspect the owner identity.
+2. As the owner profile, create the external user.
+3. As the external profile, inspect identity and confirm the token resolves to
+   the external user, not the owner.
+4. As the owner profile, open the user/chat candidate surface and confirm the
+   external user is manageable by this account without a relationship request.
+5. As the external profile, request to join a group or send in a chat where it
+   is already a member.
+6. As a different user with no relationship/contact, confirm the external user
+   is not implicitly available just because its creator is a user.
+
+## Pass Bar
+
+- The external user's management link is durable backend state.
+- The external user's chat sender identity comes from its own token.
+- The external user does not carry managed-agent runtime fields such as
+  `owner_user_id` or `agent_config_id`.
+- The CLI/SDK do not pass sender user ids in request bodies.
+- The test never reads database rows directly as the proof.
+
+## Pitfalls
+
+- Do not treat a JWT claim alone as durable ownership proof.
+- Do not reuse managed-agent `owner_user_id` for external users.
+- Do not approve relationship or join requests by calling storage helpers.
+- Do not make the CLI remember a private ownership concept that the backend
+  cannot report.

--- a/tests/yatu/relationship-and-chat-join.md
+++ b/tests/yatu/relationship-and-chat-join.md
@@ -20,8 +20,9 @@ Approving one must not secretly approve the other.
 ## Setup
 
 1. Start the backend from the current branch.
-2. Prepare an owner or human profile, an external-agent profile, and at least
-   one managed-agent runtime thread.
+2. Prepare a human profile that created an external-agent profile through the
+   public auth onboarding surface, plus at least one managed-agent runtime
+   thread.
 3. Prepare one active group chat with a clear owner.
 4. Prepare a non-member visitor profile.
 


### PR DESCRIPTION
## Summary
- add a durable `created_by_user_id` management link for external users instead of overloading managed-agent `owner_user_id`
- persist the creator when creating external users and expose it in the auth response
- make owned-by-viewer checks include creator-managed external users while keeping agent default-thread handling limited to managed agents
- add a YATU card for external user auth management

## Verification
- `uv run python -m pytest -q` -> 2073 passed, 8 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright storage/contracts.py storage/providers/supabase/user_repo.py backend/identity/auth/service.py backend/web/routers/users.py messaging/user_ownership.py`
- `npm run build` in `frontend/app`
- `npm install && npm run build` in `frontend/monitor`

## Notes
- Full-repo `uv run pyright` still fails on existing unrelated type debt; targeted pyright for touched production files passes.
- Live CLI/backend YATU was not run in this shell because required Supabase/PGL smoke env vars are not present.