### PR TITLE
fix: notify external chat join rejections

### DIFF
--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -7,7 +7,13 @@ from typing import Any
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
-from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+from protocols.agent_runtime import (
+    AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+    AgentRuntimeNotificationEnvelope,
+    AgentThreadInputEnvelope,
+)
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -21,7 +27,33 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
         chat_id = _required_str(row, "chat_id")
         requester = _require_user(user_repo, requester_id, "requester")
         decider = _require_user(user_repo, decider_id, "decider")
-        if _user_type(requester, requester_id) != "agent":
+        requester_type = _user_type(requester, requester_id)
+        content = f"{_display_name(decider, decider_id)} rejected your request to join chat {chat_id}."
+        metadata = {
+            "chat_join_request_id": _required_str(row, "id"),
+            "chat_id": chat_id,
+            "state": "rejected",
+        }
+
+        if requester_type == "external":
+            await get_agent_runtime_gateway(app).dispatch_notification(
+                AgentRuntimeNotificationEnvelope(
+                    event_type="chat.join.rejected",
+                    recipient=AgentChatRecipient(agent_user_id=requester_id, runtime_source="external"),
+                    sender=AgentRuntimeActor(
+                        user_id=decider_id,
+                        user_type=_user_type(decider, decider_id),
+                        display_name=_display_name(decider, decider_id),
+                        avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                        source="chat_join",
+                    ),
+                    message=AgentRuntimeMessage(content=content, metadata=metadata),
+                    notification_type="chat_join",
+                )
+            )
+            return
+
+        if requester_type != "agent":
             return
 
         thread_id = select_runtime_thread_for_recipient(
@@ -43,12 +75,8 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
                     source="chat_join",
                 ),
                 message=AgentRuntimeMessage(
-                    content=f"{_display_name(decider, decider_id)} rejected your request to join chat {chat_id}.",
-                    metadata={
-                        "chat_join_request_id": _required_str(row, "id"),
-                        "chat_id": chat_id,
-                        "state": "rejected",
-                    },
+                    content=content,
+                    metadata=metadata,
                 ),
             )
         )

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from config.agent_config_types import AgentConfig, Skill, SkillPackage
 
-NotificationType = Literal["steer", "command", "agent", "chat", "relationship"]
+NotificationType = Literal["steer", "command", "agent", "chat", "relationship", "chat_join"]
 
 
 # Sandbox — repo protocols

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -70,11 +70,65 @@ async def test_chat_join_rejection_notification_dispatches_to_agent_requester() 
 
 
 @pytest.mark.asyncio
-async def test_chat_join_rejection_notification_ignores_non_agent_requester() -> None:
+async def test_chat_join_rejection_notification_dispatches_runtime_notification_to_external_requester() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_notification(self, envelope):
+            self.envelope = envelope
+            return SimpleNamespace(status="accepted", thread_id=f"external:{envelope.recipient.agent_user_id}")
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+            "external-user-1": SimpleNamespace(id="external-user-1", type="external", display_name="External", avatar=None),
+        }.get(uid)
+    )
+    notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        {
+            "id": "chat_join:chat-1:external-user-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "external-user-1",
+            "state": "rejected",
+            "decided_by_user_id": "owner-1",
+        },
+    )
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
+    assert gateway.envelope.recipient.runtime_source == "external"
+    assert gateway.envelope.sender.user_id == "owner-1"
+    assert gateway.envelope.sender.user_type == "human"
+    assert gateway.envelope.sender.display_name == "Owner"
+    assert gateway.envelope.sender.source == "chat_join"
+    assert gateway.envelope.event_type == "chat.join.rejected"
+    assert gateway.envelope.notification_type == "chat_join"
+    assert "Owner rejected your request to join chat chat-1." in gateway.envelope.message.content
+    assert gateway.envelope.message.metadata == {
+        "chat_join_request_id": "chat_join:chat-1:external-user-1",
+        "chat_id": "chat-1",
+        "state": "rejected",
+    }
+
+
+@pytest.mark.asyncio
+async def test_chat_join_rejection_notification_ignores_human_requester() -> None:
     class RecordingGateway:
         called = False
 
         async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+        async def dispatch_notification(self, _envelope):
             self.called = True
 
     gateway = RecordingGateway()


### PR DESCRIPTION
## Summary\n- route rejected chat join requests for external users through the generic runtime notification gateway\n- add a typed chat_join notification category so non-chat runtime events do not masquerade as chat messages\n- cover managed agent, external agent, and human requester behavior with unit tests\n\n## Verification\n- uv run ruff check .\n- uv run ruff format --check .\n- uv run pytest tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q\n- uv run pytest -q\n- YATU: branch backend on 8043, cel group join request/reject flow, external requester drains chat.join.rejected notification