### PR TITLE
fix: use runtime Supabase client factory in web bootstrap

### DIFF
--- a/backend/bootstrap/storage.py
+++ b/backend/bootstrap/storage.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from backend.identity.auth.supabase_runtime import create_supabase_client
-from storage.runtime import build_storage_container
+from storage.runtime import build_storage_container, build_supabase_client
 
 
 @dataclass(frozen=True)
@@ -14,7 +13,7 @@ class RuntimeStorageState:
 
 
 def build_runtime_storage_state() -> RuntimeStorageState:
-    supabase_client = create_supabase_client()
+    supabase_client = build_supabase_client()
     storage_container = build_storage_container(supabase_client=supabase_client)
     recipe_repo = storage_container.recipe_repo()
     return RuntimeStorageState(

--- a/storage/runtime.py
+++ b/storage/runtime.py
@@ -30,6 +30,10 @@ def build_storage_container(
     return StorageContainer(supabase_client=client)
 
 
+def build_supabase_client(*, supabase_client_factory: str | None = None) -> Any:
+    return _resolve_supabase_client(factory_ref=supabase_client_factory)
+
+
 def _build_storage_repo(
     repo_method: str,
     *,

--- a/tests/Unit/backend/test_runtime_storage_bootstrap.py
+++ b/tests/Unit/backend/test_runtime_storage_bootstrap.py
@@ -9,7 +9,7 @@ def test_build_runtime_storage_state_uses_shared_supabase_client(monkeypatch):
     fake_container = SimpleNamespace()
     fake_recipe_repo = object()
 
-    monkeypatch.setattr(runtime_storage_bootstrap, "create_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(runtime_storage_bootstrap, "build_supabase_client", lambda: fake_client)
 
     def _build_storage_container(*, supabase_client):
         calls.append(supabase_client)

--- a/tests/Unit/core/test_runtime_side_store_defaults.py
+++ b/tests/Unit/core/test_runtime_side_store_defaults.py
@@ -9,6 +9,22 @@ from storage.providers.sqlite.queue_repo import SQLiteQueueRepo
 from storage.providers.sqlite.summary_repo import SQLiteSummaryRepo
 
 
+def test_build_supabase_client_uses_runtime_factory_ref(monkeypatch) -> None:
+    from storage import runtime as storage_runtime
+
+    fake_client = object()
+    calls: list[str | None] = []
+
+    def _resolve(*, factory_ref=None):
+        calls.append(factory_ref)
+        return fake_client
+
+    monkeypatch.setattr(storage_runtime, "_resolve_supabase_client", _resolve)
+
+    assert storage_runtime.build_supabase_client(supabase_client_factory="tests.fake:create_client") is fake_client
+    assert calls == ["tests.fake:create_client"]
+
+
 class _FakeQueueRepo:
     def close(self) -> None:
         return None


### PR DESCRIPTION
## Summary
- add a public storage.runtime.build_supabase_client boundary
- route backend runtime storage bootstrap through that boundary
- keep one Supabase client shared between runtime storage state and StorageContainer

## Why
Real Claude Stop-hook YATU exposed that backend.bootstrap.storage hard-coded create_supabase_client and bypassed LEON_SUPABASE_CLIENT_FACTORY. The runtime already had a factory abstraction; web bootstrap now uses it.

## Verification
- uv run pytest tests/Unit/backend/test_runtime_storage_bootstrap.py tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/core/test_supabase_factory.py tests/Unit/backend/test_web_lifespan_ordering.py -q
- uv run ruff check .
- uv run pytest -q
- real YATU: local backend with LEON_SUPABASE_CLIENT_FACTORY=mycel_yatu_supabase_factory:create_supabase_client handled chat read/send and /api/runtime/inbox/drain with 200 responses