### PR TITLE
fix: make runtime chat notifications durable projections

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -46,7 +46,6 @@ def drain_runtime_inbox_items(
 ) -> list[dict[str, Any]]:
     items = queue_manager.drain_all(external_inbox_key(user_id))
     drained: list[dict[str, Any]] = []
-    chat_ids: set[str] = set()
     for item in items:
         try:
             payload = json.loads(item.content)
@@ -59,13 +58,10 @@ def drain_runtime_inbox_items(
         payload["sender_id"] = item.sender_id
         payload["sender_name"] = item.sender_name
         if payload["notification_type"] == "chat":
-            chat_id = payload.get("chat_id")
-            if isinstance(chat_id, str) and chat_id:
-                chat_ids.add(chat_id)
             continue
         drained.append(payload)
-    if messaging_service is not None and chat_ids:
-        drained.extend(chat_runtime_notifications(user_id, messaging_service, chat_ids=chat_ids))
+    if messaging_service is not None:
+        drained.extend(chat_runtime_notifications(user_id, messaging_service))
     return drained
 
 

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -114,6 +114,65 @@ def test_drain_runtime_inbox_items_replaces_queued_chat_tokens_with_unread_proje
     )
 
 
+def test_drain_runtime_inbox_items_projects_unread_chat_after_wake_token_is_gone() -> None:
+    queued = [
+        SimpleNamespace(
+            content='{"event_type":"chat.message","chat_id":"chat-2"}',
+            notification_type="chat",
+            source="external",
+            sender_id="human-user-1",
+            sender_name="Human",
+        )
+    ]
+
+    def _drain_all(_key: str) -> list[SimpleNamespace]:
+        items = list(queued)
+        queued.clear()
+        return items
+
+    messaging_service = SimpleNamespace(
+        list_chats_for_user=lambda _user_id: [
+            {
+                "id": "chat-2",
+                "unread_count": 1,
+                "last_message": {
+                    "id": "msg-2",
+                    "seq": 8,
+                    "sender_name": "Human",
+                    "content": "must not leak",
+                },
+            }
+        ]
+    )
+
+    first = drain_runtime_inbox_items(
+        "external-user-1",
+        SimpleNamespace(drain_all=_drain_all),
+        messaging_service=messaging_service,
+    )
+    second = drain_runtime_inbox_items(
+        "external-user-1",
+        SimpleNamespace(drain_all=_drain_all),
+        messaging_service=messaging_service,
+    )
+
+    assert (
+        first
+        == second
+        == [
+            {
+                "event_type": "chat.message",
+                "notification_type": "chat",
+                "chat_id": "chat-2",
+                "message_id": "msg-2",
+                "message_seq": 8,
+                "sender_name": "Human",
+                "unread_count": 1,
+            }
+        ]
+    )
+
+
 def test_drain_runtime_inbox_items_drops_chat_token_when_chat_is_already_read() -> None:
     queue_manager = SimpleNamespace(
         drain_all=lambda _key: [


### PR DESCRIPTION
## Summary\n- Treat chat runtime notifications as unread chat projections instead of one-shot queue tokens\n- Keep external queue tokens as wake signals while preserving non-chat durable queue drain behavior\n- Add regression coverage for a consumed chat wake token followed by a later drain\n\n## Verification\n- uv run ruff check backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py\n- uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py -q\n- uv run pytest tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py -q\n- YATU: cel runtime restart while unread chat message was sent offline; restart hook delivered the pending notification and cel chat read consumed the message