### PR TITLE
fix: verify staging openapi route

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -115,25 +115,21 @@ jobs:
           printf '%s' "$body" | jq -e '.docker_compose | contains("LEON_LOCAL_WORKSPACE_ROOT=/root/.leon/workspaces") or contains("LEON_LOCAL_WORKSPACE_ROOT: /root/.leon/workspaces")' >/dev/null
           printf '%s' "$body" | jq -e --arg sha "${{ steps.target.outputs.sha }}" '.docker_compose | contains($sha)' >/dev/null
 
-      - name: Verify staging API contract
+      - name: Verify staging OpenAPI contract
         run: |
           set -euo pipefail
           for attempt in $(seq 1 18); do
-            configs_status="$(curl -sS -o /tmp/staging-sandbox-configs.json -w '%{http_code}' "https://app.staging.mycel.nextmind.space/api/monitor/sandbox-configs")"
-            sandboxes_status="$(curl -sS -o /tmp/staging-sandboxes.json -w '%{http_code}' "https://app.staging.mycel.nextmind.space/api/monitor/sandboxes")"
-            echo "api attempt ${attempt}: sandbox-configs=${configs_status} sandboxes=${sandboxes_status}"
-            if [ "$configs_status" = "200" ] && [ "$sandboxes_status" = "200" ]; then
-              cat /tmp/staging-sandbox-configs.json
-              cat /tmp/staging-sandboxes.json
-              jq -e '.source == "runtime_sandbox_inventory" and (.count | type == "number") and (.providers | type == "array") and all(.providers[]?; has("provider") and has("available") and has("capability"))' /tmp/staging-sandbox-configs.json >/dev/null
-              jq -e '.source == "sandbox_canonical" and (.count | type == "number") and (.items | type == "array") and all(.items[]?; has("sandbox_id") and has("provider") and (has("lease_id") | not))' /tmp/staging-sandboxes.json >/dev/null
+            status="$(curl -sS -o /tmp/staging-openapi.json -w '%{http_code}' "https://app.staging.mycel.nextmind.space/openapi.json")"
+            echo "openapi attempt ${attempt}: status=${status}"
+            if [ "$status" = "200" ]; then
+              cat /tmp/staging-openapi.json
+              jq -e '.openapi and .info.title == "Mycel Web Backend" and (.paths | has("/api/runtime/inbox/wait"))' /tmp/staging-openapi.json >/dev/null
               exit 0
             fi
-            cat /tmp/staging-sandbox-configs.json || true
-            cat /tmp/staging-sandboxes.json || true
+            cat /tmp/staging-openapi.json || true
             sleep 10
           done
-          echo "Staging API contract did not become ready in time"
+          echo "Staging OpenAPI contract did not become ready in time"
           exit 1
 
       - name: Comment on PR with staging URL

--- a/tests/Unit/backend/test_deploy_staging_workflow.py
+++ b/tests/Unit/backend/test_deploy_staging_workflow.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_staging_deploy_verifies_public_openapi_not_private_monitor_routes() -> None:
+    workflow = Path(".github/workflows/deploy-staging.yml").read_text(encoding="utf-8")
+
+    assert "Verify staging OpenAPI contract" in workflow
+    assert "https://app.staging.mycel.nextmind.space/openapi.json" in workflow
+    assert ".openapi" in workflow
+    assert "/api/monitor/sandbox-configs" not in workflow
+    assert "/api/monitor/sandboxes" not in workflow


### PR DESCRIPTION
## Summary
- update staging deploy verification to check the public same-origin OpenAPI route
- stop probing private monitor resource routes without auth
- add a regression test for the staging workflow contract

## Evidence
- `uv run pytest tests/Unit/backend/test_deploy_staging_workflow.py tests/Unit/frontend/test_nginx_proxy_config.py -q` -> 3 passed
- `uv run pytest tests/Unit/backend/test_deploy_staging_workflow.py tests/Unit/frontend/test_nginx_proxy_config.py tests/Unit/backend/test_web_app_profiles.py tests/Integration/test_chat_app_router.py tests/Unit/integration_contracts/test_auth_router.py -q` -> 24 passed
- Previous staging run `25496977063` deployed commit `25c96c6` but failed old monitor probes with repeated `401 Missing or invalid Authorization header`.
- Independent staging probe after that deploy: `https://app.staging.mycel.nextmind.space/openapi.json` returned `Content-Type: application/json` and OpenAPI body.
