### PR TITLE
feat: add runtime inbox wait endpoint

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.chat.api.http.dependencies import get_app, get_current_user_id
 from backend.threads.chat_adapters.external_inbox_handler import external_inbox_key
@@ -30,6 +31,25 @@ def drain_runtime_inbox_items(user_id: str, queue_manager: Any) -> list[dict[str
     return drained
 
 
+def wait_runtime_inbox_items(
+    user_id: str,
+    queue_manager: Any,
+    *,
+    timeout_seconds: float,
+) -> list[dict[str, Any]]:
+    key = external_inbox_key(user_id)
+    event = threading.Event()
+    queue_manager.register_wake(key, lambda _item: event.set())
+    try:
+        items = drain_runtime_inbox_items(user_id, queue_manager)
+        if items:
+            return items
+        event.wait(timeout=max(0.0, timeout_seconds))
+        return drain_runtime_inbox_items(user_id, queue_manager)
+    finally:
+        queue_manager.unregister_wake(key)
+
+
 @router.post("/inbox/drain")
 async def drain_runtime_inbox(
     app: Annotated[Any, Depends(get_app)],
@@ -41,6 +61,28 @@ async def drain_runtime_inbox(
         raise HTTPException(500, "Runtime queue manager unavailable")
     try:
         items = await asyncio.to_thread(drain_runtime_inbox_items, user_id, queue_manager)
+    except RuntimeError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    return {"count": len(items), "notifications": items}
+
+
+@router.post("/inbox/wait")
+async def wait_runtime_inbox(
+    app: Annotated[Any, Depends(get_app)],
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    timeout_seconds: Annotated[float, Query(ge=0.0, le=30.0)] = 25.0,
+) -> dict[str, Any]:
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    queue_manager = getattr(runtime_state, "queue_manager", None)
+    if queue_manager is None:
+        raise HTTPException(500, "Runtime queue manager unavailable")
+    try:
+        items = await asyncio.to_thread(
+            wait_runtime_inbox_items,
+            user_id,
+            queue_manager,
+            timeout_seconds=timeout_seconds,
+        )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc
     return {"count": len(items), "notifications": items}

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 
 import pytest
 
-from backend.chat.api.http.runtime_inbox_router import drain_runtime_inbox_items
+from backend.chat.api.http.runtime_inbox_router import (
+    drain_runtime_inbox_items,
+    wait_runtime_inbox,
+    wait_runtime_inbox_items,
+)
 
 
 def test_drain_runtime_inbox_items_returns_metadata_and_clears_external_queue() -> None:
@@ -55,3 +60,85 @@ def test_drain_runtime_inbox_items_fails_loudly_on_invalid_payload() -> None:
 
     with pytest.raises(RuntimeError, match="Invalid external runtime inbox payload"):
         drain_runtime_inbox_items("external-user-1", queue_manager)
+
+
+def test_wait_runtime_inbox_items_returns_after_external_queue_wake() -> None:
+    queued: list[SimpleNamespace] = []
+    registered: dict[str, object] = {}
+
+    def _drain_all(key: str) -> list[SimpleNamespace]:
+        assert key == "external:external-user-1"
+        items = list(queued)
+        queued.clear()
+        return items
+
+    def _register_wake(key: str, handler) -> None:
+        assert key == "external:external-user-1"
+        registered["handler"] = handler
+
+    def _unregister_wake(key: str) -> None:
+        assert key == "external:external-user-1"
+        registered["unregistered"] = True
+
+    queue_manager = SimpleNamespace(
+        drain_all=_drain_all,
+        register_wake=_register_wake,
+        unregister_wake=_unregister_wake,
+    )
+
+    result_holder: dict[str, list[dict[str, object]]] = {}
+    worker = threading.Thread(
+        target=lambda: result_holder.update(
+            items=wait_runtime_inbox_items(
+                "external-user-1",
+                queue_manager,
+                timeout_seconds=1.0,
+            )
+        )
+    )
+
+    worker.start()
+    while "handler" not in registered:
+        pass
+    queued.append(
+        SimpleNamespace(
+            content='{"event_type":"chat.message","chat_id":"chat-1"}',
+            notification_type="chat",
+            source="external",
+            sender_id="human-user-1",
+            sender_name="Human",
+        )
+    )
+    registered["handler"](queued[0])
+    worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert registered["unregistered"] is True
+    assert result_holder["items"] == [
+        {
+            "event_type": "chat.message",
+            "chat_id": "chat-1",
+            "notification_type": "chat",
+            "source": "external",
+            "sender_id": "human-user-1",
+            "sender_name": "Human",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wait_runtime_inbox_endpoint_returns_count_and_notifications() -> None:
+    queue_manager = SimpleNamespace(
+        drain_all=lambda _key: [],
+        register_wake=lambda _key, _handler: None,
+        unregister_wake=lambda _key: None,
+    )
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(queue_manager=queue_manager)))
+
+    result = await wait_runtime_inbox(
+        app,
+        "external-user-1",
+        timeout_seconds=0.0,
+    )
+
+    assert result == {"count": 0, "notifications": []}


### PR DESCRIPTION
## Summary
- add a public runtime inbox wait endpoint for external runtime notifications
- keep the endpoint as a thin wrapper around the existing external inbox queue
- add unit coverage for delayed wake delivery and HTTP response shape

## Verification
- uv run ruff format --check backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py
- uv run ruff check backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py
- uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/core/test_message_queue_manager_wake.py -q