### PR TITLE
refactor: route runtime notifications through gateway

### DIFF
--- a/backend/threads/chat_adapters/bootstrap.py
+++ b/backend/threads/chat_adapters/bootstrap.py
@@ -10,6 +10,7 @@ from backend.threads.chat_adapters.chat_handler import NativeAgentChatDeliveryHa
 from backend.threads.chat_adapters.chat_runtime_services import AppAgentChatRuntimeServices
 from backend.threads.chat_adapters.external_inbox_handler import ExternalRuntimeInboxHandler
 from backend.threads.chat_adapters.gateway import NativeAgentRuntimeGateway
+from backend.threads.chat_adapters.notification_handler import NativeAgentNotificationHandler
 from backend.threads.chat_adapters.thread_handler import NativeAgentThreadInputHandler
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
 from backend.threads.streaming import _ensure_thread_handlers, start_agent_run
@@ -30,6 +31,17 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
         queue_manager=app.state.queue_manager,
         wake_bus=app.state.runtime_inbox_wake_bus,
     )
+    thread_input_handler = NativeAgentThreadInputHandler(
+        app,
+        queue_manager=app.state.queue_manager,
+        thread_tasks=app.state.thread_tasks,
+        thread_locks=app.state.thread_locks,
+        thread_locks_guard=app.state.thread_locks_guard,
+        get_or_create_agent=get_or_create_agent,
+        resolve_thread_sandbox=resolve_thread_sandbox,
+        start_agent_run=start_agent_run,
+        clear_resource_overview_cache=clear_resource_overview_cache,
+    )
     gateway = NativeAgentRuntimeGateway(
         chat_handlers={
             "mycel": NativeAgentChatDeliveryHandler(
@@ -48,18 +60,11 @@ def build_agent_runtime_state(app: Any, *, typing_tracker: Any) -> AgentRuntimeG
             ),
             "external": external_runtime_handler,
         },
-        notification_handlers={"external": external_runtime_handler},
-        thread_input_handler=NativeAgentThreadInputHandler(
-            app,
-            queue_manager=app.state.queue_manager,
-            thread_tasks=app.state.thread_tasks,
-            thread_locks=app.state.thread_locks,
-            thread_locks_guard=app.state.thread_locks_guard,
-            get_or_create_agent=get_or_create_agent,
-            resolve_thread_sandbox=resolve_thread_sandbox,
-            start_agent_run=start_agent_run,
-            clear_resource_overview_cache=clear_resource_overview_cache,
-        ),
+        notification_handlers={
+            "mycel": NativeAgentNotificationHandler(thread_input_handler=thread_input_handler),
+            "external": external_runtime_handler,
+        },
+        thread_input_handler=thread_input_handler,
     )
     # @@@gateway-bootstrap-borrowable-state - gateway bootstrap now returns the
     # runtime handles without mirroring them onto loose app.state attrs, so

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,22 +1,17 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from enum import Enum
 from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
+from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from protocols.agent_runtime import (
-    AgentChatRecipient,
     AgentRuntimeActor,
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
-    AgentThreadInputEnvelope,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -37,40 +32,19 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
             "chat_id": chat_id,
             "state": "rejected",
         }
-
-        if requester_type == "external":
-            await get_agent_runtime_gateway(app).dispatch_notification(
-                AgentRuntimeNotificationEnvelope(
-                    event_type="chat.join.rejected",
-                    recipient=AgentChatRecipient(agent_user_id=requester_id, runtime_source="external"),
-                    sender=AgentRuntimeActor(
-                        user_id=decider_id,
-                        user_type=_user_type(decider, decider_id),
-                        display_name=_display_name(decider, decider_id),
-                        avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
-                        source="chat_join",
-                    ),
-                    message=AgentRuntimeMessage(content=content, metadata=metadata),
-                    notification_type="chat_join",
-                )
-            )
-            return
-
-        if requester_type != "agent":
-            return
-
-        thread_id = select_runtime_thread_for_recipient(
+        recipient = select_runtime_notification_recipient(
             requester_id,
+            requester_type,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
+            context="chat join",
         )
-        if thread_id is None:
-            logger.info("Skipped chat join wake for agent without runtime thread: %s", requester_id)
+        if recipient is None:
             return
-
-        await get_agent_runtime_gateway(app).dispatch_thread_input(
-            AgentThreadInputEnvelope(
-                thread_id=thread_id,
+        await get_agent_runtime_gateway(app).dispatch_notification(
+            AgentRuntimeNotificationEnvelope(
+                event_type="chat.join.rejected",
+                recipient=recipient,
                 sender=AgentRuntimeActor(
                     user_id=decider_id,
                     user_type=_user_type(decider, decider_id),
@@ -82,6 +56,7 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
                     content=content,
                     metadata=metadata,
                 ),
+                notification_type="chat_join",
             )
         )
 

--- a/backend/threads/chat_adapters/notification_handler.py
+++ b/backend/threads/chat_adapters/notification_handler.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from protocols import agent_runtime as agent_runtime_protocol
+
+
+class NativeAgentNotificationHandler:
+    def __init__(self, *, thread_input_handler: Any) -> None:
+        self._thread_input_handler = thread_input_handler
+
+    async def dispatch_notification(
+        self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope
+    ) -> agent_runtime_protocol.AgentRuntimeNotificationResult:
+        thread_id = envelope.recipient.thread_id
+        if not thread_id:
+            raise RuntimeError(f"Agent runtime notification recipient has no runtime thread: {envelope.recipient.agent_user_id}")
+        result = await self._thread_input_handler.dispatch(
+            agent_runtime_protocol.AgentThreadInputEnvelope(
+                thread_id=thread_id,
+                sender=envelope.sender,
+                message=envelope.message,
+            )
+        )
+        return agent_runtime_protocol.AgentRuntimeNotificationResult(status="accepted", thread_id=result.thread_id)

--- a/backend/threads/chat_adapters/port.py
+++ b/backend/threads/chat_adapters/port.py
@@ -5,6 +5,8 @@ from typing import Any, Protocol
 from protocols.agent_runtime import (
     AgentChatDeliveryEnvelope,
     AgentChatDeliveryResult,
+    AgentRuntimeNotificationEnvelope,
+    AgentRuntimeNotificationResult,
     AgentThreadInputEnvelope,
     AgentThreadInputResult,
 )
@@ -12,6 +14,8 @@ from protocols.agent_runtime import (
 
 class AgentRuntimeGatewayPort(Protocol):
     async def dispatch_chat(self, envelope: AgentChatDeliveryEnvelope) -> AgentChatDeliveryResult: ...
+
+    async def dispatch_notification(self, envelope: AgentRuntimeNotificationEnvelope) -> AgentRuntimeNotificationResult: ...
 
     async def dispatch_thread_input(self, envelope: AgentThreadInputEnvelope) -> AgentThreadInputResult: ...
 

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,28 +1,24 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from enum import Enum
 from typing import Any
 
 from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from messaging.contracts import RelationshipEvent, RelationshipRow
-from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
 from protocols.agent_runtime import (
     AgentChatRecipient,
     AgentRuntimeActor,
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
-    AgentThreadInputEnvelope,
 )
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
     "approve": "approved",
     "reject": "rejected",
 }
-
-logger = logging.getLogger(__name__)
 
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -36,57 +32,33 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
         requester = _require_user(user_repo, requester_id, "requester")
         target = _require_user(user_repo, target_id, "target")
         target_type = _user_type(target, target_id)
-        if target_type == "external":
-            await _dispatch_external_notification(
-                app,
-                recipient_id=target_id,
-                sender=AgentRuntimeActor(
-                    user_id=requester_id,
-                    user_type=_user_type(requester, requester_id),
-                    display_name=_display_name(requester, requester_id),
-                    avatar_url=avatar_url(requester_id, bool(getattr(requester, "avatar", None))),
-                    source="relationship",
-                ),
-                message=AgentRuntimeMessage(
-                    content=_notification_content(
-                        _display_name(requester, requester_id),
-                        row.message,
-                    ),
-                    metadata={"relationship_id": row.id},
-                ),
-                event_type="relationship.requested",
-            )
-            return
-        if target_type != "agent":
-            return
-
-        thread_id = select_runtime_thread_for_recipient(
+        recipient = select_runtime_notification_recipient(
             target_id,
+            target_type,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
+            context="relationship request",
         )
-        if thread_id is None:
-            logger.info("Skipped relationship request wake for agent without runtime thread: %s", target_id)
+        if recipient is None:
             return
-
-        await get_agent_runtime_gateway(app).dispatch_thread_input(
-            AgentThreadInputEnvelope(
-                thread_id=thread_id,
-                sender=AgentRuntimeActor(
-                    user_id=requester_id,
-                    user_type=_user_type(requester, requester_id),
-                    display_name=_display_name(requester, requester_id),
-                    avatar_url=avatar_url(requester_id, bool(getattr(requester, "avatar", None))),
-                    source="relationship",
+        await _dispatch_notification(
+            app,
+            recipient=recipient,
+            sender=AgentRuntimeActor(
+                user_id=requester_id,
+                user_type=_user_type(requester, requester_id),
+                display_name=_display_name(requester, requester_id),
+                avatar_url=avatar_url(requester_id, bool(getattr(requester, "avatar", None))),
+                source="relationship",
+            ),
+            message=AgentRuntimeMessage(
+                content=_notification_content(
+                    _display_name(requester, requester_id),
+                    row.message,
                 ),
-                message=AgentRuntimeMessage(
-                    content=_notification_content(
-                        _display_name(requester, requester_id),
-                        row.message,
-                    ),
-                    metadata={"relationship_id": row.id},
-                ),
-            )
+                metadata={"relationship_id": row.id},
+            ),
+            event_type="relationship.requested",
         )
 
     def _notify(row: RelationshipRow) -> None:
@@ -107,59 +79,34 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
         requester = _require_user(user_repo, requester_id, "requester")
         decider = _require_user(user_repo, decider_id, "decider")
         requester_type = _user_type(requester, requester_id)
-        if requester_type == "external":
-            await _dispatch_external_notification(
-                app,
-                recipient_id=requester_id,
-                sender=AgentRuntimeActor(
-                    user_id=decider_id,
-                    user_type=_user_type(decider, decider_id),
-                    display_name=_display_name(decider, decider_id),
-                    avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
-                    source="relationship",
-                ),
-                message=AgentRuntimeMessage(
-                    content=f"{_display_name(decider, decider_id)} {_decision_verb(event)} your relationship request.",
-                    metadata={
-                        "relationship_id": row.id,
-                        "event": event,
-                        "state": row.state,
-                    },
-                ),
-                event_type=f"relationship.{_decision_verb(event)}",
-            )
-            return
-        if requester_type != "agent":
-            return
-
-        thread_id = select_runtime_thread_for_recipient(
+        recipient = select_runtime_notification_recipient(
             requester_id,
+            requester_type,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
+            context="relationship decision",
         )
-        if thread_id is None:
-            logger.info("Skipped relationship decision wake for agent without runtime thread: %s", requester_id)
+        if recipient is None:
             return
-
-        await get_agent_runtime_gateway(app).dispatch_thread_input(
-            AgentThreadInputEnvelope(
-                thread_id=thread_id,
-                sender=AgentRuntimeActor(
-                    user_id=decider_id,
-                    user_type=_user_type(decider, decider_id),
-                    display_name=_display_name(decider, decider_id),
-                    avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
-                    source="relationship",
-                ),
-                message=AgentRuntimeMessage(
-                    content=f"{_display_name(decider, decider_id)} {_decision_verb(event)} your relationship request.",
-                    metadata={
-                        "relationship_id": row.id,
-                        "event": event,
-                        "state": row.state,
-                    },
-                ),
-            )
+        await _dispatch_notification(
+            app,
+            recipient=recipient,
+            sender=AgentRuntimeActor(
+                user_id=decider_id,
+                user_type=_user_type(decider, decider_id),
+                display_name=_display_name(decider, decider_id),
+                avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                source="relationship",
+            ),
+            message=AgentRuntimeMessage(
+                content=f"{_display_name(decider, decider_id)} {_decision_verb(event)} your relationship request.",
+                metadata={
+                    "relationship_id": row.id,
+                    "event": event,
+                    "state": row.state,
+                },
+            ),
+            event_type=f"relationship.{_decision_verb(event)}",
         )
 
     def _notify(row: RelationshipRow, event: RelationshipEvent) -> None:
@@ -169,10 +116,10 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
     return _notify
 
 
-async def _dispatch_external_notification(
+async def _dispatch_notification(
     app: Any,
     *,
-    recipient_id: str,
+    recipient: AgentChatRecipient,
     sender: AgentRuntimeActor,
     message: AgentRuntimeMessage,
     event_type: str,
@@ -180,7 +127,7 @@ async def _dispatch_external_notification(
     await get_agent_runtime_gateway(app).dispatch_notification(
         AgentRuntimeNotificationEnvelope(
             event_type=event_type,
-            recipient=AgentChatRecipient(agent_user_id=recipient_id, runtime_source="external"),
+            recipient=recipient,
             sender=sender,
             message=message,
             notification_type="relationship",

--- a/backend/threads/chat_adapters/runtime_recipient.py
+++ b/backend/threads/chat_adapters/runtime_recipient.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
+from protocols.agent_runtime import AgentChatRecipient
+
+logger = logging.getLogger(__name__)
+
+
+def select_runtime_notification_recipient(
+    user_id: str,
+    user_type: str,
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+    context: str,
+) -> AgentChatRecipient | None:
+    if user_type == "external":
+        return AgentChatRecipient(agent_user_id=user_id, runtime_source="external")
+    if user_type != "agent":
+        return None
+    thread_id = select_runtime_thread_for_recipient(
+        user_id,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    if thread_id is None:
+        logger.info("Skipped %s wake for agent without runtime thread: %s", context, user_id)
+        return None
+    return AgentChatRecipient(agent_user_id=user_id, runtime_source="mycel", thread_id=thread_id)

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -6,7 +6,8 @@ from typing import Any
 import pytest
 
 from backend.threads.chat_adapters.gateway import NativeAgentRuntimeGateway
-from protocols.agent_runtime import AgentChatDeliveryResult, AgentThreadInputResult
+from backend.threads.chat_adapters.notification_handler import NativeAgentNotificationHandler
+from protocols.agent_runtime import AgentChatDeliveryResult, AgentRuntimeNotificationResult, AgentThreadInputResult
 
 
 @dataclass
@@ -27,6 +28,15 @@ class _FakeThreadInputHandler:
         return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
 
 
+@dataclass
+class _FakeNotificationHandler:
+    called_with: object | None = None
+
+    async def dispatch_notification(self, envelope):
+        self.called_with = envelope
+        return AgentRuntimeNotificationResult(status="accepted", thread_id="thread-1")
+
+
 @pytest.mark.asyncio
 async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> None:
     from protocols.agent_runtime import (
@@ -35,13 +45,16 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
         AgentChatRecipient,
         AgentRuntimeActor,
         AgentRuntimeMessage,
+        AgentRuntimeNotificationEnvelope,
         AgentThreadInputEnvelope,
     )
 
     chat_handler = _FakeChatHandler()
+    notification_handler = _FakeNotificationHandler()
     thread_input_handler = _FakeThreadInputHandler()
     gateway = NativeAgentRuntimeGateway(
         chat_handlers={"mycel": chat_handler},
+        notification_handlers={"mycel": notification_handler},
         thread_input_handler=thread_input_handler,
     )
     chat_envelope = AgentChatDeliveryEnvelope(
@@ -55,13 +68,23 @@ async def test_gateway_delegates_chat_and_thread_input_to_split_handlers() -> No
         sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Owner", source="owner"),
         message=AgentRuntimeMessage(content="hello"),
     )
+    notification_envelope = AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Owner", source="relationship"),
+        message=AgentRuntimeMessage(content="hello"),
+        notification_type="relationship",
+    )
 
     chat_result = await gateway.dispatch_chat(chat_envelope)
+    notification_result = await gateway.dispatch_notification(notification_envelope)
     thread_result = await gateway.dispatch_thread_input(thread_envelope)
 
     assert chat_result == AgentChatDeliveryResult(status="accepted", thread_id="thread-1")
+    assert notification_result == AgentRuntimeNotificationResult(status="accepted", thread_id="thread-1")
     assert thread_result == AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
     assert chat_handler.called_with is chat_envelope
+    assert notification_handler.called_with is notification_envelope
     assert thread_input_handler.called_with is thread_envelope
 
 
@@ -125,3 +148,84 @@ async def test_gateway_rejects_unregistered_chat_runtime_source() -> None:
 
     with pytest.raises(ValueError, match="No Agent chat runtime handler registered for runtime_source='external-hook'"):
         await gateway.dispatch_chat(envelope)
+
+
+@pytest.mark.asyncio
+async def test_gateway_routes_notifications_by_runtime_source() -> None:
+    from protocols.agent_runtime import (
+        AgentChatRecipient,
+        AgentRuntimeActor,
+        AgentRuntimeMessage,
+        AgentRuntimeNotificationEnvelope,
+    )
+
+    handler = _FakeNotificationHandler()
+    gateway = NativeAgentRuntimeGateway(
+        notification_handlers={"mycel": handler},
+        thread_input_handler=_FakeThreadInputHandler(),
+    )
+    envelope = AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human"),
+        message=AgentRuntimeMessage(content="hello"),
+        notification_type="relationship",
+    )
+
+    result = await gateway.dispatch_notification(envelope)
+
+    assert result == AgentRuntimeNotificationResult(status="accepted", thread_id="thread-1")
+    assert handler.called_with is envelope
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_unregistered_notification_runtime_source() -> None:
+    from protocols.agent_runtime import (
+        AgentChatRecipient,
+        AgentRuntimeActor,
+        AgentRuntimeMessage,
+        AgentRuntimeNotificationEnvelope,
+    )
+
+    gateway = NativeAgentRuntimeGateway(
+        notification_handlers={"mycel": _FakeNotificationHandler()},
+        thread_input_handler=_FakeThreadInputHandler(),
+    )
+    envelope = AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="external-hook"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human"),
+        message=AgentRuntimeMessage(content="hello"),
+        notification_type="relationship",
+    )
+
+    with pytest.raises(ValueError, match="No Agent runtime notification handler registered for runtime_source='external-hook'"):
+        await gateway.dispatch_notification(envelope)
+
+
+@pytest.mark.asyncio
+async def test_native_notification_handler_converts_to_thread_input_at_runtime_boundary() -> None:
+    from protocols.agent_runtime import (
+        AgentChatRecipient,
+        AgentRuntimeActor,
+        AgentRuntimeMessage,
+        AgentRuntimeNotificationEnvelope,
+    )
+
+    thread_input_handler = _FakeThreadInputHandler()
+    handler = NativeAgentNotificationHandler(thread_input_handler=thread_input_handler)
+    envelope = AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human", source="relationship"),
+        message=AgentRuntimeMessage(content="hello", metadata={"relationship_id": "rel-1"}),
+        notification_type="relationship",
+    )
+
+    result = await handler.dispatch_notification(envelope)
+
+    assert result == AgentRuntimeNotificationResult(status="accepted", thread_id="thread-1")
+    assert thread_input_handler.called_with is not None
+    assert thread_input_handler.called_with.thread_id == "thread-1"
+    assert thread_input_handler.called_with.sender is envelope.sender
+    assert thread_input_handler.called_with.message is envelope.message

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 import pytest
 
 from backend.threads.chat_adapters import chat_join_inlet
-from protocols.agent_runtime import AgentThreadInputResult
 
 
 def _hook_app(gateway: object) -> SimpleNamespace:
@@ -22,13 +21,13 @@ def _thread_repo() -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
-async def test_chat_join_rejection_notification_dispatches_to_agent_requester() -> None:
+async def test_chat_join_rejection_notification_dispatches_runtime_notification_to_agent_requester() -> None:
     class RecordingGateway:
         envelope = None
 
-        async def dispatch_thread_input(self, envelope):
+        async def dispatch_notification(self, envelope):
             self.envelope = envelope
-            return AgentThreadInputResult(status="injected", routing="steer", thread_id=envelope.thread_id)
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
 
     gateway = RecordingGateway()
     user_repo = SimpleNamespace(
@@ -56,11 +55,15 @@ async def test_chat_join_rejection_notification_dispatches_to_agent_requester() 
     )
 
     assert gateway.envelope is not None
-    assert gateway.envelope.thread_id == "thread-main"
+    assert gateway.envelope.recipient.agent_user_id == "agent-user-1"
+    assert gateway.envelope.recipient.runtime_source == "mycel"
+    assert gateway.envelope.recipient.thread_id == "thread-main"
     assert gateway.envelope.sender.user_id == "owner-1"
     assert gateway.envelope.sender.user_type == "human"
     assert gateway.envelope.sender.display_name == "Owner"
     assert gateway.envelope.sender.source == "chat_join"
+    assert gateway.envelope.event_type == "chat.join.rejected"
+    assert gateway.envelope.notification_type == "chat_join"
     assert "Owner rejected your request to join chat chat-1." in gateway.envelope.message.content
     assert gateway.envelope.message.metadata == {
         "chat_join_request_id": "chat_join:chat-1:agent-user-1",
@@ -125,7 +128,7 @@ async def test_chat_join_rejection_notification_skips_agent_wake_when_no_runtime
     class RecordingGateway:
         called = False
 
-        async def dispatch_thread_input(self, _envelope):
+        async def dispatch_notification(self, _envelope):
             self.called = True
 
     gateway = RecordingGateway()

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -8,7 +8,6 @@ import pytest
 
 from backend.threads.chat_adapters import relationship_inlet
 from messaging.contracts import RelationshipRow, RelationshipState
-from protocols.agent_runtime import AgentThreadInputResult
 
 
 def _relationship_row(
@@ -46,13 +45,13 @@ def _thread_repo() -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
-async def test_relationship_request_notification_dispatches_thread_input_to_agent_target() -> None:
+async def test_relationship_request_notification_dispatches_runtime_notification_to_agent_target() -> None:
     class RecordingGateway:
         envelope = None
 
-        async def dispatch_thread_input(self, envelope):
+        async def dispatch_notification(self, envelope):
             self.envelope = envelope
-            return AgentThreadInputResult(status="injected", routing="steer", thread_id=envelope.thread_id)
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
 
     gateway = RecordingGateway()
     user_repo = SimpleNamespace(
@@ -81,11 +80,15 @@ async def test_relationship_request_notification_dispatches_thread_input_to_agen
     await asyncio.to_thread(notify, _relationship_row(message="Please add me to the planning chat."))
 
     assert gateway.envelope is not None
-    assert gateway.envelope.thread_id == "thread-main"
+    assert gateway.envelope.recipient.agent_user_id == "agent-user-1"
+    assert gateway.envelope.recipient.runtime_source == "mycel"
+    assert gateway.envelope.recipient.thread_id == "thread-main"
     assert gateway.envelope.sender.user_id == "human-user-1"
     assert gateway.envelope.sender.user_type == "human"
     assert gateway.envelope.sender.display_name == "Human"
     assert gateway.envelope.sender.source == "relationship"
+    assert gateway.envelope.event_type == "relationship.requested"
+    assert gateway.envelope.notification_type == "relationship"
     assert "Human requested a relationship with you." in gateway.envelope.message.content
     assert "Please add me to the planning chat." in gateway.envelope.message.content
     assert gateway.envelope.message.metadata == {"relationship_id": "hire_visit:agent-user-1:human-user-1"}
@@ -149,7 +152,7 @@ async def test_relationship_request_notification_does_not_dispatch_to_non_agent_
     class RecordingGateway:
         called = False
 
-        async def dispatch_thread_input(self, _envelope):
+        async def dispatch_notification(self, _envelope):
             self.called = True
 
     gateway = RecordingGateway()
@@ -179,7 +182,7 @@ async def test_relationship_request_notification_skips_agent_wake_when_no_runtim
     class RecordingGateway:
         called = False
 
-        async def dispatch_thread_input(self, _envelope):
+        async def dispatch_notification(self, _envelope):
             self.called = True
 
     gateway = RecordingGateway()
@@ -202,13 +205,13 @@ async def test_relationship_request_notification_skips_agent_wake_when_no_runtim
 
 
 @pytest.mark.asyncio
-async def test_relationship_decision_notification_dispatches_to_agent_requester() -> None:
+async def test_relationship_decision_notification_dispatches_runtime_notification_to_agent_requester() -> None:
     class RecordingGateway:
         envelope = None
 
-        async def dispatch_thread_input(self, envelope):
+        async def dispatch_notification(self, envelope):
             self.envelope = envelope
-            return AgentThreadInputResult(status="injected", routing="steer", thread_id=envelope.thread_id)
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
 
     gateway = RecordingGateway()
     user_repo = SimpleNamespace(
@@ -236,11 +239,15 @@ async def test_relationship_decision_notification_dispatches_to_agent_requester(
     )
 
     assert gateway.envelope is not None
-    assert gateway.envelope.thread_id == "thread-main"
+    assert gateway.envelope.recipient.agent_user_id == "agent-user-1"
+    assert gateway.envelope.recipient.runtime_source == "mycel"
+    assert gateway.envelope.recipient.thread_id == "thread-main"
     assert gateway.envelope.sender.user_id == "human-user-1"
     assert gateway.envelope.sender.user_type == "human"
     assert gateway.envelope.sender.display_name == "Human"
     assert gateway.envelope.sender.source == "relationship"
+    assert gateway.envelope.event_type == "relationship.approved"
+    assert gateway.envelope.notification_type == "relationship"
     assert "Human approved your relationship request." in gateway.envelope.message.content
     assert gateway.envelope.message.metadata == {
         "relationship_id": "hire_visit:agent-user-1:human-user-1",
@@ -302,7 +309,7 @@ async def test_relationship_decision_notification_ignores_non_agent_requester() 
     class RecordingGateway:
         called = False
 
-        async def dispatch_thread_input(self, _envelope):
+        async def dispatch_notification(self, _envelope):
             self.called = True
 
     gateway = RecordingGateway()
@@ -333,7 +340,7 @@ async def test_relationship_decision_notification_skips_agent_wake_when_no_runti
     class RecordingGateway:
         called = False
 
-        async def dispatch_thread_input(self, _envelope):
+        async def dispatch_notification(self, _envelope):
             self.called = True
 
     gateway = RecordingGateway()


### PR DESCRIPTION
## Summary
- route relationship and chat-join runtime notifications through `AgentRuntimeNotificationEnvelope` for both external and managed agents
- add a native notification handler that converts notifications to thread input only at the Mycel runtime boundary
- share runtime recipient selection for agent/external/human notification targets

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_chat_thread_selector.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py -q`
- `uv run pytest tests/Unit/backend/web/services -q`
- `uv run pytest tests/Unit/messaging/test_wake_policy.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/messaging/test_runtime_read_protocol_owner.py -q`
- `uv run ruff check . && uv run ruff format --check .`
