### PR TITLE
test: add chat yatu cards

### DIFF
--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -7,6 +7,8 @@ maintained prompts.
 ## Chat And Delivery
 
 - `chat-wake-policy.md`
+- `chat-managed-agent-word-chain.md`
+- `external-managed-agent-chat.md`
 
 ## Relationship And Join
 

--- a/tests/yatu/chat-managed-agent-word-chain.md
+++ b/tests/yatu/chat-managed-agent-word-chain.md
@@ -1,0 +1,50 @@
+# YATU: Managed-Agent Word Chain
+
+## User Story
+
+As a user in a group chat with two Mycel-managed agents, I can start a word
+chain with one natural sentence and the agents continue for several turns
+without me coordinating each word.
+
+## Product Surface
+
+- Real Mycel backend from current `origin/dev`.
+- Real Mycel-managed agents with LLM execution enabled.
+- Public chat UI or public chat API/CLI.
+- Durable chat messages visible to all group members.
+
+## Setup
+
+1. Start the backend from the current app branch.
+2. Create or reuse one human/owner user.
+3. Create two managed agents owned by that user.
+4. Create a group chat containing the owner and both managed agents.
+5. Ensure both managed agents can be woken by normal group-chat delivery.
+
+## Flow
+
+1. As the owner, send one natural-language message:
+
+   ```text
+   我们来玩成语接龙。你们两个轮流接，每次只发一个成语，至少接 8 轮。
+   ```
+
+2. Do not send per-turn instructions.
+3. Watch the chat until the agents have had enough time to respond.
+4. Read the final transcript through the same public chat surface.
+
+## Pass Criteria
+
+- The owner sends only the initial instruction.
+- Both managed agents reply through the chat.
+- The transcript contains at least 8 agent turns after the initial user message.
+- Replies are visible as normal chat messages, not as hidden internal state.
+- The test does not require manual per-word coordination.
+
+## Failure Signals
+
+- Only one agent wakes when the default group-chat behavior should wake both.
+- The user has to mention every managed agent manually for the simple default
+  group case.
+- The workflow requires direct thread-memory reads or private agent state.
+- The agents respond only when the tester sends one instruction per turn.

--- a/tests/yatu/external-managed-agent-chat.md
+++ b/tests/yatu/external-managed-agent-chat.md
@@ -1,0 +1,50 @@
+# YATU: External Agent And Managed Agent Chat
+
+## User Story
+
+As an external code agent using the installed `mycel` CLI, I can join a normal
+Mycel development chat and talk with a Mycel-managed agent through the same
+chat surface a user sees.
+
+## Product Surface
+
+- Real Mycel backend from current `origin/dev`.
+- Installed `mycel` executable from the SDK repository.
+- CLI profile containing `base_url` and bearer token.
+- Real Mycel-managed agent with LLM execution enabled.
+- Public relationship and chat flows.
+
+## Setup
+
+1. Start the backend from the current app branch.
+2. Install or use the current `mycel` executable.
+3. Use an owner profile to create or reuse a managed agent.
+4. Use `mycel skill external-dev-chat` as the guide for the external profile.
+5. Establish the required relationship or group membership through public
+   product commands.
+
+## Flow
+
+1. As the external profile, identify yourself with `mycel agent whoami`.
+2. Read the target chat.
+3. Send a natural message asking the managed agent to reply in the chat.
+4. If the managed agent is muted or attention-controlled, use the public
+   mention flag rather than editing hidden state.
+5. Read the chat again.
+
+## Pass Criteria
+
+- The external identity is derived from the profile token.
+- The CLI does not ask for a sender user id.
+- Relationship or group access is enforced by the backend.
+- The managed agent's reply arrives as a normal chat message.
+- The external profile can continue the conversation after marking messages
+  read.
+
+## Failure Signals
+
+- The external agent can bypass relationship or group membership rules.
+- The CLI invents product concepts not present in the backend.
+- The reply requires a private endpoint or direct storage read.
+- The external profile must pass environment facts as flags every time instead
+  of using a local profile.


### PR DESCRIPTION
## Summary
- add a managed-agent word-chain YATU card for the one-sentence group chat baseline
- add an external-agent-to-managed-agent chat YATU card for installed `mycel` CLI dogfood
- index both cards in the app YATU catalog

## Verification
- `git diff --check`
- scanned `tests/yatu` for forbidden artifact path and retired repo/command strings

No runtime code changed.