### PR TITLE
docs: clarify worktree dev ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,28 @@ Sandbox provider SDKs are installed by default. Docker still requires Docker ins
 
 ### 3. Start the services
 
+The default ports are backend `8001` and frontend `5173`. A git worktree may
+override them with `worktree.ports.backend` and `worktree.ports.frontend`; the
+backend and Vite config read those values automatically.
+
+```bash
+git config --worktree --get worktree.ports.backend || echo 8001
+git config --worktree --get worktree.ports.frontend || echo 5173
+```
+
 ```bash
 # Terminal 1: Backend
 uv run python -m backend.web.main
-# → http://localhost:8001
+# → http://localhost:<backend-port>
 
 # Terminal 2: Frontend
 cd frontend/app && npm run dev
-# → http://localhost:5173
+# → http://localhost:<frontend-port>
 ```
 
 ### 4. Open and configure
 
-1. Open **http://localhost:5173** in your browser
+1. Open the frontend URL from the previous step in your browser
 2. **Register** an account
 3. Go to **Settings** → configure your LLM provider (API key, model)
 4. Start chatting with your first agent

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,19 +55,28 @@ cd frontend/app && npm install && cd ../..
 
 ### 3. 启动服务
 
+默认端口是后端 `8001`、前端 `5173`。某个 git worktree 可以用
+`worktree.ports.backend` 和 `worktree.ports.frontend` 覆盖端口；后端和
+Vite 配置会自动读取这些值。
+
+```bash
+git config --worktree --get worktree.ports.backend || echo 8001
+git config --worktree --get worktree.ports.frontend || echo 5173
+```
+
 ```bash
 # 终端 1：后端
 uv run python -m backend.web.main
-# → http://localhost:8001
+# → http://localhost:<backend-port>
 
 # 终端 2：前端
 cd frontend/app && npm run dev
-# → http://localhost:5173
+# → http://localhost:<frontend-port>
 ```
 
 ### 4. 打开并配置
 
-1. 浏览器打开 **http://localhost:5173**
+1. 浏览器打开上一步输出的前端地址
 2. **注册**账号
 3. 进入**设置** → 配置 LLM 提供商（API 密钥、模型）
 4. 开始和你的第一个 Agent 对话


### PR DESCRIPTION
## Summary

- Clarify that README service ports default to backend 8001 and frontend 5173, but git worktrees may override them through `worktree.ports.backend` and `worktree.ports.frontend`.
- Add copyable commands for checking the effective worktree ports.
- Update both English and Chinese README quick-start instructions to open the frontend URL reported by the current worktree, not a hard-coded port.

## Verification

- `git config --worktree --get worktree.ports.backend && git config --worktree --get worktree.ports.frontend` -> `8042` / `5189` in this worktree
- `uv run python - <<'PY'
from backend.bootstrap.app_entrypoint import resolve_app_port
print(resolve_app_port('LEON_BACKEND_PORT', 'worktree.ports.backend', 8001))
PY` -> `8042`
- `uv run pytest tests/Unit/backend/test_app_entrypoint.py tests/Unit/monitor/test_monitor_app_entrypoint.py tests/Unit/monitor/test_monitor_execution_target.py -q` -> 16 passed
- `npm ci` in `frontend/monitor`
- `npm test -- monitor-ports.test.ts --run` in `frontend/monitor` -> 3 passed
