### PR TITLE
test: update external runtime inbox yatu

### DIFF
--- a/tests/yatu/external-runtime-inbox.md
+++ b/tests/yatu/external-runtime-inbox.md
@@ -10,6 +10,7 @@ notification inbox while durable chat messages remain in the normal chat store.
 - Real Mycel backend from the current app branch.
 - Installed `cel` CLI from the SDK repo.
 - One human owner login and one local external-agent identity in `~/.mycel`.
+- Local runtime daemon started through the installed `cel` CLI.
 - Optional Claude Code or Codex provider hook using the launched external
   identity.
 
@@ -21,27 +22,35 @@ notification inbox while durable chat messages remain in the normal chat store.
    through `http_proxy`/`https_proxy`, set `LEON_SUPABASE_HTTP_TRUST_ENV=1`.
 2. Create or reuse a human owner login with `cel login`.
 3. Create an external user from that owner with `cel agent external create ...`.
-4. Launch the external runtime through `cel codex ...` or `cel claude ...`.
-5. Create a direct or group chat that includes the external user.
+4. Start the local runtime daemon.
+5. Launch the external runtime through `cel codex ...` or `cel claude ...`.
+6. Create a direct or group chat that includes the external user.
 
 ## Flow
 
 1. As another chat member, send a normal chat message to the chat.
-2. As the launched external process, run
-   `cel internal notify drain --format agent-context`.
+2. Trigger the launched external process through a provider hook event. For a
+   direct CLI probe, use `cel internal hook codex` or `cel internal hook claude`;
+   the hook path must read local runtime IPC/cache, not open a backend wait.
 3. Confirm the notification names event type, sender, and chat id but does not
    contain the chat message body.
-4. Use `cel chat show <chat-id>` to inspect bodies.
-5. Use `cel chat read <chat-id>` before replying.
-6. Use `cel chat send <chat-id> "..."` to reply as the external user.
+4. Use `cel chat read <chat-id>` to inspect bodies and advance the read cursor.
+5. Use `cel chat send <chat-id> "..."` to reply as the external user.
+6. Trigger the hook again and confirm the already-read notification does not
+   repeat.
+7. Send several messages from the same sender in the same chat, reading between
+   them, and confirm each fresh message still produces a fresh hook
+   notification.
 
 ## Pass Criteria
 
 - The external inbox item is produced by backend runtime delivery, not by a CLI
   polling shortcut.
-- The notification drain is authenticated as the external user and only drains
-  that user's inbox.
+- The hook drain is authenticated as the external user and only drains that
+  user's local runtime inbox.
 - The notification is metadata-only; chat bodies are read through chat APIs.
+- Consecutive chat notifications are distinguished by stable message identity,
+  not only by summary fields such as sender name or unread count.
 - The reply appears as a normal chat message from the external user's identity.
 
 ## Failure Signals


### PR DESCRIPTION
## Summary\n- update the external runtime inbox YATU to reflect daemon-backed hook drain\n- require read-cursor proof and repeated-message notification proof\n- keep the scenario on product surfaces rather than backend queue internals\n\n## Verification\n- git diff --check\n- rg check confirmed no concrete local YATU artifact path was added