### PR TITLE
fix: gate monitor control plane

### DIFF
--- a/backend/monitor/api/http/global_router.py
+++ b/backend/monitor/api/http/global_router.py
@@ -5,10 +5,15 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, R
 from pydantic import BaseModel, Field
 
 from backend.identity.auth.user_resolution import get_current_user_id
+from backend.identity.capabilities import Capability
 from backend.monitor.api.http.execution_target import resolve_monitor_evaluation_base_url
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
+from backend.web.core.dependencies import require_capability
 
 router = APIRouter()
+
+MonitorReadCapability = Annotated[None, Depends(require_capability(Capability.INSPECT_RESOURCES))]
+MonitorControlCapability = Annotated[None, Depends(require_capability(Capability.USE_SANDBOX))]
 
 
 class EvaluationBatchCreateRequest(BaseModel):
@@ -54,62 +59,62 @@ async def _resource_io(fn, *args):
 
 
 @router.get("/sandboxes")
-def sandboxes_snapshot():
+def sandboxes_snapshot(_capability: MonitorReadCapability):
     return monitor_gateway.list_sandboxes()
 
 
 @router.get("/provider-orphan-runtimes")
-def provider_orphan_runtimes_snapshot():
+def provider_orphan_runtimes_snapshot(_capability: MonitorReadCapability):
     return monitor_gateway.list_provider_orphan_runtimes()
 
 
 @router.get("/providers/{provider_id}")
-def provider_detail_snapshot(provider_id: str):
+def provider_detail_snapshot(provider_id: str, _capability: MonitorReadCapability):
     return _or_404(monitor_gateway.get_provider_detail, provider_id)
 
 
 @router.get("/sandboxes/{sandbox_id}")
-def sandbox_detail_snapshot(sandbox_id: str):
+def sandbox_detail_snapshot(sandbox_id: str, _capability: MonitorReadCapability):
     return _or_404(monitor_gateway.get_sandbox_detail, sandbox_id)
 
 
 @router.post("/sandboxes/{sandbox_id}/cleanup")
-def sandbox_cleanup_action(sandbox_id: str):
+def sandbox_cleanup_action(sandbox_id: str, _capability: MonitorControlCapability):
     return _or_404(monitor_gateway.request_sandbox_cleanup, sandbox_id)
 
 
 @router.post("/provider-orphan-runtimes/{provider_id}/{runtime_id}/cleanup")
-def provider_orphan_runtime_cleanup_action(provider_id: str, runtime_id: str):
+def provider_orphan_runtime_cleanup_action(provider_id: str, runtime_id: str, _capability: MonitorControlCapability):
     return monitor_gateway.request_provider_orphan_runtime_cleanup(provider_id, runtime_id)
 
 
 @router.get("/operations/{operation_id}")
-def operation_detail_snapshot(operation_id: str):
+def operation_detail_snapshot(operation_id: str, _capability: MonitorReadCapability):
     return _or_404_or_503(monitor_gateway.get_operation_detail, operation_id)
 
 
 @router.get("/runtimes/{runtime_id}")
-def runtime_detail_snapshot(runtime_id: str):
+def runtime_detail_snapshot(runtime_id: str, _capability: MonitorReadCapability):
     return _or_404(monitor_gateway.get_runtime_detail, runtime_id)
 
 
 @router.get("/sandbox-configs")
-def sandbox_configs_snapshot():
+def sandbox_configs_snapshot(_capability: MonitorReadCapability):
     return monitor_gateway.get_sandbox_configs()
 
 
 @router.get("/dashboard")
-def dashboard_snapshot():
+def dashboard_snapshot(_capability: MonitorReadCapability):
     return monitor_gateway.get_dashboard()
 
 
 @router.get("/evaluation")
-def evaluation_snapshot():
+def evaluation_snapshot(_capability: MonitorReadCapability):
     return monitor_gateway.get_evaluation_workbench()
 
 
 @router.get("/evaluation/batches")
-def evaluation_batches_snapshot(limit: int = Query(default=50, ge=1, le=200)):
+def evaluation_batches_snapshot(_capability: MonitorReadCapability, limit: int = Query(default=50, ge=1, le=200)):
     return monitor_gateway.get_evaluation_batches(limit=limit)
 
 
@@ -117,6 +122,7 @@ def evaluation_batches_snapshot(limit: int = Query(default=50, ge=1, le=200)):
 def evaluation_batch_create_action(
     payload: EvaluationBatchCreateRequest,
     user_id: Annotated[str, Depends(get_current_user_id)],
+    _capability: MonitorControlCapability,
 ):
     return monitor_gateway.create_evaluation_batch(
         submitted_by_user_id=user_id,
@@ -133,6 +139,7 @@ def evaluation_batch_start_action(
     request: Request,
     background_tasks: BackgroundTasks,
     _user_id: Annotated[str, Depends(get_current_user_id)],
+    _capability: MonitorControlCapability,
 ):
     try:
         return monitor_gateway.start_evaluation_batch(
@@ -150,36 +157,36 @@ def evaluation_batch_start_action(
 
 
 @router.get("/evaluation/scenarios")
-def evaluation_scenarios_snapshot():
+def evaluation_scenarios_snapshot(_capability: MonitorReadCapability):
     return monitor_gateway.get_evaluation_scenarios()
 
 
 @router.get("/evaluation/batches/{batch_id}")
-def evaluation_batch_detail_snapshot(batch_id: str):
+def evaluation_batch_detail_snapshot(batch_id: str, _capability: MonitorReadCapability):
     return _or_404(monitor_gateway.get_evaluation_batch_detail, batch_id)
 
 
 @router.get("/evaluation/runs/{run_id}")
-def evaluation_run_detail_snapshot(run_id: str):
+def evaluation_run_detail_snapshot(run_id: str, _capability: MonitorReadCapability):
     return _or_404(monitor_gateway.get_evaluation_run_detail, run_id)
 
 
 @router.get("/resources")
-def resources_overview():
+def resources_overview(_capability: MonitorReadCapability):
     return monitor_gateway.get_resource_overview()
 
 
 @router.post("/resources/refresh")
-async def resources_refresh():
+async def resources_refresh(_capability: MonitorControlCapability):
     # @@@refresh-off-main-loop - provider I/O stays off event loop to avoid request head-of-line blocking.
     return await asyncio.to_thread(monitor_gateway.refresh_resource_overview)
 
 
 @router.get("/sandboxes/{sandbox_id}/browse")
-async def sandbox_browse(sandbox_id: str, path: str = Query(default="/")):
+async def sandbox_browse(sandbox_id: str, _capability: MonitorReadCapability, path: str = Query(default="/")):
     return await _resource_io(monitor_gateway.browse_sandbox, sandbox_id, path)
 
 
 @router.get("/sandboxes/{sandbox_id}/read")
-async def sandbox_read_file(sandbox_id: str, path: str = Query(...)):
+async def sandbox_read_file(sandbox_id: str, _capability: MonitorReadCapability, path: str = Query(...)):
     return await _resource_io(monitor_gateway.read_sandbox, sandbox_id, path)

--- a/tests/Unit/integration_contracts/test_monitor_resources_route.py
+++ b/tests/Unit/integration_contracts/test_monitor_resources_route.py
@@ -11,16 +11,17 @@ from backend.monitor.infrastructure.web import gateway as monitor_gateway_impl
 from backend.web.core.dependencies import get_current_user, get_current_user_id
 from backend.web.routers import monitor_threads as monitor_threads_router
 from backend.web.routers import resources
+from storage.contracts import UserType
 
 
 def _app(*, include_product_resources: bool = False) -> FastAPI:
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
     app.include_router(monitor_threads_router.router, prefix="/api/monitor")
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, owner_profile=None)
+    app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
     if include_product_resources:
         app.include_router(resources.router)
-        app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type="human", owner_profile=None)
-        app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
     return app
 
 
@@ -145,6 +146,35 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
     }
 
 
+@pytest.mark.parametrize(
+    ("method", "path", "body", "detail"),
+    [
+        ("get", "/api/monitor/resources", None, "Capability required: inspect_resources"),
+        ("get", "/api/monitor/sandboxes", None, "Capability required: inspect_resources"),
+        ("get", "/api/monitor/dashboard", None, "Capability required: inspect_resources"),
+        ("post", "/api/monitor/resources/refresh", None, "Capability required: use_sandbox"),
+        ("post", "/api/monitor/sandboxes/sandbox-1/cleanup", None, "Capability required: use_sandbox"),
+        (
+            "post",
+            "/api/monitor/evaluation/batches",
+            {"agent_user_id": "agent-1", "scenario_ids": ["scenario-1"]},
+            "Capability required: use_sandbox",
+        ),
+    ],
+)
+def test_guest_owner_cannot_use_monitor_control_plane(method, path, body, detail):
+    app = FastAPI()
+    app.include_router(global_router.router, prefix="/api/monitor")
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="guest-1", type=UserType.HUMAN, owner_profile="guest")
+    app.dependency_overrides[get_current_user_id] = lambda: "guest-1"
+
+    with TestClient(app) as client:
+        response = getattr(client, method)(path, json=body) if body is not None else getattr(client, method)(path)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == detail
+
+
 def test_global_monitor_router_accepts_evaluation_batch_create(monkeypatch):
     monkeypatch.setattr(
         monitor_gateway_impl,
@@ -153,6 +183,7 @@ def test_global_monitor_router_accepts_evaluation_batch_create(monkeypatch):
     )
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, owner_profile=None)
     app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
     try:
         with TestClient(app) as client:

--- a/tests/Unit/integration_contracts/test_resource_overview_contract_split.py
+++ b/tests/Unit/integration_contracts/test_resource_overview_contract_split.py
@@ -133,6 +133,7 @@ def test_monitor_resources_route_stays_global(monkeypatch) -> None:
 
     test_app = FastAPI()
     test_app.include_router(global_router.router, prefix="/api/monitor")
+    test_app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="user-1", type=UserType.HUMAN, owner_profile=None)
     test_app.dependency_overrides[get_current_user_id] = lambda: "user-1"
     try:
         with TestClient(test_app) as client:

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -10,6 +10,7 @@ from backend.monitor.api.http import execution_target as monitor_execution_targe
 from backend.monitor.app import lifespan as monitor_app_lifespan
 from backend.monitor.app import main as monitor_app_main
 from backend.monitor.infrastructure.web import gateway as monitor_gateway
+from storage.contracts import UserType
 
 app = monitor_app_main.app
 
@@ -35,7 +36,7 @@ def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.Monke
 
 
 def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=None))
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
@@ -101,7 +102,7 @@ def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatc
 
 
 def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPatch):
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=None))
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
@@ -143,7 +144,7 @@ def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPa
 
 
 def test_monitor_app_maps_missing_remote_execution_target_to_503(monkeypatch: pytest.MonkeyPatch):
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: {"user_id": user_id})
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=None))
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )


### PR DESCRIPTION
## Summary
- Gate global monitor read routes behind `inspect_resources`.
- Gate monitor refresh, cleanup, and evaluation control routes behind `use_sandbox`.
- Update monitor route tests so guest owners are denied before service execution while full owners still pass.

## Verification
- `uv run ruff check .`
- `uv run pyright backend/monitor/api/http/global_router.py tests/Unit/integration_contracts/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_app_entrypoint.py`
- `uv run pytest tests/Unit/integration_contracts/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_app_entrypoint.py -q`
- `uv run pytest tests/Unit/integration_contracts/test_resource_overview_contract_split.py tests/Unit/integration_contracts/test_monitor_resources_route.py tests/Unit/monitor/test_monitor_app_entrypoint.py -q`
- `uv run pytest -q` (`2179 passed, 8 skipped`)

## Live Probe
Before this change, a public guest token could read `/api/monitor/resources`, `/api/monitor/sandboxes`, `/api/monitor/dashboard`, and trigger `/api/monitor/resources/refresh`. The exact temporary guest rows from that probe were removed from production after the test.
