### PR TITLE
docs: clarify chat wake without runtime thread

### DIFF
--- a/docs/en/multi-agent-chat.mdx
+++ b/docs/en/multi-agent-chat.mdx
@@ -25,7 +25,8 @@ flowchart LR
     T --> Chat
 ```
 
-Every participant on the platform is either a human user or an Agent User. When a message arrives for an Agent User, the system wakes its Thread to process it.
+Every participant on the platform is either a human user or an Agent User. When a message arrives for an Agent User, the system tries to wake its Thread to process it.
+If no runtime Thread exists yet, the message is still stored in Chat; only the wake hint is skipped.
 
 ## Creating an agent
 
@@ -47,7 +48,7 @@ Every participant on the platform is either a human user or an Agent User. When 
     | MCP servers | Advanced external service integrations (GitHub, databases, etc.) |
   </Step>
   <Step title="Set to active">
-    Change status from `draft` to `active` and save. The backend stores the Agent Config and Agent User identity. The Thread is created automatically on first message.
+    Change status from `draft` to `active` and save. The backend stores the Agent Config and Agent User identity. A runtime Thread is created when the agent is opened or started through the Thread surface; Chat delivery then wakes that existing Thread.
   </Step>
 </Steps>
 
@@ -113,7 +114,7 @@ sequenceDiagram
     H->>API: POST /api/chats/{id}/messages
     API->>DB: Store message
     API->>H: SSE push (message event)
-    API->>Q: Enqueue notification
+    API->>Q: Enqueue wake hint when a runtime thread is addressable
     Q->>T: Wake thread (if idle)
     T->>API: read_messages (get actual message)
     T->>T: Process message
@@ -124,6 +125,7 @@ sequenceDiagram
 
 <Note>
   Notifications don't include message content — the agent must call `read_messages` to read them. This enforces a consistent **read → respond** pattern and prevents agents from acting on stale summaries.
+  Wake is best-effort. Chat persistence is not rolled back when no runtime Thread is currently addressable.
 </Note>
 
 ## Real-time updates

--- a/docs/zh/multi-agent-chat.mdx
+++ b/docs/zh/multi-agent-chat.mdx
@@ -25,6 +25,8 @@ flowchart LR
     T --> Chat
 ```
 
+每个参与者都是人类用户或 Agent User。消息进入 Chat 后会先持久化；如果 Agent 当前有可寻址的运行 Thread，系统会发送唤醒提示。若还没有运行 Thread，消息仍然保留在 Chat 中，只是跳过唤醒。
+
 ## 创建一个 Agent
 
 <Steps>
@@ -45,7 +47,7 @@ flowchart LR
     | MCP 服务器 | 高级外部服务集成（GitHub、数据库等） |
   </Step>
   <Step title="设为激活状态">
-    将状态从 `draft` 改为 `active` 并保存。后端保存 Agent Config 和 Agent User 身份。Thread 在首次收到消息时自动创建。
+    将状态从 `draft` 改为 `active` 并保存。后端保存 Agent Config 和 Agent User 身份。运行 Thread 会在用户通过 Thread 界面打开或启动 Agent 时创建；之后 Chat 投递会唤醒这个已有 Thread。
   </Step>
 </Steps>
 
@@ -109,7 +111,7 @@ sequenceDiagram
     H->>API: POST /api/chats/{id}/messages
     API->>DB: 存储消息
     API->>H: SSE 推送（message 事件）
-    API->>Q: 入队通知
+    API->>Q: 若存在可寻址运行 Thread，则入队唤醒提示
     Q->>T: 唤醒 Thread（若空闲）
     T->>API: read_messages（读取实际消息）
     T->>T: 处理消息
@@ -120,6 +122,7 @@ sequenceDiagram
 
 <Note>
   通知不包含消息内容 — Agent 必须调用 `read_messages` 才能读到。这强制执行「先读后发」的一致模式。
+  唤醒是 best-effort；如果当前没有可寻址的运行 Thread，Chat 消息不会回滚，只会跳过唤醒。
 </Note>
 
 ## 联系人与投递设置

--- a/tests/yatu/chat-wake-policy.md
+++ b/tests/yatu/chat-wake-policy.md
@@ -56,6 +56,8 @@ Targeted/no-wake flow:
 - After the second send, Agent 1, Agent 2, and Agent 3 can all reply.
 - Message visibility and read/unread behavior are still normal chat behavior;
   wake policy only changes runtime interruption.
+- If a managed-agent recipient has no runtime thread, the message still
+  persists and remains readable; only the runtime wake is skipped.
 
 ## Pitfalls
 

--- a/tests/yatu/external-managed-agent-chat.md
+++ b/tests/yatu/external-managed-agent-chat.md
@@ -32,15 +32,22 @@ chat surface a user sees.
 2. Read the target chat with `cel chat show <chat-id>`.
 3. Send a natural message asking the managed agent to reply in the chat with
    `cel chat send <chat-id> "..."`.
-4. If the managed agent is muted or attention-controlled, use the public
+4. If the managed agent has no runtime thread yet, the send should still
+   succeed and the message should remain visible in chat; only the wake is
+   skipped.
+5. Open or start the managed agent through the normal Thread surface.
+6. Send another natural message asking for a reply.
+7. If the managed agent is muted or attention-controlled, use the public
    mention flag rather than editing hidden state.
-5. Read the chat again.
+8. Read the chat again.
 
 ## Pass Criteria
 
 - The external identity is derived from the launched local identity token.
 - The CLI does not ask for a sender user id.
 - Relationship or group access is enforced by the backend.
+- A cold managed agent without a runtime thread does not make the external
+  `cel chat send` fail.
 - The managed agent's reply arrives as a normal chat message.
 - The external identity can continue the conversation after marking messages
   read.


### PR DESCRIPTION
## Summary
- document that chat persistence is independent from runtime wake delivery
- remove stale wording that implied chat send auto-creates a managed-agent runtime thread
- update YATU cards to cover cold managed-agent recipients

## Verification
- git diff --check
- previous YATU: ~/share/ops/yatu-artifacts/cel-managed-agent-cold-wake-fix-20260430T223829+0800/summary.md