### PR TITLE
Name workflow event runtime planning explicitly

### DIFF
--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
 from typing import Any
 
@@ -24,7 +24,7 @@ def make_workflow_event_notification_fn(
     thread_repo: Any,
     user_repo: Any,
     messaging_service: Any,
-):
+) -> Callable[[WorkflowEventChange], None]:
     loop = asyncio.get_running_loop()
 
     async def notify_runtime(change: WorkflowEventChange) -> None:
@@ -48,13 +48,13 @@ async def dispatch_workflow_event_notifications(
     app: Any,
     *,
     change: WorkflowEventChange,
-    members: list[Mapping[str, Any]],
+    members: Sequence[Mapping[str, Any]],
     user_repo: Any,
     thread_repo: Any,
     activity_reader: Any,
 ) -> None:
     gateway = get_agent_runtime_gateway(app)
-    for envelope in make_workflow_event_notification_envelopes(
+    for envelope in plan_workflow_event_runtime_notifications(
         change=change,
         members=members,
         user_repo=user_repo,
@@ -64,10 +64,10 @@ async def dispatch_workflow_event_notifications(
         await gateway.dispatch_notification(envelope)
 
 
-def make_workflow_event_notification_envelopes(
+def plan_workflow_event_runtime_notifications(
     *,
     change: WorkflowEventChange,
-    members: list[Mapping[str, Any]],
+    members: Sequence[Mapping[str, Any]],
     user_repo: Any,
     thread_repo: Any,
     activity_reader: Any,

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -9,8 +9,8 @@ import pytest
 from backend.threads.chat_adapters.workflow_event_inlet import (
     dispatch_workflow_event_notifications,
     make_workflow_event_notification_envelope,
-    make_workflow_event_notification_envelopes,
     make_workflow_event_notification_fn,
+    plan_workflow_event_runtime_notifications,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentChatRecipient, AgentRuntimeActor
@@ -132,7 +132,7 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
 
 
 def test_workflow_event_notification_planner_selects_runtime_members() -> None:
-    envelopes = make_workflow_event_notification_envelopes(
+    envelopes = plan_workflow_event_runtime_notifications(
         change=_change("updated"),
         members=[
             {"user_id": "owner-1"},


### PR DESCRIPTION
## Summary
- rename the workflow event notification planner to `plan_workflow_event_runtime_notifications`
- make the factory return type and planner member input type explicit
- keep this slice behavior-only-neutral: no DSL, action registry, or transport change

## Verification
- `uv run pyright backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff format --check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py -q` -> 16 passed
