### PR TITLE
fix: accept Supabase auth clock skew during registration

### DIFF
--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -17,6 +17,7 @@ from storage.providers.supabase import _query as q
 logger = logging.getLogger(__name__)
 
 SUPABASE_JWT_ALGORITHM = "HS256"
+SUPABASE_JWT_LEEWAY_SECONDS = 60
 
 
 class ExternalUserAlreadyExistsError(ValueError):
@@ -82,7 +83,13 @@ class AuthService:
         if not jwt_secret:
             raise RuntimeError("SUPABASE_JWT_SECRET not set.")
         try:
-            payload = jwt.decode(temp_token, jwt_secret, algorithms=[SUPABASE_JWT_ALGORITHM], options={"verify_aud": False})
+            payload = jwt.decode(
+                temp_token,
+                jwt_secret,
+                algorithms=[SUPABASE_JWT_ALGORITHM],
+                leeway=SUPABASE_JWT_LEEWAY_SECONDS,
+                options={"verify_aud": False},
+            )
         except jwt.InvalidTokenError as e:
             raise ValueError("会话已过期，请重新验证邮箱") from e
         auth_user_id = payload["sub"]
@@ -175,7 +182,7 @@ class AuthService:
                 token,
                 jwt_secret,
                 algorithms=[SUPABASE_JWT_ALGORITHM],
-                leeway=60,
+                leeway=SUPABASE_JWT_LEEWAY_SECONDS,
                 options={"verify_aud": False},
             )
             return {"user_id": payload["sub"]}

--- a/tests/Unit/backend/test_auth_service_token_verification.py
+++ b/tests/Unit/backend/test_auth_service_token_verification.py
@@ -155,6 +155,52 @@ def test_verify_token_accepts_supabase_iat_clock_boundary(monkeypatch: pytest.Mo
     assert payload == {"user_id": "user-local"}
 
 
+def test_complete_register_accepts_supabase_iat_clock_boundary(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-1")
+    monkeypatch.setattr("backend.sandboxes.recipe_bootstrap.available_sandbox_types", lambda: [])
+    token = jwt.encode(
+        {
+            "sub": "owner-1",
+            "email": "fresh@example.com",
+            "iat": int(time.time()) + 30,
+        },
+        "secret-1",
+        algorithm="HS256",
+    )
+    existing_user = SimpleNamespace(
+        id="owner-1",
+        display_name="fresh",
+        mycel_id=10001,
+        email="fresh@example.com",
+        avatar=None,
+    )
+    owned_agent = SimpleNamespace(
+        id="agent-1",
+        display_name="Toad",
+        type=UserType.AGENT,
+        avatar="avatars/agent-1.png",
+    )
+    user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: existing_user if user_id == "owner-1" else None,
+        list_by_owner_user_id=lambda _user_id: [owned_agent],
+    )
+    invite_codes = SimpleNamespace(
+        is_usable_by=lambda code, user_id: code == "invite-1" and user_id == "owner-1",
+        use=lambda code, user_id: {"code": code, "used_by": user_id},
+    )
+    recipe_repo = SimpleNamespace(get=lambda _owner_user_id, _recipe_id: None, upsert=lambda **_payload: None)
+
+    result = _service(
+        supabase_client=SimpleNamespace(),
+        user_repo=user_repo,
+        invite_codes=invite_codes,
+        recipe_repo=recipe_repo,
+    ).complete_register(token, "invite-1")
+
+    assert result["user"]["id"] == "owner-1"
+    assert result["agent"] == {"id": "agent-1", "name": "Toad", "type": "agent", "avatar": "avatars/agent-1.png"}
+
+
 def test_create_external_user_token_creates_external_user_and_signed_token(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-1")
     created_rows: list[Any] = []


### PR DESCRIPTION
## Summary
- Accept Supabase JWT iat clock skew consistently during registration and token verification.
- Add regression coverage for complete_register with a slightly future iat.

## Verification
- uv run pytest tests/Unit/backend/test_auth_service_token_verification.py -q
- uv run ruff format --check backend/identity/auth/service.py tests/Unit/backend/test_auth_service_token_verification.py
- uv run ruff check backend/identity/auth/service.py tests/Unit/backend/test_auth_service_token_verification.py

## YATU context
- Found during real SDK chat workflow YATU against local app backend and live pgl.
