### PR TITLE
feat: add cli minimal deploy contract

### DIFF
--- a/deploy/cli-minimal/README.md
+++ b/deploy/cli-minimal/README.md
@@ -1,0 +1,21 @@
+# Mycel CLI-Minimal Deploy
+
+This compose profile is the local communication backend for CLI-first users.
+It is not the full Mycel platform and it is not a forked schema.
+
+Long-running services:
+
+- `postgres`: the only database.
+- `postgrest`: Supabase-compatible REST storage surface.
+- `gateway`: thin nginx route for `/rest/v1/*`.
+- `mycel-backend`: Mycel business API with `MYCEL_RUNTIME_PROFILE=communication`.
+
+One-shot service:
+
+- `schema-init`: runs `scripts/apply_app_schema.py` against `storage/schema/app_schema.sql`
+  and manifest patches, then exits.
+
+The ordinary CLI install must not pull Docker images. This stack is only used
+when a user explicitly asks for local communication service startup.
+
+Full platform deployment belongs to operator runbooks, not this profile.

--- a/deploy/cli-minimal/compose.yml
+++ b/deploy/cli-minimal/compose.yml
@@ -1,0 +1,67 @@
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - mycel-cli-minimal-postgres:/var/lib/postgresql/data
+
+  schema-init:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command:
+      - python
+      - scripts/apply_app_schema.py
+      - --prepare-supabase-roles
+      - --database-url
+      - postgresql://postgres:postgres@postgres:5432/postgres
+
+  postgrest:
+    image: postgrest/postgrest:v12.2.8
+    depends_on:
+      schema-init:
+        condition: service_completed_successfully
+    environment:
+      PGRST_DB_URI: postgresql://postgres:postgres@postgres:5432/postgres
+      PGRST_DB_SCHEMAS: identity,chat,agent,container,library,observability
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}
+
+  gateway:
+    image: nginx:1.27-alpine
+    depends_on:
+      - postgrest
+    volumes:
+      - ./rest-gateway.conf:/etc/nginx/conf.d/default.conf:ro
+
+  mycel-backend:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      - gateway
+    ports:
+      - "127.0.0.1:8042:8900"
+    environment:
+      MYCEL_RUNTIME_PROFILE: communication
+      LEON_STORAGE_STRATEGY: supabase
+      LEON_DB_SCHEMA: identity
+      SUPABASE_INTERNAL_URL: http://gateway:8000
+      SUPABASE_PUBLIC_URL: http://127.0.0.1:8042
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:?SUPABASE_ANON_KEY is required}
+      LEON_SUPABASE_SERVICE_ROLE_KEY: ${LEON_SUPABASE_SERVICE_ROLE_KEY:?LEON_SUPABASE_SERVICE_ROLE_KEY is required}
+      SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}
+
+volumes:
+  mycel-cli-minimal-postgres:

--- a/deploy/cli-minimal/rest-gateway.conf
+++ b/deploy/cli-minimal/rest-gateway.conf
@@ -1,0 +1,14 @@
+server {
+    listen 8000;
+
+    location /rest/v1/ {
+        proxy_pass http://postgrest:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/tests/Unit/backend/test_local_communication_deploy.py
+++ b/tests/Unit/backend/test_local_communication_deploy.py
@@ -6,6 +6,8 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = ROOT / "storage/schema/local_communication.sql"
+CLI_MINIMAL_COMPOSE = ROOT / "deploy/cli-minimal/compose.yml"
+CLI_MINIMAL_GATEWAY_CONF = ROOT / "deploy/cli-minimal/rest-gateway.conf"
 
 
 def _compose_files() -> list[Path]:
@@ -26,3 +28,46 @@ def test_active_deploys_do_not_mount_handwritten_local_communication_schema() ->
 
 def test_local_communication_schema_is_not_a_product_bootstrap_source() -> None:
     assert not SCHEMA_PATH.exists()
+
+
+def test_cli_minimal_compose_is_four_long_running_services_plus_schema_init() -> None:
+    compose = yaml.safe_load(CLI_MINIMAL_COMPOSE.read_text()) or {}
+    services = compose.get("services") or {}
+
+    assert set(services) == {"postgres", "schema-init", "postgrest", "gateway", "mycel-backend"}
+    assert services["schema-init"]["restart"] == "no"
+    assert services["schema-init"]["command"] == [
+        "python",
+        "scripts/apply_app_schema.py",
+        "--prepare-supabase-roles",
+        "--database-url",
+        "postgresql://postgres:postgres@postgres:5432/postgres",
+    ]
+    assert "local_communication.sql" not in CLI_MINIMAL_COMPOSE.read_text()
+
+
+def test_cli_minimal_backend_uses_communication_profile_and_thin_gateway() -> None:
+    compose = yaml.safe_load(CLI_MINIMAL_COMPOSE.read_text()) or {}
+    backend_env = compose["services"]["mycel-backend"]["environment"]
+    postgrest_env = compose["services"]["postgrest"]["environment"]
+
+    assert backend_env["MYCEL_RUNTIME_PROFILE"] == "communication"
+    assert backend_env["LEON_STORAGE_STRATEGY"] == "supabase"
+    assert backend_env["SUPABASE_INTERNAL_URL"] == "http://gateway:8000"
+    assert backend_env["LEON_DB_SCHEMA"] == "identity"
+    assert postgrest_env["PGRST_DB_SCHEMAS"] == "identity,chat,agent,container,library,observability"
+    assert postgrest_env["PGRST_JWT_SECRET"] == "${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}"
+    assert backend_env["SUPABASE_JWT_SECRET"] == "${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}"
+
+
+def test_cli_minimal_gateway_is_nginx_rest_only_not_supabase_bundle() -> None:
+    compose = yaml.safe_load(CLI_MINIMAL_COMPOSE.read_text()) or {}
+    services = compose.get("services") or {}
+    gateway = services["gateway"]
+    gateway_conf = CLI_MINIMAL_GATEWAY_CONF.read_text()
+
+    assert gateway["image"] == "nginx:1.27-alpine"
+    assert "postgrest:3000" in gateway_conf
+    assert "/rest/v1/" in gateway_conf
+    assert "/auth/v1/" not in gateway_conf
+    assert not {"gotrue", "studio", "realtime", "storage", "analytics", "kong"} & set(services)


### PR DESCRIPTION
## Summary
- add an app-owned `deploy/cli-minimal` compose profile for the local communication backend
- use canonical `scripts/apply_app_schema.py` as a one-shot schema init instead of reviving `local_communication.sql`
- add an nginx `/rest/v1/*` gateway in front of PostgREST, without GoTrue/Kong/Storage/Realtime/Studio
- lock the deploy contract with unit tests

## Verification
- `uv run pytest tests/Unit/backend/test_local_communication_deploy.py tests/Unit/storage/test_app_schema_discipline.py tests/Unit/storage/test_app_schema_applier.py -q`
- `uv run ruff check tests/Unit/backend/test_local_communication_deploy.py scripts/apply_app_schema.py`
- `SUPABASE_JWT_SECRET=dev-secret SUPABASE_ANON_KEY=dev-anon LEON_SUPABASE_SERVICE_ROLE_KEY=dev-service docker compose -f deploy/cli-minimal/compose.yml config`

## Notes
This PR is a deploy contract/skeleton slice. It does not add a public `cel self local up` command and does not claim a full compose smoke run. Docker daemon probing on the current Mac host hung, so real container smoke should run in an isolated macmini/Ubuntu YATU lane.
