### PR TITLE
Wire workflow event runtime notifications

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -10,6 +10,7 @@ from backend.threads.chat_adapters.relationship_inlet import (
     make_relationship_decision_notification_fn,
     make_relationship_request_notification_fn,
 )
+from backend.threads.chat_adapters.workflow_event_inlet import make_workflow_event_notification_fn
 from core.work_item.chat_workflow.service import ChatTaskService, ChatWorkflowEventService, ChatWorkflowService
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.join_requests import ChatJoinRequestService
@@ -164,5 +165,25 @@ def wire_chat_join_request_notifications(
             activity_reader=activity_reader,
             thread_repo=thread_repo,
             user_repo=user_repo,
+        )
+    )
+
+
+def wire_workflow_event_notifications(
+    app: Any,
+    *,
+    chat_workflow_event_service: Any,
+    messaging_service: Any,
+    activity_reader: Any,
+    thread_repo: Any,
+    user_repo: Any,
+) -> None:
+    chat_workflow_event_service.set_event_notification_fn(
+        make_workflow_event_notification_fn(
+            app,
+            activity_reader=activity_reader,
+            thread_repo=thread_repo,
+            user_repo=user_repo,
+            messaging_service=messaging_service,
         )
     )

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
+from enum import Enum
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from protocols.agent_runtime import (
     AgentChatRecipient,
     AgentRuntimeActor,
@@ -11,6 +14,73 @@ from protocols.agent_runtime import (
     AgentRuntimeNotificationEnvelope,
     AgentRuntimeTransport,
 )
+
+
+def make_workflow_event_notification_fn(
+    app: Any,
+    *,
+    activity_reader: Any,
+    thread_repo: Any,
+    user_repo: Any,
+    messaging_service: Any,
+):
+    loop = asyncio.get_running_loop()
+
+    async def notify_runtime(event: Mapping[str, Any], sender_user_id: str) -> None:
+        await dispatch_workflow_event_notifications(
+            app,
+            event=event,
+            members=messaging_service.list_chat_members(_required_str(event, "chat_id")),
+            sender_user_id=sender_user_id,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+
+    def _notify(event: Mapping[str, Any], sender_user_id: str) -> None:
+        future = asyncio.run_coroutine_threadsafe(notify_runtime(event, sender_user_id), loop)
+        future.result()
+
+    return _notify
+
+
+async def dispatch_workflow_event_notifications(
+    app: Any,
+    *,
+    event: Mapping[str, Any],
+    members: list[Mapping[str, Any]],
+    sender_user_id: str,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> None:
+    sender_user = _require_user(user_repo, sender_user_id, "sender")
+    sender = AgentRuntimeActor(
+        user_id=sender_user_id,
+        user_type=_user_type(sender_user, sender_user_id),
+        display_name=_display_name(sender_user, sender_user_id),
+        source="workflow",
+    )
+    for member in members:
+        recipient_user_id = _member_user_id(member)
+        if recipient_user_id == sender_user_id:
+            continue
+        recipient_user = _require_user(user_repo, recipient_user_id, "recipient")
+        recipient = select_runtime_notification_recipient(
+            recipient_user_id,
+            _user_type(recipient_user, recipient_user_id),
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+            context="workflow event",
+        )
+        if recipient is None:
+            continue
+        await dispatch_workflow_event_notification(
+            app,
+            event=event,
+            recipient=recipient,
+            sender=sender,
+        )
 
 
 async def dispatch_workflow_event_notification(
@@ -76,3 +146,31 @@ def _required_int(event: Mapping[str, Any], key: str) -> int:
     if type(value) is not int:
         raise RuntimeError(f"Workflow event notification has invalid {key}")
     return value
+
+
+def _member_user_id(member: Mapping[str, Any]) -> str:
+    user_id = str(member.get("user_id") or "").strip()
+    if not user_id:
+        raise RuntimeError("Workflow event notification member row is missing user_id")
+    return user_id
+
+
+def _require_user(user_repo: Any, user_id: str, role: str) -> Any:
+    user = user_repo.get_by_id(user_id)
+    if user is None:
+        raise RuntimeError(f"Workflow event notification {role} user not found: {user_id}")
+    return user
+
+
+def _user_type(user: Any, user_id: str) -> str:
+    raw_type = getattr(user, "type", None)
+    if raw_type is None:
+        raise RuntimeError(f"Workflow event notification user is missing type: {user_id}")
+    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
+
+
+def _display_name(user: Any, user_id: str) -> str:
+    display_name = getattr(user, "display_name", None)
+    if display_name is None:
+        raise RuntimeError(f"Workflow event notification user is missing display name: {user_id}")
+    return str(display_name)

--- a/backend/web/core/lifespan.py
+++ b/backend/web/core/lifespan.py
@@ -64,6 +64,7 @@ async def lifespan(app: FastAPI):
         wire_chat_join_request_notifications,
         wire_relationship_decision_notifications,
         wire_relationship_request_notifications,
+        wire_workflow_event_notifications,
     )
     from backend.threads.bootstrap import attach_runtime_inbox_runtime, attach_threads_runtime
 
@@ -130,6 +131,14 @@ async def lifespan(app: FastAPI):
     wire_chat_join_request_notifications(
         app,
         chat_join_request_service=chat_runtime.chat_join_request_service,
+        activity_reader=threads_runtime.activity_reader,
+        thread_repo=app.state.thread_repo,
+        user_repo=app.state.user_repo,
+    )
+    wire_workflow_event_notifications(
+        app,
+        chat_workflow_event_service=chat_runtime.chat_workflow_event_service,
+        messaging_service=chat_runtime.messaging_service,
         activity_reader=threads_runtime.activity_reader,
         thread_repo=app.state.thread_repo,
         user_repo=app.state.user_repo,

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -121,6 +121,10 @@ class ChatTaskService:
 class ChatWorkflowEventService:
     def __init__(self, event_repo: Any) -> None:
         self._repo = event_repo
+        self._event_notification_fn: Any | None = None
+
+    def set_event_notification_fn(self, notification_fn: Any) -> None:
+        self._event_notification_fn = notification_fn
 
     def list_events(self, chat_id: str) -> list[dict[str, Any]]:
         return [_event_response(event) for event in self._repo.list_all(chat_id)]
@@ -155,7 +159,12 @@ class ChatWorkflowEventService:
             created_at=time.time(),
         )
         self._repo.insert(chat_id, event)
-        return _event_response(event)
+        response = _event_response(event)
+        if self._event_notification_fn is not None:
+            if requested_by_user_id is None:
+                raise RuntimeError("Workflow event notification requires requested_by_user_id")
+            self._event_notification_fn(response, requested_by_user_id)
+        return response
 
     def update_event(
         self,

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -249,3 +249,36 @@ def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(mo
     )
 
     assert chat_join_request_service.notification_fn is notification_fn
+
+
+def test_wire_workflow_event_notifications_binds_notification_fn(monkeypatch):
+    notification_fn = object()
+    chat_workflow_event_service = SimpleNamespace(notification_fn=None)
+    messaging_service = object()
+    activity_reader = object()
+    thread_repo = object()
+    user_repo = object()
+
+    def _set_notification_fn(value):
+        chat_workflow_event_service.notification_fn = value
+
+    chat_workflow_event_service.set_event_notification_fn = _set_notification_fn
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    monkeypatch.setattr(
+        chat_bootstrap,
+        "make_workflow_event_notification_fn",
+        lambda target_app, *, activity_reader, thread_repo, user_repo, messaging_service: notification_fn,
+    )
+
+    chat_bootstrap.wire_workflow_event_notifications(
+        app,
+        chat_workflow_event_service=chat_workflow_event_service,
+        messaging_service=messaging_service,
+        activity_reader=activity_reader,
+        thread_repo=thread_repo,
+        user_repo=user_repo,
+    )
+
+    assert chat_workflow_event_service.notification_fn is notification_fn

--- a/tests/Unit/backend/test_web_lifespan_ordering.py
+++ b/tests/Unit/backend/test_web_lifespan_ordering.py
@@ -27,6 +27,7 @@ def _patch_lifespan_runtime_contract(
     wire_relationship_request_notifications,
     wire_relationship_decision_notifications=lambda *_args, **_kwargs: None,
     wire_chat_join_request_notifications=lambda *_args, **_kwargs: None,
+    wire_workflow_event_notifications=lambda *_args, **_kwargs: None,
 ):
     monkeypatch.setattr(web_lifespan, "_require_web_runtime_contract", lambda: None)
     monkeypatch.setenv("LEON_POSTGRES_URL", "postgres://unit-test")
@@ -78,6 +79,7 @@ def _patch_lifespan_runtime_contract(
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", wire_relationship_request_notifications)
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_decision_notifications", wire_relationship_decision_notifications)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_join_request_notifications", wire_chat_join_request_notifications)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_workflow_event_notifications", wire_workflow_event_notifications)
     monkeypatch.setattr("backend.threads.bootstrap.attach_threads_runtime", attach_threads_runtime)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
@@ -91,6 +93,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_relationship_service = object()
     returned_chat_join_request_service = object()
+    returned_chat_workflow_event_service = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
         contact_repo = object()
@@ -100,6 +103,7 @@ async def test_web_lifespan_attaches_chat_runtime_before_threads_runtime(monkeyp
             messaging_service=returned_messaging_service,
             relationship_service=returned_relationship_service,
             chat_join_request_service=returned_chat_join_request_service,
+            chat_workflow_event_service=returned_chat_workflow_event_service,
         )
 
     def _attach_threads_runtime(
@@ -140,6 +144,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_relationship_service = object()
     returned_chat_join_request_service = object()
+    returned_chat_workflow_event_service = object()
     returned_contact_repo = object()
     returned_activity_reader = object()
 
@@ -151,6 +156,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
             messaging_service=returned_messaging_service,
             relationship_service=returned_relationship_service,
             chat_join_request_service=returned_chat_join_request_service,
+            chat_workflow_event_service=returned_chat_workflow_event_service,
         )
 
     def _attach_auth_runtime(_app, *, storage_state, contact_repo, managed_onboarding):
@@ -196,6 +202,20 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         assert chat_join_request_service is returned_chat_join_request_service
         assert activity_reader is returned_activity_reader
 
+    def _wire_workflow_event_notifications(
+        _app,
+        *,
+        chat_workflow_event_service,
+        messaging_service,
+        activity_reader,
+        thread_repo,
+        user_repo,
+    ):
+        call_log.append("wire-workflow-event")
+        assert chat_workflow_event_service is returned_chat_workflow_event_service
+        assert messaging_service is returned_messaging_service
+        assert activity_reader is returned_activity_reader
+
     _patch_lifespan_runtime_contract(
         monkeypatch,
         attach_chat_runtime=_attach_chat_runtime,
@@ -205,6 +225,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
         wire_relationship_request_notifications=_wire_relationship_request_notifications,
         wire_relationship_decision_notifications=_wire_relationship_decision_notifications,
         wire_chat_join_request_notifications=_wire_chat_join_request_notifications,
+        wire_workflow_event_notifications=_wire_workflow_event_notifications,
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
@@ -218,6 +239,7 @@ async def test_web_lifespan_wires_chat_delivery_after_threads_runtime(monkeypatc
             "wire-relationship",
             "wire-relationship-decision",
             "wire-chat-join",
+            "wire-workflow-event",
         ]
 
 
@@ -276,6 +298,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
             messaging_service=SimpleNamespace(set_delivery_fn=lambda _fn: None),
             relationship_service=object(),
             chat_join_request_service=object(),
+            chat_workflow_event_service=object(),
         ),
     )
     monkeypatch.setattr(
@@ -286,6 +309,7 @@ async def test_web_lifespan_passes_borrowed_contact_repo_into_auth_runtime(monke
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_request_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.chat.bootstrap.wire_relationship_decision_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.chat.bootstrap.wire_chat_join_request_notifications", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("backend.chat.bootstrap.wire_workflow_event_notifications", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("backend.threads.display.builder.DisplayBuilder", lambda: object())
     monkeypatch.setattr("backend.sandboxes.service.init_providers_and_managers", lambda: None)
     monkeypatch.setattr("backend.threads.pool.idle_reaper.idle_reaper_loop", lambda _app: _never())
@@ -303,6 +327,7 @@ async def test_communication_lifespan_uses_external_inbox_runtime_without_manage
     returned_messaging_service = SimpleNamespace(set_delivery_fn=lambda _fn: None)
     returned_relationship_service = object()
     returned_chat_join_request_service = object()
+    returned_chat_workflow_event_service = object()
     returned_contact_repo = object()
 
     def _attach_chat_runtime(app, _storage_container, *, user_repo, thread_repo):
@@ -313,6 +338,7 @@ async def test_communication_lifespan_uses_external_inbox_runtime_without_manage
             messaging_service=returned_messaging_service,
             relationship_service=returned_relationship_service,
             chat_join_request_service=returned_chat_join_request_service,
+            chat_workflow_event_service=returned_chat_workflow_event_service,
         )
 
     def _attach_auth_runtime(_app, *, storage_state, contact_repo, managed_onboarding):
@@ -350,6 +376,20 @@ async def test_communication_lifespan_uses_external_inbox_runtime_without_manage
         assert chat_join_request_service is returned_chat_join_request_service
         assert activity_reader is None
 
+    def _wire_workflow_event_notifications(
+        _app,
+        *,
+        chat_workflow_event_service,
+        messaging_service,
+        activity_reader,
+        thread_repo,
+        user_repo,
+    ):
+        call_log.append("wire-workflow-event")
+        assert chat_workflow_event_service is returned_chat_workflow_event_service
+        assert messaging_service is returned_messaging_service
+        assert activity_reader is None
+
     _patch_lifespan_runtime_contract(
         monkeypatch,
         attach_chat_runtime=_attach_chat_runtime,
@@ -359,6 +399,7 @@ async def test_communication_lifespan_uses_external_inbox_runtime_without_manage
         wire_relationship_request_notifications=_wire_relationship_request_notifications,
         wire_relationship_decision_notifications=_wire_relationship_decision_notifications,
         wire_chat_join_request_notifications=_wire_chat_join_request_notifications,
+        wire_workflow_event_notifications=_wire_workflow_event_notifications,
     )
     monkeypatch.setattr(
         web_lifespan,
@@ -391,6 +432,7 @@ async def test_communication_lifespan_uses_external_inbox_runtime_without_manage
             "wire-relationship",
             "wire-relationship-decision",
             "wire-chat-join",
+            "wire-workflow-event",
         ]
 
 

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -1,14 +1,61 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
 from backend.threads.chat_adapters.workflow_event_inlet import (
-    dispatch_workflow_event_notification,
+    dispatch_workflow_event_notifications,
     make_workflow_event_notification_envelope,
+    make_workflow_event_notification_fn,
 )
 from protocols.agent_runtime import AgentChatRecipient, AgentRuntimeActor
+
+
+def _event() -> dict[str, object]:
+    return {
+        "chat_id": "chat-1",
+        "event_id": "event-1",
+        "kind": "task_proposed_review",
+        "state": "open",
+        "state_version": 3,
+    }
+
+
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.envelopes = []
+
+    async def dispatch_notification(self, envelope):
+        self.envelopes.append(envelope)
+        return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+
+def _runtime_app(gateway: _RecordingGateway) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+
+def _users(*agent_ids: str):
+    rows = {
+        "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner"),
+        "external-1": SimpleNamespace(id="external-1", type="external", display_name="External"),
+        "human-2": SimpleNamespace(id="human-2", type="human", display_name="Human"),
+    }
+    rows.update({agent_id: SimpleNamespace(id=agent_id, type="agent", display_name=agent_id) for agent_id in agent_ids})
+    return SimpleNamespace(get_by_id=lambda uid: rows.get(uid))
+
+
+def _thread_repo(*agent_ids: str) -> SimpleNamespace:
+    def _thread(uid: str) -> dict[str, object] | None:
+        if uid in agent_ids:
+            return {"id": f"thread-{uid}", "agent_user_id": uid, "is_main": True, "branch_index": 0}
+        return None
+
+    return SimpleNamespace(
+        get_by_user_id=_thread,
+        list_by_agent_user=lambda uid: [_thread(uid)] if _thread(uid) is not None else [],
+    )
 
 
 def test_workflow_event_notification_is_metadata_only() -> None:
@@ -65,30 +112,49 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_workflow_event_notification_uses_runtime_gateway() -> None:
-    class RecordingGateway:
-        envelope = None
+async def test_dispatch_workflow_event_notifications_fans_out_to_runtime_members() -> None:
+    gateway = _RecordingGateway()
 
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
-    app = SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
-
-    await dispatch_workflow_event_notification(
-        app,
-        event={
-            "chat_id": "chat-1",
-            "event_id": "event-1",
-            "kind": "task_proposed_review",
-            "state": "open",
-            "state_version": 3,
-        },
-        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
-        sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
+    await dispatch_workflow_event_notifications(
+        _runtime_app(gateway),
+        event=_event(),
+        members=[
+            {"user_id": "owner-1"},
+            {"user_id": "agent-1"},
+            {"user_id": "agent-without-thread"},
+            {"user_id": "external-1"},
+            {"user_id": "human-2"},
+        ],
+        sender_user_id="owner-1",
+        user_repo=_users("agent-1", "agent-without-thread"),
+        thread_repo=_thread_repo("agent-1"),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
     )
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.event_type == "chat.workflow.event"
-    assert gateway.envelope.message.metadata["event_id"] == "event-1"
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1", "external-1"]
+    assert [envelope.recipient.runtime_source for envelope in gateway.envelopes] == ["mycel", "external"]
+    assert gateway.envelopes[0].recipient.thread_id == "thread-agent-1"
+    assert all(envelope.sender.user_id == "owner-1" for envelope in gateway.envelopes)
+    assert all(envelope.message.metadata["event_id"] == "event-1" for envelope in gateway.envelopes)
+
+
+@pytest.mark.asyncio
+async def test_workflow_event_notification_fn_reads_members_and_schedules_runtime_delivery() -> None:
+    gateway = _RecordingGateway()
+    messaging_service = SimpleNamespace(list_chat_members=lambda chat_id: [{"user_id": "owner-1"}, {"user_id": "agent-1"}])
+    notify = make_workflow_event_notification_fn(
+        _runtime_app(gateway),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=_thread_repo("agent-1"),
+        user_repo=_users("agent-1"),
+        messaging_service=messaging_service,
+    )
+
+    await asyncio.to_thread(
+        notify,
+        _event(),
+        "owner-1",
+    )
+
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
+    assert gateway.envelopes[0].transport.delivery_id == "workflow:chat-1:event-1:3"

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -279,3 +279,31 @@ def test_chat_workflow_event_service_versions_updates_and_rejects_stale_writes()
         raise AssertionError("stale workflow event write did not fail")
 
     assert service.get_event("chat-1", event["event_id"]) == updated
+
+
+def test_chat_workflow_event_service_notifies_after_create_when_wired() -> None:
+    repo = _WorkflowEventRepo()
+    notifications = []
+    service = ChatWorkflowEventService(repo)
+    service.set_event_notification_fn(lambda event, sender_user_id: notifications.append((event, sender_user_id)))
+
+    event = service.create_event(
+        "chat-1",
+        kind="task_proposed_review",
+        requested_by_user_id="owner-1",
+    )
+
+    assert notifications == [(event, "owner-1")]
+
+
+def test_chat_workflow_event_service_requires_requester_for_wired_notification() -> None:
+    repo = _WorkflowEventRepo()
+    service = ChatWorkflowEventService(repo)
+    service.set_event_notification_fn(lambda _event, _sender_user_id: None)
+
+    try:
+        service.create_event("chat-1", kind="task_proposed_review")
+    except RuntimeError as exc:
+        assert str(exc) == "Workflow event notification requires requested_by_user_id"
+    else:
+        raise AssertionError("wired workflow event notification accepted missing requester")


### PR DESCRIPTION
## Summary
- wire `ChatWorkflowEventService.create_event` to a post-create notification callback
- add workflow event notification fanout over existing runtime inbox/gateway delivery
- bind the workflow event notification function from chat bootstrap/lifespan

## Architecture
- `chat.workflow_events` remains the durable source of truth.
- Runtime inbox receives metadata-only wake hints: `chat_id`, `event_id`, `kind`, `state`, `state_version`.
- The HTTP router stays runtime-agnostic; bootstrap owns the runtime wiring.
- Recipients are resolved from chat members by `user_id`; human members are skipped, runtime-capable members receive existing runtime notifications.

## Verification
- `uv run ruff format --check backend/threads/chat_adapters/workflow_event_inlet.py core/work_item/chat_workflow/service.py backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py`
- `uv run ruff check backend/threads/chat_adapters/workflow_event_inlet.py core/work_item/chat_workflow/service.py backend/chat/bootstrap.py backend/web/core/lifespan.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py`
- `uv run pyright backend/threads/chat_adapters/workflow_event_inlet.py core/work_item/chat_workflow/service.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/integration_contracts/test_messaging_router.py -q`
