### PR TITLE
feat: add external runtime inbox

### DIFF
--- a/backend/chat/api/http/app_router.py
+++ b/backend/chat/api/http/app_router.py
@@ -4,6 +4,7 @@ from backend.chat.api.http import (
     chats_router,
     conversations_router,
     relationships_router,
+    runtime_inbox_router,
 )
 
 router = APIRouter()
@@ -11,3 +12,4 @@ router = APIRouter()
 router.include_router(chats_router.router)
 router.include_router(relationships_router.router)
 router.include_router(conversations_router.router)
+router.include_router(runtime_inbox_router.router)

--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.chat.api.http.dependencies import get_app, get_current_user_id
+from backend.threads.chat_adapters.external_inbox_handler import external_inbox_key
+
+router = APIRouter(prefix="/api/runtime", tags=["runtime"])
+
+
+def drain_runtime_inbox_items(user_id: str, queue_manager: Any) -> list[dict[str, Any]]:
+    items = queue_manager.drain_all(external_inbox_key(user_id))
+    drained: list[dict[str, Any]] = []
+    for item in items:
+        try:
+            payload = json.loads(item.content)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Invalid external runtime inbox payload") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("Invalid external runtime inbox payload")
+        payload["notification_type"] = item.notification_type
+        payload["source"] = item.source
+        payload["sender_id"] = item.sender_id
+        payload["sender_name"] = item.sender_name
+        drained.append(payload)
+    return drained
+
+
+@router.post("/inbox/drain")
+async def drain_runtime_inbox(
+    app: Annotated[Any, Depends(get_app)],
+    user_id: Annotated[str, Depends(get_current_user_id)],
+) -> dict[str, Any]:
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    queue_manager = getattr(runtime_state, "queue_manager", None)
+    if queue_manager is None:
+        raise HTTPException(500, "Runtime queue manager unavailable")
+    try:
+        items = await asyncio.to_thread(drain_runtime_inbox_items, user_id, queue_manager)
+    except RuntimeError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    return {"count": len(items), "notifications": items}

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -8,6 +8,7 @@ from backend.threads.activity_pool_service import get_or_create_agent
 from backend.threads.chat_adapters.activity_reader import AppRuntimeThreadActivityReader
 from backend.threads.chat_adapters.chat_handler import NativeAgentChatDeliveryHandler
 from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
+from backend.threads.chat_adapters.external_inbox_handler import ExternalRuntimeInboxHandler
 from backend.threads.chat_adapters.gateway import NativeAgentRuntimeGateway
 from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
@@ -40,7 +41,8 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
                     resolve_thread_sandbox=resolve_thread_sandbox,
                     ensure_thread_handlers=_ensure_thread_handlers,
                 ),
-            )
+            ),
+            "external": ExternalRuntimeInboxHandler(queue_manager=app.state.queue_manager),
         },
         thread_input_handler=NativeAgentThreadInputHandler(
             app,

--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -39,13 +39,20 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
             request.unread_count,
             signal=request.signal,
         )
-        thread_id = select_runtime_thread_for_recipient(
-            request.recipient_id,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-        if thread_id is None:
-            raise RuntimeError(f"Agent chat recipient has no runtime thread: {request.recipient_id}")
+        if recipient_type == "external":
+            runtime_source = "external"
+            thread_id = None
+        elif recipient_type == "agent":
+            runtime_source = "mycel"
+            thread_id = select_runtime_thread_for_recipient(
+                request.recipient_id,
+                thread_repo=thread_repo,
+                activity_reader=activity_reader,
+            )
+            if thread_id is None:
+                raise RuntimeError(f"Agent chat recipient has no runtime thread: {request.recipient_id}")
+        else:
+            raise RuntimeError(f"Chat delivery recipient type is not runtime-addressable: {recipient_type}")
         envelope = AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=request.chat_id),
             sender=AgentRuntimeActor(
@@ -55,7 +62,7 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
                 avatar_url=request.sender_avatar_url,
                 source="chat",
             ),
-            recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source="mycel", thread_id=thread_id),
+            recipient=AgentChatRecipient(agent_user_id=request.recipient_id, runtime_source=runtime_source, thread_id=thread_id),
             message=AgentRuntimeMessage(content=rendered_content, signal=request.signal),
             extensions={
                 "mycel": {

--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from protocols import agent_runtime as agent_runtime_protocol
+
+
+def external_inbox_key(user_id: str) -> str:
+    normalized = str(user_id or "").strip()
+    if not normalized:
+        raise RuntimeError("external runtime inbox requires recipient user id")
+    return f"external:{normalized}"
+
+
+class ExternalRuntimeInboxHandler:
+    def __init__(self, *, queue_manager: Any) -> None:
+        self._queue_manager = queue_manager
+
+    async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
+        inbox_id = external_inbox_key(envelope.recipient.agent_user_id)
+        sender_name = envelope.sender.display_name or envelope.sender.user_id
+        payload = {
+            "event_type": envelope.event_type,
+            "chat_id": envelope.chat.chat_id,
+            "sender_id": envelope.sender.user_id,
+            "sender_name": envelope.sender.display_name,
+            "summary": f"New chat message from {sender_name}.",
+        }
+        self._queue_manager.enqueue(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            inbox_id,
+            "chat",
+            source="external",
+            sender_id=envelope.sender.user_id,
+            sender_name=envelope.sender.display_name,
+            wake=False,
+        )
+        return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=inbox_id)

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -64,7 +64,7 @@ class ChatDeliveryDispatcher:
         if sender_raw_type is None:
             raise RuntimeError(f"Chat delivery sender type is missing: {sender_id}")
         sender_type = sender_raw_type.value if isinstance(sender_raw_type, Enum) else str(sender_raw_type)
-        sender_owner_id = sender_user.id if sender_type == "human" else getattr(sender_user, "owner_user_id", None)
+        sender_owner_id = self._runtime_owner_id(sender_user)
 
         for member in members:
             uid = member.get("user_id")
@@ -77,7 +77,7 @@ class ChatDeliveryDispatcher:
                 raise RuntimeError(f"Chat delivery recipient identity not found: {uid}")
             member_raw_type = getattr(recipient, "type", None)
             member_type = member_raw_type.value if isinstance(member_raw_type, Enum) else str(member_raw_type)
-            if member_type != "agent":
+            if member_type not in {"agent", "external"}:
                 continue
 
             action = DeliveryAction.DELIVER
@@ -132,8 +132,17 @@ class ChatDeliveryDispatcher:
             raise RuntimeError("Chat delivery avatar URL builder is not configured")
         return self._avatar_url_builder(user_id, has_avatar)
 
+    def _runtime_owner_id(self, user: Any) -> str | None:
+        raw_type = getattr(user, "type", None)
+        user_type = raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
+        if user_type == "human":
+            return getattr(user, "id", None)
+        if user_type == "external":
+            return getattr(user, "created_by_user_id", None)
+        return getattr(user, "owner_user_id", None)
+
     def _needs_access_resolver(self, sender_owner_id: str | None, recipient: Any) -> bool:
-        return not (sender_owner_id and getattr(recipient, "owner_user_id", None) == sender_owner_id)
+        return not (sender_owner_id and self._runtime_owner_id(recipient) == sender_owner_id)
 
     def _deliver(
         self,

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -93,6 +93,44 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_delivery_hook_routes_external_user_to_external_runtime_without_thread() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_chat(self, envelope):
+            self.envelope = envelope
+
+    gateway = RecordingGateway()
+    app = _hook_app(gateway)
+    deliver = owner_chat_inlet.make_chat_delivery_fn(
+        app,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
+        thread_repo=app.state.thread_repo,
+    )
+    request = ChatDeliveryRequest(
+        recipient_id="external-user-1",
+        recipient_user=SimpleNamespace(id="external-user-1", type="external"),
+        content="hello",
+        sender_name="Human",
+        sender_type="human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        unread_count=4,
+        signal=None,
+    )
+
+    await asyncio.to_thread(deliver, request)
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
+    assert gateway.envelope.recipient.runtime_source == "external"
+    assert gateway.envelope.recipient.thread_id is None
+    assert "New message from Human in chat chat-1 (4 unread)." in gateway.envelope.message.content
+    assert gateway.envelope.extensions["mycel"]["raw_content"] == "hello"
+
+
+@pytest.mark.asyncio
 async def test_chat_delivery_hook_requires_recipient_user_type() -> None:
     class RecordingGateway:
         called = False

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from backend.threads.chat_adapters.external_inbox_handler import ExternalRuntimeInboxHandler, external_inbox_key
+from protocols.agent_runtime import (
+    AgentChatContext,
+    AgentChatDeliveryEnvelope,
+    AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+)
+
+
+def _envelope() -> AgentChatDeliveryEnvelope:
+    return AgentChatDeliveryEnvelope(
+        chat=AgentChatContext(chat_id="chat-1"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human"),
+        recipient=AgentChatRecipient(agent_user_id="external-user-1", runtime_source="external"),
+        message=AgentRuntimeMessage(content="<system-reminder>managed runtime prompt must not leak</system-reminder>"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_inbox_handler_queues_metadata_only_notification() -> None:
+    enqueued: list[tuple[str, str, str, dict]] = []
+    handler = ExternalRuntimeInboxHandler(
+        queue_manager=SimpleNamespace(
+            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
+        )
+    )
+
+    result = await handler.dispatch(_envelope())
+
+    assert result.status == "accepted"
+    assert result.thread_id == external_inbox_key("external-user-1")
+    assert len(enqueued) == 1
+    content, inbox_id, notification_type, meta = enqueued[0]
+    payload = json.loads(content)
+    assert inbox_id == "external:external-user-1"
+    assert notification_type == "chat"
+    assert meta["source"] == "external"
+    assert meta["sender_id"] == "human-user-1"
+    assert meta["sender_name"] == "Human"
+    assert payload == {
+        "event_type": "chat.message",
+        "chat_id": "chat-1",
+        "sender_id": "human-user-1",
+        "sender_name": "Human",
+        "summary": "New chat message from Human.",
+    }
+
+
+def test_external_inbox_key_rejects_blank_user_id() -> None:
+    with pytest.raises(RuntimeError, match="external runtime inbox requires recipient user id"):
+        external_inbox_key(" ")

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -10,16 +10,18 @@ from backend.chat.api.http.runtime_inbox_router import drain_runtime_inbox_items
 def test_drain_runtime_inbox_items_returns_metadata_and_clears_external_queue() -> None:
     drained_keys: list[str] = []
     queue_manager = SimpleNamespace(
-        drain_all=lambda key: drained_keys.append(key)
-        or [
-            SimpleNamespace(
-                content='{"event_type":"chat.message","chat_id":"chat-1","sender_name":"Human","summary":"New message"}',
-                notification_type="chat",
-                source="external",
-                sender_id="human-user-1",
-                sender_name="Human",
-            )
-        ]
+        drain_all=lambda key: (
+            drained_keys.append(key)
+            or [
+                SimpleNamespace(
+                    content='{"event_type":"chat.message","chat_id":"chat-1","sender_name":"Human","summary":"New message"}',
+                    notification_type="chat",
+                    source="external",
+                    sender_id="human-user-1",
+                    sender_name="Human",
+                )
+            ]
+        )
     )
 
     result = drain_runtime_inbox_items("external-user-1", queue_manager)

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.chat.api.http.runtime_inbox_router import drain_runtime_inbox_items
+
+
+def test_drain_runtime_inbox_items_returns_metadata_and_clears_external_queue() -> None:
+    drained_keys: list[str] = []
+    queue_manager = SimpleNamespace(
+        drain_all=lambda key: drained_keys.append(key)
+        or [
+            SimpleNamespace(
+                content='{"event_type":"chat.message","chat_id":"chat-1","sender_name":"Human","summary":"New message"}',
+                notification_type="chat",
+                source="external",
+                sender_id="human-user-1",
+                sender_name="Human",
+            )
+        ]
+    )
+
+    result = drain_runtime_inbox_items("external-user-1", queue_manager)
+
+    assert drained_keys == ["external:external-user-1"]
+    assert result == [
+        {
+            "event_type": "chat.message",
+            "chat_id": "chat-1",
+            "sender_name": "Human",
+            "summary": "New message",
+            "notification_type": "chat",
+            "source": "external",
+            "sender_id": "human-user-1",
+        }
+    ]
+
+
+def test_drain_runtime_inbox_items_fails_loudly_on_invalid_payload() -> None:
+    queue_manager = SimpleNamespace(
+        drain_all=lambda _key: [
+            SimpleNamespace(
+                content="not-json",
+                notification_type="chat",
+                source="external",
+                sender_id=None,
+                sender_name=None,
+            )
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid external runtime inbox payload"):
+        drain_runtime_inbox_items("external-user-1", queue_manager)

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -173,7 +173,7 @@ def test_dispatcher_agent_turn_delivers_only_to_sibling_agent() -> None:
     assert delivered == ["agent-user-2"]
 
 
-def test_dispatcher_does_not_runtime_deliver_to_external_users() -> None:
+def test_dispatcher_delivers_to_external_users_as_runtime_recipients() -> None:
     delivered: list[str] = []
     dispatcher = ChatDeliveryDispatcher(
         chat_member_repo=_member_repo(["agent-user-1", "external-user-1"]),
@@ -186,7 +186,7 @@ def test_dispatcher_does_not_runtime_deliver_to_external_users() -> None:
 
     dispatcher.dispatch("chat-1", "agent-user-1", "hello", [])
 
-    assert delivered == []
+    assert delivered == ["external-user-1"]
 
 
 def test_dispatcher_keeps_notify_policy_out_of_runtime_queue() -> None:

--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -9,6 +9,7 @@ maintained prompts.
 - `chat-wake-policy.md`
 - `chat-managed-agent-word-chain.md`
 - `external-managed-agent-chat.md`
+- `external-runtime-inbox.md`
 
 ## Relationship And Join
 

--- a/tests/yatu/external-runtime-inbox.md
+++ b/tests/yatu/external-runtime-inbox.md
@@ -1,0 +1,48 @@
+# YATU: External Runtime Inbox
+
+## User Story
+
+As an external code agent, I should receive runtime wake hints through a public
+notification inbox while durable chat messages remain in the normal chat store.
+
+## Product Surface
+
+- Real Mycel backend from the current app branch.
+- Installed `mycel` CLI from the SDK repo.
+- One human owner profile and one external-agent profile.
+- Optional Claude Code hook adapter using the external profile.
+
+## Setup
+
+1. Start the backend from the current app branch.
+2. Create or reuse a human owner profile.
+3. Create an external user from that owner profile.
+4. Save the external token into a CLI profile.
+5. Create a direct or group chat that includes the external user.
+
+## Flow
+
+1. As another chat member, send a normal chat message to the chat.
+2. As the external profile, run `mycel notify drain --format claude-context`.
+3. Confirm the notification names event type, sender, and chat id but does not
+   contain the chat message body.
+4. Use `mycel chat messages list <chat-id>` to inspect bodies.
+5. Use `mycel chat read <chat-id>` before replying.
+6. Use `mycel chat send <chat-id> "..."` to reply as the external user.
+
+## Pass Criteria
+
+- The external inbox item is produced by backend runtime delivery, not by a CLI
+  polling shortcut.
+- The notification drain is authenticated as the external user and only drains
+  that user's inbox.
+- The notification is metadata-only; chat bodies are read through chat APIs.
+- The reply appears as a normal chat message from the external user's identity.
+
+## Failure Signals
+
+- The backend emits Claude-specific branches instead of a general external
+  runtime inbox.
+- Notification drain includes raw chat bodies or managed-agent prompt text.
+- The external user can send as another user by passing sender ids.
+- The test proves success through queue internals instead of product surfaces.


### PR DESCRIPTION
## Summary
- routes external chat recipients through a general external runtime inbox
- adds authenticated /api/runtime/inbox/drain for metadata-only notification stubs
- keeps chat persistence and managed-agent delivery semantics separate
- adds backend unit coverage and an app YATU card for external runtime inbox proof

## Verification
- uv run pytest tests/Unit/messaging tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
- uv run ruff check messaging backend/threads/chat_adapters backend/chat/api/http tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py

## YATU
- backend ran from this branch on 127.0.0.1:8042
- external Claude profile received metadata-only notification via /api/runtime/inbox/drain
- full Claude Code adapter YATU recorded in SDK PR artifacts