### PR TITLE
fix: make direct chat lookup deterministic

### DIFF
--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -54,18 +54,26 @@ class SupabaseChatMemberRepo:
     def find_chat_between(self, user_a: str, user_b: str) -> str | None:
         chats_a = set(self.list_chats_for_user(user_a))
         chats_b = set(self.list_chats_for_user(user_b))
-        common = chats_a & chats_b
-        for chat_id in common:
+        candidates: list[dict[str, Any]] = []
+        for chat_id in chats_a & chats_b:
             members = self.list_members(chat_id)
-            if len(members) == 2 and self._chat_type(chat_id) == "direct":
-                return chat_id
-        return None
-
-    def _chat_type(self, chat_id: str) -> str | None:
-        res = q.schema_table(self._client, _SCHEMA, "chats", "chat member repo").select("type").eq("id", chat_id).limit(1).execute()
-        if not res.data:
+            chat = self._chat_row(chat_id)
+            if len(members) == 2 and chat and chat.get("type") == "direct":
+                candidates.append(chat)
+        if not candidates:
             return None
-        return str(res.data[0].get("type") or "")
+        candidates.sort(key=lambda row: (float(row.get("created_at") or 0), str(row.get("id") or "")))
+        return str(candidates[0]["id"])
+
+    def _chat_row(self, chat_id: str) -> dict[str, Any] | None:
+        res = (
+            q.schema_table(self._client, _SCHEMA, "chats", "chat member repo")
+            .select("id,type,created_at")
+            .eq("id", chat_id)
+            .limit(1)
+            .execute()
+        )
+        return res.data[0] if res.data else None
 
     def update_last_read(self, chat_id: str, user_id: str, last_read_seq: int) -> None:
         self._t().update({"last_read_seq": last_read_seq}).eq("chat_id", chat_id).eq("user_id", user_id).execute()

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -184,6 +184,40 @@ def test_supabase_find_chat_between_only_returns_direct_chat() -> None:
     assert SupabaseChatMemberRepo(group_only_client).find_chat_between("user-1", "user-2") is None
 
 
+def test_supabase_find_chat_between_uses_oldest_direct_chat_when_duplicates_exist() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.chats": [
+            {
+                "id": "direct-two-new",
+                "type": "direct",
+                "created_by_user_id": "user-1",
+                "title": None,
+                "status": "active",
+                "next_message_seq": 0,
+                "created_at": 2.0,
+            },
+            {
+                "id": "direct-one-old",
+                "type": "direct",
+                "created_by_user_id": "user-1",
+                "title": None,
+                "status": "active",
+                "next_message_seq": 0,
+                "created_at": 1.0,
+            },
+        ],
+        "chat.chat_members": [
+            {"chat_id": "direct-two-new", "user_id": "user-1", "last_read_seq": 0},
+            {"chat_id": "direct-two-new", "user_id": "user-2", "last_read_seq": 0},
+            {"chat_id": "direct-one-old", "user_id": "user-1", "last_read_seq": 0},
+            {"chat_id": "direct-one-old", "user_id": "user-2", "last_read_seq": 0},
+        ],
+    }
+    client = FakeSupabaseClient(tables=tables)
+
+    assert SupabaseChatMemberRepo(client).find_chat_between("user-1", "user-2") == "direct-one-old"
+
+
 def test_supabase_contact_and_relationship_repos_use_chat_schema() -> None:
     tables: dict[str, list[dict]] = {"chat.contacts": [], "chat.relationships": []}
     client = FakeSupabaseClient(tables=tables)


### PR DESCRIPTION
## Summary
- make Supabase direct chat lookup deterministic when historical duplicate direct chats exist
- keep the existing chat primitive and return the oldest matching direct chat instead of iterating an unordered set
- add a storage contract for duplicate direct rows

## Verification
- watched `test_supabase_find_chat_between_uses_oldest_direct_chat_when_duplicates_exist` fail red before implementation
- `uv run pytest tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py::test_supabase_find_chat_between_only_returns_direct_chat tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py::test_supabase_find_chat_between_uses_oldest_direct_chat_when_duplicates_exist -q`
- `uv run ruff format --check storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
- `uv run ruff check storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
- `uv run pytest tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py -q`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py -q`
- `uv run ruff format --check . && uv run ruff check . && uv run pytest -q`
