### PR TITLE
Plan workflow event runtime notifications

### DIFF
--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -53,6 +53,25 @@ async def dispatch_workflow_event_notifications(
     thread_repo: Any,
     activity_reader: Any,
 ) -> None:
+    gateway = get_agent_runtime_gateway(app)
+    for envelope in make_workflow_event_notification_envelopes(
+        change=change,
+        members=members,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    ):
+        await gateway.dispatch_notification(envelope)
+
+
+def make_workflow_event_notification_envelopes(
+    *,
+    change: WorkflowEventChange,
+    members: list[Mapping[str, Any]],
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> list[AgentRuntimeNotificationEnvelope]:
     sender_user_id = change.actor_user_id
     sender_user = _require_user(user_repo, sender_user_id, "sender")
     sender = AgentRuntimeActor(
@@ -61,6 +80,7 @@ async def dispatch_workflow_event_notifications(
         display_name=_display_name(sender_user, sender_user_id),
         source="workflow",
     )
+    envelopes: list[AgentRuntimeNotificationEnvelope] = []
     for member in members:
         recipient_user_id = _member_user_id(member)
         if recipient_user_id == sender_user_id:
@@ -75,28 +95,14 @@ async def dispatch_workflow_event_notifications(
         )
         if recipient is None:
             continue
-        await dispatch_workflow_event_notification(
-            app,
-            change=change,
-            recipient=recipient,
-            sender=sender,
+        envelopes.append(
+            make_workflow_event_notification_envelope(
+                change=change,
+                recipient=recipient,
+                sender=sender,
+            )
         )
-
-
-async def dispatch_workflow_event_notification(
-    app: Any,
-    *,
-    change: WorkflowEventChange,
-    recipient: AgentChatRecipient,
-    sender: AgentRuntimeActor,
-) -> None:
-    await get_agent_runtime_gateway(app).dispatch_notification(
-        make_workflow_event_notification_envelope(
-            change=change,
-            recipient=recipient,
-            sender=sender,
-        )
-    )
+    return envelopes
 
 
 def make_workflow_event_notification_envelope(

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -9,6 +9,7 @@ import pytest
 from backend.threads.chat_adapters.workflow_event_inlet import (
     dispatch_workflow_event_notifications,
     make_workflow_event_notification_envelope,
+    make_workflow_event_notification_envelopes,
     make_workflow_event_notification_fn,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
@@ -130,12 +131,8 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
         raise AssertionError("missing workflow event identity did not fail")
 
 
-@pytest.mark.asyncio
-async def test_dispatch_workflow_event_notifications_fans_out_to_runtime_members() -> None:
-    gateway = _RecordingGateway()
-
-    await dispatch_workflow_event_notifications(
-        _runtime_app(gateway),
+def test_workflow_event_notification_planner_selects_runtime_members() -> None:
+    envelopes = make_workflow_event_notification_envelopes(
         change=_change("updated"),
         members=[
             {"user_id": "owner-1"},
@@ -149,12 +146,30 @@ async def test_dispatch_workflow_event_notifications_fans_out_to_runtime_members
         activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
     )
 
-    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1", "external-1"]
-    assert [envelope.recipient.runtime_source for envelope in gateway.envelopes] == ["mycel", "external"]
-    assert gateway.envelopes[0].recipient.thread_id == "thread-agent-1"
-    assert all(envelope.sender.user_id == "owner-1" for envelope in gateway.envelopes)
-    assert all(envelope.message.metadata["event_id"] == "event-1" for envelope in gateway.envelopes)
-    assert all(envelope.message.metadata["operation"] == "updated" for envelope in gateway.envelopes)
+    assert [envelope.recipient.agent_user_id for envelope in envelopes] == ["agent-1", "external-1"]
+    assert [envelope.recipient.runtime_source for envelope in envelopes] == ["mycel", "external"]
+    assert envelopes[0].recipient.thread_id == "thread-agent-1"
+    assert all(envelope.sender.user_id == "owner-1" for envelope in envelopes)
+    for envelope in envelopes:
+        assert envelope.message.metadata is not None
+        assert envelope.message.metadata["event_id"] == "event-1"
+        assert envelope.message.metadata["operation"] == "updated"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_workflow_event_notifications_executes_planned_envelopes() -> None:
+    gateway = _RecordingGateway()
+
+    await dispatch_workflow_event_notifications(
+        _runtime_app(gateway),
+        change=_change(),
+        members=[{"user_id": "owner-1"}, {"user_id": "agent-1"}],
+        user_repo=_users("agent-1"),
+        thread_repo=_thread_repo("agent-1"),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a pure workflow event notification planner that maps `WorkflowEventChange` plus chat members to runtime notification envelopes
- keep dispatch as the executor over planned envelopes
- remove the one-envelope pass-through dispatch helper

## Notes

This is a small event/action architecture step: durable workflow event change -> concrete runtime notification envelopes -> gateway execution. It does not add a DSL, registry, second transport, or duplicate runtime path.

## Verification

- `uv run pyright backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff format --check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py -q`
