### PR TITLE
feat: add runtime inbox websocket stream

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -5,9 +5,10 @@ import json
 import threading
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 
 from backend.chat.api.http.dependencies import get_app, get_current_user_id
+from backend.chat.runtime_inbox_stream import RuntimeInboxStreamState
 from backend.threads.chat_adapters.external_inbox_handler import external_inbox_key
 
 router = APIRouter(prefix="/api/runtime", tags=["runtime"])
@@ -100,7 +101,7 @@ def wait_runtime_inbox_items(
             wake_bus.unregister(key)
 
 
-def _runtime_inbox_parts(app: Any) -> tuple[Any, Any, Any]:
+def _runtime_inbox_parts(app: Any) -> tuple[Any, Any, Any, RuntimeInboxStreamState]:
     runtime_state = getattr(app.state, "threads_runtime_state", None)
     queue_manager = getattr(runtime_state, "queue_manager", None)
     if queue_manager is None:
@@ -112,7 +113,60 @@ def _runtime_inbox_parts(app: Any) -> tuple[Any, Any, Any]:
     messaging_service = getattr(chat_runtime, "messaging_service", None)
     if messaging_service is None:
         raise HTTPException(500, "Messaging service unavailable")
-    return queue_manager, messaging_service, wake_bus
+    stream = getattr(runtime_state, "runtime_inbox_stream", None)
+    if stream is None:
+        raise HTTPException(500, "Runtime inbox stream unavailable")
+    return queue_manager, messaging_service, wake_bus, stream
+
+
+def _runtime_inbox_parts_for_websocket(websocket: WebSocket) -> tuple[Any, Any, Any, RuntimeInboxStreamState]:
+    try:
+        return _runtime_inbox_parts(websocket.app)
+    except HTTPException as exc:
+        raise RuntimeError(str(exc.detail)) from exc
+
+
+async def _websocket_user_id(websocket: WebSocket) -> str:
+    protocol = str(websocket.headers.get("sec-websocket-protocol") or "")
+    token = _bearer_subprotocol_token(protocol)
+    if not token:
+        raise RuntimeError("Missing runtime inbox websocket bearer subprotocol")
+    auth_service = getattr(getattr(websocket.app.state, "auth_runtime_state", None), "auth_service", None)
+    if auth_service is None:
+        raise RuntimeError("Auth service not initialized")
+    payload = auth_service.verify_token(token)
+    if not isinstance(payload, dict) or not payload.get("user_id"):
+        raise RuntimeError("Invalid runtime inbox websocket token")
+    user_id = str(payload["user_id"])
+    user_repo = getattr(websocket.app.state, "user_repo", None)
+    if user_repo is not None:
+        user = await asyncio.to_thread(user_repo.get_by_id, user_id)
+        if user is None:
+            raise RuntimeError("User no longer exists — please re-login")
+    return user_id
+
+
+def _bearer_subprotocol_token(protocol: str) -> str | None:
+    for item in (part.strip() for part in protocol.split(",")):
+        if item.startswith("bearer."):
+            return item.removeprefix("bearer.")
+    return None
+
+
+def _resume_since_from_payload(payload: Any) -> int | None:
+    if not isinstance(payload, dict) or payload.get("type") != "resume":
+        return None
+    return int(payload.get("since_seq") or 0)
+
+
+def _sequence_notifications(
+    user_id: str,
+    notifications: list[dict[str, Any]],
+    stream: RuntimeInboxStreamState,
+) -> list[dict[str, Any]]:
+    if not notifications:
+        return []
+    return stream.assign(user_id, notifications)
 
 
 @router.post("/inbox/drain")
@@ -120,7 +174,7 @@ async def drain_runtime_inbox(
     app: Annotated[Any, Depends(get_app)],
     user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> dict[str, Any]:
-    queue_manager, messaging_service, _wake_bus = _runtime_inbox_parts(app)
+    queue_manager, messaging_service, _wake_bus, stream = _runtime_inbox_parts(app)
     try:
         items = await asyncio.to_thread(
             drain_runtime_inbox_items,
@@ -130,6 +184,7 @@ async def drain_runtime_inbox(
         )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc
+    items = _sequence_notifications(user_id, items, stream)
     return {"count": len(items), "notifications": items}
 
 
@@ -139,7 +194,7 @@ async def wait_runtime_inbox(
     user_id: Annotated[str, Depends(get_current_user_id)],
     timeout_seconds: Annotated[float, Query(ge=0.0, le=30.0)] = 25.0,
 ) -> dict[str, Any]:
-    queue_manager, messaging_service, wake_bus = _runtime_inbox_parts(app)
+    queue_manager, messaging_service, wake_bus, stream = _runtime_inbox_parts(app)
     try:
         items = await asyncio.to_thread(
             wait_runtime_inbox_items,
@@ -151,4 +206,66 @@ async def wait_runtime_inbox(
         )
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc
+    items = _sequence_notifications(user_id, items, stream)
     return {"count": len(items), "notifications": items}
+
+
+@router.websocket("/inbox/subscribe")
+async def subscribe_runtime_inbox(websocket: WebSocket) -> None:
+    try:
+        user_id = await _websocket_user_id(websocket)
+        queue_manager, messaging_service, wake_bus, stream = _runtime_inbox_parts_for_websocket(websocket)
+    except RuntimeError:
+        await websocket.close(code=1008)
+        return
+    await websocket.accept()
+    inbox_id = external_inbox_key(user_id)
+    signal: asyncio.Queue[None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    def _wake() -> None:
+        loop.call_soon_threadsafe(signal.put_nowait, None)
+
+    async def _send_live_notifications() -> bool:
+        try:
+            items = await asyncio.to_thread(
+                drain_runtime_inbox_items,
+                user_id,
+                queue_manager,
+                messaging_service=messaging_service,
+            )
+        except RuntimeError as exc:
+            await websocket.close(code=1011, reason=str(exc))
+            return False
+        sequenced = stream.assign(user_id, items)
+        if not sequenced:
+            return True
+        since_seq = int(sequenced[0]["seq"]) - 1
+        last_seq = int(sequenced[-1]["seq"])
+        for frame in stream.frames_between(user_id, after_seq=since_seq, through_seq=last_seq):
+            await websocket.send_json(frame)
+        return True
+
+    wake_bus.register(inbox_id, _wake)
+    try:
+        resume_task = asyncio.create_task(websocket.receive_json())
+        signal_task = asyncio.create_task(signal.get())
+        done, pending = await asyncio.wait({resume_task, signal_task}, return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()
+        if resume_task in done:
+            since_seq = _resume_since_from_payload(resume_task.result())
+            if since_seq is not None:
+                for frame in stream.replay_since(user_id, since_seq):
+                    await websocket.send_json(frame)
+        else:
+            if not await _send_live_notifications():
+                return
+        while True:
+            await signal.get()
+            if not await _send_live_notifications():
+                return
+    except WebSocketDisconnect:
+        return
+    finally:
+        wake_bus.unregister(inbox_id)

--- a/backend/chat/runtime_inbox_stream.py
+++ b/backend/chat/runtime_inbox_stream.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RuntimeInboxFrame:
+    type: str
+    seq: int
+    fingerprint: str
+    ts: float
+    metadata: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "seq": self.seq,
+            "fingerprint": self.fingerprint,
+            "ts": self.ts,
+            "metadata": self.metadata,
+        }
+
+
+class RuntimeInboxStreamState:
+    def __init__(self, *, replay_limit: int = 256) -> None:
+        self._replay_limit = replay_limit
+        self._seq_by_user: dict[str, int] = defaultdict(int)
+        self._frames_by_user: dict[str, deque[RuntimeInboxFrame]] = defaultdict(lambda: deque(maxlen=replay_limit))
+        self._lock = threading.Lock()
+
+    def assign(self, user_id: str, notifications: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        sequenced: list[dict[str, Any]] = []
+        with self._lock:
+            for notification in notifications:
+                self._seq_by_user[user_id] += 1
+                seq = self._seq_by_user[user_id]
+                metadata = dict(notification)
+                sequenced_item = {"seq": seq, **metadata}
+                self._frames_by_user[user_id].append(
+                    RuntimeInboxFrame(
+                        type="notify",
+                        seq=seq,
+                        fingerprint=fingerprint_runtime_notification(metadata),
+                        ts=time.time(),
+                        metadata=metadata,
+                    )
+                )
+                sequenced.append(sequenced_item)
+        return sequenced
+
+    def replay_since(self, user_id: str, since_seq: int) -> list[dict[str, Any]]:
+        with self._lock:
+            frames = list(self._frames_by_user[user_id])
+        if frames and since_seq < frames[0].seq - 1:
+            return [
+                {
+                    "type": "replay_overflow",
+                    "since_seq": since_seq,
+                    "oldest_seq": frames[0].seq,
+                }
+            ]
+        return [frame.as_dict() for frame in frames if frame.seq > since_seq]
+
+    def frames_between(self, user_id: str, *, after_seq: int, through_seq: int) -> list[dict[str, Any]]:
+        with self._lock:
+            frames = list(self._frames_by_user[user_id])
+        return [frame.as_dict() for frame in frames if after_seq < frame.seq <= through_seq]
+
+
+def fingerprint_runtime_notification(metadata: dict[str, Any]) -> str:
+    payload = json.dumps(metadata, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -5,6 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
+from backend.chat.runtime_inbox_stream import RuntimeInboxStreamState
 from backend.chat.runtime_inbox_wake import PostgresRuntimeInboxWakeBus, RuntimeInboxWakeBus
 from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from core.runtime.middleware.queue import MessageQueueManager
@@ -14,6 +15,7 @@ from core.runtime.middleware.queue import MessageQueueManager
 class ThreadsRuntimeState:
     queue_manager: Any
     runtime_inbox_wake_bus: Any
+    runtime_inbox_stream: Any
     agent_runtime_gateway: Any
     activity_reader: Any
     messaging_service: Any | None = None
@@ -36,6 +38,7 @@ def attach_threads_runtime(
 ) -> ThreadsRuntimeState:
     app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
     app.state.runtime_inbox_wake_bus = build_runtime_inbox_wake_bus()
+    app.state.runtime_inbox_stream = RuntimeInboxStreamState()
     app.state.agent_pool = {}
     app.state.thread_sandbox = {}
     app.state.thread_cwd = {}
@@ -56,6 +59,7 @@ def attach_threads_runtime(
     state = ThreadsRuntimeState(
         queue_manager=app.state.queue_manager,
         runtime_inbox_wake_bus=app.state.runtime_inbox_wake_bus,
+        runtime_inbox_stream=app.state.runtime_inbox_stream,
         agent_runtime_gateway=runtime_state.gateway,
         activity_reader=runtime_state.activity_reader,
         messaging_service=messaging_service,

--- a/tests/Unit/backend/test_threads_bootstrap.py
+++ b/tests/Unit/backend/test_threads_bootstrap.py
@@ -11,6 +11,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     queue_manager = object()
     gateway = object()
     activity_reader = object()
+    runtime_inbox_stream = object()
     typing_tracker = object()
     messaging_service = object()
     relationship_service = object()
@@ -34,6 +35,11 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     )
     monkeypatch.setattr(
         threads_bootstrap,
+        "RuntimeInboxStreamState",
+        lambda: seen.append(("runtime_inbox_stream", app)) or runtime_inbox_stream,
+    )
+    monkeypatch.setattr(
+        threads_bootstrap,
         "build_agent_runtime_state",
         lambda target_app, *, typing_tracker: (
             seen.append(("runtime_state", target_app))
@@ -53,6 +59,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
 
     assert app.state.queue_manager is queue_manager
     assert app.state.runtime_inbox_wake_bus is runtime_inbox_wake_bus
+    assert app.state.runtime_inbox_stream is runtime_inbox_stream
     assert app.state.agent_pool == {}
     assert app.state.thread_sandbox == {}
     assert app.state.thread_cwd == {}
@@ -63,6 +70,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert app.state.threads_runtime_state is state
     assert state.queue_manager is queue_manager
     assert state.runtime_inbox_wake_bus is runtime_inbox_wake_bus
+    assert state.runtime_inbox_stream is runtime_inbox_stream
     assert state.agent_runtime_gateway is gateway
     assert state.activity_reader is activity_reader
     assert state.messaging_service is messaging_service
@@ -75,6 +83,7 @@ def test_attach_threads_runtime_wires_runtime_dependencies(monkeypatch):
     assert seen == [
         ("queue_manager", queue_repo),
         ("runtime_inbox_wake_bus", app),
+        ("runtime_inbox_stream", app),
         ("runtime_state", app),
         ("typing_tracker", typing_tracker),
     ]

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -5,13 +5,20 @@ import time
 from types import SimpleNamespace
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from backend.chat.api.http.runtime_inbox_router import (
     chat_runtime_notifications,
+    drain_runtime_inbox,
     drain_runtime_inbox_items,
     wait_runtime_inbox,
     wait_runtime_inbox_items,
 )
+from backend.chat.api.http.runtime_inbox_router import (
+    router as runtime_inbox_router,
+)
+from backend.chat.runtime_inbox_stream import RuntimeInboxStreamState
 from core.runtime.middleware.queue.manager import MessageQueueManager
 
 
@@ -435,7 +442,11 @@ async def test_wait_runtime_inbox_endpoint_returns_count_and_notifications() -> 
     )
     app = SimpleNamespace(
         state=SimpleNamespace(
-            threads_runtime_state=SimpleNamespace(queue_manager=queue_manager, runtime_inbox_wake_bus=wake_bus),
+            threads_runtime_state=SimpleNamespace(
+                queue_manager=queue_manager,
+                runtime_inbox_wake_bus=wake_bus,
+                runtime_inbox_stream=RuntimeInboxStreamState(),
+            ),
             chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace(list_chats_for_user=lambda _user_id: [])),
         )
     )
@@ -451,3 +462,143 @@ async def test_wait_runtime_inbox_endpoint_returns_count_and_notifications() -> 
         ("register", "external:external-user-1"),
         ("unregister", "external:external-user-1"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_drain_runtime_inbox_endpoint_assigns_monotonic_seq() -> None:
+    queue_manager = SimpleNamespace(
+        drain_all=lambda _key: [
+            SimpleNamespace(
+                content='{"event_type":"relationship.requested","summary":"Human requested contact."}',
+                notification_type="relationship",
+                source="external",
+                sender_id="human-user-1",
+                sender_name="Human",
+            )
+        ]
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            threads_runtime_state=SimpleNamespace(
+                queue_manager=queue_manager,
+                runtime_inbox_wake_bus=SimpleNamespace(),
+                runtime_inbox_stream=RuntimeInboxStreamState(),
+            ),
+            chat_runtime_state=SimpleNamespace(messaging_service=SimpleNamespace(list_chats_for_user=lambda _user_id: [])),
+        )
+    )
+
+    result = await drain_runtime_inbox(app, "external-user-1")
+
+    assert result["notifications"] == [
+        {
+            "seq": 1,
+            "event_type": "relationship.requested",
+            "summary": "Human requested contact.",
+            "notification_type": "relationship",
+            "source": "external",
+            "sender_id": "human-user-1",
+            "sender_name": "Human",
+        }
+    ]
+
+
+def test_runtime_inbox_websocket_streams_metadata_frame_after_wake(tmp_path) -> None:
+    app, queue_manager, wake_bus = _runtime_ws_test_app("external-user-1", tmp_path)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/runtime/inbox/subscribe", subprotocols=["bearer.tok-1"]) as websocket:
+            _wait_for_wake_handler(wake_bus, "external:external-user-1")
+            queue_manager.enqueue(
+                '{"event_type":"relationship.requested","summary":"Human requested contact."}',
+                "external:external-user-1",
+                notification_type="relationship",
+                source="external",
+                sender_id="human-user-1",
+                sender_name="Human",
+                wake=False,
+            )
+            wake_bus.publish("external:external-user-1")
+
+            frame = websocket.receive_json()
+
+    assert frame == {
+        "type": "notify",
+        "seq": 1,
+        "fingerprint": frame["fingerprint"],
+        "ts": frame["ts"],
+        "metadata": {
+            "event_type": "relationship.requested",
+            "summary": "Human requested contact.",
+            "notification_type": "relationship",
+            "source": "external",
+            "sender_id": "human-user-1",
+            "sender_name": "Human",
+        },
+    }
+    assert "content" not in str(frame).lower()
+
+
+def test_runtime_inbox_websocket_replays_after_resume(tmp_path) -> None:
+    app, queue_manager, wake_bus = _runtime_ws_test_app("external-user-1", tmp_path)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/runtime/inbox/subscribe", subprotocols=["bearer.tok-1"]) as websocket:
+            _wait_for_wake_handler(wake_bus, "external:external-user-1")
+            queue_manager.enqueue(
+                '{"event_type":"relationship.requested","summary":"Human requested contact."}',
+                "external:external-user-1",
+                notification_type="relationship",
+                source="external",
+                sender_id="human-user-1",
+                sender_name="Human",
+                wake=False,
+            )
+            wake_bus.publish("external:external-user-1")
+            first = websocket.receive_json()
+
+        with client.websocket_connect("/api/runtime/inbox/subscribe", subprotocols=["bearer.tok-1"]) as websocket:
+            websocket.send_json({"type": "resume", "since_seq": 0})
+            replay = websocket.receive_json()
+
+    assert replay == first
+
+
+def test_runtime_inbox_stream_reports_replay_overflow() -> None:
+    stream = RuntimeInboxStreamState(replay_limit=1)
+
+    stream.assign("external-user-1", [{"event_type": "relationship.one"}])
+    stream.assign("external-user-1", [{"event_type": "relationship.two"}])
+
+    assert stream.replay_since("external-user-1", 0) == [
+        {
+            "type": "replay_overflow",
+            "since_seq": 0,
+            "oldest_seq": 2,
+        }
+    ]
+
+
+def _runtime_ws_test_app(user_id: str, tmp_path) -> tuple[FastAPI, MessageQueueManager, _SharedRuntimeInboxWakeBus]:
+    app = FastAPI()
+    queue_manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
+    wake_bus = _SharedRuntimeInboxWakeBus()
+    app.state.auth_runtime_state = SimpleNamespace(
+        auth_service=SimpleNamespace(verify_token=lambda token: {"user_id": user_id} if token == "tok-1" else None)
+    )
+    app.state.user_repo = SimpleNamespace(get_by_id=lambda seen: object() if seen == user_id else None)
+    app.state.threads_runtime_state = SimpleNamespace(
+        queue_manager=queue_manager,
+        runtime_inbox_wake_bus=wake_bus,
+        runtime_inbox_stream=RuntimeInboxStreamState(),
+    )
+    app.state.chat_runtime_state = SimpleNamespace(messaging_service=SimpleNamespace(list_chats_for_user=lambda _user_id: []))
+    app.include_router(runtime_inbox_router)
+    return app, queue_manager, wake_bus
+
+
+def _wait_for_wake_handler(wake_bus: _SharedRuntimeInboxWakeBus, inbox_id: str) -> None:
+    deadline = time.monotonic() + 1.0
+    while inbox_id not in wake_bus.handlers and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert inbox_id in wake_bus.handlers

--- a/tests/yatu/external-runtime-inbox.md
+++ b/tests/yatu/external-runtime-inbox.md
@@ -46,6 +46,20 @@ notification inbox while durable chat messages remain in the normal chat store.
    the provider hook. The hook should surface the unread chat notification
    before the user calls `cel chat read`.
 
+## WebSocket Stream Variant
+
+1. Open `/api/runtime/inbox/subscribe` with the external user's token carried as
+   `Sec-WebSocket-Protocol: bearer.<token>`.
+2. Send a chat or relationship notification to that external user from another
+   real user.
+3. Confirm the socket receives a `notify` frame with a monotonic `seq`,
+   `fingerprint`, timestamp, and metadata only.
+4. Close the socket, send another notification, reconnect, and send
+   `{"type":"resume","since_seq":<last-seen-seq>}`.
+5. Confirm replay returns the missed frame in order. If replay retention is
+   exceeded, confirm the socket reports `replay_overflow` and the local daemon
+   falls back to authenticated HTTP drain for catch-up.
+
 ## Pass Criteria
 
 - The external inbox item is produced by backend runtime delivery, not by a CLI
@@ -58,6 +72,8 @@ notification inbox while durable chat messages remain in the normal chat store.
 - The notification is metadata-only; chat bodies are read through chat APIs.
 - Consecutive chat notifications are distinguished by stable message identity,
   not only by summary fields such as sender name or unread count.
+- WebSocket steady-state delivery and HTTP drain catch-up share the same
+  metadata projection and monotonic sequence source.
 - A daemon restart does not lose a chat notification just because an old wait
   request consumed a wake token while the local daemon was stopping.
 - The reply appears as a normal chat message from the external user's identity.


### PR DESCRIPTION
Summary
- add a per-user runtime inbox stream state with monotonic seq, metadata fingerprints, replay, and replay_overflow reporting
- expose /api/runtime/inbox/subscribe as a token-derived WebSocket stream over existing runtime inbox queue/wake bus and unread chat projection
- include seq on HTTP drain/wait catch-up notifications and document the WebSocket YATU path

Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest -q  (2121 passed, 8 skipped)
