### PR TITLE
Add workflow event state version guards

### DIFF
--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -14,7 +14,10 @@ from backend.chat.api.http.dependencies import (
     get_current_user_id,
     get_messaging_service,
 )
-from storage.errors import StaleChatWorkflowVersionError
+from storage.errors import (
+    StaleChatWorkflowEventVersionError,
+    StaleChatWorkflowVersionError,
+)
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
@@ -75,6 +78,7 @@ class UpdateChatWorkflowEventBody(BaseModel):
     final_state: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None
     settled_at: float | None = None
+    expected_state_version: int | None = Field(default=None, ge=0)
 
 
 @router.get("/{chat_id}/workflow")
@@ -197,16 +201,29 @@ def update_chat_workflow_event(
     chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
 ):
     get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
-    event = chat_workflow_event_service.update_event(
-        chat_id,
-        event_id,
-        state=body.state,
-        decision_states=body.decision_states,
-        rationales=body.rationales,
-        final_state=body.final_state,
-        metadata=body.metadata,
-        settled_at=body.settled_at,
-    )
+    try:
+        event = chat_workflow_event_service.update_event(
+            chat_id,
+            event_id,
+            state=body.state,
+            decision_states=body.decision_states,
+            rationales=body.rationales,
+            final_state=body.final_state,
+            metadata=body.metadata,
+            settled_at=body.settled_at,
+            expected_state_version=body.expected_state_version,
+        )
+    except StaleChatWorkflowEventVersionError as exc:
+        raise HTTPException(
+            409,
+            {
+                "error": "stale_chat_workflow_event_state_version",
+                "chat_id": exc.chat_id,
+                "event_id": exc.event_id,
+                "expected_state_version": exc.expected_state_version,
+                "actual_state_version": exc.actual_state_version,
+            },
+        ) from exc
     if event is None:
         raise HTTPException(404, "Chat workflow event not found")
     return event

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -168,10 +168,12 @@ class ChatWorkflowEventService:
         final_state: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
         settled_at: float | None = None,
+        expected_state_version: int | None = None,
     ) -> dict[str, Any] | None:
         event = self._repo.get(chat_id, event_id)
         if event is None:
             return None
+        event = event.model_copy(deep=True)
         if state is not None:
             event.state = state
         if decision_states is not None:
@@ -184,8 +186,8 @@ class ChatWorkflowEventService:
             event.metadata = dict(metadata)
         if settled_at is not None:
             event.settled_at = settled_at
-        self._repo.update(chat_id, event)
-        return _event_response(event)
+        updated = self._repo.update(chat_id, event, expected_state_version=expected_state_version)
+        return _event_response(updated)
 
     def delete_event(self, chat_id: str, event_id: str) -> None:
         self._repo.delete(chat_id, event_id)
@@ -222,6 +224,7 @@ def _event_response(event: ChatWorkflowEventRow) -> dict[str, Any]:
         "rationales": dict(event.rationales),
         "final_state": dict(event.final_state),
         "metadata": dict(event.metadata),
+        "state_version": event.state_version,
         "created_at": event.created_at,
         "updated_at": event.updated_at,
         "settled_at": event.settled_at,

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -314,6 +314,7 @@ class ChatWorkflowEventRow(BaseModel):
     rationales: dict[str, Any] = Field(default_factory=dict)
     final_state: dict[str, Any] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    state_version: int = 0
     created_at: float
     updated_at: float | None = None
     settled_at: float | None = None
@@ -323,6 +324,13 @@ class ChatWorkflowEventRow(BaseModel):
     def _validate_chat_workflow_event_identity_fields(cls, value: str, info: Any) -> str:
         if not value.strip():
             raise ValueError(f"chat_workflow_event.{info.field_name} must not be blank")
+        return value
+
+    @field_validator("state_version")
+    @classmethod
+    def _validate_chat_workflow_event_state_version(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("chat_workflow_event.state_version must be non-negative")
         return value
 
 
@@ -548,7 +556,13 @@ class ChatWorkflowEventRepo(Protocol):
     def get(self, scope_id: str, event_id: str) -> ChatWorkflowEventRow | None: ...
     def list_all(self, scope_id: str) -> list[ChatWorkflowEventRow]: ...
     def insert(self, scope_id: str, event: ChatWorkflowEventRow) -> None: ...
-    def update(self, scope_id: str, event: ChatWorkflowEventRow) -> None: ...
+    def update(
+        self,
+        scope_id: str,
+        event: ChatWorkflowEventRow,
+        *,
+        expected_state_version: int | None = None,
+    ) -> ChatWorkflowEventRow: ...
     def delete(self, scope_id: str, event_id: str) -> None: ...
 
 

--- a/storage/errors.py
+++ b/storage/errors.py
@@ -19,3 +19,22 @@ class StaleChatWorkflowVersionError(StorageConflictError):
         super().__init__(
             f"stale chat workflow state version: chat_id={chat_id!r} expected={expected_state_version!r} actual={actual_state_version!r}"
         )
+
+
+class StaleChatWorkflowEventVersionError(StorageConflictError):
+    def __init__(
+        self,
+        *,
+        chat_id: str,
+        event_id: str,
+        expected_state_version: int,
+        actual_state_version: int | None,
+    ) -> None:
+        self.chat_id = chat_id
+        self.event_id = event_id
+        self.expected_state_version = expected_state_version
+        self.actual_state_version = actual_state_version
+        super().__init__(
+            f"stale chat workflow event state version: chat_id={chat_id!r} event_id={event_id!r} "
+            f"expected={expected_state_version!r} actual={actual_state_version!r}"
+        )

--- a/storage/providers/supabase/chat_workflow_repo.py
+++ b/storage/providers/supabase/chat_workflow_repo.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
-from storage.errors import StaleChatWorkflowVersionError
+from storage.errors import (
+    StaleChatWorkflowEventVersionError,
+    StaleChatWorkflowVersionError,
+)
 from storage.providers.supabase import _query as q
 
 _SCHEMA = "chat"
@@ -174,10 +177,39 @@ class SupabaseChatWorkflowEventRepo:
     def insert(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
         self._t().insert(_workflow_event_payload(scope_id, event)).execute()
 
-    def update(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
+    def update(
+        self,
+        scope_id: str,
+        event: ChatWorkflowEventRow,
+        *,
+        expected_state_version: int | None = None,
+    ) -> ChatWorkflowEventRow:
+        existing = self.get(scope_id, event.event_id)
+        actual_state_version = existing.state_version if existing is not None else None
+        if expected_state_version is not None and actual_state_version != expected_state_version:
+            raise StaleChatWorkflowEventVersionError(
+                chat_id=scope_id,
+                event_id=event.event_id,
+                expected_state_version=expected_state_version,
+                actual_state_version=actual_state_version,
+            )
+        next_state_version = 0 if existing is None else existing.state_version + 1
         payload = _workflow_event_payload(scope_id, event)
         payload.pop("created_at", None)
-        self._t().update(payload).eq("chat_id", scope_id).eq("event_id", event.event_id).execute()
+        payload["state_version"] = next_state_version
+        query = self._t().update(payload).eq("chat_id", scope_id).eq("event_id", event.event_id)
+        if expected_state_version is not None:
+            query = query.eq("state_version", expected_state_version)
+        rows = q.rows(query.execute(), _EVENT_REPO, "update")
+        if expected_state_version is not None and not rows:
+            current = self.get(scope_id, event.event_id)
+            raise StaleChatWorkflowEventVersionError(
+                chat_id=scope_id,
+                event_id=event.event_id,
+                expected_state_version=expected_state_version,
+                actual_state_version=current.state_version if current is not None else None,
+            )
+        return _row_to_workflow_event(rows[0] if rows else payload)
 
     def delete(self, scope_id: str, event_id: str) -> None:
         self._t().delete().eq("chat_id", scope_id).eq("event_id", event_id).execute()
@@ -225,6 +257,7 @@ def _row_to_workflow_event(row: dict[str, Any]) -> ChatWorkflowEventRow:
         rationales=dict(row.get("rationales_json") or row.get("rationales") or {}),
         final_state=dict(row.get("final_state_json") or row.get("final_state") or {}),
         metadata=dict(row.get("metadata_json") or row.get("metadata") or {}),
+        state_version=int(row.get("state_version") or 0),
         created_at=float(row["created_at"]),
         updated_at=float(row["updated_at"]) if row.get("updated_at") is not None else None,
         settled_at=float(row["settled_at"]) if row.get("settled_at") is not None else None,
@@ -263,6 +296,7 @@ def _workflow_event_payload(scope_id: str, event: ChatWorkflowEventRow) -> dict[
         "rationales_json": dict(event.rationales),
         "final_state_json": dict(event.final_state),
         "metadata_json": dict(event.metadata),
+        "state_version": event.state_version,
         "created_at": event.created_at,
         "updated_at": now,
         "settled_at": event.settled_at,

--- a/storage/schema/chat_workflow_state_and_tasks.sql
+++ b/storage/schema/chat_workflow_state_and_tasks.sql
@@ -39,11 +39,15 @@ create table if not exists chat.workflow_events (
     rationales_json         jsonb not null default '{}'::jsonb,
     final_state_json        jsonb not null default '{}'::jsonb,
     metadata_json           jsonb not null default '{}'::jsonb,
+    state_version           integer not null default 0,
     created_at              double precision not null,
     updated_at              double precision,
     settled_at              double precision,
     primary key (chat_id, event_id)
 );
+
+alter table if exists chat.workflow_events
+    add column if not exists state_version integer not null default 0;
 
 create index if not exists idx_chat_tasks_owner_user_id
     on chat.tasks(owner_user_id)

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -9,7 +9,10 @@ from core.work_item.chat_workflow.service import (
 )
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
-from storage.errors import StaleChatWorkflowVersionError
+from storage.errors import (
+    StaleChatWorkflowEventVersionError,
+    StaleChatWorkflowVersionError,
+)
 
 
 class _WorkflowRepo:
@@ -93,8 +96,25 @@ class _WorkflowEventRepo:
     def insert(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
         self.rows.setdefault(scope_id, {})[event.event_id] = event
 
-    def update(self, scope_id: str, event: ChatWorkflowEventRow) -> None:
-        self.rows.setdefault(scope_id, {})[event.event_id] = event
+    def update(
+        self,
+        scope_id: str,
+        event: ChatWorkflowEventRow,
+        *,
+        expected_state_version: int | None = None,
+    ) -> ChatWorkflowEventRow:
+        existing = self.rows.get(scope_id, {}).get(event.event_id)
+        existing_version = int(getattr(existing, "state_version", 0)) if existing is not None else None
+        if expected_state_version is not None and existing_version != expected_state_version:
+            raise StaleChatWorkflowEventVersionError(
+                chat_id=scope_id,
+                event_id=event.event_id,
+                expected_state_version=expected_state_version,
+                actual_state_version=existing_version,
+            )
+        updated = event.model_copy(update={"state_version": 0 if existing is None else existing_version + 1})
+        self.rows.setdefault(scope_id, {})[event.event_id] = updated
+        return updated
 
     def delete(self, scope_id: str, event_id: str) -> None:
         self.rows.get(scope_id, {}).pop(event_id, None)
@@ -226,3 +246,36 @@ def test_chat_workflow_event_service_keeps_events_scoped_to_chat_id() -> None:
     assert updated["decision_states"] == {"reviewer-user": {"1": "pending"}}
     assert updated["final_state"] == {"1": "pending"}
     assert updated["settled_at"] == 42.0
+
+
+def test_chat_workflow_event_service_versions_updates_and_rejects_stale_writes() -> None:
+    repo = _WorkflowEventRepo()
+    service = ChatWorkflowEventService(repo)
+
+    event = service.create_event("chat-1", kind="task_proposed_review")
+    updated = service.update_event(
+        "chat-1",
+        event["event_id"],
+        decision_states={"reviewer-a": {"1": "completed"}},
+        expected_state_version=event["state_version"],
+    )
+
+    assert event["state_version"] == 0
+    assert updated is not None
+    assert updated["state_version"] == 1
+    try:
+        service.update_event(
+            "chat-1",
+            event["event_id"],
+            decision_states={"reviewer-b": {"1": "pending"}},
+            expected_state_version=event["state_version"],
+        )
+    except StaleChatWorkflowEventVersionError as exc:
+        assert exc.chat_id == "chat-1"
+        assert exc.event_id == event["event_id"]
+        assert exc.expected_state_version == 0
+        assert exc.actual_state_version == 1
+    else:
+        raise AssertionError("stale workflow event write did not fail")
+
+    assert service.get_event("chat-1", event["event_id"]) == updated

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -12,7 +12,10 @@ from backend.chat.api.http import chat_workflow_router, chats_router, relationsh
 from backend.identity.avatar.urls import avatar_url
 from backend.web.core.dependencies import get_current_user_id
 from storage.contracts import ContactEdgeRow
-from storage.errors import StaleChatWorkflowVersionError
+from storage.errors import (
+    StaleChatWorkflowEventVersionError,
+    StaleChatWorkflowVersionError,
+)
 
 
 def _chat(chat_id: str) -> SimpleNamespace:
@@ -574,6 +577,63 @@ def test_chat_workflow_event_routes_use_chat_access_helper(monkeypatch: pytest.M
                 },
             ),
         ),
+    ]
+
+
+def test_chat_workflow_event_patch_carries_expected_version_and_returns_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def update_event(chat_id: str, event_id: str, **kwargs):
+        calls.append({"chat_id": chat_id, "event_id": event_id, **kwargs})
+        raise StaleChatWorkflowEventVersionError(
+            chat_id=chat_id,
+            event_id=event_id,
+            expected_state_version=4,
+            actual_state_version=5,
+        )
+
+    app = FastAPI()
+    app.include_router(chat_workflow_router.router)
+    app.dependency_overrides[chat_workflow_router.get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[chat_workflow_router.get_chat_repo] = lambda: SimpleNamespace(name="chat-repo")
+    app.dependency_overrides[chat_workflow_router.get_messaging_service] = lambda: SimpleNamespace(name="messaging")
+    app.dependency_overrides[chat_workflow_router.get_chat_workflow_event_service] = lambda: SimpleNamespace(update_event=update_event)
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    try:
+        with TestClient(app) as client:
+            response = client.patch(
+                "/api/chats/chat-1/workflow/events/evt-1",
+                json={
+                    "decision_states": {"reviewer-a": {"1": "completed"}},
+                    "expected_state_version": 4,
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error": "stale_chat_workflow_event_state_version",
+        "chat_id": "chat-1",
+        "event_id": "evt-1",
+        "expected_state_version": 4,
+        "actual_state_version": 5,
+    }
+    assert calls == [
+        {
+            "chat_id": "chat-1",
+            "event_id": "evt-1",
+            "state": None,
+            "decision_states": {"reviewer-a": {"1": "completed"}},
+            "rationales": None,
+            "final_state": None,
+            "metadata": None,
+            "settled_at": None,
+            "expected_state_version": 4,
+        }
     ]
 
 

--- a/tests/Unit/storage/test_app_schema_applier.py
+++ b/tests/Unit/storage/test_app_schema_applier.py
@@ -45,6 +45,13 @@ def test_chat_workflow_state_version_patch_updates_existing_tables() -> None:
     assert "add column if not exists state_version" in sql
 
 
+def test_chat_workflow_event_state_version_patch_updates_existing_tables() -> None:
+    sql = (ROOT / "storage/schema/chat_workflow_state_and_tasks.sql").read_text(encoding="utf-8")
+
+    assert "alter table if exists chat.workflow_events" in sql
+    assert "add column if not exists state_version integer not null default 0" in sql
+
+
 def test_applier_print_files_is_connection_free() -> None:
     result = subprocess.run(
         [sys.executable, str(APPLIER_PATH), "--print-files"],

--- a/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
+++ b/tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py
@@ -6,7 +6,11 @@ import pytest
 
 from core.work_item.types import WorkItem
 from storage.contracts import ChatRow, ChatWorkflowEventRow, ContactEdgeRow
-from storage.errors import StaleChatWorkflowVersionError, StorageConflictError
+from storage.errors import (
+    StaleChatWorkflowEventVersionError,
+    StaleChatWorkflowVersionError,
+    StorageConflictError,
+)
 from storage.providers.supabase.chat_repo import SupabaseChatRepo
 from storage.providers.supabase.chat_workflow_repo import (
     SupabaseChatTaskRepo,
@@ -181,6 +185,45 @@ def test_supabase_chat_workflow_event_repo_uses_chat_schema_sibling_table() -> N
     assert event.resource_refs == [{"type": "task", "id": "1"}]
     assert tables["chat.workflow_events"][0]["chat_id"] == "chat-1"
     assert "workflow_events" not in tables
+
+
+def test_supabase_chat_workflow_event_repo_rejects_stale_state_version() -> None:
+    tables: dict[str, list[dict]] = {
+        "chat.workflow_events": [
+            {
+                "chat_id": "chat-1",
+                "event_id": "1",
+                "kind": "task_proposed_review",
+                "state": "open",
+                "resource_refs_json": [],
+                "decision_states_json": {},
+                "rationales_json": {},
+                "final_state_json": {},
+                "metadata_json": {},
+                "state_version": 0,
+                "created_at": 1.0,
+                "updated_at": 1.0,
+            }
+        ]
+    }
+    repo = SupabaseChatWorkflowEventRepo(FakeSupabaseClient(tables=tables))
+    event = repo.get("chat-1", "1")
+    assert event is not None
+
+    updated = event.model_copy(update={"decision_states": {"reviewer-a": {"1": "completed"}}})
+    stored = repo.update("chat-1", updated, expected_state_version=0)
+    assert stored.state_version == 1
+    assert tables["chat.workflow_events"][0]["decision_states_json"] == {"reviewer-a": {"1": "completed"}}
+
+    stale = stored.model_copy(update={"decision_states": {"reviewer-b": {"1": "pending"}}})
+    with pytest.raises(StaleChatWorkflowEventVersionError) as exc:
+        repo.update("chat-1", stale, expected_state_version=0)
+
+    assert exc.value.chat_id == "chat-1"
+    assert exc.value.event_id == "1"
+    assert exc.value.expected_state_version == 0
+    assert exc.value.actual_state_version == 1
+    assert tables["chat.workflow_events"][0]["decision_states_json"] == {"reviewer-a": {"1": "completed"}}
 
 
 def test_supabase_find_chat_between_only_returns_direct_chat() -> None:


### PR DESCRIPTION
## Summary
- add state_version to chat workflow events and schema migration
- make workflow event updates support expected_state_version with stale-write conflicts
- expose the expected version through the workflow event PATCH API

## Verification
- uv run pytest -q tests/Unit/core/test_chat_workflow_service.py tests/Unit/storage/test_supabase_chat_and_messaging_root_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/storage/test_app_schema_applier.py
- uv run pytest -q tests/Unit/core/test_chat_workflow_service.py tests/Unit/storage tests/Unit/integration_contracts/test_messaging_router.py
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .
- uv run python scripts/check_app_schema.py
- uv run pyright --pythonversion 3.12 (fails with pre-existing errors; CI marks continue-on-error)