### PR TITLE
feat: add chat workflow event primitive

### DIFF
--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -9,6 +9,7 @@ from backend.chat.api.http.dependencies import (
     get_accessible_chat_or_404,
     get_chat_repo,
     get_chat_task_service,
+    get_chat_workflow_event_service,
     get_chat_workflow_service,
     get_current_user_id,
     get_messaging_service,
@@ -49,6 +50,29 @@ class UpdateChatTaskBody(BaseModel):
     blocks: list[str] | None = None
     blocked_by: list[str] | None = None
     metadata: dict[str, Any] | None = None
+
+
+class CreateChatWorkflowEventBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    resource_refs: list[dict[str, Any]] = Field(default_factory=list)
+    requested_by_user_id: str | None = None
+    decision_states: dict[str, dict[str, str]] = Field(default_factory=dict)
+    rationales: dict[str, Any] = Field(default_factory=dict)
+    final_state: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateChatWorkflowEventBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: str | None = None
+    decision_states: dict[str, dict[str, str]] | None = None
+    rationales: dict[str, Any] | None = None
+    final_state: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    settled_at: float | None = None
 
 
 @router.get("/{chat_id}/workflow")
@@ -95,6 +119,96 @@ def delete_chat_workflow(
 ):
     get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
     chat_workflow_service.delete_workflow(chat_id)
+    return {"status": "deleted"}
+
+
+@router.get("/{chat_id}/workflow/events")
+def list_chat_workflow_events(
+    chat_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    return chat_workflow_event_service.list_events(chat_id)
+
+
+@router.post("/{chat_id}/workflow/events")
+def create_chat_workflow_event(
+    chat_id: str,
+    body: CreateChatWorkflowEventBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    return chat_workflow_event_service.create_event(
+        chat_id,
+        kind=body.kind,
+        resource_refs=body.resource_refs,
+        requested_by_user_id=body.requested_by_user_id,
+        decision_states=body.decision_states,
+        rationales=body.rationales,
+        final_state=body.final_state,
+        metadata=body.metadata,
+    )
+
+
+@router.get("/{chat_id}/workflow/events/{event_id}")
+def get_chat_workflow_event(
+    chat_id: str,
+    event_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    event = chat_workflow_event_service.get_event(chat_id, event_id)
+    if event is None:
+        raise HTTPException(404, "Chat workflow event not found")
+    return event
+
+
+@router.patch("/{chat_id}/workflow/events/{event_id}")
+def update_chat_workflow_event(
+    chat_id: str,
+    event_id: str,
+    body: UpdateChatWorkflowEventBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    event = chat_workflow_event_service.update_event(
+        chat_id,
+        event_id,
+        state=body.state,
+        decision_states=body.decision_states,
+        rationales=body.rationales,
+        final_state=body.final_state,
+        metadata=body.metadata,
+        settled_at=body.settled_at,
+    )
+    if event is None:
+        raise HTTPException(404, "Chat workflow event not found")
+    return event
+
+
+@router.delete("/{chat_id}/workflow/events/{event_id}")
+def delete_chat_workflow_event(
+    chat_id: str,
+    event_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_repo: Annotated[Any, Depends(get_chat_repo)],
+    messaging_service: Annotated[Any, Depends(get_messaging_service)],
+    chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
+):
+    get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
+    chat_workflow_event_service.delete_event(chat_id, event_id)
     return {"status": "deleted"}
 
 

--- a/backend/chat/api/http/dependencies.py
+++ b/backend/chat/api/http/dependencies.py
@@ -48,6 +48,11 @@ def get_chat_task_service(app: Annotated[Any, Depends(get_app)]) -> Any:
     return runtime_state.chat_task_service
 
 
+def get_chat_workflow_event_service(app: Annotated[Any, Depends(get_app)]) -> Any:
+    runtime_state = _require_state_attr(app, "chat_runtime_state", "Chat workflow event service unavailable")
+    return runtime_state.chat_workflow_event_service
+
+
 def get_user_repo(app: Annotated[Any, Depends(get_app)]) -> Any:
     return _require_state_attr(app, "user_repo", "User repo unavailable")
 

--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -10,7 +10,7 @@ from backend.threads.chat_adapters.relationship_inlet import (
     make_relationship_decision_notification_fn,
     make_relationship_request_notification_fn,
 )
-from core.work_item.chat_workflow.service import ChatTaskService, ChatWorkflowService
+from core.work_item.chat_workflow.service import ChatTaskService, ChatWorkflowEventService, ChatWorkflowService
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.join_requests import ChatJoinRequestService
 from messaging.realtime.events import ChatEventBus
@@ -29,6 +29,7 @@ class ChatRuntimeState:
     chat_join_request_service: Any
     chat_workflow_service: Any
     chat_task_service: Any
+    chat_workflow_event_service: Any
     messaging_service: Any
 
 
@@ -47,6 +48,7 @@ def attach_chat_runtime(
     chat_join_request_repo = storage_container.chat_join_request_repo()
     chat_workflow_repo = storage_container.chat_workflow_repo()
     chat_task_repo = storage_container.chat_task_repo()
+    chat_workflow_event_repo = storage_container.chat_workflow_event_repo()
     chat_event_bus = ChatEventBus()
     typing_tracker = TypingTracker(chat_event_bus)
     relationship_service = RelationshipService(relationship_repo)
@@ -77,6 +79,7 @@ def attach_chat_runtime(
     )
     chat_workflow_service = ChatWorkflowService(workflow_repo=chat_workflow_repo)
     chat_task_service = ChatTaskService(task_repo=chat_task_repo)
+    chat_workflow_event_service = ChatWorkflowEventService(event_repo=chat_workflow_event_repo)
 
     # @@@chat-bootstrap-borrowable-state - chat bootstrap now keeps its owned
     # runtime objects inside the returned chat_runtime_state so the app
@@ -90,6 +93,7 @@ def attach_chat_runtime(
         chat_join_request_service=chat_join_request_service,
         chat_workflow_service=chat_workflow_service,
         chat_task_service=chat_task_service,
+        chat_workflow_event_service=chat_workflow_event_service,
         messaging_service=messaging_service,
     )
     app.state.chat_runtime_state = state

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from core.work_item.types import WorkItem
+from storage.contracts import ChatWorkflowEventRow
 
 
 class ChatWorkflowService:
@@ -114,6 +116,79 @@ class ChatTaskService:
         self._repo.delete(chat_id, task_id)
 
 
+class ChatWorkflowEventService:
+    def __init__(self, event_repo: Any) -> None:
+        self._repo = event_repo
+
+    def list_events(self, chat_id: str) -> list[dict[str, Any]]:
+        return [_event_response(event) for event in self._repo.list_all(chat_id)]
+
+    def get_event(self, chat_id: str, event_id: str) -> dict[str, Any] | None:
+        event = self._repo.get(chat_id, event_id)
+        return _event_response(event) if event is not None else None
+
+    def create_event(
+        self,
+        chat_id: str,
+        *,
+        kind: str,
+        resource_refs: list[dict[str, Any]] | None = None,
+        requested_by_user_id: str | None = None,
+        decision_states: dict[str, dict[str, str]] | None = None,
+        rationales: dict[str, Any] | None = None,
+        final_state: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        event = ChatWorkflowEventRow(
+            chat_id=chat_id,
+            event_id=self._repo.next_id(chat_id),
+            kind=kind,
+            state="open",
+            resource_refs=resource_refs or [],
+            requested_by_user_id=requested_by_user_id,
+            decision_states=decision_states or {},
+            rationales=rationales or {},
+            final_state=final_state or {},
+            metadata=metadata or {},
+            created_at=time.time(),
+        )
+        self._repo.insert(chat_id, event)
+        return _event_response(event)
+
+    def update_event(
+        self,
+        chat_id: str,
+        event_id: str,
+        *,
+        state: str | None = None,
+        decision_states: dict[str, dict[str, str]] | None = None,
+        rationales: dict[str, Any] | None = None,
+        final_state: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        settled_at: float | None = None,
+    ) -> dict[str, Any] | None:
+        event = self._repo.get(chat_id, event_id)
+        if event is None:
+            return None
+        if state is not None:
+            event.state = state
+        if decision_states is not None:
+            event.decision_states = dict(decision_states)
+        if rationales is not None:
+            event.rationales = dict(rationales)
+        if final_state is not None:
+            event.final_state = dict(final_state)
+        if metadata is not None:
+            event.metadata = dict(metadata)
+        if settled_at is not None:
+            event.settled_at = settled_at
+        self._repo.update(chat_id, event)
+        return _event_response(event)
+
+    def delete_event(self, chat_id: str, event_id: str) -> None:
+        self._repo.delete(chat_id, event_id)
+
+
 def _workflow_response(row: Any) -> dict[str, Any]:
     return {
         "chat_id": row.chat_id,
@@ -130,3 +205,21 @@ def _task_response(item: WorkItem) -> dict[str, Any]:
     payload = item.to_detail()
     payload["status"] = item.status.value if hasattr(item.status, "value") else str(item.status)
     return payload
+
+
+def _event_response(event: ChatWorkflowEventRow) -> dict[str, Any]:
+    return {
+        "chat_id": event.chat_id,
+        "event_id": event.event_id,
+        "kind": event.kind,
+        "state": event.state,
+        "resource_refs": [dict(ref) for ref in event.resource_refs],
+        "requested_by_user_id": event.requested_by_user_id,
+        "decision_states": {user_id: dict(states) for user_id, states in event.decision_states.items()},
+        "rationales": dict(event.rationales),
+        "final_state": dict(event.final_state),
+        "metadata": dict(event.metadata),
+        "created_at": event.created_at,
+        "updated_at": event.updated_at,
+        "settled_at": event.settled_at,
+    }

--- a/storage/container.py
+++ b/storage/container.py
@@ -7,6 +7,7 @@ from .contracts import (
     AgentConfigRepo,
     ChatRepo,
     ChatTaskRepo,
+    ChatWorkflowEventRepo,
     ChatWorkflowRepo,
     CheckpointRepo,
     ContactRepo,
@@ -59,6 +60,7 @@ _REPO_REGISTRY: dict[str, tuple[str, str]] = {
     "chat_join_request_repo": ("storage.providers.supabase.messaging_repo", "SupabaseChatJoinRequestRepo"),
     "chat_workflow_repo": ("storage.providers.supabase.chat_workflow_repo", "SupabaseChatWorkflowRepo"),
     "chat_task_repo": ("storage.providers.supabase.chat_workflow_repo", "SupabaseChatTaskRepo"),
+    "chat_workflow_event_repo": ("storage.providers.supabase.chat_workflow_repo", "SupabaseChatWorkflowEventRepo"),
     "messages_repo": ("storage.providers.supabase.messaging_repo", "SupabaseMessagesRepo"),
     "relationship_repo": ("storage.providers.supabase.messaging_repo", "SupabaseRelationshipRepo"),
     "invite_code_repo": ("storage.providers.supabase.invite_code_repo", "SupabaseInviteCodeRepo"),
@@ -157,6 +159,9 @@ class StorageContainer:
 
     def chat_task_repo(self) -> ChatTaskRepo:
         return self._build("chat_task_repo")
+
+    def chat_workflow_event_repo(self) -> ChatWorkflowEventRepo:
+        return self._build("chat_workflow_event_repo")
 
     def messages_repo(self) -> Any:
         return self._build("messages_repo")

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -290,6 +290,29 @@ class ChatWorkflowRow(BaseModel):
         return value
 
 
+class ChatWorkflowEventRow(BaseModel):
+    chat_id: str
+    event_id: str
+    kind: str
+    state: str = "open"
+    resource_refs: list[dict[str, Any]] = Field(default_factory=list)
+    requested_by_user_id: str | None = None
+    decision_states: dict[str, dict[str, str]] = Field(default_factory=dict)
+    rationales: dict[str, Any] = Field(default_factory=dict)
+    final_state: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: float
+    updated_at: float | None = None
+    settled_at: float | None = None
+
+    @field_validator("chat_id", "event_id", "kind", "state")
+    @classmethod
+    def _validate_chat_workflow_event_identity_fields(cls, value: str, info: Any) -> str:
+        if not value.strip():
+            raise ValueError(f"chat_workflow_event.{info.field_name} must not be blank")
+        return value
+
+
 class MessageRow(BaseModel):
     id: str
     chat_id: str
@@ -501,6 +524,16 @@ class ChatWorkflowRepo(Protocol):
 
 class ChatTaskRepo(WorkItemRepo, Protocol):
     pass
+
+
+class ChatWorkflowEventRepo(Protocol):
+    def close(self) -> None: ...
+    def next_id(self, scope_id: str) -> str: ...
+    def get(self, scope_id: str, event_id: str) -> ChatWorkflowEventRow | None: ...
+    def list_all(self, scope_id: str) -> list[ChatWorkflowEventRow]: ...
+    def insert(self, scope_id: str, event: ChatWorkflowEventRow) -> None: ...
+    def update(self, scope_id: str, event: ChatWorkflowEventRow) -> None: ...
+    def delete(self, scope_id: str, event_id: str) -> None: ...
 
 
 class ResourceSnapshotRepo(Protocol):

--- a/storage/providers/supabase/chat_workflow_repo.py
+++ b/storage/providers/supabase/chat_workflow_repo.py
@@ -4,12 +4,13 @@ import time
 from typing import Any
 
 from core.work_item.types import WorkItem
-from storage.contracts import ChatWorkflowRow
+from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
 from storage.providers.supabase import _query as q
 
 _SCHEMA = "chat"
 _WORKFLOW_REPO = "chat workflow repo"
 _TASK_REPO = "chat task repo"
+_EVENT_REPO = "chat workflow event repo"
 
 
 class SupabaseChatWorkflowRepo:
@@ -107,6 +108,56 @@ class SupabaseChatTaskRepo:
         return q.schema_table(self._client, _SCHEMA, "tasks", _TASK_REPO)
 
 
+class SupabaseChatWorkflowEventRepo:
+    def __init__(self, client: Any) -> None:
+        self._client = q.validate_client(client, _EVENT_REPO)
+
+    def close(self) -> None:
+        return None
+
+    def next_id(self, scope_id: str) -> str:
+        rows = q.rows(self._t().select("event_id").eq("chat_id", scope_id).execute(), _EVENT_REPO, "next_id")
+        if not rows:
+            return "1"
+        return str(max(int(str(row["event_id"])) for row in rows) + 1)
+
+    def get(self, scope_id: str, event_id: str) -> ChatWorkflowEventRow | None:
+        rows = q.rows(
+            self._t().select("*").eq("chat_id", scope_id).eq("event_id", event_id).limit(1).execute(),
+            _EVENT_REPO,
+            "get",
+        )
+        return _row_to_workflow_event(rows[0]) if rows else None
+
+    def list_all(self, scope_id: str) -> list[ChatWorkflowEventRow]:
+        rows = q.rows(
+            q.order(
+                self._t().select("*").eq("chat_id", scope_id),
+                "event_id",
+                desc=False,
+                repo=_EVENT_REPO,
+                operation="list_all",
+            ).execute(),
+            _EVENT_REPO,
+            "list_all",
+        )
+        return [_row_to_workflow_event(row) for row in rows]
+
+    def insert(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
+        self._t().insert(_workflow_event_payload(scope_id, event)).execute()
+
+    def update(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
+        payload = _workflow_event_payload(scope_id, event)
+        payload.pop("created_at", None)
+        self._t().update(payload).eq("chat_id", scope_id).eq("event_id", event.event_id).execute()
+
+    def delete(self, scope_id: str, event_id: str) -> None:
+        self._t().delete().eq("chat_id", scope_id).eq("event_id", event_id).execute()
+
+    def _t(self) -> Any:
+        return q.schema_table(self._client, _SCHEMA, "workflow_events", _EVENT_REPO)
+
+
 def _row_to_workflow(row: dict[str, Any]) -> ChatWorkflowRow:
     return ChatWorkflowRow(
         chat_id=str(row["chat_id"]),
@@ -133,6 +184,24 @@ def _row_to_work_item(row: dict[str, Any]) -> WorkItem:
     )
 
 
+def _row_to_workflow_event(row: dict[str, Any]) -> ChatWorkflowEventRow:
+    return ChatWorkflowEventRow(
+        chat_id=str(row["chat_id"]),
+        event_id=str(row["event_id"]),
+        kind=str(row["kind"]),
+        state=str(row.get("state") or "open"),
+        resource_refs=list(row.get("resource_refs_json") or row.get("resource_refs") or []),
+        requested_by_user_id=row.get("requested_by_user_id"),
+        decision_states=dict(row.get("decision_states_json") or row.get("decision_states") or {}),
+        rationales=dict(row.get("rationales_json") or row.get("rationales") or {}),
+        final_state=dict(row.get("final_state_json") or row.get("final_state") or {}),
+        metadata=dict(row.get("metadata_json") or row.get("metadata") or {}),
+        created_at=float(row["created_at"]),
+        updated_at=float(row["updated_at"]) if row.get("updated_at") is not None else None,
+        settled_at=float(row["settled_at"]) if row.get("settled_at") is not None else None,
+    )
+
+
 def _work_item_payload(scope_id: str, item: WorkItem) -> dict[str, Any]:
     now = time.time()
     status = item.status.value if hasattr(item.status, "value") else str(item.status)
@@ -149,4 +218,23 @@ def _work_item_payload(scope_id: str, item: WorkItem) -> dict[str, Any]:
         "metadata_json": dict(item.metadata),
         "created_at": now,
         "updated_at": now,
+    }
+
+
+def _workflow_event_payload(scope_id: str, event: ChatWorkflowEventRow) -> dict[str, Any]:
+    now = time.time()
+    return {
+        "chat_id": scope_id,
+        "event_id": event.event_id,
+        "kind": event.kind,
+        "state": event.state,
+        "resource_refs_json": list(event.resource_refs),
+        "requested_by_user_id": event.requested_by_user_id,
+        "decision_states_json": dict(event.decision_states),
+        "rationales_json": dict(event.rationales),
+        "final_state_json": dict(event.final_state),
+        "metadata_json": dict(event.metadata),
+        "created_at": event.created_at,
+        "updated_at": now,
+        "settled_at": event.settled_at,
     }

--- a/storage/schema/chat_workflow_state_and_tasks.sql
+++ b/storage/schema/chat_workflow_state_and_tasks.sql
@@ -24,13 +24,39 @@ create table if not exists chat.tasks (
     primary key (chat_id, task_id)
 );
 
+create table if not exists chat.workflow_events (
+    chat_id                 text not null references chat.chats(id) on delete cascade,
+    event_id                text not null,
+    kind                    text not null,
+    state                   text not null default 'open',
+    resource_refs_json      jsonb not null default '[]'::jsonb,
+    requested_by_user_id    text references identity.users(id) on delete set null,
+    decision_states_json    jsonb not null default '{}'::jsonb,
+    rationales_json         jsonb not null default '{}'::jsonb,
+    final_state_json        jsonb not null default '{}'::jsonb,
+    metadata_json           jsonb not null default '{}'::jsonb,
+    created_at              double precision not null,
+    updated_at              double precision,
+    settled_at              double precision,
+    primary key (chat_id, event_id)
+);
+
 create index if not exists idx_chat_tasks_owner_user_id
     on chat.tasks(owner_user_id)
     where owner_user_id is not null;
+
+create index if not exists idx_chat_workflow_events_kind_state
+    on chat.workflow_events(kind, state);
+
+create index if not exists idx_chat_workflow_events_requested_by_user_id
+    on chat.workflow_events(requested_by_user_id)
+    where requested_by_user_id is not null;
 
 grant select, insert, update, delete on chat.workflow_state to service_role;
 grant select, insert, update, delete on chat.workflow_state to authenticated;
 grant select, insert, update, delete on chat.tasks to service_role;
 grant select, insert, update, delete on chat.tasks to authenticated;
+grant select, insert, update, delete on chat.workflow_events to service_role;
+grant select, insert, update, delete on chat.workflow_events to authenticated;
 
 notify pgrst, 'reload schema';

--- a/tests/Integration/test_chat_app_router.py
+++ b/tests/Integration/test_chat_app_router.py
@@ -20,6 +20,8 @@ def test_chat_app_router_mounts_chat_relationship_and_conversation_routes() -> N
     assert "/api/chats/{chat_id}/join-target" in paths
     assert "/api/chats/{chat_id}/join-requests/{request_id}/approve" in paths
     assert "/api/chats/{chat_id}/workflow" in paths
+    assert "/api/chats/{chat_id}/workflow/events" in paths
+    assert "/api/chats/{chat_id}/workflow/events/{event_id}" in paths
     assert "/api/chats/{chat_id}/tasks" in paths
     assert "/api/chats/{chat_id}/tasks/{task_id}" in paths
     assert "/api/relationships" in paths

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -12,6 +12,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     chat_join_request_repo = object()
     chat_workflow_repo = object()
     chat_task_repo = object()
+    chat_workflow_event_repo = object()
 
     storage_container = SimpleNamespace(
         chat_repo=lambda: chat_repo,
@@ -22,6 +23,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         chat_join_request_repo=lambda: chat_join_request_repo,
         chat_workflow_repo=lambda: chat_workflow_repo,
         chat_task_repo=lambda: chat_task_repo,
+        chat_workflow_event_repo=lambda: chat_workflow_event_repo,
     )
 
     class _EventBus:
@@ -55,6 +57,10 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
+    class _ChatWorkflowEventService:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
     event_bus = _EventBus()
 
     monkeypatch.setattr(chat_bootstrap, "ChatEventBus", lambda: event_bus)
@@ -65,6 +71,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     monkeypatch.setattr(chat_bootstrap, "ChatJoinRequestService", _ChatJoinRequestService)
     monkeypatch.setattr(chat_bootstrap, "ChatWorkflowService", _ChatWorkflowService)
     monkeypatch.setattr(chat_bootstrap, "ChatTaskService", _ChatTaskService)
+    monkeypatch.setattr(chat_bootstrap, "ChatWorkflowEventService", _ChatWorkflowEventService)
     app = SimpleNamespace(
         state=SimpleNamespace(
             user_repo=object(),
@@ -91,6 +98,7 @@ def test_attach_chat_runtime_wires_chat_state(monkeypatch):
     assert state.chat_join_request_service.kwargs["messaging_service"] is state.messaging_service
     assert state.chat_workflow_service.kwargs["workflow_repo"] is chat_workflow_repo
     assert state.chat_task_service.kwargs["task_repo"] is chat_task_repo
+    assert state.chat_workflow_event_service.kwargs["event_repo"] is chat_workflow_event_repo
     assert state.messaging_service.kwargs["chat_repo"] is chat_repo
     assert state.messaging_service.kwargs["delivery_resolver"]["contact_repo"] is contact_repo
     assert state.messaging_service.kwargs["thread_repo"] is app.state.thread_repo
@@ -106,6 +114,9 @@ def test_attach_chat_runtime_requires_explicit_user_repo_and_thread_repo():
         messages_repo=lambda: object(),
         relationship_repo=lambda: object(),
         chat_join_request_repo=lambda: object(),
+        chat_workflow_repo=lambda: object(),
+        chat_task_repo=lambda: object(),
+        chat_workflow_event_repo=lambda: object(),
     )
 
     try:

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.work_item.chat_workflow.service import ChatTaskService, ChatWorkflowService
+from core.work_item.chat_workflow.service import (
+    ChatTaskService,
+    ChatWorkflowEventService,
+    ChatWorkflowService,
+)
 from core.work_item.types import WorkItem
-from storage.contracts import ChatWorkflowRow
+from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
 
 
 class _WorkflowRepo:
@@ -62,6 +66,29 @@ class _TaskRepo:
         self.rows.get(scope_id, {}).pop(item_id, None)
 
 
+class _WorkflowEventRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, ChatWorkflowEventRow]] = {}
+
+    def next_id(self, scope_id: str) -> str:
+        return str(len(self.rows.get(scope_id, {})) + 1)
+
+    def get(self, scope_id: str, event_id: str) -> ChatWorkflowEventRow | None:
+        return self.rows.get(scope_id, {}).get(event_id)
+
+    def list_all(self, scope_id: str) -> list[ChatWorkflowEventRow]:
+        return list(self.rows.get(scope_id, {}).values())
+
+    def insert(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
+        self.rows.setdefault(scope_id, {})[event.event_id] = event
+
+    def update(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
+        self.rows.setdefault(scope_id, {})[event.event_id] = event
+
+    def delete(self, scope_id: str, event_id: str) -> None:
+        self.rows.get(scope_id, {}).pop(event_id, None)
+
+
 def test_chat_workflow_service_projects_explicit_chat_scope() -> None:
     repo = _WorkflowRepo()
     service = ChatWorkflowService(repo)
@@ -110,3 +137,43 @@ def test_chat_task_service_keeps_tasks_scoped_to_chat_id() -> None:
     assert other["id"] == "1"
     assert [row["subject"] for row in service.list_tasks("chat-1")] == ["Review worker patch"]
     assert [row["subject"] for row in service.list_tasks("chat-2")] == ["Separate room task"]
+
+
+def test_chat_workflow_event_service_keeps_events_scoped_to_chat_id() -> None:
+    repo = _WorkflowEventRepo()
+    service = ChatWorkflowEventService(repo)
+
+    event = service.create_event(
+        "chat-1",
+        kind="task_proposed_review",
+        resource_refs=[{"type": "task", "id": "1"}],
+        requested_by_user_id="supervisor-user",
+        metadata={"rationale_ref": "msg-1"},
+    )
+    other = service.create_event(
+        "chat-2",
+        kind="group_stop",
+        resource_refs=[{"type": "group", "id": "group"}],
+    )
+
+    assert event["event_id"] == "1"
+    assert event["state"] == "open"
+    assert event["resource_refs"] == [{"type": "task", "id": "1"}]
+    assert event["requested_by_user_id"] == "supervisor-user"
+    assert service.list_events("chat-1") == [event]
+    assert service.list_events("chat-2") == [other]
+
+    updated = service.update_event(
+        "chat-1",
+        "1",
+        decision_states={"reviewer-user": {"1": "pending"}},
+        state="settled",
+        final_state={"1": "pending"},
+        settled_at=42.0,
+    )
+
+    assert updated is not None
+    assert updated["state"] == "settled"
+    assert updated["decision_states"] == {"reviewer-user": {"1": "pending"}}
+    assert updated["final_state"] == {"1": "pending"}
+    assert updated["settled_at"] == 42.0

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -341,6 +341,59 @@ def test_chat_task_routes_use_chat_access_helper(monkeypatch: pytest.MonkeyPatch
     ]
 
 
+def test_chat_workflow_event_routes_use_chat_access_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, object]] = []
+    chat = _chat("chat-1")
+    chat_repo = SimpleNamespace(name="chat-repo")
+    messaging_service = SimpleNamespace(name="messaging")
+
+    def fake_helper(chat_repo_arg, messaging_service_arg, chat_id: str, user_id: str):
+        seen.append(("helper", (chat_repo_arg, messaging_service_arg, chat_id, user_id)))
+        return chat
+
+    event_service = SimpleNamespace(
+        create_event=lambda chat_id, **kwargs: (
+            seen.append(("create_event", (chat_id, kwargs)))
+            or {"event_id": "1", "kind": kwargs["kind"], "resource_refs": kwargs["resource_refs"]}
+        )
+    )
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", fake_helper)
+
+    result = chat_workflow_router.create_chat_workflow_event(
+        "chat-1",
+        chat_workflow_router.CreateChatWorkflowEventBody(
+            kind="task_proposed_review",
+            resource_refs=[{"type": "task", "id": "1"}],
+            requested_by_user_id="supervisor-user",
+            metadata={"rationale_ref": "msg-1"},
+        ),
+        user_id="user-1",
+        chat_repo=chat_repo,
+        messaging_service=messaging_service,
+        chat_workflow_event_service=event_service,
+    )
+
+    assert result == {"event_id": "1", "kind": "task_proposed_review", "resource_refs": [{"type": "task", "id": "1"}]}
+    assert seen == [
+        ("helper", (chat_repo, messaging_service, "chat-1", "user-1")),
+        (
+            "create_event",
+            (
+                "chat-1",
+                {
+                    "kind": "task_proposed_review",
+                    "resource_refs": [{"type": "task", "id": "1"}],
+                    "requested_by_user_id": "supervisor-user",
+                    "decision_states": {},
+                    "rationales": {},
+                    "final_state": {},
+                    "metadata": {"rationale_ref": "msg-1"},
+                },
+            ),
+        ),
+    ]
+
+
 def test_resolve_display_user_delegates_to_messaging_service(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[tuple[str, str]] = []
     expected = SimpleNamespace(id="agent-user-1", display_name="Toad")

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -5,10 +5,14 @@ from pathlib import Path
 import pytest
 
 from core.work_item.types import WorkItem
-from storage.contracts import ChatRow, ContactEdgeRow
+from storage.contracts import ChatRow, ChatWorkflowEventRow, ContactEdgeRow
 from storage.errors import StorageConflictError
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
-from storage.providers.supabase.chat_workflow_repo import SupabaseChatTaskRepo, SupabaseChatWorkflowRepo
+from storage.providers.supabase.chat_workflow_repo import (
+    SupabaseChatTaskRepo,
+    SupabaseChatWorkflowEventRepo,
+    SupabaseChatWorkflowRepo,
+)
 from storage.providers.supabase.contact_repo import SupabaseContactRepo
 from storage.providers.supabase.messaging_repo import (
     SupabaseChatJoinRequestRepo,
@@ -104,6 +108,38 @@ def test_supabase_chat_task_repo_uses_work_item_shape_in_chat_schema() -> None:
     assert tables["chat.tasks"][0]["chat_id"] == "chat-1"
     assert tables["chat.tasks"][0]["subject"] == "Review worker patch"
     assert "tasks" not in tables
+
+
+def test_supabase_chat_workflow_event_repo_uses_chat_schema_sibling_table() -> None:
+    tables: dict[str, list[dict]] = {"chat.workflow_events": []}
+    client = FakeSupabaseClient(tables=tables)
+    repo = SupabaseChatWorkflowEventRepo(client)
+    event_id = repo.next_id("chat-1")
+
+    repo.insert(
+        "chat-1",
+        ChatWorkflowEventRow(
+            chat_id="chat-1",
+            event_id=event_id,
+            kind="task_proposed_review",
+            state="open",
+            resource_refs=[{"type": "task", "id": "1"}],
+            requested_by_user_id="supervisor-user",
+            decision_states={},
+            rationales={},
+            final_state={},
+            metadata={"rationale_ref": "msg-1"},
+            created_at=123.0,
+        ),
+    )
+    event = repo.get("chat-1", event_id)
+
+    assert event is not None
+    assert event.event_id == "1"
+    assert event.kind == "task_proposed_review"
+    assert event.resource_refs == [{"type": "task", "id": "1"}]
+    assert tables["chat.workflow_events"][0]["chat_id"] == "chat-1"
+    assert "workflow_events" not in tables
 
 
 def test_supabase_find_chat_between_only_returns_direct_chat() -> None:


### PR DESCRIPTION
## Summary

Adds a generic chat-scoped workflow event primitive to the app backend. This is the backend-first slice for moving group review consensus off local CLI state without making group/review a backend root concept.

## Shape

- Adds `ChatWorkflowEventRow` / `ChatWorkflowEventRepo` storage contract.
- Adds Supabase storage under `chat.workflow_events` beside `chat.workflow_state` and `chat.tasks`.
- Adds `ChatWorkflowEventService` for list/get/create/update/delete.
- Exposes public chat-scoped routes under `/api/chats/{chat_id}/workflow/events`.
- Wires the service through chat runtime state and dependency helpers.

## Verification

- `uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Integration/test_chat_app_router.py tests/Unit/backend/test_chat_bootstrap.py -q` -> 73 passed
- `uv run ruff check . && uv run ruff format --check .` -> passed
- `uv run pyright --pythonversion 3.12 core/work_item/chat_workflow/service.py storage/contracts.py storage/container.py storage/providers/supabase/chat_workflow_repo.py backend/chat/bootstrap.py backend/chat/api/http/dependencies.py backend/chat/api/http/chat_workflow_router.py` -> 0 errors
- `uv run pytest tests/ --ignore=tests/test_e2e_providers.py --ignore=tests/test_sandbox_e2e.py --ignore=tests/test_daytona_e2e.py --ignore=tests/test_e2e_backend_api.py --ignore=tests/test_e2e_summary_persistence.py --ignore=tests/test_p3_e2e.py --maxfail=5 --timeout=60 -q` -> 2138 passed, 8 skipped

Full-repo pyright still reports existing unrelated type debt in monitor/web/thread/test areas, so this PR records scoped pyright proof rather than global pyright closure.
