### PR TITLE
feat: allow owner-only group chats

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/api/chats", tags=["chats"])
 
 class CreateChatBody(BaseModel):
     user_ids: list[str] = Field(
-        min_length=1,
+        default_factory=list,
         description="Other participant user ids. Do not include the authenticated user; the backend adds it from the bearer token.",
     )
     title: str | None = None
@@ -114,9 +114,10 @@ def _chat_participant_ids_for_request(
     thread_repo: Any,
     participant_ids: list[str],
     requester_user_id: str,
+    kind: str,
 ) -> list[str]:
     other_participants = _validate_chat_participant_ids(user_repo, thread_repo, participant_ids, requester_user_id)
-    if not other_participants:
+    if not other_participants and kind != "group":
         raise ValueError("Chat must include at least one other participant")
     return list(dict.fromkeys([requester_user_id, *other_participants]))
 
@@ -138,7 +139,7 @@ def create_chat(
     thread_repo: Annotated[Any, Depends(get_thread_repo)],
 ):
     try:
-        participant_ids = _chat_participant_ids_for_request(user_repo, thread_repo, body.user_ids, user_id)
+        participant_ids = _chat_participant_ids_for_request(user_repo, thread_repo, body.user_ids, user_id, body.kind)
         if body.kind == "group":
             chat = messaging_service.create_group_chat(participant_ids, body.title)
         elif body.kind == "direct":

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -152,8 +152,8 @@ class MessagingService:
         return self._create_chat(user_ids, chat_type="direct", title=title)
 
     def create_group_chat(self, user_ids: list[str], title: str | None = None) -> dict[str, Any]:
-        if len(user_ids) < 2:
-            raise ValueError("Group chat requires 2+ users")
+        if not user_ids:
+            raise ValueError("Group chat requires at least one user")
         self._require_resolvable_chat_users(user_ids)
         self._require_group_chat_access(user_ids)
         return self._create_chat(user_ids, chat_type="group", title=title)

--- a/tests/Integration/test_chat_external_user_contract.py
+++ b/tests/Integration/test_chat_external_user_contract.py
@@ -27,6 +27,7 @@ def test_validate_chat_participant_ids_accepts_external_user() -> None:
         SimpleNamespace(get_by_user_id=lambda _user_id: None),
         participant_ids=["external-1"],
         requester_user_id="human-1",
+        kind="auto",
     )
 
     assert result == ["human-1", "external-1"]

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -925,6 +925,23 @@ def test_create_chat_can_explicitly_create_two_person_group_chat() -> None:
     assert result["id"] == "chat-1"
 
 
+def test_create_chat_can_explicitly_create_owner_only_group_chat() -> None:
+    state, called = _create_chat_route_state(group_route=True)
+    app = SimpleNamespace(state=state)
+
+    result = _create_chat(
+        app,
+        chats_router.CreateChatBody(
+            user_ids=[],
+            title="cel group",
+            kind="group",
+        ),
+    )
+
+    assert called == [(["human-user-1"], "cel group")]
+    assert result["id"] == "chat-1"
+
+
 def test_create_chat_accepts_human_and_thread_social_user_ids_for_group_participants() -> None:
     state, called = _create_chat_route_state(thread_user_ids={"thread-user-1", "thread-user-2"})
     app = SimpleNamespace(state=state)
@@ -964,11 +981,19 @@ def test_create_chat_rejects_explicit_authenticated_user_id() -> None:
     assert called == []
 
 
-def test_create_chat_rejects_empty_other_participants() -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        chats_router.CreateChatBody(user_ids=[], title="empty-group")
+def test_create_chat_rejects_empty_other_participants_for_auto_chat() -> None:
+    state, called = _create_chat_route_state()
+    app = SimpleNamespace(state=state)
 
-    assert "at least 1 item" in str(exc_info.value)
+    with pytest.raises(HTTPException) as exc_info:
+        _create_chat(
+            app,
+            chats_router.CreateChatBody(user_ids=[], title="empty-chat"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "participant" in str(exc_info.value.detail).lower()
+    assert called == []
 
 
 def test_create_group_chat_rejects_external_participant_without_active_relationship() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2056,6 +2056,29 @@ def test_messaging_service_group_chat_creation_accepts_two_members() -> None:
     assert members == [(chat["id"], "agent-user-1"), (chat["id"], "human-user-1")]
 
 
+def test_messaging_service_group_chat_creation_accepts_owner_only_group() -> None:
+    created: list[Any] = []
+    members: list[tuple[str, str]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(create=lambda row: created.append(row)),
+        chat_member_repo=SimpleNamespace(add_member=lambda chat_id, user_id: members.append((chat_id, user_id))),
+        messages_repo=SimpleNamespace(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, owner_user_id=None, display_name=uid, type="human", avatar=None)
+        ),
+        contact_repo=SimpleNamespace(get=lambda _owner_id, _target_id: None),
+        relationship_service=SimpleNamespace(get_state=lambda _viewer_id, _target_id: "none"),
+    )
+
+    chat = service.create_group_chat(["agent-user-1"], title="owner-only group")
+
+    assert chat["title"] == "owner-only group"
+    assert len(created) == 1
+    assert created[0].type == "group"
+    assert created[0].created_by_user_id == "agent-user-1"
+    assert members == [(chat["id"], "agent-user-1")]
+
+
 def test_messaging_service_group_chat_creation_accepts_same_owner_external_users() -> None:
     created: list[Any] = []
     members: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary
- allow explicit `kind="group"` chat creation with only the authenticated creator
- keep auto/direct empty participant creation rejected at the router boundary
- allow `MessagingService.create_group_chat` to persist one-member group chats

## Why
This is the backend capability needed for `cel group create` to use a durable Mycel `chat_id` as the group id instead of minting a local-only id. The change is at the chat primitive layer, not in CLI glue.

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_messaging_router.py::test_create_chat_can_explicitly_create_owner_only_group_chat tests/Unit/integration_contracts/test_messaging_router.py::test_create_chat_rejects_empty_other_participants_for_auto_chat tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_group_chat_creation_accepts_owner_only_group`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run ruff format --check backend/chat/api/http/chats_router.py messaging/service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run ruff check backend/chat/api/http/chats_router.py messaging/service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run pyright backend/chat/api/http/chats_router.py messaging/service.py`
