### PR TITLE
fix(runtime): deliver external chat notifications once

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-from collections.abc import Callable
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -14,9 +13,12 @@ from backend.threads.chat_adapters.external_inbox_handler import external_inbox_
 router = APIRouter(prefix="/api/runtime", tags=["runtime"])
 
 
-def chat_runtime_notifications(user_id: str, messaging_service: Any) -> list[dict[str, Any]]:
+def chat_runtime_notifications(user_id: str, messaging_service: Any, *, chat_ids: set[str] | None = None) -> list[dict[str, Any]]:
     notifications: list[dict[str, Any]] = []
     for chat in messaging_service.list_chats_for_user(user_id):
+        chat_id = str(chat.get("id") or "")
+        if chat_ids is not None and chat_id not in chat_ids:
+            continue
         unread_count = chat.get("unread_count")
         if type(unread_count) is not int or unread_count <= 0:
             continue
@@ -26,7 +28,7 @@ def chat_runtime_notifications(user_id: str, messaging_service: Any) -> list[dic
             {
                 "event_type": "chat.message",
                 "notification_type": "chat",
-                "chat_id": chat["id"],
+                "chat_id": chat_id,
                 "sender_name": sender_name,
                 "unread_count": unread_count,
             }
@@ -38,10 +40,11 @@ def drain_runtime_inbox_items(
     user_id: str,
     queue_manager: Any,
     *,
-    chat_notifications: list[dict[str, Any]] | None = None,
+    messaging_service: Any | None = None,
 ) -> list[dict[str, Any]]:
     items = queue_manager.drain_all(external_inbox_key(user_id))
     drained: list[dict[str, Any]] = []
+    chat_ids: set[str] = set()
     for item in items:
         try:
             payload = json.loads(item.content)
@@ -54,9 +57,13 @@ def drain_runtime_inbox_items(
         payload["sender_id"] = item.sender_id
         payload["sender_name"] = item.sender_name
         if payload["notification_type"] == "chat":
+            chat_id = payload.get("chat_id")
+            if isinstance(chat_id, str) and chat_id:
+                chat_ids.add(chat_id)
             continue
         drained.append(payload)
-    drained.extend(chat_notifications or [])
+    if messaging_service is not None and chat_ids:
+        drained.extend(chat_runtime_notifications(user_id, messaging_service, chat_ids=chat_ids))
     return drained
 
 
@@ -65,7 +72,7 @@ def wait_runtime_inbox_items(
     queue_manager: Any,
     *,
     timeout_seconds: float,
-    chat_notifications: Callable[[], list[dict[str, Any]]] | None = None,
+    messaging_service: Any | None = None,
 ) -> list[dict[str, Any]]:
     key = external_inbox_key(user_id)
     event = threading.Event()
@@ -74,7 +81,7 @@ def wait_runtime_inbox_items(
         items = drain_runtime_inbox_items(
             user_id,
             queue_manager,
-            chat_notifications=chat_notifications() if chat_notifications else None,
+            messaging_service=messaging_service,
         )
         if items:
             return items
@@ -82,7 +89,7 @@ def wait_runtime_inbox_items(
         return drain_runtime_inbox_items(
             user_id,
             queue_manager,
-            chat_notifications=chat_notifications() if chat_notifications else None,
+            messaging_service=messaging_service,
         )
     finally:
         queue_manager.unregister_wake(key)
@@ -111,7 +118,7 @@ async def drain_runtime_inbox(
             drain_runtime_inbox_items,
             user_id,
             queue_manager,
-            chat_notifications=chat_runtime_notifications(user_id, messaging_service),
+            messaging_service=messaging_service,
         )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc
@@ -131,7 +138,7 @@ async def wait_runtime_inbox(
             user_id,
             queue_manager,
             timeout_seconds=timeout_seconds,
-            chat_notifications=lambda: chat_runtime_notifications(user_id, messaging_service),
+            messaging_service=messaging_service,
         )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc

--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -20,13 +20,17 @@ class ExternalRuntimeInboxHandler:
     async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
         inbox_id = external_inbox_key(envelope.recipient.agent_user_id)
         self._queue_manager.enqueue(
-            json.dumps({"event_type": "chat.wake"}, ensure_ascii=False, separators=(",", ":")),
+            json.dumps(
+                {"event_type": "chat.message", "chat_id": envelope.chat.chat_id},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
             inbox_id,
             "chat",
             source="external",
             sender_id=envelope.sender.user_id,
             sender_name=envelope.sender.display_name,
-            wake=False,
+            wake=True,
         )
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=inbox_id)
 

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -46,7 +46,8 @@ async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> N
     assert meta["source"] == "external"
     assert meta["sender_id"] == "human-user-1"
     assert meta["sender_name"] == "Human"
-    assert payload == {"event_type": "chat.wake"}
+    assert meta["wake"] is True
+    assert payload == {"event_type": "chat.message", "chat_id": "chat-1"}
     assert "managed runtime prompt must not leak" not in content
 
 

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -46,30 +46,33 @@ def test_drain_runtime_inbox_items_returns_non_chat_metadata_and_clears_external
 
 
 def test_drain_runtime_inbox_items_replaces_queued_chat_tokens_with_unread_projection() -> None:
-    queue_manager = SimpleNamespace(
-        drain_all=lambda _key: [
-            SimpleNamespace(
-                content='{"event_type":"chat.message","chat_id":"old-chat","summary":"stale token"}',
-                notification_type="chat",
-                source="external",
-                sender_id="human-user-1",
-                sender_name="Human",
-            )
-        ]
-    )
+    queued = [
+        SimpleNamespace(
+            content='{"event_type":"chat.message","chat_id":"chat-2","summary":"stale token"}',
+            notification_type="chat",
+            source="external",
+            sender_id="human-user-1",
+            sender_name="Human",
+        )
+    ]
+
+    def _drain_all(_key: str) -> list[SimpleNamespace]:
+        items = list(queued)
+        queued.clear()
+        return items
 
     result = drain_runtime_inbox_items(
         "external-user-1",
-        queue_manager,
-        chat_notifications=[
-            {
-                "event_type": "chat.message",
-                "notification_type": "chat",
-                "chat_id": "chat-2",
-                "sender_name": "Human",
-                "unread_count": 1,
-            }
-        ],
+        SimpleNamespace(drain_all=_drain_all),
+        messaging_service=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-2",
+                    "unread_count": 1,
+                    "last_message": {"sender_name": "Human", "content": "must not leak"},
+                }
+            ]
+        ),
     )
 
     assert result == [
@@ -81,6 +84,44 @@ def test_drain_runtime_inbox_items_replaces_queued_chat_tokens_with_unread_proje
             "unread_count": 1,
         }
     ]
+    assert (
+        drain_runtime_inbox_items(
+            "external-user-1",
+            SimpleNamespace(drain_all=_drain_all),
+            messaging_service=SimpleNamespace(list_chats_for_user=lambda _user_id: []),
+        )
+        == []
+    )
+
+
+def test_drain_runtime_inbox_items_drops_chat_token_when_chat_is_already_read() -> None:
+    queue_manager = SimpleNamespace(
+        drain_all=lambda _key: [
+            SimpleNamespace(
+                content='{"event_type":"chat.message","chat_id":"chat-2"}',
+                notification_type="chat",
+                source="external",
+                sender_id="human-user-1",
+                sender_name="Human",
+            )
+        ]
+    )
+
+    result = drain_runtime_inbox_items(
+        "external-user-1",
+        queue_manager,
+        messaging_service=SimpleNamespace(
+            list_chats_for_user=lambda _user_id: [
+                {
+                    "id": "chat-2",
+                    "unread_count": 0,
+                    "last_message": {"sender_name": "Human", "content": "must not leak"},
+                }
+            ]
+        ),
+    )
+
+    assert result == []
 
 
 def test_chat_runtime_notifications_derive_from_unread_chat_projection() -> None:
@@ -100,6 +141,7 @@ def test_chat_runtime_notifications_derive_from_unread_chat_projection() -> None
                 },
             ]
         ),
+        chat_ids={"chat-2"},
     )
 
     assert notifications == [
@@ -189,15 +231,6 @@ def test_wait_runtime_inbox_items_returns_after_external_queue_wake() -> None:
 def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake() -> None:
     queued: list[SimpleNamespace] = []
     registered: dict[str, object] = {}
-    projected = [
-        {
-            "event_type": "chat.message",
-            "notification_type": "chat",
-            "chat_id": "chat-2",
-            "sender_name": "Human",
-            "unread_count": 1,
-        }
-    ]
 
     def _drain_all(_key: str) -> list[SimpleNamespace]:
         items = list(queued)
@@ -216,7 +249,15 @@ def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake()
                 "external-user-1",
                 queue_manager,
                 timeout_seconds=1.0,
-                chat_notifications=lambda: projected if "woken" in registered else [],
+                messaging_service=SimpleNamespace(
+                    list_chats_for_user=lambda _user_id: [
+                        {
+                            "id": "chat-2",
+                            "unread_count": 1,
+                            "last_message": {"sender_name": "Human", "content": "must not leak"},
+                        }
+                    ]
+                ),
             )
         )
     )
@@ -237,7 +278,15 @@ def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake()
     registered["handler"](queued[0])
     worker.join(timeout=1.0)
 
-    assert result_holder["items"] == projected
+    assert result_holder["items"] == [
+        {
+            "event_type": "chat.message",
+            "notification_type": "chat",
+            "chat_id": "chat-2",
+            "sender_name": "Human",
+            "unread_count": 1,
+        }
+    ]
     assert registered["unregistered"] is True
 
 


### PR DESCRIPTION
## Summary
- treat external chat queue items as one-shot notification tokens instead of deriving hook notifications from every unread chat on every drain
- keep chat unread/read state unchanged; the queue token decides whether a notification is delivered, and unread projection only supplies current metadata at delivery time
- include `chat_id` in external chat tokens and wake runtime inbox waiters for chat tokens

## Why
Real dogfood showed the same unread chat notification being injected on every hook event until the agent read the chat. That conflated two meanings: `last_read_seq` / `unread_count` answers whether content was consumed, not whether a hook reminder was already delivered.

This keeps the existing durable queue as the notification cursor: a chat token is drained once, projected against current unread state, then gone. If the agent already read before the hook drains, unread is 0 and the token produces no notification.

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py -q` -> 11 passed
- `uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q` -> 196 passed
- `uv run pytest tests/Unit -q` -> 2045 passed, 3 skipped
- `uv run ruff check ...` and `uv run ruff format --check ...` passed for changed files
- Real YATU on local backend 8017: coordinator sent a fresh message to codex-fresh; fresh hook returned one notification on first hook, empty output on second hook without reading; `cel chat list` still showed unread_count 1; after `cel chat read`, hook stayed empty.
