### PR TITLE
feat: add app schema applier

### DIFF
--- a/scripts/apply_app_schema.py
+++ b/scripts/apply_app_schema.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = REPO_ROOT / "storage/schema"
+MANIFEST_PATH = SCHEMA_DIR / "app_schema_manifest.json"
+
+SUPABASE_ROLE_PRELUDE = """
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then create role service_role; end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then create role authenticated; end if;
+  if not exists (select 1 from pg_roles where rolname = 'anon') then create role anon; end if;
+end $$;
+""".strip()
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise RuntimeError(f"schema manifest must be a JSON object: {path}")
+    return data
+
+
+def ordered_schema_files(schema_dir: Path = SCHEMA_DIR) -> list[Path]:
+    manifest = load_manifest(schema_dir / "app_schema_manifest.json")
+    baseline = manifest.get("baseline")
+    patches = manifest.get("patches")
+    if not isinstance(baseline, str) or not isinstance(patches, list) or not all(isinstance(item, str) for item in patches):
+        raise RuntimeError("schema manifest must define string baseline and string patch list")
+    files = [schema_dir / baseline, *(schema_dir / patch for patch in patches)]
+    missing = [path for path in files if not path.is_file()]
+    if missing:
+        rel = ", ".join(path.relative_to(REPO_ROOT).as_posix() for path in missing)
+        raise RuntimeError(f"schema manifest references missing SQL files: {rel}")
+    return files
+
+
+def apply_schema(database_url: str, *, prepare_supabase_roles: bool = False, schema_dir: Path = SCHEMA_DIR) -> list[Path]:
+    import psycopg
+
+    files = ordered_schema_files(schema_dir)
+    if prepare_supabase_roles:
+        with psycopg.connect(database_url, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(SUPABASE_ROLE_PRELUDE)
+
+    for path in files:
+        with psycopg.connect(database_url, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(path.read_text(encoding="utf-8"))
+    return files
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Apply the Mycel app schema baseline and manifest patches to a PostgreSQL database.")
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("LEON_POSTGRES_URL"),
+        help="PostgreSQL URL. Defaults to LEON_POSTGRES_URL.",
+    )
+    parser.add_argument(
+        "--prepare-supabase-roles",
+        action="store_true",
+        help="Create service_role, authenticated, and anon if missing. Use for plain local PostgreSQL, not managed Supabase.",
+    )
+    parser.add_argument("--print-files", action="store_true", help="Print the manifest apply order and exit without connecting.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        files = ordered_schema_files()
+        if args.print_files:
+            for path in files:
+                print(path.relative_to(REPO_ROOT).as_posix())
+            return 0
+        if not args.database_url:
+            raise RuntimeError("missing database URL: pass --database-url or set LEON_POSTGRES_URL")
+        applied = apply_schema(args.database_url, prepare_supabase_roles=args.prepare_supabase_roles)
+    except Exception as exc:
+        print(f"App schema apply failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"App schema apply passed: {len(applied)} SQL files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/Unit/storage/test_app_schema_applier.py
+++ b/tests/Unit/storage/test_app_schema_applier.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+APPLIER_PATH = ROOT / "scripts/apply_app_schema.py"
+
+
+def _load_applier():
+    spec = importlib.util.spec_from_file_location("apply_app_schema", APPLIER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_applier_uses_manifest_order() -> None:
+    applier = _load_applier()
+
+    files = [path.relative_to(ROOT).as_posix() for path in applier.ordered_schema_files(ROOT / "storage/schema")]
+
+    assert files[0] == "storage/schema/app_schema.sql"
+    assert files[1:] == [
+        "storage/schema/agent_config_resolved_config_hardcut.sql",
+        "storage/schema/chat_join_requests.sql",
+        "storage/schema/chat_message_delivery_scope.sql",
+        "storage/schema/chat_workflow_state_and_tasks.sql",
+        "storage/schema/external_user_creator.sql",
+        "storage/schema/relationship_pair_constraint.sql",
+        "storage/schema/relationship_request_message.sql",
+        "storage/schema/sandbox_control_plane_supabase.sql",
+        "storage/schema/user_is_guest.sql",
+    ]
+
+
+def test_applier_print_files_is_connection_free() -> None:
+    result = subprocess.run(
+        [sys.executable, str(APPLIER_PATH), "--print-files"],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.splitlines()[0] == "storage/schema/app_schema.sql"
+    assert result.stderr == ""
+
+
+def test_applier_fails_loudly_without_database_url() -> None:
+    env = os.environ.copy()
+    env.pop("LEON_POSTGRES_URL", None)
+    result = subprocess.run(
+        [sys.executable, str(APPLIER_PATH)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert "missing database URL" in result.stderr
+
+
+def test_supabase_role_prelude_is_explicit() -> None:
+    applier = _load_applier()
+
+    assert "create role service_role" in applier.SUPABASE_ROLE_PRELUDE
+    assert "create role authenticated" in applier.SUPABASE_ROLE_PRELUDE
+    assert "create role anon" in applier.SUPABASE_ROLE_PRELUDE
+
+
+def test_applier_isolates_session_state_between_schema_files(tmp_path, monkeypatch) -> None:
+    applier = _load_applier()
+    schema_dir = tmp_path / "schema"
+    schema_dir.mkdir()
+    (schema_dir / "app_schema_manifest.json").write_text(
+        '{"baseline": "baseline.sql", "patches": ["patch.sql"]}',
+        encoding="utf-8",
+    )
+    (schema_dir / "baseline.sql").write_text("select set_config('search_path', '', false);", encoding="utf-8")
+    (schema_dir / "patch.sql").write_text("create extension if not exists pgcrypto;", encoding="utf-8")
+    executed: list[list[str]] = []
+
+    class Cursor:
+        def __init__(self, statements: list[str]) -> None:
+            self._statements = statements
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def execute(self, statement: str) -> None:
+            self._statements.append(statement)
+
+    class Connection:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+            executed.append(self.statements)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return Cursor(self.statements)
+
+    fake_psycopg = types.SimpleNamespace(connect=lambda *args, **kwargs: Connection())
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    applier.apply_schema("postgresql://example", prepare_supabase_roles=True, schema_dir=schema_dir)
+
+    assert executed == [
+        [applier.SUPABASE_ROLE_PRELUDE],
+        ["select set_config('search_path', '', false);"],
+        ["create extension if not exists pgcrypto;"],
+    ]


### PR DESCRIPTION
## Summary

- Add `scripts/apply_app_schema.py` to apply the app schema baseline plus manifest patches in order.
- Keep the Supabase-compatible role prelude explicit behind `--prepare-supabase-roles` for plain local PostgreSQL.
- Add storage unit tests that pin the manifest order, fail-loud CLI behavior, connection-free `--print-files`, and per-file session isolation.

## Verification

- `uv run pytest tests/Unit/storage/test_app_schema_applier.py tests/Unit/storage/test_app_schema_discipline.py -q`
- `uv run ruff check scripts/apply_app_schema.py tests/Unit/storage/test_app_schema_applier.py`
- `uv run ruff format --check scripts/apply_app_schema.py tests/Unit/storage/test_app_schema_applier.py`
- `uv run python scripts/check_app_schema.py`
- PGL/Ubuntu fresh-clone Docker proof on `codex/app-schema-applier @ 3ecaee0`: `scripts/apply_app_schema.py --prepare-supabase-roles` applied 10 SQL files to `postgres:15-alpine`, producing `tables=47`, `functions=4`.
