### PR TITLE
Share runtime identity helpers across chat adapters

### DIFF
--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from enum import Enum
 from typing import Any
 
-from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_identity import display_name, make_runtime_actor, require_user, user_type
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from protocols.agent_runtime import (
-    AgentRuntimeActor,
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
 )
@@ -21,10 +19,10 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
         requester_id = _required_str(row, "requester_user_id")
         decider_id = _required_str(row, "decided_by_user_id")
         chat_id = _required_str(row, "chat_id")
-        requester = _require_user(user_repo, requester_id, "requester")
-        decider = _require_user(user_repo, decider_id, "decider")
-        requester_type = _user_type(requester, requester_id)
-        content = f"{_display_name(decider, decider_id)} rejected your request to join chat {chat_id}."
+        requester = require_user(user_repo, requester_id, context="Chat join rejection", role="requester")
+        decider = require_user(user_repo, decider_id, context="Chat join rejection", role="decider")
+        requester_type = user_type(requester, requester_id, context="Chat join rejection")
+        content = f"{display_name(decider, decider_id, context='Chat join rejection')} rejected your request to join chat {chat_id}."
         metadata = {
             "chat_join_request_id": _required_str(row, "id"),
             "chat_id": chat_id,
@@ -43,12 +41,12 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
             AgentRuntimeNotificationEnvelope(
                 event_type="chat.join.rejected",
                 recipient=recipient,
-                sender=AgentRuntimeActor(
+                sender=make_runtime_actor(
                     user_id=decider_id,
-                    user_type=_user_type(decider, decider_id),
-                    display_name=_display_name(decider, decider_id),
-                    avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                    user=decider,
                     source="chat_join",
+                    context="Chat join rejection",
+                    include_avatar=True,
                 ),
                 message=AgentRuntimeMessage(
                     content=content,
@@ -70,24 +68,3 @@ def _required_str(row: dict[str, Any], key: str) -> str:
     if not value:
         raise RuntimeError(f"Chat join rejection row is missing {key}: {row.get('id') or '<missing>'}")
     return str(value)
-
-
-def _require_user(user_repo: Any, user_id: str, role: str) -> Any:
-    user = user_repo.get_by_id(user_id)
-    if user is None:
-        raise RuntimeError(f"Chat join rejection {role} user not found: {user_id}")
-    return user
-
-
-def _user_type(user: Any, user_id: str) -> str:
-    raw_type = getattr(user, "type", None)
-    if raw_type is None:
-        raise RuntimeError(f"Chat join rejection user is missing type: {user_id}")
-    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
-
-
-def _display_name(user: Any, user_id: str) -> str:
-    display_name = getattr(user, "display_name", None)
-    if display_name is None:
-        raise RuntimeError(f"Chat join rejection user is missing display name: {user_id}")
-    return str(display_name)

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from enum import Enum
 from typing import Any
 
-from backend.identity.avatar.urls import avatar_url
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_identity import display_name, make_runtime_actor, require_user, user_type
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from messaging.contracts import RelationshipEvent, RelationshipRow
 from protocols.agent_runtime import (
@@ -27,9 +26,9 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
     async def notify_runtime(row: RelationshipRow) -> None:
         requester_id = _requester_id(row)
         target_id = _target_id(row, requester_id)
-        requester = _require_user(user_repo, requester_id, "requester")
-        target = _require_user(user_repo, target_id, "target")
-        target_type = _user_type(target, target_id)
+        requester = require_user(user_repo, requester_id, context="Relationship request", role="requester")
+        target = require_user(user_repo, target_id, context="Relationship request", role="target")
+        target_type = user_type(target, target_id, context="Relationship request")
         recipient = select_runtime_notification_recipient(
             target_id,
             target_type,
@@ -42,16 +41,16 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
         await _dispatch_notification(
             app,
             recipient=recipient,
-            sender=AgentRuntimeActor(
+            sender=make_runtime_actor(
                 user_id=requester_id,
-                user_type=_user_type(requester, requester_id),
-                display_name=_display_name(requester, requester_id),
-                avatar_url=avatar_url(requester_id, bool(getattr(requester, "avatar", None))),
+                user=requester,
                 source="relationship",
+                context="Relationship request",
+                include_avatar=True,
             ),
             message=AgentRuntimeMessage(
                 content=_notification_content(
-                    _display_name(requester, requester_id),
+                    display_name(requester, requester_id, context="Relationship request"),
                     row.message,
                 ),
                 metadata={"relationship_id": row.id},
@@ -72,9 +71,9 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
     async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
         requester_id = _requester_id(row)
         decider_id = _target_id(row, requester_id)
-        requester = _require_user(user_repo, requester_id, "requester")
-        decider = _require_user(user_repo, decider_id, "decider")
-        requester_type = _user_type(requester, requester_id)
+        requester = require_user(user_repo, requester_id, context="Relationship request", role="requester")
+        decider = require_user(user_repo, decider_id, context="Relationship request", role="decider")
+        requester_type = user_type(requester, requester_id, context="Relationship request")
         recipient = select_runtime_notification_recipient(
             requester_id,
             requester_type,
@@ -87,15 +86,18 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
         await _dispatch_notification(
             app,
             recipient=recipient,
-            sender=AgentRuntimeActor(
+            sender=make_runtime_actor(
                 user_id=decider_id,
-                user_type=_user_type(decider, decider_id),
-                display_name=_display_name(decider, decider_id),
-                avatar_url=avatar_url(decider_id, bool(getattr(decider, "avatar", None))),
+                user=decider,
                 source="relationship",
+                context="Relationship request",
+                include_avatar=True,
             ),
             message=AgentRuntimeMessage(
-                content=f"{_display_name(decider, decider_id)} {_decision_verb(event)} your relationship request.",
+                content=(
+                    f"{display_name(decider, decider_id, context='Relationship request')} "
+                    f"{_decision_verb(event)} your relationship request."
+                ),
                 metadata={
                     "relationship_id": row.id,
                     "event": event,
@@ -143,27 +145,6 @@ def _target_id(row: RelationshipRow, requester_id: str) -> str:
     if requester_id == row.user_high:
         return row.user_low
     raise RuntimeError(f"Relationship request initiator is not a party: {row.id}")
-
-
-def _require_user(user_repo: Any, user_id: str, role: str) -> Any:
-    user = user_repo.get_by_id(user_id)
-    if user is None:
-        raise RuntimeError(f"Relationship request {role} user not found: {user_id}")
-    return user
-
-
-def _user_type(user: Any, user_id: str) -> str:
-    raw_type = getattr(user, "type", None)
-    if raw_type is None:
-        raise RuntimeError(f"Relationship request user is missing type: {user_id}")
-    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
-
-
-def _display_name(user: Any, user_id: str) -> str:
-    display_name = getattr(user, "display_name", None)
-    if display_name is None:
-        raise RuntimeError(f"Relationship request user is missing display name: {user_id}")
-    return str(display_name)
 
 
 def _notification_content(requester_name: str, message: str | None) -> str:

--- a/backend/threads/chat_adapters/runtime_identity.py
+++ b/backend/threads/chat_adapters/runtime_identity.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from backend.identity.avatar.urls import avatar_url
+from protocols.agent_runtime import AgentRuntimeActor
+
+
+def require_user(user_repo: Any, user_id: str, *, context: str, role: str) -> Any:
+    user = user_repo.get_by_id(user_id)
+    if user is None:
+        raise RuntimeError(f"{context} {role} user not found: {user_id}")
+    return user
+
+
+def user_type(user: Any, user_id: str, *, context: str) -> str:
+    raw_type = getattr(user, "type", None)
+    if raw_type is None:
+        raise RuntimeError(f"{context} user is missing type: {user_id}")
+    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
+
+
+def display_name(user: Any, user_id: str, *, context: str) -> str:
+    name = getattr(user, "display_name", None)
+    if name is None:
+        raise RuntimeError(f"{context} user is missing display name: {user_id}")
+    return str(name)
+
+
+def make_runtime_actor(
+    *,
+    user_id: str,
+    user: Any,
+    source: str,
+    context: str,
+    include_avatar: bool = False,
+) -> AgentRuntimeActor:
+    return AgentRuntimeActor(
+        user_id=user_id,
+        user_type=user_type(user, user_id, context=context),
+        display_name=display_name(user, user_id, context=context),
+        avatar_url=avatar_url(user_id, bool(getattr(user, "avatar", None))) if include_avatar else None,
+        source=source,
+    )

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping, Sequence
-from enum import Enum
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user, user_type
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import (
@@ -73,22 +73,22 @@ def plan_workflow_event_runtime_notifications(
     activity_reader: Any,
 ) -> list[AgentRuntimeNotificationEnvelope]:
     sender_user_id = change.actor_user_id
-    sender_user = _require_user(user_repo, sender_user_id, "sender")
-    sender = AgentRuntimeActor(
+    sender_user = require_user(user_repo, sender_user_id, context="Workflow event notification", role="sender")
+    sender = make_runtime_actor(
         user_id=sender_user_id,
-        user_type=_user_type(sender_user, sender_user_id),
-        display_name=_display_name(sender_user, sender_user_id),
+        user=sender_user,
         source="workflow",
+        context="Workflow event notification",
     )
     envelopes: list[AgentRuntimeNotificationEnvelope] = []
     for member in members:
         recipient_user_id = _member_user_id(member)
         if recipient_user_id == sender_user_id:
             continue
-        recipient_user = _require_user(user_repo, recipient_user_id, "recipient")
+        recipient_user = require_user(user_repo, recipient_user_id, context="Workflow event notification", role="recipient")
         recipient = select_runtime_notification_recipient(
             recipient_user_id,
-            _user_type(recipient_user, recipient_user_id),
+            user_type(recipient_user, recipient_user_id, context="Workflow event notification"),
             thread_repo=thread_repo,
             activity_reader=activity_reader,
             context="workflow event",
@@ -161,24 +161,3 @@ def _member_user_id(member: Mapping[str, Any]) -> str:
     if not user_id:
         raise RuntimeError("Workflow event notification member row is missing user_id")
     return user_id
-
-
-def _require_user(user_repo: Any, user_id: str, role: str) -> Any:
-    user = user_repo.get_by_id(user_id)
-    if user is None:
-        raise RuntimeError(f"Workflow event notification {role} user not found: {user_id}")
-    return user
-
-
-def _user_type(user: Any, user_id: str) -> str:
-    raw_type = getattr(user, "type", None)
-    if raw_type is None:
-        raise RuntimeError(f"Workflow event notification user is missing type: {user_id}")
-    return raw_type.value if isinstance(raw_type, Enum) else str(raw_type)
-
-
-def _display_name(user: Any, user_id: str) -> str:
-    display_name = getattr(user, "display_name", None)
-    if display_name is None:
-        raise RuntimeError(f"Workflow event notification user is missing display name: {user_id}")
-    return str(display_name)


### PR DESCRIPTION
## Summary
- add one shared runtime identity helper for user lookup, type/display-name extraction, and runtime actor construction
- remove duplicate local identity helpers from relationship, chat-join, and workflow-event notification inlets
- keep notification content, metadata, recipient selection, and gateway dispatch behavior unchanged

## Verification
- `uv run pyright backend/threads/chat_adapters tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_identity.py backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/chat_join_inlet.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_identity.py backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/chat_join_inlet.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` -> 36 passed
