### PR TITLE
Use current branch in YATU backend setup

### DIFF
--- a/tests/yatu/chat-managed-agent-word-chain.md
+++ b/tests/yatu/chat-managed-agent-word-chain.md
@@ -8,7 +8,7 @@ without me coordinating each word.
 
 ## Product Surface
 
-- Real Mycel backend from current `origin/dev`.
+- Real Mycel backend from the current branch.
 - Real Mycel-managed agents with LLM execution enabled.
 - Public chat UI or public chat API/CLI.
 - Durable chat messages visible to all group members.

--- a/tests/yatu/external-managed-agent-chat.md
+++ b/tests/yatu/external-managed-agent-chat.md
@@ -8,7 +8,7 @@ chat surface a user sees.
 
 ## Product Surface
 
-- Real Mycel backend from current `origin/dev`.
+- Real Mycel backend from the current branch.
 - Installed `cel` executable from the SDK repository.
 - Global `~/.mycel` owner login and local external-agent identity.
 - Real Mycel-managed agent with LLM execution enabled.


### PR DESCRIPTION
## Summary

- update two YATU cards to require a backend from the current branch instead of `origin/dev`

## Notes

This prevents branch-local backend/runtime proofs from accidentally exercising stale shared dev. No product code changes.

## Verification

- `if rg -n --fixed-strings 'origin/dev' tests/yatu; then exit 1; else echo 'no origin/dev in tests/yatu'; fi`
- `rg -n --fixed-strings 'Real Mycel backend from the current branch.' tests/yatu/chat-managed-agent-word-chain.md tests/yatu/external-managed-agent-chat.md`
- `git diff --check -- tests/yatu/chat-managed-agent-word-chain.md tests/yatu/external-managed-agent-chat.md`
