### PR TITLE
Expose workflow event changes from core service

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -178,7 +178,7 @@ def wire_workflow_event_notifications(
     thread_repo: Any,
     user_repo: Any,
 ) -> None:
-    chat_workflow_event_service.set_event_notification_fn(
+    chat_workflow_event_service.set_event_change_fn(
         make_workflow_event_notification_fn(
             app,
             activity_reader=activity_reader,

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -130,10 +130,10 @@ class ChatTaskService:
 class ChatWorkflowEventService:
     def __init__(self, event_repo: Any) -> None:
         self._repo = event_repo
-        self._event_notification_fn: Callable[[WorkflowEventChange], None] | None = None
+        self._event_change_fn: Callable[[WorkflowEventChange], None] | None = None
 
-    def set_event_notification_fn(self, notification_fn: Callable[[WorkflowEventChange], None]) -> None:
-        self._event_notification_fn = notification_fn
+    def set_event_change_fn(self, change_fn: Callable[[WorkflowEventChange], None]) -> None:
+        self._event_change_fn = change_fn
 
     def list_events(self, chat_id: str) -> list[dict[str, Any]]:
         return [_event_response(event) for event in self._repo.list_all(chat_id)]
@@ -169,10 +169,10 @@ class ChatWorkflowEventService:
         )
         self._repo.insert(chat_id, event)
         response = _event_response(event)
-        if self._event_notification_fn is not None:
+        if self._event_change_fn is not None:
             if requested_by_user_id is None:
-                raise RuntimeError("Workflow event notification requires requested_by_user_id")
-            self._event_notification_fn(
+                raise RuntimeError("Workflow event change requires requested_by_user_id")
+            self._event_change_fn(
                 WorkflowEventChange(
                     operation="created",
                     event=response,
@@ -213,10 +213,10 @@ class ChatWorkflowEventService:
             event.settled_at = settled_at
         updated = self._repo.update(chat_id, event, expected_state_version=expected_state_version)
         response = _event_response(updated)
-        if self._event_notification_fn is not None:
+        if self._event_change_fn is not None:
             if updated_by_user_id is None:
-                raise RuntimeError("Workflow event update notification requires updated_by_user_id")
-            self._event_notification_fn(
+                raise RuntimeError("Workflow event change requires updated_by_user_id")
+            self._event_change_fn(
                 WorkflowEventChange(
                     operation="updated",
                     event=response,

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -120,7 +120,8 @@ def test_attach_chat_runtime_requires_explicit_user_repo_and_thread_repo():
     )
 
     try:
-        chat_bootstrap.attach_chat_runtime(app, storage_container)
+        attach = getattr(chat_bootstrap, "attach_chat_runtime")
+        attach(app, storage_container)
     except TypeError as exc:
         message = str(exc)
         assert "user_repo" in message
@@ -251,25 +252,25 @@ def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(mo
     assert chat_join_request_service.notification_fn is notification_fn
 
 
-def test_wire_workflow_event_notifications_binds_notification_fn(monkeypatch):
-    notification_fn = object()
-    chat_workflow_event_service = SimpleNamespace(notification_fn=None)
+def test_wire_workflow_event_notifications_binds_change_fn(monkeypatch):
+    change_fn = object()
+    chat_workflow_event_service = SimpleNamespace(change_fn=None)
     messaging_service = object()
     activity_reader = object()
     thread_repo = object()
     user_repo = object()
 
-    def _set_notification_fn(value):
-        chat_workflow_event_service.notification_fn = value
+    def _set_change_fn(value):
+        chat_workflow_event_service.change_fn = value
 
-    chat_workflow_event_service.set_event_notification_fn = _set_notification_fn
+    chat_workflow_event_service.set_event_change_fn = _set_change_fn
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     monkeypatch.setattr(
         chat_bootstrap,
         "make_workflow_event_notification_fn",
-        lambda target_app, *, activity_reader, thread_repo, user_repo, messaging_service: notification_fn,
+        lambda target_app, *, activity_reader, thread_repo, user_repo, messaging_service: change_fn,
     )
 
     chat_bootstrap.wire_workflow_event_notifications(
@@ -281,4 +282,4 @@ def test_wire_workflow_event_notifications_binds_notification_fn(monkeypatch):
         user_repo=user_repo,
     )
 
-    assert chat_workflow_event_service.notification_fn is notification_fn
+    assert chat_workflow_event_service.change_fn is change_fn

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -48,7 +48,7 @@ class _WorkflowRepo:
             updated_by_user_id=updated_by_user_id,
             created_at=1.0,
             updated_at=2.0,
-            state_version=0 if existing is None else existing_version + 1,
+            state_version=0 if existing is None else existing.state_version + 1,
         )
         self.rows[chat_id] = row
         return row
@@ -112,7 +112,7 @@ class _WorkflowEventRepo:
                 expected_state_version=expected_state_version,
                 actual_state_version=existing_version,
             )
-        updated = event.model_copy(update={"state_version": 0 if existing is None else existing_version + 1})
+        updated = event.model_copy(update={"state_version": 0 if existing is None else existing.state_version + 1})
         self.rows.setdefault(scope_id, {})[event.event_id] = updated
         return updated
 
@@ -281,11 +281,11 @@ def test_chat_workflow_event_service_versions_updates_and_rejects_stale_writes()
     assert service.get_event("chat-1", event["event_id"]) == updated
 
 
-def test_chat_workflow_event_service_notifies_after_create_when_wired() -> None:
+def test_chat_workflow_event_service_emits_change_after_create_when_wired() -> None:
     repo = _WorkflowEventRepo()
-    notifications = []
+    changes = []
     service = ChatWorkflowEventService(repo)
-    service.set_event_notification_fn(notifications.append)
+    service.set_event_change_fn(changes.append)
 
     event = service.create_event(
         "chat-1",
@@ -293,31 +293,31 @@ def test_chat_workflow_event_service_notifies_after_create_when_wired() -> None:
         requested_by_user_id="owner-1",
     )
 
-    assert len(notifications) == 1
-    assert notifications[0].operation == "created"
-    assert notifications[0].event == event
-    assert notifications[0].actor_user_id == "owner-1"
+    assert len(changes) == 1
+    assert changes[0].operation == "created"
+    assert changes[0].event == event
+    assert changes[0].actor_user_id == "owner-1"
 
 
-def test_chat_workflow_event_service_requires_requester_for_wired_notification() -> None:
+def test_chat_workflow_event_service_requires_requester_for_wired_change() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
-    service.set_event_notification_fn(lambda _change: None)
+    service.set_event_change_fn(lambda _change: None)
 
     try:
         service.create_event("chat-1", kind="task_proposed_review")
     except RuntimeError as exc:
-        assert str(exc) == "Workflow event notification requires requested_by_user_id"
+        assert str(exc) == "Workflow event change requires requested_by_user_id"
     else:
-        raise AssertionError("wired workflow event notification accepted missing requester")
+        raise AssertionError("wired workflow event change accepted missing requester")
 
 
-def test_chat_workflow_event_service_notifies_after_update_when_wired() -> None:
+def test_chat_workflow_event_service_emits_change_after_update_when_wired() -> None:
     repo = _WorkflowEventRepo()
-    notifications = []
+    changes = []
     service = ChatWorkflowEventService(repo)
     event = service.create_event("chat-1", kind="task_proposed_review")
-    service.set_event_notification_fn(notifications.append)
+    service.set_event_change_fn(changes.append)
 
     updated = service.update_event(
         "chat-1",
@@ -326,21 +326,21 @@ def test_chat_workflow_event_service_notifies_after_update_when_wired() -> None:
         updated_by_user_id="reviewer-1",
     )
 
-    assert len(notifications) == 1
-    assert notifications[0].operation == "updated"
-    assert notifications[0].event == updated
-    assert notifications[0].actor_user_id == "reviewer-1"
+    assert len(changes) == 1
+    assert changes[0].operation == "updated"
+    assert changes[0].event == updated
+    assert changes[0].actor_user_id == "reviewer-1"
 
 
-def test_chat_workflow_event_service_requires_actor_for_wired_update_notification() -> None:
+def test_chat_workflow_event_service_requires_actor_for_wired_update_change() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
     event = service.create_event("chat-1", kind="task_proposed_review")
-    service.set_event_notification_fn(lambda _change: None)
+    service.set_event_change_fn(lambda _change: None)
 
     try:
         service.update_event("chat-1", event["event_id"], state="settled")
     except RuntimeError as exc:
-        assert str(exc) == "Workflow event update notification requires updated_by_user_id"
+        assert str(exc) == "Workflow event change requires updated_by_user_id"
     else:
-        raise AssertionError("wired workflow event update notification accepted missing actor")
+        raise AssertionError("wired workflow event change accepted missing actor")


### PR DESCRIPTION
## Summary

- rename the core workflow event hook from notification-oriented wording to `set_event_change_fn`
- keep runtime notification mapping in the backend adapter layer
- clean small type noise in the touched unit test helpers

## Notes

This keeps the domain service at the event/change boundary. The backend still maps the change to the existing runtime notification path; no new DSL, transport, or duplicate runtime mechanism is introduced.

## Verification

- `uv run pyright core/work_item/chat_workflow/service.py backend/chat/bootstrap.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py`
- `uv run ruff format --check core/work_item/chat_workflow/service.py backend/chat/bootstrap.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py`
- `uv run ruff check core/work_item/chat_workflow/service.py backend/chat/bootstrap.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py`
- `uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/test_web_lifespan_ordering.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/core/test_chat_workflow_service.py -q`
- `uv run pyright core/work_item/chat_workflow/service.py backend/chat/bootstrap.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/core/test_chat_workflow_service.py`
