### PR TITLE
fix: forward runtime inbox websocket upgrades

### DIFF
--- a/frontend/app/nginx.conf
+++ b/frontend/app/nginx.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     listen 80;
     server_name _;
@@ -7,9 +12,12 @@ server {
     # Proxy API calls to the backend service (docker-compose internal network)
     location /api/ {
         proxy_pass http://backend:8900;
+        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
 
         # SSE support (streaming responses)
         proxy_buffering off;

--- a/tests/Unit/frontend/test_nginx_proxy_config.py
+++ b/tests/Unit/frontend/test_nginx_proxy_config.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_frontend_api_proxy_forwards_websocket_upgrade() -> None:
+    config = Path("frontend/app/nginx.conf").read_text(encoding="utf-8")
+
+    assert "map $http_upgrade $connection_upgrade" in config
+    assert "proxy_http_version 1.1;" in config
+    assert "proxy_set_header Upgrade $http_upgrade;" in config
+    assert "proxy_set_header Connection $connection_upgrade;" in config


### PR DESCRIPTION
## Summary\n- forward WebSocket Upgrade headers through the frontend /api reverse proxy\n- add a small regression test for the nginx API proxy contract\n\n## Verification\n- uv run pytest -q tests/Unit/frontend/test_nginx_proxy_config.py\n- uv run ruff format --check .\n- uv run ruff check .\n- git diff --check\n\n## Live smoke before fix\n- https://mycel.nextmind.space/api/runtime/inbox/drain -> 401 without auth\n- wss://mycel.nextmind.space/api/runtime/inbox/subscribe -> 404 during handshake, because the frontend proxy did not forward Upgrade\n