### PR TITLE
feat: add addressed chat delivery scope

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -38,6 +38,8 @@ class SendMessageBody(BaseModel):
 
     content: str
     mentioned_ids: list[str] | None = None
+    delivery_scope: Literal["broadcast", "addressed"] = "broadcast"
+    addressed_to_user_ids: list[str] | None = None
     reply_to: str | None = None
     enforce_caught_up: bool = False
 
@@ -269,10 +271,14 @@ def send_message(
             signal=None,
             message_type="human",
             reply_to=body.reply_to,
+            delivery_scope=body.delivery_scope,
+            addressed_to_user_ids=body.addressed_to_user_ids,
             enforce_caught_up=body.enforce_caught_up,
         )
     except ChatNotCaughtUpError as exc:
         raise HTTPException(409, "Read unread messages before sending.") from exc
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
     return messaging_service.project_message_response(msg)
 
 

--- a/messaging/delivery/dispatcher.py
+++ b/messaging/delivery/dispatcher.py
@@ -51,9 +51,12 @@ class ChatDeliveryDispatcher:
         content: str,
         mentions: list[str],
         signal: str | None = None,
+        addressed_to_user_ids: list[str] | None = None,
     ) -> None:
         mention_set = set(mentions)
-        sender_scope = SenderWakeScope.from_mentions(mentions)
+        addressed_set = set(addressed_to_user_ids or [])
+        target_set = addressed_set or mention_set
+        sender_scope = SenderWakeScope.TARGETED if target_set else SenderWakeScope.OPEN
         members = self._chat_members_repo.list_members(chat_id)
         sender_user = self._resolve_display_user(sender_id)
         if sender_user is None:
@@ -72,6 +75,8 @@ class ChatDeliveryDispatcher:
                 raise RuntimeError(f"Chat delivery member row is missing user_id in chat {chat_id}")
             if uid == sender_id:
                 continue
+            if addressed_set and uid not in addressed_set:
+                continue
             recipient = self._resolve_display_user(uid)
             if not recipient:
                 raise RuntimeError(f"Chat delivery recipient identity not found: {uid}")
@@ -85,14 +90,14 @@ class ChatDeliveryDispatcher:
             # is already enough access for runtime delivery; resolver policy is only needed
             # across ownership boundaries.
             if self._needs_access_resolver(sender_owner_id, recipient) and self._delivery_resolver:
-                is_mentioned = uid in mention_set
+                is_mentioned = uid in target_set
                 action = self._delivery_resolver.resolve(uid, chat_id, sender_id, is_mentioned=is_mentioned)
 
             wake_action = compose_wake_action(
                 safety=self._wake_safety(action),
                 sender_scope=sender_scope,
                 receiver_preference=self._receiver_preference(member, action),
-                recipient_is_mentioned=uid in mention_set,
+                recipient_is_mentioned=uid in target_set,
             )
             if wake_action is WakeAction.DROP_RUNTIME:
                 logger.info("[messaging] POLICY %s for %s", action.value, uid[:15])

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -23,15 +23,18 @@ from messaging.display_user import resolve_messaging_display_user
 from messaging.errors import ChatNotCaughtUpError
 from messaging.social_access import can_group_chat_with_participant
 from messaging.user_ownership import is_owned_by_viewer, shares_ownership_scope
-from storage.errors import StorageConflictError
 
 logger = logging.getLogger(__name__)
 
 
-def _should_dispatch_chat_delivery(message_type: MessageType, mentions: list[str] | None) -> bool:
+def _should_dispatch_chat_delivery(
+    message_type: MessageType,
+    mentions: list[str] | None,
+    addressed_to_user_ids: list[str] | None = None,
+) -> bool:
     # @@@notification-mention-delivery - request notifications are durable chat messages,
     # but mentioned managed agents still need a runtime wakeup to inspect them.
-    return message_type in {"human", "ai"} or (message_type == "notification" and bool(mentions))
+    return message_type in {"human", "ai"} or (message_type == "notification" and (bool(mentions) or bool(addressed_to_user_ids)))
 
 
 class MessagingService:
@@ -76,6 +79,8 @@ class MessagingService:
             **row,
             "sender_id": row.get("sender_id") or row.get("sender_user_id"),
             "mentioned_ids": row.get("mentioned_ids") or row.get("mentions") or row.get("mentions_json") or [],
+            "delivery_scope": row.get("delivery_scope") or "broadcast",
+            "addressed_to_user_ids": row.get("addressed_to_user_ids") or row.get("addressed_to_user_ids_json") or [],
             "reply_to": row.get("reply_to") or row.get("reply_to_message_id"),
             "ai_metadata": row.get("ai_metadata") or row.get("ai_metadata_json") or {},
         }
@@ -96,6 +101,8 @@ class MessagingService:
             "content": message["content"],
             "message_type": message.get("message_type", "human"),
             "mentioned_ids": message.get("mentioned_ids") or [],
+            "delivery_scope": message.get("delivery_scope") or "broadcast",
+            "addressed_to_user_ids": message.get("addressed_to_user_ids") or [],
             "seq": message.get("seq"),
             "signal": message.get("signal"),
             "retracted_at": message.get("retracted_at"),
@@ -226,10 +233,18 @@ class MessagingService:
         signal: str | None = None,
         reply_to: str | None = None,
         ai_metadata: dict[str, Any] | None = None,
+        delivery_scope: str = "broadcast",
+        addressed_to_user_ids: list[str] | None = None,
         enforce_caught_up: bool = False,
     ) -> dict[str, Any]:
         if self._resolve_display_user(sender_id) is None:
             raise RuntimeError(f"Chat message sender identity not found: {sender_id}")
+        normalized_delivery_scope, normalized_addressed_to = self._normalize_delivery_scope(
+            chat_id,
+            sender_id,
+            delivery_scope,
+            addressed_to_user_ids,
+        )
 
         msg_id = str(uuid.uuid4())
 
@@ -241,6 +256,8 @@ class MessagingService:
             "content_type": content_type,
             "message_type": message_type,
             "mentions_json": mentions or [],
+            "delivery_scope": normalized_delivery_scope,
+            "addressed_to_user_ids_json": normalized_addressed_to,
             "created_at": time.time(),
         }
         if signal in ("open", "yield", "close"):
@@ -251,13 +268,12 @@ class MessagingService:
             row["ai_metadata_json"] = ai_metadata
 
         if enforce_caught_up:
-            last_read_seq = getattr(self._chat_members_repo, "last_read_seq", None)
-            if last_read_seq is None:
-                raise RuntimeError("chat_member_repo must expose last_read_seq for caught-up sends")
-            try:
-                created_row = self._messages.create(row, expected_read_seq=int(last_read_seq(chat_id, sender_id)))
-            except StorageConflictError as exc:
-                raise ChatNotCaughtUpError(str(exc)) from exc
+            unread_count = self._messages.count_unread(chat_id, sender_id)
+            if type(unread_count) is not int:
+                raise RuntimeError("messages_repo.count_unread must return an int for caught-up sends")
+            if unread_count > 0:
+                raise ChatNotCaughtUpError(f"Read {unread_count} unread messages before sending.")
+            created_row = self._messages.create(row)
         else:
             created_row = self._messages.create(row)
         created = self._normalize_message_row(created_row)
@@ -279,10 +295,39 @@ class MessagingService:
             )
 
         # Deliver to agent recipients
-        if _should_dispatch_chat_delivery(message_type, mentions):
-            self._delivery_dispatcher.dispatch(chat_id, sender_id, content, mentions or [], signal=signal)
+        if _should_dispatch_chat_delivery(message_type, mentions, normalized_addressed_to):
+            self._delivery_dispatcher.dispatch(
+                chat_id,
+                sender_id,
+                content,
+                mentions or [],
+                signal=signal,
+                addressed_to_user_ids=normalized_addressed_to,
+            )
 
         return created
+
+    def _normalize_delivery_scope(
+        self,
+        chat_id: str,
+        sender_id: str,
+        delivery_scope: str,
+        addressed_to_user_ids: list[str] | None,
+    ) -> tuple[str, list[str]]:
+        addressed_to = [str(uid) for uid in dict.fromkeys(addressed_to_user_ids or []) if str(uid)]
+        if delivery_scope not in {"broadcast", "addressed"}:
+            raise ValueError("delivery_scope must be 'broadcast' or 'addressed'")
+        if delivery_scope == "broadcast":
+            if addressed_to:
+                raise ValueError("broadcast messages must not include addressed_to_user_ids")
+            return "broadcast", []
+        addressed_to = [uid for uid in addressed_to if uid != sender_id]
+        if not addressed_to:
+            raise ValueError("addressed messages require at least one recipient other than the sender")
+        for uid in addressed_to:
+            if not self._chat_members_repo.is_member(chat_id, uid):
+                raise ValueError(f"Addressed recipient is not a chat member: {uid}")
+        return "addressed", addressed_to
 
     # ------------------------------------------------------------------
     # Lifecycle operations
@@ -381,7 +426,7 @@ class MessagingService:
         """List all active chats for user with summary info."""
         chat_rows, members_by_chat, users_by_id, unread_by_chat = self._chat_projection_inputs(user_id)
         chat_ids = [chat.id for chat in chat_rows]
-        latest_messages = self._messages.list_latest_by_chat_ids(chat_ids)
+        latest_messages = self._messages.list_latest_by_chat_ids(chat_ids, viewer_id=user_id)
         if not isinstance(latest_messages, Mapping):
             raise RuntimeError("Latest message collection is invalid")
         chat_id_set = set(chat_ids)

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -323,6 +323,8 @@ class MessageRow(BaseModel):
     message_type: str = "text"
     signal: str | None = None
     mentions: list[str] = Field(default_factory=list)
+    delivery_scope: Literal["broadcast", "addressed"] = "broadcast"
+    addressed_to_user_ids: list[str] = Field(default_factory=list)
     reply_to_message_id: str | None = None
     ai_metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: float

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -190,14 +190,17 @@ class SupabaseMessagesRepo:
         q = self._t().select("*").eq("chat_id", chat_id).is_("deleted_at", "null")
         if before:
             q = q.lt("seq", int(before))
-        res = q.order("seq", desc=True).limit(limit).execute()
+        q = q.order("seq", desc=True)
+        if viewer_id is None:
+            q = q.limit(limit)
+        res = q.execute()
         rows = list(reversed(res.data or []))
-        # Filter soft-deleted for viewer
         if viewer_id:
-            rows = [r for r in rows if viewer_id not in (r.get("deleted_for") or [])]
+            rows = [r for r in rows if self._is_visible_to(r, viewer_id) and viewer_id not in (r.get("deleted_for") or [])]
+            rows = rows[-limit:]
         return rows
 
-    def list_latest_by_chat_ids(self, chat_ids: list[str]) -> dict[str, dict[str, Any]]:
+    def list_latest_by_chat_ids(self, chat_ids: list[str], *, viewer_id: str | None = None) -> dict[str, dict[str, Any]]:
         if not chat_ids:
             return {}
         latest_by_chat: dict[str, dict[str, Any]] = {}
@@ -216,6 +219,8 @@ class SupabaseMessagesRepo:
         )
         for row in rows:
             chat_id = str(row.get("chat_id") or "")
+            if viewer_id and (not self._is_visible_to(row, viewer_id) or viewer_id in (row.get("deleted_for") or [])):
+                continue
             if chat_id and chat_id not in latest_by_chat:
                 latest_by_chat[chat_id] = row
         return latest_by_chat
@@ -228,16 +233,10 @@ class SupabaseMessagesRepo:
             q = q.gt("seq", last_read_seq)
         res = q.order("seq", desc=False).execute()
         rows = res.data or []
-        return [r for r in rows if user_id not in (r.get("deleted_for") or [])]
+        return [r for r in rows if self._is_visible_to(r, user_id) and user_id not in (r.get("deleted_for") or [])]
 
     def count_unread(self, chat_id: str, user_id: str) -> int:
-        last_read_seq = self._last_read_seq(chat_id, user_id)
-
-        q = self._t().select("id", count="exact").eq("chat_id", chat_id).neq("sender_user_id", user_id).is_("deleted_at", "null")
-        if last_read_seq > 0:
-            q = q.gt("seq", last_read_seq)
-        res = q.execute()
-        return res.count or 0
+        return len(self.list_unread(chat_id, user_id))
 
     def count_unread_by_chat_ids(self, user_id: str, last_read_by_chat: dict[str, int]) -> dict[str, int]:
         if not last_read_by_chat:
@@ -246,7 +245,7 @@ class SupabaseMessagesRepo:
         min_last_read_seq = min(last_read_by_chat.values())
 
         def unread_query():
-            query = self._t().select("chat_id,seq").neq("sender_user_id", user_id).is_("deleted_at", "null")
+            query = self._t().select("*").neq("sender_user_id", user_id).is_("deleted_at", "null")
             if min_last_read_seq > 0:
                 query = query.gt("seq", min_last_read_seq)
             return query
@@ -255,8 +254,30 @@ class SupabaseMessagesRepo:
             chat_id = str(row.get("chat_id") or "")
             if int(row.get("seq") or 0) <= last_read_by_chat.get(chat_id, 0):
                 continue
+            if not self._is_visible_to(row, user_id):
+                continue
+            if user_id in (row.get("deleted_for") or []):
+                continue
             counts[chat_id] += 1
         return counts
+
+    def _is_visible_to(self, row: dict[str, Any], user_id: str) -> bool:
+        scope = str(row.get("delivery_scope") or "broadcast")
+        if scope != "addressed":
+            return True
+        if row.get("sender_user_id") == user_id:
+            return True
+        return user_id in self._addressed_to_user_ids(row)
+
+    def _addressed_to_user_ids(self, row: dict[str, Any]) -> list[str]:
+        value = row.get("addressed_to_user_ids_json")
+        if value is None:
+            value = row.get("addressed_to_user_ids")
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise RuntimeError(f"Message {row.get('id') or '<missing>'} has invalid addressed recipient list")
+        return [str(item) for item in value]
 
     def _last_read_seq(self, chat_id: str, user_id: str) -> int:
         member_res = self._members_t().select("last_read_seq").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()

--- a/storage/schema/chat_message_delivery_scope.sql
+++ b/storage/schema/chat_message_delivery_scope.sql
@@ -1,0 +1,10 @@
+alter table chat.messages
+  add column if not exists delivery_scope text not null default 'broadcast',
+  add column if not exists addressed_to_user_ids_json jsonb not null default '[]'::jsonb;
+
+alter table chat.messages
+  drop constraint if exists messages_delivery_scope_check;
+
+alter table chat.messages
+  add constraint messages_delivery_scope_check
+  check (delivery_scope in ('broadcast', 'addressed'));

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -778,6 +778,8 @@ def test_send_message_ignores_external_sender_authority_by_contract() -> None:
             "signal": None,
             "message_type": "human",
             "reply_to": None,
+            "delivery_scope": "broadcast",
+            "addressed_to_user_ids": None,
             "enforce_caught_up": True,
         }
     ]
@@ -837,9 +839,45 @@ def test_send_message_can_enforce_authenticated_user_caught_up_state() -> None:
             "signal": None,
             "message_type": "human",
             "reply_to": "msg-0",
+            "delivery_scope": "broadcast",
+            "addressed_to_user_ids": None,
             "enforce_caught_up": True,
         }
     ]
+
+
+def test_send_message_passes_addressed_delivery_scope_to_messaging_service() -> None:
+    seen: list[dict[str, object]] = []
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: SimpleNamespace(id=uid, owner_user_id=None),
+        is_chat_member=lambda _chat_id, _user_id: True,
+        send=lambda chat_id, sender_id, content, **kwargs: (
+            seen.append({"chat_id": chat_id, "sender_id": sender_id, "content": content, **kwargs})
+            or {
+                "id": "msg-1",
+                "chat_id": chat_id,
+                "sender_id": sender_id,
+                "content": content,
+                "message_type": "human",
+                "created_at": "2026-04-07T00:00:00Z",
+            }
+        ),
+        project_message_response=lambda msg: msg,
+    )
+
+    chats_router.send_message(
+        "chat-1",
+        chats_router.SendMessageBody(
+            content="worker only",
+            delivery_scope="addressed",
+            addressed_to_user_ids=["agent-user-2"],
+        ),
+        user_id="external-user-1",
+        messaging_service=messaging_service,
+    )
+
+    assert seen[0]["delivery_scope"] == "addressed"
+    assert seen[0]["addressed_to_user_ids"] == ["agent-user-2"]
 
 
 def test_send_message_maps_caught_up_conflict_to_409() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -1115,9 +1115,7 @@ def test_messaging_service_addressed_send_rejects_non_member_recipient() -> None
         ),
         messages_repo=SimpleNamespace(create=lambda row: {**row, "seq": 1}),
         user_repo=SimpleNamespace(
-            get_by_id=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="agent", avatar=None)
-            if uid == "agent-user-1"
-            else None
+            get_by_id=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="agent", avatar=None) if uid == "agent-user-1" else None
         ),
     )
 

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -924,6 +924,8 @@ def test_messaging_service_list_message_responses_projects_sender_name_from_agen
             "content": "hello",
             "message_type": "human",
             "mentioned_ids": [],
+            "delivery_scope": "broadcast",
+            "addressed_to_user_ids": [],
             "seq": 42,
             "signal": None,
             "retracted_at": None,
@@ -957,22 +959,22 @@ def test_messaging_service_list_message_responses_fails_on_unknown_sender() -> N
     assert str(excinfo.value) == "Chat message sender identity not found: missing-user"
 
 
-def test_messaging_service_agent_send_passes_expected_read_seq_to_messages_repo() -> None:
+def test_messaging_service_agent_send_checks_visible_unread_before_caught_up_send() -> None:
     created_rows: list[tuple[dict[str, Any], int | None]] = []
+    unread_checks: list[tuple[str, str]] = []
 
     class _StatefulChatMemberRepo:
         def list_members(self, _chat_id: str) -> list[dict[str, Any]]:
             return []
 
-        def last_read_seq(self, chat_id: str, user_id: str) -> int:
-            assert chat_id == "chat-1"
-            assert user_id == "agent-user-1"
-            return 7
-
         def update_last_read(self, _chat_id: str, _user_id: str, _last_read_seq: int) -> None:
             pass
 
     class _MessagesRepo:
+        def count_unread(self, chat_id: str, user_id: str) -> int:
+            unread_checks.append((chat_id, user_id))
+            return 0
+
         def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
             created_rows.append((row, expected_read_seq))
             return {**row, "seq": 8}
@@ -991,7 +993,10 @@ def test_messaging_service_agent_send_passes_expected_read_seq_to_messages_repo(
     assert len(created_rows) == 1
     row, expected_read_seq = created_rows[0]
     assert row["sender_user_id"] == "agent-user-1"
-    assert expected_read_seq == 7
+    assert row["delivery_scope"] == "broadcast"
+    assert row["addressed_to_user_ids_json"] == []
+    assert expected_read_seq is None
+    assert unread_checks == [("chat-1", "agent-user-1")]
 
 
 def test_messaging_service_send_advances_sender_read_watermark_to_created_message() -> None:
@@ -1010,8 +1015,11 @@ def test_messaging_service_send_advances_sender_read_watermark_to_created_messag
             read_updates.append((chat_id, user_id, last_read_seq))
 
     class _MessagesRepo:
+        def count_unread(self, _chat_id: str, _user_id: str) -> int:
+            return 0
+
         def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
-            assert expected_read_seq == 7
+            assert expected_read_seq is None
             return {**row, "seq": 8}
 
     service = MessagingService(
@@ -1048,22 +1056,94 @@ def test_messaging_service_plain_send_does_not_advance_sender_read_watermark() -
     assert read_updates == []
 
 
-def test_messaging_service_agent_send_maps_storage_conflict_to_not_caught_up_error() -> None:
+def test_messaging_service_addressed_send_writes_scope_and_dispatches_only_recipient() -> None:
+    created_rows: list[dict[str, Any]] = []
+    delivered: list[str] = []
+
+    class _ChatMemberRepo:
+        def list_members(self, _chat_id: str) -> list[dict[str, Any]]:
+            return [{"user_id": "agent-user-1"}, {"user_id": "agent-user-2"}, {"user_id": "agent-user-3"}]
+
+        def is_member(self, _chat_id: str, user_id: str) -> bool:
+            return user_id in {"agent-user-1", "agent-user-2", "agent-user-3"}
+
+    class _MessagesRepo:
+        def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
+            assert expected_read_seq is None
+            created_rows.append(row)
+            return {**row, "seq": 1}
+
+        def count_unread(self, _chat_id: str, _user_id: str) -> int:
+            return 1
+
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=_ChatMemberRepo(),
+        messages_repo=_MessagesRepo(),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(
+                id=uid,
+                display_name=uid,
+                type="agent",
+                avatar=None,
+                owner_user_id="human-user-1",
+            )
+        ),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    service.send(
+        "chat-1",
+        "agent-user-1",
+        "worker only",
+        delivery_scope="addressed",
+        addressed_to_user_ids=["agent-user-2"],
+    )
+
+    assert created_rows[0]["delivery_scope"] == "addressed"
+    assert created_rows[0]["addressed_to_user_ids_json"] == ["agent-user-2"]
+    assert delivered == ["agent-user-2"]
+
+
+def test_messaging_service_addressed_send_rejects_non_member_recipient() -> None:
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [],
+            is_member=lambda _chat_id, _user_id: False,
+        ),
+        messages_repo=SimpleNamespace(create=lambda row: {**row, "seq": 1}),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: SimpleNamespace(id=uid, display_name=uid, type="agent", avatar=None)
+            if uid == "agent-user-1"
+            else None
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Addressed recipient is not a chat member: missing-user"):
+        service.send(
+            "chat-1",
+            "agent-user-1",
+            "hello",
+            delivery_scope="addressed",
+            addressed_to_user_ids=["missing-user"],
+        )
+
+
+def test_messaging_service_agent_send_maps_visible_unread_to_not_caught_up_error() -> None:
     from messaging.errors import ChatNotCaughtUpError
-    from storage.errors import StorageConflictError
 
     class _StatefulChatMemberRepo:
         def list_members(self, _chat_id: str) -> list[dict[str, Any]]:
             return []
 
-        def last_read_seq(self, chat_id: str, user_id: str) -> int:
-            assert chat_id == "chat-1"
-            assert user_id == "agent-user-1"
-            return 7
-
     class _MessagesRepo:
-        def create(self, row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
-            raise StorageConflictError("Chat advanced after your last read.")
+        def count_unread(self, _chat_id: str, _user_id: str) -> int:
+            return 2
+
+        def create(self, _row: dict[str, Any], expected_read_seq: int | None = None) -> dict[str, Any]:
+            raise AssertionError("caught-up send should not create while visible unread exists")
 
     service = MessagingService(
         chat_repo=SimpleNamespace(),
@@ -1077,7 +1157,7 @@ def test_messaging_service_agent_send_maps_storage_conflict_to_not_caught_up_err
     with pytest.raises(ChatNotCaughtUpError) as excinfo:
         service.send("chat-1", "agent-user-1", "hello", enforce_caught_up=True)
 
-    assert str(excinfo.value) == "Chat advanced after your last read."
+    assert str(excinfo.value) == "Read 2 unread messages before sending."
 
 
 def test_messaging_service_list_chats_exposes_agent_user_participant_id() -> None:
@@ -1104,7 +1184,7 @@ def test_messaging_service_list_chats_exposes_agent_user_participant_id() -> Non
             list_members=lambda _chat_id: (_ for _ in ()).throw(AssertionError("chat list should not fetch members one by one")),
         ),
         messages_repo=SimpleNamespace(
-            list_latest_by_chat_ids=lambda _chat_ids: {},
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: {},
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {"chat-1": 0},
             list_by_chat=lambda _chat_id, limit=1: (_ for _ in ()).throw(
                 AssertionError("chat list should not fetch messages one chat at a time")
@@ -1225,7 +1305,7 @@ def test_messaging_service_list_chats_ignores_blank_other_names_in_title_default
             ],
         ),
         messages_repo=SimpleNamespace(
-            list_latest_by_chat_ids=lambda _chat_ids: {},
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: {},
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {"chat-1": 0},
         ),
         user_repo=SimpleNamespace(
@@ -1548,7 +1628,7 @@ def test_messaging_service_list_chats_fail_on_unrequested_latest_message_chat_id
         ),
         messages_repo=SimpleNamespace(
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
-            list_latest_by_chat_ids=lambda _chat_ids: {
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: {
                 "chat-extra": {
                     "id": "msg-1",
                     "chat_id": "chat-extra",
@@ -1578,7 +1658,7 @@ def test_messaging_service_list_chats_fails_on_latest_message_missing_content() 
         ),
         messages_repo=SimpleNamespace(
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
-            list_latest_by_chat_ids=lambda _chat_ids: {
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: {
                 "chat-1": {
                     "id": "msg-1",
                     "chat_id": "chat-1",
@@ -1607,7 +1687,7 @@ def test_messaging_service_list_chats_fails_on_latest_message_invalid_content() 
         ),
         messages_repo=SimpleNamespace(
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
-            list_latest_by_chat_ids=lambda _chat_ids: {
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: {
                 "chat-1": {
                     "id": "msg-1",
                     "chat_id": "chat-1",
@@ -1637,7 +1717,7 @@ def test_messaging_service_list_chats_fails_on_invalid_latest_message_collection
         ),
         messages_repo=SimpleNamespace(
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
-            list_latest_by_chat_ids=lambda _chat_ids: ["chat-1"],
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: ["chat-1"],
         ),
         user_repo=SimpleNamespace(
             list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
@@ -1659,7 +1739,7 @@ def test_messaging_service_list_chats_fails_on_invalid_latest_message_row() -> N
         ),
         messages_repo=SimpleNamespace(
             count_unread_by_chat_ids=lambda _user_id, _last_read_by_chat: {},
-            list_latest_by_chat_ids=lambda _chat_ids: {"chat-1": "msg-1"},
+            list_latest_by_chat_ids=lambda _chat_ids, **_kwargs: {"chat-1": "msg-1"},
         ),
         user_repo=SimpleNamespace(
             list_by_ids=lambda _user_ids: [SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)],
@@ -1892,7 +1972,7 @@ def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_water
                 },
             ]
 
-        def list_latest_by_chat_ids(self, _chat_ids: list[str]) -> dict[str, dict[str, Any]]:
+        def list_latest_by_chat_ids(self, _chat_ids: list[str], **_kwargs) -> dict[str, dict[str, Any]]:
             return {"chat-1": self._rows[-1]}
 
         def list_by_chat(self, _chat_id: str, limit: int = 50, viewer_id: str | None = None) -> list[dict[str, Any]]:

--- a/tests/Unit/messaging/test_chat_delivery_dispatcher.py
+++ b/tests/Unit/messaging/test_chat_delivery_dispatcher.py
@@ -134,6 +134,23 @@ def test_dispatcher_explicit_mentions_deliver_only_to_mentioned_default_agents()
     assert delivered == ["agent-user-2"]
 
 
+def test_dispatcher_addressed_delivery_only_wakes_addressed_runtime_recipients() -> None:
+    delivered: list[str] = []
+    unread_checks: list[str] = []
+    dispatcher = ChatDeliveryDispatcher(
+        chat_member_repo=_member_repo(["human-user-1", "agent-user-1", "agent-user-2"]),
+        user_repo=_user_repo(),
+        avatar_url_builder=lambda _user_id, _has_avatar: None,
+        unread_counter=lambda _chat_id, user_id: unread_checks.append(user_id) or 0,
+        delivery_fn=lambda request: delivered.append(request.recipient_id),
+    )
+
+    dispatcher.dispatch("chat-1", "human-user-1", "direct note", [], addressed_to_user_ids=["agent-user-2"])
+
+    assert delivered == ["agent-user-2"]
+    assert unread_checks == ["agent-user-2"]
+
+
 def test_dispatcher_keeps_no_wake_recipients_out_of_runtime_queue() -> None:
     delivered: list[str] = []
     dispatcher = ChatDeliveryDispatcher(

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -665,7 +665,10 @@ def test_supabase_messages_repo_list_by_chat_uses_seq_ordering() -> None:
 def test_supabase_messages_repo_count_unread_uses_last_read_seq_and_sender_user_id() -> None:
     client = _FakeClient()
     client.schema("chat").table("chat_members").rows = [{"last_read_seq": 5}]
-    client.schema("chat").table("messages").count = 2
+    client.schema("chat").table("messages").rows = [
+        {"id": "msg-6", "chat_id": "chat-1", "seq": 6, "sender_user_id": "user-2"},
+        {"id": "msg-7", "chat_id": "chat-1", "seq": 7, "sender_user_id": "user-2"},
+    ]
     repo = SupabaseMessagesRepo(client)
 
     count = repo.count_unread("chat-1", "user-1")
@@ -675,3 +678,74 @@ def test_supabase_messages_repo_count_unread_uses_last_read_seq_and_sender_user_
     assert ("seq", 5) in client.tables["chat.messages"].gt_calls
     assert ("sender_user_id", "user-1") in client.tables["chat.messages"].neq_calls
     assert ("sender_id", "user-1") not in client.tables["chat.messages"].neq_calls
+
+
+def test_supabase_messages_repo_filters_addressed_messages_from_non_recipients() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.chat_members": [
+            {"chat_id": "chat-1", "user_id": "user-1", "last_read_seq": 0},
+            {"chat_id": "chat-1", "user_id": "user-2", "last_read_seq": 0},
+            {"chat_id": "chat-1", "user_id": "user-3", "last_read_seq": 0},
+        ],
+        "chat.messages": [
+            {
+                "id": "broadcast-1",
+                "chat_id": "chat-1",
+                "seq": 1,
+                "sender_user_id": "user-1",
+                "content": "everyone sees this",
+                "delivery_scope": "broadcast",
+                "addressed_to_user_ids_json": [],
+            },
+            {
+                "id": "addressed-1",
+                "chat_id": "chat-1",
+                "seq": 2,
+                "sender_user_id": "user-1",
+                "content": "only user-2 sees this",
+                "delivery_scope": "addressed",
+                "addressed_to_user_ids_json": ["user-2"],
+            },
+        ],
+    }
+    repo = SupabaseMessagesRepo(FakeSupabaseClient(tables=tables))
+
+    user_2_unread = repo.list_unread("chat-1", "user-2")
+    user_3_unread = repo.list_unread("chat-1", "user-3")
+    user_3_history = repo.list_by_chat("chat-1", viewer_id="user-3")
+
+    assert [row["id"] for row in user_2_unread] == ["broadcast-1", "addressed-1"]
+    assert [row["id"] for row in user_3_unread] == ["broadcast-1"]
+    assert [row["id"] for row in user_3_history] == ["broadcast-1"]
+    assert repo.count_unread("chat-1", "user-3") == 1
+    assert repo.count_unread_by_chat_ids("user-3", {"chat-1": 0}) == {"chat-1": 1}
+
+
+def test_supabase_messages_repo_latest_message_is_viewer_visible() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.messages": [
+            {
+                "id": "broadcast-1",
+                "chat_id": "chat-1",
+                "seq": 1,
+                "sender_user_id": "user-1",
+                "content": "visible latest for user-3",
+                "delivery_scope": "broadcast",
+                "addressed_to_user_ids_json": [],
+            },
+            {
+                "id": "addressed-1",
+                "chat_id": "chat-1",
+                "seq": 2,
+                "sender_user_id": "user-1",
+                "content": "hidden from user-3",
+                "delivery_scope": "addressed",
+                "addressed_to_user_ids_json": ["user-2"],
+            },
+        ]
+    }
+    repo = SupabaseMessagesRepo(FakeSupabaseClient(tables=tables))
+
+    latest = repo.list_latest_by_chat_ids(["chat-1"], viewer_id="user-3")
+
+    assert latest["chat-1"]["id"] == "broadcast-1"

--- a/tests/fakes/supabase.py
+++ b/tests/fakes/supabase.py
@@ -84,7 +84,9 @@ class FakeSupabaseQuery:
                 return False
             if op == "gte" and not (cell is not None and cell >= value):
                 return False
-            if op == "is" and cell is not value:
+            if op == "is" and value == "null" and cell is not None:
+                return False
+            if op == "is" and value != "null" and cell is not value:
                 return False
         if self._in_filter is not None:
             column, values = self._in_filter


### PR DESCRIPTION
## Summary
- add backend chat message delivery scope: `broadcast` vs `addressed`
- make addressed messages visible/unread only to sender and addressed recipients while keeping group as a single Mycel chat
- route runtime wake notifications only to addressed recipients for addressed sends

## Verification
- `uv run pytest tests/Unit -q` -> 2089 passed, 3 skipped
- `uv run ruff check backend/chat/api/http/chats_router.py messaging/delivery/dispatcher.py messaging/service.py storage/contracts.py storage/providers/supabase/messaging_repo.py tests/fakes/supabase.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py` -> All checks passed

## YATU / rollout note
- Real product YATU against a deployed backend should run after the target database has the new `chat.messages.delivery_scope` and `chat.messages.addressed_to_user_ids_json` columns. Hitting an older deployed schema would be a stale-environment failure, not a product proof.
