### PR TITLE
fix: route frontend openapi probe to backend

### DIFF
--- a/frontend/app/nginx.conf
+++ b/frontend/app/nginx.conf
@@ -9,6 +9,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Public OpenAPI discovery for SDK/CLI clients.
+    location = /openapi.json {
+        proxy_pass http://backend:8900;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     # Proxy API calls to the backend service (docker-compose internal network)
     location /api/ {
         proxy_pass http://backend:8900;

--- a/tests/Unit/frontend/test_nginx_proxy_config.py
+++ b/tests/Unit/frontend/test_nginx_proxy_config.py
@@ -8,3 +8,12 @@ def test_frontend_api_proxy_forwards_websocket_upgrade() -> None:
     assert "proxy_http_version 1.1;" in config
     assert "proxy_set_header Upgrade $http_upgrade;" in config
     assert "proxy_set_header Connection $connection_upgrade;" in config
+
+
+def test_frontend_openapi_probe_is_backend_route_not_spa_fallback() -> None:
+    config = Path("frontend/app/nginx.conf").read_text(encoding="utf-8")
+
+    assert "location = /openapi.json" in config
+    openapi_location = config.split("location = /openapi.json", 1)[1].split("location", 1)[0]
+    assert "proxy_pass http://backend:8900" in openapi_location
+    assert "try_files" not in openapi_location


### PR DESCRIPTION
## Summary
- proxy exact `/openapi.json` from the frontend nginx container to the backend service
- keep SPA fallback from swallowing SDK/CLI backend discovery probes
- add a frontend nginx contract test for the route

## Verification
- uv run pytest tests/Unit/frontend/test_nginx_proxy_config.py -q
- uv run pytest tests/Unit/frontend/test_nginx_proxy_config.py tests/Unit/backend/test_web_app_profiles.py tests/Integration/test_chat_app_router.py tests/Unit/integration_contracts/test_auth_router.py -q

## Notes
- Fresh PyPI YATU for `mycel-cli==0.1.52` proved `cel connect https://mycel.nextmind.space` no longer tracebacks, but it still fails because production `/openapi.json` currently serves the frontend HTML shell.
- Local Docker CLI was unresponsive on this host, so nginx container syntax validation was not used as evidence in this slice.
