### PR TITLE
feat: let chat owners add members

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -61,6 +61,12 @@ class ChatJoinRequestActionBody(BaseModel):
     pass
 
 
+class ChatMemberAddBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+
+
 def _map_chat_join_error(exc: Exception) -> HTTPException:
     if isinstance(exc, LookupError):
         return HTTPException(404, str(exc))
@@ -245,6 +251,24 @@ def reject_chat_join(
 ):
     try:
         return chat_join_request_service.reject(chat_id, request_id, user_id)
+    except Exception as exc:
+        raise _map_chat_join_error(exc) from exc
+
+
+@router.post("/{chat_id}/members")
+def add_chat_member(
+    chat_id: str,
+    body: ChatMemberAddBody,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    chat_join_request_service: Annotated[Any, Depends(get_chat_join_request_service)],
+    user_repo: Annotated[Any, Depends(get_user_repo)],
+    thread_repo: Annotated[Any, Depends(get_thread_repo)],
+):
+    try:
+        [target_user_id] = _validate_chat_participant_ids(user_repo, thread_repo, [body.user_id], user_id)
+        return chat_join_request_service.add_member(chat_id, target_user_id, user_id)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
         raise _map_chat_join_error(exc) from exc
 

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -57,6 +57,13 @@ class ChatJoinRequestService:
         self._require_chat_owner(chat_id, viewer_user_id)
         return [self._project_request(row) for row in self._requests.list_for_chat(chat_id)]
 
+    def add_member(self, chat_id: str, target_user_id: str, owner_user_id: str) -> dict[str, Any]:
+        self._require_chat_owner(chat_id, owner_user_id)
+        if self._members.is_member(chat_id, target_user_id):
+            return {"chat_id": chat_id, "user_id": target_user_id, "state": "member"}
+        self._members.add_member(chat_id, target_user_id)
+        return {"chat_id": chat_id, "user_id": target_user_id, "state": "member"}
+
     def approve(self, chat_id: str, request_id: str, approver_user_id: str) -> dict[str, Any]:
         self._require_chat_owner(chat_id, approver_user_id)
         request = self._require_pending_request(chat_id, request_id)

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -109,6 +109,7 @@ def test_messaging_crud_routes_are_sync_threadpool_boundaries() -> None:
         chats_router.create_chat,
         chats_router.get_chat,
         chats_router.list_messages,
+        chats_router.add_chat_member,
         chats_router.send_message,
         chats_router.retract_message,
         chats_router.delete_message_for_self,
@@ -146,6 +147,16 @@ def test_chat_join_request_bodies_do_not_accept_identity_fields() -> None:
         chats_router.ChatJoinRequestActionBody.model_validate({"requester_user_id": "user-1"})
     with pytest.raises(ValidationError):
         chats_router.ChatJoinRequestBody.model_validate({"message": "please add me", "actor_" + "user_id": "user-1"})
+
+
+def test_chat_member_add_body_does_not_accept_identity_fields() -> None:
+    body = chats_router.ChatMemberAddBody(user_id="external-1")
+
+    assert body.user_id == "external-1"
+    with pytest.raises(ValidationError):
+        chats_router.ChatMemberAddBody.model_validate({"user_id": "external-1", "owner_user_id": "user-1"})
+    with pytest.raises(ValidationError):
+        chats_router.ChatMemberAddBody.model_validate({"user_id": "external-1", "actor_" + "user_id": "user-1"})
 
 
 def test_request_chat_join_uses_current_token_user() -> None:
@@ -222,6 +233,46 @@ def test_approve_chat_join_uses_current_token_user() -> None:
 
     assert seen == [("chat-1", "join-request-1", "human-user-1")]
     assert result == expected
+
+
+def test_add_chat_member_uses_current_token_user_and_validates_target() -> None:
+    seen: list[tuple[str, str, str]] = []
+    expected = {"chat_id": "chat-1", "user_id": "external-1", "state": "member"}
+    chat_join_request_service = SimpleNamespace(
+        add_member=lambda chat_id, target_user_id, owner_user_id: seen.append((chat_id, target_user_id, owner_user_id)) or expected
+    )
+    user_repo = SimpleNamespace(get_by_id=lambda uid: SimpleNamespace(id=uid) if uid == "external-1" else None)
+    thread_repo = SimpleNamespace(get_by_user_id=lambda _uid: None)
+
+    result = chats_router.add_chat_member(
+        "chat-1",
+        chats_router.ChatMemberAddBody(user_id="external-1"),
+        user_id="human-user-1",
+        chat_join_request_service=chat_join_request_service,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+    )
+
+    assert seen == [("chat-1", "external-1", "human-user-1")]
+    assert result == expected
+
+
+def test_add_chat_member_rejects_unknown_target() -> None:
+    chat_join_request_service = SimpleNamespace(add_member=lambda *_args: None)
+    user_repo = SimpleNamespace(get_by_id=lambda _uid: None)
+    thread_repo = SimpleNamespace(get_by_user_id=lambda _uid: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        chats_router.add_chat_member(
+            "chat-1",
+            chats_router.ChatMemberAddBody(user_id="missing-user"),
+            user_id="human-user-1",
+            chat_join_request_service=chat_join_request_service,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+        )
+
+    assert exc_info.value.status_code == 400
 
 
 def test_get_accessible_chat_or_404_returns_chat():

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -196,6 +196,23 @@ def test_chat_join_approve_requires_owner_and_adds_member_before_notification() 
     )
 
 
+def test_chat_owner_can_add_member_without_join_request() -> None:
+    service, members, _requests, messaging = _service()
+
+    row = service.add_member("chat-1", "visitor-1", "owner-1")
+
+    assert row == {"chat_id": "chat-1", "user_id": "visitor-1", "state": "member"}
+    assert members.added == [("chat-1", "visitor-1")]
+    assert messaging.sent == []
+
+
+def test_chat_owner_add_member_rejects_non_owner() -> None:
+    service, _members, _requests, _messaging = _service()
+
+    with pytest.raises(PermissionError):
+        service.add_member("chat-1", "visitor-1", "visitor-1")
+
+
 def test_chat_join_reject_mentions_requester_in_notification() -> None:
     service, _members, _requests, messaging = _service()
     pending = service.request("chat-1", "visitor-1", "please add me")


### PR DESCRIPTION
## Summary

Adds a small public chat primitive for owner-managed membership:

- `POST /api/chats/{chat_id}/members` with `{ "user_id": "..." }`
- owner-only service method over the existing chat member repo
- target user validation through the same participant validation path used by chat creation

This is needed because a Cel group is now a Mycel group chat. Role creation must be able to add owned external agent users to that chat instead of inventing local pair channels or bypassing membership.

## Verification

- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py::test_chat_owner_can_add_member_without_join_request tests/Unit/messaging/test_chat_join_requests.py::test_chat_owner_add_member_rejects_non_owner tests/Unit/integration_contracts/test_messaging_router.py::test_chat_member_add_body_does_not_accept_identity_fields tests/Unit/integration_contracts/test_messaging_router.py::test_add_chat_member_uses_current_token_user_and_validates_target tests/Unit/integration_contracts/test_messaging_router.py::test_add_chat_member_rejects_unknown_target -q`
- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/integration_contracts/test_messaging_router.py -q`
- `uv run pytest tests/Unit -q`
- `uv run ruff format --check . && uv run ruff check .`

## YATU Context

Real public CLI group YATU exposed the gap: supervisor/worker/reviewer identities existed, but their external users were not chat members, so role message send failed with `HTTP 403: Not a participant of this chat`. This PR fixes the backend primitive; SDK/CLI will regenerate and call it from role creation in a separate PR.
