### PR TITLE
fix: make cli minimal deploy repeatable

### DIFF
--- a/deploy/cli-minimal/README.md
+++ b/deploy/cli-minimal/README.md
@@ -19,3 +19,34 @@ The ordinary CLI install must not pull Docker images. This stack is only used
 when a user explicitly asks for local communication service startup.
 
 Full platform deployment belongs to operator runbooks, not this profile.
+
+## Network Shape
+
+Default startup is local-only:
+
+```bash
+SUPABASE_JWT_SECRET=... \
+SUPABASE_ANON_KEY=... \
+LEON_SUPABASE_SERVICE_ROLE_KEY=... \
+docker compose -f deploy/cli-minimal/compose.yml up
+```
+
+That publishes `mycel-backend` on `127.0.0.1:8042`. This is the safe default
+for a single laptop.
+
+To let `cel` on another machine connect to this CLI-minimal backend, publish an
+explicit reachable URL:
+
+```bash
+MYCEL_BIND_HOST=0.0.0.0 \
+MYCEL_PORT=8042 \
+MYCEL_PUBLIC_URL=http://<host-or-lan-ip>:8042 \
+SUPABASE_JWT_SECRET=... \
+SUPABASE_ANON_KEY=... \
+LEON_SUPABASE_SERVICE_ROLE_KEY=... \
+docker compose -f deploy/cli-minimal/compose.yml up
+```
+
+Other machines should configure `cel` with `MYCEL_PUBLIC_URL`. Future CLI
+onboarding should accept that URL, probe backend version/capabilities, and fail
+loudly if the target is not a compatible Mycel communication backend.

--- a/deploy/cli-minimal/compose.yml
+++ b/deploy/cli-minimal/compose.yml
@@ -52,13 +52,13 @@ services:
     depends_on:
       - gateway
     ports:
-      - "127.0.0.1:8042:8900"
+      - "${MYCEL_BIND_HOST:-127.0.0.1}:${MYCEL_PORT:-8042}:8900"
     environment:
       MYCEL_RUNTIME_PROFILE: communication
       LEON_STORAGE_STRATEGY: supabase
       LEON_DB_SCHEMA: identity
       SUPABASE_INTERNAL_URL: http://gateway:8000
-      SUPABASE_PUBLIC_URL: http://127.0.0.1:8042
+      SUPABASE_PUBLIC_URL: ${MYCEL_PUBLIC_URL:-http://127.0.0.1:8042}
       SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:?SUPABASE_ANON_KEY is required}
       LEON_SUPABASE_SERVICE_ROLE_KEY: ${LEON_SUPABASE_SERVICE_ROLE_KEY:?LEON_SUPABASE_SERVICE_ROLE_KEY is required}
       SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}

--- a/scripts/apply_app_schema.py
+++ b/scripts/apply_app_schema.py
@@ -21,6 +21,13 @@ begin
 end $$;
 """.strip()
 
+APP_SCHEMA_STATE_SQL = """
+select
+  (select count(*) from information_schema.schemata where schema_name = any(%s)) as schema_count,
+  (select count(*) from information_schema.tables where table_schema = any(%s) and table_type = 'BASE TABLE') as table_count,
+  (select count(*) from information_schema.routines where specific_schema = any(%s) and routine_type = 'FUNCTION') as function_count
+""".strip()
+
 
 def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -43,14 +50,46 @@ def ordered_schema_files(schema_dir: Path = SCHEMA_DIR) -> list[Path]:
     return files
 
 
+def app_schema_expectations(schema_dir: Path = SCHEMA_DIR) -> tuple[list[str], int, int]:
+    manifest = load_manifest(schema_dir / "app_schema_manifest.json")
+    schemas = manifest.get("app_owned_schemas")
+    table_count = manifest.get("baseline_table_count")
+    function_count = manifest.get("baseline_function_count")
+    if (
+        not isinstance(schemas, list)
+        or not all(isinstance(item, str) and item for item in schemas)
+        or not isinstance(table_count, int)
+        or not isinstance(function_count, int)
+    ):
+        raise RuntimeError("schema manifest must define app_owned_schemas, baseline_table_count, and baseline_function_count")
+    return schemas, table_count, function_count
+
+
 def apply_schema(database_url: str, *, prepare_supabase_roles: bool = False, schema_dir: Path = SCHEMA_DIR) -> list[Path]:
     import psycopg
 
     files = ordered_schema_files(schema_dir)
+    schemas, expected_tables, expected_functions = app_schema_expectations(schema_dir)
     if prepare_supabase_roles:
         with psycopg.connect(database_url, autocommit=True) as conn:
             with conn.cursor() as cur:
                 cur.execute(SUPABASE_ROLE_PRELUDE)
+
+    with psycopg.connect(database_url, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(APP_SCHEMA_STATE_SQL, (schemas, schemas, schemas))
+            row = cur.fetchone()
+    schema_count, table_count, function_count = row
+    if (schema_count, table_count, function_count) == (0, 0, 0):
+        pass
+    elif (schema_count, table_count, function_count) == (len(schemas), expected_tables, expected_functions):
+        return []
+    else:
+        raise RuntimeError(
+            "database already contains a partial or drifted app schema: "
+            f"schemas={schema_count}/{len(schemas)}, tables={table_count}/{expected_tables}, "
+            f"functions={function_count}/{expected_functions}"
+        )
 
     for path in files:
         with psycopg.connect(database_url, autocommit=True) as conn:

--- a/tests/Unit/backend/test_local_communication_deploy.py
+++ b/tests/Unit/backend/test_local_communication_deploy.py
@@ -49,11 +49,14 @@ def test_cli_minimal_compose_is_four_long_running_services_plus_schema_init() ->
 def test_cli_minimal_backend_uses_communication_profile_and_thin_gateway() -> None:
     compose = yaml.safe_load(CLI_MINIMAL_COMPOSE.read_text()) or {}
     backend_env = compose["services"]["mycel-backend"]["environment"]
+    backend_ports = compose["services"]["mycel-backend"]["ports"]
     postgrest_env = compose["services"]["postgrest"]["environment"]
 
+    assert backend_ports == ["${MYCEL_BIND_HOST:-127.0.0.1}:${MYCEL_PORT:-8042}:8900"]
     assert backend_env["MYCEL_RUNTIME_PROFILE"] == "communication"
     assert backend_env["LEON_STORAGE_STRATEGY"] == "supabase"
     assert backend_env["SUPABASE_INTERNAL_URL"] == "http://gateway:8000"
+    assert backend_env["SUPABASE_PUBLIC_URL"] == "${MYCEL_PUBLIC_URL:-http://127.0.0.1:8042}"
     assert backend_env["LEON_DB_SCHEMA"] == "identity"
     assert postgrest_env["PGRST_DB_SCHEMAS"] == "identity,chat,agent,container,library,observability"
     assert postgrest_env["PGRST_JWT_SECRET"] == "${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}"

--- a/tests/Unit/storage/test_app_schema_applier.py
+++ b/tests/Unit/storage/test_app_schema_applier.py
@@ -82,12 +82,16 @@ def test_applier_isolates_session_state_between_schema_files(tmp_path, monkeypat
     schema_dir = tmp_path / "schema"
     schema_dir.mkdir()
     (schema_dir / "app_schema_manifest.json").write_text(
-        '{"baseline": "baseline.sql", "patches": ["patch.sql"]}',
+        (
+            '{"baseline": "baseline.sql", "patches": ["patch.sql"], '
+            '"app_owned_schemas": ["identity"], "baseline_table_count": 0, "baseline_function_count": 0}'
+        ),
         encoding="utf-8",
     )
     (schema_dir / "baseline.sql").write_text("select set_config('search_path', '', false);", encoding="utf-8")
     (schema_dir / "patch.sql").write_text("create extension if not exists pgcrypto;", encoding="utf-8")
     executed: list[list[str]] = []
+    fetch_results = [(0, 0, 0)]
 
     class Cursor:
         def __init__(self, statements: list[str]) -> None:
@@ -99,8 +103,11 @@ def test_applier_isolates_session_state_between_schema_files(tmp_path, monkeypat
         def __exit__(self, *args) -> None:
             return None
 
-        def execute(self, statement: str) -> None:
+        def execute(self, statement: str, params=None) -> None:
             self._statements.append(statement)
+
+        def fetchone(self):
+            return fetch_results.pop(0)
 
     class Connection:
         def __init__(self) -> None:
@@ -123,6 +130,109 @@ def test_applier_isolates_session_state_between_schema_files(tmp_path, monkeypat
 
     assert executed == [
         [applier.SUPABASE_ROLE_PRELUDE],
+        [applier.APP_SCHEMA_STATE_SQL],
         ["select set_config('search_path', '', false);"],
         ["create extension if not exists pgcrypto;"],
     ]
+
+
+def test_applier_skips_database_that_already_matches_manifest(tmp_path, monkeypatch) -> None:
+    applier = _load_applier()
+    schema_dir = tmp_path / "schema"
+    schema_dir.mkdir()
+    (schema_dir / "app_schema_manifest.json").write_text(
+        (
+            '{"baseline": "baseline.sql", "patches": ["patch.sql"], '
+            '"app_owned_schemas": ["identity"], "baseline_table_count": 2, "baseline_function_count": 1}'
+        ),
+        encoding="utf-8",
+    )
+    (schema_dir / "baseline.sql").write_text("create schema identity;", encoding="utf-8")
+    (schema_dir / "patch.sql").write_text("alter table identity.users add column name text;", encoding="utf-8")
+    executed: list[list[str]] = []
+
+    class Cursor:
+        def __init__(self, statements: list[str]) -> None:
+            self._statements = statements
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def execute(self, statement: str, params=None) -> None:
+            self._statements.append(statement)
+
+        def fetchone(self):
+            return (1, 2, 1)
+
+    class Connection:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+            executed.append(self.statements)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return Cursor(self.statements)
+
+    fake_psycopg = types.SimpleNamespace(connect=lambda *args, **kwargs: Connection())
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    applied = applier.apply_schema("postgresql://example", schema_dir=schema_dir)
+
+    assert applied == []
+    assert len(executed) == 1
+    assert "information_schema.schemata" in executed[0][0]
+
+
+def test_applier_fails_loudly_on_partial_app_schema(tmp_path, monkeypatch) -> None:
+    applier = _load_applier()
+    schema_dir = tmp_path / "schema"
+    schema_dir.mkdir()
+    (schema_dir / "app_schema_manifest.json").write_text(
+        (
+            '{"baseline": "baseline.sql", "patches": [], '
+            '"app_owned_schemas": ["identity", "chat"], "baseline_table_count": 2, "baseline_function_count": 0}'
+        ),
+        encoding="utf-8",
+    )
+    (schema_dir / "baseline.sql").write_text("create schema identity; create schema chat;", encoding="utf-8")
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def execute(self, statement: str, params=None) -> None:
+            return None
+
+        def fetchone(self):
+            return (1, 1, 0)
+
+    class Connection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+    fake_psycopg = types.SimpleNamespace(connect=lambda *args, **kwargs: Connection())
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    try:
+        applier.apply_schema("postgresql://example", schema_dir=schema_dir)
+    except RuntimeError as exc:
+        assert "already contains a partial or drifted app schema" in str(exc)
+    else:
+        raise AssertionError("expected partial schema to fail loudly")


### PR DESCRIPTION
## Summary

- make `scripts/apply_app_schema.py` repeatable for already-initialized app databases
- fail loudly when the target database has a partial or drifted app schema instead of replaying the dump
- parameterize `deploy/cli-minimal` backend bind/public URL so a local minimal backend can intentionally serve other machines' `cel` clients

## Verification

- `uv run pytest tests/Unit/storage/test_app_schema_applier.py tests/Unit/storage/test_app_schema_discipline.py tests/Unit/backend/test_local_communication_deploy.py -q`
- `uv run ruff check scripts/apply_app_schema.py tests/Unit/storage/test_app_schema_applier.py tests/Unit/backend/test_local_communication_deploy.py`
- `SUPABASE_JWT_SECRET=dev-secret SUPABASE_ANON_KEY=dev-anon LEON_SUPABASE_SERVICE_ROLE_KEY=dev-service docker compose -f deploy/cli-minimal/compose.yml config`
- `MYCEL_BIND_HOST=0.0.0.0 MYCEL_PORT=19042 MYCEL_PUBLIC_URL=http://192.0.2.10:19042 SUPABASE_JWT_SECRET=dev-secret SUPABASE_ANON_KEY=dev-anon LEON_SUPABASE_SERVICE_ROLE_KEY=dev-service docker compose -f deploy/cli-minimal/compose.yml config`
- PGL Ubuntu fresh clone smoke: 47 app-owned tables, second `schema-init` prints `App schema apply passed: 0 SQL files`, Postgres/PostgREST/nginx gateway run, `/rest/v1/` returns PostgREST OpenAPI, project containers/volumes/tmp dir cleaned.
