### PR TITLE
refactor: hardcut settings models to GPT-5.5

### DIFF
--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+import re
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
@@ -95,18 +96,50 @@ def _build_model_http_client_kwargs(
     }, (async_client, sync_client)
 
 
+def _is_current_openai_gpt5_streaming_model(model_id: str) -> bool:
+    name = model_id.removeprefix("openai/").removeprefix("openai:")
+    return re.match(r"^gpt-5\.5(?:-.+)?$", name) is not None
+
+
 def _is_visible_settings_pool_model(provider_name: str, model_id: str) -> bool:
     if provider_name != "openai":
         return True
-    return model_id.startswith("gpt-5.4")
+    return _is_current_openai_gpt5_streaming_model(model_id)
+
+
+def _append_available_model(
+    models_list: list[dict[str, Any]],
+    seen: set[str],
+    *,
+    model_id: str,
+    name: str,
+    provider: str | None,
+    context_length: int | None = None,
+    custom: bool = False,
+) -> None:
+    if provider and not custom and not _is_visible_settings_pool_model(provider, model_id):
+        return
+    if model_id in seen:
+        return
+    seen.add(model_id)
+    item: dict[str, Any] = {
+        "id": model_id,
+        "name": name,
+        "provider": provider,
+    }
+    if context_length is not None:
+        item["context_length"] = context_length
+    if custom:
+        item["custom"] = True
+    models_list.append(item)
 
 
 def _validate_openai_settings_probe_or_400(resolved_model: str, provider_name: str | None) -> None:
     if provider_name != "openai":
         return
-    if resolved_model.startswith("gpt-5.4"):
+    if _is_current_openai_gpt5_streaming_model(resolved_model):
         return
-    raise RuntimeError("settings model probe only supports openai gpt-5.4 streaming path; choose gpt-5.4")
+    raise RuntimeError("settings model probe only supports current OpenAI GPT-5 streaming models")
 
 
 async def _run_streaming_model_probe(model: Any) -> str:
@@ -320,41 +353,46 @@ async def get_available_models(req: Request, user_id: CurrentUserId) -> dict[str
         bundled_providers: dict[str, str] = {}
         models_list = []
         seen: set[str] = set()
+        repo = _get_settings_repo(req)
+        mc = _load_merged_models_for_storage(repo, user_id)
         for m in raw_data.get("data", []):
             model_id = m.get("id", "")
             if "/" not in model_id:
                 continue
             provider, short_name = model_id.split("/", 1)
-            if not _is_visible_settings_pool_model(provider, short_name):
-                continue
-            if short_name in seen:
-                continue
-            seen.add(short_name)
             bundled_providers[short_name] = provider
-            models_list.append(
-                {
-                    "id": short_name,
-                    "name": m.get("name", short_name),
-                    "provider": provider,
-                    "context_length": m.get("context_length"),
-                }
+            _append_available_model(
+                models_list,
+                seen,
+                model_id=short_name,
+                name=m.get("name", short_name),
+                provider=provider,
+                context_length=m.get("context_length"),
             )
-        pricing_ids = seen
+
+        for catalog_item in getattr(mc, "catalog", []):
+            _append_available_model(
+                models_list,
+                seen,
+                model_id=catalog_item.id,
+                name=catalog_item.name,
+                provider=catalog_item.provider,
+                context_length=getattr(catalog_item, "context_length", None),
+            )
+        known_model_ids = set(seen)
 
         # Merge custom + orphaned enabled models
-        repo = _get_settings_repo(req)
-        mc = _load_merged_models_for_storage(repo, user_id)
         data = repo.get_models_config(user_id) or {}
         custom_providers = data.get("pool", {}).get("custom_providers", {})
-        extra_ids = set(mc.pool.custom) | (set(mc.pool.enabled) - pricing_ids)
+        extra_ids = set(mc.pool.custom) | (set(mc.pool.enabled) - known_model_ids)
         for mid in sorted(extra_ids):
-            models_list.append(
-                {
-                    "id": mid,
-                    "name": mid,
-                    "custom": True,
-                    "provider": custom_providers.get(mid) or bundled_providers.get(mid),
-                }
+            _append_available_model(
+                models_list,
+                seen,
+                model_id=mid,
+                name=mid,
+                provider=custom_providers.get(mid) or bundled_providers.get(mid),
+                custom=True,
             )
 
         # Virtual models from system defaults

--- a/config/defaults/models.json
+++ b/config/defaults/models.json
@@ -2,22 +2,22 @@
   "providers": {},
   "mapping": {
     "leon:mini": {
-      "model": "gpt-5.4",
+      "model": "gpt-5.5",
       "provider": "openai",
       "description": "快速响应，简单任务"
     },
     "leon:medium": {
-      "model": "gpt-5.4",
+      "model": "gpt-5.5",
       "provider": "openai",
       "description": "平衡性能，日常任务"
     },
     "leon:large": {
-      "model": "gpt-5.4",
+      "model": "gpt-5.5",
       "provider": "openai",
       "description": "复杂推理，困难任务"
     },
     "leon:max": {
-      "model": "gpt-5.4",
+      "model": "gpt-5.5",
       "provider": "openai",
       "temperature": 0.0,
       "description": "极限性能，最难任务"
@@ -29,8 +29,8 @@
   },
   "catalog": [
     {
-      "id": "gpt-5.4",
-      "name": "GPT-5.4",
+      "id": "gpt-5.5",
+      "name": "GPT-5.5",
       "provider": "openai",
       "description": "Platform default model"
     },

--- a/config/models_schema.py
+++ b/config/models_schema.py
@@ -42,7 +42,7 @@ class ModelSpec(BaseModel):
 class ActiveModel(BaseModel):
     """Currently active model selection."""
 
-    model: str = "claude-sonnet-4-5-20250929"
+    model: str = "gpt-5.5"
     provider: str | None = None
     based_on: str | None = None
     context_limit: int | None = Field(None, gt=0)

--- a/config/schema.py
+++ b/config/schema.py
@@ -16,7 +16,7 @@ from typing import Annotated, Any
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
 
 # Default model used across the codebase — single source of truth
-DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+DEFAULT_MODEL = "gpt-5.5"
 
 # ============================================================================
 # Runtime Configuration (non-model behavior parameters)

--- a/tests/Unit/integration_contracts/test_settings_persistence_contract.py
+++ b/tests/Unit/integration_contracts/test_settings_persistence_contract.py
@@ -14,9 +14,9 @@ class _FakeSettingsRepo:
         self.workspace_row = {
             "default_workspace": "/repo/ws",
             "recent_workspaces": ["/repo/ws", "/repo/alt"],
-            "default_model": "openai:gpt-5.4",
+            "default_model": "openai:gpt-5.5",
         }
-        self.models_config = {"pool": {"enabled": ["openai:gpt-5.4"], "custom": []}}
+        self.models_config = {"pool": {"enabled": ["openai:gpt-5.5"], "custom": []}}
         self.account_resource_limits = None
 
     def get(self, user_id: str):
@@ -85,9 +85,9 @@ def test_get_settings_route_prefers_repo_backed_workspace_and_models(monkeypatch
         settings_router,
         "_load_merged_models_for_storage",
         lambda _repo, _user_id: SimpleNamespace(
-            mapping={"default": SimpleNamespace(model="openai:gpt-5.4")},
+            mapping={"default": SimpleNamespace(model="openai:gpt-5.5")},
             providers={"openai": SimpleNamespace(api_key=None, base_url="https://api.openai.com")},
-            pool=SimpleNamespace(enabled=["openai:gpt-5.4"], custom=[]),
+            pool=SimpleNamespace(enabled=["openai:gpt-5.5"], custom=[]),
         ),
     )
 
@@ -98,9 +98,9 @@ def test_get_settings_route_prefers_repo_backed_workspace_and_models(monkeypatch
     assert response.json() == {
         "default_workspace": "/repo/ws",
         "recent_workspaces": ["/repo/ws", "/repo/alt"],
-        "default_model": "openai:gpt-5.4",
-        "model_mapping": {"default": "openai:gpt-5.4"},
-        "enabled_models": ["openai:gpt-5.4"],
+        "default_model": "openai:gpt-5.5",
+        "model_mapping": {"default": "openai:gpt-5.5"},
+        "enabled_models": ["openai:gpt-5.5"],
         "custom_models": [],
         "custom_config": {},
         "providers": {
@@ -198,7 +198,7 @@ def test_update_provider_rejects_user_credential_source_without_key():
 
     assert response.status_code == 400
     assert response.json()["detail"] == "User credential source requires an API key"
-    assert repo.models_config == {"pool": {"enabled": ["openai:gpt-5.4"], "custom": []}}
+    assert repo.models_config == {"pool": {"enabled": ["openai:gpt-5.5"], "custom": []}}
 
 
 def test_update_provider_preserves_existing_key_when_base_url_changes():
@@ -355,15 +355,15 @@ def test_get_available_models_route_prefers_repo_backed_model_pool(monkeypatch):
     assert "fs-custom" not in model_ids
 
 
-def test_get_available_models_route_filters_openai_pool_to_gpt_5_4_family(monkeypatch):
+def test_get_available_models_route_filters_openai_pool_to_current_gpt_5_5_families(monkeypatch):
     repo = _FakeSettingsRepo()
     monkeypatch.setattr(
         settings_router.json,
         "load",
         lambda _f: {
             "data": [
-                {"id": "openai/gpt-5.4", "name": "GPT-5.4", "context_length": 400000},
-                {"id": "openai/gpt-5.4-pro", "name": "GPT-5.4 Pro", "context_length": 400000},
+                {"id": "openai/gpt-5.5", "name": "GPT-5.5", "context_length": 400000},
+                {"id": "openai/gpt-5", "name": "GPT-5", "context_length": 400000},
                 {"id": "openai/gpt-5.1", "name": "GPT-5.1", "context_length": 400000},
                 {"id": "openai/gpt-4o", "name": "GPT-4o", "context_length": 128000},
                 {"id": "anthropic/claude-sonnet-4.5", "name": "Claude Sonnet", "context_length": 200000},
@@ -384,11 +384,49 @@ def test_get_available_models_route_filters_openai_pool_to_gpt_5_4_family(monkey
 
     assert response.status_code == 200
     model_ids = [item["id"] for item in response.json()["models"]]
-    assert "gpt-5.4" in model_ids
-    assert "gpt-5.4-pro" in model_ids
+    assert "gpt-5.5" in model_ids
     assert "claude-sonnet-4.5" in model_ids
+    assert "gpt-5" not in model_ids
     assert "gpt-5.1" not in model_ids
     assert "gpt-4o" not in model_ids
+
+
+def test_get_available_models_route_includes_system_catalog_when_provider_catalog_lags(monkeypatch):
+    repo = _FakeSettingsRepo()
+    monkeypatch.setattr(
+        settings_router.json,
+        "load",
+        lambda _f: {
+            "data": [
+                {"id": "openai/gpt-5", "name": "GPT-5", "context_length": 400000},
+                {"id": "anthropic/claude-sonnet-4.5", "name": "Claude Sonnet", "context_length": 200000},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        settings_router,
+        "_load_merged_models_for_storage",
+        lambda _repo, _user_id: SimpleNamespace(
+            pool=SimpleNamespace(enabled=[], custom=[]),
+            virtual_models=[],
+            catalog=[
+                SimpleNamespace(
+                    id="gpt-5.5",
+                    name="GPT-5.5",
+                    provider="openai",
+                    context_length=400000,
+                )
+            ],
+        ),
+    )
+
+    with TestClient(_settings_test_app(repo)) as client:
+        response = client.get("/api/settings/available-models")
+
+    assert response.status_code == 200
+    model_ids = [item["id"] for item in response.json()["models"]]
+    assert "gpt-5.5" in model_ids
+    assert "gpt-5" not in model_ids
 
 
 def test_test_model_route_prefers_repo_backed_provider_config(monkeypatch):
@@ -402,7 +440,7 @@ def test_test_model_route_prefers_repo_backed_provider_config(monkeypatch):
         "_load_merged_models_for_storage",
         lambda _repo, _user_id: SimpleNamespace(
             active=SimpleNamespace(provider=None),
-            resolve_model=lambda _model_id: ("gpt-5.4", {}),
+            resolve_model=lambda _model_id: ("gpt-5.5", {}),
             get_provider=lambda _provider_name: SimpleNamespace(api_key="repo-key", base_url="https://repo.example"),
             resolve_api_key=lambda _provider_name: "repo-key",
             resolve_base_url=lambda _provider_name: "https://repo.example",
@@ -417,7 +455,7 @@ def test_test_model_route_prefers_repo_backed_provider_config(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["success"] is True
-    assert captured["model"] == "gpt-5.4"
+    assert captured["model"] == "gpt-5.5"
     assert captured["kwargs"] == {
         "model_provider": "openai",
         "api_key": "repo-key",
@@ -439,11 +477,11 @@ def test_test_model_route_uses_platform_base_url_when_provider_row_missing(monke
     captured = _patch_streaming_chat_model(monkeypatch)
 
     with TestClient(_settings_test_app(repo)) as client:
-        response = client.post("/api/settings/models/test", json={"model_id": "openai:gpt-5.4"})
+        response = client.post("/api/settings/models/test", json={"model_id": "openai:gpt-5.5"})
 
     assert response.status_code == 200
     assert response.json()["success"] is True
-    assert captured["model"] == "gpt-5.4"
+    assert captured["model"] == "gpt-5.5"
     assert captured["kwargs"] == {
         "model_provider": "openai",
         "api_key": "platform-key",
@@ -455,7 +493,7 @@ def test_test_model_route_uses_platform_base_url_when_provider_row_missing(monke
     assert captured["kwargs"]["http_async_client"]._trust_env is False
 
 
-def test_test_model_route_uses_streaming_probe_for_openai_gpt_5_4(monkeypatch):
+def test_test_model_route_uses_streaming_probe_for_openai_gpt_5_5(monkeypatch):
     repo = _FakeSettingsRepo()
     repo.models_config = {}
     monkeypatch.setenv("OPENAI_API_KEY", "platform-key")
@@ -465,15 +503,37 @@ def test_test_model_route_uses_streaming_probe_for_openai_gpt_5_4(monkeypatch):
     captured = _patch_streaming_chat_model(monkeypatch)
 
     with TestClient(_settings_test_app(repo)) as client:
-        response = client.post("/api/settings/models/test", json={"model_id": "openai:gpt-5.4"})
+        response = client.post("/api/settings/models/test", json={"model_id": "openai:gpt-5.5"})
 
     assert response.status_code == 200
-    assert response.json() == {"success": True, "model": "gpt-5.4", "response": "Hi"}
-    assert captured["model"] == "gpt-5.4"
+    assert response.json() == {"success": True, "model": "gpt-5.5", "response": "Hi"}
+    assert captured["model"] == "gpt-5.5"
     assert captured["kwargs"]["model_provider"] == "openai"
 
 
-def test_test_model_route_fails_loudly_for_non_gpt_5_4_openai_models(monkeypatch):
+def test_test_model_route_rejects_bare_openai_gpt_5(monkeypatch):
+    repo = _FakeSettingsRepo()
+    repo.models_config = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "platform-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://platform.example")
+    monkeypatch.setattr("core.model_params.normalize_model_kwargs", lambda _resolved, kwargs: kwargs)
+
+    def _unexpected_init_chat_model(*_args, **_kwargs):
+        raise AssertionError("unsupported openai models should fail before model init")
+
+    monkeypatch.setattr("langchain.chat_models.init_chat_model", _unexpected_init_chat_model)
+
+    with TestClient(_settings_test_app(repo)) as client:
+        response = client.post("/api/settings/models/test", json={"model_id": "openai:gpt-5"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": False,
+        "error": "settings model probe only supports current OpenAI GPT-5 streaming models",
+    }
+
+
+def test_test_model_route_fails_loudly_for_unsupported_openai_models(monkeypatch):
     repo = _FakeSettingsRepo()
     repo.models_config = {}
     monkeypatch.setenv("OPENAI_API_KEY", "platform-key")
@@ -490,5 +550,5 @@ def test_test_model_route_fails_loudly_for_non_gpt_5_4_openai_models(monkeypatch
     assert response.status_code == 200
     assert response.json() == {
         "success": False,
-        "error": "settings model probe only supports openai gpt-5.4 streaming path; choose gpt-5.4",
+        "error": "settings model probe only supports current OpenAI GPT-5 streaming models",
     }

--- a/tests/Unit/platform/test_models_schema.py
+++ b/tests/Unit/platform/test_models_schema.py
@@ -5,9 +5,9 @@ from config.models_schema import ModelsConfig, ProviderConfig
 def test_provider_qualified_model_id_resolves_provider_and_model_name():
     config = ModelsConfig(providers={"openai": ProviderConfig(api_key="key", base_url="https://proxy.example")})
 
-    model_name, overrides = config.resolve_model("openai:gpt-5.4")
+    model_name, overrides = config.resolve_model("openai:gpt-5.5")
 
-    assert model_name == "gpt-5.4"
+    assert model_name == "gpt-5.5"
     assert overrides == {"model_provider": "openai"}
 
 
@@ -49,6 +49,6 @@ def test_repo_backed_empty_user_config_uses_platform_default_mapping(monkeypatch
 
     model_name, overrides = config.resolve_model("leon:large")
 
-    assert model_name == "gpt-5.4"
+    assert model_name == "gpt-5.5"
     assert overrides["model_provider"] == "openai"
     assert config.resolve_api_key("openai") == "platform-key"


### PR DESCRIPTION
## Summary
- move default Mycel model mappings to GPT-5.5
- hardcut OpenAI settings probe and visible settings model list to GPT-5.5 family
- include system catalog entries in available settings models when provider catalog lags

## Verification
- uv run pytest tests/Unit/integration_contracts/test_settings_persistence_contract.py tests/Unit/platform/test_models_schema.py tests/Unit/platform/test_model_params.py -q
- live backend probe: /api/settings/models/test accepts gpt-5.5 and rejects bare gpt-5
- live available-models exposes gpt-5.5 and not bare gpt-5