### PR TITLE
feat(chat): expose unread read API

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -270,7 +270,7 @@ def send_message(
             enforce_caught_up=body.enforce_caught_up,
         )
     except ChatNotCaughtUpError as exc:
-        raise HTTPException(409, str(exc)) from exc
+        raise HTTPException(409, "Read unread messages before sending.") from exc
     return messaging_service.project_message_response(msg)
 
 
@@ -283,6 +283,20 @@ def list_unread_messages(
     if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
     return [messaging_service.project_message_response(msg) for msg in messaging_service.list_unread(chat_id, user_id)]
+
+
+@router.post("/{chat_id}/messages/read")
+def read_unread_messages(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+):
+    if not messaging_service.is_chat_member(chat_id, user_id):
+        raise HTTPException(403, "Not a participant of this chat")
+    unread_messages = [messaging_service.project_message_response(msg) for msg in messaging_service.list_unread(chat_id, user_id)]
+    if unread_messages:
+        messaging_service.mark_read(chat_id, user_id)
+    return unread_messages
 
 
 @router.post("/{chat_id}/messages/{message_id}/retract")

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -710,7 +710,7 @@ def test_send_message_maps_caught_up_conflict_to_409() -> None:
     messaging_service = SimpleNamespace(
         resolve_display_user=lambda uid: SimpleNamespace(id=uid, owner_user_id=None),
         is_chat_member=lambda _chat_id, _user_id: True,
-        send=lambda *_args, **_kwargs: (_ for _ in ()).throw(ChatNotCaughtUpError("read unread messages first")),
+        send=lambda *_args, **_kwargs: (_ for _ in ()).throw(ChatNotCaughtUpError("Call read_messages(chat_id='chat-1') first.")),
     )
 
     with pytest.raises(HTTPException) as exc_info:
@@ -722,7 +722,7 @@ def test_send_message_maps_caught_up_conflict_to_409() -> None:
         )
 
     assert exc_info.value.status_code == 409
-    assert "read unread" in str(exc_info.value.detail)
+    assert exc_info.value.detail == "Read unread messages before sending."
 
 
 def test_list_unread_messages_uses_authenticated_user_membership() -> None:
@@ -741,6 +741,37 @@ def test_list_unread_messages_uses_authenticated_user_membership() -> None:
 
     assert seen == [("chat-1", "external-user-1")]
     assert result == [{"id": "msg-1", "chat_id": "chat-1", "sender_id": "human-1"}]
+
+
+def test_read_unread_messages_returns_messages_before_marking_read() -> None:
+    calls: list[tuple[str, str, str]] = []
+
+    def _project(msg: dict[str, str]) -> dict[str, str]:
+        calls.append(("project", msg["chat_id"], msg["id"]))
+        return {"id": msg["id"], "chat_id": msg["chat_id"], "sender_id": msg["sender_id"]}
+
+    messaging_service = SimpleNamespace(
+        is_chat_member=lambda chat_id, user_id: calls.append(("member", chat_id, user_id)) or True,
+        list_unread=lambda chat_id, user_id: (
+            calls.append(("unread", chat_id, user_id)) or [{"id": "msg-1", "chat_id": chat_id, "sender_id": "human-1"}]
+        ),
+        project_message_response=_project,
+        mark_read=lambda chat_id, user_id: calls.append(("read", chat_id, user_id)),
+    )
+
+    result = chats_router.read_unread_messages(
+        "chat-1",
+        user_id="external-user-1",
+        messaging_service=messaging_service,
+    )
+
+    assert result == [{"id": "msg-1", "chat_id": "chat-1", "sender_id": "human-1"}]
+    assert calls == [
+        ("member", "chat-1", "external-user-1"),
+        ("unread", "chat-1", "external-user-1"),
+        ("project", "chat-1", "msg-1"),
+        ("read", "chat-1", "external-user-1"),
+    ]
 
 
 def test_mark_read_rejects_non_member_user() -> None:


### PR DESCRIPTION
## Summary
- add a public chat API action that returns unread messages and advances the read cursor
- keep caught-up send errors in public HTTP language instead of leaking agent tool names
- cover membership, read cursor, and conflict mapping in router contract tests

## Test Plan
- uv run pytest tests/Unit/integration_contracts/test_messaging_router.py::test_send_message_maps_caught_up_conflict_to_409 tests/Unit/integration_contracts/test_messaging_router.py::test_read_unread_messages_returns_messages_before_marking_read tests/Unit/integration_contracts/test_messaging_router.py::test_list_unread_messages_uses_authenticated_user_membership tests/Unit/integration_contracts/test_messaging_router.py::test_mark_read_rejects_non_member_user
- uv run ruff check backend/chat/api/http/chats_router.py tests/Unit/integration_contracts/test_messaging_router.py