### PR TITLE
Share sync runtime event hook bridge

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from messaging.delivery.contracts import ChatDeliveryRequest
 from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
 from protocols.agent_runtime import (
@@ -20,10 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
-    import asyncio
-
-    loop = asyncio.get_running_loop()
-
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
         raw_recipient_type = getattr(request.recipient_user, "type", None)
         if raw_recipient_type is None:
@@ -78,8 +75,4 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
         )
         await get_agent_runtime_gateway(app).dispatch_chat(envelope)
 
-    def _deliver(request: ChatDeliveryRequest) -> None:
-        future = asyncio.run_coroutine_threadsafe(deliver_to_runtime_gateway(request), loop)
-        future.result()
-
-    return _deliver
+    return make_sync_runtime_event_hook(deliver_to_runtime_gateway)

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, make_runtime_actor, require_user, user_type
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from protocols.agent_runtime import (
@@ -13,8 +13,6 @@ from protocols.agent_runtime import (
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    loop = asyncio.get_running_loop()
-
     async def notify_runtime(row: dict[str, Any]) -> None:
         requester_id = _required_str(row, "requester_user_id")
         decider_id = _required_str(row, "decided_by_user_id")
@@ -56,11 +54,7 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
             )
         )
 
-    def _notify(row: dict[str, Any]) -> None:
-        future = asyncio.run_coroutine_threadsafe(notify_runtime(row), loop)
-        future.result()
-
-    return _notify
+    return make_sync_runtime_event_hook(notify_runtime)
 
 
 def _required_str(row: dict[str, Any], key: str) -> str:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, make_runtime_actor, require_user, user_type
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from messaging.contracts import RelationshipEvent, RelationshipRow
@@ -21,8 +21,6 @@ _DECISION_VERBS: dict[RelationshipEvent, str] = {
 
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    loop = asyncio.get_running_loop()
-
     async def notify_runtime(row: RelationshipRow) -> None:
         requester_id = _requester_id(row)
         target_id = _target_id(row, requester_id)
@@ -58,16 +56,10 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
             event_type="relationship.requested",
         )
 
-    def _notify(row: RelationshipRow) -> None:
-        future = asyncio.run_coroutine_threadsafe(notify_runtime(row), loop)
-        future.result()
-
-    return _notify
+    return make_sync_runtime_event_hook(notify_runtime)
 
 
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    loop = asyncio.get_running_loop()
-
     async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
         requester_id = _requester_id(row)
         decider_id = _target_id(row, requester_id)
@@ -107,11 +99,7 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
             event_type=f"relationship.{_decision_verb(event)}",
         )
 
-    def _notify(row: RelationshipRow, event: RelationshipEvent) -> None:
-        future = asyncio.run_coroutine_threadsafe(notify_runtime(row, event), loop)
-        future.result()
-
-    return _notify
+    return make_sync_runtime_event_hook(notify_runtime)
 
 
 async def _dispatch_notification(

--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+
+def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, None]]) -> Callable[P, None]:
+    loop = asyncio.get_running_loop()
+
+    def hook(*args: P.args, **kwargs: P.kwargs) -> None:
+        future = asyncio.run_coroutine_threadsafe(async_fn(*args, **kwargs), loop)
+        future.result()
+
+    return hook

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user, user_type
 from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
 from core.work_item.chat_workflow.service import WorkflowEventChange
@@ -25,8 +25,6 @@ def make_workflow_event_notification_fn(
     user_repo: Any,
     messaging_service: Any,
 ) -> Callable[[WorkflowEventChange], None]:
-    loop = asyncio.get_running_loop()
-
     async def notify_runtime(change: WorkflowEventChange) -> None:
         await dispatch_workflow_event_notifications(
             app,
@@ -37,11 +35,7 @@ def make_workflow_event_notification_fn(
             activity_reader=activity_reader,
         )
 
-    def _notify(change: WorkflowEventChange) -> None:
-        future = asyncio.run_coroutine_threadsafe(notify_runtime(change), loop)
-        future.result()
-
-    return _notify
+    return make_sync_runtime_event_hook(notify_runtime)
 
 
 async def dispatch_workflow_event_notifications(


### PR DESCRIPTION
## Summary
- add one shared sync-to-async runtime event hook bridge for chat adapter callbacks
- remove duplicated `get_running_loop` / `run_coroutine_threadsafe` wrappers from chat delivery, relationship, chat join, and workflow event inlets
- keep fail-loud behavior by preserving `future.result()` propagation

## Verification
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/chat_join_inlet.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/chat_join_inlet.py`
- `uv run pyright backend/threads/chat_adapters tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` -> 36 passed
