### PR TITLE
Add workflow event runtime notification boundary

### DIFF
--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from protocols.agent_runtime import (
+    AgentChatRecipient,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+    AgentRuntimeNotificationEnvelope,
+    AgentRuntimeTransport,
+)
+
+
+async def dispatch_workflow_event_notification(
+    app: Any,
+    *,
+    event: Mapping[str, Any],
+    recipient: AgentChatRecipient,
+    sender: AgentRuntimeActor,
+) -> None:
+    await get_agent_runtime_gateway(app).dispatch_notification(
+        make_workflow_event_notification_envelope(
+            event=event,
+            recipient=recipient,
+            sender=sender,
+        )
+    )
+
+
+def make_workflow_event_notification_envelope(
+    *,
+    event: Mapping[str, Any],
+    recipient: AgentChatRecipient,
+    sender: AgentRuntimeActor,
+) -> AgentRuntimeNotificationEnvelope:
+    chat_id = _required_str(event, "chat_id")
+    event_id = _required_str(event, "event_id")
+    kind = _required_str(event, "kind")
+    state = _required_str(event, "state")
+    state_version = _required_int(event, "state_version")
+    delivery_key = f"workflow:{chat_id}:{event_id}:{state_version}"
+    return AgentRuntimeNotificationEnvelope(
+        event_type="chat.workflow.event",
+        recipient=recipient,
+        sender=sender,
+        message=AgentRuntimeMessage(
+            content=f"Workflow event {kind} is {state}.",
+            metadata={
+                "chat_id": chat_id,
+                "event_id": event_id,
+                "kind": kind,
+                "state": state,
+                "state_version": state_version,
+            },
+        ),
+        notification_type="workflow_event",
+        transport=AgentRuntimeTransport(
+            delivery_id=delivery_key,
+            correlation_id=f"workflow:{chat_id}:{event_id}",
+            idempotency_key=delivery_key,
+        ),
+    )
+
+
+def _required_str(event: Mapping[str, Any], key: str) -> str:
+    value = str(event.get(key) or "").strip()
+    if not value:
+        raise RuntimeError(f"Workflow event notification is missing {key}")
+    return value
+
+
+def _required_int(event: Mapping[str, Any], key: str) -> int:
+    value = event.get(key)
+    if type(value) is not int:
+        raise RuntimeError(f"Workflow event notification has invalid {key}")
+    return value

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.threads.chat_adapters.workflow_event_inlet import (
+    dispatch_workflow_event_notification,
+    make_workflow_event_notification_envelope,
+)
+from protocols.agent_runtime import AgentChatRecipient, AgentRuntimeActor
+
+
+def test_workflow_event_notification_is_metadata_only() -> None:
+    envelope = make_workflow_event_notification_envelope(
+        event={
+            "chat_id": "chat-1",
+            "event_id": "event-1",
+            "kind": "task_proposed_review",
+            "state": "open",
+            "state_version": 3,
+            "resource_refs": [{"type": "task", "id": "1"}],
+            "rationales": {"reviewer-1": "must not leak"},
+            "final_state": {"1": "completed"},
+        },
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
+        sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
+    )
+
+    assert envelope.event_type == "chat.workflow.event"
+    assert envelope.notification_type == "workflow_event"
+    assert envelope.recipient.agent_user_id == "agent-1"
+    assert envelope.sender.user_id == "owner-1"
+    assert envelope.message.content == "Workflow event task_proposed_review is open."
+    assert envelope.message.metadata == {
+        "chat_id": "chat-1",
+        "event_id": "event-1",
+        "kind": "task_proposed_review",
+        "state": "open",
+        "state_version": 3,
+    }
+    assert envelope.transport.delivery_id == "workflow:chat-1:event-1:3"
+    assert envelope.transport.correlation_id == "workflow:chat-1:event-1"
+    assert envelope.transport.idempotency_key == "workflow:chat-1:event-1:3"
+    assert "must not leak" not in str(envelope)
+
+
+def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
+    try:
+        make_workflow_event_notification_envelope(
+            event={
+                "chat_id": "chat-1",
+                "event_id": "",
+                "kind": "task_proposed_review",
+                "state": "open",
+                "state_version": 3,
+            },
+            recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
+            sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "Workflow event notification is missing event_id"
+    else:
+        raise AssertionError("missing workflow event identity did not fail")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_workflow_event_notification_uses_runtime_gateway() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_notification(self, envelope):
+            self.envelope = envelope
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+    gateway = RecordingGateway()
+    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+    await dispatch_workflow_event_notification(
+        app,
+        event={
+            "chat_id": "chat-1",
+            "event_id": "event-1",
+            "kind": "task_proposed_review",
+            "state": "open",
+            "state_version": 3,
+        },
+        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
+        sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
+    )
+
+    assert gateway.envelope is not None
+    assert gateway.envelope.event_type == "chat.workflow.event"
+    assert gateway.envelope.message.metadata["event_id"] == "event-1"


### PR DESCRIPTION
## Summary

- Add a narrow workflow-event-to-runtime-notification boundary.
- Keep runtime notification payloads metadata-only: chat id, event id, kind, state, state version.
- Add stable transport keys derived from workflow event identity/version for future runtime dedupe/replay.

## Verification

- `uv run ruff check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff format --check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pyright backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_runtime_inbox_router.py -q`
