### PR TITLE
fix(runtime): derive external chat inbox from unread state

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+from collections.abc import Callable
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -13,7 +14,32 @@ from backend.threads.chat_adapters.external_inbox_handler import external_inbox_
 router = APIRouter(prefix="/api/runtime", tags=["runtime"])
 
 
-def drain_runtime_inbox_items(user_id: str, queue_manager: Any) -> list[dict[str, Any]]:
+def chat_runtime_notifications(user_id: str, messaging_service: Any) -> list[dict[str, Any]]:
+    notifications: list[dict[str, Any]] = []
+    for chat in messaging_service.list_chats_for_user(user_id):
+        unread_count = chat.get("unread_count")
+        if type(unread_count) is not int or unread_count <= 0:
+            continue
+        last_message = chat.get("last_message") or {}
+        sender_name = str(last_message.get("sender_name") or "someone")
+        notifications.append(
+            {
+                "event_type": "chat.message",
+                "notification_type": "chat",
+                "chat_id": chat["id"],
+                "sender_name": sender_name,
+                "unread_count": unread_count,
+            }
+        )
+    return notifications
+
+
+def drain_runtime_inbox_items(
+    user_id: str,
+    queue_manager: Any,
+    *,
+    chat_notifications: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
     items = queue_manager.drain_all(external_inbox_key(user_id))
     drained: list[dict[str, Any]] = []
     for item in items:
@@ -27,7 +53,10 @@ def drain_runtime_inbox_items(user_id: str, queue_manager: Any) -> list[dict[str
         payload["source"] = item.source
         payload["sender_id"] = item.sender_id
         payload["sender_name"] = item.sender_name
+        if payload["notification_type"] == "chat":
+            continue
         drained.append(payload)
+    drained.extend(chat_notifications or [])
     return drained
 
 
@@ -36,18 +65,39 @@ def wait_runtime_inbox_items(
     queue_manager: Any,
     *,
     timeout_seconds: float,
+    chat_notifications: Callable[[], list[dict[str, Any]]] | None = None,
 ) -> list[dict[str, Any]]:
     key = external_inbox_key(user_id)
     event = threading.Event()
     queue_manager.register_wake(key, lambda _item: event.set())
     try:
-        items = drain_runtime_inbox_items(user_id, queue_manager)
+        items = drain_runtime_inbox_items(
+            user_id,
+            queue_manager,
+            chat_notifications=chat_notifications() if chat_notifications else None,
+        )
         if items:
             return items
         event.wait(timeout=max(0.0, timeout_seconds))
-        return drain_runtime_inbox_items(user_id, queue_manager)
+        return drain_runtime_inbox_items(
+            user_id,
+            queue_manager,
+            chat_notifications=chat_notifications() if chat_notifications else None,
+        )
     finally:
         queue_manager.unregister_wake(key)
+
+
+def _runtime_inbox_parts(app: Any) -> tuple[Any, Any]:
+    runtime_state = getattr(app.state, "threads_runtime_state", None)
+    queue_manager = getattr(runtime_state, "queue_manager", None)
+    if queue_manager is None:
+        raise HTTPException(500, "Runtime queue manager unavailable")
+    chat_runtime = getattr(app.state, "chat_runtime_state", None)
+    messaging_service = getattr(chat_runtime, "messaging_service", None)
+    if messaging_service is None:
+        raise HTTPException(500, "Messaging service unavailable")
+    return queue_manager, messaging_service
 
 
 @router.post("/inbox/drain")
@@ -55,12 +105,14 @@ async def drain_runtime_inbox(
     app: Annotated[Any, Depends(get_app)],
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    runtime_state = getattr(app.state, "threads_runtime_state", None)
-    queue_manager = getattr(runtime_state, "queue_manager", None)
-    if queue_manager is None:
-        raise HTTPException(500, "Runtime queue manager unavailable")
+    queue_manager, messaging_service = _runtime_inbox_parts(app)
     try:
-        items = await asyncio.to_thread(drain_runtime_inbox_items, user_id, queue_manager)
+        items = await asyncio.to_thread(
+            drain_runtime_inbox_items,
+            user_id,
+            queue_manager,
+            chat_notifications=chat_runtime_notifications(user_id, messaging_service),
+        )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc
     return {"count": len(items), "notifications": items}
@@ -72,16 +124,14 @@ async def wait_runtime_inbox(
     user_id: Annotated[str, Depends(get_current_user_id)],
     timeout_seconds: Annotated[float, Query(ge=0.0, le=30.0)] = 25.0,
 ) -> dict[str, Any]:
-    runtime_state = getattr(app.state, "threads_runtime_state", None)
-    queue_manager = getattr(runtime_state, "queue_manager", None)
-    if queue_manager is None:
-        raise HTTPException(500, "Runtime queue manager unavailable")
+    queue_manager, messaging_service = _runtime_inbox_parts(app)
     try:
         items = await asyncio.to_thread(
             wait_runtime_inbox_items,
             user_id,
             queue_manager,
             timeout_seconds=timeout_seconds,
+            chat_notifications=lambda: chat_runtime_notifications(user_id, messaging_service),
         )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc

--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -19,16 +19,8 @@ class ExternalRuntimeInboxHandler:
 
     async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
         inbox_id = external_inbox_key(envelope.recipient.agent_user_id)
-        sender_name = envelope.sender.display_name or envelope.sender.user_id
-        payload = {
-            "event_type": envelope.event_type,
-            "chat_id": envelope.chat.chat_id,
-            "sender_id": envelope.sender.user_id,
-            "sender_name": envelope.sender.display_name,
-            "summary": f"New chat message from {sender_name}.",
-        }
         self._queue_manager.enqueue(
-            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            json.dumps({"event_type": "chat.wake"}, ensure_ascii=False, separators=(",", ":")),
             inbox_id,
             "chat",
             source="external",

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -26,7 +26,7 @@ def _envelope() -> AgentChatDeliveryEnvelope:
 
 
 @pytest.mark.asyncio
-async def test_external_runtime_inbox_handler_queues_metadata_only_notification() -> None:
+async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> None:
     enqueued: list[tuple[str, str, str, dict]] = []
     handler = ExternalRuntimeInboxHandler(
         queue_manager=SimpleNamespace(
@@ -46,13 +46,8 @@ async def test_external_runtime_inbox_handler_queues_metadata_only_notification(
     assert meta["source"] == "external"
     assert meta["sender_id"] == "human-user-1"
     assert meta["sender_name"] == "Human"
-    assert payload == {
-        "event_type": "chat.message",
-        "chat_id": "chat-1",
-        "sender_id": "human-user-1",
-        "sender_name": "Human",
-        "summary": "New chat message from Human.",
-    }
+    assert payload == {"event_type": "chat.wake"}
+    assert "managed runtime prompt must not leak" not in content
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -6,21 +6,22 @@ from types import SimpleNamespace
 import pytest
 
 from backend.chat.api.http.runtime_inbox_router import (
+    chat_runtime_notifications,
     drain_runtime_inbox_items,
     wait_runtime_inbox,
     wait_runtime_inbox_items,
 )
 
 
-def test_drain_runtime_inbox_items_returns_metadata_and_clears_external_queue() -> None:
+def test_drain_runtime_inbox_items_returns_non_chat_metadata_and_clears_external_queue() -> None:
     drained_keys: list[str] = []
     queue_manager = SimpleNamespace(
         drain_all=lambda key: (
             drained_keys.append(key)
             or [
                 SimpleNamespace(
-                    content='{"event_type":"chat.message","chat_id":"chat-1","sender_name":"Human","summary":"New message"}',
-                    notification_type="chat",
+                    content='{"event_type":"relationship.requested","summary":"Human requested contact."}',
+                    notification_type="relationship",
                     source="external",
                     sender_id="human-user-1",
                     sender_name="Human",
@@ -34,15 +35,83 @@ def test_drain_runtime_inbox_items_returns_metadata_and_clears_external_queue() 
     assert drained_keys == ["external:external-user-1"]
     assert result == [
         {
-            "event_type": "chat.message",
-            "chat_id": "chat-1",
-            "sender_name": "Human",
-            "summary": "New message",
-            "notification_type": "chat",
+            "event_type": "relationship.requested",
+            "summary": "Human requested contact.",
+            "notification_type": "relationship",
             "source": "external",
             "sender_id": "human-user-1",
+            "sender_name": "Human",
         }
     ]
+
+
+def test_drain_runtime_inbox_items_replaces_queued_chat_tokens_with_unread_projection() -> None:
+    queue_manager = SimpleNamespace(
+        drain_all=lambda _key: [
+            SimpleNamespace(
+                content='{"event_type":"chat.message","chat_id":"old-chat","summary":"stale token"}',
+                notification_type="chat",
+                source="external",
+                sender_id="human-user-1",
+                sender_name="Human",
+            )
+        ]
+    )
+
+    result = drain_runtime_inbox_items(
+        "external-user-1",
+        queue_manager,
+        chat_notifications=[
+            {
+                "event_type": "chat.message",
+                "notification_type": "chat",
+                "chat_id": "chat-2",
+                "sender_name": "Human",
+                "unread_count": 1,
+            }
+        ],
+    )
+
+    assert result == [
+        {
+            "event_type": "chat.message",
+            "notification_type": "chat",
+            "chat_id": "chat-2",
+            "sender_name": "Human",
+            "unread_count": 1,
+        }
+    ]
+
+
+def test_chat_runtime_notifications_derive_from_unread_chat_projection() -> None:
+    notifications = chat_runtime_notifications(
+        "external-user-1",
+        SimpleNamespace(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-1",
+                    "unread_count": 0,
+                    "last_message": {"sender_name": "Read Sender", "content": "must not leak"},
+                },
+                {
+                    "id": "chat-2",
+                    "unread_count": 2,
+                    "last_message": {"sender_name": "Unread Sender", "content": "must not leak"},
+                },
+            ]
+        ),
+    )
+
+    assert notifications == [
+        {
+            "event_type": "chat.message",
+            "notification_type": "chat",
+            "chat_id": "chat-2",
+            "sender_name": "Unread Sender",
+            "unread_count": 2,
+        }
+    ]
+    assert "must not leak" not in str(notifications)
 
 
 def test_drain_runtime_inbox_items_fails_loudly_on_invalid_payload() -> None:
@@ -114,16 +183,62 @@ def test_wait_runtime_inbox_items_returns_after_external_queue_wake() -> None:
 
     assert not worker.is_alive()
     assert registered["unregistered"] is True
-    assert result_holder["items"] == [
+    assert result_holder["items"] == []
+
+
+def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake() -> None:
+    queued: list[SimpleNamespace] = []
+    registered: dict[str, object] = {}
+    projected = [
         {
             "event_type": "chat.message",
-            "chat_id": "chat-1",
             "notification_type": "chat",
-            "source": "external",
-            "sender_id": "human-user-1",
+            "chat_id": "chat-2",
             "sender_name": "Human",
+            "unread_count": 1,
         }
     ]
+
+    def _drain_all(_key: str) -> list[SimpleNamespace]:
+        items = list(queued)
+        queued.clear()
+        return items
+
+    queue_manager = SimpleNamespace(
+        drain_all=_drain_all,
+        register_wake=lambda _key, handler: registered.update(handler=handler),
+        unregister_wake=lambda _key: registered.update(unregistered=True),
+    )
+    result_holder: dict[str, list[dict[str, object]]] = {}
+    worker = threading.Thread(
+        target=lambda: result_holder.update(
+            items=wait_runtime_inbox_items(
+                "external-user-1",
+                queue_manager,
+                timeout_seconds=1.0,
+                chat_notifications=lambda: projected if "woken" in registered else [],
+            )
+        )
+    )
+
+    worker.start()
+    while "handler" not in registered:
+        pass
+    queued.append(
+        SimpleNamespace(
+            content='{"event_type":"chat.message","chat_id":"chat-2"}',
+            notification_type="chat",
+            source="external",
+            sender_id="human-user-1",
+            sender_name="Human",
+        )
+    )
+    registered["woken"] = True
+    registered["handler"](queued[0])
+    worker.join(timeout=1.0)
+
+    assert result_holder["items"] == projected
+    assert registered["unregistered"] is True
 
 
 @pytest.mark.asyncio
@@ -133,7 +248,12 @@ async def test_wait_runtime_inbox_endpoint_returns_count_and_notifications() -> 
         register_wake=lambda _key, _handler: None,
         unregister_wake=lambda _key: None,
     )
-    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(queue_manager=queue_manager)))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            threads_runtime_state=SimpleNamespace(queue_manager=queue_manager),
+            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace(list_chats_for_user=lambda _user_id: [])),
+        )
+    )
 
     result = await wait_runtime_inbox(
         app,


### PR DESCRIPTION
## Summary
- derive external chat hook notifications from durable unread chat state instead of queued chat snapshots
- keep queued external chat items as wake tokens only; drain drops queued chat tokens and merges current unread chat metadata
- preserve generic runtime queue behavior for non-chat notifications

## Verification
- uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_notification_format.py -q
- uv run ruff check backend/chat/api/http/runtime_inbox_router.py backend/threads/chat_adapters/external_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
- uv run ruff format --check backend/chat/api/http/runtime_inbox_router.py backend/threads/chat_adapters/external_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
- YATU: restarted local backend on 8017; verified chat read consumes stale queued wake token so hook is empty, then verified a fresh unread chat produces exactly one hook notification with unread_count 1