### PR TITLE
fix: keep addressed chat history visible

### DIFF
--- a/storage/providers/supabase/messaging_repo.py
+++ b/storage/providers/supabase/messaging_repo.py
@@ -211,7 +211,7 @@ class SupabaseMessagesRepo:
         res = q.execute()
         rows = list(reversed(res.data or []))
         if viewer_id:
-            rows = [r for r in rows if self._is_visible_to(r, viewer_id) and viewer_id not in (r.get("deleted_for") or [])]
+            rows = [r for r in rows if viewer_id not in (r.get("deleted_for") or [])]
             rows = rows[-limit:]
         return rows
 
@@ -234,7 +234,7 @@ class SupabaseMessagesRepo:
         )
         for row in rows:
             chat_id = str(row.get("chat_id") or "")
-            if viewer_id and (not self._is_visible_to(row, viewer_id) or viewer_id in (row.get("deleted_for") or [])):
+            if viewer_id and viewer_id in (row.get("deleted_for") or []):
                 continue
             if chat_id and chat_id not in latest_by_chat:
                 latest_by_chat[chat_id] = row
@@ -248,7 +248,7 @@ class SupabaseMessagesRepo:
             q = q.gt("seq", last_read_seq)
         res = q.order("seq", desc=False).execute()
         rows = res.data or []
-        return [r for r in rows if self._is_visible_to(r, user_id) and user_id not in (r.get("deleted_for") or [])]
+        return [r for r in rows if self._is_unread_for(r, user_id) and user_id not in (r.get("deleted_for") or [])]
 
     def count_unread(self, chat_id: str, user_id: str) -> int:
         return len(self.list_unread(chat_id, user_id))
@@ -269,18 +269,16 @@ class SupabaseMessagesRepo:
             chat_id = str(row.get("chat_id") or "")
             if int(row.get("seq") or 0) <= last_read_by_chat.get(chat_id, 0):
                 continue
-            if not self._is_visible_to(row, user_id):
+            if not self._is_unread_for(row, user_id):
                 continue
             if user_id in (row.get("deleted_for") or []):
                 continue
             counts[chat_id] += 1
         return counts
 
-    def _is_visible_to(self, row: dict[str, Any], user_id: str) -> bool:
+    def _is_unread_for(self, row: dict[str, Any], user_id: str) -> bool:
         scope = str(row.get("delivery_scope") or "broadcast")
         if scope != "addressed":
-            return True
-        if row.get("sender_user_id") == user_id:
             return True
         return user_id in self._addressed_to_user_ids(row)
 

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -714,7 +714,7 @@ def test_supabase_messages_repo_count_unread_uses_last_read_seq_and_sender_user_
     assert ("sender_id", "user-1") not in client.tables["chat.messages"].neq_calls
 
 
-def test_supabase_messages_repo_filters_addressed_messages_from_non_recipients() -> None:
+def test_supabase_messages_repo_addressed_messages_stay_visible_but_do_not_create_unread_for_others() -> None:
     tables: dict[str, list[dict]] = {
         "chat.chat_members": [
             {"chat_id": "chat-1", "user_id": "user-1", "last_read_seq": 0},
@@ -736,7 +736,7 @@ def test_supabase_messages_repo_filters_addressed_messages_from_non_recipients()
                 "chat_id": "chat-1",
                 "seq": 2,
                 "sender_user_id": "user-1",
-                "content": "only user-2 sees this",
+                "content": "user-2 should wake for this",
                 "delivery_scope": "addressed",
                 "addressed_to_user_ids_json": ["user-2"],
             },
@@ -750,12 +750,12 @@ def test_supabase_messages_repo_filters_addressed_messages_from_non_recipients()
 
     assert [row["id"] for row in user_2_unread] == ["broadcast-1", "addressed-1"]
     assert [row["id"] for row in user_3_unread] == ["broadcast-1"]
-    assert [row["id"] for row in user_3_history] == ["broadcast-1"]
+    assert [row["id"] for row in user_3_history] == ["broadcast-1", "addressed-1"]
     assert repo.count_unread("chat-1", "user-3") == 1
     assert repo.count_unread_by_chat_ids("user-3", {"chat-1": 0}) == {"chat-1": 1}
 
 
-def test_supabase_messages_repo_latest_message_is_viewer_visible() -> None:
+def test_supabase_messages_repo_latest_message_uses_chat_history_visibility_not_wake_target() -> None:
     tables: dict[str, list[dict]] = {
         "chat.messages": [
             {
@@ -772,7 +772,7 @@ def test_supabase_messages_repo_latest_message_is_viewer_visible() -> None:
                 "chat_id": "chat-1",
                 "seq": 2,
                 "sender_user_id": "user-1",
-                "content": "hidden from user-3",
+                "content": "latest history for all members",
                 "delivery_scope": "addressed",
                 "addressed_to_user_ids_json": ["user-2"],
             },
@@ -782,4 +782,4 @@ def test_supabase_messages_repo_latest_message_is_viewer_visible() -> None:
 
     latest = repo.list_latest_by_chat_ids(["chat-1"], viewer_id="user-3")
 
-    assert latest["chat-1"]["id"] == "broadcast-1"
+    assert latest["chat-1"]["id"] == "addressed-1"


### PR DESCRIPTION
## Summary

- Make addressed chat messages remain visible in shared chat history for all chat members.
- Keep unread/count semantics scoped to broadcast messages and addressed recipients, so quiet group members are not woken or blocked by read-before-send.
- Update storage contract tests for the split between history visibility and wake/unread targeting.

## Why

Group workflow review needs to audit worker/supervisor evidence through Mycel chat, not local message-store files. The previous storage filter hid addressed worker/silent evidence from reviewers, which forced the wrong proof path.

## Verification

- `uv run pytest tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py -q` = 25 passed
- `uv run pytest tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q` = 221 passed
- `uv run ruff check storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
- `uv run ruff format --check storage/providers/supabase/messaging_repo.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
