### PR TITLE
feat: add chat workflow data plane

### DIFF
--- a/backend/chat/api/http/app_router.py
+++ b/backend/chat/api/http/app_router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from backend.chat.api.http import (
+    chat_workflow_router,
     chats_router,
     conversations_router,
     relationships_router,
@@ -10,6 +11,7 @@ from backend.chat.api.http import (
 router = APIRouter()
 
 router.include_router(chats_router.router)
+router.include_router(chat_workflow_router.router)
 router.include_router(relationships_router.router)
 router.include_router(conversations_router.router)
 router.include_router(runtime_inbox_router.router)

--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from backend.chat.api.http.dependencies import (
+    get_accessible_chat_or_404,
+    get_chat_repo,
+    get_chat_task_service,
+    get_chat_workflow_service,
+    get_current_user_id,
+    get_messaging_service,
+)
+
+router = APIRouter(prefix="/api/chats", tags=["chats"])
+
+
+class SetChatWorkflowBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    state: str = "active"
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class CreateChatTaskBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subject: str
+    description: str
+    active_form: str | None = None
+    owner: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateChatTaskBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str | None = None
+    subject: str | None = None
+    description: str | None = None
+    active_form: str | None = None
+    owner: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+@router.get("/{chat_id}/workflow")
+def get_chat_workflow(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_service: Annotated[Any, Depends(get_chat_workflow_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    workflow = chat_workflow_service.get_workflow(chat_id)
+    if workflow is None:
+        raise HTTPException(404, "Chat workflow not found")
+    return workflow
+
+
+@router.put("/{chat_id}/workflow")
+def set_chat_workflow(
+    chat_id: str,
+    body: SetChatWorkflowBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_service: Annotated[Any, Depends(get_chat_workflow_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    return chat_workflow_service.set_workflow(
+        chat_id,
+        kind=body.kind,
+        state=body.state,
+        config=body.config,
+        updated_by_user_id=user_id,
+    )
+
+
+@router.delete("/{chat_id}/workflow")
+def delete_chat_workflow(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_service: Annotated[Any, Depends(get_chat_workflow_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    chat_workflow_service.delete_workflow(chat_id)
+    return {"status": "deleted"}
+
+
+@router.get("/{chat_id}/tasks")
+def list_chat_tasks(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_task_service: Annotated[Any, Depends(get_chat_task_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    return chat_task_service.list_tasks(chat_id)
+
+
+@router.post("/{chat_id}/tasks")
+def create_chat_task(
+    chat_id: str,
+    body: CreateChatTaskBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_task_service: Annotated[Any, Depends(get_chat_task_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    return chat_task_service.create_task(
+        chat_id,
+        subject=body.subject,
+        description=body.description,
+        active_form=body.active_form,
+        owner=body.owner,
+        metadata=body.metadata,
+    )
+
+
+@router.get("/{chat_id}/tasks/{task_id}")
+def get_chat_task(
+    chat_id: str,
+    task_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_task_service: Annotated[Any, Depends(get_chat_task_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    task = chat_task_service.get_task(chat_id, task_id)
+    if task is None:
+        raise HTTPException(404, "Chat task not found")
+    return task
+
+
+@router.patch("/{chat_id}/tasks/{task_id}")
+def update_chat_task(
+    chat_id: str,
+    task_id: str,
+    body: UpdateChatTaskBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_task_service: Annotated[Any, Depends(get_chat_task_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    task = chat_task_service.update_task(
+        chat_id,
+        task_id,
+        status=body.status,
+        subject=body.subject,
+        description=body.description,
+        active_form=body.active_form,
+        owner=body.owner,
+        metadata=body.metadata,
+    )
+    if task is None:
+        raise HTTPException(404, "Chat task not found")
+    return task
+
+
+@router.delete("/{chat_id}/tasks/{task_id}")
+def delete_chat_task(
+    chat_id: str,
+    task_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_task_service: Annotated[Any, Depends(get_chat_task_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    chat_task_service.delete_task(chat_id, task_id)
+    return {"status": "deleted"}

--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from backend.chat.api.http.dependencies import (
+    get_accessible_chat_or_404,
     get_chat_event_bus,
     get_chat_join_request_service,
     get_chat_repo,
@@ -80,12 +81,7 @@ def _verify_user_ownership(messaging_service: Any, sender_id: str, user_id: str)
 
 
 def _get_accessible_chat_or_404(chat_repo: Any, messaging_service: Any, chat_id: str, user_id: str) -> Any:
-    chat = chat_repo.get_by_id(chat_id)
-    if not chat:
-        raise HTTPException(404, "Chat not found")
-    if not messaging_service.is_chat_member(chat_id, user_id):
-        raise HTTPException(403, "Not a participant of this chat")
-    return chat
+    return get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
 
 
 def _resolve_display_user(messaging_service: Any, social_user_id: str) -> Any | None:

--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -38,6 +38,16 @@ def get_chat_join_request_service(app: Annotated[Any, Depends(get_app)]) -> Any:
     return runtime_state.chat_join_request_service
 
 
+def get_chat_workflow_service(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat workflow service unavailable")
+    return runtime_state.chat_workflow_service
+
+
+def get_chat_task_service(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat task service unavailable")
+    return runtime_state.chat_task_service
+
+
 def get_user_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "user_repo", "User repo unavailable")
 
@@ -59,6 +69,15 @@ def get_chat_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
 def get_chat_event_bus(app: Annotated[Any, Depends(get_app)]) -> Any:
     runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat event bus unavailable")
     return runtime_state.chat_event_bus
+
+
+def get_accessible_chat_or_404(chat_repo: Any, messaging_service: Any, chat_id: str, user_id: str) -> Any:
+    chat = chat_repo.get_by_id(chat_id)
+    if not chat:
+        raise HTTPException(404, "Chat not found")
+    if not messaging_service.is_chat_member(chat_id, user_id):
+        raise HTTPException(403, "Not a participant of this chat")
+    return chat
 
 
 def get_runtime_thread_activity_reader(app: Annotated[Any, Depends(get_app)]) -> Any:

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -10,6 +10,7 @@ from backend.threads.chat_adapters.relationship_inlet import (
     make_relationship_decision_notification_fn,
     make_relationship_request_notification_fn,
 )
+from core.work_item.chat_workflow.service import ChatTaskService, ChatWorkflowService
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.join_requests import ChatJoinRequestService
 from messaging.realtime.events import ChatEventBus
@@ -26,6 +27,8 @@ class ChatRuntimeState:
     typing_tracker: Any
     relationship_service: Any
     chat_join_request_service: Any
+    chat_workflow_service: Any
+    chat_task_service: Any
     messaging_service: Any
 
 
@@ -42,6 +45,8 @@ def attach_chat_runtime(
     messages_repo = storage_container.messages_repo()
     relationship_repo = storage_container.relationship_repo()
     chat_join_request_repo = storage_container.chat_join_request_repo()
+    chat_workflow_repo = storage_container.chat_workflow_repo()
+    chat_task_repo = storage_container.chat_task_repo()
     chat_event_bus = ChatEventBus()
     typing_tracker = TypingTracker(chat_event_bus)
     relationship_service = RelationshipService(relationship_repo)
@@ -70,6 +75,8 @@ def attach_chat_runtime(
         chat_join_request_repo=chat_join_request_repo,
         messaging_service=messaging_service,
     )
+    chat_workflow_service = ChatWorkflowService(workflow_repo=chat_workflow_repo)
+    chat_task_service = ChatTaskService(task_repo=chat_task_repo)
 
     # @@@chat-bootstrap-borrowable-state - chat bootstrap now keeps its owned
     # runtime objects inside the returned chat_runtime_state so the app
@@ -81,6 +88,8 @@ def attach_chat_runtime(
         typing_tracker=typing_tracker,
         relationship_service=relationship_service,
         chat_join_request_service=chat_join_request_service,
+        chat_workflow_service=chat_workflow_service,
+        chat_task_service=chat_task_service,
         messaging_service=messaging_service,
     )
     app.state.chat_runtime_state = state

--- a/core/tools/task/service.py
+++ b/core/tools/task/service.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry, make_tool_schema
 from core.tools.task.types import Task, TaskStatus
+from storage.contracts import WorkItemRepo
 from storage.runtime import build_tool_task_repo
 
 TASK_CREATE_SCHEMA = make_tool_schema(
@@ -110,7 +111,7 @@ class TaskService:
         self,
         registry: ToolRegistry,
         thread_id: str | None = None,
-        repo: Any | None = None,
+        repo: WorkItemRepo | None = None,
     ):
         self._repo = repo or build_tool_task_repo()
         self._default_thread_id = thread_id  # override for tests / single-agent TUI

--- a/core/tools/task/types.py
+++ b/core/tools/task/types.py
@@ -1,7 +1,6 @@
 from enum import StrEnum
-from typing import Any
 
-from pydantic import BaseModel, Field
+from core.work_item.types import WorkItem
 
 
 class TaskStatus(StrEnum):
@@ -10,43 +9,5 @@ class TaskStatus(StrEnum):
     COMPLETED = "completed"
 
 
-class Task(BaseModel):
-    id: str
-    subject: str
-    description: str
+class Task(WorkItem):
     status: TaskStatus = TaskStatus.PENDING
-    active_form: str | None = None  # Present continuous form for spinner
-    owner: str | None = None
-    blocks: list[str] = Field(default_factory=list)  # Task IDs this task blocks
-    blocked_by: list[str] = Field(default_factory=list)  # Task IDs blocking this task
-    metadata: dict[str, Any] = Field(default_factory=dict)
-
-    def is_blocked(self, all_tasks: dict[str, "Task"]) -> bool:
-        for task_id in self.blocked_by:
-            if task_id in all_tasks:
-                blocker = all_tasks[task_id]
-                if blocker.status != TaskStatus.COMPLETED:
-                    return True
-        return False
-
-    def to_summary(self) -> dict:
-        return {
-            "id": self.id,
-            "subject": self.subject,
-            "status": self.status.value,
-            "owner": self.owner,
-            "blockedBy": [bid for bid in self.blocked_by],
-        }
-
-    def to_detail(self) -> dict:
-        return {
-            "id": self.id,
-            "subject": self.subject,
-            "description": self.description,
-            "status": self.status.value,
-            "activeForm": self.active_form,
-            "owner": self.owner,
-            "blocks": self.blocks,
-            "blockedBy": self.blocked_by,
-            "metadata": self.metadata,
-        }

--- a/core/work_item/__init__.py
+++ b/core/work_item/__init__.py
@@ -1,0 +1,2 @@
+"""Shared work-item primitives."""
+

--- a/core/work_item/__init__.py
+++ b/core/work_item/__init__.py
@@ -1,2 +1,1 @@
 """Shared work-item primitives."""
-

--- a/core/work_item/chat_workflow/__init__.py
+++ b/core/work_item/chat_workflow/__init__.py
@@ -1,0 +1,1 @@
+"""Chat-scoped workflow services built on WorkItem primitives."""

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.work_item.types import WorkItem
+
+
+class ChatWorkflowService:
+    def __init__(self, workflow_repo: Any) -> None:
+        self._repo = workflow_repo
+
+    def get_workflow(self, chat_id: str) -> dict[str, Any] | None:
+        row = self._repo.get(chat_id)
+        return _workflow_response(row) if row is not None else None
+
+    def set_workflow(
+        self,
+        chat_id: str,
+        *,
+        kind: str,
+        state: str = "active",
+        config: dict[str, Any] | None = None,
+        updated_by_user_id: str | None = None,
+    ) -> dict[str, Any]:
+        return _workflow_response(
+            self._repo.upsert(
+                chat_id,
+                kind=kind,
+                state=state,
+                config=config or {},
+                updated_by_user_id=updated_by_user_id,
+            )
+        )
+
+    def delete_workflow(self, chat_id: str) -> None:
+        self._repo.delete(chat_id)
+
+
+class ChatTaskService:
+    def __init__(self, task_repo: Any) -> None:
+        self._repo = task_repo
+
+    def list_tasks(self, chat_id: str) -> list[dict[str, Any]]:
+        return [_task_response(item) for item in self._repo.list_all(chat_id)]
+
+    def get_task(self, chat_id: str, task_id: str) -> dict[str, Any] | None:
+        item = self._repo.get(chat_id, task_id)
+        return _task_response(item) if item is not None else None
+
+    def create_task(
+        self,
+        chat_id: str,
+        *,
+        subject: str,
+        description: str,
+        active_form: str | None = None,
+        owner: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        item = WorkItem(
+            id=self._repo.next_id(chat_id),
+            subject=subject,
+            description=description,
+            status="pending",
+            active_form=active_form,
+            owner=owner,
+            metadata=metadata or {},
+        )
+        self._repo.insert(chat_id, item)
+        return _task_response(item)
+
+    def update_task(
+        self,
+        chat_id: str,
+        task_id: str,
+        *,
+        status: str | None = None,
+        subject: str | None = None,
+        description: str | None = None,
+        active_form: str | None = None,
+        owner: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        item = self._repo.get(chat_id, task_id)
+        if item is None:
+            return None
+        if status is not None:
+            item.status = status
+        if subject is not None:
+            item.subject = subject
+        if description is not None:
+            item.description = description
+        if active_form is not None:
+            item.active_form = active_form
+        if owner is not None:
+            item.owner = owner
+        if metadata is not None:
+            item.metadata = dict(metadata)
+        self._repo.update(chat_id, item)
+        return _task_response(item)
+
+    def delete_task(self, chat_id: str, task_id: str) -> None:
+        self._repo.delete(chat_id, task_id)
+
+
+def _workflow_response(row: Any) -> dict[str, Any]:
+    return {
+        "chat_id": row.chat_id,
+        "kind": row.kind,
+        "state": row.state,
+        "config": dict(row.config),
+        "updated_by_user_id": row.updated_by_user_id,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+def _task_response(item: WorkItem) -> dict[str, Any]:
+    payload = item.to_detail()
+    payload["status"] = item.status.value if hasattr(item.status, "value") else str(item.status)
+    return payload

--- a/core/work_item/types.py
+++ b/core/work_item/types.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class WorkItem(BaseModel):
+    id: str
+    subject: str
+    description: str
+    status: Any
+    active_form: str | None = None
+    owner: str | None = None
+    blocks: list[str] = Field(default_factory=list)
+    blocked_by: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def is_blocked(self, all_items: dict[str, WorkItem]) -> bool:
+        for item_id in self.blocked_by:
+            if item_id in all_items:
+                blocker = all_items[item_id]
+                if _status_value(blocker.status) != "completed":
+                    return True
+        return False
+
+    def to_summary(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "subject": self.subject,
+            "status": _status_value(self.status),
+            "owner": self.owner,
+            "blockedBy": [item_id for item_id in self.blocked_by],
+        }
+
+    def to_detail(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "subject": self.subject,
+            "description": self.description,
+            "status": _status_value(self.status),
+            "activeForm": self.active_form,
+            "owner": self.owner,
+            "blocks": self.blocks,
+            "blockedBy": self.blocked_by,
+            "metadata": self.metadata,
+        }
+
+
+def _status_value(status: Any) -> str:
+    value = getattr(status, "value", status)
+    return str(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ packages = [
     "core.runtime.middleware.queue",
     "core.runtime.middleware.spill_buffer",
     "core.tools",
+    "core.work_item",
+    "core.work_item.chat_workflow",
     "core.tools.command",
     "core.tools.command.bash",
     "core.tools.command.zsh",

--- a/storage/container.py
+++ b/storage/container.py
@@ -6,6 +6,8 @@ from typing import Any
 from .contracts import (
     AgentConfigRepo,
     ChatRepo,
+    ChatTaskRepo,
+    ChatWorkflowRepo,
     CheckpointRepo,
     ContactRepo,
     EvalRepo,
@@ -55,6 +57,8 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "chat_repo": ("storage.providers.supabase.chat_repo", "SupabaseChatRepo"),
     "chat_member_repo": ("storage.providers.supabase.messaging_repo", "SupabaseChatMemberRepo"),
     "chat_join_request_repo": ("storage.providers.supabase.messaging_repo", "SupabaseChatJoinRequestRepo"),
+    "chat_workflow_repo": ("storage.providers.supabase.chat_workflow_repo", "SupabaseChatWorkflowRepo"),
+    "chat_task_repo": ("storage.providers.supabase.chat_workflow_repo", "SupabaseChatTaskRepo"),
     "messages_repo": ("storage.providers.supabase.messaging_repo", "SupabaseMessagesRepo"),
     "relationship_repo": ("storage.providers.supabase.messaging_repo", "SupabaseRelationshipRepo"),
     "invite_code_repo": ("storage.providers.supabase.invite_code_repo", "SupabaseInviteCodeRepo"),
@@ -147,6 +151,12 @@ class StorageContainer:
 
     def chat_join_request_repo(self) -> Any:
         return self._build("chat_join_request_repo")
+
+    def chat_workflow_repo(self) -> ChatWorkflowRepo:
+        return self._build("chat_workflow_repo")
+
+    def chat_task_repo(self) -> ChatTaskRepo:
+        return self._build("chat_task_repo")
 
     def messages_repo(self) -> Any:
         return self._build("messages_repo")

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -273,6 +273,23 @@ class ChatJoinRequestRow(BaseModel):
         return value
 
 
+class ChatWorkflowRow(BaseModel):
+    chat_id: str
+    kind: str
+    state: str = "active"
+    config: dict[str, Any] = Field(default_factory=dict)
+    updated_by_user_id: str | None = None
+    created_at: float
+    updated_at: float | None = None
+
+    @field_validator("chat_id", "kind", "state")
+    @classmethod
+    def _validate_chat_workflow_identity_fields(cls, value: str, info: Any) -> str:
+        if not value.strip():
+            raise ValueError(f"chat_workflow.{info.field_name} must not be blank")
+        return value
+
+
 class MessageRow(BaseModel):
     id: str
     chat_id: str
@@ -457,14 +474,37 @@ class SkillRepo(Protocol):
     def delete(self, owner_user_id: str, skill_id: str) -> None: ...
 
 
-class ToolTaskRepo(Protocol):
+class WorkItemRepo(Protocol):
     def close(self) -> None: ...
-    def next_id(self, thread_id: str) -> str: ...
-    def get(self, thread_id: str, task_id: str) -> Any | None: ...
-    def list_all(self, thread_id: str) -> list[Any]: ...
-    def insert(self, thread_id: str, task: Any) -> None: ...
-    def update(self, thread_id: str, task: Any) -> None: ...
-    def delete(self, thread_id: str, task_id: str) -> None: ...
+    def next_id(self, scope_id: str) -> str: ...
+    def get(self, scope_id: str, item_id: str) -> Any | None: ...
+    def list_all(self, scope_id: str) -> list[Any]: ...
+    def insert(self, scope_id: str, item: Any) -> None: ...
+    def update(self, scope_id: str, item: Any) -> None: ...
+    def delete(self, scope_id: str, item_id: str) -> None: ...
+
+
+class ToolTaskRepo(WorkItemRepo, Protocol):
+    pass
+
+
+class ChatWorkflowRepo(Protocol):
+    def close(self) -> None: ...
+    def get(self, chat_id: str) -> ChatWorkflowRow | None: ...
+    def upsert(
+        self,
+        chat_id: str,
+        *,
+        kind: str,
+        state: str,
+        config: dict[str, Any],
+        updated_by_user_id: str | None = None,
+    ) -> ChatWorkflowRow: ...
+    def delete(self, chat_id: str) -> None: ...
+
+
+class ChatTaskRepo(WorkItemRepo, Protocol):
+    pass
 
 
 class ResourceSnapshotRepo(Protocol):

--- a/storage/providers/supabase/chat_workflow_repo.py
+++ b/storage/providers/supabase/chat_workflow_repo.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.work_item.types import WorkItem
+from storage.contracts import ChatWorkflowRow
+from storage.providers.supabase import _query as q
+
+_SCHEMA = "chat"
+_WORKFLOW_REPO = "chat workflow repo"
+_TASK_REPO = "chat task repo"
+
+
+class SupabaseChatWorkflowRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _WORKFLOW_REPO)
+
+    def close(self) -> None:
+        return None
+
+    def get(self, chat_id: str) -> ChatWorkflowRow | None:
+        rows = q.rows(self._t().select("*").eq("chat_id", chat_id).limit(1).execute(), _WORKFLOW_REPO, "get")
+        return _row_to_workflow(rows[0]) if rows else None
+
+    def upsert(
+        self,
+        chat_id: str,
+        *,
+        kind: str,
+        state: str = "active",
+        config: dict[str, Any] | None = None,
+        updated_by_user_id: str | None = None,
+    ) -> ChatWorkflowRow:
+        now = time.time()
+        existing = self.get(chat_id)
+        payload = {
+            "chat_id": chat_id,
+            "kind": kind,
+            "state": state,
+            "config_json": config or {},
+            "updated_by_user_id": updated_by_user_id,
+            "created_at": existing.created_at if existing else now,
+            "updated_at": now,
+        }
+        rows = q.rows(
+            self._t().upsert(payload, on_conflict="chat_id").execute(),
+            _WORKFLOW_REPO,
+            "upsert",
+        )
+        return _row_to_workflow(rows[0] if rows else payload)
+
+    def delete(self, chat_id: str) -> None:
+        self._t().delete().eq("chat_id", chat_id).execute()
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "workflow_state", _WORKFLOW_REPO)
+
+
+class SupabaseChatTaskRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _TASK_REPO)
+
+    def close(self) -> None:
+        return None
+
+    def next_id(self, scope_id: str) -> str:
+        rows = q.rows(self._t().select("task_id").eq("chat_id", scope_id).execute(), _TASK_REPO, "next_id")
+        if not rows:
+            return "1"
+        return str(max(int(str(row["task_id"])) for row in rows) + 1)
+
+    def get(self, scope_id: str, item_id: str) -> WorkItem | None:
+        rows = q.rows(
+            self._t().select("*").eq("chat_id", scope_id).eq("task_id", item_id).limit(1).execute(),
+            _TASK_REPO,
+            "get",
+        )
+        return _row_to_work_item(rows[0]) if rows else None
+
+    def list_all(self, scope_id: str) -> list[WorkItem]:
+        rows = q.rows(
+            q.order(
+                self._t().select("*").eq("chat_id", scope_id),
+                "task_id",
+                desc=False,
+                repo=_TASK_REPO,
+                operation="list_all",
+            ).execute(),
+            _TASK_REPO,
+            "list_all",
+        )
+        return [_row_to_work_item(row) for row in rows]
+
+    def insert(self, scope_id: str, item: WorkItem) -> None:
+        self._t().insert(_work_item_payload(scope_id, item)).execute()
+
+    def update(self, scope_id: str, item: WorkItem) -> None:
+        payload = _work_item_payload(scope_id, item)
+        payload.pop("created_at", None)
+        self._t().update(payload).eq("chat_id", scope_id).eq("task_id", item.id).execute()
+
+    def delete(self, scope_id: str, item_id: str) -> None:
+        self._t().delete().eq("chat_id", scope_id).eq("task_id", item_id).execute()
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "tasks", _TASK_REPO)
+
+
+def _row_to_workflow(row: dict[str, Any]) -> ChatWorkflowRow:
+    return ChatWorkflowRow(
+        chat_id=str(row["chat_id"]),
+        kind=str(row["kind"]),
+        state=str(row.get("state") or "active"),
+        config=dict(row.get("config_json") or row.get("config") or {}),
+        updated_by_user_id=row.get("updated_by_user_id"),
+        created_at=float(row["created_at"]),
+        updated_at=float(row["updated_at"]) if row.get("updated_at") is not None else None,
+    )
+
+
+def _row_to_work_item(row: dict[str, Any]) -> WorkItem:
+    return WorkItem(
+        id=str(row["task_id"]),
+        subject=str(row.get("subject") or ""),
+        description=str(row.get("description") or ""),
+        status=str(row.get("status") or "pending"),
+        active_form=row.get("active_form"),
+        owner=row.get("owner_user_id") or row.get("owner"),
+        blocks=list(row.get("blocks_json") or row.get("blocks") or []),
+        blocked_by=list(row.get("blocked_by_json") or row.get("blocked_by") or []),
+        metadata=dict(row.get("metadata_json") or row.get("metadata") or {}),
+    )
+
+
+def _work_item_payload(scope_id: str, item: WorkItem) -> dict[str, Any]:
+    now = time.time()
+    status = item.status.value if hasattr(item.status, "value") else str(item.status)
+    return {
+        "chat_id": scope_id,
+        "task_id": item.id,
+        "subject": item.subject,
+        "description": item.description,
+        "status": status,
+        "active_form": item.active_form,
+        "owner_user_id": item.owner,
+        "blocks_json": list(item.blocks),
+        "blocked_by_json": list(item.blocked_by),
+        "metadata_json": dict(item.metadata),
+        "created_at": now,
+        "updated_at": now,
+    }

--- a/storage/providers/supabase/tool_task_repo.py
+++ b/storage/providers/supabase/tool_task_repo.py
@@ -21,9 +21,9 @@ class SupabaseToolTaskRepo:
     def _table(self) -> Any:
         return q.schema_table(self._client, _SCHEMA, _TABLE, _REPO)
 
-    def next_id(self, thread_id: str) -> str:
+    def next_id(self, scope_id: str) -> str:
         rows = q.rows(
-            self._table().select("task_id", count="exact").eq("thread_id", thread_id).execute(),
+            self._table().select("task_id", count="exact").eq("thread_id", scope_id).execute(),
             _REPO,
             "next_id",
         )
@@ -31,18 +31,18 @@ class SupabaseToolTaskRepo:
             return "1"
         return str(max(int(str(row["task_id"])) for row in rows) + 1)
 
-    def get(self, thread_id: str, task_id: str) -> Task | None:
+    def get(self, scope_id: str, item_id: str) -> Task | None:
         rows = q.rows(
-            self._table().select("*").eq("thread_id", thread_id).eq("task_id", task_id).execute(),
+            self._table().select("*").eq("thread_id", scope_id).eq("task_id", item_id).execute(),
             _REPO,
             "get",
         )
         return self._row_to_task(rows[0]) if rows else None
 
-    def list_all(self, thread_id: str) -> list[Task]:
+    def list_all(self, scope_id: str) -> list[Task]:
         rows = q.rows(
             q.order(
-                self._table().select("*").eq("thread_id", thread_id),
+                self._table().select("*").eq("thread_id", scope_id),
                 "task_id",
                 desc=False,
                 repo=_REPO,
@@ -53,38 +53,38 @@ class SupabaseToolTaskRepo:
         )
         return [self._row_to_task(r) for r in rows]
 
-    def insert(self, thread_id: str, task: Task) -> None:
+    def insert(self, scope_id: str, item: Task) -> None:
         self._table().insert(
             {
-                "thread_id": thread_id,
-                "task_id": task.id,
-                "subject": task.subject,
-                "description": task.description,
-                "status": task.status.value,
-                "active_form": task.active_form,
-                "owner": task.owner,
-                "blocks": task.blocks,
-                "blocked_by": task.blocked_by,
-                "metadata": task.metadata,
+                "thread_id": scope_id,
+                "task_id": item.id,
+                "subject": item.subject,
+                "description": item.description,
+                "status": item.status.value,
+                "active_form": item.active_form,
+                "owner": item.owner,
+                "blocks": item.blocks,
+                "blocked_by": item.blocked_by,
+                "metadata": item.metadata,
             }
         ).execute()
 
-    def update(self, thread_id: str, task: Task) -> None:
+    def update(self, scope_id: str, item: Task) -> None:
         self._table().update(
             {
-                "subject": task.subject,
-                "description": task.description,
-                "status": task.status.value,
-                "active_form": task.active_form,
-                "owner": task.owner,
-                "blocks": task.blocks,
-                "blocked_by": task.blocked_by,
-                "metadata": task.metadata,
+                "subject": item.subject,
+                "description": item.description,
+                "status": item.status.value,
+                "active_form": item.active_form,
+                "owner": item.owner,
+                "blocks": item.blocks,
+                "blocked_by": item.blocked_by,
+                "metadata": item.metadata,
             }
-        ).eq("thread_id", thread_id).eq("task_id", task.id).execute()
+        ).eq("thread_id", scope_id).eq("task_id", item.id).execute()
 
-    def delete(self, thread_id: str, task_id: str) -> None:
-        self._table().delete().eq("thread_id", thread_id).eq("task_id", task_id).execute()
+    def delete(self, scope_id: str, item_id: str) -> None:
+        self._table().delete().eq("thread_id", scope_id).eq("task_id", item_id).execute()
 
     @staticmethod
     def _row_to_task(row: dict[str, Any]) -> Task:

--- a/storage/schema/chat_workflow_state_and_tasks.sql
+++ b/storage/schema/chat_workflow_state_and_tasks.sql
@@ -1,0 +1,36 @@
+create table if not exists chat.workflow_state (
+    chat_id             text primary key references chat.chats(id) on delete cascade,
+    kind                text not null,
+    state               text not null default 'active',
+    config_json         jsonb not null default '{}'::jsonb,
+    updated_by_user_id  text references identity.users(id) on delete set null,
+    created_at          double precision not null,
+    updated_at          double precision
+);
+
+create table if not exists chat.tasks (
+    chat_id          text not null references chat.chats(id) on delete cascade,
+    task_id          text not null,
+    subject          text not null,
+    description      text not null default '',
+    status           text not null default 'pending',
+    active_form      text,
+    owner_user_id    text references identity.users(id) on delete set null,
+    blocks_json      jsonb not null default '[]'::jsonb,
+    blocked_by_json  jsonb not null default '[]'::jsonb,
+    metadata_json    jsonb not null default '{}'::jsonb,
+    created_at       double precision not null,
+    updated_at       double precision,
+    primary key (chat_id, task_id)
+);
+
+create index if not exists idx_chat_tasks_owner_user_id
+    on chat.tasks(owner_user_id)
+    where owner_user_id is not null;
+
+grant select, insert, update, delete on chat.workflow_state to service_role;
+grant select, insert, update, delete on chat.workflow_state to authenticated;
+grant select, insert, update, delete on chat.tasks to service_role;
+grant select, insert, update, delete on chat.tasks to authenticated;
+
+notify pgrst, 'reload schema';

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -19,6 +19,9 @@ def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> N
     assert "/api/chats/{chat_id}/join-requests" in paths
     assert "/api/chats/{chat_id}/join-target" in paths
     assert "/api/chats/{chat_id}/join-requests/{request_id}/approve" in paths
+    assert "/api/chats/{chat_id}/workflow" in paths
+    assert "/api/chats/{chat_id}/tasks" in paths
+    assert "/api/chats/{chat_id}/tasks/{task_id}" in paths
     assert "/api/relationships" in paths
     assert "/api/conversations" in paths
 

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -10,6 +10,8 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     messages_repo = object()
     relationship_repo = object()
     chat_join_request_repo = object()
+    chat_workflow_repo = object()
+    chat_task_repo = object()
 
     storage_container = SimpleNamespace(
         chat_repo=lambda: chat_repo,
@@ -18,6 +20,8 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         messages_repo=lambda: messages_repo,
         relationship_repo=lambda: relationship_repo,
         chat_join_request_repo=lambda: chat_join_request_repo,
+        chat_workflow_repo=lambda: chat_workflow_repo,
+        chat_task_repo=lambda: chat_task_repo,
     )
 
     class _EventBus:
@@ -43,6 +47,14 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
+    class _ChatWorkflowService:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _ChatTaskService:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
     event_bus = _EventBus()
 
     monkeypatch.setattr(chat_bootstrap, "ChatEventBus", lambda: event_bus)
@@ -51,6 +63,8 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     monkeypatch.setattr(chat_bootstrap, "HireVisitDeliveryResolver", lambda **kwargs: kwargs)
     monkeypatch.setattr(chat_bootstrap, "MessagingService", _MessagingService)
     monkeypatch.setattr(chat_bootstrap, "ChatJoinRequestService", _ChatJoinRequestService)
+    monkeypatch.setattr(chat_bootstrap, "ChatWorkflowService", _ChatWorkflowService)
+    monkeypatch.setattr(chat_bootstrap, "ChatTaskService", _ChatTaskService)
     app = SimpleNamespace(
         state=SimpleNamespace(
             user_repo=object(),
@@ -75,6 +89,8 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     assert state.chat_join_request_service.kwargs["chat_repo"] is chat_repo
     assert state.chat_join_request_service.kwargs["chat_member_repo"] is chat_member_repo
     assert state.chat_join_request_service.kwargs["messaging_service"] is state.messaging_service
+    assert state.chat_workflow_service.kwargs["workflow_repo"] is chat_workflow_repo
+    assert state.chat_task_service.kwargs["task_repo"] is chat_task_repo
     assert state.messaging_service.kwargs["chat_repo"] is chat_repo
     assert state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
     assert state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.work_item.chat_workflow.service import ChatTaskService, ChatWorkflowService
+from core.work_item.types import WorkItem
+from storage.contracts import ChatWorkflowRow
+
+
+class _WorkflowRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, ChatWorkflowRow] = {}
+
+    def get(self, chat_id: str) -> ChatWorkflowRow | None:
+        return self.rows.get(chat_id)
+
+    def upsert(
+        self,
+        chat_id: str,
+        *,
+        kind: str,
+        state: str,
+        config: dict[str, Any],
+        updated_by_user_id: str | None = None,
+    ) -> ChatWorkflowRow:
+        row = ChatWorkflowRow(
+            chat_id=chat_id,
+            kind=kind,
+            state=state,
+            config=config,
+            updated_by_user_id=updated_by_user_id,
+            created_at=1.0,
+            updated_at=2.0,
+        )
+        self.rows[chat_id] = row
+        return row
+
+    def delete(self, chat_id: str) -> None:
+        self.rows.pop(chat_id, None)
+
+
+class _TaskRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, WorkItem]] = {}
+
+    def next_id(self, scope_id: str) -> str:
+        return str(len(self.rows.get(scope_id, {})) + 1)
+
+    def get(self, scope_id: str, item_id: str) -> WorkItem | None:
+        return self.rows.get(scope_id, {}).get(item_id)
+
+    def list_all(self, scope_id: str) -> list[WorkItem]:
+        return list(self.rows.get(scope_id, {}).values())
+
+    def insert(self, scope_id: str, item: WorkItem) -> None:
+        self.rows.setdefault(scope_id, {})[item.id] = item
+
+    def update(self, scope_id: str, item: WorkItem) -> None:
+        self.rows.setdefault(scope_id, {})[item.id] = item
+
+    def delete(self, scope_id: str, item_id: str) -> None:
+        self.rows.get(scope_id, {}).pop(item_id, None)
+
+
+def test_chat_workflow_service_projects_explicit_chat_scope() -> None:
+    repo = _WorkflowRepo()
+    service = ChatWorkflowService(repo)
+
+    created = service.set_workflow(
+        "chat-1",
+        kind="keep",
+        state="active",
+        config={"reviewer": "reviewer-user"},
+        updated_by_user_id="human-user",
+    )
+
+    assert created["chat_id"] == "chat-1"
+    assert created["config"] == {"reviewer": "reviewer-user"}
+    assert service.get_workflow("chat-1") == created
+    assert service.get_workflow("chat-2") is None
+
+
+def test_chat_task_service_keeps_tasks_scoped_to_chat_id() -> None:
+    repo = _TaskRepo()
+    service = ChatTaskService(repo)
+
+    task = service.create_task(
+        "chat-1",
+        subject="Review worker patch",
+        description="Read the worker result and decide next step.",
+        owner="reviewer-user",
+    )
+    other = service.create_task(
+        "chat-2",
+        subject="Separate room task",
+        description="This must not appear in chat-1.",
+    )
+
+    assert task["id"] == "1"
+    assert other["id"] == "1"
+    assert [row["subject"] for row in service.list_tasks("chat-1")] == ["Review worker patch"]
+    assert [row["subject"] for row in service.list_tasks("chat-2")] == ["Separate room task"]

--- a/tests/Unit/core/test_work_item_primitive.py
+++ b/tests/Unit/core/test_work_item_primitive.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from core.tools.task.types import Task, TaskStatus
+from core.work_item.types import WorkItem
+from storage.contracts import WorkItemRepo
+from storage.providers.supabase.tool_task_repo import SupabaseToolTaskRepo
+from tests.fakes.supabase import FakeSupabaseClient
+
+
+def test_agent_task_uses_work_item_base_without_chat_workflow_fields() -> None:
+    task = Task(
+        id="1",
+        subject="Keep agent todo simple",
+        description="Task remains an agent-private todo surface.",
+        status=TaskStatus.PENDING,
+    )
+
+    assert isinstance(task, WorkItem)
+    assert task.to_summary() == {
+        "id": "1",
+        "subject": "Keep agent todo simple",
+        "status": "pending",
+        "owner": None,
+        "blockedBy": [],
+    }
+    assert "review_event_id" not in Task.model_fields
+    assert "review_rationale" not in Task.model_fields
+    assert "evidence" not in Task.model_fields
+
+
+def test_work_item_repo_protocol_names_scope_without_chat_or_thread_bias() -> None:
+    annotations = WorkItemRepo.next_id.__annotations__
+
+    assert "scope_id" in annotations
+    assert "thread_id" not in annotations
+    assert "chat_id" not in annotations
+
+
+def test_agent_task_repo_conforms_to_work_item_repo_protocol() -> None:
+    repo: WorkItemRepo = SupabaseToolTaskRepo(FakeSupabaseClient(tables={}))
+
+    assert repo.next_id("thread-scope") == "1"

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -297,8 +297,9 @@ def test_chat_task_routes_use_chat_access_helper(monkeypatch: pytest.MonkeyPatch
         return chat
 
     chat_task_service = SimpleNamespace(
-        create_task=lambda chat_id, **kwargs: seen.append(("create_task", (chat_id, kwargs)))
-        or {"id": "1", "subject": kwargs["subject"], "owner": kwargs.get("owner")}
+        create_task=lambda chat_id, **kwargs: (
+            seen.append(("create_task", (chat_id, kwargs))) or {"id": "1", "subject": kwargs["subject"], "owner": kwargs.get("owner")}
+        )
     )
     monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", fake_helper)
 

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
-from backend.chat.api.http import chats_router, relationships_router
+from backend.chat.api.http import chat_workflow_router, chats_router, relationships_router
 from backend.identity.avatar.urls import avatar_url
 from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow
@@ -254,6 +254,84 @@ def test_get_accessible_chat_or_404_raises_403_for_non_member():
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Not a participant of this chat"
+
+
+def test_chat_workflow_routes_use_chat_access_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, object]] = []
+    chat = _chat("chat-1")
+    chat_repo = SimpleNamespace(name="chat-repo")
+    messaging_service = SimpleNamespace(name="messaging")
+
+    def fake_helper(chat_repo, messaging_service, chat_id: str, user_id: str):
+        seen.append(("helper", (chat_repo, messaging_service, chat_id, user_id)))
+        return chat
+
+    workflow_service = SimpleNamespace(
+        get_workflow=lambda chat_id: seen.append(("get_workflow", chat_id)) or {"chat_id": chat_id, "kind": "keep", "state": "active"}
+    )
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", fake_helper)
+
+    result = chat_workflow_router.get_chat_workflow(
+        "chat-1",
+        user_id="user-1",
+        chat_repo=chat_repo,
+        messaging_service=messaging_service,
+        chat_workflow_service=workflow_service,
+    )
+
+    assert result == {"chat_id": "chat-1", "kind": "keep", "state": "active"}
+    assert seen == [
+        ("helper", (chat_repo, messaging_service, "chat-1", "user-1")),
+        ("get_workflow", "chat-1"),
+    ]
+
+
+def test_chat_task_routes_use_chat_access_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, object]] = []
+    chat = _chat("chat-1")
+    chat_repo = SimpleNamespace(name="chat-repo")
+    messaging_service = SimpleNamespace(name="messaging")
+
+    def fake_helper(chat_repo_arg, messaging_service_arg, chat_id: str, user_id: str):
+        seen.append(("helper", (chat_repo_arg, messaging_service_arg, chat_id, user_id)))
+        return chat
+
+    chat_task_service = SimpleNamespace(
+        create_task=lambda chat_id, **kwargs: seen.append(("create_task", (chat_id, kwargs)))
+        or {"id": "1", "subject": kwargs["subject"], "owner": kwargs.get("owner")}
+    )
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", fake_helper)
+
+    result = chat_workflow_router.create_chat_task(
+        "chat-1",
+        chat_workflow_router.CreateChatTaskBody(
+            subject="Review worker patch",
+            description="Check the result.",
+            owner="reviewer-user",
+        ),
+        user_id="user-1",
+        chat_repo=chat_repo,
+        messaging_service=messaging_service,
+        chat_task_service=chat_task_service,
+    )
+
+    assert result == {"id": "1", "subject": "Review worker patch", "owner": "reviewer-user"}
+    assert seen == [
+        ("helper", (chat_repo, messaging_service, "chat-1", "user-1")),
+        (
+            "create_task",
+            (
+                "chat-1",
+                {
+                    "subject": "Review worker patch",
+                    "description": "Check the result.",
+                    "active_form": None,
+                    "owner": "reviewer-user",
+                    "metadata": {},
+                },
+            ),
+        ),
+    ]
 
 
 def test_resolve_display_user_delegates_to_messaging_service(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from core.work_item.types import WorkItem
 from storage.contracts import ChatRow, ContactEdgeRow
 from storage.errors import StorageConflictError
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
+from storage.providers.supabase.chat_workflow_repo import SupabaseChatTaskRepo, SupabaseChatWorkflowRepo
 from storage.providers.supabase.contact_repo import SupabaseContactRepo
 from storage.providers.supabase.messaging_repo import (
     SupabaseChatJoinRequestRepo,
@@ -55,6 +57,53 @@ def test_supabase_chat_stack_uses_chat_schema_for_root_tables() -> None:
     assert "chats" not in tables
     assert "chat_members" not in tables
     assert "messages" not in tables
+
+
+def test_supabase_chat_workflow_repo_uses_chat_schema_sibling_table() -> None:
+    tables: dict[str, list[dict]] = {"chat.workflow_state": []}
+    client = FakeSupabaseClient(tables=tables)
+    repo = SupabaseChatWorkflowRepo(client)
+
+    workflow = repo.upsert(
+        "chat-1",
+        kind="keep",
+        state="active",
+        config={"reviewer": "reviewer-user"},
+        updated_by_user_id="human-user-1",
+    )
+
+    assert workflow.chat_id == "chat-1"
+    assert workflow.kind == "keep"
+    assert workflow.config == {"reviewer": "reviewer-user"}
+    assert tables["chat.workflow_state"][0]["chat_id"] == "chat-1"
+    assert "workflow_state" not in tables
+
+
+def test_supabase_chat_task_repo_uses_work_item_shape_in_chat_schema() -> None:
+    tables: dict[str, list[dict]] = {"chat.tasks": []}
+    client = FakeSupabaseClient(tables=tables)
+    repo = SupabaseChatTaskRepo(client)
+    task_id = repo.next_id("chat-1")
+
+    repo.insert(
+        "chat-1",
+        WorkItem(
+            id=task_id,
+            subject="Review worker patch",
+            description="Check the worker result and decide next step.",
+            status="pending",
+            owner="reviewer-user",
+            metadata={"source": "group"},
+        ),
+    )
+    task = repo.get("chat-1", task_id)
+
+    assert task is not None
+    assert task.to_summary()["id"] == "1"
+    assert task.to_summary()["owner"] == "reviewer-user"
+    assert tables["chat.tasks"][0]["chat_id"] == "chat-1"
+    assert tables["chat.tasks"][0]["subject"] == "Review worker patch"
+    assert "tasks" not in tables
 
 
 def test_supabase_find_chat_between_only_returns_direct_chat() -> None:


### PR DESCRIPTION
## Summary

This PR adds the backend data plane needed for chat-scoped workflow state and chat-scoped tasks while keeping Mycel Chat as the only shared message timeline.

Key points:
- extracts a shared `WorkItem` primitive and keeps agent todo as `Task(WorkItem)`
- adds storage contracts and Supabase repos for `chat.workflow_state` and `chat.tasks`
- adds chat workflow/task services under `core.work_item.chat_workflow`
- exposes backend routes under existing `/api/chats/{chat_id}/...`
- keeps this slice backend-only: no CLI/SDK/wake/runtime event emission changes

## Architecture Boundaries

- Group remains a workflow facade over Mycel Chat, not a second messaging system.
- Agent todo and chat task share `WorkItem` code/protocol but use separate physical storage.
- Workflow/task routes reuse the existing chat membership gate.
- New workflow/task writes do not emit runtime notifications in this slice.

## Verification

```text
uv run pytest tests/Unit/core/test_work_item_primitive.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py tests/Integration/test_chat_app_router.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/integration_contracts/test_messaging_router.py::test_get_accessible_chat_or_404_returns_chat tests/Unit/integration_contracts/test_messaging_router.py::test_get_accessible_chat_or_404_raises_404_for_missing_chat tests/Unit/integration_contracts/test_messaging_router.py::test_get_accessible_chat_or_404_raises_403_for_non_member tests/Unit/integration_contracts/test_messaging_router.py::test_chat_workflow_routes_use_chat_access_helper tests/Unit/integration_contracts/test_messaging_router.py::test_chat_task_routes_use_chat_access_helper -q
# 41 passed in 0.62s

uv run ruff check backend/chat/api/http/app_router.py backend/chat/api/http/chats_router.py backend/chat/api/http/chat_workflow_router.py backend/chat/api/http/dependencies.py backend/chat/bootstrap.py core/work_item core/tools/task/types.py core/tools/task/service.py storage/contracts.py storage/container.py storage/providers/supabase/chat_workflow_repo.py storage/providers/supabase/tool_task_repo.py tests/Integration/test_chat_app_router.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/integration_contracts/test_messaging_router.py
# All checks passed!

uv run pyright backend/chat/api/http/app_router.py backend/chat/api/http/chats_router.py backend/chat/api/http/chat_workflow_router.py backend/chat/api/http/dependencies.py backend/chat/bootstrap.py core/work_item core/tools/task/types.py core/tools/task/service.py storage/contracts.py storage/container.py storage/providers/supabase/chat_workflow_repo.py storage/providers/supabase/tool_task_repo.py
# 0 errors, 0 warnings, 0 informations
```

## Follow-up Stop Line

Before SDK/CLI/group UX work, apply `storage/schema/chat_workflow_state_and_tasks.sql` to the target Supabase environment and prove the live backend can use these routes.
