### PR TITLE
feat: route relationship notifications to external inbox

### DIFF
--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -26,6 +26,7 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
         thread_repo=app.state.thread_repo,
         agent_pool=app.state.agent_pool,
     )
+    external_runtime_handler = ExternalRuntimeInboxHandler(queue_manager=app.state.queue_manager)
     gateway = NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(
@@ -42,8 +43,9 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
                     ensure_thread_handlers=_ensure_thread_handlers,
                 ),
             ),
-            "external": ExternalRuntimeInboxHandler(queue_manager=app.state.queue_manager),
+            "external": external_runtime_handler,
         },
+        notification_handlers={"external": external_runtime_handler},
         thread_input_handler=NativeAgentThreadInputHandler(
             app,
             queue_manager=app.state.queue_manager,

--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -37,3 +37,26 @@ class ExternalRuntimeInboxHandler:
             wake=False,
         )
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=inbox_id)
+
+    async def dispatch_notification(
+        self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope
+    ) -> agent_runtime_protocol.AgentRuntimeNotificationResult:
+        inbox_id = external_inbox_key(envelope.recipient.agent_user_id)
+        payload = {
+            "event_type": envelope.event_type,
+            "sender_id": envelope.sender.user_id,
+            "sender_name": envelope.sender.display_name,
+            "summary": envelope.message.content,
+        }
+        if envelope.message.metadata:
+            payload.update(envelope.message.metadata)
+        self._queue_manager.enqueue(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            inbox_id,
+            envelope.notification_type,
+            source="external",
+            sender_id=envelope.sender.user_id,
+            sender_name=envelope.sender.display_name,
+            wake=envelope.wake,
+        )
+        return agent_runtime_protocol.AgentRuntimeNotificationResult(status="accepted", thread_id=inbox_id)

--- a/backend/threads/chat_adapters/gateway.py
+++ b/backend/threads/chat_adapters/gateway.py
@@ -18,14 +18,22 @@ class AgentThreadInputRuntimeHandler(Protocol):
     ) -> agent_runtime_protocol.AgentThreadInputResult: ...
 
 
+class AgentRuntimeNotificationHandler(Protocol):
+    async def dispatch_notification(
+        self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope
+    ) -> agent_runtime_protocol.AgentRuntimeNotificationResult: ...
+
+
 class NativeAgentRuntimeGateway:
     def __init__(
         self,
         *,
         chat_handlers: Mapping[str, AgentChatRuntimeHandler] | None = None,
+        notification_handlers: Mapping[str, AgentRuntimeNotificationHandler] | None = None,
         thread_input_handler: AgentThreadInputRuntimeHandler | None = None,
     ) -> None:
         self._chat_handlers = dict(chat_handlers or {})
+        self._notification_handlers = dict(notification_handlers or {})
         self._thread_input_handler = thread_input_handler
 
     async def dispatch_chat(
@@ -35,6 +43,14 @@ class NativeAgentRuntimeGateway:
         if handler is None:
             raise ValueError(f"No Agent chat runtime handler registered for runtime_source={envelope.recipient.runtime_source!r}")
         return await handler.dispatch(envelope)
+
+    async def dispatch_notification(
+        self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope
+    ) -> agent_runtime_protocol.AgentRuntimeNotificationResult:
+        handler = self._notification_handlers.get(envelope.recipient.runtime_source)
+        if handler is None:
+            raise ValueError(f"No Agent runtime notification handler registered for runtime_source={envelope.recipient.runtime_source!r}")
+        return await handler.dispatch_notification(envelope)
 
     async def dispatch_thread_input(
         self, envelope: agent_runtime_protocol.AgentThreadInputEnvelope

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -8,7 +8,13 @@ from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from messaging.contracts import RelationshipEvent, RelationshipRow
 from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
-from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+from protocols.agent_runtime import (
+    AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+    AgentRuntimeNotificationEnvelope,
+    AgentThreadInputEnvelope,
+)
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
     "approve": "approved",
@@ -26,7 +32,29 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
         target_id = _target_id(row, requester_id)
         requester = _require_user(user_repo, requester_id, "requester")
         target = _require_user(user_repo, target_id, "target")
-        if _user_type(target, target_id) != "agent":
+        target_type = _user_type(target, target_id)
+        if target_type == "external":
+            await _dispatch_external_notification(
+                app,
+                recipient_id=target_id,
+                sender=AgentRuntimeActor(
+                    user_id=requester_id,
+                    user_type=_user_type(requester, requester_id),
+                    display_name=_display_name(requester, requester_id),
+                    avatar_url=avatar_url(requester_id, bool(getattr(requester, "avatar", None))),
+                    source="relationship",
+                ),
+                message=AgentRuntimeMessage(
+                    content=_notification_content(
+                        _display_name(requester, requester_id),
+                        row.message,
+                    ),
+                    metadata={"relationship_id": row.id},
+                ),
+                event_type="relationship.requested",
+            )
+            return
+        if target_type != "agent":
             return
 
         thread_id = select_runtime_thread_for_recipient(
@@ -74,7 +102,30 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
         decider_id = _target_id(row, requester_id)
         requester = _require_user(user_repo, requester_id, "requester")
         decider = _require_user(user_repo, decider_id, "decider")
-        if _user_type(requester, requester_id) != "agent":
+        requester_type = _user_type(requester, requester_id)
+        if requester_type == "external":
+            await _dispatch_external_notification(
+                app,
+                recipient_id=requester_id,
+                sender=AgentRuntimeActor(
+                    user_id=decider_id,
+                    user_type=_user_type(decider, decider_id),
+                    display_name=_display_name(decider, decider_id),
+                    avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                    source="relationship",
+                ),
+                message=AgentRuntimeMessage(
+                    content=f"{_display_name(decider, decider_id)} {_decision_verb(event)} your relationship request.",
+                    metadata={
+                        "relationship_id": row.id,
+                        "event": event,
+                        "state": row.state,
+                    },
+                ),
+                event_type=f"relationship.{_decision_verb(event)}",
+            )
+            return
+        if requester_type != "agent":
             return
 
         thread_id = select_runtime_thread_for_recipient(
@@ -111,6 +162,25 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
         future.result()
 
     return _notify
+
+
+async def _dispatch_external_notification(
+    app: Any,
+    *,
+    recipient_id: str,
+    sender: AgentRuntimeActor,
+    message: AgentRuntimeMessage,
+    event_type: str,
+) -> None:
+    await get_agent_runtime_gateway(app).dispatch_notification(
+        AgentRuntimeNotificationEnvelope(
+            event_type=event_type,
+            recipient=AgentChatRecipient(agent_user_id=recipient_id, runtime_source="external"),
+            sender=sender,
+            message=message,
+            notification_type="relationship",
+        )
+    )
 
 
 def _requester_id(row: RelationshipRow) -> str:

--- a/protocols/agent_runtime.py
+++ b/protocols/agent_runtime.py
@@ -60,6 +60,19 @@ class AgentChatDeliveryEnvelope:
 
 
 @dataclass(frozen=True)
+class AgentRuntimeNotificationEnvelope:
+    event_type: str
+    recipient: AgentChatRecipient
+    sender: AgentRuntimeActor
+    message: AgentRuntimeMessage
+    notification_type: str
+    wake: bool = True
+    transport: AgentRuntimeTransport = AgentRuntimeTransport()
+    protocol_version: Literal["agent.runtime.notification.v1"] = "agent.runtime.notification.v1"
+    extensions: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
 class AgentThreadInputEnvelope:
     thread_id: str
     sender: AgentRuntimeActor
@@ -72,6 +85,12 @@ class AgentThreadInputEnvelope:
 
 @dataclass(frozen=True)
 class AgentChatDeliveryResult:
+    status: Literal["accepted"]
+    thread_id: str
+
+
+@dataclass(frozen=True)
+class AgentRuntimeNotificationResult:
     status: Literal["accepted"]
     thread_id: str
 

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from config.agent_config_types import AgentConfig, Skill, SkillPackage
 
-NotificationType = Literal["steer", "command", "agent", "chat"]
+NotificationType = Literal["steer", "command", "agent", "chat", "relationship"]
 
 
 # Sandbox — repo protocols

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -12,6 +12,7 @@ from protocols.agent_runtime import (
     AgentChatRecipient,
     AgentRuntimeActor,
     AgentRuntimeMessage,
+    AgentRuntimeNotificationEnvelope,
 )
 
 
@@ -51,6 +52,45 @@ async def test_external_runtime_inbox_handler_queues_metadata_only_notification(
         "sender_id": "human-user-1",
         "sender_name": "Human",
         "summary": "New chat message from Human.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_inbox_handler_queues_generic_runtime_notification() -> None:
+    enqueued: list[tuple[str, str, str, dict]] = []
+    handler = ExternalRuntimeInboxHandler(
+        queue_manager=SimpleNamespace(
+            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
+        )
+    )
+    envelope = AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="external-user-1", runtime_source="external"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human", source="relationship"),
+        message=AgentRuntimeMessage(
+            content="Human requested a relationship with you.",
+            metadata={"relationship_id": "hire_visit:external-user-1:human-user-1"},
+        ),
+        notification_type="relationship",
+    )
+
+    result = await handler.dispatch_notification(envelope)
+
+    assert result.status == "accepted"
+    assert result.thread_id == external_inbox_key("external-user-1")
+    content, inbox_id, notification_type, meta = enqueued[0]
+    payload = json.loads(content)
+    assert inbox_id == "external:external-user-1"
+    assert notification_type == "relationship"
+    assert meta["source"] == "external"
+    assert meta["sender_id"] == "human-user-1"
+    assert meta["sender_name"] == "Human"
+    assert payload == {
+        "event_type": "relationship.requested",
+        "sender_id": "human-user-1",
+        "sender_name": "Human",
+        "summary": "Human requested a relationship with you.",
+        "relationship_id": "hire_visit:external-user-1:human-user-1",
     }
 
 

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -92,6 +92,59 @@ async def test_relationship_request_notification_dispatches_thread_input_to_agen
 
 
 @pytest.mark.asyncio
+async def test_relationship_request_notification_dispatches_external_runtime_notification_to_external_target() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_notification(self, envelope):
+            self.envelope = envelope
+            return SimpleNamespace(status="accepted", thread_id=f"external:{envelope.recipient.agent_user_id}")
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(
+                id="human-user-1",
+                type="human",
+                display_name="Human",
+                avatar=None,
+            ),
+            "external-user-1": SimpleNamespace(
+                id="external-user-1",
+                type="external",
+                display_name="External",
+                avatar=None,
+            ),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_request_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _relationship_row(
+            user_low="external-user-1",
+            user_high="human-user-1",
+            initiator_user_id="human-user-1",
+            message="Please add me.",
+        ),
+    )
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
+    assert gateway.envelope.recipient.runtime_source == "external"
+    assert gateway.envelope.sender.user_id == "human-user-1"
+    assert gateway.envelope.sender.source == "relationship"
+    assert gateway.envelope.event_type == "relationship.requested"
+    assert "Human requested a relationship with you." in gateway.envelope.message.content
+    assert gateway.envelope.message.metadata == {"relationship_id": "hire_visit:external-user-1:human-user-1"}
+
+
+@pytest.mark.asyncio
 async def test_relationship_request_notification_does_not_dispatch_to_non_agent_target() -> None:
     class RecordingGateway:
         called = False
@@ -192,6 +245,54 @@ async def test_relationship_decision_notification_dispatches_to_agent_requester(
     assert "Human approved your relationship request." in gateway.envelope.message.content
     assert gateway.envelope.message.metadata == {
         "relationship_id": "hire_visit:agent-user-1:human-user-1",
+        "event": "approve",
+        "state": "visit",
+    }
+
+
+@pytest.mark.asyncio
+async def test_relationship_decision_notification_dispatches_external_runtime_notification_to_external_requester() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_notification(self, envelope):
+            self.envelope = envelope
+            return SimpleNamespace(status="accepted", thread_id=f"external:{envelope.recipient.agent_user_id}")
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+            "external-user-1": SimpleNamespace(id="external-user-1", type="external", display_name="External", avatar=None),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_decision_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _relationship_row(
+            user_low="external-user-1",
+            user_high="human-user-1",
+            initiator_user_id="external-user-1",
+            state="visit",
+        ),
+        "approve",
+    )
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
+    assert gateway.envelope.recipient.runtime_source == "external"
+    assert gateway.envelope.sender.user_id == "human-user-1"
+    assert gateway.envelope.sender.source == "relationship"
+    assert gateway.envelope.event_type == "relationship.approved"
+    assert "Human approved your relationship request." in gateway.envelope.message.content
+    assert gateway.envelope.message.metadata == {
+        "relationship_id": "hire_visit:external-user-1:human-user-1",
         "event": "approve",
         "state": "visit",
     }


### PR DESCRIPTION
## Summary
- add a generic runtime notification envelope/gateway path for non-chat runtime notifications
- route relationship request/decision notifications to external users via the external runtime inbox
- keep managed Mycel agents on the existing thread-input path

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q
- YATU: /Users/lexicalmathical/share/yatu/relationship-runtime-notify-20260427T180732Z