### PR TITLE
Preserve runtime notification transport metadata

### DIFF
--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -49,6 +49,7 @@ class ExternalRuntimeInboxHandler:
         }
         if envelope.message.metadata:
             payload.update(envelope.message.metadata)
+        payload.update(_transport_payload(envelope.transport))
         self._queue_manager.enqueue(
             json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
             inbox_id,
@@ -61,3 +62,14 @@ class ExternalRuntimeInboxHandler:
         if self._wake_bus is not None and envelope.wake:
             self._wake_bus.publish(inbox_id)
         return agent_runtime_protocol.AgentRuntimeNotificationResult(status="accepted", thread_id=inbox_id)
+
+
+def _transport_payload(transport: agent_runtime_protocol.AgentRuntimeTransport) -> dict[str, str]:
+    payload: dict[str, str] = {}
+    if transport.delivery_id is not None:
+        payload["delivery_id"] = transport.delivery_id
+    if transport.correlation_id is not None:
+        payload["correlation_id"] = transport.correlation_id
+    if transport.idempotency_key is not None:
+        payload["idempotency_key"] = transport.idempotency_key
+    return payload

--- a/backend/threads/chat_adapters/notification_handler.py
+++ b/backend/threads/chat_adapters/notification_handler.py
@@ -20,6 +20,7 @@ class NativeAgentNotificationHandler:
                 thread_id=thread_id,
                 sender=envelope.sender,
                 message=envelope.message,
+                transport=envelope.transport,
             )
         )
         return agent_runtime_protocol.AgentRuntimeNotificationResult(status="accepted", thread_id=result.thread_id)

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -210,6 +210,7 @@ async def test_native_notification_handler_converts_to_thread_input_at_runtime_b
         AgentRuntimeActor,
         AgentRuntimeMessage,
         AgentRuntimeNotificationEnvelope,
+        AgentRuntimeTransport,
     )
 
     thread_input_handler = _FakeThreadInputHandler()
@@ -220,6 +221,11 @@ async def test_native_notification_handler_converts_to_thread_input_at_runtime_b
         sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human", source="relationship"),
         message=AgentRuntimeMessage(content="hello", metadata={"relationship_id": "rel-1"}),
         notification_type="relationship",
+        transport=AgentRuntimeTransport(
+            delivery_id="delivery-1",
+            correlation_id="corr-1",
+            idempotency_key="idem-1",
+        ),
     )
 
     result = await handler.dispatch_notification(envelope)
@@ -229,3 +235,4 @@ async def test_native_notification_handler_converts_to_thread_input_at_runtime_b
     assert thread_input_handler.called_with.thread_id == "thread-1"
     assert thread_input_handler.called_with.sender is envelope.sender
     assert thread_input_handler.called_with.message is envelope.message
+    assert thread_input_handler.called_with.transport is envelope.transport

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -13,6 +13,7 @@ from protocols.agent_runtime import (
     AgentRuntimeActor,
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
+    AgentRuntimeTransport,
 )
 
 
@@ -81,6 +82,11 @@ async def test_external_runtime_inbox_handler_queues_generic_runtime_notificatio
             metadata={"relationship_id": "hire_visit:external-user-1:human-user-1"},
         ),
         notification_type="relationship",
+        transport=AgentRuntimeTransport(
+            delivery_id="delivery-1",
+            correlation_id="corr-1",
+            idempotency_key="idem-1",
+        ),
     )
 
     result = await handler.dispatch_notification(envelope)
@@ -102,6 +108,9 @@ async def test_external_runtime_inbox_handler_queues_generic_runtime_notificatio
         "sender_name": "Human",
         "summary": "Human requested a relationship with you.",
         "relationship_id": "hire_visit:external-user-1:human-user-1",
+        "delivery_id": "delivery-1",
+        "correlation_id": "corr-1",
+        "idempotency_key": "idem-1",
     }
 
 


### PR DESCRIPTION
## Summary

- Preserve runtime notification transport metadata in external runtime inbox payloads.
- Preserve the same transport object when native runtime notifications are converted to thread input.
- Cover both paths with focused backend unit tests.

## Verification

- `uv run ruff format --check backend/threads/chat_adapters/external_inbox_handler.py backend/threads/chat_adapters/notification_handler.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py`
- `uv run ruff check backend/threads/chat_adapters/external_inbox_handler.py backend/threads/chat_adapters/notification_handler.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py`
- `uv run pytest tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py -q`
