### PR TITLE
refactor: add communication-only runtime profile

### DIFF
--- a/backend/threads/bootstrap.py
+++ b/backend/threads/bootstrap.py
@@ -8,7 +8,9 @@ from typing import Any
 from backend.chat.runtime_inbox_stream import RuntimeInboxStreamState
 from backend.chat.runtime_inbox_wake import PostgresRuntimeInboxWakeBus, RuntimeInboxWakeBus
 from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
+from backend.threads.chat_adapters.external_inbox_handler import ExternalRuntimeInboxHandler
 from core.runtime.middleware.queue import MessageQueueManager
+from protocols import agent_runtime as agent_runtime_protocol
 
 
 @dataclass(frozen=True)
@@ -66,6 +68,58 @@ def attach_threads_runtime(
         relationship_service=relationship_service,
         chat_join_request_service=chat_join_request_service,
         typing_tracker=typing_tracker,
+    )
+    app.state.threads_runtime_state = state
+    return state
+
+
+class ExternalOnlyRuntimeGateway:
+    def __init__(self, handler: ExternalRuntimeInboxHandler) -> None:
+        self._handler = handler
+
+    async def dispatch_chat(
+        self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope
+    ) -> agent_runtime_protocol.AgentChatDeliveryResult:
+        if envelope.recipient.runtime_source != "external":
+            raise RuntimeError("Communication profile only supports external runtime chat delivery")
+        return await self._handler.dispatch(envelope)
+
+    async def dispatch_notification(
+        self,
+        envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope,
+    ) -> agent_runtime_protocol.AgentRuntimeNotificationResult:
+        if envelope.recipient.runtime_source != "external":
+            raise RuntimeError("Communication profile only supports external runtime notifications")
+        return await self._handler.dispatch_notification(envelope)
+
+    async def dispatch_thread_input(
+        self,
+        _envelope: agent_runtime_protocol.AgentThreadInputEnvelope,
+    ) -> agent_runtime_protocol.AgentThreadInputResult:
+        raise RuntimeError("Managed agent runtime is unavailable in communication profile")
+
+
+def attach_runtime_inbox_runtime(
+    app: Any,
+    storage_container: Any,
+    *,
+    messaging_service: Any,
+) -> ThreadsRuntimeState:
+    app.state.queue_manager = MessageQueueManager(repo=storage_container.queue_repo())
+    app.state.runtime_inbox_wake_bus = build_runtime_inbox_wake_bus()
+    app.state.runtime_inbox_stream = RuntimeInboxStreamState()
+    app.state.agent_pool = {}
+    handler = ExternalRuntimeInboxHandler(
+        queue_manager=app.state.queue_manager,
+        wake_bus=app.state.runtime_inbox_wake_bus,
+    )
+    state = ThreadsRuntimeState(
+        queue_manager=app.state.queue_manager,
+        runtime_inbox_wake_bus=app.state.runtime_inbox_wake_bus,
+        runtime_inbox_stream=app.state.runtime_inbox_stream,
+        agent_runtime_gateway=ExternalOnlyRuntimeGateway(handler),
+        activity_reader=None,
+        messaging_service=messaging_service,
     )
     app.state.threads_runtime_state = state
     return state

--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -22,8 +22,6 @@ logger = logging.getLogger(__name__)
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
     import asyncio
 
-    if activity_reader is None:
-        raise RuntimeError("Agent runtime thread activity reader is not configured")
     loop = asyncio.get_running_loop()
 
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
@@ -46,6 +44,8 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
             runtime_source = "external"
             thread_id = None
         elif recipient_type == "agent":
+            if activity_reader is None:
+                raise RuntimeError(f"Managed agent runtime is unavailable for chat delivery to {request.recipient_id}")
             runtime_source = "mycel"
             thread_id = select_runtime_thread_for_recipient(
                 request.recipient_id,

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -15,8 +15,6 @@ from protocols.agent_runtime import (
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    if activity_reader is None:
-        raise RuntimeError("Agent runtime thread activity reader is not configured")
     loop = asyncio.get_running_loop()
 
     async def notify_runtime(row: dict[str, Any]) -> None:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -22,8 +22,6 @@ _DECISION_VERBS: dict[RelationshipEvent, str] = {
 
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    if activity_reader is None:
-        raise RuntimeError("Agent runtime thread activity reader is not configured")
     loop = asyncio.get_running_loop()
 
     async def notify_runtime(row: RelationshipRow) -> None:
@@ -69,8 +67,6 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
 
 
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    if activity_reader is None:
-        raise RuntimeError("Agent runtime thread activity reader is not configured")
     loop = asyncio.get_running_loop()
 
     async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:

--- a/backend/threads/chat_adapters/runtime_recipient.py
+++ b/backend/threads/chat_adapters/runtime_recipient.py
@@ -21,6 +21,8 @@ def select_runtime_notification_recipient(
         return AgentChatRecipient(agent_user_id=user_id, runtime_source="external")
     if user_type != "agent":
         return None
+    if activity_reader is None:
+        raise RuntimeError(f"Managed agent runtime is unavailable for {context} wake: {user_id}")
     thread_id = select_runtime_thread_for_recipient(
         user_id,
         thread_repo=thread_repo,

--- a/backend/web/app_factory.py
+++ b/backend/web/app_factory.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import FastAPI
+
+from backend.bootstrap.app_entrypoint import add_permissive_cors
+from backend.web.core.lifespan import lifespan
+from backend.web.core.runtime_profile import RuntimeProfile, resolve_runtime_profile
+
+
+def create_app(
+    *,
+    profile: RuntimeProfile | str | None = None,
+    lifespan_context: Callable[[FastAPI], Any] | None = lifespan,
+) -> FastAPI:
+    runtime_profile = profile if isinstance(profile, RuntimeProfile) else resolve_runtime_profile(profile)
+    app = FastAPI(title="Mycel Web Backend", lifespan=lifespan_context)
+    app.state.runtime_profile = runtime_profile
+    add_permissive_cors(app)
+    if runtime_profile is RuntimeProfile.COMMUNICATION:
+        include_communication_routes(app)
+    else:
+        include_full_routes(app)
+    return app
+
+
+def include_communication_routes(app: FastAPI) -> None:
+    from backend.chat.api.http import app_router as chat_app_router
+    from backend.web.routers import auth, contacts, users
+
+    app.include_router(auth.router)
+    app.include_router(chat_app_router.router)
+    app.include_router(contacts.router)
+    app.include_router(users.users_router)
+
+
+def include_full_routes(app: FastAPI) -> None:
+    from backend.chat.api.http import app_router as chat_app_router
+    from backend.monitor.api.http import global_router
+    from backend.web.routers import (
+        auth,
+        contacts,
+        invite_codes,
+        marketplace,
+        monitor_threads,
+        panel,
+        resources,
+        sandbox,
+        settings,
+        thread_files,
+        threads,
+        users,
+        webhooks,
+    )
+
+    app.include_router(auth.router)
+    app.include_router(invite_codes.router)
+    app.include_router(threads.router)
+    app.include_router(chat_app_router.router)
+    app.include_router(contacts.router)
+    app.include_router(users.users_router)
+    app.include_router(sandbox.router)
+    app.include_router(webhooks.router)
+    app.include_router(thread_files.router)
+    app.include_router(thread_files._public)
+    app.include_router(settings.router)
+    app.include_router(panel.router)
+    app.include_router(global_router.router, prefix="/api/monitor")
+    app.include_router(monitor_threads.router, prefix="/api/monitor")
+    app.include_router(resources.router)
+    app.include_router(marketplace.router)

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -8,6 +8,12 @@ from fastapi import FastAPI
 from psycopg import AsyncConnection
 
 from backend.threads.pool import idle_reaper as idle_reaper_owner
+from backend.web.core.runtime_profile import RuntimeProfile
+
+
+def _runtime_profile(app: FastAPI) -> RuntimeProfile:
+    raw = getattr(app.state, "runtime_profile", RuntimeProfile.FULL)
+    return raw if isinstance(raw, RuntimeProfile) else RuntimeProfile(raw)
 
 
 def _require_web_runtime_contract() -> None:
@@ -34,8 +40,10 @@ async def _validate_web_checkpointer_contract() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    _require_web_runtime_contract()
-    await _validate_web_checkpointer_contract()
+    runtime_profile = _runtime_profile(app)
+    if runtime_profile is RuntimeProfile.FULL:
+        _require_web_runtime_contract()
+        await _validate_web_checkpointer_contract()
 
     # ---- Chat repos + services ----
     from backend.bootstrap.storage import attach_runtime_storage_state
@@ -44,13 +52,6 @@ async def lifespan(app: FastAPI):
     runtime_storage = attach_runtime_storage_state(app)
     _supabase_client = runtime_storage.supabase_client
     storage_container = runtime_storage.storage_container
-    from core.runtime.langgraph_checkpoint_store import LangGraphCheckpointStore, agent_checkpoint_saver_from_conn_string
-
-    pg_url = os.environ["LEON_POSTGRES_URL"]
-    app.state._thread_checkpoint_saver_ctx = agent_checkpoint_saver_from_conn_string(pg_url)
-    app.state._thread_checkpoint_saver = await app.state._thread_checkpoint_saver_ctx.__aenter__()
-    await app.state._thread_checkpoint_saver.setup()
-    thread_checkpoint_store = LangGraphCheckpointStore(app.state._thread_checkpoint_saver)
 
     app.state.user_repo = storage_container.user_repo()
     app.state.thread_repo = storage_container.thread_repo()
@@ -64,7 +65,7 @@ async def lifespan(app: FastAPI):
         wire_relationship_decision_notifications,
         wire_relationship_request_notifications,
     )
-    from backend.threads.bootstrap import attach_threads_runtime
+    from backend.threads.bootstrap import attach_runtime_inbox_runtime, attach_threads_runtime
 
     # @@@web-chat-before-threads - threads bootstrap now constructs the agent
     # runtime gateway eagerly, and that path requires chat-owned typing state
@@ -79,14 +80,28 @@ async def lifespan(app: FastAPI):
     # owner-agent contact repo, but web bootstrap should borrow the chat-owned
     # contact_repo returned by chat bootstrap instead of reopening storage.
     attach_auth_runtime_state(app, storage_state=runtime_storage, contact_repo=chat_runtime.contact_repo)
-    threads_runtime = attach_threads_runtime(
-        app,
-        storage_container,
-        typing_tracker=chat_runtime.typing_tracker,
-        messaging_service=chat_runtime.messaging_service,
-        relationship_service=chat_runtime.relationship_service,
-        chat_join_request_service=chat_runtime.chat_join_request_service,
-    )
+    if runtime_profile is RuntimeProfile.COMMUNICATION:
+        threads_runtime = attach_runtime_inbox_runtime(
+            app,
+            storage_container,
+            messaging_service=chat_runtime.messaging_service,
+        )
+    else:
+        from core.runtime.langgraph_checkpoint_store import LangGraphCheckpointStore, agent_checkpoint_saver_from_conn_string
+
+        pg_url = os.environ["LEON_POSTGRES_URL"]
+        app.state._thread_checkpoint_saver_ctx = agent_checkpoint_saver_from_conn_string(pg_url)
+        app.state._thread_checkpoint_saver = await app.state._thread_checkpoint_saver_ctx.__aenter__()
+        await app.state._thread_checkpoint_saver.setup()
+        thread_checkpoint_store = LangGraphCheckpointStore(app.state._thread_checkpoint_saver)
+        threads_runtime = attach_threads_runtime(
+            app,
+            storage_container,
+            typing_tracker=chat_runtime.typing_tracker,
+            messaging_service=chat_runtime.messaging_service,
+            relationship_service=chat_runtime.relationship_service,
+            chat_join_request_service=chat_runtime.chat_join_request_service,
+        )
     wire_chat_delivery(
         app,
         messaging_service=chat_runtime.messaging_service,
@@ -114,6 +129,12 @@ async def lifespan(app: FastAPI):
         thread_repo=app.state.thread_repo,
         user_repo=app.state.user_repo,
     )
+    app.state.idle_reaper_task = None
+
+    if runtime_profile is RuntimeProfile.COMMUNICATION:
+        app.state.threads_runtime_state = threads_runtime
+        yield
+        return
 
     # ---- Existing state ----
     from backend.threads.display.builder import DisplayBuilder
@@ -135,7 +156,6 @@ async def lifespan(app: FastAPI):
             checkpoint_store=thread_checkpoint_store,
         )
     app.state.threads_runtime_state = threads_runtime
-    app.state.idle_reaper_task = None
 
     try:
         from backend.sandboxes.service import init_providers_and_managers

--- a/backend/web/core/runtime_profile.py
+++ b/backend/web/core/runtime_profile.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+
+
+class RuntimeProfile(StrEnum):
+    FULL = "full"
+    COMMUNICATION = "communication"
+
+
+def resolve_runtime_profile(raw: str | None = None) -> RuntimeProfile:
+    value = (raw if raw is not None else os.getenv("MYCEL_RUNTIME_PROFILE") or RuntimeProfile.FULL.value).strip().lower()
+    try:
+        return RuntimeProfile(value)
+    except ValueError as exc:
+        allowed = ", ".join(profile.value for profile in RuntimeProfile)
+        raise RuntimeError(f"MYCEL_RUNTIME_PROFILE must be one of: {allowed}") from exc

--- a/backend/web/main.py
+++ b/backend/web/main.py
@@ -1,50 +1,10 @@
-from backend.bootstrap.app_entrypoint import add_permissive_cors, load_env_file_from_env, resolve_app_port, run_reloadable_app
+from backend.bootstrap.app_entrypoint import load_env_file_from_env, resolve_app_port, run_reloadable_app
 
 load_env_file_from_env()
 
-from fastapi import FastAPI  # noqa: E402
+from backend.web.app_factory import create_app  # noqa: E402
 
-from backend.chat.api.http import app_router as chat_app_router  # noqa: E402
-from backend.monitor.api.http import global_router  # noqa: E402
-from backend.web.core.lifespan import lifespan  # noqa: E402
-from backend.web.routers import (  # noqa: E402
-    auth,
-    contacts,
-    invite_codes,
-    marketplace,
-    monitor_threads,
-    panel,
-    resources,
-    sandbox,
-    settings,
-    thread_files,
-    threads,
-    users,
-    webhooks,
-)
-
-app = FastAPI(title="Mycel Web Backend", lifespan=lifespan)
-
-add_permissive_cors(app)
-
-app.include_router(auth.router)
-app.include_router(invite_codes.router)
-app.include_router(threads.router)
-
-app.include_router(chat_app_router.router)
-
-app.include_router(contacts.router)
-app.include_router(users.users_router)
-app.include_router(sandbox.router)
-app.include_router(webhooks.router)
-app.include_router(thread_files.router)
-app.include_router(thread_files._public)
-app.include_router(settings.router)
-app.include_router(panel.router)
-app.include_router(global_router.router, prefix="/api/monitor")
-app.include_router(monitor_threads.router, prefix="/api/monitor")
-app.include_router(resources.router)
-app.include_router(marketplace.router)
+app = create_app()
 
 
 if __name__ == "__main__":

--- a/tests/Unit/backend/test_web_app_profiles.py
+++ b/tests/Unit/backend/test_web_app_profiles.py
@@ -1,0 +1,61 @@
+import pytest
+
+from backend.web.app_factory import RuntimeProfile, create_app, resolve_runtime_profile
+
+
+def _paths(profile: RuntimeProfile) -> set[str]:
+    return set(create_app(profile=profile, lifespan_context=None).openapi()["paths"])
+
+
+def test_default_runtime_profile_is_full(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MYCEL_RUNTIME_PROFILE", raising=False)
+
+    assert resolve_runtime_profile() is RuntimeProfile.FULL
+
+
+def test_unknown_runtime_profile_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MYCEL_RUNTIME_PROFILE", "tiny")
+
+    with pytest.raises(RuntimeError, match="MYCEL_RUNTIME_PROFILE"):
+        resolve_runtime_profile()
+
+
+def test_full_profile_preserves_current_web_backend_surface() -> None:
+    paths = _paths(RuntimeProfile.FULL)
+
+    assert "/api/auth/guest" in paths
+    assert "/api/chats" in paths
+    assert any(path.startswith("/api/threads") for path in paths)
+    assert any(path.startswith("/api/sandbox") for path in paths)
+    assert any(path.startswith("/api/panel") for path in paths)
+    assert any(path.startswith("/api/monitor") for path in paths)
+    assert any(path.startswith("/api/resources") for path in paths)
+    assert any(path.startswith("/api/marketplace") for path in paths)
+
+
+def test_communication_profile_mounts_only_auth_chat_and_social_surfaces() -> None:
+    paths = _paths(RuntimeProfile.COMMUNICATION)
+
+    assert "/api/auth/guest" in paths
+    assert "/api/auth/external-users" in paths
+    assert "/api/chats" in paths
+    assert "/api/runtime/inbox/drain" in paths
+    assert "/api/relationships" in paths
+    assert "/api/conversations" in paths
+    assert "/api/contacts" in paths
+    assert "/api/users" in paths
+
+    excluded_prefixes = (
+        "/api/invite-codes",
+        "/api/marketplace",
+        "/api/monitor",
+        "/api/panel",
+        "/api/resources",
+        "/api/sandbox",
+        "/api/settings",
+        "/api/threads",
+        "/api/webhooks",
+    )
+    leaked = sorted(path for path in paths if path.startswith(excluded_prefixes))
+
+    assert leaked == []

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from backend.web.app_factory import RuntimeProfile
 from backend.web.core import lifespan as web_lifespan
 
 
@@ -293,6 +294,102 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
 
     async with web_lifespan.lifespan(app):
         assert seen == [contact_repo]
+
+
+@pytest.mark.asyncio
+async def test_communication_lifespan_uses_external_inbox_runtime_without_managed_threads(monkeypatch):
+    call_log: list[str] = []
+    returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
+    returned_relationship_service = object()
+    returned_chat_join_request_service = object()
+    returned_contact_repo = object()
+
+    def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
+        call_log.append("chat")
+        return SimpleNamespace(
+            contact_repo=returned_contact_repo,
+            typing_tracker=object(),
+            messaging_service=returned_messaging_service,
+            relationship_service=returned_relationship_service,
+            chat_join_request_service=returned_chat_join_request_service,
+        )
+
+    def _attach_auth_runtime(_app, *, storage_state, contact_repo):
+        call_log.append("auth")
+        assert contact_repo is returned_contact_repo
+        return object()
+
+    def _attach_runtime_inbox_runtime(app, _storage_container, *, messaging_service):
+        call_log.append("runtime-inbox")
+        assert messaging_service is returned_messaging_service
+        app.state.agent_pool = {}
+        return SimpleNamespace(activity_reader=None)
+
+    def _attach_threads_runtime(*_args, **_kwargs):
+        raise AssertionError("communication profile must not bootstrap managed-agent threads runtime")
+
+    def _wire_chat_delivery(_app, *, messaging_service, activity_reader, thread_repo):
+        call_log.append("wire-chat")
+        assert messaging_service is returned_messaging_service
+        assert activity_reader is None
+
+    def _wire_relationship_request_notifications(_app, *, relationship_service, activity_reader, thread_repo, user_repo):
+        call_log.append("wire-relationship")
+        assert relationship_service is returned_relationship_service
+        assert activity_reader is None
+
+    def _wire_relationship_decision_notifications(_app, *, relationship_service, activity_reader, thread_repo, user_repo):
+        call_log.append("wire-relationship-decision")
+        assert relationship_service is returned_relationship_service
+        assert activity_reader is None
+
+    def _wire_chat_join_request_notifications(_app, *, chat_join_request_service, activity_reader, thread_repo, user_repo):
+        call_log.append("wire-chat-join")
+        assert chat_join_request_service is returned_chat_join_request_service
+        assert activity_reader is None
+
+    _patch_lifespan_runtime_contract(
+        monkeypatch,
+        attach_chat_runtime=_attach_chat_runtime,
+        attach_auth_runtime=_attach_auth_runtime,
+        attach_threads_runtime=_attach_threads_runtime,
+        wire_chat_delivery=_wire_chat_delivery,
+        wire_relationship_request_notifications=_wire_relationship_request_notifications,
+        wire_relationship_decision_notifications=_wire_relationship_decision_notifications,
+        wire_chat_join_request_notifications=_wire_chat_join_request_notifications,
+    )
+    monkeypatch.setattr(
+        web_lifespan,
+        "_require_web_runtime_contract",
+        lambda: (_ for _ in ()).throw(AssertionError("communication profile must not require managed runtime config")),
+    )
+
+    async def _validate_must_not_run():
+        raise AssertionError("communication profile must not validate managed runtime checkpointer")
+
+    monkeypatch.setattr(web_lifespan, "_validate_web_checkpointer_contract", _validate_must_not_run)
+    monkeypatch.setattr("backend.threads.bootstrap.attach_runtime_inbox_runtime", _attach_runtime_inbox_runtime)
+    monkeypatch.setattr(
+        "backend.threads.pool.idle_reaper.idle_reaper_loop",
+        lambda _app: (_ for _ in ()).throw(AssertionError("idle reaper must stay off in communication profile")),
+    )
+    monkeypatch.setattr(
+        "core.runtime.langgraph_checkpoint_store.agent_checkpoint_saver_from_conn_string",
+        lambda _pg_url: (_ for _ in ()).throw(AssertionError("communication profile must not initialize checkpointer")),
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace(runtime_profile=RuntimeProfile.COMMUNICATION))
+
+    async with web_lifespan.lifespan(app):
+        assert call_log == [
+            "chat",
+            "auth",
+            "runtime-inbox",
+            "wire-chat",
+            "wire-relationship",
+            "wire-relationship-decision",
+            "wire-chat-join",
+        ]
 
 
 async def _never():

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -236,16 +236,71 @@ async def test_chat_delivery_hook_requires_recipient_user_id() -> None:
     assert gateway.called is False
 
 
-def test_make_chat_delivery_fn_requires_activity_reader():
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            threads_runtime_state=SimpleNamespace(agent_runtime_gateway=object(), activity_reader=None),
-        )
+@pytest.mark.asyncio
+async def test_chat_delivery_hook_routes_external_user_without_managed_activity_reader() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_chat(self, envelope):
+            self.envelope = envelope
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+    deliver = owner_chat_inlet.make_chat_delivery_fn(
+        app,
+        activity_reader=None,
+        thread_repo=object(),
+    )
+    request = ChatDeliveryRequest(
+        recipient_id="external-user-1",
+        recipient_user=SimpleNamespace(id="external-user-1", type="external"),
+        content="hello",
+        sender_name="Human",
+        sender_type="human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        unread_count=2,
+        signal=None,
     )
 
-    with pytest.raises(RuntimeError, match="Agent runtime thread activity reader is not configured"):
-        owner_chat_inlet.make_chat_delivery_fn(
-            app,
-            activity_reader=None,
-            thread_repo=object(),
-        )
+    await asyncio.to_thread(deliver, request)
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
+    assert gateway.envelope.recipient.runtime_source == "external"
+    assert gateway.envelope.recipient.thread_id is None
+
+
+@pytest.mark.asyncio
+async def test_chat_delivery_hook_fails_loudly_for_managed_agent_without_activity_reader() -> None:
+    class RecordingGateway:
+        called = False
+
+        async def dispatch_chat(self, _envelope):
+            self.called = True
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+    deliver = owner_chat_inlet.make_chat_delivery_fn(
+        app,
+        activity_reader=None,
+        thread_repo=object(),
+    )
+    request = ChatDeliveryRequest(
+        recipient_id="agent-user-1",
+        recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+        content="hello",
+        sender_name="Human",
+        sender_type="human",
+        chat_id="chat-1",
+        sender_id="human-user-1",
+        sender_avatar_url=None,
+        unread_count=2,
+        signal=None,
+    )
+
+    with pytest.raises(RuntimeError, match="Managed agent runtime is unavailable for chat delivery to agent-user-1"):
+        await asyncio.to_thread(deliver, request)
+
+    assert gateway.called is False

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -90,7 +90,7 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
     )
     notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=None,
         thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
         user_repo=user_repo,
     )

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -122,7 +122,7 @@ async def test_relationship_request_notification_dispatches_external_runtime_not
     )
     notify = relationship_inlet.make_relationship_request_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=None,
         thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
         user_repo=user_repo,
     )
@@ -274,7 +274,7 @@ async def test_relationship_decision_notification_dispatches_external_runtime_no
     )
     notify = relationship_inlet.make_relationship_decision_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=None,
         thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
         user_repo=user_repo,
     )


### PR DESCRIPTION
## Summary

Adds a thin web runtime profile boundary for running Mycel as a communication-only backend without booting the full managed-agent/sandbox platform.

This slice keeps the full profile as the default and adds `MYCEL_RUNTIME_PROFILE=communication` for auth/chat/contact/user/runtime-inbox surfaces only. It also splits out an external-only runtime inbox bootstrap so external agent users can receive chat, relationship, and chat-join runtime notifications without a managed-agent activity reader.

## What changed

- Added `backend.web.app_factory.create_app()` and `backend.web.core.runtime_profile`.
- Kept default full backend route surface intact.
- Added communication route slicing that exposes auth, chat, runtime inbox, contacts, and users while excluding threads, sandbox, panel, monitor, resources, marketplace, settings, webhooks, invite-code routes.
- Added external-only runtime inbox state construction in `backend.threads.bootstrap`.
- Skipped managed checkpointer / managed thread runtime / idle reaper for communication profile.
- Kept unsupported managed-agent wake loud: attempting to deliver to a managed agent without managed runtime raises instead of silently skipping.

## Verification

- `uv run pytest -q`
  - `2185 passed, 8 skipped, 15 warnings`
- `uv run ruff check .`
  - `All checks passed!`
- `uv run ruff format --check .`
  - `686 files already formatted`
- Local process smoke against real ops Supabase/Postgres:
  - Started backend with `MYCEL_RUNTIME_PROFILE=communication` on `127.0.0.1:8042`.
  - Verified `/openapi.json` returned 43 communication paths and no full-platform route prefixes.
  - With installed `cel` and temporary `MYCEL_HOME`, created a guest owner plus two external identities.
  - Sent and read messages A -> B and B -> A through `cel send-message` / `cel read-message`.
  - Cleaned the staging rows and temporary local state afterwards.

## Explicit non-claims

- This is not yet a fresh-host local self-hosting proof.
- Current repo compose still depends on an external `supabase_default` network.
- Fresh Docker/Mac/Ubuntu self-host YATU still needs a reproducible Supabase baseline.
- During the smoke, shutdown with active daemon WebSocket subscribers needed a second Ctrl-C and logged `CancelledError`; that is recorded as runtime hygiene follow-up, not hidden.
