### PR TITLE
fix: declare staging local workspace root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ SUPABASE_JWT_SECRET=your-jwt-secret
 # Required when auth registration or avatar APIs write avatar image files.
 LEON_AVATAR_ROOT=./local-workspace-root/avatars
 
+# Required by the local sandbox provider.
+LEON_LOCAL_WORKSPACE_ROOT=./local-workspace-root/workspaces
+
 # Default is direct HTTP. Set to 1 only when the host network requires normal
 # http_proxy/https_proxy env for Supabase REST/Auth reachability.
 LEON_SUPABASE_HTTP_TRUST_ENV=0

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           grep -F "leon-home:/root/.leon" docker-compose.yml >/dev/null
+          grep -F "LEON_LOCAL_WORKSPACE_ROOT: /root/.leon/workspaces" docker-compose.yml >/dev/null
           grep -F "volumes:" docker-compose.yml >/dev/null
 
       - name: Update staging stack branch
@@ -109,7 +110,9 @@ jobs:
           echo "$body" | jq '{uuid,git_branch,docker_compose_location}'
           printf '%s' "$body" | jq -e --arg ref "${{ steps.ref.outputs.ref }}" '.git_branch == $ref' >/dev/null
           printf '%s' "$body" | jq -e '.docker_compose_raw | contains("leon-home:/root/.leon")' >/dev/null
+          printf '%s' "$body" | jq -e '.docker_compose_raw | contains("LEON_LOCAL_WORKSPACE_ROOT: /root/.leon/workspaces")' >/dev/null
           printf '%s' "$body" | jq -e --arg volume "${STAGING_STACK_UUID}_leon-home:/root/.leon" '.docker_compose | contains($volume)' >/dev/null
+          printf '%s' "$body" | jq -e '.docker_compose | contains("LEON_LOCAL_WORKSPACE_ROOT=/root/.leon/workspaces") or contains("LEON_LOCAL_WORKSPACE_ROOT: /root/.leon/workspaces")' >/dev/null
           printf '%s' "$body" | jq -e --arg sha "${{ steps.target.outputs.sha }}" '.docker_compose | contains($sha)' >/dev/null
 
       - name: Verify staging API contract

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       # @@@staging-leon-home-volume - staging runtime state (models/members/sandboxes)
       # must survive container replacement, otherwise each deploy boots with an empty ~/.leon.
       - leon-home:/root/.leon
+    environment:
+      LEON_LOCAL_WORKSPACE_ROOT: /root/.leon/workspaces
     restart: unless-stopped
 
   frontend:


### PR DESCRIPTION
## Summary
- declare LEON_LOCAL_WORKSPACE_ROOT in docker-compose so the local sandbox provider has a persisted root under the existing leon-home volume
- make deploy-staging assert the source and rendered Coolify compose both carry that runtime contract
- document the required local workspace root in .env.example

## Verification
- docker compose config
- LEON_LOCAL_WORKSPACE_ROOT=/root/.leon/workspaces uv run python - <<'PY'
from backend.sandboxes.local_workspace import local_workspace_root
from backend.sandboxes.inventory import _build_providers
print(local_workspace_root())
print(sorted(_build_providers(local_workspace_root_path=local_workspace_root()).keys()))
PY
- uv run python -m pytest -q tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/sandbox/test_sandbox_config_paths.py
- git diff --check