### PR TITLE
refactor(chat): require explicit read watermark

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -50,6 +50,12 @@ class MuteChatBody(BaseModel):
     mute_until: float | None = None
 
 
+class MarkReadBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    up_to_seq: int = Field(ge=0)
+
+
 class ChatJoinRequestBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -355,12 +361,13 @@ def delete_message_for_self(
 @router.post("/{chat_id}/read")
 def mark_read(
     chat_id: str,
+    body: MarkReadBody,
     user_id: Annotated[str, Depends(get_current_user_id)],
     messaging_service: Annotated[Any, Depends(get_messaging_service)],
 ):
     if not messaging_service.is_chat_member(chat_id, user_id):
         raise HTTPException(403, "Not a participant of this chat")
-    messaging_service.mark_read(chat_id, user_id)
+    messaging_service.mark_read(chat_id, user_id, body.up_to_seq)
     return {"status": "ok"}
 
 

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -37,6 +37,13 @@ def _should_dispatch_chat_delivery(
     return message_type in {"human", "ai"} or (message_type == "notification" and (bool(mentions) or bool(addressed_to_user_ids)))
 
 
+def _max_message_seq(messages: list[dict[str, Any]]) -> int:
+    seqs = [int(message.get("seq") or 0) for message in messages]
+    if not seqs or max(seqs) <= 0:
+        raise RuntimeError("Unread chat message rows must include positive seq")
+    return max(seqs)
+
+
 class MessagingService:
     """Core messaging operations backed by Supabase repos."""
 
@@ -339,11 +346,11 @@ class MessagingService:
     def delete_for(self, message_id: str, user_id: str) -> None:
         self._messages.delete_for(message_id, user_id)
 
-    def mark_read(self, chat_id: str, user_id: str) -> None:
-        """Mark all messages in a chat as read for user."""
-        msgs = self._messages.list_by_chat(chat_id, limit=1, viewer_id=user_id)
-        last_read_seq = int(msgs[-1].get("seq") or 0) if msgs else 0
-        self._chat_members_repo.update_last_read(chat_id, user_id, last_read_seq)
+    def mark_read(self, chat_id: str, user_id: str, up_to_seq: int) -> None:
+        """Mark messages consumed up to a concrete sequence watermark."""
+        if up_to_seq < 0:
+            raise ValueError("up_to_seq must be >= 0")
+        self._chat_members_repo.update_last_read(chat_id, user_id, up_to_seq)
 
     # ------------------------------------------------------------------
     # Queries
@@ -374,7 +381,8 @@ class MessagingService:
     def read_unread(self, chat_id: str, user_id: str, consume: Callable[[list[dict[str, Any]]], Any]) -> Any:
         messages = self.list_unread(chat_id, user_id)
         result = consume(messages)
-        self.mark_read(chat_id, user_id)
+        if messages:
+            self.mark_read(chat_id, user_id, _max_message_seq(messages))
         return result
 
     def read_unread_message_responses(self, chat_id: str, user_id: str) -> list[dict[str, Any]]:

--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -66,6 +66,16 @@ def _parse_time_endpoint(s: str, now: float) -> float | None:
     raise ValueError(f"Cannot parse time '{s}'. Use '-2h', '-1d', '-30m', or '2026-03-20'.")
 
 
+def _max_message_seq(messages: list[dict]) -> int:
+    seqs = []
+    for message in messages:
+        seq = message.get("seq")
+        if type(seq) is not int:
+            raise RuntimeError("Chat message row is missing integer seq")
+        seqs.append(seq)
+    return max(seqs)
+
+
 class ChatToolService:
     """Registers chat tools into ToolRegistry (messaging module version)."""
 
@@ -343,7 +353,7 @@ class ChatToolService:
                 if not msgs:
                     return "No messages in that range."
                 rendered = self._format_msgs(msgs, eid)
-                self._messaging.mark_read(chat_id, eid)
+                self._messaging.mark_read(chat_id, eid, _max_message_seq(msgs))
                 return rendered
 
             rendered = self._messaging.read_unread(chat_id, eid, lambda msgs: self._format_msgs(msgs, eid) if msgs else "")

--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -76,7 +76,14 @@ class SupabaseChatMemberRepo:
         return res.data[0] if res.data else None
 
     def update_last_read(self, chat_id: str, user_id: str, last_read_seq: int) -> None:
-        self._t().update({"last_read_seq": last_read_seq}).eq("chat_id", chat_id).eq("user_id", user_id).execute()
+        (
+            self._t()
+            .update({"last_read_seq": last_read_seq})
+            .eq("chat_id", chat_id)
+            .eq("user_id", user_id)
+            .lt("last_read_seq", int(last_read_seq))
+            .execute()
+        )
 
     def last_read_seq(self, chat_id: str, user_id: str) -> int:
         member_res = self._t().select("last_read_seq").eq("chat_id", chat_id).eq("user_id", user_id).limit(1).execute()

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -1002,12 +1002,31 @@ def test_mark_read_rejects_non_member_user() -> None:
     with pytest.raises(HTTPException) as exc_info:
         chats_router.mark_read(
             "chat-1",
+            body=chats_router.MarkReadBody(up_to_seq=7),
             user_id="external-user-1",
             messaging_service=messaging_service,
         )
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Not a participant of this chat"
+
+
+def test_mark_read_requires_explicit_consumed_sequence() -> None:
+    calls: list[tuple[str, str, int]] = []
+    messaging_service = SimpleNamespace(
+        is_chat_member=lambda _chat_id, _user_id: True,
+        mark_read=lambda chat_id, user_id, up_to_seq: calls.append((chat_id, user_id, up_to_seq)),
+    )
+
+    result = chats_router.mark_read(
+        "chat-1",
+        body=chats_router.MarkReadBody(up_to_seq=7),
+        user_id="external-user-1",
+        messaging_service=messaging_service,
+    )
+
+    assert result == {"status": "ok"}
+    assert calls == [("chat-1", "external-user-1", 7)]
 
 
 def test_create_chat_accepts_agent_user_ids_for_group_participants() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -2014,20 +2014,26 @@ def test_messaging_service_mark_read_resets_unread_count_via_last_read_seq_water
 
     assert before[0]["unread_count"] == 1
 
-    service.mark_read("chat-1", "human-user-1")
+    service.mark_read("chat-1", "human-user-1", 2)
 
     after = service.list_chats_for_user("human-user-1")
 
     assert after[0]["unread_count"] == 0
 
 
-def test_messaging_service_read_unread_consumes_messages_before_marking_latest_seq() -> None:
+def test_messaging_service_read_unread_marks_only_returned_unread_batch() -> None:
     calls: list[tuple[str, str, str]] = []
     service = MessagingService(
         chat_repo=SimpleNamespace(),
         chat_member_repo=SimpleNamespace(update_last_read=lambda _chat_id, user_id, seq: calls.append(("read", user_id, str(seq)))),
         messages_repo=SimpleNamespace(
-            list_unread=lambda chat_id, user_id: calls.append(("unread", chat_id, user_id)) or [],
+            list_unread=lambda chat_id, user_id: (
+                calls.append(("unread", chat_id, user_id))
+                or [
+                    {"id": "msg-2", "seq": 2, "content": "returned"},
+                    {"id": "msg-4", "seq": 4, "content": "returned"},
+                ]
+            ),
             list_by_chat=lambda chat_id, limit=50, viewer_id=None: calls.append(("latest", chat_id, viewer_id or "")) or [{"seq": 9}],
         ),
         user_repo=SimpleNamespace(get_by_id=lambda _uid: None),
@@ -2042,9 +2048,31 @@ def test_messaging_service_read_unread_consumes_messages_before_marking_latest_s
     assert result == []
     assert calls == [
         ("unread", "chat-1", "external-user-1"),
+        ("consume", "messages", "2"),
+        ("read", "external-user-1", "4"),
+    ]
+
+
+def test_messaging_service_read_unread_does_not_advance_when_no_unread_batch() -> None:
+    calls: list[tuple[str, str, str]] = []
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(update_last_read=lambda _chat_id, user_id, seq: calls.append(("read", user_id, str(seq)))),
+        messages_repo=SimpleNamespace(
+            list_unread=lambda chat_id, user_id: calls.append(("unread", chat_id, user_id)) or [],
+        ),
+        user_repo=SimpleNamespace(get_by_id=lambda _uid: None),
+    )
+
+    service.read_unread(
+        "chat-1",
+        "external-user-1",
+        lambda messages: calls.append(("consume", "messages", str(len(messages)))),
+    )
+
+    assert calls == [
+        ("unread", "chat-1", "external-user-1"),
         ("consume", "messages", "0"),
-        ("latest", "chat-1", "external-user-1"),
-        ("read", "external-user-1", "9"),
     ]
 
 
@@ -2210,18 +2238,19 @@ def test_chat_tool_formats_agent_user_id_sender_as_agent_name() -> None:
 
 def test_read_messages_fails_before_mark_read_on_unknown_message_sender() -> None:
     registry = ToolRegistry()
-    marked: list[tuple[str, str]] = []
+    marked: list[tuple[str, str, int]] = []
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
                 {
+                    "seq": 2,
                     "sender_id": "missing-user",
                     "content": f"after={after};before={before}",
                 }
             ],
-            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+            mark_read=lambda chat_id, user_id, up_to_seq: marked.append((chat_id, user_id, up_to_seq)),
         ),
     )
 
@@ -2237,13 +2266,13 @@ def test_read_messages_fails_before_mark_read_on_unknown_message_sender() -> Non
 
 def test_read_messages_fails_before_mark_read_on_invalid_message_row() -> None:
     registry = ToolRegistry()
-    marked: list[tuple[str, str]] = []
+    marked: list[tuple[str, str, int]] = []
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: ["message-1"],
-            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+            mark_read=lambda chat_id, user_id, up_to_seq: marked.append((chat_id, user_id, up_to_seq)),
         ),
     )
 
@@ -2259,13 +2288,13 @@ def test_read_messages_fails_before_mark_read_on_invalid_message_row() -> None:
 
 def test_read_messages_fails_before_mark_read_on_invalid_history_collection() -> None:
     registry = ToolRegistry()
-    marked: list[tuple[str, str]] = []
+    marked: list[tuple[str, str, int]] = []
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: {"sender_id": "agent-user-1"},
-            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+            mark_read=lambda chat_id, user_id, up_to_seq: marked.append((chat_id, user_id, up_to_seq)),
         ),
     )
 
@@ -2308,17 +2337,18 @@ def test_read_messages_fails_before_mark_read_on_invalid_unread_collection() -> 
 
 def test_read_messages_fails_before_mark_read_on_missing_message_content() -> None:
     registry = ToolRegistry()
-    marked: list[tuple[str, str]] = []
+    marked: list[tuple[str, str, int]] = []
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
                 {
+                    "seq": 2,
                     "sender_id": "agent-user-1",
                 }
             ],
-            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+            mark_read=lambda chat_id, user_id, up_to_seq: marked.append((chat_id, user_id, up_to_seq)),
         ),
     )
 
@@ -2334,18 +2364,19 @@ def test_read_messages_fails_before_mark_read_on_missing_message_content() -> No
 
 def test_read_messages_fails_before_mark_read_on_invalid_message_content() -> None:
     registry = ToolRegistry()
-    marked: list[tuple[str, str]] = []
+    marked: list[tuple[str, str, int]] = []
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
                 {
+                    "seq": 2,
                     "sender_id": "agent-user-1",
                     "content": None,
                 }
             ],
-            mark_read=lambda chat_id, user_id: marked.append((chat_id, user_id)),
+            mark_read=lambda chat_id, user_id, up_to_seq: marked.append((chat_id, user_id, up_to_seq)),
         ),
     )
 
@@ -2849,17 +2880,19 @@ def test_read_messages_uses_messaging_service_direct_chat_lookup_without_member_
 
 def test_read_messages_uses_messaging_service_time_range_history_without_messages_repo() -> None:
     registry = ToolRegistry()
+    marked: list[tuple[str, str, int]] = []
     ChatToolService(
         registry=registry,
         chat_identity_id="human-user-1",
         messaging_service=_messaging_display_service(
             list_messages_by_time_range=lambda _chat_id, *, after=None, before=None: [
                 {
+                    "seq": 4,
                     "sender_id": "agent-user-1",
                     "content": f"after={after};before={before}",
                 }
             ],
-            mark_read=lambda *_args, **_kwargs: None,
+            mark_read=lambda chat_id, user_id, up_to_seq: marked.append((chat_id, user_id, up_to_seq)),
         ),
     )
 
@@ -2869,6 +2902,7 @@ def test_read_messages_uses_messaging_service_time_range_history_without_message
     result = read_messages.handler(chat_id="chat-1", range="-1h:")
 
     assert "[Toad]: after=" in result
+    assert marked == [("chat-1", "human-user-1", 4)]
 
 
 def test_chat_tool_search_requires_direct_chat_for_agent_user_target() -> None:


### PR DESCRIPTION
## Summary
- Require explicit read watermarks for chat read acknowledgement instead of implicit cursor advancement.
- Make HTTP `POST /api/chats/{chat_id}/read` accept `up_to_seq` and keep repository updates monotonic.
- Update managed chat tools so rendered history determines the acknowledged sequence, with regression coverage for malformed rows and consumed unread boundaries.

## Test Plan
- `uv run pytest tests/Unit -q`
- `uv run ruff check backend/chat/api/http/chats_router.py messaging/service.py messaging/tools/chat_tool_service.py storage/providers/supabase/messaging_repo.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run ruff format --check backend/chat/api/http/chats_router.py messaging/service.py messaging/tools/chat_tool_service.py storage/providers/supabase/messaging_repo.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `git diff --check`

## Notes
- This is the backend half of the SDK/CLI workflow-message contract. The SDK branch depends on this read watermark contract.
