### PR TITLE
Model workflow event changes explicitly

### DIFF
--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
+from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import (
     AgentChatRecipient,
     AgentRuntimeActor,
@@ -26,19 +27,18 @@ def make_workflow_event_notification_fn(
 ):
     loop = asyncio.get_running_loop()
 
-    async def notify_runtime(event: Mapping[str, Any], sender_user_id: str) -> None:
+    async def notify_runtime(change: WorkflowEventChange) -> None:
         await dispatch_workflow_event_notifications(
             app,
-            event=event,
-            members=messaging_service.list_chat_members(_required_str(event, "chat_id")),
-            sender_user_id=sender_user_id,
+            change=change,
+            members=messaging_service.list_chat_members(_required_str(change.event, "chat_id")),
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
-    def _notify(event: Mapping[str, Any], sender_user_id: str) -> None:
-        future = asyncio.run_coroutine_threadsafe(notify_runtime(event, sender_user_id), loop)
+    def _notify(change: WorkflowEventChange) -> None:
+        future = asyncio.run_coroutine_threadsafe(notify_runtime(change), loop)
         future.result()
 
     return _notify
@@ -47,13 +47,13 @@ def make_workflow_event_notification_fn(
 async def dispatch_workflow_event_notifications(
     app: Any,
     *,
-    event: Mapping[str, Any],
+    change: WorkflowEventChange,
     members: list[Mapping[str, Any]],
-    sender_user_id: str,
     user_repo: Any,
     thread_repo: Any,
     activity_reader: Any,
 ) -> None:
+    sender_user_id = change.actor_user_id
     sender_user = _require_user(user_repo, sender_user_id, "sender")
     sender = AgentRuntimeActor(
         user_id=sender_user_id,
@@ -77,7 +77,7 @@ async def dispatch_workflow_event_notifications(
             continue
         await dispatch_workflow_event_notification(
             app,
-            event=event,
+            change=change,
             recipient=recipient,
             sender=sender,
         )
@@ -86,13 +86,13 @@ async def dispatch_workflow_event_notifications(
 async def dispatch_workflow_event_notification(
     app: Any,
     *,
-    event: Mapping[str, Any],
+    change: WorkflowEventChange,
     recipient: AgentChatRecipient,
     sender: AgentRuntimeActor,
 ) -> None:
     await get_agent_runtime_gateway(app).dispatch_notification(
         make_workflow_event_notification_envelope(
-            event=event,
+            change=change,
             recipient=recipient,
             sender=sender,
         )
@@ -101,10 +101,11 @@ async def dispatch_workflow_event_notification(
 
 def make_workflow_event_notification_envelope(
     *,
-    event: Mapping[str, Any],
+    change: WorkflowEventChange,
     recipient: AgentChatRecipient,
     sender: AgentRuntimeActor,
 ) -> AgentRuntimeNotificationEnvelope:
+    event = change.event
     chat_id = _required_str(event, "chat_id")
     event_id = _required_str(event, "event_id")
     kind = _required_str(event, "kind")
@@ -116,11 +117,12 @@ def make_workflow_event_notification_envelope(
         recipient=recipient,
         sender=sender,
         message=AgentRuntimeMessage(
-            content=f"Workflow event {kind} is {state}.",
+            content=f"Workflow event {kind} was {change.operation} and is {state}.",
             metadata={
                 "chat_id": chat_id,
                 "event_id": event_id,
                 "kind": kind,
+                "operation": change.operation,
                 "state": state,
                 "state_version": state_version,
             },

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
 import time
-from typing import Any
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow
+
+
+@dataclass(frozen=True)
+class WorkflowEventChange:
+    operation: Literal["created", "updated"]
+    event: dict[str, Any]
+    actor_user_id: str
 
 
 class ChatWorkflowService:
@@ -121,9 +130,9 @@ class ChatTaskService:
 class ChatWorkflowEventService:
     def __init__(self, event_repo: Any) -> None:
         self._repo = event_repo
-        self._event_notification_fn: Any | None = None
+        self._event_notification_fn: Callable[[WorkflowEventChange], None] | None = None
 
-    def set_event_notification_fn(self, notification_fn: Any) -> None:
+    def set_event_notification_fn(self, notification_fn: Callable[[WorkflowEventChange], None]) -> None:
         self._event_notification_fn = notification_fn
 
     def list_events(self, chat_id: str) -> list[dict[str, Any]]:
@@ -163,7 +172,13 @@ class ChatWorkflowEventService:
         if self._event_notification_fn is not None:
             if requested_by_user_id is None:
                 raise RuntimeError("Workflow event notification requires requested_by_user_id")
-            self._event_notification_fn(response, requested_by_user_id)
+            self._event_notification_fn(
+                WorkflowEventChange(
+                    operation="created",
+                    event=response,
+                    actor_user_id=requested_by_user_id,
+                )
+            )
         return response
 
     def update_event(
@@ -201,7 +216,13 @@ class ChatWorkflowEventService:
         if self._event_notification_fn is not None:
             if updated_by_user_id is None:
                 raise RuntimeError("Workflow event update notification requires updated_by_user_id")
-            self._event_notification_fn(response, updated_by_user_id)
+            self._event_notification_fn(
+                WorkflowEventChange(
+                    operation="updated",
+                    event=response,
+                    actor_user_id=updated_by_user_id,
+                )
+            )
         return response
 
     def delete_event(self, chat_id: str, event_id: str) -> None:

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Literal
 
 import pytest
 
@@ -10,6 +11,7 @@ from backend.threads.chat_adapters.workflow_event_inlet import (
     make_workflow_event_notification_envelope,
     make_workflow_event_notification_fn,
 )
+from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentChatRecipient, AgentRuntimeActor
 
 
@@ -21,6 +23,14 @@ def _event() -> dict[str, object]:
         "state": "open",
         "state_version": 3,
     }
+
+
+def _change(operation: Literal["created", "updated"] = "created") -> WorkflowEventChange:
+    return WorkflowEventChange(
+        operation=operation,
+        event=_event(),
+        actor_user_id="owner-1",
+    )
 
 
 class _RecordingGateway:
@@ -60,16 +70,20 @@ def _thread_repo(*agent_ids: str) -> SimpleNamespace:
 
 def test_workflow_event_notification_is_metadata_only() -> None:
     envelope = make_workflow_event_notification_envelope(
-        event={
-            "chat_id": "chat-1",
-            "event_id": "event-1",
-            "kind": "task_proposed_review",
-            "state": "open",
-            "state_version": 3,
-            "resource_refs": [{"type": "task", "id": "1"}],
-            "rationales": {"reviewer-1": "must not leak"},
-            "final_state": {"1": "completed"},
-        },
+        change=WorkflowEventChange(
+            operation="created",
+            event={
+                "chat_id": "chat-1",
+                "event_id": "event-1",
+                "kind": "task_proposed_review",
+                "state": "open",
+                "state_version": 3,
+                "resource_refs": [{"type": "task", "id": "1"}],
+                "rationales": {"reviewer-1": "must not leak"},
+                "final_state": {"1": "completed"},
+            },
+            actor_user_id="owner-1",
+        ),
         recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
         sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
     )
@@ -78,11 +92,12 @@ def test_workflow_event_notification_is_metadata_only() -> None:
     assert envelope.notification_type == "workflow_event"
     assert envelope.recipient.agent_user_id == "agent-1"
     assert envelope.sender.user_id == "owner-1"
-    assert envelope.message.content == "Workflow event task_proposed_review is open."
+    assert envelope.message.content == "Workflow event task_proposed_review was created and is open."
     assert envelope.message.metadata == {
         "chat_id": "chat-1",
         "event_id": "event-1",
         "kind": "task_proposed_review",
+        "operation": "created",
         "state": "open",
         "state_version": 3,
     }
@@ -95,13 +110,17 @@ def test_workflow_event_notification_is_metadata_only() -> None:
 def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
     try:
         make_workflow_event_notification_envelope(
-            event={
-                "chat_id": "chat-1",
-                "event_id": "",
-                "kind": "task_proposed_review",
-                "state": "open",
-                "state_version": 3,
-            },
+            change=WorkflowEventChange(
+                operation="created",
+                event={
+                    "chat_id": "chat-1",
+                    "event_id": "",
+                    "kind": "task_proposed_review",
+                    "state": "open",
+                    "state_version": 3,
+                },
+                actor_user_id="owner-1",
+            ),
             recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
             sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
         )
@@ -117,7 +136,7 @@ async def test_dispatch_workflow_event_notifications_fans_out_to_runtime_members
 
     await dispatch_workflow_event_notifications(
         _runtime_app(gateway),
-        event=_event(),
+        change=_change("updated"),
         members=[
             {"user_id": "owner-1"},
             {"user_id": "agent-1"},
@@ -125,7 +144,6 @@ async def test_dispatch_workflow_event_notifications_fans_out_to_runtime_members
             {"user_id": "external-1"},
             {"user_id": "human-2"},
         ],
-        sender_user_id="owner-1",
         user_repo=_users("agent-1", "agent-without-thread"),
         thread_repo=_thread_repo("agent-1"),
         activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
@@ -136,6 +154,7 @@ async def test_dispatch_workflow_event_notifications_fans_out_to_runtime_members
     assert gateway.envelopes[0].recipient.thread_id == "thread-agent-1"
     assert all(envelope.sender.user_id == "owner-1" for envelope in gateway.envelopes)
     assert all(envelope.message.metadata["event_id"] == "event-1" for envelope in gateway.envelopes)
+    assert all(envelope.message.metadata["operation"] == "updated" for envelope in gateway.envelopes)
 
 
 @pytest.mark.asyncio
@@ -152,8 +171,7 @@ async def test_workflow_event_notification_fn_reads_members_and_schedules_runtim
 
     await asyncio.to_thread(
         notify,
-        _event(),
-        "owner-1",
+        _change(),
     )
 
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -285,7 +285,7 @@ def test_chat_workflow_event_service_notifies_after_create_when_wired() -> None:
     repo = _WorkflowEventRepo()
     notifications = []
     service = ChatWorkflowEventService(repo)
-    service.set_event_notification_fn(lambda event, sender_user_id: notifications.append((event, sender_user_id)))
+    service.set_event_notification_fn(notifications.append)
 
     event = service.create_event(
         "chat-1",
@@ -293,13 +293,16 @@ def test_chat_workflow_event_service_notifies_after_create_when_wired() -> None:
         requested_by_user_id="owner-1",
     )
 
-    assert notifications == [(event, "owner-1")]
+    assert len(notifications) == 1
+    assert notifications[0].operation == "created"
+    assert notifications[0].event == event
+    assert notifications[0].actor_user_id == "owner-1"
 
 
 def test_chat_workflow_event_service_requires_requester_for_wired_notification() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
-    service.set_event_notification_fn(lambda _event, _sender_user_id: None)
+    service.set_event_notification_fn(lambda _change: None)
 
     try:
         service.create_event("chat-1", kind="task_proposed_review")
@@ -314,7 +317,7 @@ def test_chat_workflow_event_service_notifies_after_update_when_wired() -> None:
     notifications = []
     service = ChatWorkflowEventService(repo)
     event = service.create_event("chat-1", kind="task_proposed_review")
-    service.set_event_notification_fn(lambda event, sender_user_id: notifications.append((event, sender_user_id)))
+    service.set_event_notification_fn(notifications.append)
 
     updated = service.update_event(
         "chat-1",
@@ -323,14 +326,17 @@ def test_chat_workflow_event_service_notifies_after_update_when_wired() -> None:
         updated_by_user_id="reviewer-1",
     )
 
-    assert notifications == [(updated, "reviewer-1")]
+    assert len(notifications) == 1
+    assert notifications[0].operation == "updated"
+    assert notifications[0].event == updated
+    assert notifications[0].actor_user_id == "reviewer-1"
 
 
 def test_chat_workflow_event_service_requires_actor_for_wired_update_notification() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
     event = service.create_event("chat-1", kind="task_proposed_review")
-    service.set_event_notification_fn(lambda _event, _sender_user_id: None)
+    service.set_event_notification_fn(lambda _change: None)
 
     try:
         service.update_event("chat-1", event["event_id"], state="settled")


### PR DESCRIPTION
## Summary

- model workflow event notifications as a service-level `WorkflowEventChange`
- carry `operation`, durable event payload, and actor user id through the existing runtime wake path
- keep the external runtime event type as `chat.workflow.event`; expose the operation only as metadata

## Notes

This is a small architecture cleanup for the event/action lane. It does not add a generic DSL, a second transport path, or a new product surface.

## Verification

- `uv run pyright core/work_item/chat_workflow/service.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff format --check core/work_item/chat_workflow/service.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check core/work_item/chat_workflow/service.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/integration_contracts/test_messaging_router.py -q`
