### PR TITLE
fix(chat): share unread read action

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -293,10 +293,7 @@ def read_unread_messages(
 ):
     if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
-    unread_messages = [messaging_service.project_message_response(msg) for msg in messaging_service.list_unread(chat_id, user_id)]
-    if unread_messages:
-        messaging_service.mark_read(chat_id, user_id)
-    return unread_messages
+    return messaging_service.read_unread_message_responses(chat_id, user_id)
 
 
 @router.post("/{chat_id}/messages/{message_id}/retract")

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -317,6 +317,15 @@ class MessagingService:
             viewer_id=viewer_id,
         )
         return [self._project_message_response(row) for row in rows]
+
+    def read_unread(self, chat_id: str, user_id: str, consume: Callable[[list[dict[str, Any]]], Any]) -> Any:
+        messages = self.list_unread(chat_id, user_id)
+        result = consume(messages)
+        self.mark_read(chat_id, user_id)
+        return result
+
+    def read_unread_message_responses(self, chat_id: str, user_id: str) -> list[dict[str, Any]]:
+        return self.read_unread(chat_id, user_id, lambda rows: [self._project_message_response(row) for row in rows])
 
     def list_unread(self, chat_id: str, user_id: str) -> list[dict[str, Any]]:
         return [self._normalize_message_row(row) for row in self._messages.list_unread(chat_id, user_id)]

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -346,10 +346,8 @@ class ChatToolService:
                 self._messaging.mark_read(chat_id, eid)
                 return rendered
 
-            msgs = self._messaging.list_unread(chat_id, eid)
-            if msgs:
-                rendered = self._format_msgs(msgs, eid)
-                self._messaging.mark_read(chat_id, eid)
+            rendered = self._messaging.read_unread(chat_id, eid, lambda msgs: self._format_msgs(msgs, eid) if msgs else "")
+            if rendered:
                 return rendered
 
             return (

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -743,20 +743,14 @@ def test_list_unread_messages_uses_authenticated_user_membership() -> None:
     assert result == [{"id": "msg-1", "chat_id": "chat-1", "sender_id": "human-1"}]
 
 
-def test_read_unread_messages_returns_messages_before_marking_read() -> None:
+def test_read_unread_messages_delegates_to_messaging_service_read_action() -> None:
     calls: list[tuple[str, str, str]] = []
-
-    def _project(msg: dict[str, str]) -> dict[str, str]:
-        calls.append(("project", msg["chat_id"], msg["id"]))
-        return {"id": msg["id"], "chat_id": msg["chat_id"], "sender_id": msg["sender_id"]}
 
     messaging_service = SimpleNamespace(
         is_chat_member=lambda chat_id, user_id: calls.append(("member", chat_id, user_id)) or True,
-        list_unread=lambda chat_id, user_id: (
-            calls.append(("unread", chat_id, user_id)) or [{"id": "msg-1", "chat_id": chat_id, "sender_id": "human-1"}]
+        read_unread_message_responses=lambda chat_id, user_id: (
+            calls.append(("read_unread", chat_id, user_id)) or [{"id": "msg-1", "chat_id": chat_id, "sender_id": "human-1"}]
         ),
-        project_message_response=_project,
-        mark_read=lambda chat_id, user_id: calls.append(("read", chat_id, user_id)),
     )
 
     result = chats_router.read_unread_messages(
@@ -768,9 +762,7 @@ def test_read_unread_messages_returns_messages_before_marking_read() -> None:
     assert result == [{"id": "msg-1", "chat_id": "chat-1", "sender_id": "human-1"}]
     assert calls == [
         ("member", "chat-1", "external-user-1"),
-        ("unread", "chat-1", "external-user-1"),
-        ("project", "chat-1", "msg-1"),
-        ("read", "chat-1", "external-user-1"),
+        ("read_unread", "chat-1", "external-user-1"),
     ]
 
 

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -1883,6 +1883,33 @@ def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_water
     assert after[0]["unread_count"] == 0
 
 
+def test_messaging_service_read_unread_consumes_messages_before_marking_latest_seq() -> None:
+    calls: list[tuple[str, str, str]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(update_last_read=lambda _chat_id, user_id, seq: calls.append(("read", user_id, str(seq)))),
+        messages_repo=SimpleNamespace(
+            list_unread=lambda chat_id, user_id: calls.append(("unread", chat_id, user_id)) or [],
+            list_by_chat=lambda chat_id, limit=50, viewer_id=None: calls.append(("latest", chat_id, viewer_id or "")) or [{"seq": 9}],
+        ),
+        user_repo=SimpleNamespace(get_by_id=lambda _uid: None),
+    )
+
+    result = service.read_unread(
+        "chat-1",
+        "external-user-1",
+        lambda messages: calls.append(("consume", "messages", str(len(messages)))) or [],
+    )
+
+    assert result == []
+    assert calls == [
+        ("unread", "chat-1", "external-user-1"),
+        ("consume", "messages", "0"),
+        ("latest", "chat-1", "external-user-1"),
+        ("read", "external-user-1", "9"),
+    ]
+
+
 def test_messaging_service_group_chat_creation_requires_social_access_collaborators() -> None:
     created: list[Any] = []
     service = MessagingService(
@@ -2034,12 +2061,17 @@ def test_read_messages_fails_before_mark_read_on_invalid_history_collection() ->
 def test_read_messages_fails_before_mark_read_on_invalid_unread_collection() -> None:
     registry = ToolRegistry()
     marked: list[tuple[str, str]] = []
+
+    def _read_unread(chat_id: str, user_id: str, consume):
+        result = consume({"sender_id": "agent-user-1"})
+        marked.append((chat_id, user_id))
+        return result
+
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
-            list_unread=lambda _chat_id, _user_id: {"sender_id": "agent-user-1"},
-            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+            read_unread=_read_unread,
         ),
     )
 


### PR DESCRIPTION
## Summary
- centralize read-unread-and-advance cursor semantics in MessagingService
- keep HTTP as a thin transport adapter through read_unread_message_responses
- make managed read_messages use the same read action instead of composing list_unread + mark_read itself

## Verification
- uv run ruff check backend/chat/api/http/chats_router.py messaging/service.py messaging/tools/chat_tool_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
- uv run ruff format --check backend/chat/api/http/chats_router.py messaging/service.py messaging/tools/chat_tool_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
- uv run pytest tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q
- real cel dogfood on 127.0.0.1:8017: MYCEL_LOCAL_ID=codex-fresh-20260428 cel chat read ca616533-cb95-4b66-9509-447973d5bf7c returned [] and the following cel chat send succeeded