### PR TITLE
fix: support explicit two-person group chats

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
@@ -29,6 +29,7 @@ class CreateChatBody(BaseModel):
         description="Other participant user ids. Do not include the authenticated user; the backend adds it from the bearer token.",
     )
     title: str | None = None
+    kind: Literal["auto", "direct", "group"] = "auto"
 
 
 class SendMessageBody(BaseModel):
@@ -142,7 +143,11 @@ def create_chat(
 ):
     try:
         participant_ids = _chat_participant_ids_for_request(user_repo, thread_repo, body.user_ids, user_id)
-        if len(participant_ids) >= 3:
+        if body.kind == "group":
+            chat = messaging_service.create_group_chat(participant_ids, body.title)
+        elif body.kind == "direct":
+            chat = messaging_service.find_or_create_chat(participant_ids, body.title)
+        elif len(participant_ids) >= 3:
             chat = messaging_service.create_group_chat(participant_ids, body.title)
         else:
             chat = messaging_service.find_or_create_chat(participant_ids, body.title)

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -22,7 +22,7 @@ from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
 from messaging.display_user import resolve_messaging_display_user
 from messaging.errors import ChatNotCaughtUpError
 from messaging.social_access import can_group_chat_with_participant
-from messaging.user_ownership import is_owned_by_viewer
+from messaging.user_ownership import is_owned_by_viewer, shares_ownership_scope
 from storage.errors import StorageConflictError
 
 logger = logging.getLogger(__name__)
@@ -152,8 +152,8 @@ class MessagingService:
         return self._create_chat(user_ids, chat_type="direct", title=title)
 
     def create_group_chat(self, user_ids: list[str], title: str | None = None) -> dict[str, Any]:
-        if len(user_ids) < 3:
-            raise ValueError("Group chat requires 3+ users")
+        if len(user_ids) < 2:
+            raise ValueError("Group chat requires 2+ users")
         self._require_resolvable_chat_users(user_ids)
         self._require_group_chat_access(user_ids)
         return self._create_chat(user_ids, chat_type="group", title=title)
@@ -168,6 +168,7 @@ class MessagingService:
 
     def _require_group_chat_access(self, user_ids: list[str]) -> None:
         requester_user_id = user_ids[0]
+        requester_user = self._resolve_display_user(requester_user_id)
         if self._contact_repo is None:
             raise RuntimeError("contact_repo is required for social access checks")
         if self._relationship_service is None:
@@ -177,6 +178,8 @@ class MessagingService:
                 continue
             participant_user = self._resolve_display_user(participant_id)
             if is_owned_by_viewer(requester_user_id, participant_user):
+                continue
+            if shares_ownership_scope(requester_user, participant_user):
                 continue
             if can_group_chat_with_participant(
                 viewer_user_id=requester_user_id,

--- a/messaging/user_ownership.py
+++ b/messaging/user_ownership.py
@@ -14,5 +14,20 @@ def is_owned_by_viewer(viewer_user_id: str, candidate_user: Any | None) -> bool:
 
 
 def access_scope_targets(candidate_user: Any | None, user_id: str) -> list[str]:
-    owner_user_id = getattr(candidate_user, "owner_user_id", None) if candidate_user is not None else None
-    return [user_id, str(owner_user_id)] if owner_user_id else [user_id]
+    targets = [user_id]
+    if candidate_user is not None:
+        for attr in ("owner_user_id", "created_by_user_id"):
+            owner_id = getattr(candidate_user, attr, None)
+            if owner_id:
+                targets.append(str(owner_id))
+    return list(dict.fromkeys(targets))
+
+
+def shares_ownership_scope(left_user: Any | None, right_user: Any | None) -> bool:
+    if left_user is None or right_user is None:
+        return False
+    left_id = str(getattr(left_user, "id", "") or "")
+    right_id = str(getattr(right_user, "id", "") or "")
+    if not left_id or not right_id:
+        return False
+    return bool(set(access_scope_targets(left_user, user_id=left_id)) & set(access_scope_targets(right_user, user_id=right_id)))

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -57,9 +57,15 @@ class SupabaseChatMemberRepo:
         common = chats_a & chats_b
         for chat_id in common:
             members = self.list_members(chat_id)
-            if len(members) == 2:
+            if len(members) == 2 and self._chat_type(chat_id) == "direct":
                 return chat_id
         return None
+
+    def _chat_type(self, chat_id: str) -> str | None:
+        res = q.schema_table(self._client, _SCHEMA, "chats", "chat member repo").select("type").eq("id", chat_id).limit(1).execute()
+        if not res.data:
+            return None
+        return str(res.data[0].get("type") or "")
 
     def update_last_read(self, chat_id: str, user_id: str, last_read_seq: int) -> None:
         self._t().update({"last_read_seq": last_read_seq}).eq("chat_id", chat_id).eq("user_id", user_id).execute()

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -825,6 +825,27 @@ def test_create_chat_accepts_agent_user_id_for_direct_participant() -> None:
     assert result["id"] == "chat-1"
 
 
+def test_create_chat_can_explicitly_create_two_person_group_chat() -> None:
+    state, called = _create_chat_route_state(
+        users={"agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", owner_user_id="human-user-1")},
+        thread_user_ids={"owned-agent-1"},
+        group_route=True,
+    )
+    app = SimpleNamespace(state=state)
+
+    result = _create_chat(
+        app,
+        chats_router.CreateChatBody(
+            user_ids=["agent-user-1"],
+            title="cel group bridge",
+            kind="group",
+        ),
+    )
+
+    assert called == [(["human-user-1", "agent-user-1"], "cel group bridge")]
+    assert result["id"] == "chat-1"
+
+
 def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_participants() -> None:
     state, called = _create_chat_route_state(thread_user_ids={"thread-user-1", "thread-user-2"})
     app = SimpleNamespace(state=state)

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2034,6 +2034,66 @@ def test_messaging_service_group_chat_creation_accepts_active_relationships() ->
     ]
 
 
+def test_messaging_service_group_chat_creation_accepts_two_members() -> None:
+    created: list[Any] = []
+    members: list[tuple[str, str]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(create=lambda row: created.append(row)),
+        chat_member_repo=SimpleNamespace(add_member=lambda chat_id, user_id: members.append((chat_id, user_id))),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, owner_user_id=None, display_name=uid, type="human", avatar=None)
+        ),
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        relationship_service=SimpleNamespace(get_state=lambda _viewer_id, _target_id: "visit"),
+    )
+
+    chat = service.create_group_chat(["agent-user-1", "human-user-1"], title="two-person group")
+
+    assert chat["title"] == "two-person group"
+    assert len(created) == 1
+    assert created[0].type == "group"
+    assert members == [(chat["id"], "agent-user-1"), (chat["id"], "human-user-1")]
+
+
+def test_messaging_service_group_chat_creation_accepts_same_owner_external_users() -> None:
+    created: list[Any] = []
+    members: list[tuple[str, str]] = []
+    users = {
+        "external-a": SimpleNamespace(
+            id="external-a",
+            owner_user_id=None,
+            created_by_user_id="owner-user-1",
+            display_name="External A",
+            type="external",
+            avatar=None,
+        ),
+        "external-b": SimpleNamespace(
+            id="external-b",
+            owner_user_id=None,
+            created_by_user_id="owner-user-1",
+            display_name="External B",
+            type="external",
+            avatar=None,
+        ),
+    }
+    service = MessagingService(
+        chat_repo=SimpleNamespace(create=lambda row: created.append(row)),
+        chat_member_repo=SimpleNamespace(add_member=lambda chat_id, user_id: members.append((chat_id, user_id))),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(get_by_id=lambda uid: users.get(uid)),
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        relationship_service=SimpleNamespace(get_state=lambda _viewer_id, _target_id: "none"),
+    )
+
+    chat = service.create_group_chat(["external-a", "external-b"], title="same owner external group")
+
+    assert chat["title"] == "same owner external group"
+    assert len(created) == 1
+    assert created[0].type == "group"
+    assert members == [(chat["id"], "external-a"), (chat["id"], "external-b")]
+
+
 def test_chat_tool_formats_agent_user_id_sender_as_agent_name() -> None:
     registry = ToolRegistry()
     service = ChatToolService(

--- a/tests/Unit/messaging/test_user_ownership.py
+++ b/tests/Unit/messaging/test_user_ownership.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from messaging.user_ownership import access_scope_targets, is_owned_by_viewer
+from messaging.user_ownership import (
+    access_scope_targets,
+    is_owned_by_viewer,
+    shares_ownership_scope,
+)
 
 
 def test_is_owned_by_viewer_accepts_self() -> None:
@@ -43,3 +47,23 @@ def test_access_scope_targets_uses_user_id_without_owner_scope() -> None:
     user = SimpleNamespace(id="human-user-2", owner_user_id=None)
 
     assert access_scope_targets(user, user_id="human-user-2") == ["human-user-2"]
+
+
+def test_access_scope_targets_expands_created_external_scope() -> None:
+    user = SimpleNamespace(id="external-user-1", owner_user_id=None, created_by_user_id="viewer-1")
+
+    assert access_scope_targets(user, user_id="external-user-1") == ["external-user-1", "viewer-1"]
+
+
+def test_shares_ownership_scope_accepts_same_owner_external_users() -> None:
+    left = SimpleNamespace(id="external-a", owner_user_id=None, created_by_user_id="owner-1")
+    right = SimpleNamespace(id="external-b", owner_user_id=None, created_by_user_id="owner-1")
+
+    assert shares_ownership_scope(left, right) is True
+
+
+def test_shares_ownership_scope_rejects_unrelated_users() -> None:
+    left = SimpleNamespace(id="external-a", owner_user_id=None, created_by_user_id="owner-1")
+    right = SimpleNamespace(id="external-b", owner_user_id=None, created_by_user_id="owner-2")
+
+    assert shares_ownership_scope(left, right) is False

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -57,6 +57,48 @@ def test_supabase_chat_stack_uses_chat_schema_for_root_tables() -> None:
     assert "messages" not in tables
 
 
+def test_supabase_find_chat_between_only_returns_direct_chat() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.chats": [
+            {
+                "id": "group-1",
+                "type": "group",
+                "created_by_user_id": "user-1",
+                "title": "Group",
+                "status": "active",
+                "next_message_seq": 0,
+                "created_at": 1.0,
+            },
+            {
+                "id": "direct-1",
+                "type": "direct",
+                "created_by_user_id": "user-1",
+                "title": None,
+                "status": "active",
+                "next_message_seq": 0,
+                "created_at": 1.0,
+            },
+        ],
+        "chat.chat_members": [
+            {"chat_id": "group-1", "user_id": "user-1", "last_read_seq": 0},
+            {"chat_id": "group-1", "user_id": "user-2", "last_read_seq": 0},
+            {"chat_id": "direct-1", "user_id": "user-1", "last_read_seq": 0},
+            {"chat_id": "direct-1", "user_id": "user-2", "last_read_seq": 0},
+        ],
+    }
+    client = FakeSupabaseClient(tables=tables)
+
+    assert SupabaseChatMemberRepo(client).find_chat_between("user-1", "user-2") == "direct-1"
+
+    group_only_client = FakeSupabaseClient(
+        tables={
+            "chat.chats": [tables["chat.chats"][0]],
+            "chat.chat_members": tables["chat.chat_members"][:2],
+        }
+    )
+    assert SupabaseChatMemberRepo(group_only_client).find_chat_between("user-1", "user-2") is None
+
+
 def test_supabase_contact_and_relationship_repos_use_chat_schema() -> None:
     tables: dict[str, list[dict]] = {"chat.contacts": [], "chat.relationships": []}
     client = FakeSupabaseClient(tables=tables)


### PR DESCRIPTION
## Summary
- adds explicit `kind=auto|direct|group` handling to public chat creation
- keeps two-user direct chat reuse isolated from explicit group chat creation
- allows same-owner external agent users to create group chats without relationship boilerplate while keeping stranger relationship checks

## YATU
- backend on `http://127.0.0.1:8017` from this branch
- `cel chat direct codex-dogfood-20260430T003701 --create` returned direct chat `0b429940-b758-4a88-903f-264fd8dc2fb7` twice
- `cel chat create codex-dogfood-20260430T003701 --kind group --title yatu-two-person-group-20260430` created group chat `6b7a0fe1-71fb-4f3d-a5e6-8e38c1484e92`
- `cel chat send ...` as coordinator, then `cel chat read ...` as dogfood returned the sent message

## Verification
- `uv run pytest tests/Unit/messaging/test_user_ownership.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py -q`
- `uv run pytest tests/Unit -q` -> 2052 passed, 3 skipped
- `uv run ruff check . && uv run ruff format --check .`