### PR TITLE
fix: wire cli minimal backend runtime

### DIFF
--- a/deploy/cli-minimal/compose.yml
+++ b/deploy/cli-minimal/compose.yml
@@ -56,7 +56,9 @@ services:
     environment:
       MYCEL_RUNTIME_PROFILE: communication
       LEON_STORAGE_STRATEGY: supabase
+      LEON_SUPABASE_CLIENT_FACTORY: backend.identity.auth.supabase_runtime:create_supabase_client
       LEON_DB_SCHEMA: identity
+      LEON_POSTGRES_URL: postgresql://postgres:postgres@postgres:5432/postgres
       SUPABASE_INTERNAL_URL: http://gateway:8000
       SUPABASE_PUBLIC_URL: ${MYCEL_PUBLIC_URL:-http://127.0.0.1:8042}
       SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:?SUPABASE_ANON_KEY is required}

--- a/tests/Unit/backend/test_local_communication_deploy.py
+++ b/tests/Unit/backend/test_local_communication_deploy.py
@@ -55,9 +55,11 @@ def test_cli_minimal_backend_uses_communication_profile_and_thin_gateway() -> No
     assert backend_ports == ["${MYCEL_BIND_HOST:-127.0.0.1}:${MYCEL_PORT:-8042}:8900"]
     assert backend_env["MYCEL_RUNTIME_PROFILE"] == "communication"
     assert backend_env["LEON_STORAGE_STRATEGY"] == "supabase"
+    assert backend_env["LEON_SUPABASE_CLIENT_FACTORY"] == "backend.identity.auth.supabase_runtime:create_supabase_client"
     assert backend_env["SUPABASE_INTERNAL_URL"] == "http://gateway:8000"
     assert backend_env["SUPABASE_PUBLIC_URL"] == "${MYCEL_PUBLIC_URL:-http://127.0.0.1:8042}"
     assert backend_env["LEON_DB_SCHEMA"] == "identity"
+    assert backend_env["LEON_POSTGRES_URL"] == "postgresql://postgres:postgres@postgres:5432/postgres"
     assert postgrest_env["PGRST_DB_SCHEMAS"] == "identity,chat,agent,container,library,observability"
     assert postgrest_env["PGRST_JWT_SECRET"] == "${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}"
     assert backend_env["SUPABASE_JWT_SECRET"] == "${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET is required}"


### PR DESCRIPTION
## Summary
- wire cli-minimal backend to the existing Supabase runtime client factory
- pass the same Postgres URL to the runtime inbox wake bus
- lock both runtime contracts in the deploy unit test

## YATU
- Started `deploy/cli-minimal/compose.yml` on PGL with `MYCEL_BIND_HOST=0.0.0.0` and `MYCEL_PORT=18042`.
- Before this patch, `mycel-backend` failed startup first on missing `LEON_SUPABASE_CLIENT_FACTORY`, then on missing `LEON_POSTGRES_URL`.
- After applying both env entries, remote backend returned `GET /openapi.json` with HTTP 200 and the expected Mycel Web Backend OpenAPI document.
- Proved a separate local CLI process can connect through an SSH tunnel with `cel connect http://127.0.0.1:18042 --json`.
- Removed the PGL containers, volume, temp clone, and local SSH tunnel after proof.

## Verification
- `uv run pytest tests/Unit/backend/test_local_communication_deploy.py -q`
- `uv run ruff check tests/Unit/backend/test_local_communication_deploy.py`
