### PR TITLE
fix: keep chat sends durable when managed agent is cold

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from enum import Enum
 from typing import Any
 
@@ -14,6 +15,8 @@ from protocols.agent_runtime import (
     AgentRuntimeActor,
     AgentRuntimeMessage,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
@@ -50,7 +53,8 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
                 activity_reader=activity_reader,
             )
             if thread_id is None:
-                raise RuntimeError(f"Agent chat recipient has no runtime thread: {request.recipient_id}")
+                logger.info("Skipped chat wake for agent without runtime thread: %s", request.recipient_id)
+                return
         else:
             raise RuntimeError(f"Chat delivery recipient type is not runtime-addressable: {recipient_type}")
         envelope = AgentChatDeliveryEnvelope(

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from enum import Enum
 from typing import Any
 
@@ -14,6 +15,8 @@ from protocols.agent_runtime import (
     AgentRuntimeNotificationEnvelope,
     AgentThreadInputEnvelope,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -62,7 +65,8 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
             activity_reader=activity_reader,
         )
         if thread_id is None:
-            raise RuntimeError(f"Chat join request requester agent has no runtime thread: {requester_id}")
+            logger.info("Skipped chat join wake for agent without runtime thread: %s", requester_id)
+            return
 
         await get_agent_runtime_gateway(app).dispatch_thread_input(
             AgentThreadInputEnvelope(

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from enum import Enum
 from typing import Any
 
@@ -20,6 +21,8 @@ _DECISION_VERBS: dict[RelationshipEvent, str] = {
     "approve": "approved",
     "reject": "rejected",
 }
+
+logger = logging.getLogger(__name__)
 
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -63,7 +66,8 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
             activity_reader=activity_reader,
         )
         if thread_id is None:
-            raise RuntimeError(f"Relationship request target agent has no runtime thread: {target_id}")
+            logger.info("Skipped relationship request wake for agent without runtime thread: %s", target_id)
+            return
 
         await get_agent_runtime_gateway(app).dispatch_thread_input(
             AgentThreadInputEnvelope(
@@ -134,7 +138,8 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
             activity_reader=activity_reader,
         )
         if thread_id is None:
-            raise RuntimeError(f"Relationship decision requester agent has no runtime thread: {requester_id}")
+            logger.info("Skipped relationship decision wake for agent without runtime thread: %s", requester_id)
+            return
 
         await get_agent_runtime_gateway(app).dispatch_thread_input(
             AgentThreadInputEnvelope(

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -93,6 +93,44 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_delivery_hook_skips_agent_wake_when_no_runtime_thread() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_chat(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway),
+            thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        )
+    )
+    deliver = owner_chat_inlet.make_chat_delivery_fn(
+        app,
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=app.state.thread_repo,
+    )
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+        content="hello",
+        sender_name="Human",
+        sender_type="human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        unread_count=3,
+        signal=None,
+    )
+
+    await asyncio.to_thread(deliver, request)
+
+    assert gateway.called is False
+
+
+@pytest.mark.asyncio
 async def test_chat_delivery_hook_routes_external_user_to_external_runtime_without_thread() -> None:
     class RecordingGateway:
         envelope = None

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -121,6 +121,42 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
 
 
 @pytest.mark.asyncio
+async def test_chat_join_rejection_notification_skips_agent_wake_when_no_runtime_thread() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
+        }.get(uid)
+    )
+    notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        {
+            "id": "chat_join:chat-1:agent-user-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "agent-user-1",
+            "state": "rejected",
+            "decided_by_user_id": "owner-1",
+        },
+    )
+
+    assert gateway.called is False
+
+
+@pytest.mark.asyncio
 async def test_chat_join_rejection_notification_ignores_human_requester() -> None:
     class RecordingGateway:
         called = False

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -175,7 +175,7 @@ async def test_relationship_request_notification_does_not_dispatch_to_non_agent_
 
 
 @pytest.mark.asyncio
-async def test_relationship_request_notification_fails_when_agent_target_has_no_runtime_thread() -> None:
+async def test_relationship_request_notification_skips_agent_wake_when_no_runtime_thread() -> None:
     class RecordingGateway:
         called = False
 
@@ -196,8 +196,7 @@ async def test_relationship_request_notification_fails_when_agent_target_has_no_
         user_repo=user_repo,
     )
 
-    with pytest.raises(RuntimeError, match="Relationship request target agent has no runtime thread: agent-user-1"):
-        await asyncio.to_thread(notify, _relationship_row())
+    await asyncio.to_thread(notify, _relationship_row())
 
     assert gateway.called is False
 
@@ -324,6 +323,42 @@ async def test_relationship_decision_notification_ignores_non_agent_requester() 
         notify,
         _relationship_row(user_low="human-user-1", user_high="human-user-2", initiator_user_id="human-user-1"),
         "reject",
+    )
+
+    assert gateway.called is False
+
+
+@pytest.mark.asyncio
+async def test_relationship_decision_notification_skips_agent_wake_when_no_runtime_thread() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_thread_input(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
+        }.get(uid)
+    )
+    notify = relationship_inlet.make_relationship_decision_notification_fn(
+        _hook_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        user_repo=user_repo,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _relationship_row(
+            user_low="agent-user-1",
+            user_high="human-user-1",
+            initiator_user_id="agent-user-1",
+            state="visit",
+        ),
+        "approve",
     )
 
     assert gateway.called is False


### PR DESCRIPTION
## Summary
- keep durable chat sends successful when a managed-agent recipient has no runtime thread to wake
- apply the same no-runtime-thread no-op wake semantics to chat, chat-join, and relationship runtime inlets
- preserve downstream gateway fail-loud behavior for malformed envelopes and real runtime gateway failures

## Verification
- uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/messaging/test_runtime_thread_selector.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q
- uv run pytest tests/Unit/backend/web/services tests/Unit/messaging -q
- YATU: ~/share/ops/yatu-artifacts/cel-managed-agent-cold-wake-fix-20260430T223829+0800/summary.md