### PR TITLE
docs: clarify deploy profile boundary

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,32 @@
+# Mycel Deploy Profiles
+
+This directory is not the whole production deployment system. It contains
+repo-owned compose profiles that are useful as product contracts.
+
+## Profiles
+
+### `cli-minimal`
+
+`deploy/cli-minimal` is the local communication backend for CLI-first users.
+It runs the Mycel business API in `MYCEL_RUNTIME_PROFILE=communication` and
+uses the formal app schema bootstrap path.
+
+It is intentionally small:
+
+- one PostgreSQL database
+- one PostgREST service exposing the Supabase-style storage surface
+- one thin nginx gateway for `/rest/v1/*`
+- one Mycel backend process
+- one `schema-init` one-shot service
+
+It is not a forked schema and it is not the full Mycel platform.
+
+### Full Platform
+
+Full deployment is not currently represented as `deploy/full`. The current full
+runtime path is the root `docker-compose.yml` plus operator-managed Supabase /
+Coolify configuration. Promoting that into `deploy/full` needs a separate
+architecture decision because it would become a public self-hosting contract.
+
+Do not infer from this directory that CLI-minimal is the only supported Mycel
+deployment shape.

--- a/docs/en/deployment.mdx
+++ b/docs/en/deployment.mdx
@@ -76,7 +76,14 @@ ANTHROPIC_API_KEY=sk-ant-xxx
 
 The previous `deploy/local-communication/compose.yml` path has been removed because it booted from a hand-written schema fork. That was useful as a prototype, but it is not a valid self-hosting contract.
 
-For now, use the hosted backend for first-minute CLI onboarding, or run the full development stack below. The next local communication package must reuse the formal Mycel schema/init path instead of maintaining a separate local SQL file.
+`deploy/cli-minimal/compose.yml` is the current CLI-minimal local communication
+profile. It reuses the formal Mycel app schema/init path, runs PostgreSQL plus
+PostgREST, exposes `/rest/v1/*` through a thin nginx gateway, and starts the
+backend with `MYCEL_RUNTIME_PROFILE=communication`.
+
+It is not the full Mycel platform. Full deployment is still represented by the
+root `docker-compose.yml` plus operator-managed Supabase/Coolify configuration,
+not by a `deploy/full` public self-hosting contract.
 
 ### Full development stack
 

--- a/docs/zh/deployment.mdx
+++ b/docs/zh/deployment.mdx
@@ -76,7 +76,9 @@ ANTHROPIC_API_KEY=sk-ant-xxx
 
 之前的 `deploy/local-communication/compose.yml` 路径已经移除，因为它从手写 schema fork 启动。那条路径可以证明 prototype 能跑，但不能作为自部署契约。
 
-目前第一分钟 CLI onboarding 使用 hosted backend；本地开发使用下面的完整开发栈。下一版本地通信包必须复用 Mycel 正式 schema/init path，不能维护单独的 local SQL 文件。
+`deploy/cli-minimal/compose.yml` 是当前的 CLI-minimal 本地通信 profile。它复用正式 Mycel app schema/init path，运行 PostgreSQL + PostgREST，通过很薄的 nginx gateway 暴露 `/rest/v1/*`，并用 `MYCEL_RUNTIME_PROFILE=communication` 启动后端。
+
+它不是完整 Mycel 平台。完整部署目前仍由根目录 `docker-compose.yml` 加 operator 管理的 Supabase/Coolify 配置表示，还没有被提升为 `deploy/full` 这个公开自部署契约。
 
 ### 完整开发栈
 

--- a/tests/Unit/backend/test_local_communication_deploy.py
+++ b/tests/Unit/backend/test_local_communication_deploy.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = ROOT / "storage/schema/local_communication.sql"
 CLI_MINIMAL_COMPOSE = ROOT / "deploy/cli-minimal/compose.yml"
 CLI_MINIMAL_GATEWAY_CONF = ROOT / "deploy/cli-minimal/rest-gateway.conf"
+DEPLOY_README = ROOT / "deploy/README.md"
 
 
 def _compose_files() -> list[Path]:
@@ -76,3 +77,12 @@ def test_cli_minimal_gateway_is_nginx_rest_only_not_supabase_bundle() -> None:
     assert "/rest/v1/" in gateway_conf
     assert "/auth/v1/" not in gateway_conf
     assert not {"gotrue", "studio", "realtime", "storage", "analytics", "kong"} & set(services)
+
+
+def test_deploy_readme_names_cli_minimal_boundary_and_full_deploy_absence() -> None:
+    text = DEPLOY_README.read_text(encoding="utf-8")
+
+    assert "`deploy/cli-minimal` is the local communication backend" in text
+    assert "It is not a forked schema and it is not the full Mycel platform." in text
+    assert "Full deployment is not currently represented as `deploy/full`" in text
+    assert "root `docker-compose.yml` plus operator-managed Supabase" in text


### PR DESCRIPTION
## Summary

- add `deploy/README.md` so `deploy/cli-minimal` is explicitly framed as the CLI-first communication profile, not the full Mycel deployment system
- update EN/ZH deployment docs now that `deploy/cli-minimal` exists and no longer uses a handwritten schema fork
- add a contract test that keeps the deploy boundary explicit

## Verification

- `uv run pytest tests/Unit/backend/test_local_communication_deploy.py -q`
- `uv run ruff check tests/Unit/backend/test_local_communication_deploy.py`
- `git diff --check`
