### PR TITLE
Add chat workflow state version guard

### DIFF
--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -14,6 +14,7 @@ from backend.chat.api.http.dependencies import (
     get_current_user_id,
     get_messaging_service,
 )
+from storage.errors import StaleChatWorkflowVersionError
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
@@ -24,6 +25,7 @@ class SetChatWorkflowBody(BaseModel):
     kind: str
     state: str = "active"
     config: dict[str, Any] = Field(default_factory=dict)
+    expected_state_version: int | None = Field(default=None, ge=0)
 
 
 class CreateChatTaskBody(BaseModel):
@@ -100,13 +102,25 @@ def set_chat_workflow(
     chat_workflow_service: Annotated[Any, Depends(get_chat_workflow_service)],
 ):
     get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
-    return chat_workflow_service.set_workflow(
-        chat_id,
-        kind=body.kind,
-        state=body.state,
-        config=body.config,
-        updated_by_user_id=user_id,
-    )
+    try:
+        return chat_workflow_service.set_workflow(
+            chat_id,
+            kind=body.kind,
+            state=body.state,
+            config=body.config,
+            updated_by_user_id=user_id,
+            expected_state_version=body.expected_state_version,
+        )
+    except StaleChatWorkflowVersionError as exc:
+        raise HTTPException(
+            409,
+            {
+                "error": "stale_chat_workflow_state_version",
+                "chat_id": exc.chat_id,
+                "expected_state_version": exc.expected_state_version,
+                "actual_state_version": exc.actual_state_version,
+            },
+        ) from exc
 
 
 @router.delete("/{chat_id}/workflow")

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -23,6 +23,7 @@ class ChatWorkflowService:
         state: str = "active",
         config: dict[str, Any] | None = None,
         updated_by_user_id: str | None = None,
+        expected_state_version: int | None = None,
     ) -> dict[str, Any]:
         return _workflow_response(
             self._repo.upsert(
@@ -31,6 +32,7 @@ class ChatWorkflowService:
                 state=state,
                 config=config or {},
                 updated_by_user_id=updated_by_user_id,
+                expected_state_version=expected_state_version,
             )
         )
 
@@ -195,6 +197,7 @@ def _workflow_response(row: Any) -> dict[str, Any]:
         "kind": row.kind,
         "state": row.state,
         "config": dict(row.config),
+        "state_version": row.state_version,
         "updated_by_user_id": row.updated_by_user_id,
         "created_at": row.created_at,
         "updated_at": row.updated_at,

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -283,6 +283,7 @@ class ChatWorkflowRow(BaseModel):
     kind: str
     state: str = "active"
     config: dict[str, Any] = Field(default_factory=dict)
+    state_version: int = 0
     updated_by_user_id: str | None = None
     created_at: float
     updated_at: float | None = None
@@ -292,6 +293,13 @@ class ChatWorkflowRow(BaseModel):
     def _validate_chat_workflow_identity_fields(cls, value: str, info: Any) -> str:
         if not value.strip():
             raise ValueError(f"chat_workflow.{info.field_name} must not be blank")
+        return value
+
+    @field_validator("state_version")
+    @classmethod
+    def _validate_chat_workflow_state_version(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("chat_workflow.state_version must be non-negative")
         return value
 
 
@@ -525,6 +533,7 @@ class ChatWorkflowRepo(Protocol):
         state: str,
         config: dict[str, Any],
         updated_by_user_id: str | None = None,
+        expected_state_version: int | None = None,
     ) -> ChatWorkflowRow: ...
     def delete(self, chat_id: str) -> None: ...
 

--- a/storage/errors.py
+++ b/storage/errors.py
@@ -3,3 +3,19 @@ from __future__ import annotations
 
 class StorageConflictError(RuntimeError):
     pass
+
+
+class StaleChatWorkflowVersionError(StorageConflictError):
+    def __init__(
+        self,
+        *,
+        chat_id: str,
+        expected_state_version: int,
+        actual_state_version: int | None,
+    ) -> None:
+        self.chat_id = chat_id
+        self.expected_state_version = expected_state_version
+        self.actual_state_version = actual_state_version
+        super().__init__(
+            f"stale chat workflow state version: chat_id={chat_id!r} expected={expected_state_version!r} actual={actual_state_version!r}"
+        )

--- a/storage/providers/supabase/chat_workflow_repo.py
+++ b/storage/providers/supabase/chat_workflow_repo.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
+from storage.errors import StaleChatWorkflowVersionError
 from storage.providers.supabase import _query as q
 
 _SCHEMA = "chat"
@@ -32,23 +33,50 @@ class SupabaseChatWorkflowRepo:
         state: str = "active",
         config: dict[str, Any] | None = None,
         updated_by_user_id: str | None = None,
+        expected_state_version: int | None = None,
     ) -> ChatWorkflowRow:
         now = time.time()
         existing = self.get(chat_id)
+        actual_state_version = existing.state_version if existing is not None else None
+        if expected_state_version is not None and actual_state_version != expected_state_version:
+            raise StaleChatWorkflowVersionError(
+                chat_id=chat_id,
+                expected_state_version=expected_state_version,
+                actual_state_version=actual_state_version,
+            )
+        next_state_version = 0 if existing is None else existing.state_version + 1
         payload = {
             "chat_id": chat_id,
             "kind": kind,
             "state": state,
             "config_json": config or {},
+            "state_version": next_state_version,
             "updated_by_user_id": updated_by_user_id,
             "created_at": existing.created_at if existing else now,
             "updated_at": now,
         }
-        rows = q.rows(
-            self._t().upsert(payload, on_conflict="chat_id").execute(),
-            _WORKFLOW_REPO,
-            "upsert",
-        )
+        if expected_state_version is None:
+            rows = q.rows(
+                self._t().upsert(payload, on_conflict="chat_id").execute(),
+                _WORKFLOW_REPO,
+                "upsert",
+            )
+        else:
+            update_payload = dict(payload)
+            update_payload.pop("chat_id", None)
+            update_payload.pop("created_at", None)
+            rows = q.rows(
+                self._t().update(update_payload).eq("chat_id", chat_id).eq("state_version", expected_state_version).execute(),
+                _WORKFLOW_REPO,
+                "upsert",
+            )
+            if not rows:
+                current = self.get(chat_id)
+                raise StaleChatWorkflowVersionError(
+                    chat_id=chat_id,
+                    expected_state_version=expected_state_version,
+                    actual_state_version=current.state_version if current is not None else None,
+                )
         return _row_to_workflow(rows[0] if rows else payload)
 
     def delete(self, chat_id: str) -> None:
@@ -164,6 +192,7 @@ def _row_to_workflow(row: dict[str, Any]) -> ChatWorkflowRow:
         kind=str(row["kind"]),
         state=str(row.get("state") or "active"),
         config=dict(row.get("config_json") or row.get("config") or {}),
+        state_version=int(row.get("state_version") or 0),
         updated_by_user_id=row.get("updated_by_user_id"),
         created_at=float(row["created_at"]),
         updated_at=float(row["updated_at"]) if row.get("updated_at") is not None else None,

--- a/storage/schema/app_schema.sql
+++ b/storage/schema/app_schema.sql
@@ -902,6 +902,7 @@ CREATE TABLE chat.workflow_state (
     kind text NOT NULL,
     state text DEFAULT 'active'::text NOT NULL,
     config_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    state_version integer DEFAULT 0 NOT NULL,
     updated_by_user_id text,
     created_at double precision NOT NULL,
     updated_at double precision

--- a/storage/schema/chat_workflow_state_and_tasks.sql
+++ b/storage/schema/chat_workflow_state_and_tasks.sql
@@ -3,10 +3,14 @@ create table if not exists chat.workflow_state (
     kind                text not null,
     state               text not null default 'active',
     config_json         jsonb not null default '{}'::jsonb,
+    state_version       integer not null default 0,
     updated_by_user_id  text references identity.users(id) on delete set null,
     created_at          double precision not null,
     updated_at          double precision
 );
+
+alter table if exists chat.workflow_state
+    add column if not exists state_version integer not null default 0;
 
 create table if not exists chat.tasks (
     chat_id          text not null references chat.chats(id) on delete cascade,

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -9,6 +9,7 @@ from core.work_item.chat_workflow.service import (
 )
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
+from storage.errors import StaleChatWorkflowVersionError
 
 
 class _WorkflowRepo:
@@ -26,7 +27,16 @@ class _WorkflowRepo:
         state: str,
         config: dict[str, Any],
         updated_by_user_id: str | None = None,
+        expected_state_version: int | None = None,
     ) -> ChatWorkflowRow:
+        existing = self.rows.get(chat_id)
+        existing_version = int(getattr(existing, "state_version", 0)) if existing is not None else None
+        if expected_state_version is not None and existing_version != expected_state_version:
+            raise StaleChatWorkflowVersionError(
+                chat_id=chat_id,
+                expected_state_version=expected_state_version,
+                actual_state_version=existing_version,
+            )
         row = ChatWorkflowRow(
             chat_id=chat_id,
             kind=kind,
@@ -35,6 +45,7 @@ class _WorkflowRepo:
             updated_by_user_id=updated_by_user_id,
             created_at=1.0,
             updated_at=2.0,
+            state_version=0 if existing is None else existing_version + 1,
         )
         self.rows[chat_id] = row
         return row
@@ -105,6 +116,44 @@ def test_chat_workflow_service_projects_explicit_chat_scope() -> None:
     assert created["config"] == {"reviewer": "reviewer-user"}
     assert service.get_workflow("chat-1") == created
     assert service.get_workflow("chat-2") is None
+
+
+def test_chat_workflow_service_versions_config_writes_and_rejects_stale_updates() -> None:
+    repo = _WorkflowRepo()
+    service = ChatWorkflowService(repo)
+
+    created = service.set_workflow(
+        "chat-1",
+        kind="cel-group",
+        state="active",
+        config={"participants": []},
+    )
+    updated = service.set_workflow(
+        "chat-1",
+        kind="cel-group",
+        state="active",
+        config={"participants": [{"handle": "worker-a"}]},
+        expected_state_version=created["state_version"],
+    )
+
+    assert created["state_version"] == 0
+    assert updated["state_version"] == 1
+    try:
+        service.set_workflow(
+            "chat-1",
+            kind="cel-group",
+            state="active",
+            config={"participants": [{"handle": "worker-b"}]},
+            expected_state_version=created["state_version"],
+        )
+    except StaleChatWorkflowVersionError as exc:
+        assert exc.chat_id == "chat-1"
+        assert exc.expected_state_version == 0
+        assert exc.actual_state_version == 1
+    else:
+        raise AssertionError("stale workflow config write did not fail")
+
+    assert service.get_workflow("chat-1") == updated
 
 
 def test_chat_task_service_keeps_tasks_scoped_to_chat_id() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -12,6 +12,7 @@ from backend.chat.api.http import chat_workflow_router, chats_router, relationsh
 from backend.identity.avatar.urls import avatar_url
 from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow
+from storage.errors import StaleChatWorkflowVersionError
 
 
 def _chat(chat_id: str) -> SimpleNamespace:
@@ -334,6 +335,137 @@ def test_chat_workflow_routes_use_chat_access_helper(monkeypatch: pytest.MonkeyP
     assert seen == [
         ("helper", (chat_repo, messaging_service, "chat-1", "user-1")),
         ("get_workflow", "chat-1"),
+    ]
+
+
+def test_set_chat_workflow_returns_conflict_for_stale_state_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    chat_repo = SimpleNamespace(name="chat-repo")
+    messaging_service = SimpleNamespace(name="messaging")
+
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    def set_workflow(_chat_id: str, **_kwargs):
+        raise StaleChatWorkflowVersionError(
+            chat_id="chat-1",
+            expected_state_version=0,
+            actual_state_version=1,
+        )
+
+    with pytest.raises(HTTPException) as exc:
+        chat_workflow_router.set_chat_workflow(
+            "chat-1",
+            chat_workflow_router.SetChatWorkflowBody(
+                kind="cel-group",
+                config={"participants": []},
+                expected_state_version=0,
+            ),
+            user_id="user-1",
+            chat_repo=chat_repo,
+            messaging_service=messaging_service,
+            chat_workflow_service=SimpleNamespace(set_workflow=set_workflow),
+        )
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == {
+        "error": "stale_chat_workflow_state_version",
+        "chat_id": "chat-1",
+        "expected_state_version": 0,
+        "actual_state_version": 1,
+    }
+
+
+def test_chat_workflow_http_put_carries_expected_version_and_returns_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def set_workflow(chat_id: str, **kwargs):
+        calls.append({"chat_id": chat_id, **kwargs})
+        raise StaleChatWorkflowVersionError(
+            chat_id=chat_id,
+            expected_state_version=2,
+            actual_state_version=3,
+        )
+
+    app = FastAPI()
+    app.include_router(chat_workflow_router.router)
+    app.dependency_overrides[chat_workflow_router.get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[chat_workflow_router.get_chat_repo] = lambda: SimpleNamespace(name="chat-repo")
+    app.dependency_overrides[chat_workflow_router.get_messaging_service] = lambda: SimpleNamespace(name="messaging")
+    app.dependency_overrides[chat_workflow_router.get_chat_workflow_service] = lambda: SimpleNamespace(set_workflow=set_workflow)
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    try:
+        with TestClient(app) as client:
+            response = client.put(
+                "/api/chats/chat-1/workflow",
+                json={
+                    "kind": "cel-group",
+                    "state": "active",
+                    "config": {"participants": []},
+                    "expected_state_version": 2,
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error": "stale_chat_workflow_state_version",
+        "chat_id": "chat-1",
+        "expected_state_version": 2,
+        "actual_state_version": 3,
+    }
+    assert calls == [
+        {
+            "chat_id": "chat-1",
+            "kind": "cel-group",
+            "state": "active",
+            "config": {"participants": []},
+            "updated_by_user_id": "user-1",
+            "expected_state_version": 2,
+        }
+    ]
+
+
+def test_chat_workflow_http_put_omits_expected_version_when_not_supplied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def set_workflow(chat_id: str, **kwargs):
+        calls.append({"chat_id": chat_id, **kwargs})
+        return {"chat_id": chat_id, "kind": kwargs["kind"], "state": kwargs["state"]}
+
+    app = FastAPI()
+    app.include_router(chat_workflow_router.router)
+    app.dependency_overrides[chat_workflow_router.get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[chat_workflow_router.get_chat_repo] = lambda: SimpleNamespace(name="chat-repo")
+    app.dependency_overrides[chat_workflow_router.get_messaging_service] = lambda: SimpleNamespace(name="messaging")
+    app.dependency_overrides[chat_workflow_router.get_chat_workflow_service] = lambda: SimpleNamespace(set_workflow=set_workflow)
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    try:
+        with TestClient(app) as client:
+            response = client.put(
+                "/api/chats/chat-1/workflow",
+                json={
+                    "kind": "cel-group",
+                    "state": "active",
+                    "config": {"participants": []},
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert calls == [
+        {
+            "chat_id": "chat-1",
+            "kind": "cel-group",
+            "state": "active",
+            "config": {"participants": []},
+            "updated_by_user_id": "user-1",
+            "expected_state_version": None,
+        }
     ]
 
 

--- a/tests/Unit/storage/test_app_schema_applier.py
+++ b/tests/Unit/storage/test_app_schema_applier.py
@@ -39,6 +39,12 @@ def test_applier_uses_manifest_order() -> None:
     ]
 
 
+def test_chat_workflow_state_version_patch_updates_existing_tables() -> None:
+    sql = (ROOT / "storage/schema/chat_workflow_state_and_tasks.sql").read_text(encoding="utf-8")
+
+    assert "add column if not exists state_version" in sql
+
+
 def test_applier_print_files_is_connection_free() -> None:
     result = subprocess.run(
         [sys.executable, str(APPLIER_PATH), "--print-files"],

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -6,7 +6,7 @@ import pytest
 
 from core.work_item.types import WorkItem
 from storage.contracts import ChatRow, ChatWorkflowEventRow, ContactEdgeRow
-from storage.errors import StorageConflictError
+from storage.errors import StaleChatWorkflowVersionError, StorageConflictError
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
 from storage.providers.supabase.chat_workflow_repo import (
     SupabaseChatTaskRepo,
@@ -81,6 +81,47 @@ def test_supabase_chat_workflow_repo_uses_chat_schema_sibling_table() -> None:
     assert workflow.config == {"reviewer": "reviewer-user"}
     assert tables["chat.workflow_state"][0]["chat_id"] == "chat-1"
     assert "workflow_state" not in tables
+
+
+def test_supabase_chat_workflow_repo_rejects_stale_state_version() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.workflow_state": [
+            {
+                "chat_id": "chat-1",
+                "kind": "cel-group",
+                "state": "active",
+                "config_json": {"participants": []},
+                "state_version": 0,
+                "created_at": 1.0,
+                "updated_at": 1.0,
+            }
+        ]
+    }
+    repo = SupabaseChatWorkflowRepo(FakeSupabaseClient(tables=tables))
+
+    updated = repo.upsert(
+        "chat-1",
+        kind="cel-group",
+        state="active",
+        config={"participants": [{"handle": "worker-a"}]},
+        expected_state_version=0,
+    )
+    assert updated.state_version == 1
+    assert tables["chat.workflow_state"][0]["config_json"] == {"participants": [{"handle": "worker-a"}]}
+
+    with pytest.raises(StaleChatWorkflowVersionError) as exc:
+        repo.upsert(
+            "chat-1",
+            kind="cel-group",
+            state="active",
+            config={"participants": [{"handle": "worker-b"}]},
+            expected_state_version=0,
+        )
+
+    assert exc.value.chat_id == "chat-1"
+    assert exc.value.expected_state_version == 0
+    assert exc.value.actual_state_version == 1
+    assert tables["chat.workflow_state"][0]["config_json"] == {"participants": [{"handle": "worker-a"}]}
 
 
 def test_supabase_chat_task_repo_uses_work_item_shape_in_chat_schema() -> None:

--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -27,3 +27,4 @@ maintained prompts.
 ## Multi-Agent Workflows
 
 - `multi-agent-natural-language-workflows.md`
+- `distributed-group-workflow.md`

--- a/tests/yatu/distributed-group-workflow.md
+++ b/tests/yatu/distributed-group-workflow.md
@@ -1,0 +1,66 @@
+# Distributed Group Workflow YATU
+
+## User Story
+
+A user wants to prove that Mycel group workflow is a thin workflow layer over
+chat, not a separate local collaboration system. A supervisor and worker may run
+on different machines, but they still share one backend chat, workflow state,
+task store, and message history.
+
+## Entry Surfaces
+
+- Real backend process from the current branch.
+- Installed `cel` CLI or SDK against that backend.
+- Public HTTP API through SDK/CLI, not in-process service calls.
+
+Do not inspect storage directly as proof. Direct DB checks are allowed only as
+debugging after the user-facing proof fails.
+
+Group workflow commands manage workflow state. Agent-to-agent communication
+must still happen through top-level `cel send-message` and `cel read-message`.
+
+## Setup
+
+1. Start the current-branch backend with the real schema, including
+   `chat.workflow_state.state_version`.
+2. Use a fresh `MYCEL_HOME`.
+3. Create a guest owner or login as an owner.
+4. Create at least two external identities.
+5. Start local `cel self start` only where terminal/runtime wake is part of the
+   test.
+
+## User Loop
+
+1. Create a group through `cel group create`.
+2. Create at least one task through `cel group <group_id> task create <subject>`.
+3. Send supervisor-to-worker and worker-to-supervisor messages through
+   top-level `cel send-message`, not through a group-specific send helper.
+4. Read messages through top-level `cel read-message`.
+5. Delete one machine's local group file.
+6. Confirm `cel group show`, `cel group <group_id> task list`, and
+   `cel group <group_id> task show <task_id>` still reconstruct from backend
+   workflow/task truth.
+7. Run a stale workflow-write probe from two clients and confirm the backend
+   rejects or resolves the race without silent overwrite.
+
+## Pass Bar
+
+- `group_id` is a backend chat id.
+- Workflow config writes carry an explicit version when they depend on current
+  backend state.
+- Stale workflow writes produce HTTP 409 or a successful bounded retry that
+  preserves both participants.
+- Chat messages and read cursors remain regular chat behavior.
+- Guest users can create external users but cannot access sandbox resources.
+- Worker stop may forward the worker's real output as chat; worker silent/idle
+  detection is a local health observation and must not create a chat message.
+- No local-only schema, copied group JSON, or DB-side special case is required.
+
+## Pitfalls
+
+- A helper-level service test is not YATU.
+- A local-only group file passing the test is not proof of distributed workflow.
+- A separate group message channel fails the architecture even if the demo
+  appears to work.
+- A silent 422/409 swallowed by CLI output fails the card; errors must explain
+  the backend contract mismatch.


### PR DESCRIPTION
## Summary

- add `state_version` to chat workflow state and expose it through the workflow API
- reject stale workflow config writes with HTTP 409 instead of silently overwriting concurrent updates
- add the distributed group workflow YATU card and schema patch guard for existing workflow_state tables

## Verification

- `uv run pytest -q tests/Unit/storage/test_app_schema_applier.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
- `uv run ruff check scripts/apply_app_schema.py tests/Unit/storage/test_app_schema_applier.py backend/chat/api/http/chat_workflow_router.py core/work_item/chat_workflow/service.py storage/contracts.py storage/errors.py storage/providers/supabase/chat_workflow_repo.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
- `uv run ruff format --check scripts/apply_app_schema.py tests/Unit/storage/test_app_schema_applier.py backend/chat/api/http/chat_workflow_router.py core/work_item/chat_workflow/service.py storage/contracts.py storage/errors.py storage/providers/supabase/chat_workflow_repo.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py`
