### PR TITLE
refactor: remove tool task repo protocol alias

### DIFF
--- a/storage/container.py
+++ b/storage/container.py
@@ -26,9 +26,9 @@ from .contracts import (
     SkillRepo,
     SummaryRepo,
     ThreadRepo,
-    ToolTaskRepo,
     UserRepo,
     UserSettingsRepo,
+    WorkItemRepo,
     WorkspaceRepo,
 )
 
@@ -119,7 +119,7 @@ class StorageContainer:
     def chat_session_repo(self) -> Any:
         return self._build("chat_session_repo")
 
-    def tool_task_repo(self) -> ToolTaskRepo:
+    def tool_task_repo(self) -> WorkItemRepo:
         return self._build("tool_task_repo")
 
     def resource_snapshot_repo(self) -> ResourceSnapshotRepo:

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -484,10 +484,6 @@ class WorkItemRepo(Protocol):
     def delete(self, scope_id: str, item_id: str) -> None: ...
 
 
-class ToolTaskRepo(WorkItemRepo, Protocol):
-    pass
-
-
 class ChatWorkflowRepo(Protocol):
     def close(self) -> None: ...
     def get(self, chat_id: str) -> ChatWorkflowRow | None: ...

--- a/tests/Unit/core/test_work_item_primitive.py
+++ b/tests/Unit/core/test_work_item_primitive.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import storage.contracts as storage_contracts
 from core.tools.task.types import Task, TaskStatus
 from core.work_item.types import WorkItem
 from storage.contracts import WorkItemRepo
@@ -40,3 +41,7 @@ def test_agent_task_repo_conforms_to_work_item_repo_protocol() -> None:
     repo: WorkItemRepo = SupabaseToolTaskRepo(FakeSupabaseClient(tables={}))
 
     assert repo.next_id("thread-scope") == "1"
+
+
+def test_tool_task_repo_protocol_name_is_not_public_alias() -> None:
+    assert not hasattr(storage_contracts, "ToolTaskRepo")


### PR DESCRIPTION
## Summary

- remove the empty `ToolTaskRepo` storage protocol alias
- type the container's `tool_task_repo()` as the generic `WorkItemRepo`
- add a regression test so the old alias does not re-enter the public storage contract

## Verification

- `uv run pytest tests/Unit/core/test_work_item_primitive.py tests/Unit/core/test_task_service_agent_thread_tasks_routing.py tests/Unit/storage/test_supabase_tool_task_repo.py -q`
- `uv run ruff format --check storage/contracts.py storage/container.py tests/Unit/core/test_work_item_primitive.py`
- `uv run ruff check storage/contracts.py storage/container.py tests/Unit/core/test_work_item_primitive.py`
- `uv run pyright storage/contracts.py storage/container.py core/tools/task/service.py tests/Unit/core/test_work_item_primitive.py`
