### PR TITLE
fix: track external user creator schema source

### DIFF
--- a/storage/schema/external_user_creator.sql
+++ b/storage/schema/external_user_creator.sql
@@ -1,0 +1,8 @@
+alter table identity.users
+    add column if not exists created_by_user_id text references identity.users(id) on delete set null;
+
+create index if not exists idx_identity_users_created_by_user_id
+    on identity.users(created_by_user_id)
+    where created_by_user_id is not null;
+
+notify pgrst, 'reload schema';

--- a/tests/Unit/storage/test_external_user_creator_schema_sql.py
+++ b/tests/Unit/storage/test_external_user_creator_schema_sql.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_external_user_creator_schema_source_declares_creator_column() -> None:
+    sql = Path("storage/schema/external_user_creator.sql").read_text(encoding="utf-8")
+
+    assert "alter table identity.users" in sql
+    assert "created_by_user_id text" in sql
+    assert "references identity.users(id)" in sql
+    assert "notify pgrst, 'reload schema'" in sql


### PR DESCRIPTION
## Summary
- add semantic schema source for identity.users.created_by_user_id
- add a focused storage test so the source stays tracked

## Verification
- RED: uv run pytest tests/Unit/storage/test_external_user_creator_schema_sql.py -q failed before the SQL source existed
- GREEN: uv run pytest tests/Unit/storage/test_external_user_creator_schema_sql.py tests/Unit/storage/test_external_user_type.py tests/Unit/storage/test_supabase_user_repo.py -q
- uv run ruff check tests/Unit/storage/test_external_user_creator_schema_sql.py
- uv run ruff format --check tests/Unit/storage/test_external_user_creator_schema_sql.py
- git grep forbidden terms on touched files returned no matches

## YATU context
Current-dev CLI word-chain YATU exposed the missing live DB column before this source file existed. Live DB was aligned manually, then this PR records the contract in source.