### PR TITLE
Default workflow event requester to auth user

### DIFF
--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -166,7 +166,7 @@ def create_chat_workflow_event(
         chat_id,
         kind=body.kind,
         resource_refs=body.resource_refs,
-        requested_by_user_id=body.requested_by_user_id,
+        requested_by_user_id=body.requested_by_user_id or user_id,
         decision_states=body.decision_states,
         rationales=body.rationales,
         final_state=body.final_state,

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -580,6 +580,49 @@ def test_chat_workflow_event_routes_use_chat_access_helper(monkeypatch: pytest.M
     ]
 
 
+def test_chat_workflow_event_create_defaults_requester_to_authenticated_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, object]] = []
+    chat_repo = SimpleNamespace(name="chat-repo")
+    messaging_service = SimpleNamespace(name="messaging")
+    event_service = SimpleNamespace(
+        create_event=lambda chat_id, **kwargs: (
+            seen.append(("create_event", (chat_id, kwargs))) or {"event_id": "1", "requested_by_user_id": kwargs["requested_by_user_id"]}
+        )
+    )
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    result = chat_workflow_router.create_chat_workflow_event(
+        "chat-1",
+        chat_workflow_router.CreateChatWorkflowEventBody(
+            kind="task_proposed_review",
+            resource_refs=[{"type": "task", "id": "1"}],
+        ),
+        user_id="user-1",
+        chat_repo=chat_repo,
+        messaging_service=messaging_service,
+        chat_workflow_event_service=event_service,
+    )
+
+    assert result == {"event_id": "1", "requested_by_user_id": "user-1"}
+    assert seen == [
+        (
+            "create_event",
+            (
+                "chat-1",
+                {
+                    "kind": "task_proposed_review",
+                    "resource_refs": [{"type": "task", "id": "1"}],
+                    "requested_by_user_id": "user-1",
+                    "decision_states": {},
+                    "rationales": {},
+                    "final_state": {},
+                    "metadata": {},
+                },
+            ),
+        )
+    ]
+
+
 def test_chat_workflow_event_patch_carries_expected_version_and_returns_conflict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Default HTTP-created workflow events to the authenticated user when `requested_by_user_id` is omitted.
- Preserve explicit caller-provided requester ids for current role-origin workflows.
- Add a focused messaging router contract test for the defaulting behavior.

## Verification

- `uv run ruff format --check backend/chat/api/http/chat_workflow_router.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run ruff check backend/chat/api/http/chat_workflow_router.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/core/test_chat_workflow_service.py -q`
