### PR TITLE
feat: add restricted guest owner capabilities

### DIFF
--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 from collections.abc import Callable
+from uuid import uuid4
 
 import jwt
 
@@ -11,7 +12,7 @@ from backend.identity.avatar.files import process_and_save_avatar
 from backend.identity.contact_bootstrap import ensure_owner_agent_contact
 from backend.sandboxes.recipe_bootstrap import seed_default_recipes
 from config.agent_config_types import AgentConfig
-from storage.contracts import InviteCodeRepo, UserRepo, UserRow, UserType
+from storage.contracts import InviteCodeRepo, OwnerProfile, UserRepo, UserRow, UserType
 from storage.providers.supabase import _query as q
 
 logger = logging.getLogger(__name__)
@@ -232,6 +233,48 @@ class AuthService:
                 "name": external_display_name,
                 "type": "external",
                 "created_by_user_id": created_by_user_id,
+            },
+        }
+
+    def create_guest_owner_token(self, *, display_name: str | None = None) -> dict:
+        jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
+        if not jwt_secret:
+            raise RuntimeError("SUPABASE_JWT_SECRET env var required for guest owner token creation.")
+
+        guest_user_id = f"guest-{uuid4()}"
+        if self._users.get_by_id(guest_user_id) is not None:
+            raise ValueError("guest user id collision")
+        guest_display_name = (display_name or "").strip() or "Guest"
+        now = time.time()
+        self._users.create(
+            UserRow(
+                id=guest_user_id,
+                type=UserType.HUMAN,
+                display_name=guest_display_name,
+                owner_profile=OwnerProfile.GUEST,
+                created_at=now,
+            )
+        )
+        token = jwt.encode(
+            {
+                "sub": guest_user_id,
+                "iat": int(now),
+                "mycel_user_type": "human",
+                "mycel_owner_profile": OwnerProfile.GUEST.value,
+            },
+            jwt_secret,
+            algorithm=SUPABASE_JWT_ALGORITHM,
+        )
+        return {
+            "token": token,
+            "user": {
+                "id": guest_user_id,
+                "name": guest_display_name,
+                "type": "human",
+                "owner_profile": OwnerProfile.GUEST.value,
+                "email": None,
+                "mycel_id": None,
+                "avatar": None,
             },
         }
 

--- a/backend/identity/capabilities.py
+++ b/backend/identity/capabilities.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from fastapi import HTTPException
+
+from storage.contracts import OwnerProfile, UserType
+
+
+class Capability(StrEnum):
+    CREATE_EXTERNAL_USER = "create_external_user"
+    CREATE_MANAGED_AGENT = "create_managed_agent"
+    MANAGE_INVITE_CODES = "manage_invite_codes"
+    USE_SANDBOX = "use_sandbox"
+    INSPECT_RESOURCES = "inspect_resources"
+
+
+_COMMUNICATION_CAPABILITIES = frozenset[Capability]()
+_GUEST_OWNER_CAPABILITIES = frozenset({Capability.CREATE_EXTERNAL_USER})
+_OWNER_CAPABILITIES = frozenset(Capability)
+_CAPABILITIES_BY_USER_TYPE = {
+    UserType.AGENT: _COMMUNICATION_CAPABILITIES,
+    UserType.EXTERNAL: _COMMUNICATION_CAPABILITIES,
+}
+
+
+@dataclass(frozen=True)
+class UserCapabilities:
+    user_id: str
+    values: frozenset[Capability]
+
+    def has(self, capability: Capability) -> bool:
+        return capability in self.values
+
+
+def resolve_user_capabilities(user: Any) -> UserCapabilities:
+    raw_user_type = getattr(user, "type", None)
+    user_type: UserType | None
+    if isinstance(raw_user_type, UserType):
+        user_type = raw_user_type
+    elif isinstance(raw_user_type, str):
+        try:
+            user_type = UserType(raw_user_type)
+        except ValueError as exc:
+            raise HTTPException(403, "Unknown user capability profile") from exc
+    else:
+        user_type = None
+    user_id = str(getattr(user, "id", ""))
+    if user_type is None:
+        raise HTTPException(403, "Unknown user capability profile")
+    if user_type is UserType.HUMAN:
+        owner_profile = getattr(user, "owner_profile", None)
+        values = _OWNER_CAPABILITIES
+        if owner_profile in {OwnerProfile.GUEST, OwnerProfile.GUEST.value}:
+            values = _GUEST_OWNER_CAPABILITIES
+    else:
+        values = _CAPABILITIES_BY_USER_TYPE[user_type]
+    return UserCapabilities(user_id=user_id, values=values)
+
+
+def require_user_capability(user: Any, capability: Capability) -> None:
+    capabilities = resolve_user_capabilities(user)
+    if not capabilities.has(capability):
+        raise HTTPException(403, f"Capability required: {capability.value}")

--- a/backend/web/core/dependencies.py
+++ b/backend/web/core/dependencies.py
@@ -6,6 +6,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from backend.identity.auth.dependencies import _get_auth_service as _get_auth_service
 from backend.identity.auth.user_resolution import get_current_user as get_current_user
 from backend.identity.auth.user_resolution import get_current_user_id as get_current_user_id
+from backend.identity.capabilities import Capability, require_user_capability
 from backend.threads import convergence as thread_runtime_convergence
 from backend.threads.activity_pool_service import get_or_create_agent
 from backend.threads.sandbox_resolution import resolve_thread_sandbox
@@ -21,11 +22,19 @@ __all__ = [
     "_get_auth_service",
     "get_current_user",
     "get_current_user_id",
+    "require_capability",
     "verify_thread_owner",
     "verify_thread_row_owner",
     "get_thread_lock",
     "get_thread_agent",
 ]
+
+
+def require_capability(capability: Capability):
+    async def _dependency(user: Annotated[Any, Depends(get_current_user)]) -> None:
+        require_user_capability(user, capability)
+
+    return _dependency
 
 
 async def verify_thread_owner(

--- a/backend/web/routers/auth.py
+++ b/backend/web/routers/auth.py
@@ -7,7 +7,13 @@ from pydantic import BaseModel
 
 from backend.identity.auth.dependencies import _get_auth_service
 from backend.identity.auth.service import ExternalUserAlreadyExistsError
-from backend.web.core.dependencies import get_app, get_current_user, get_current_user_id
+from backend.identity.capabilities import Capability
+from backend.web.core.dependencies import (
+    get_app,
+    get_current_user,
+    get_current_user_id,
+    require_capability,
+)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -78,6 +84,19 @@ async def login(payload: LoginRequest, app: Annotated[Any, Depends(get_app)]) ->
     )
 
 
+class CreateGuestOwnerRequest(BaseModel):
+    display_name: str | None = None
+
+
+@router.post("/guest")
+async def create_guest_owner(payload: CreateGuestOwnerRequest, app: Annotated[Any, Depends(get_app)]) -> dict:
+    return await _call_auth_service(
+        app,
+        400,
+        lambda service: service.create_guest_owner_token(display_name=payload.display_name),
+    )
+
+
 class CreateExternalUserRequest(BaseModel):
     user_id: str
     display_name: str
@@ -86,12 +105,14 @@ class CreateExternalUserRequest(BaseModel):
 @router.get("/me")
 async def me(user: Annotated[Any, Depends(get_current_user)]) -> dict:
     user_type = getattr(user.type, "value", user.type)
+    owner_profile = getattr(user, "owner_profile", None)
     return {
         "id": user.id,
         "name": user.display_name,
         "type": user_type,
         "email": user.email,
         "mycel_id": user.mycel_id,
+        "owner_profile": getattr(owner_profile, "value", owner_profile),
         "avatar": user.avatar,
     }
 
@@ -101,6 +122,8 @@ async def create_external_user(
     payload: CreateExternalUserRequest,
     app: Annotated[Any, Depends(get_app)],
     current_user_id: Annotated[str, Depends(get_current_user_id)],
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.CREATE_EXTERNAL_USER))],
 ) -> dict:
     try:
         return await asyncio.to_thread(

--- a/backend/web/routers/invite_codes.py
+++ b/backend/web/routers/invite_codes.py
@@ -1,11 +1,12 @@
 import asyncio
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.web.core.dependencies import get_current_user_id
+from backend.identity.capabilities import Capability
+from backend.web.core.dependencies import get_current_user_id, require_capability
 from storage.contracts import InviteCodeRepo
 
 router = APIRouter(prefix="/api/invite-codes", tags=["invite-codes"])
@@ -25,7 +26,7 @@ def _invite_code_repo(request: Request) -> InviteCodeRepo:
     repo = repo_factory() if callable(repo_factory) else None
     if repo is None:
         raise HTTPException(503, "邀请码仓库未初始化")
-    return repo
+    return cast(InviteCodeRepo, repo)
 
 
 async def _call_invite_code_repo(error_prefix: str, call: Callable[[], Any]) -> Any:
@@ -41,6 +42,8 @@ async def _call_invite_code_repo(error_prefix: str, call: Callable[[], Any]) -> 
 async def list_invite_codes(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.MANAGE_INVITE_CODES))],
 ) -> dict:
     repo = _invite_code_repo(request)
     codes = await _call_invite_code_repo("获取邀请码列表失败：", repo.list_all)
@@ -56,6 +59,8 @@ async def generate_invite_code(
     payload: GenerateInviteCodeRequest,
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.MANAGE_INVITE_CODES))],
 ) -> dict:
     repo = _invite_code_repo(request)
     code = await _call_invite_code_repo(
@@ -70,6 +75,8 @@ async def revoke_invite_code(
     code: str,
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_id)],
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.MANAGE_INVITE_CODES))],
 ) -> dict:
     repo = _invite_code_repo(request)
     ok = await _call_invite_code_repo("吊销邀请码失败：", lambda: repo.revoke(code))

--- a/backend/web/routers/panel.py
+++ b/backend/web/routers/panel.py
@@ -5,9 +5,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.chat.api.http.dependencies import get_contact_repo, get_thread_repo
 from backend.identity import profile as profile_owner
+from backend.identity.capabilities import Capability
 from backend.library import service as library_service
 from backend.threads import agent_user_service
-from backend.web.core.dependencies import get_current_user, get_current_user_id
+from backend.web.core.dependencies import get_current_user, get_current_user_id, require_capability
 from backend.web.models.panel import (
     AgentConfigPayload,
     CreateAgentRequest,
@@ -152,6 +153,8 @@ async def create_agent(
     req: CreateAgentRequest,
     user_id: CurrentUserId,
     request: Request,
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.CREATE_MANAGED_AGENT))],
 ) -> dict[str, Any]:
     user_repo = request.app.state.user_repo
     agent_config_repo = _agent_config_repo(request)

--- a/backend/web/routers/resources.py
+++ b/backend/web/routers/resources.py
@@ -5,8 +5,9 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from backend.identity.capabilities import Capability
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
-from backend.web.core.dependencies import get_current_user_id
+from backend.web.core.dependencies import get_current_user_id, require_capability
 
 router = APIRouter(prefix="/api/resources", tags=["resources"])
 
@@ -15,6 +16,8 @@ router = APIRouter(prefix="/api/resources", tags=["resources"])
 async def resources_overview(
     user_id: Annotated[str, Depends(get_current_user_id)],
     request: Request,
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
 ) -> dict[str, Any]:
     try:
         return await asyncio.to_thread(

--- a/backend/web/routers/sandbox.py
+++ b/backend/web/routers/sandbox.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from backend.identity.avatar.urls import avatar_url
+from backend.identity.capabilities import Capability
 from backend.sandboxes import provider_availability as sandbox_provider_availability
 from backend.sandboxes import user_reads as user_sandbox_reads
 from backend.sandboxes.inventory import init_providers_and_managers
@@ -12,7 +13,7 @@ from backend.sandboxes.runtime import mutations as sandbox_runtime_mutations
 from backend.sandboxes.runtime.reads import find_runtime_and_manager, load_all_sandbox_runtimes
 from backend.threads.projection import canonical_owner_threads
 from backend.threads.virtual_threads import is_virtual_thread_id
-from backend.web.core.dependencies import get_current_user_id
+from backend.web.core.dependencies import get_current_user_id, require_capability
 from storage.runtime import build_sandbox_monitor_repo as make_sandbox_monitor_repo
 
 router = APIRouter(prefix="/api/sandbox", tags=["sandbox"])
@@ -45,7 +46,9 @@ def _public_runtime_payload(row: dict[str, Any]) -> dict[str, Any]:
 
 
 @router.get("/types")
-async def list_sandbox_types() -> dict[str, Any]:
+async def list_sandbox_types(
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
+) -> dict[str, Any]:
     """List available sandbox types."""
     # @@@sandbox-type-availability - this route reflects the current process
     # inventory contract: configured providers are either instantiated and
@@ -55,7 +58,9 @@ async def list_sandbox_types() -> dict[str, Any]:
 
 
 @router.get("/runtimes")
-async def list_sandbox_runtimes() -> dict[str, Any]:
+async def list_sandbox_runtimes(
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
+) -> dict[str, Any]:
     """List all sandbox runtime rows across providers."""
     _, managers = await asyncio.to_thread(init_providers_and_managers)
     runtime_rows = await asyncio.to_thread(load_all_sandbox_runtimes, managers)
@@ -66,6 +71,8 @@ async def list_sandbox_runtimes() -> dict[str, Any]:
 async def list_my_sandboxes(
     user_id: Annotated[str, Depends(get_current_user_id)],
     request: Request,
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
 ) -> dict[str, Any]:
     thread_repo = getattr(request.app.state, "thread_repo", None)
     user_repo = getattr(request.app.state, "user_repo", None)
@@ -83,7 +90,12 @@ async def list_my_sandboxes(
 
 
 @router.get("/runtimes/{runtime_id}/metrics")
-async def get_sandbox_runtime_metrics(runtime_id: str, provider: str | None = Query(default=None)) -> dict[str, Any]:
+async def get_sandbox_runtime_metrics(
+    runtime_id: str,
+    provider: str | None = Query(default=None),
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
+) -> dict[str, Any]:
     """Get metrics for a specific sandbox runtime row."""
     try:
         return await asyncio.to_thread(
@@ -99,18 +111,33 @@ async def get_sandbox_runtime_metrics(runtime_id: str, provider: str | None = Qu
 
 
 @router.post("/runtimes/{runtime_id}/pause")
-async def pause_sandbox_runtime(runtime_id: str, provider: str | None = Query(default=None)) -> dict[str, Any]:
+async def pause_sandbox_runtime(
+    runtime_id: str,
+    provider: str | None = Query(default=None),
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.USE_SANDBOX))],
+) -> dict[str, Any]:
     """Pause a sandbox runtime row."""
     return await _mutate_runtime_action(runtime_id, "pause", provider)
 
 
 @router.post("/runtimes/{runtime_id}/resume")
-async def resume_sandbox_runtime(runtime_id: str, provider: str | None = Query(default=None)) -> dict[str, Any]:
+async def resume_sandbox_runtime(
+    runtime_id: str,
+    provider: str | None = Query(default=None),
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.USE_SANDBOX))],
+) -> dict[str, Any]:
     """Resume a paused sandbox runtime row."""
     return await _mutate_runtime_action(runtime_id, "resume", provider)
 
 
 @router.delete("/runtimes/{runtime_id}")
-async def destroy_sandbox_runtime(runtime_id: str, provider: str | None = Query(default=None)) -> dict[str, Any]:
+async def destroy_sandbox_runtime(
+    runtime_id: str,
+    provider: str | None = Query(default=None),
+    *,
+    _capability: Annotated[None, Depends(require_capability(Capability.USE_SANDBOX))],
+) -> dict[str, Any]:
     """Destroy a sandbox runtime row."""
     return await _mutate_runtime_action(runtime_id, "destroy", provider)

--- a/backend/web/routers/settings.py
+++ b/backend/web/routers/settings.py
@@ -9,8 +9,9 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from backend.identity.capabilities import Capability
 from backend.sandboxes import account as account_resource_service
-from backend.web.core.dependencies import get_current_user_id
+from backend.web.core.dependencies import get_current_user_id, require_capability
 from backend.web.utils.serializers import extract_text_content
 from config.models_loader import ModelsLoader
 from config.models_schema import ModelsConfig
@@ -208,7 +209,11 @@ async def get_account_resources(request: Request, user_id: CurrentUserId) -> dic
 
 
 @router.get("/browse")
-async def browse_filesystem(path: str = Query(default="~"), include_files: bool = Query(default=False)) -> dict[str, Any]:
+async def browse_filesystem(
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
+    path: str = Query(default="~"),
+    include_files: bool = Query(default=False),
+) -> dict[str, Any]:
     """Browse filesystem directories (and optionally files)."""
     try:
         target_path = Path(path).expanduser().resolve()
@@ -237,7 +242,10 @@ async def browse_filesystem(path: str = Query(default="~"), include_files: bool 
 
 
 @router.get("/read")
-async def read_local_file(path: str = Query(...)) -> dict[str, Any]:
+async def read_local_file(
+    _capability: Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))],
+    path: str = Query(...),
+) -> dict[str, Any]:
     """Read a local file's content (for SandboxBrowser in resources page)."""
     _read_max_bytes = 100 * 1024
     try:

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -97,6 +97,11 @@ class UserType(StrEnum):
     EXTERNAL = "external"
 
 
+class OwnerProfile(StrEnum):
+    FULL = "full"
+    GUEST = "guest"
+
+
 class UserRow(BaseModel):
     id: str
     type: UserType
@@ -108,6 +113,7 @@ class UserRow(BaseModel):
     email: str | None = None
     mycel_id: int | None = None
     created_by_user_id: str | None = None
+    owner_profile: OwnerProfile | None = None
     created_at: float
     updated_at: float | None = None
 
@@ -131,6 +137,8 @@ class UserRow(BaseModel):
                 raise ValueError("external users must not carry agent_config_id")
             if self.created_by_user_id is None:
                 raise ValueError("external users require created_by_user_id")
+            if self.owner_profile is not None:
+                raise ValueError("external users must not carry owner_profile")
             return self
         if self.owner_user_id is None:
             raise ValueError("agent users require owner_user_id")
@@ -138,6 +146,8 @@ class UserRow(BaseModel):
             raise ValueError("agent users require agent_config_id")
         if self.created_by_user_id is not None:
             raise ValueError("agent users must not carry created_by_user_id")
+        if self.owner_profile is not None:
+            raise ValueError("agent users must not carry owner_profile")
         return self
 
 

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -19,6 +19,7 @@ _COLS = (
     "email",
     "mycel_id",
     "created_by_user_id",
+    "owner_profile",
     "created_at",
     "updated_at",
 )
@@ -44,6 +45,7 @@ class SupabaseUserRepo:
                 "email": row.email,
                 "mycel_id": row.mycel_id,
                 "created_by_user_id": row.created_by_user_id,
+                "owner_profile": row.owner_profile.value if row.owner_profile is not None else None,
                 "created_at": row.created_at,
                 "updated_at": row.updated_at,
             }
@@ -93,7 +95,7 @@ class SupabaseUserRepo:
         return [UserRow.model_validate(row) for row in rows]
 
     def update(self, user_id: str, **fields: Any) -> None:
-        allowed = {"display_name", "owner_user_id", "agent_config_id", "avatar", "email", "mycel_id", "updated_at"}
+        allowed = {"display_name", "owner_user_id", "agent_config_id", "avatar", "email", "mycel_id", "owner_profile", "updated_at"}
         updates = {key: value for key, value in fields.items() if key in allowed}
         if not updates:
             return

--- a/storage/schema/owner_profile.sql
+++ b/storage/schema/owner_profile.sql
@@ -1,0 +1,4 @@
+alter table identity.users
+    add column if not exists owner_profile text;
+
+notify pgrst, 'reload schema';

--- a/tests/Unit/backend/test_auth_guest_owner.py
+++ b/tests/Unit/backend/test_auth_guest_owner.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID
+
+import jwt
+import pytest
+
+from backend.identity.auth.service import AuthService
+from storage.contracts import OwnerProfile, UserType
+
+
+def test_create_guest_owner_token_creates_restricted_human_without_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-1")
+    monkeypatch.setattr("backend.identity.auth.service.uuid4", lambda: UUID("12345678-1234-5678-1234-567812345678"))
+    created_rows: list[Any] = []
+    user_repo = SimpleNamespace(
+        get_by_id=lambda _user_id: None,
+        create=lambda row: created_rows.append(row),
+    )
+    service = AuthService(
+        users=cast(Any, user_repo),
+        agent_configs=SimpleNamespace(save_agent_config=lambda _config: pytest.fail("guest must not create managed agents")),
+        contact_repo=SimpleNamespace(upsert=lambda _row: pytest.fail("guest must not seed contacts")),
+        recipe_repo=SimpleNamespace(upsert=lambda **_payload: pytest.fail("guest must not seed recipes")),
+    )
+
+    result = service.create_guest_owner_token(display_name="Guest Runner")
+
+    assert len(created_rows) == 1
+    assert created_rows[0].id == "guest-12345678-1234-5678-1234-567812345678"
+    assert created_rows[0].type is UserType.HUMAN
+    assert created_rows[0].owner_profile is OwnerProfile.GUEST
+    assert created_rows[0].display_name == "Guest Runner"
+    assert created_rows[0].email is None
+    assert created_rows[0].mycel_id is None
+    decoded = jwt.decode(result["token"], "secret-1", algorithms=["HS256"], options={"verify_aud": False})
+    assert decoded["sub"] == "guest-12345678-1234-5678-1234-567812345678"
+    assert decoded["mycel_owner_profile"] == "guest"
+    assert service.verify_token(result["token"]) == {"user_id": "guest-12345678-1234-5678-1234-567812345678"}
+    assert result["user"] == {
+        "id": "guest-12345678-1234-5678-1234-567812345678",
+        "name": "Guest Runner",
+        "type": "human",
+        "owner_profile": "guest",
+        "email": None,
+        "mycel_id": None,
+        "avatar": None,
+    }

--- a/tests/Unit/backend/test_identity_capabilities.py
+++ b/tests/Unit/backend/test_identity_capabilities.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.identity.capabilities import Capability, require_user_capability, resolve_user_capabilities
+from storage.contracts import UserType
+
+
+def _user(user_id: str, user_type: UserType | str):
+    return SimpleNamespace(id=user_id, type=user_type)
+
+
+def _owner(user_id: str, owner_profile: str | None = None):
+    return SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=owner_profile)
+
+
+def test_human_owner_has_admin_capabilities() -> None:
+    capabilities = resolve_user_capabilities(_user("owner-1", UserType.HUMAN))
+
+    assert capabilities.user_id == "owner-1"
+    assert capabilities.has(Capability.CREATE_EXTERNAL_USER)
+    assert capabilities.has(Capability.MANAGE_INVITE_CODES)
+    assert capabilities.has(Capability.USE_SANDBOX)
+
+
+def test_guest_owner_has_communication_profile_only() -> None:
+    capabilities = resolve_user_capabilities(_owner("guest-1", "guest"))
+
+    assert capabilities.has(Capability.CREATE_EXTERNAL_USER)
+    assert not capabilities.has(Capability.CREATE_MANAGED_AGENT)
+    assert not capabilities.has(Capability.MANAGE_INVITE_CODES)
+    assert not capabilities.has(Capability.USE_SANDBOX)
+
+
+def test_external_user_has_communication_profile_only() -> None:
+    capabilities = resolve_user_capabilities(_user("external-1", UserType.EXTERNAL))
+
+    assert not capabilities.has(Capability.CREATE_EXTERNAL_USER)
+    assert not capabilities.has(Capability.MANAGE_INVITE_CODES)
+    assert not capabilities.has(Capability.USE_SANDBOX)
+
+
+def test_require_user_capability_fails_loud_for_external_user() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        require_user_capability(_user("external-1", "external"), Capability.CREATE_EXTERNAL_USER)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Capability required: create_external_user"
+
+
+def test_unknown_user_type_fails_loud() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_user_capabilities(_user("odd-1", "odd"))
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Unknown user capability profile"

--- a/tests/Unit/integration_contracts/test_auth_router.py
+++ b/tests/Unit/integration_contracts/test_auth_router.py
@@ -9,21 +9,29 @@ from fastapi.testclient import TestClient
 from backend.chat.api.http import chats_router
 from backend.identity.auth.service import ExternalUserAlreadyExistsError
 from backend.web.routers import auth as auth_router
+from storage.contracts import UserType
 
 
 class _FakeAuthService:
     def __init__(self) -> None:
         self.send_otp_calls: list[tuple[str, str, str]] = []
         self.login_calls: list[tuple[str, str]] = []
+        self.create_guest_owner_token_calls: list[str | None] = []
         self.create_external_user_token_calls: list[tuple[str, str, str]] = []
         self.login_result = {"token": "tok-login"}
+        self.create_guest_owner_token_result = {
+            "token": "tok-guest",
+            "user": {"id": "guest-1", "name": "Guest", "type": "human", "owner_profile": "guest"},
+        }
         self.create_external_user_token_result = {
             "token": "tok-external",
             "user": {"id": "external-1", "name": "Codex Local", "type": "external"},
         }
         self.send_otp_error: Exception | None = None
         self.login_error: Exception | None = None
+        self.create_guest_owner_token_error: Exception | None = None
         self.create_external_user_token_error: Exception | None = None
+        self.verify_token_result: dict = {}
 
     def send_otp(self, email: str, password: str, invite_code: str) -> None:
         self.send_otp_calls.append((email, password, invite_code))
@@ -35,6 +43,15 @@ class _FakeAuthService:
         if self.login_error is not None:
             raise self.login_error
         return self.login_result
+
+    def verify_token(self, token: str) -> dict:
+        return self.verify_token_result
+
+    def create_guest_owner_token(self, *, display_name: str | None = None) -> dict:
+        self.create_guest_owner_token_calls.append(display_name)
+        if self.create_guest_owner_token_error is not None:
+            raise self.create_guest_owner_token_error
+        return self.create_guest_owner_token_result
 
     def create_external_user_token(self, user_id: str, display_name: str, *, created_by_user_id: str) -> dict:
         self.create_external_user_token_calls.append((user_id, display_name, created_by_user_id))
@@ -87,6 +104,31 @@ async def test_login_maps_value_error_to_unauthorized():
 
 
 @pytest.mark.asyncio
+async def test_create_guest_owner_calls_auth_service_without_current_user():
+    service = _FakeAuthService()
+    app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
+
+    result = await auth_router.create_guest_owner(auth_router.CreateGuestOwnerRequest(display_name="Forum Visitor"), app)
+
+    assert result == service.create_guest_owner_token_result
+    assert service.create_guest_owner_token_calls == ["Forum Visitor"]
+
+
+def test_create_guest_owner_route_is_public_auth_surface():
+    service = _FakeAuthService()
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(auth_service=service)
+    app.include_router(auth_router.router)
+
+    with TestClient(app) as client:
+        response = client.post("/api/auth/guest", json={"display_name": "Forum Visitor"})
+
+    assert response.status_code == 200
+    assert response.json() == service.create_guest_owner_token_result
+    assert service.create_guest_owner_token_calls == ["Forum Visitor"]
+
+
+@pytest.mark.asyncio
 async def test_create_external_user_calls_auth_service_with_current_user():
     service = _FakeAuthService()
     app = SimpleNamespace(state=SimpleNamespace(auth_runtime_state=SimpleNamespace(auth_service=service)))
@@ -95,6 +137,7 @@ async def test_create_external_user_calls_auth_service_with_current_user():
         auth_router.CreateExternalUserRequest(user_id="external-1", display_name="Codex Local"),
         app,
         current_user_id="owner-1",
+        _capability=None,
     )
 
     assert result == service.create_external_user_token_result
@@ -120,6 +163,7 @@ async def test_auth_me_returns_authenticated_user_identity():
         "type": "external",
         "email": None,
         "mycel_id": None,
+        "owner_profile": None,
         "avatar": None,
     }
 
@@ -135,6 +179,7 @@ async def test_create_external_user_maps_duplicate_to_conflict():
             auth_router.CreateExternalUserRequest(user_id="external-1", display_name="Codex Local"),
             app,
             current_user_id="owner-1",
+            _capability=None,
         )
 
     assert exc_info.value.status_code == 409
@@ -152,6 +197,53 @@ def test_create_external_user_route_requires_current_user_dependency():
 
     assert response.status_code == 401
     assert service.create_external_user_token_calls == []
+
+
+def test_external_user_cannot_create_another_external_user_over_http():
+    service = _FakeAuthService()
+    service.verify_token_result = {"user_id": "external-1"}
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(auth_service=service)
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.EXTERNAL, display_name="Codex Local") if user_id == "external-1" else None
+        )
+    )
+    app.include_router(auth_router.router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/auth/external-users",
+            headers={"Authorization": "Bearer tok-external"},
+            json={"user_id": "nested-external", "display_name": "Nested External"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Capability required: create_external_user"
+    assert service.create_external_user_token_calls == []
+
+
+def test_guest_owner_can_create_external_user_over_http():
+    service = _FakeAuthService()
+    service.verify_token_result = {"user_id": "guest-1"}
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(auth_service=service)
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile="guest", display_name="Guest") if user_id == "guest-1" else None
+        )
+    )
+    app.include_router(auth_router.router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/auth/external-users",
+            headers={"Authorization": "Bearer tok-guest"},
+            json={"user_id": "guest-codex-1", "display_name": "Guest Codex"},
+        )
+
+    assert response.status_code == 200
+    assert service.create_external_user_token_calls == [("guest-codex-1", "Guest Codex", "guest-1")]
 
 
 def test_create_external_user_openapi_is_public_auth_surface():

--- a/tests/Unit/integration_contracts/test_invite_codes_router.py
+++ b/tests/Unit/integration_contracts/test_invite_codes_router.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from backend.web.routers import invite_codes as invite_codes_router
+from storage.contracts import UserType
 
 
 class _FakeInviteCodeRepo:
@@ -43,7 +46,7 @@ class _FakeInviteCodeRepo:
         return self.is_valid_result
 
 
-def _request(repo: _FakeInviteCodeRepo):
+def _request(repo: _FakeInviteCodeRepo) -> Any:
     return SimpleNamespace(
         app=SimpleNamespace(
             state=SimpleNamespace(
@@ -54,6 +57,31 @@ def _request(repo: _FakeInviteCodeRepo):
             )
         )
     )
+
+
+def test_external_user_cannot_generate_invite_code_over_http():
+    repo = _FakeInviteCodeRepo()
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(
+        auth_service=SimpleNamespace(verify_token=lambda token: {"user_id": "external-1"} if token == "tok-external" else None)
+    )
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.EXTERNAL, display_name="Codex Local") if user_id == "external-1" else None
+        )
+    )
+    app.state.runtime_storage_state = SimpleNamespace(
+        supabase_client=object(),
+        storage_container=SimpleNamespace(invite_code_repo=lambda: repo),
+    )
+    app.include_router(invite_codes_router.router)
+
+    with TestClient(app) as client:
+        response = client.post("/api/invite-codes", headers={"Authorization": "Bearer tok-external"}, json={"expires_days": 7})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Capability required: manage_invite_codes"
+    assert repo.generate_calls == []
 
 
 @pytest.mark.asyncio
@@ -93,7 +121,7 @@ async def test_revoke_invite_code_raises_404_when_repo_reports_missing():
     request = _request(repo)
 
     with pytest.raises(HTTPException) as exc_info:
-        await invite_codes_router.revoke_invite_code("invite-1", request=request, user_id="user-1")
+        await invite_codes_router.revoke_invite_code("invite-1", request=request, user_id="user-1", _capability=None)
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "邀请码不存在"
@@ -120,7 +148,7 @@ async def test_list_invite_codes_returns_app_contract_from_repo_rows():
         },
     ]
 
-    result = await invite_codes_router.list_invite_codes(request=_request(repo), user_id="user-1")
+    result = await invite_codes_router.list_invite_codes(request=_request(repo), user_id="user-1", _capability=None)
 
     assert result == {
         "codes": [
@@ -159,6 +187,7 @@ async def test_generate_invite_code_returns_app_contract_from_repo_row():
         invite_codes_router.GenerateInviteCodeRequest(expires_days=7),
         request=_request(repo),
         user_id="user-1",
+        _capability=None,
     )
 
     assert result == {

--- a/tests/Unit/integration_contracts/test_monitor_resources_route.py
+++ b/tests/Unit/integration_contracts/test_monitor_resources_route.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -6,7 +8,7 @@ from backend.monitor.api.http import global_router
 from backend.monitor.application.use_cases import resources as monitor_resources_impl
 from backend.monitor.infrastructure.io import resource_io_service as monitor_resource_io_service
 from backend.monitor.infrastructure.web import gateway as monitor_gateway_impl
-from backend.web.core.dependencies import get_current_user_id
+from backend.web.core.dependencies import get_current_user, get_current_user_id
 from backend.web.routers import monitor_threads as monitor_threads_router
 from backend.web.routers import resources
 
@@ -17,6 +19,7 @@ def _app(*, include_product_resources: bool = False) -> FastAPI:
     app.include_router(monitor_threads_router.router, prefix="/api/monitor")
     if include_product_resources:
         app.include_router(resources.router)
+        app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type="human", owner_profile=None)
         app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
     return app
 

--- a/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
+++ b/tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py
@@ -2262,10 +2262,39 @@ async def test_create_agent_route_fails_loud_when_contact_repo_missing():
             panel_router.CreateAgentRequest(name="Toad", description="probe"),
             request=request,
             user_id="user-1",
+            _capability=None,
         )
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "chat bootstrap not attached: contact_repo"
+
+
+def test_external_user_cannot_create_managed_agent_over_http(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        agent_user_service,
+        "create_agent_user",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("capability gate should run before agent creation")),
+    )
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(
+        auth_service=SimpleNamespace(verify_token=lambda token: {"user_id": "external-1"} if token == "tok-external" else None)
+    )
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.EXTERNAL, display_name="Codex Local") if user_id == "external-1" else None
+        )
+    )
+    app.include_router(panel_router.router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/panel/agents",
+            headers={"Authorization": "Bearer tok-external"},
+            json={"name": "Managed", "description": "probe"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Capability required: create_managed_agent"
 
 
 @pytest.mark.asyncio
@@ -2322,6 +2351,9 @@ def test_panel_agents_http_surface_does_not_expose_query_app_param(monkeypatch: 
     app = FastAPI()
     app.include_router(panel_router.router)
     app.dependency_overrides[panel_router.get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[panel_router.get_current_user] = lambda: SimpleNamespace(
+        id="user-1", type=UserType.HUMAN, display_name="Owner"
+    )
     app.state.user_repo = SimpleNamespace()
     app.state.runtime_storage_state = _runtime_storage_state(SimpleNamespace())
     app.state.thread_repo = SimpleNamespace(list_by_agent_user=lambda _agent_id: [])
@@ -2346,6 +2378,7 @@ def test_panel_agents_http_surface_does_not_expose_query_app_param(monkeypatch: 
             headers={"Authorization": "Bearer token"},
         )
         delete = client.delete("/api/panel/agents/agent-1", headers={"Authorization": "Bearer token"})
+    app.dependency_overrides.clear()
 
     assert create_params == []
     assert delete_params == [

--- a/tests/Unit/integration_contracts/test_resource_overview_contract_split.py
+++ b/tests/Unit/integration_contracts/test_resource_overview_contract_split.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -12,8 +13,9 @@ from backend.monitor.api.http import global_router
 from backend.monitor.infrastructure.read_models import resource_read_service as monitor_resource_read_service
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
 from backend.sandboxes.resources import common as resource_common
-from backend.web.core.dependencies import get_current_user_id
+from backend.web.core.dependencies import get_current_user, get_current_user_id
 from backend.web.routers import resources as resources_router
+from storage.contracts import UserType
 
 
 class _State:
@@ -114,6 +116,7 @@ def test_resources_overview_maps_runtime_error_to_500(monkeypatch) -> None:
             resources_router.resources_overview(
                 user_id="user-1",
                 request=request,
+                _capability=None,
             )
         )
 
@@ -139,6 +142,30 @@ def test_monitor_resources_route_stays_global(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert response.json()["providers"][0]["id"] == "global-daytona"
+
+
+def test_external_user_cannot_get_resource_overview_over_http(monkeypatch) -> None:
+    monkeypatch.setattr(
+        monitor_gateway,
+        "list_user_resource_providers",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("capability gate should run before monitor read")),
+    )
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(
+        auth_service=SimpleNamespace(verify_token=lambda token: {"user_id": "external-1"} if token == "tok-external" else None)
+    )
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.EXTERNAL, display_name="Codex Local") if user_id == "external-1" else None
+        )
+    )
+    app.include_router(resources_router.router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/resources/overview", headers={"Authorization": "Bearer tok-external"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Capability required: inspect_resources"
 
 
 def test_user_resource_projection_groups_visible_sandboxes_into_provider_cards(monkeypatch) -> None:
@@ -376,6 +403,7 @@ def test_resources_overview_route_surfaces_actor_first_user_payload(monkeypatch)
     test_app.state = _State()
     test_app.include_router(resources_router.router)
     test_app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
+    test_app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, display_name="Owner")
 
     monkeypatch.setattr(
         resource_provider_boundary_service,

--- a/tests/Unit/integration_contracts/test_sandbox_router_user_shell.py
+++ b/tests/Unit/integration_contracts/test_sandbox_router_user_shell.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from backend.sandboxes import service as sandbox_service
 from backend.web.routers import sandbox as sandbox_router
+from storage.contracts import UserType
 
 
 @pytest.mark.asyncio
 async def test_list_my_sandboxes_uses_canonical_sandbox_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
-    seen: dict[str, object] = {}
+    seen: dict[str, Any] = {}
 
     def fake_list_user_sandboxes(user_id: str, *, thread_repo=None, user_repo=None, **kwargs) -> list[dict[str, object]]:
         seen.update(
@@ -25,10 +29,10 @@ async def test_list_my_sandboxes_uses_canonical_sandbox_envelope(monkeypatch: py
 
     thread_repo = SimpleNamespace()
     user_repo = SimpleNamespace()
-    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(thread_repo=thread_repo, user_repo=user_repo)))
+    request: Any = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(thread_repo=thread_repo, user_repo=user_repo)))
     monkeypatch.setattr(sandbox_router.user_sandbox_reads, "list_user_sandboxes", fake_list_user_sandboxes, raising=False)
 
-    result = await sandbox_router.list_my_sandboxes(user_id="owner-1", request=request)
+    result = cast(dict[str, Any], await sandbox_router.list_my_sandboxes(user_id="owner-1", request=request, _capability=None))
 
     assert result == {"sandboxes": [{"sandbox_id": "sandbox-1"}]}
     assert seen["user_id"] == "owner-1"
@@ -51,6 +55,30 @@ def test_sandbox_runtime_routes_do_not_expose_session_paths() -> None:
     assert not any("/sessions" in path for path in route_paths)
 
 
+def test_external_user_cannot_list_sandbox_runtimes_over_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sandbox_router,
+        "init_providers_and_managers",
+        lambda: (_ for _ in ()).throw(AssertionError("capability gate should run before provider init")),
+    )
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(
+        auth_service=SimpleNamespace(verify_token=lambda token: {"user_id": "external-1"} if token == "tok-external" else None)
+    )
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.EXTERNAL, display_name="Codex Local") if user_id == "external-1" else None
+        )
+    )
+    app.include_router(sandbox_router.router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/sandbox/runtimes", headers={"Authorization": "Bearer tok-external"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Capability required: inspect_resources"
+
+
 @pytest.mark.asyncio
 async def test_list_sandbox_types_reports_current_daytona_provider_when_inventory_builds(
     monkeypatch: pytest.MonkeyPatch,
@@ -64,7 +92,7 @@ async def test_list_sandbox_types_reports_current_daytona_provider_when_inventor
         ],
     )
 
-    result = await sandbox_router.list_sandbox_types()
+    result = await sandbox_router.list_sandbox_types(None)
 
     assert result["types"] == [
         {"name": "local", "provider": "local", "available": True},
@@ -90,7 +118,7 @@ async def test_list_sandbox_runtimes_strips_runtime_identity(monkeypatch: pytest
         ],
     )
 
-    result = await sandbox_router.list_sandbox_runtimes()
+    result = await sandbox_router.list_sandbox_runtimes(None)
 
     assert "sess" + "ions" not in result
     assert result["runtime_rows"] == [
@@ -126,7 +154,7 @@ async def test_sandbox_runtime_mutation_response_strips_runtime_identity(monkeyp
         fake_mutate_sandbox_runtime,
     )
 
-    result = await sandbox_router.pause_sandbox_runtime("runtime-1")
+    result = await sandbox_router.pause_sandbox_runtime("runtime-1", _capability=None)
 
     assert result == {
         "ok": True,
@@ -154,7 +182,7 @@ async def test_get_sandbox_runtime_metrics_passes_provider_hint(monkeypatch: pyt
         fake_get_runtime_metrics,
     )
 
-    result = await sandbox_router.get_sandbox_runtime_metrics("runtime-1", provider="local")
+    result = await sandbox_router.get_sandbox_runtime_metrics("runtime-1", provider="local", _capability=None)
 
     assert result == {"session_id": "runtime-1", "provider": "local", "metrics": None}
     assert seen["args"] == ("runtime-1", "local")

--- a/tests/Unit/integration_contracts/test_settings_local_path_shell.py
+++ b/tests/Unit/integration_contracts/test_settings_local_path_shell.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from backend.web.routers import settings as settings_router
+from storage.contracts import UserType
 
 
 @pytest.mark.asyncio
@@ -13,7 +16,7 @@ async def test_browse_filesystem_lists_directory_entries(tmp_path: Path):
     child = tmp_path / "child"
     child.mkdir()
 
-    result = await settings_router.browse_filesystem(path=str(tmp_path), include_files=False)
+    result = await settings_router.browse_filesystem(_capability=None, path=str(tmp_path), include_files=False)
 
     assert result == {
         "current_path": str(tmp_path.resolve()),
@@ -27,7 +30,7 @@ async def test_read_local_file_reads_content(tmp_path: Path):
     file_path = tmp_path / "note.txt"
     file_path.write_text("hello world", encoding="utf-8")
 
-    result = await settings_router.read_local_file(path=str(file_path))
+    result = await settings_router.read_local_file(_capability=None, path=str(file_path))
 
     assert result == {"path": str(file_path.resolve()), "content": "hello world", "truncated": False}
 
@@ -39,16 +42,16 @@ async def test_browse_and_read_keep_route_specific_path_errors(tmp_path: Path):
     file_path.write_text("hello", encoding="utf-8")
 
     with pytest.raises(HTTPException) as browse_missing_exc:
-        await settings_router.browse_filesystem(path=str(missing), include_files=False)
+        await settings_router.browse_filesystem(_capability=None, path=str(missing), include_files=False)
 
     with pytest.raises(HTTPException) as browse_wrong_type_exc:
-        await settings_router.browse_filesystem(path=str(file_path), include_files=False)
+        await settings_router.browse_filesystem(_capability=None, path=str(file_path), include_files=False)
 
     with pytest.raises(HTTPException) as read_missing_exc:
-        await settings_router.read_local_file(path=str(missing))
+        await settings_router.read_local_file(_capability=None, path=str(missing))
 
     with pytest.raises(HTTPException) as read_wrong_type_exc:
-        await settings_router.read_local_file(path=str(tmp_path))
+        await settings_router.read_local_file(_capability=None, path=str(tmp_path))
 
     assert browse_missing_exc.value.status_code == 404
     assert browse_missing_exc.value.detail == "Path does not exist"
@@ -68,7 +71,29 @@ async def test_browse_filesystem_reports_permission_denied(monkeypatch: pytest.M
     monkeypatch.setattr(Path, "iterdir", _raise_permission_denied)
 
     with pytest.raises(HTTPException) as exc:
-        await settings_router.browse_filesystem(path=str(tmp_path), include_files=False)
+        await settings_router.browse_filesystem(_capability=None, path=str(tmp_path), include_files=False)
 
     assert exc.value.status_code == 403
     assert exc.value.detail == "Permission denied"
+
+
+def test_external_user_cannot_browse_local_filesystem_over_http() -> None:
+    app = FastAPI()
+    app.state.auth_runtime_state = SimpleNamespace(
+        auth_service=SimpleNamespace(verify_token=lambda token: {"user_id": "external-1"} if token == "tok-external" else None)
+    )
+    app.state.user_repo = SimpleNamespace(
+        get_by_id=lambda user_id: (
+            SimpleNamespace(id=user_id, type=UserType.EXTERNAL, display_name="Codex Local") if user_id == "external-1" else None
+        )
+    )
+    app.include_router(settings_router.router)
+
+    with TestClient(app) as client:
+        browse_response = client.get("/api/settings/browse", headers={"Authorization": "Bearer tok-external"})
+        read_response = client.get("/api/settings/read", headers={"Authorization": "Bearer tok-external"}, params={"path": "/"})
+
+    assert browse_response.status_code == 403
+    assert browse_response.json()["detail"] == "Capability required: inspect_resources"
+    assert read_response.status_code == 403
+    assert read_response.json()["detail"] == "Capability required: inspect_resources"

--- a/tests/Unit/storage/test_external_user_type.py
+++ b/tests/Unit/storage/test_external_user_type.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from storage.contracts import UserRow, UserType
+from storage.contracts import OwnerProfile, UserRow, UserType
 
 
 def test_external_user_row_requires_creator_and_no_agent_config() -> None:
@@ -51,5 +51,40 @@ def test_external_user_row_rejects_agent_config_id() -> None:
             display_name="Codex External",
             created_by_user_id="owner-1",
             agent_config_id="cfg-1",
+            created_at=1.0,
+        )
+
+
+def test_human_user_row_can_carry_guest_owner_profile() -> None:
+    row = UserRow(
+        id="guest-owner-1",
+        type=UserType.HUMAN,
+        display_name="Guest",
+        owner_profile=OwnerProfile.GUEST,
+        created_at=1.0,
+    )
+
+    assert row.owner_profile is OwnerProfile.GUEST
+
+
+def test_agent_and_external_rows_reject_owner_profile() -> None:
+    with pytest.raises(ValueError, match="external users must not carry owner_profile"):
+        UserRow(
+            id="external-user-1",
+            type=UserType.EXTERNAL,
+            display_name="Codex External",
+            created_by_user_id="owner-1",
+            owner_profile=OwnerProfile.GUEST,
+            created_at=1.0,
+        )
+
+    with pytest.raises(ValueError, match="agent users must not carry owner_profile"):
+        UserRow(
+            id="agent-1",
+            type=UserType.AGENT,
+            display_name="Toad",
+            owner_user_id="owner-1",
+            agent_config_id="cfg-1",
+            owner_profile=OwnerProfile.GUEST,
             created_at=1.0,
         )

--- a/tests/Unit/storage/test_supabase_user_repo.py
+++ b/tests/Unit/storage/test_supabase_user_repo.py
@@ -1,4 +1,4 @@
-from storage.contracts import UserRow, UserType
+from storage.contracts import OwnerProfile, UserRow, UserType
 from storage.providers.supabase.user_repo import SupabaseUserRepo
 
 
@@ -17,6 +17,7 @@ class _FakeTable:
                 "avatar": "toad.png",
                 "email": "toad@example.com",
                 "mycel_id": 10001,
+                "owner_profile": None,
                 "next_thread_seq": 3,
                 "created_at": 1.0,
                 "updated_at": 2.0,
@@ -85,6 +86,7 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
             email="toad@example.com",
             mycel_id=10001,
             created_by_user_id=None,
+            owner_profile=None,
             next_thread_seq=3,
             created_at=1.0,
             updated_at=2.0,
@@ -97,6 +99,7 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
     assert client.table_obj.insert_payload["owner_user_id"] == "owner-1"
     assert client.table_obj.insert_payload["agent_config_id"] == "cfg-1"
     assert client.table_obj.insert_payload["created_by_user_id"] is None
+    assert client.table_obj.insert_payload["owner_profile"] is None
     assert client.table_obj.insert_payload["next_thread_seq"] == 3
 
 
@@ -120,6 +123,27 @@ def test_supabase_user_repo_create_persists_external_creator() -> None:
     assert client.table_obj.insert_payload["created_by_user_id"] == "owner-1"
     assert client.table_obj.insert_payload["owner_user_id"] is None
     assert client.table_obj.insert_payload["agent_config_id"] is None
+    assert client.table_obj.insert_payload["owner_profile"] is None
+
+
+def test_supabase_user_repo_create_persists_guest_owner_profile() -> None:
+    client = _FakeClient()
+    repo = SupabaseUserRepo(client)
+
+    repo.create(
+        UserRow(
+            id="guest-owner-1",
+            type=UserType.HUMAN,
+            display_name="Guest",
+            owner_profile=OwnerProfile.GUEST,
+            created_at=1.0,
+        )
+    )
+
+    assert client.table_name == "identity.users"
+    assert client.table_obj.insert_payload is not None
+    assert client.table_obj.insert_payload["type"] == "human"
+    assert client.table_obj.insert_payload["owner_profile"] == "guest"
 
 
 def test_supabase_user_repo_get_by_id_returns_user_row() -> None:


### PR DESCRIPTION
## Summary

Adds a backend-owned guest capability profile without introducing a new user type.

- Adds `owner_profile` for human owner rows and a restricted guest profile.
- Adds one shared capability resolver/dependency for sensitive HTTP surfaces.
- Adds `POST /api/auth/guest` to issue a restricted owner token.
- Gates external-user minting, managed-agent creation, invite-code admin, sandbox/resource inspection, and local settings filesystem read.

## Verification

- `uv run ruff check ...` on touched backend/storage/tests passed.
- `uv run ruff format --check ...` on touched backend/storage/tests passed.
- `uv run pyright backend/identity/capabilities.py backend/identity/auth/service.py backend/web/core/dependencies.py backend/web/routers/auth.py storage/contracts.py storage/providers/supabase/user_repo.py tests/Unit/backend/test_identity_capabilities.py tests/Unit/backend/test_auth_guest_owner.py tests/Unit/storage/test_external_user_type.py tests/Unit/storage/test_supabase_user_repo.py tests/Unit/integration_contracts/test_auth_router.py` passed with 0 errors.
- `uv run pytest tests/Unit/backend/test_identity_capabilities.py tests/Unit/backend/test_auth_guest_owner.py tests/Unit/storage/test_external_user_type.py tests/Unit/storage/test_supabase_user_repo.py tests/Unit/backend/test_auth_service_token_verification.py tests/Unit/integration_contracts/test_auth_router.py tests/Unit/integration_contracts/test_invite_codes_router.py tests/Unit/integration_contracts/test_sandbox_router_user_shell.py tests/Unit/integration_contracts/test_settings_local_path_shell.py tests/Unit/integration_contracts/test_resource_overview_contract_split.py tests/Unit/integration_contracts/test_panel_auth_shell_coherence.py -q` passed: 185 passed.

## Notes

Public-backend YATU still requires applying `storage/schema/owner_profile.sql` and deploying this backend branch first. SDK/CLI exposure is in the paired SDK PR.
