### PR TITLE
fix: identify runtime chat notifications

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -29,6 +29,8 @@ def chat_runtime_notifications(user_id: str, messaging_service: Any, *, chat_ids
                 "event_type": "chat.message",
                 "notification_type": "chat",
                 "chat_id": chat_id,
+                "message_id": last_message.get("id"),
+                "message_seq": last_message.get("seq"),
                 "sender_name": sender_name,
                 "unread_count": unread_count,
             }

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -547,8 +547,10 @@ class MessagingService:
         if not isinstance(message["content"], str):
             raise RuntimeError(f"Latest message {message.get('id') or '<missing>'} has invalid content")
         return {
+            "id": message.get("id"),
             "content": message["content"],
             "sender_name": sender.display_name,
+            "seq": message.get("seq"),
             "created_at": message.get("created_at"),
         }
 

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -87,7 +87,7 @@ def test_drain_runtime_inbox_items_replaces_queued_chat_tokens_with_unread_proje
                 {
                     "id": "chat-2",
                     "unread_count": 1,
-                    "last_message": {"sender_name": "Human", "content": "must not leak"},
+                    "last_message": {"id": "msg-2", "seq": 7, "sender_name": "Human", "content": "must not leak"},
                 }
             ]
         ),
@@ -98,6 +98,8 @@ def test_drain_runtime_inbox_items_replaces_queued_chat_tokens_with_unread_proje
             "event_type": "chat.message",
             "notification_type": "chat",
             "chat_id": "chat-2",
+            "message_id": "msg-2",
+            "message_seq": 7,
             "sender_name": "Human",
             "unread_count": 1,
         }
@@ -155,7 +157,7 @@ def test_chat_runtime_notifications_derive_from_unread_chat_projection() -> None
                 {
                     "id": "chat-2",
                     "unread_count": 2,
-                    "last_message": {"sender_name": "Unread Sender", "content": "must not leak"},
+                    "last_message": {"id": "msg-2", "seq": 9, "sender_name": "Unread Sender", "content": "must not leak"},
                 },
             ]
         ),
@@ -167,6 +169,8 @@ def test_chat_runtime_notifications_derive_from_unread_chat_projection() -> None
             "event_type": "chat.message",
             "notification_type": "chat",
             "chat_id": "chat-2",
+            "message_id": "msg-2",
+            "message_seq": 9,
             "sender_name": "Unread Sender",
             "unread_count": 2,
         }
@@ -272,7 +276,7 @@ def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake()
                         {
                             "id": "chat-2",
                             "unread_count": 1,
-                            "last_message": {"sender_name": "Human", "content": "must not leak"},
+                            "last_message": {"id": "msg-2", "seq": 8, "sender_name": "Human", "content": "must not leak"},
                         }
                     ]
                 ),
@@ -301,6 +305,8 @@ def test_wait_runtime_inbox_items_returns_derived_chat_notification_after_wake()
             "event_type": "chat.message",
             "notification_type": "chat",
             "chat_id": "chat-2",
+            "message_id": "msg-2",
+            "message_seq": 8,
             "sender_name": "Human",
             "unread_count": 1,
         }


### PR DESCRIPTION
## Summary\n- include message id and seq in latest chat projection\n- include that message identity in runtime chat notifications so subscriber dedupe can distinguish consecutive messages\n\n## Verification\n- uv run ruff format messaging/service.py backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py\n- uv run ruff check messaging/service.py backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py\n- uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/integration_contracts/test_messaging_router.py -q\n- uv run pytest tests/Unit -q\n\n## YATU\n- Real local backend on 8042 plus isolated MYCEL_HOME runtime daemon\n- Artifact: ~/share/ops/yatu-artifacts/runtime-daemon-latency-fixed-20260430T130754Z\n- Three consecutive A -> B chat messages each produced one local hook notification; after each cel chat read, repeated hook drain was empty.