### PR TITLE
feat: add runtime inbox wake bus

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -73,10 +73,14 @@ def wait_runtime_inbox_items(
     *,
     timeout_seconds: float,
     messaging_service: Any | None = None,
+    wake_bus: Any | None = None,
 ) -> list[dict[str, Any]]:
     key = external_inbox_key(user_id)
     event = threading.Event()
-    queue_manager.register_wake(key, lambda _item: event.set())
+    if wake_bus is None:
+        queue_manager.register_wake(key, lambda _item: event.set())
+    else:
+        wake_bus.register(key, event.set)
     try:
         items = drain_runtime_inbox_items(
             user_id,
@@ -92,19 +96,25 @@ def wait_runtime_inbox_items(
             messaging_service=messaging_service,
         )
     finally:
-        queue_manager.unregister_wake(key)
+        if wake_bus is None:
+            queue_manager.unregister_wake(key)
+        else:
+            wake_bus.unregister(key)
 
 
-def _runtime_inbox_parts(app: Any) -> tuple[Any, Any]:
+def _runtime_inbox_parts(app: Any) -> tuple[Any, Any, Any]:
     runtime_state = getattr(app.state, "threads_runtime_state", None)
     queue_manager = getattr(runtime_state, "queue_manager", None)
     if queue_manager is None:
         raise HTTPException(500, "Runtime queue manager unavailable")
+    wake_bus = getattr(runtime_state, "runtime_inbox_wake_bus", None)
+    if wake_bus is None:
+        raise HTTPException(500, "Runtime inbox wake bus unavailable")
     chat_runtime = getattr(app.state, "chat_runtime_state", None)
     messaging_service = getattr(chat_runtime, "messaging_service", None)
     if messaging_service is None:
         raise HTTPException(500, "Messaging service unavailable")
-    return queue_manager, messaging_service
+    return queue_manager, messaging_service, wake_bus
 
 
 @router.post("/inbox/drain")
@@ -112,7 +122,7 @@ async def drain_runtime_inbox(
     app: Annotated[Any, Depends(get_app)],
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    queue_manager, messaging_service = _runtime_inbox_parts(app)
+    queue_manager, messaging_service, _wake_bus = _runtime_inbox_parts(app)
     try:
         items = await asyncio.to_thread(
             drain_runtime_inbox_items,
@@ -131,7 +141,7 @@ async def wait_runtime_inbox(
     user_id: Annotated[str, Depends(get_current_user_id)],
     timeout_seconds: Annotated[float, Query(ge=0.0, le=30.0)] = 25.0,
 ) -> dict[str, Any]:
-    queue_manager, messaging_service = _runtime_inbox_parts(app)
+    queue_manager, messaging_service, wake_bus = _runtime_inbox_parts(app)
     try:
         items = await asyncio.to_thread(
             wait_runtime_inbox_items,
@@ -139,6 +149,7 @@ async def wait_runtime_inbox(
             queue_manager,
             timeout_seconds=timeout_seconds,
             messaging_service=messaging_service,
+            wake_bus=wake_bus,
         )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc

--- a/backend/chat/runtime_inbox_wake.py
+++ b/backend/chat/runtime_inbox_wake.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import time
+from collections.abc import Callable, Generator
+from typing import Any
+
+logger = logging.getLogger(__name__)
+_CHANNEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+DEFAULT_POSTGRES_WAKE_CHANNEL = "mycel_runtime_inbox_wake"
+
+
+class RuntimeInboxWakeBus:
+    def __init__(self) -> None:
+        self._handlers: dict[str, Callable[[], None]] = {}
+        self._lock = threading.Lock()
+
+    def register(self, inbox_id: str, handler: Callable[[], None]) -> None:
+        with self._lock:
+            self._handlers[inbox_id] = handler
+
+    def unregister(self, inbox_id: str) -> None:
+        with self._lock:
+            self._handlers.pop(inbox_id, None)
+
+    def publish(self, inbox_id: str) -> None:
+        with self._lock:
+            handler = self._handlers.get(inbox_id)
+        if not handler:
+            return
+        try:
+            handler()
+        except Exception:
+            logger.exception("Runtime inbox wake handler raised for %s", inbox_id)
+
+
+class PostgresRuntimeInboxWakeBus(RuntimeInboxWakeBus):
+    def __init__(
+        self,
+        pg_url: str,
+        *,
+        connect: Callable[..., Any] | None = None,
+        channel: str = DEFAULT_POSTGRES_WAKE_CHANNEL,
+    ) -> None:
+        super().__init__()
+        self._pg_url = pg_url
+        self._connect = connect
+        self._channel = _validate_channel(channel)
+        self._listener_lock = threading.Lock()
+        self._listener_started = False
+
+    def register(
+        self,
+        inbox_id: str,
+        handler: Callable[[], None],
+        *,
+        start_listener: bool = True,
+    ) -> None:
+        super().register(inbox_id, handler)
+        if start_listener:
+            self._ensure_listener()
+
+    def publish(self, inbox_id: str) -> None:
+        super().publish(inbox_id)
+        payload = json.dumps({"inbox_id": inbox_id}, ensure_ascii=False, separators=(",", ":"))
+        with self._connect_pg() as conn:
+            conn.execute("SELECT pg_notify(%s, %s)", (self._channel, payload))
+
+    def dispatch_payload(self, payload: str) -> None:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Invalid runtime inbox wake payload") from exc
+        inbox_id = data.get("inbox_id") if isinstance(data, dict) else None
+        if not isinstance(inbox_id, str) or not inbox_id:
+            raise RuntimeError("Invalid runtime inbox wake payload")
+        super().publish(inbox_id)
+
+    def _ensure_listener(self) -> None:
+        with self._listener_lock:
+            if self._listener_started:
+                return
+            thread = threading.Thread(
+                target=self._listen_forever,
+                name="runtime-inbox-postgres-wake",
+                daemon=True,
+            )
+            thread.start()
+            self._listener_started = True
+
+    def _listen_forever(self) -> None:
+        while True:
+            try:
+                with self._connect_pg() as conn:
+                    conn.execute(f"LISTEN {self._channel}")
+                    while True:
+                        for item in _iter_notifies(conn.notifies(timeout=30.0)):
+                            self.dispatch_payload(str(item.payload))
+            except Exception:
+                logger.exception("Runtime inbox Postgres wake listener failed")
+                time.sleep(1.0)
+
+    def _connect_pg(self) -> Any:
+        if self._connect is not None:
+            return self._connect(self._pg_url, autocommit=True)
+        import psycopg
+
+        return psycopg.connect(self._pg_url, autocommit=True)
+
+
+def _iter_notifies(notifies: Generator[Any]) -> Generator[Any]:
+    yield from notifies
+
+
+def _validate_channel(channel: str) -> str:
+    if not _CHANNEL_RE.match(channel):
+        raise RuntimeError("Invalid Postgres notification channel")
+    return channel

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from dataclasses import dataclass
 from typing import Any
 
+from backend.chat.runtime_inbox_wake import PostgresRuntimeInboxWakeBus, RuntimeInboxWakeBus
 from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from core.runtime.middleware.queue import MessageQueueManager
 
@@ -11,6 +13,7 @@ from core.runtime.middleware.queue import MessageQueueManager
 @dataclass(frozen=True)
 class ThreadsRuntimeState:
     queue_manager: Any
+    runtime_inbox_wake_bus: Any
     agent_runtime_gateway: Any
     activity_reader: Any
     messaging_service: Any | None = None
@@ -32,6 +35,7 @@ def attach_threads_runtime(
     chat_join_request_service: Any,
 ) -> ThreadsRuntimeState:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
+    app.state.runtime_inbox_wake_bus = build_runtime_inbox_wake_bus()
     app.state.agent_pool = {}
     app.state.thread_sandbox = {}
     app.state.thread_cwd = {}
@@ -51,6 +55,7 @@ def attach_threads_runtime(
     # has one canonical read surface instead of loose app.state mirrors.
     state = ThreadsRuntimeState(
         queue_manager=app.state.queue_manager,
+        runtime_inbox_wake_bus=app.state.runtime_inbox_wake_bus,
         agent_runtime_gateway=runtime_state.gateway,
         activity_reader=runtime_state.activity_reader,
         messaging_service=messaging_service,
@@ -60,3 +65,10 @@ def attach_threads_runtime(
     )
     app.state.threads_runtime_state = state
     return state
+
+
+def build_runtime_inbox_wake_bus() -> Any:
+    pg_url = str(os.getenv("LEON_POSTGRES_URL") or "").strip()
+    if pg_url:
+        return PostgresRuntimeInboxWakeBus(pg_url)
+    return RuntimeInboxWakeBus()

--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -26,7 +26,10 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
         thread_repo=app.state.thread_repo,
         agent_pool=app.state.agent_pool,
     )
-    external_runtime_handler = ExternalRuntimeInboxHandler(queue_manager=app.state.queue_manager)
+    external_runtime_handler = ExternalRuntimeInboxHandler(
+        queue_manager=app.state.queue_manager,
+        wake_bus=app.state.runtime_inbox_wake_bus,
+    )
     gateway = NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(

--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -14,8 +14,9 @@ def external_inbox_key(user_id: str) -> str:
 
 
 class ExternalRuntimeInboxHandler:
-    def __init__(self, *, queue_manager: Any) -> None:
+    def __init__(self, *, queue_manager: Any, wake_bus: Any | None = None) -> None:
         self._queue_manager = queue_manager
+        self._wake_bus = wake_bus
 
     async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
         inbox_id = external_inbox_key(envelope.recipient.agent_user_id)
@@ -30,8 +31,10 @@ class ExternalRuntimeInboxHandler:
             source="external",
             sender_id=envelope.sender.user_id,
             sender_name=envelope.sender.display_name,
-            wake=True,
+            wake=self._wake_bus is None and envelope.wake,
         )
+        if self._wake_bus is not None and envelope.wake:
+            self._wake_bus.publish(inbox_id)
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=inbox_id)
 
     async def dispatch_notification(
@@ -53,6 +56,8 @@ class ExternalRuntimeInboxHandler:
             source="external",
             sender_id=envelope.sender.user_id,
             sender_name=envelope.sender.display_name,
-            wake=envelope.wake,
+            wake=self._wake_bus is None and envelope.wake,
         )
+        if self._wake_bus is not None and envelope.wake:
+            self._wake_bus.publish(inbox_id)
         return agent_runtime_protocol.AgentRuntimeNotificationResult(status="accepted", thread_id=inbox_id)

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -15,15 +15,22 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     messaging_service = object()
     relationship_service = object()
     chat_join_request_service = object()
+    runtime_inbox_wake_bus = object()
     seen: list[tuple[str, object]] = []
 
     storage_container = SimpleNamespace(queue_repo=lambda: queue_repo)
     app = SimpleNamespace(state=SimpleNamespace())
 
+    monkeypatch.delenv("LEON_POSTGRES_URL", raising=False)
     monkeypatch.setattr(
         threads_bootstrap,
         "MessageQueueManager",
         lambda *, repo: seen.append(("queue_manager", repo)) or queue_manager,
+    )
+    monkeypatch.setattr(
+        threads_bootstrap,
+        "RuntimeInboxWakeBus",
+        lambda: seen.append(("runtime_inbox_wake_bus", app)) or runtime_inbox_wake_bus,
     )
     monkeypatch.setattr(
         threads_bootstrap,
@@ -45,6 +52,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     )
 
     assert app.state.queue_manager is queue_manager
+    assert app.state.runtime_inbox_wake_bus is runtime_inbox_wake_bus
     assert app.state.agent_pool == {}
     assert app.state.thread_sandbox == {}
     assert app.state.thread_cwd == {}
@@ -54,6 +62,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert app.state.thread_last_active == {}
     assert app.state.threads_runtime_state is state
     assert state.queue_manager is queue_manager
+    assert state.runtime_inbox_wake_bus is runtime_inbox_wake_bus
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
     assert state.messaging_service is messaging_service
@@ -65,6 +74,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert state.checkpoint_store is None
     assert seen == [
         ("queue_manager", queue_repo),
+        ("runtime_inbox_wake_bus", app),
         ("runtime_state", app),
         ("typing_tracker", typing_tracker),
     ]
@@ -80,14 +90,30 @@ def test_attach_threads_runtime_requires_explicit_typing_tracker():
         threads_bootstrap.attach_threads_runtime(app, storage_container)
 
 
+def test_build_runtime_inbox_wake_bus_uses_postgres_when_configured(monkeypatch):
+    wake_bus = object()
+
+    monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://example")
+    monkeypatch.setattr(
+        threads_bootstrap,
+        "PostgresRuntimeInboxWakeBus",
+        lambda pg_url: wake_bus if pg_url == "postgres://example" else None,
+    )
+
+    assert threads_bootstrap.build_runtime_inbox_wake_bus() is wake_bus
+
+
 def test_build_agent_runtime_state_does_not_write_top_level_activity_reader(monkeypatch):
     gateway = object()
     activity_reader = object()
+    runtime_inbox_wake_bus = object()
+    external_handler_kwargs: list[dict] = []
     app = SimpleNamespace(
         state=SimpleNamespace(
             thread_repo=object(),
             agent_pool={},
             queue_manager=object(),
+            runtime_inbox_wake_bus=runtime_inbox_wake_bus,
             thread_tasks={},
             thread_locks={},
             thread_locks_guard=object(),
@@ -99,8 +125,19 @@ def test_build_agent_runtime_state_does_not_write_top_level_activity_reader(monk
     monkeypatch.setattr(runtime_bootstrap, "NativeAgentChatDeliveryHandler", lambda **_kwargs: object())
     monkeypatch.setattr(runtime_bootstrap, "AppAgentChatRuntimeServices", lambda *args, **kwargs: object())
     monkeypatch.setattr(runtime_bootstrap, "NativeAgentThreadInputHandler", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        runtime_bootstrap,
+        "ExternalRuntimeInboxHandler",
+        lambda **kwargs: external_handler_kwargs.append(kwargs) or object(),
+    )
 
     state = runtime_bootstrap.build_agent_runtime_state(app, typing_tracker=object())
 
     assert state.gateway is gateway
     assert state.activity_reader is activity_reader
+    assert external_handler_kwargs == [
+        {
+            "queue_manager": app.state.queue_manager,
+            "wake_bus": runtime_inbox_wake_bus,
+        }
+    ]

--- a/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py
@@ -37,6 +37,7 @@ async def test_gateway_chat_delivery_uses_preselected_thread_id_from_envelope(mo
                 ),
             ),
             agent_pool={},
+            runtime_inbox_wake_bus=object(),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, _notification_type, **_meta: enqueued.append((content, thread_id))
             ),

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py
@@ -35,6 +35,7 @@ def _app(
                 get_by_id=lambda thread_id: next((row for row in thread_rows if row["id"] == thread_id), None),
             ),
             agent_pool=pool or {},
+            runtime_inbox_wake_bus=object(),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"), meta.get("wake"))

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -39,6 +39,7 @@ def _fake_app() -> SimpleNamespace:
                 list_by_agent_user=lambda _uid: [],
             ),
             agent_pool={},
+            runtime_inbox_wake_bus=object(),
             queue_manager=_FakeQueueManager(),
             thread_cwd={},
             thread_sandbox={},

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -16,6 +16,14 @@ from protocols.agent_runtime import (
 )
 
 
+class _RecordingWakeBus:
+    def __init__(self) -> None:
+        self.published: list[str] = []
+
+    def publish(self, inbox_id: str) -> None:
+        self.published.append(inbox_id)
+
+
 def _envelope() -> AgentChatDeliveryEnvelope:
     return AgentChatDeliveryEnvelope(
         chat=AgentChatContext(chat_id="chat-1"),
@@ -28,10 +36,12 @@ def _envelope() -> AgentChatDeliveryEnvelope:
 @pytest.mark.asyncio
 async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> None:
     enqueued: list[tuple[str, str, str, dict]] = []
+    wake_bus = _RecordingWakeBus()
     handler = ExternalRuntimeInboxHandler(
+        wake_bus=wake_bus,
         queue_manager=SimpleNamespace(
             enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
-        )
+        ),
     )
 
     result = await handler.dispatch(_envelope())
@@ -46,18 +56,21 @@ async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> N
     assert meta["source"] == "external"
     assert meta["sender_id"] == "human-user-1"
     assert meta["sender_name"] == "Human"
-    assert meta["wake"] is True
+    assert meta["wake"] is False
     assert payload == {"event_type": "chat.message", "chat_id": "chat-1"}
+    assert wake_bus.published == ["external:external-user-1"]
     assert "managed runtime prompt must not leak" not in content
 
 
 @pytest.mark.asyncio
 async def test_external_runtime_inbox_handler_queues_generic_runtime_notification() -> None:
     enqueued: list[tuple[str, str, str, dict]] = []
+    wake_bus = _RecordingWakeBus()
     handler = ExternalRuntimeInboxHandler(
+        wake_bus=wake_bus,
         queue_manager=SimpleNamespace(
             enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
-        )
+        ),
     )
     envelope = AgentRuntimeNotificationEnvelope(
         event_type="relationship.requested",
@@ -81,6 +94,8 @@ async def test_external_runtime_inbox_handler_queues_generic_runtime_notificatio
     assert meta["source"] == "external"
     assert meta["sender_id"] == "human-user-1"
     assert meta["sender_name"] == "Human"
+    assert meta["wake"] is False
+    assert wake_bus.published == ["external:external-user-1"]
     assert payload == {
         "event_type": "relationship.requested",
         "sender_id": "human-user-1",

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -11,6 +12,23 @@ from backend.chat.api.http.runtime_inbox_router import (
     wait_runtime_inbox,
     wait_runtime_inbox_items,
 )
+from core.runtime.middleware.queue.manager import MessageQueueManager
+
+
+class _SharedRuntimeInboxWakeBus:
+    def __init__(self) -> None:
+        self.handlers = {}
+
+    def register(self, inbox_id, handler) -> None:
+        self.handlers[inbox_id] = handler
+
+    def unregister(self, inbox_id) -> None:
+        self.handlers.pop(inbox_id, None)
+
+    def publish(self, inbox_id) -> None:
+        handler = self.handlers.get(inbox_id)
+        if handler:
+            handler()
 
 
 def test_drain_runtime_inbox_items_returns_non_chat_metadata_and_clears_external_queue() -> None:
@@ -290,16 +308,69 @@ def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake()
     assert registered["unregistered"] is True
 
 
+def test_wait_runtime_inbox_items_uses_signal_bus_and_drains_durable_queue(tmp_path) -> None:
+    db_path = str(tmp_path / "queue.db")
+    waiter_queue = MessageQueueManager(db_path=db_path)
+    sender_queue = MessageQueueManager(db_path=db_path)
+    wake_bus = _SharedRuntimeInboxWakeBus()
+    result_holder: dict[str, list[dict[str, object]]] = {}
+    worker = threading.Thread(
+        target=lambda: result_holder.update(
+            items=wait_runtime_inbox_items(
+                "external-user-1",
+                waiter_queue,
+                timeout_seconds=1.0,
+                wake_bus=wake_bus,
+            )
+        )
+    )
+
+    worker.start()
+    deadline = time.monotonic() + 1.0
+    while "external:external-user-1" not in wake_bus.handlers and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert "external:external-user-1" in wake_bus.handlers
+    sender_queue.enqueue(
+        '{"event_type":"relationship.requested","summary":"Human requested contact."}',
+        "external:external-user-1",
+        notification_type="relationship",
+        source="external",
+        sender_id="human-user-1",
+        sender_name="Human",
+        wake=False,
+    )
+    wake_bus.publish("external:external-user-1")
+    worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert result_holder["items"] == [
+        {
+            "event_type": "relationship.requested",
+            "summary": "Human requested contact.",
+            "notification_type": "relationship",
+            "source": "external",
+            "sender_id": "human-user-1",
+            "sender_name": "Human",
+        }
+    ]
+    assert wake_bus.handlers == {}
+
+
 @pytest.mark.asyncio
 async def test_wait_runtime_inbox_endpoint_returns_count_and_notifications() -> None:
     queue_manager = SimpleNamespace(
         drain_all=lambda _key: [],
-        register_wake=lambda _key, _handler: None,
-        unregister_wake=lambda _key: None,
+        register_wake=lambda _key, _handler: (_ for _ in ()).throw(AssertionError("runtime inbox endpoint should use wake bus")),
+        unregister_wake=lambda _key: (_ for _ in ()).throw(AssertionError("runtime inbox endpoint should use wake bus")),
+    )
+    wake_events: list[tuple[str, str]] = []
+    wake_bus = SimpleNamespace(
+        register=lambda key, _handler: wake_events.append(("register", key)),
+        unregister=lambda key: wake_events.append(("unregister", key)),
     )
     app = SimpleNamespace(
         state=SimpleNamespace(
-            threads_runtime_state=SimpleNamespace(queue_manager=queue_manager),
+            threads_runtime_state=SimpleNamespace(queue_manager=queue_manager, runtime_inbox_wake_bus=wake_bus),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace(list_chats_for_user=lambda _user_id: [])),
         )
     )
@@ -311,3 +382,7 @@ async def test_wait_runtime_inbox_endpoint_returns_count_and_notifications() -> 
     )
 
     assert result == {"count": 0, "notifications": []}
+    assert wake_events == [
+        ("register", "external:external-user-1"),
+        ("unregister", "external:external-user-1"),
+    ]

--- a/tests/Unit/backend/web/services/test_runtime_inbox_wake_bus.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_wake_bus.py
@@ -1,0 +1,66 @@
+from backend.chat.runtime_inbox_wake import PostgresRuntimeInboxWakeBus, RuntimeInboxWakeBus
+
+
+def test_runtime_inbox_wake_bus_publishes_signal_only() -> None:
+    bus = RuntimeInboxWakeBus()
+    seen: list[str] = []
+
+    bus.register("external:user-1", lambda: seen.append("woke"))
+    bus.publish("external:user-1")
+
+    assert seen == ["woke"]
+
+
+def test_runtime_inbox_wake_bus_unregister_removes_handler() -> None:
+    bus = RuntimeInboxWakeBus()
+    seen: list[str] = []
+
+    bus.register("external:user-1", lambda: seen.append("woke"))
+    bus.unregister("external:user-1")
+    bus.publish("external:user-1")
+
+    assert seen == []
+
+
+class _RecordingConnection:
+    def __init__(self, calls: list[tuple[str, tuple]]) -> None:
+        self.calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple) -> None:
+        self.calls.append((query, params))
+
+
+def test_postgres_runtime_inbox_wake_bus_publishes_local_and_postgres_signal() -> None:
+    calls: list[tuple[str, tuple]] = []
+    bus = PostgresRuntimeInboxWakeBus(
+        "postgres://example",
+        connect=lambda _url, autocommit: _RecordingConnection(calls),
+    )
+    seen: list[str] = []
+
+    bus.register("external:user-1", lambda: seen.append("local"), start_listener=False)
+    bus.publish("external:user-1")
+
+    assert seen == ["local"]
+    assert calls == [
+        (
+            "SELECT pg_notify(%s, %s)",
+            ("mycel_runtime_inbox_wake", '{"inbox_id":"external:user-1"}'),
+        )
+    ]
+
+
+def test_postgres_runtime_inbox_wake_bus_dispatches_remote_payload() -> None:
+    bus = PostgresRuntimeInboxWakeBus("postgres://example", connect=lambda *_args, **_kwargs: None)
+    seen: list[str] = []
+
+    bus.register("external:user-1", lambda: seen.append("remote"), start_listener=False)
+    bus.dispatch_payload('{"inbox_id":"external:user-1"}')
+
+    assert seen == ["remote"]

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -3262,6 +3262,7 @@ async def test_recipient_thread_resolution_requires_current_thread_repo_contract
                 get_by_id=lambda thread_id: {"id": thread_id, "agent_user_id": "agent-user-1"} if thread_id == "thread-1" else None,
             ),
             agent_pool={},
+            runtime_inbox_wake_bus=object(),
             queue_manager=SimpleNamespace(enqueue=lambda *_args, **_kwargs: None),
             thread_cwd={},
             thread_sandbox={},
@@ -3332,6 +3333,7 @@ async def _run_chat_delivery(
                 get_by_id=lambda thread_id: next((row for row in thread_rows if row["id"] == thread_id), None),
             ),
             agent_pool=pool or {},
+            runtime_inbox_wake_bus=object(),
             queue_manager=SimpleNamespace(
                 enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append(
                     (content, thread_id, meta.get("sender_id"), meta.get("sender_name"))

--- a/tests/Unit/integration_contracts/test_query_loop_backend_contracts.py
+++ b/tests/Unit/integration_contracts/test_query_loop_backend_contracts.py
@@ -535,6 +535,7 @@ def _make_streaming_app(
         thread_event_buffers={},
         subagent_buffers={},
         queue_manager=queue_manager,
+        runtime_inbox_wake_bus=object(),
         thread_last_active={},
     )
     event_loop = None
@@ -1445,6 +1446,7 @@ async def test_route_message_cancelled_during_startup_does_not_start_run(monkeyp
             thread_locks={},
             thread_locks_guard=asyncio.Lock(),
             queue_manager=queue_manager,
+            runtime_inbox_wake_bus=object(),
             typing_tracker=SimpleNamespace(start_chat=lambda *_args, **_kwargs: None),
         )
     )


### PR DESCRIPTION
## Summary
- add a runtime inbox wake bus for signal-only external-agent notification wakeups
- wire runtime inbox waits to wake signals while durable queue items remain the payload source of truth
- publish external runtime inbox wake signals from chat adapter delivery

## Verification
- uv run pytest tests/Unit -q -> 2058 passed, 3 skipped
- uv run ruff check <touched files> -> passed
- uv run ruff format --check <touched files> -> passed

## Architecture Note
The bus is intentionally signal-only. It does not move chat payloads or queue items. Runtime inbox waiters wake on the signal and then drain the durable queue. Postgres NOTIFY is used when LEON_POSTGRES_URL is configured so multi-process app deployments can wake local waiters without turning the CLI hook path into blocking polling.