### PR TITLE
deploy: add local communication backend compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.venv
+.pytest_cache
+.ruff_cache
+.mypy_cache
+.DS_Store
+
+frontend/app/node_modules
+frontend/app/.next
+frontend/app/dist
+
+worktrees
+notes

--- a/backend/identity/auth/service.py
+++ b/backend/identity/auth/service.py
@@ -12,7 +12,7 @@ from backend.identity.avatar.files import process_and_save_avatar
 from backend.identity.contact_bootstrap import ensure_owner_agent_contact
 from backend.sandboxes.recipe_bootstrap import seed_default_recipes
 from config.agent_config_types import AgentConfig
-from storage.contracts import InviteCodeRepo, OwnerProfile, UserRepo, UserRow, UserType
+from storage.contracts import InviteCodeRepo, UserRepo, UserRow, UserType
 from storage.providers.supabase import _query as q
 
 logger = logging.getLogger(__name__)
@@ -251,7 +251,7 @@ class AuthService:
                 id=guest_user_id,
                 type=UserType.HUMAN,
                 display_name=guest_display_name,
-                owner_profile=OwnerProfile.GUEST,
+                is_guest=True,
                 created_at=now,
             )
         )
@@ -260,7 +260,7 @@ class AuthService:
                 "sub": guest_user_id,
                 "iat": int(now),
                 "mycel_user_type": "human",
-                "mycel_owner_profile": OwnerProfile.GUEST.value,
+                "mycel_is_guest": True,
             },
             jwt_secret,
             algorithm=SUPABASE_JWT_ALGORITHM,
@@ -271,7 +271,7 @@ class AuthService:
                 "id": guest_user_id,
                 "name": guest_display_name,
                 "type": "human",
-                "owner_profile": OwnerProfile.GUEST.value,
+                "is_guest": True,
                 "email": None,
                 "mycel_id": None,
                 "avatar": None,

--- a/backend/identity/capabilities.py
+++ b/backend/identity/capabilities.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import HTTPException
 
-from storage.contracts import OwnerProfile, UserType
+from storage.contracts import UserType
 
 
 class Capability(StrEnum):
@@ -51,9 +51,8 @@ def resolve_user_capabilities(user: Any) -> UserCapabilities:
     if user_type is None:
         raise HTTPException(403, "Unknown user capability profile")
     if user_type is UserType.HUMAN:
-        owner_profile = getattr(user, "owner_profile", None)
         values = _OWNER_CAPABILITIES
-        if owner_profile in {OwnerProfile.GUEST, OwnerProfile.GUEST.value}:
+        if bool(getattr(user, "is_guest", False)):
             values = _GUEST_OWNER_CAPABILITIES
     else:
         values = _CAPABILITIES_BY_USER_TYPE[user_type]

--- a/backend/web/routers/auth.py
+++ b/backend/web/routers/auth.py
@@ -105,14 +105,13 @@ class CreateExternalUserRequest(BaseModel):
 @router.get("/me")
 async def me(user: Annotated[Any, Depends(get_current_user)]) -> dict:
     user_type = getattr(user.type, "value", user.type)
-    owner_profile = getattr(user, "owner_profile", None)
     return {
         "id": user.id,
         "name": user.display_name,
         "type": user_type,
         "email": user.email,
         "mycel_id": user.mycel_id,
-        "owner_profile": getattr(owner_profile, "value", owner_profile),
+        "is_guest": bool(getattr(user, "is_guest", False)),
         "avatar": user.avatar,
     }
 

--- a/deploy/local-communication/compose.yml
+++ b/deploy/local-communication/compose.yml
@@ -1,0 +1,68 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - local-communication-db:/var/lib/postgresql/data
+      - ../../storage/schema/local_communication.sql:/docker-entrypoint-initdb.d/001-local-communication.sql:ro
+    restart: unless-stopped
+
+  postgrest:
+    image: postgrest/postgrest:v12.2.8
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://postgres:postgres@db:5432/postgres
+      PGRST_DB_SCHEMAS: public,identity,chat,agent,container,library
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: mycel-local-communication-jwt-secret-at-least-32-chars
+    restart: unless-stopped
+
+  supabase-rest:
+    image: nginx:1.27-alpine
+    depends_on:
+      - postgrest
+    ports:
+      - "${MYCEL_LOCAL_REST_PORT:-54321}:8000"
+    volumes:
+      - ./rest-gateway.conf:/etc/nginx/nginx.conf:ro
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      - supabase-rest
+    ports:
+      - "${MYCEL_LOCAL_BACKEND_PORT:-8042}:8900"
+    environment:
+      MYCEL_RUNTIME_PROFILE: communication
+      LEON_STORAGE_STRATEGY: supabase
+      LEON_SUPABASE_CLIENT_FACTORY: backend.identity.auth.supabase_runtime:create_supabase_client
+      LEON_DB_SCHEMA: public
+      SUPABASE_INTERNAL_URL: http://supabase-rest:8000
+      SUPABASE_PUBLIC_URL: http://localhost:${MYCEL_LOCAL_REST_PORT:-54321}
+      SUPABASE_ANON_KEY: >-
+        eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzc4MTExMTg4LCJleHAiOjQxMDI0NDQ4MDB9.hQfjrcDx9hvOfl2F_YPeYzideziX9jHKO6NXU0Nk8fk
+      LEON_SUPABASE_SERVICE_ROLE_KEY: >-
+        eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaXNzIjoic3VwYWJhc2UiLCJpYXQiOjE3NzgxMTExODgsImV4cCI6NDEwMjQ0NDgwMH0.eWVnZTF1ptQCPnI-afKE6G9EOBiT0PhZYfVZhgQQ3fo
+      SUPABASE_JWT_SECRET: mycel-local-communication-jwt-secret-at-least-32-chars
+      LEON_SUPABASE_HTTP_TRUST_ENV: "0"
+      LEON_LOCAL_WORKSPACE_ROOT: /data/workspaces
+      LEON_AVATAR_ROOT: /data/avatars
+    volumes:
+      - local-communication-backend:/data
+    restart: unless-stopped
+
+volumes:
+  local-communication-db:
+  local-communication-backend:

--- a/deploy/local-communication/rest-gateway.conf
+++ b/deploy/local-communication/rest-gateway.conf
@@ -1,0 +1,22 @@
+events {}
+
+http {
+  server {
+    listen 8000;
+
+    location /rest/v1/ {
+      proxy_pass http://postgrest:3000/;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_redirect off;
+    }
+
+    location = /rest/v1 {
+      return 308 /rest/v1/;
+    }
+
+    location / {
+      return 404 "local communication profile exposes only /rest/v1\n";
+    }
+  }
+}

--- a/docs/en/deployment.mdx
+++ b/docs/en/deployment.mdx
@@ -72,6 +72,34 @@ ANTHROPIC_API_KEY=sk-ant-xxx
 
 ## Starting services
 
+### Local communication backend
+
+Use this when you only need Mycel identities, chat, runtime inbox notifications, and group workflow state for the CLI. It does not start the Web UI, managed agent sandboxes, or email login.
+
+```bash
+docker compose -f deploy/local-communication/compose.yml up --build
+```
+
+The backend listens on `http://localhost:8042`. The compose file starts:
+- PostgreSQL
+- PostgREST behind a small `/rest/v1` gateway, matching the storage URL shape expected by `supabase-py`
+- Mycel backend with `MYCEL_RUNTIME_PROFILE=communication`
+
+Guest owners and external agent users are issued by the Mycel backend with the local JWT secret in the compose file. Normal email login is intentionally outside this local profile.
+
+Point `cel` at the local backend with a process override:
+
+```bash
+export MYCEL_BASE_URL=http://localhost:8042
+cel guest
+cel agent external create codex-local --name "Local Codex" --provider codex
+cel codex
+```
+
+The same `send-message` and `read-message` commands work against the public backend or this local backend; only the base URL changes.
+
+### Full development stack
+
 ```bash
 # Terminal 1: backend
 uv run python -m backend.web.main
@@ -205,14 +233,9 @@ Open the Web UI at `http://localhost:5173`, register an account, and confirm the
 
 ### Database
 
-Mycel uses SQLite by default. For production:
+Mycel runtime storage is explicit. The local communication compose uses PostgreSQL plus PostgREST through the same Supabase-style storage client used by the deployed backend. Full production deployments should provide their own managed Supabase-compatible storage and secrets.
 
-```bash
-# Backup regularly
-cp "$LEON_DB_PATH" "$LEON_DB_PATH.backup"
-```
-
-Multi-user deployments may require PostgreSQL — this requires code changes to the storage layer.
+Back up the configured database with the tools for that database. Do not treat local communication compose data as a production store.
 
 ### Security
 

--- a/docs/zh/deployment.mdx
+++ b/docs/zh/deployment.mdx
@@ -72,6 +72,34 @@ ANTHROPIC_API_KEY=sk-ant-xxx
 
 ## 启动服务
 
+### 本地通信后端
+
+当你只需要 CLI 使用的 Mycel 身份、Chat、runtime inbox 通知和 group workflow 状态时，使用这条路径。它不会启动 Web UI、托管 Agent 沙箱，也不提供邮箱登录。
+
+```bash
+docker compose -f deploy/local-communication/compose.yml up --build
+```
+
+后端监听 `http://localhost:8042`。这个 compose 会启动：
+- PostgreSQL
+- 一个很薄的 `/rest/v1` 网关后的 PostgREST，用来匹配 `supabase-py` 期望的 storage URL 形状
+- `MYCEL_RUNTIME_PROFILE=communication` 的 Mycel 后端
+
+Guest owner 和 external agent user 由 Mycel 后端用 compose 里的本地 JWT secret 签发。普通邮箱登录不属于这个本地 profile。
+
+用进程级覆盖把 `cel` 指向本地后端：
+
+```bash
+export MYCEL_BASE_URL=http://localhost:8042
+cel guest
+cel agent external create codex-local --name "Local Codex" --provider codex
+cel codex
+```
+
+同一套 `send-message` 和 `read-message` 命令可以连接公网后端，也可以连接这个本地后端；变化的只有 base URL。
+
+### 完整开发栈
+
 ```bash
 # 终端 1：后端
 uv run python -m backend.web.main
@@ -205,14 +233,9 @@ Daytona Proxy（端口 4000）必须从 Runner 可访问，文件操作依赖它
 
 ### 数据库
 
-Mycel 默认使用 SQLite。生产环境建议：
+Mycel runtime storage 是显式配置的。当前本地通信 compose 使用 PostgreSQL 和 PostgREST，并通过与线上后端相同的 Supabase-style storage client 访问。完整生产部署应提供自己的 Supabase-compatible storage 和密钥。
 
-```bash
-# 定期备份
-cp "$LEON_DB_PATH" "$LEON_DB_PATH.backup"
-```
-
-多用户部署可能需要 PostgreSQL — 需要对存储层进行代码改动。
+请使用对应数据库的工具进行备份。不要把本地通信 compose 的数据当成生产存储。
 
 ### 安全
 

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -97,11 +97,6 @@ class UserType(StrEnum):
     EXTERNAL = "external"
 
 
-class OwnerProfile(StrEnum):
-    FULL = "full"
-    GUEST = "guest"
-
-
 class UserRow(BaseModel):
     id: str
     type: UserType
@@ -113,7 +108,7 @@ class UserRow(BaseModel):
     email: str | None = None
     mycel_id: int | None = None
     created_by_user_id: str | None = None
-    owner_profile: OwnerProfile | None = None
+    is_guest: bool = False
     created_at: float
     updated_at: float | None = None
 
@@ -137,8 +132,8 @@ class UserRow(BaseModel):
                 raise ValueError("external users must not carry agent_config_id")
             if self.created_by_user_id is None:
                 raise ValueError("external users require created_by_user_id")
-            if self.owner_profile is not None:
-                raise ValueError("external users must not carry owner_profile")
+            if self.is_guest:
+                raise ValueError("external users must not be guest")
             return self
         if self.owner_user_id is None:
             raise ValueError("agent users require owner_user_id")
@@ -146,8 +141,8 @@ class UserRow(BaseModel):
             raise ValueError("agent users require agent_config_id")
         if self.created_by_user_id is not None:
             raise ValueError("agent users must not carry created_by_user_id")
-        if self.owner_profile is not None:
-            raise ValueError("agent users must not carry owner_profile")
+        if self.is_guest:
+            raise ValueError("agent users must not be guest")
         return self
 
 

--- a/storage/providers/supabase/user_repo.py
+++ b/storage/providers/supabase/user_repo.py
@@ -19,7 +19,7 @@ _COLS = (
     "email",
     "mycel_id",
     "created_by_user_id",
-    "owner_profile",
+    "is_guest",
     "created_at",
     "updated_at",
 )
@@ -45,7 +45,7 @@ class SupabaseUserRepo:
                 "email": row.email,
                 "mycel_id": row.mycel_id,
                 "created_by_user_id": row.created_by_user_id,
-                "owner_profile": row.owner_profile.value if row.owner_profile is not None else None,
+                "is_guest": row.is_guest,
                 "created_at": row.created_at,
                 "updated_at": row.updated_at,
             }
@@ -95,7 +95,7 @@ class SupabaseUserRepo:
         return [UserRow.model_validate(row) for row in rows]
 
     def update(self, user_id: str, **fields: Any) -> None:
-        allowed = {"display_name", "owner_user_id", "agent_config_id", "avatar", "email", "mycel_id", "owner_profile", "updated_at"}
+        allowed = {"display_name", "owner_user_id", "agent_config_id", "avatar", "email", "mycel_id", "is_guest", "updated_at"}
         updates = {key: value for key, value in fields.items() if key in allowed}
         if not updates:
             return

--- a/storage/schema/local_communication.sql
+++ b/storage/schema/local_communication.sql
@@ -1,0 +1,304 @@
+create extension if not exists pgcrypto;
+
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then
+    create role anon nologin;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then
+    create role service_role nologin bypassrls;
+  end if;
+end
+$$;
+
+grant anon, authenticated, service_role to postgres;
+
+create schema if not exists identity;
+create schema if not exists chat;
+create schema if not exists agent;
+create schema if not exists container;
+create schema if not exists library;
+
+create sequence if not exists identity.mycel_id_seq start with 100000;
+
+create table if not exists identity.users (
+  id text primary key,
+  type text not null,
+  display_name text not null,
+  owner_user_id text,
+  agent_config_id text,
+  next_thread_seq integer not null default 0,
+  avatar text,
+  email text unique,
+  mycel_id integer unique,
+  created_by_user_id text,
+  owner_profile text,
+  created_at double precision not null,
+  updated_at double precision,
+  check (type in ('human', 'agent', 'external')),
+  check (owner_profile is null or owner_profile in ('full', 'guest'))
+);
+
+create table if not exists identity.invite_codes (
+  code text primary key,
+  max_uses integer,
+  used_count integer not null default 0,
+  used_by_auth_user_ids_json jsonb not null default '[]'::jsonb,
+  expires_at double precision,
+  created_at double precision not null default extract(epoch from now())
+);
+
+create table if not exists identity.user_settings (
+  user_id text primary key,
+  default_workspace text,
+  recent_workspaces_json jsonb not null default '[]'::jsonb,
+  default_model text,
+  models_config_json jsonb,
+  account_resource_limits_json jsonb,
+  created_at double precision not null default extract(epoch from now()),
+  updated_at double precision
+);
+
+create or replace function identity.next_mycel_id()
+returns integer
+language sql
+as $$
+  select nextval('identity.mycel_id_seq')::integer;
+$$;
+
+create or replace function identity.increment_user_thread_seq(p_user_id text)
+returns integer
+language plpgsql
+as $$
+declare
+  next_seq integer;
+begin
+  update identity.users
+  set next_thread_seq = next_thread_seq + 1,
+      updated_at = extract(epoch from now())
+  where id = p_user_id
+  returning next_thread_seq into next_seq;
+  if next_seq is null then
+    raise exception 'user not found: %', p_user_id;
+  end if;
+  return next_seq;
+end;
+$$;
+
+create table if not exists chat.chats (
+  id text primary key,
+  type text not null,
+  title text,
+  status text not null default 'active',
+  created_by_user_id text not null,
+  next_message_seq bigint not null default 0,
+  created_at double precision not null,
+  updated_at double precision
+);
+
+create table if not exists chat.chat_members (
+  chat_id text not null references chat.chats(id) on delete cascade,
+  user_id text not null,
+  role text not null default 'member',
+  joined_at double precision not null,
+  last_read_seq bigint not null default 0,
+  muted boolean not null default false,
+  mute_until text,
+  version integer not null default 0,
+  primary key (chat_id, user_id)
+);
+
+create table if not exists chat.messages (
+  id text primary key,
+  chat_id text not null references chat.chats(id) on delete cascade,
+  seq bigint not null,
+  sender_user_id text not null,
+  content text not null,
+  content_type text not null default 'text/plain',
+  message_type text not null default 'text',
+  signal text,
+  mentions_json jsonb not null default '[]'::jsonb,
+  delivery_scope text not null default 'broadcast',
+  addressed_to_user_ids_json jsonb not null default '[]'::jsonb,
+  reply_to_message_id text,
+  ai_metadata_json jsonb not null default '{}'::jsonb,
+  deleted_for jsonb not null default '[]'::jsonb,
+  created_at double precision not null,
+  delivered_at double precision,
+  edited_at double precision,
+  retracted_at double precision,
+  deleted_at double precision,
+  unique (chat_id, seq),
+  check (delivery_scope in ('broadcast', 'addressed'))
+);
+
+create table if not exists chat.contacts (
+  source_user_id text not null,
+  target_user_id text not null,
+  kind text not null default 'normal',
+  state text not null default 'active',
+  alias text,
+  note text,
+  pinned boolean not null default false,
+  muted boolean not null default false,
+  archived boolean not null default false,
+  blocked boolean not null default false,
+  snapshot_json jsonb not null default '{}'::jsonb,
+  version integer not null default 0,
+  created_at double precision not null,
+  updated_at double precision,
+  primary key (source_user_id, target_user_id)
+);
+
+create table if not exists chat.relationships (
+  user_low text not null,
+  user_high text not null,
+  kind text not null default 'hire_visit',
+  state text not null default 'pending',
+  initiator_user_id text,
+  message text,
+  version integer not null default 0,
+  created_at double precision not null,
+  updated_at double precision,
+  primary key (user_low, user_high, kind),
+  check (user_low <> user_high)
+);
+
+create table if not exists chat.join_requests (
+  id text primary key,
+  chat_id text not null references chat.chats(id) on delete cascade,
+  requester_user_id text not null,
+  state text not null default 'pending',
+  message text,
+  decided_by_user_id text,
+  decided_at double precision,
+  created_at double precision not null,
+  updated_at double precision,
+  unique (chat_id, requester_user_id)
+);
+
+create table if not exists chat.workflow_state (
+  chat_id text primary key references chat.chats(id) on delete cascade,
+  kind text not null,
+  state text not null default 'active',
+  config_json jsonb not null default '{}'::jsonb,
+  updated_by_user_id text,
+  created_at double precision not null,
+  updated_at double precision
+);
+
+create table if not exists chat.tasks (
+  chat_id text not null references chat.chats(id) on delete cascade,
+  task_id text not null,
+  subject text not null default '',
+  description text not null default '',
+  status text not null default 'pending',
+  active_form text,
+  owner_user_id text,
+  blocks_json jsonb not null default '[]'::jsonb,
+  blocked_by_json jsonb not null default '[]'::jsonb,
+  metadata_json jsonb not null default '{}'::jsonb,
+  created_at double precision not null,
+  updated_at double precision,
+  primary key (chat_id, task_id)
+);
+
+create table if not exists chat.workflow_events (
+  chat_id text not null references chat.chats(id) on delete cascade,
+  event_id text not null,
+  kind text not null,
+  state text not null default 'open',
+  resource_refs_json jsonb not null default '[]'::jsonb,
+  requested_by_user_id text,
+  decision_states_json jsonb not null default '{}'::jsonb,
+  rationales_json jsonb not null default '{}'::jsonb,
+  final_state_json jsonb not null default '{}'::jsonb,
+  metadata_json jsonb not null default '{}'::jsonb,
+  created_at double precision not null,
+  updated_at double precision,
+  settled_at double precision,
+  primary key (chat_id, event_id)
+);
+
+create or replace function chat.increment_chat_message_seq(p_chat_id text)
+returns bigint
+language plpgsql
+as $$
+declare
+  next_seq bigint;
+begin
+  update chat.chats
+  set next_message_seq = next_message_seq + 1,
+      updated_at = extract(epoch from now())
+  where id = p_chat_id
+  returning next_message_seq into next_seq;
+  if next_seq is null then
+    raise exception 'chat not found: %', p_chat_id;
+  end if;
+  return next_seq;
+end;
+$$;
+
+create table if not exists agent.message_queue (
+  id bigserial primary key,
+  thread_id text not null,
+  content text not null,
+  notification_type text not null default 'steer',
+  source text,
+  sender_user_id text,
+  sender_name text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists agent.threads (
+  id text primary key,
+  agent_user_id text not null,
+  owner_user_id text not null,
+  current_workspace_id text not null,
+  sandbox_type text not null,
+  model text,
+  cwd text,
+  status text not null default 'active',
+  run_status text,
+  is_main boolean not null default false,
+  branch_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz,
+  last_active_at timestamptz
+);
+
+create table if not exists agent.agent_configs (
+  id text primary key,
+  agent_user_id text,
+  owner_user_id text,
+  name text,
+  description text,
+  status text,
+  version text,
+  resolved_config_json jsonb not null default '{}'::jsonb,
+  created_at double precision not null default extract(epoch from now()),
+  updated_at double precision
+);
+
+create table if not exists container.sandbox_recipes (
+  owner_user_id text not null,
+  recipe_id text not null,
+  kind text not null,
+  provider_type text not null,
+  data_json jsonb not null default '{}'::jsonb,
+  created_at double precision not null default extract(epoch from now()),
+  updated_at double precision,
+  primary key (owner_user_id, recipe_id)
+);
+
+grant usage on schema identity, chat, agent, container, library to anon, authenticated, service_role;
+grant all privileges on all tables in schema identity, chat, agent, container, library to service_role;
+grant select, insert, update, delete on all tables in schema identity, chat, agent, container, library to authenticated;
+grant select on all tables in schema identity, chat, agent, container, library to anon;
+grant usage, select on all sequences in schema identity, chat, agent, container, library to service_role, authenticated, anon;
+grant execute on all functions in schema identity, chat to service_role, authenticated, anon;
+
+notify pgrst, 'reload schema';

--- a/storage/schema/local_communication.sql
+++ b/storage/schema/local_communication.sql
@@ -35,11 +35,11 @@ create table if not exists identity.users (
   email text unique,
   mycel_id integer unique,
   created_by_user_id text,
-  owner_profile text,
+  is_guest boolean not null default false,
   created_at double precision not null,
   updated_at double precision,
   check (type in ('human', 'agent', 'external')),
-  check (owner_profile is null or owner_profile in ('full', 'guest'))
+  check (type = 'human' or is_guest = false)
 );
 
 create table if not exists identity.invite_codes (

--- a/storage/schema/owner_profile.sql
+++ b/storage/schema/owner_profile.sql
@@ -1,4 +1,0 @@
-alter table identity.users
-    add column if not exists owner_profile text;
-
-notify pgrst, 'reload schema';

--- a/storage/schema/user_is_guest.sql
+++ b/storage/schema/user_is_guest.sql
@@ -1,0 +1,22 @@
+alter table identity.users
+    add column if not exists is_guest boolean not null default false;
+
+do $$
+begin
+    if exists (
+        select 1
+        from information_schema.columns
+        where table_schema = 'identity'
+          and table_name = 'users'
+          and column_name = 'owner_profile'
+    ) then
+        update identity.users
+           set is_guest = true
+         where owner_profile = 'guest';
+
+        alter table identity.users
+            drop column owner_profile;
+    end if;
+end $$;
+
+notify pgrst, 'reload schema';

--- a/tests/Unit/backend/test_auth_guest_owner.py
+++ b/tests/Unit/backend/test_auth_guest_owner.py
@@ -8,7 +8,7 @@ import jwt
 import pytest
 
 from backend.identity.auth.service import AuthService
-from storage.contracts import OwnerProfile, UserType
+from storage.contracts import UserType
 
 
 def test_create_guest_owner_token_creates_restricted_human_without_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,19 +31,19 @@ def test_create_guest_owner_token_creates_restricted_human_without_bootstrap(mon
     assert len(created_rows) == 1
     assert created_rows[0].id == "guest-12345678-1234-5678-1234-567812345678"
     assert created_rows[0].type is UserType.HUMAN
-    assert created_rows[0].owner_profile is OwnerProfile.GUEST
+    assert created_rows[0].is_guest is True
     assert created_rows[0].display_name == "Guest Runner"
     assert created_rows[0].email is None
     assert created_rows[0].mycel_id is None
     decoded = jwt.decode(result["token"], "secret-1", algorithms=["HS256"], options={"verify_aud": False})
     assert decoded["sub"] == "guest-12345678-1234-5678-1234-567812345678"
-    assert decoded["mycel_owner_profile"] == "guest"
+    assert decoded["mycel_is_guest"] is True
     assert service.verify_token(result["token"]) == {"user_id": "guest-12345678-1234-5678-1234-567812345678"}
     assert result["user"] == {
         "id": "guest-12345678-1234-5678-1234-567812345678",
         "name": "Guest Runner",
         "type": "human",
-        "owner_profile": "guest",
+        "is_guest": True,
         "email": None,
         "mycel_id": None,
         "avatar": None,

--- a/tests/Unit/backend/test_identity_capabilities.py
+++ b/tests/Unit/backend/test_identity_capabilities.py
@@ -13,8 +13,8 @@ def _user(user_id: str, user_type: UserType | str):
     return SimpleNamespace(id=user_id, type=user_type)
 
 
-def _owner(user_id: str, owner_profile: str | None = None):
-    return SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=owner_profile)
+def _owner(user_id: str, is_guest: bool = False):
+    return SimpleNamespace(id=user_id, type=UserType.HUMAN, is_guest=is_guest)
 
 
 def test_human_owner_has_admin_capabilities() -> None:
@@ -26,8 +26,8 @@ def test_human_owner_has_admin_capabilities() -> None:
     assert capabilities.has(Capability.USE_SANDBOX)
 
 
-def test_guest_owner_has_communication_profile_only() -> None:
-    capabilities = resolve_user_capabilities(_owner("guest-1", "guest"))
+def test_guest_owner_has_communication_only() -> None:
+    capabilities = resolve_user_capabilities(_owner("guest-1", True))
 
     assert capabilities.has(Capability.CREATE_EXTERNAL_USER)
     assert not capabilities.has(Capability.CREATE_MANAGED_AGENT)
@@ -35,7 +35,7 @@ def test_guest_owner_has_communication_profile_only() -> None:
     assert not capabilities.has(Capability.USE_SANDBOX)
 
 
-def test_external_user_has_communication_profile_only() -> None:
+def test_external_user_has_communication_only() -> None:
     capabilities = resolve_user_capabilities(_user("external-1", UserType.EXTERNAL))
 
     assert not capabilities.has(Capability.CREATE_EXTERNAL_USER)

--- a/tests/Unit/backend/test_local_communication_deploy.py
+++ b/tests/Unit/backend/test_local_communication_deploy.py
@@ -38,6 +38,8 @@ def test_local_communication_schema_contains_runtime_primitives() -> None:
         "create role authenticated nologin",
         "create role service_role nologin bypassrls",
         "create table if not exists identity.users",
+        "is_guest boolean not null default false",
+        "check (type = 'human' or is_guest = false)",
         "create table if not exists chat.chats",
         "create table if not exists chat.chat_members",
         "create table if not exists chat.messages",
@@ -53,3 +55,4 @@ def test_local_communication_schema_contains_runtime_primitives() -> None:
     missing = [fragment for fragment in required_fragments if fragment not in sql]
 
     assert missing == []
+    assert "owner_profile" not in sql

--- a/tests/Unit/backend/test_local_communication_deploy.py
+++ b/tests/Unit/backend/test_local_communication_deploy.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_PATH = ROOT / "deploy/local-communication/compose.yml"
+GATEWAY_PATH = ROOT / "deploy/local-communication/rest-gateway.conf"
+SCHEMA_PATH = ROOT / "storage/schema/local_communication.sql"
+
+
+def test_local_communication_compose_is_self_contained() -> None:
+    compose = yaml.safe_load(COMPOSE_PATH.read_text())
+
+    assert "networks" not in compose
+    assert set(compose["services"]) == {"db", "postgrest", "supabase-rest", "backend"}
+    assert compose["services"]["backend"]["environment"]["MYCEL_RUNTIME_PROFILE"] == "communication"
+    assert compose["services"]["backend"]["environment"]["SUPABASE_INTERNAL_URL"] == "http://supabase-rest:8000"
+    assert compose["services"]["backend"]["environment"]["LEON_SUPABASE_CLIENT_FACTORY"] == (
+        "backend.identity.auth.supabase_runtime:create_supabase_client"
+    )
+
+
+def test_local_communication_rest_gateway_preserves_supabase_rest_shape() -> None:
+    gateway = GATEWAY_PATH.read_text()
+
+    assert "location /rest/v1/" in gateway
+    assert "proxy_pass http://postgrest:3000/" in gateway
+    assert 'return 404 "local communication profile exposes only /rest/v1\\n";' in gateway
+
+
+def test_local_communication_schema_contains_runtime_primitives() -> None:
+    sql = SCHEMA_PATH.read_text()
+
+    required_fragments = [
+        "create role anon nologin",
+        "create role authenticated nologin",
+        "create role service_role nologin bypassrls",
+        "create table if not exists identity.users",
+        "create table if not exists chat.chats",
+        "create table if not exists chat.chat_members",
+        "create table if not exists chat.messages",
+        "create table if not exists chat.workflow_state",
+        "create table if not exists chat.tasks",
+        "create table if not exists chat.workflow_events",
+        "create table if not exists agent.message_queue",
+        "create or replace function chat.increment_chat_message_seq",
+        "create or replace function identity.increment_user_thread_seq",
+        "grant execute on all functions in schema identity, chat",
+    ]
+
+    missing = [fragment for fragment in required_fragments if fragment not in sql]
+
+    assert missing == []

--- a/tests/Unit/integration_contracts/test_auth_router.py
+++ b/tests/Unit/integration_contracts/test_auth_router.py
@@ -21,7 +21,7 @@ class _FakeAuthService:
         self.login_result = {"token": "tok-login"}
         self.create_guest_owner_token_result = {
             "token": "tok-guest",
-            "user": {"id": "guest-1", "name": "Guest", "type": "human", "owner_profile": "guest"},
+            "user": {"id": "guest-1", "name": "Guest", "type": "human", "is_guest": True},
         }
         self.create_external_user_token_result = {
             "token": "tok-external",
@@ -163,7 +163,7 @@ async def test_auth_me_returns_authenticated_user_identity():
         "type": "external",
         "email": None,
         "mycel_id": None,
-        "owner_profile": None,
+        "is_guest": False,
         "avatar": None,
     }
 
@@ -230,7 +230,7 @@ def test_guest_owner_can_create_external_user_over_http():
     app.state.auth_runtime_state = SimpleNamespace(auth_service=service)
     app.state.user_repo = SimpleNamespace(
         get_by_id=lambda user_id: (
-            SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile="guest", display_name="Guest") if user_id == "guest-1" else None
+            SimpleNamespace(id=user_id, type=UserType.HUMAN, is_guest=True, display_name="Guest") if user_id == "guest-1" else None
         )
     )
     app.include_router(auth_router.router)

--- a/tests/Unit/integration_contracts/test_monitor_resources_route.py
+++ b/tests/Unit/integration_contracts/test_monitor_resources_route.py
@@ -18,7 +18,7 @@ def _app(*, include_product_resources: bool = False) -> FastAPI:
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
     app.include_router(monitor_threads_router.router, prefix="/api/monitor")
-    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, owner_profile=None)
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, is_guest=False)
     app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
     if include_product_resources:
         app.include_router(resources.router)
@@ -165,7 +165,7 @@ def test_monitor_dashboard_uses_service_summaries(monkeypatch):
 def test_guest_owner_cannot_use_monitor_control_plane(method, path, body, detail):
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
-    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="guest-1", type=UserType.HUMAN, owner_profile="guest")
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="guest-1", type=UserType.HUMAN, is_guest=True)
     app.dependency_overrides[get_current_user_id] = lambda: "guest-1"
 
     with TestClient(app) as client:
@@ -183,7 +183,7 @@ def test_global_monitor_router_accepts_evaluation_batch_create(monkeypatch):
     )
     app = FastAPI()
     app.include_router(global_router.router, prefix="/api/monitor")
-    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, owner_profile=None)
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="owner-1", type=UserType.HUMAN, is_guest=False)
     app.dependency_overrides[get_current_user_id] = lambda: "owner-1"
     try:
         with TestClient(app) as client:

--- a/tests/Unit/integration_contracts/test_resource_overview_contract_split.py
+++ b/tests/Unit/integration_contracts/test_resource_overview_contract_split.py
@@ -133,7 +133,7 @@ def test_monitor_resources_route_stays_global(monkeypatch) -> None:
 
     test_app = FastAPI()
     test_app.include_router(global_router.router, prefix="/api/monitor")
-    test_app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="user-1", type=UserType.HUMAN, owner_profile=None)
+    test_app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id="user-1", type=UserType.HUMAN, is_guest=False)
     test_app.dependency_overrides[get_current_user_id] = lambda: "user-1"
     try:
         with TestClient(test_app) as client:

--- a/tests/Unit/monitor/test_monitor_app_entrypoint.py
+++ b/tests/Unit/monitor/test_monitor_app_entrypoint.py
@@ -36,7 +36,7 @@ def test_monitor_app_mounts_only_global_monitor_routes(monkeypatch: pytest.Monke
 
 
 def test_monitor_app_accepts_evaluation_batch_create(monkeypatch: pytest.MonkeyPatch):
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=None))
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, is_guest=False))
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
@@ -102,7 +102,7 @@ def test_monitor_app_rejects_deleted_user_for_evaluation_batch_create(monkeypatc
 
 
 def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPatch):
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=None))
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, is_guest=False))
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )
@@ -144,7 +144,7 @@ def test_monitor_app_accepts_evaluation_batch_start(monkeypatch: pytest.MonkeyPa
 
 
 def test_monitor_app_maps_missing_remote_execution_target_to_503(monkeypatch: pytest.MonkeyPatch):
-    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, owner_profile=None))
+    user_repo = SimpleNamespace(get_by_id=lambda user_id: SimpleNamespace(id=user_id, type=UserType.HUMAN, is_guest=False))
     monitor_storage = SimpleNamespace(
         storage_container=SimpleNamespace(user_repo=lambda: user_repo, contact_repo=lambda: object()),
     )

--- a/tests/Unit/storage/test_external_user_type.py
+++ b/tests/Unit/storage/test_external_user_type.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from storage.contracts import OwnerProfile, UserRow, UserType
+from storage.contracts import UserRow, UserType
 
 
 def test_external_user_row_requires_creator_and_no_agent_config() -> None:
@@ -55,36 +55,36 @@ def test_external_user_row_rejects_agent_config_id() -> None:
         )
 
 
-def test_human_user_row_can_carry_guest_owner_profile() -> None:
+def test_human_user_row_can_be_guest() -> None:
     row = UserRow(
         id="guest-owner-1",
         type=UserType.HUMAN,
         display_name="Guest",
-        owner_profile=OwnerProfile.GUEST,
+        is_guest=True,
         created_at=1.0,
     )
 
-    assert row.owner_profile is OwnerProfile.GUEST
+    assert row.is_guest is True
 
 
-def test_agent_and_external_rows_reject_owner_profile() -> None:
-    with pytest.raises(ValueError, match="external users must not carry owner_profile"):
+def test_agent_and_external_rows_reject_guest_flag() -> None:
+    with pytest.raises(ValueError, match="external users must not be guest"):
         UserRow(
             id="external-user-1",
             type=UserType.EXTERNAL,
             display_name="Codex External",
             created_by_user_id="owner-1",
-            owner_profile=OwnerProfile.GUEST,
+            is_guest=True,
             created_at=1.0,
         )
 
-    with pytest.raises(ValueError, match="agent users must not carry owner_profile"):
+    with pytest.raises(ValueError, match="agent users must not be guest"):
         UserRow(
             id="agent-1",
             type=UserType.AGENT,
             display_name="Toad",
             owner_user_id="owner-1",
             agent_config_id="cfg-1",
-            owner_profile=OwnerProfile.GUEST,
+            is_guest=True,
             created_at=1.0,
         )

--- a/tests/Unit/storage/test_supabase_user_repo.py
+++ b/tests/Unit/storage/test_supabase_user_repo.py
@@ -1,4 +1,4 @@
-from storage.contracts import OwnerProfile, UserRow, UserType
+from storage.contracts import UserRow, UserType
 from storage.providers.supabase.user_repo import SupabaseUserRepo
 
 
@@ -17,7 +17,7 @@ class _FakeTable:
                 "avatar": "toad.png",
                 "email": "toad@example.com",
                 "mycel_id": 10001,
-                "owner_profile": None,
+                "is_guest": False,
                 "next_thread_seq": 3,
                 "created_at": 1.0,
                 "updated_at": 2.0,
@@ -86,7 +86,7 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
             email="toad@example.com",
             mycel_id=10001,
             created_by_user_id=None,
-            owner_profile=None,
+            is_guest=False,
             next_thread_seq=3,
             created_at=1.0,
             updated_at=2.0,
@@ -99,7 +99,7 @@ def test_supabase_user_repo_create_persists_agent_identity_fields() -> None:
     assert client.table_obj.insert_payload["owner_user_id"] == "owner-1"
     assert client.table_obj.insert_payload["agent_config_id"] == "cfg-1"
     assert client.table_obj.insert_payload["created_by_user_id"] is None
-    assert client.table_obj.insert_payload["owner_profile"] is None
+    assert client.table_obj.insert_payload["is_guest"] is False
     assert client.table_obj.insert_payload["next_thread_seq"] == 3
 
 
@@ -123,10 +123,10 @@ def test_supabase_user_repo_create_persists_external_creator() -> None:
     assert client.table_obj.insert_payload["created_by_user_id"] == "owner-1"
     assert client.table_obj.insert_payload["owner_user_id"] is None
     assert client.table_obj.insert_payload["agent_config_id"] is None
-    assert client.table_obj.insert_payload["owner_profile"] is None
+    assert client.table_obj.insert_payload["is_guest"] is False
 
 
-def test_supabase_user_repo_create_persists_guest_owner_profile() -> None:
+def test_supabase_user_repo_create_persists_guest_is_guest() -> None:
     client = _FakeClient()
     repo = SupabaseUserRepo(client)
 
@@ -135,7 +135,7 @@ def test_supabase_user_repo_create_persists_guest_owner_profile() -> None:
             id="guest-owner-1",
             type=UserType.HUMAN,
             display_name="Guest",
-            owner_profile=OwnerProfile.GUEST,
+            is_guest=True,
             created_at=1.0,
         )
     )
@@ -143,7 +143,7 @@ def test_supabase_user_repo_create_persists_guest_owner_profile() -> None:
     assert client.table_name == "identity.users"
     assert client.table_obj.insert_payload is not None
     assert client.table_obj.insert_payload["type"] == "human"
-    assert client.table_obj.insert_payload["owner_profile"] == "guest"
+    assert client.table_obj.insert_payload["is_guest"] is True
 
 
 def test_supabase_user_repo_get_by_id_returns_user_row() -> None:


### PR DESCRIPTION
## Summary

Adds a self-contained local communication backend path for users who want Mycel CLI identity/chat/runtime-inbox behavior without booting the full managed-agent/sandbox/frontend platform.

## Changes

- Add a local communication schema bootstrap for identity, chat, runtime inbox, workflow, and minimal support tables.
- Add `deploy/local-communication/compose.yml` with PostgreSQL, PostgREST, a thin `/rest/v1` gateway, and the Mycel backend running `MYCEL_RUNTIME_PROFILE=communication`.
- Add deploy contract tests for the compose/gateway/schema boundary.
- Document the local communication backend in English and Chinese deployment docs, including `MYCEL_BASE_URL=http://localhost:8042` for `cel`.
- Collapse the guest-owner axis from `owner_profile` to `identity.users.is_guest`: guest is a restricted human user, not a separate type/profile; agent/external rows fail loudly if marked guest.

## Verification

- `uv run ruff check .` -> pass
- `uv run ruff format --check .` -> `687 files already formatted`
- `uv run pytest -q tests/Unit/backend/test_local_communication_deploy.py tests/Unit/backend/test_web_app_profiles.py tests/Unit/backend/test_auth_guest_owner.py tests/Integration/test_chat_app_router.py tests/Unit/backend/test_identity_capabilities.py tests/Unit/storage/test_external_user_type.py tests/Unit/storage/test_supabase_user_repo.py tests/Unit/integration_contracts/test_auth_router.py tests/Unit/integration_contracts/test_monitor_resources_route.py tests/Unit/integration_contracts/test_resource_overview_contract_split.py tests/Unit/monitor/test_monitor_app_entrypoint.py` -> `97 passed`
- `docker compose -f deploy/local-communication/compose.yml config --quiet` -> pass
- PGL fresh Docker YATU: started PostgreSQL, PostgREST, gateway, and communication-profile backend from this branch with no existing developer Supabase network; backend API loop returned `YATU_OK` for guest owner, two external users, direct chat, send, unread, runtime inbox drain, read, and reply.
- PGL installed-CLI YATU: `uv tool run --from mycel-cli==0.1.50 cel` against the local backend ran `cel guest`, two `cel agent external create` calls, A->B `send-message/read-message`, B->A `send-message/read-message`, ending in `CLI_YATU_OK`.
- PGL is_guest installed-CLI YATU after the rename: fresh project `mycel-local-comm-isguest-yatu-090645` created a guest returning `is_guest: true`, created two external identities, completed A/B `send-message`/`read-message`, and ended in `IS_GUEST_CLI_YATU_OK`.
- PGL containers, volumes, networks, remote source snapshots, logs, and temporary `MYCEL_HOME` state were removed after proof.

## Boundaries

This is the communication-only self-host path. It intentionally does not start the Web UI, managed agent runtime, sandbox providers, marketplace, monitor resource surfaces, or normal email login.
