### PR TITLE
docs: correct CLI skill guide entry

### DIFF
--- a/tests/yatu/external-managed-agent-chat.md
+++ b/tests/yatu/external-managed-agent-chat.md
@@ -19,7 +19,9 @@ chat surface a user sees.
 1. Start the backend from the current app branch.
 2. Install or use the current `mycel` executable.
 3. Use an owner profile to create or reuse a managed agent.
-4. Use `mycel skill external-dev-chat` as the guide for the external profile.
+4. Use `mycel skill show external-dev-chat` or
+   `mycel skill prompt external-dev-chat` as the guide for the external
+   profile.
 5. Establish the required relationship or group membership through public
    product commands.
 


### PR DESCRIPTION
## Summary\n- correct the external-managed-agent YATU card to use the actual CLI skill guide commands\n\n## Verification\n- rg guard confirmed the retired bare skill entry is gone from the app YATU card\n- change is docs-only