### PR TITLE
Notify runtimes on workflow event updates

### DIFF
--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -212,6 +212,7 @@ def update_chat_workflow_event(
             metadata=body.metadata,
             settled_at=body.settled_at,
             expected_state_version=body.expected_state_version,
+            updated_by_user_id=user_id,
         )
     except StaleChatWorkflowEventVersionError as exc:
         raise HTTPException(

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -178,6 +178,7 @@ class ChatWorkflowEventService:
         metadata: dict[str, Any] | None = None,
         settled_at: float | None = None,
         expected_state_version: int | None = None,
+        updated_by_user_id: str | None = None,
     ) -> dict[str, Any] | None:
         event = self._repo.get(chat_id, event_id)
         if event is None:
@@ -196,7 +197,12 @@ class ChatWorkflowEventService:
         if settled_at is not None:
             event.settled_at = settled_at
         updated = self._repo.update(chat_id, event, expected_state_version=expected_state_version)
-        return _event_response(updated)
+        response = _event_response(updated)
+        if self._event_notification_fn is not None:
+            if updated_by_user_id is None:
+                raise RuntimeError("Workflow event update notification requires updated_by_user_id")
+            self._event_notification_fn(response, updated_by_user_id)
+        return response
 
     def delete_event(self, chat_id: str, event_id: str) -> None:
         self._repo.delete(chat_id, event_id)

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -307,3 +307,34 @@ def test_chat_workflow_event_service_requires_requester_for_wired_notification()
         assert str(exc) == "Workflow event notification requires requested_by_user_id"
     else:
         raise AssertionError("wired workflow event notification accepted missing requester")
+
+
+def test_chat_workflow_event_service_notifies_after_update_when_wired() -> None:
+    repo = _WorkflowEventRepo()
+    notifications = []
+    service = ChatWorkflowEventService(repo)
+    event = service.create_event("chat-1", kind="task_proposed_review")
+    service.set_event_notification_fn(lambda event, sender_user_id: notifications.append((event, sender_user_id)))
+
+    updated = service.update_event(
+        "chat-1",
+        event["event_id"],
+        state="settled",
+        updated_by_user_id="reviewer-1",
+    )
+
+    assert notifications == [(updated, "reviewer-1")]
+
+
+def test_chat_workflow_event_service_requires_actor_for_wired_update_notification() -> None:
+    repo = _WorkflowEventRepo()
+    service = ChatWorkflowEventService(repo)
+    event = service.create_event("chat-1", kind="task_proposed_review")
+    service.set_event_notification_fn(lambda _event, _sender_user_id: None)
+
+    try:
+        service.update_event("chat-1", event["event_id"], state="settled")
+    except RuntimeError as exc:
+        assert str(exc) == "Workflow event update notification requires updated_by_user_id"
+    else:
+        raise AssertionError("wired workflow event update notification accepted missing actor")

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -676,6 +676,7 @@ def test_chat_workflow_event_patch_carries_expected_version_and_returns_conflict
             "metadata": None,
             "settled_at": None,
             "expected_state_version": 4,
+            "updated_by_user_id": "user-1",
         }
     ]
 


### PR DESCRIPTION
## Summary
- pass the authenticated user into workflow event PATCH updates as `updated_by_user_id`
- notify runtime-capable chat members after workflow event updates when the workflow notification callback is wired
- keep create/update notifications on the same service callback and existing runtime inbox wake path

## Verification
- `uv run ruff format --check core/work_item/chat_workflow/service.py backend/chat/api/http/chat_workflow_router.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run ruff check core/work_item/chat_workflow/service.py backend/chat/api/http/chat_workflow_router.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run pyright core/work_item/chat_workflow/service.py backend/chat/api/http/chat_workflow_router.py`
- `uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q`
