### PR TITLE
Preserve runtime notification metadata through queue

### DIFF
--- a/backend/threads/chat_adapters/notification_handler.py
+++ b/backend/threads/chat_adapters/notification_handler.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from protocols import agent_runtime as agent_runtime_protocol
 
+from .runtime_metadata import notification_message_metadata
+
 
 class NativeAgentNotificationHandler:
     def __init__(self, *, thread_input_handler: Any) -> None:
@@ -19,7 +21,15 @@ class NativeAgentNotificationHandler:
             agent_runtime_protocol.AgentThreadInputEnvelope(
                 thread_id=thread_id,
                 sender=envelope.sender,
-                message=envelope.message,
+                message=agent_runtime_protocol.AgentRuntimeMessage(
+                    content=envelope.message.content,
+                    content_type=envelope.message.content_type,
+                    message_id=envelope.message.message_id,
+                    signal=envelope.message.signal,
+                    created_at=envelope.message.created_at,
+                    attachments=envelope.message.attachments,
+                    metadata=notification_message_metadata(envelope),
+                ),
                 transport=envelope.transport,
             )
         )

--- a/backend/threads/chat_adapters/runtime_metadata.py
+++ b/backend/threads/chat_adapters/runtime_metadata.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+from protocols import agent_runtime as agent_runtime_protocol
+
+
+def transport_metadata(transport: agent_runtime_protocol.AgentRuntimeTransport) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    if transport.delivery_id is not None:
+        metadata["delivery_id"] = transport.delivery_id
+    if transport.correlation_id is not None:
+        metadata["correlation_id"] = transport.correlation_id
+    if transport.idempotency_key is not None:
+        metadata["idempotency_key"] = transport.idempotency_key
+    return metadata
+
+
+def notification_message_metadata(envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope) -> dict[str, Any]:
+    metadata = dict(envelope.message.metadata or {})
+    metadata.update(
+        {
+            "event_type": envelope.event_type,
+            "notification_type": envelope.notification_type,
+            "runtime_protocol_version": envelope.protocol_version,
+        }
+    )
+    metadata.update(transport_metadata(envelope.transport))
+    return metadata
+
+
+def thread_input_message_metadata(envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
+    metadata = dict(envelope.message.metadata or {})
+    metadata.update(transport_metadata(envelope.transport))
+    if envelope.message.attachments:
+        metadata["attachments"] = envelope.message.attachments
+    return metadata
+
+
+def thread_input_metadata(envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> dict[str, Any]:
+    metadata = thread_input_message_metadata(envelope)
+    metadata.update(
+        {
+            "source": envelope.sender.source,
+            "sender_id": envelope.sender.user_id,
+            "sender_name": envelope.sender.display_name,
+            "sender_avatar_url": envelope.sender.avatar_url,
+        }
+    )
+    return metadata
+
+
+def thread_input_notification_type(envelope: agent_runtime_protocol.AgentThreadInputEnvelope) -> str:
+    metadata = envelope.message.metadata or {}
+    return str(metadata.get("notification_type") or "steer")

--- a/backend/threads/chat_adapters/thread_handler.py
+++ b/backend/threads/chat_adapters/thread_handler.py
@@ -6,6 +6,8 @@ from typing import Any
 from core.runtime.middleware.monitor import AgentState
 from protocols import agent_runtime as agent_runtime_protocol
 
+from .runtime_metadata import thread_input_message_metadata, thread_input_metadata, thread_input_notification_type
+
 
 class NativeAgentThreadInputHandler:
     def __init__(
@@ -48,16 +50,21 @@ class NativeAgentThreadInputHandler:
                 return agent_runtime_protocol.AgentThreadInputResult(status="cancelled", routing="cancelled", thread_id=thread_id)
 
             state = agent.runtime.current_state
+            meta = thread_input_metadata(envelope)
+            queue_metadata = thread_input_message_metadata(envelope)
+            notification_type = thread_input_notification_type(envelope)
 
             if state == AgentState.ACTIVE:
                 qm.enqueue(
                     envelope.message.content,
                     thread_id,
-                    "steer",
+                    notification_type,
                     source=envelope.sender.source,
+                    sender_id=envelope.sender.user_id,
                     sender_name=envelope.sender.display_name,
                     sender_avatar_url=envelope.sender.avatar_url,
                     is_steer=True,
+                    metadata=queue_metadata,
                 )
                 return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
 
@@ -69,22 +76,15 @@ class NativeAgentThreadInputHandler:
                     qm.enqueue(
                         envelope.message.content,
                         thread_id,
-                        "steer",
+                        notification_type,
                         source=envelope.sender.source,
+                        sender_id=envelope.sender.user_id,
                         sender_name=envelope.sender.display_name,
                         sender_avatar_url=envelope.sender.avatar_url,
                         is_steer=True,
+                        metadata=queue_metadata,
                     )
                     return agent_runtime_protocol.AgentThreadInputResult(status="injected", routing="steer", thread_id=thread_id)
-                meta = {
-                    "source": envelope.sender.source,
-                    "sender_name": envelope.sender.display_name,
-                    "sender_avatar_url": envelope.sender.avatar_url,
-                }
-                if envelope.message.metadata:
-                    meta.update(envelope.message.metadata)
-                if envelope.message.attachments:
-                    meta["attachments"] = envelope.message.attachments
                 run_id = self._start_agent_run(
                     agent,
                     thread_id,

--- a/backend/threads/run/buffer_wiring.py
+++ b/backend/threads/run/buffer_wiring.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from backend.threads.events.buffer import ThreadEventBuffer
 from core.runtime.middleware.monitor import AgentState
+from core.runtime.queue_metadata import queue_item_message_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -111,13 +112,7 @@ def ensure_thread_handlers(agent: Any, thread_id: str, app: Any) -> None:
                     thread_id,
                     item.content,
                     app,
-                    message_metadata={
-                        "source": getattr(item, "source", None) or "system",
-                        "notification_type": item.notification_type,
-                        "sender_name": getattr(item, "sender_name", None),
-                        "sender_avatar_url": getattr(item, "sender_avatar_url", None),
-                        "is_steer": getattr(item, "is_steer", False),
-                    },
+                    message_metadata=queue_item_message_metadata(item),
                 )
             except Exception:
                 logger.error("wake_handler failed for thread %s", thread_id, exc_info=True)

--- a/backend/threads/run/cancellation.py
+++ b/backend/threads/run/cancellation.py
@@ -123,6 +123,7 @@ async def flush_cancelled_owner_steers(
             sender_name=item.sender_name,
             sender_avatar_url=item.sender_avatar_url,
             is_steer=item.is_steer,
+            metadata=item.metadata,
         )
 
 
@@ -147,6 +148,7 @@ async def emit_queued_terminal_followups(
                 sender_name=item.sender_name,
                 sender_avatar_url=item.sender_avatar_url,
                 is_steer=item.is_steer,
+                metadata=item.metadata,
             )
         for item in extra_terminal:
             await emit(

--- a/backend/threads/run/followups.py
+++ b/backend/threads/run/followups.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from core.runtime.middleware.monitor import AgentState
+from core.runtime.queue_metadata import queue_item_message_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -31,18 +32,22 @@ async def consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
             thread_id,
             item.content,
             app,
-            message_metadata={
-                "source": item.source or "system",
-                "notification_type": item.notification_type,
-                "sender_name": item.sender_name,
-                "sender_avatar_url": item.sender_avatar_url,
-                "is_steer": getattr(item, "is_steer", False),
-            },
+            message_metadata=queue_item_message_metadata(item),
         )
     except Exception:
         logger.exception("Failed to consume followup queue for thread %s", thread_id)
         if item:
             try:
-                app.state.queue_manager.enqueue(item.content, thread_id, notification_type=item.notification_type)
+                app.state.queue_manager.enqueue(
+                    item.content,
+                    thread_id,
+                    notification_type=item.notification_type,
+                    source=item.source,
+                    sender_id=item.sender_id,
+                    sender_name=item.sender_name,
+                    sender_avatar_url=item.sender_avatar_url,
+                    is_steer=item.is_steer,
+                    metadata=item.metadata,
+                )
             except Exception:
                 logger.error("Failed to re-enqueue followup for thread %s — message lost: %.200s", thread_id, item.content)

--- a/core/runtime/middleware/queue/manager.py
+++ b/core/runtime/middleware/queue/manager.py
@@ -4,6 +4,7 @@ import logging
 import threading
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from storage.contracts import NotificationType, QueueItem, QueueRepo
 from storage.runtime import build_queue_repo, uses_supabase_runtime_defaults
@@ -37,6 +38,7 @@ class MessageQueueManager:
         sender_name: str | None = None,
         sender_avatar_url: str | None = None,
         is_steer: bool = False,
+        metadata: dict[str, Any] | None = None,
         wake: bool = True,
     ) -> None:
         self._repo.enqueue(
@@ -46,6 +48,7 @@ class MessageQueueManager:
             source=source,
             sender_id=sender_id,
             sender_name=sender_name,
+            metadata=metadata,
         )
         if not wake:
             return
@@ -62,6 +65,7 @@ class MessageQueueManager:
                         sender_name=sender_name,
                         sender_avatar_url=sender_avatar_url,
                         is_steer=is_steer,
+                        metadata=metadata,
                     )
                 )
             except Exception:

--- a/core/runtime/middleware/queue/middleware.py
+++ b/core/runtime/middleware/queue/middleware.py
@@ -12,6 +12,7 @@ from core.runtime.middleware import (
     ModelResponse,
 )
 from core.runtime.notifications import is_terminal_background_notification
+from core.runtime.queue_metadata import queue_item_message_metadata
 
 from .manager import MessageQueueManager
 
@@ -109,6 +110,7 @@ class SteeringMiddleware(AgentMiddleware):
                 source=item.source,
                 sender_id=item.sender_id,
                 sender_name=item.sender_name,
+                metadata=item.metadata,
             )
         items = inject_now
         if not items:
@@ -125,14 +127,7 @@ class SteeringMiddleware(AgentMiddleware):
             messages.append(
                 HumanMessage(
                     content=item.content,
-                    metadata={
-                        "source": source,
-                        "notification_type": item.notification_type,
-                        "sender_name": item.sender_name,
-                        "sender_avatar_url": item.sender_avatar_url,
-                        "sender_id": item.sender_id,
-                        "is_steer": is_steer,
-                    },
+                    metadata=queue_item_message_metadata(item),
                 )
             )
 

--- a/core/runtime/queue_metadata.py
+++ b/core/runtime/queue_metadata.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def queue_item_message_metadata(item: Any, *, default_source: str = "system") -> dict[str, Any]:
+    metadata = dict(getattr(item, "metadata", None) or {})
+    source = getattr(item, "source", None) or default_source
+    is_steer = bool(getattr(item, "is_steer", False) or source == "owner")
+    metadata.update(
+        {
+            "source": source,
+            "notification_type": getattr(item, "notification_type", None),
+            "sender_name": getattr(item, "sender_name", None),
+            "sender_avatar_url": getattr(item, "sender_avatar_url", None),
+            "sender_id": getattr(item, "sender_id", None),
+            "is_steer": is_steer,
+        }
+    )
+    return metadata

--- a/storage/contracts.py
+++ b/storage/contracts.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from config.agent_config_types import AgentConfig, Skill, SkillPackage
 
-NotificationType = Literal["steer", "command", "agent", "chat", "relationship", "chat_join"]
+NotificationType = str
 
 
 # Sandbox — repo protocols
@@ -634,6 +634,7 @@ class QueueItem(BaseModel):
     sender_name: str | None = None
     sender_avatar_url: str | None = None
     is_steer: bool = False
+    metadata: dict[str, Any] | None = None
 
 
 class QueueRepo(Protocol):
@@ -646,6 +647,7 @@ class QueueRepo(Protocol):
         source: str | None = None,
         sender_id: str | None = None,
         sender_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None: ...
     def dequeue(self, thread_id: str) -> QueueItem | None: ...
     def drain_all(self, thread_id: str) -> list[QueueItem]: ...

--- a/storage/providers/sqlite/queue_repo.py
+++ b/storage/providers/sqlite/queue_repo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 from pathlib import Path
@@ -36,14 +37,26 @@ class SQLiteQueueRepo:
         source: str | None = None,
         sender_id: str | None = None,
         sender_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         with self._lock:
             self._conn.execute(
-                "INSERT INTO message_queue (thread_id, content, notification_type, source, sender_id, sender_name)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
-                (thread_id, content, notification_type, source, sender_id, sender_name),
+                "INSERT INTO message_queue (thread_id, content, notification_type, source, sender_id, sender_name, metadata_json)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (thread_id, content, notification_type, source, sender_id, sender_name, json.dumps(metadata) if metadata else None),
             )
             self._conn.commit()
+
+    def _hydrate_item(self, row: sqlite3.Row | tuple[Any, ...]) -> QueueItem:
+        metadata = json.loads(row[5]) if row[5] else None
+        return QueueItem(
+            content=row[0],
+            notification_type=row[1],
+            source=row[2],
+            sender_id=row[3],
+            sender_name=row[4],
+            metadata=metadata,
+        )
 
     def dequeue(self, thread_id: str) -> QueueItem | None:
         with self._lock:
@@ -56,11 +69,11 @@ class SQLiteQueueRepo:
             row = self._conn.execute(
                 "DELETE FROM message_queue "
                 "WHERE id = (SELECT MIN(id) FROM message_queue WHERE thread_id = ?) "
-                "RETURNING content, notification_type, source, sender_id, sender_name",
+                "RETURNING content, notification_type, source, sender_id, sender_name, metadata_json",
                 (thread_id,),
             ).fetchone()
             self._conn.commit()
-            return QueueItem(content=row[0], notification_type=row[1], source=row[2], sender_id=row[3], sender_name=row[4]) if row else None
+            return self._hydrate_item(row) if row else None
 
     def drain_all(self, thread_id: str) -> list[QueueItem]:
         with self._lock:
@@ -71,14 +84,12 @@ class SQLiteQueueRepo:
             if has_row is None:
                 return []
             rows = self._conn.execute(
-                "DELETE FROM message_queue WHERE thread_id = ? RETURNING content, notification_type, id, source, sender_id, sender_name",
+                "DELETE FROM message_queue WHERE thread_id = ? "
+                "RETURNING content, notification_type, id, source, sender_id, sender_name, metadata_json",
                 (thread_id,),
             ).fetchall()
             self._conn.commit()
-        return [
-            QueueItem(content=r[0], notification_type=r[1], source=r[3], sender_id=r[4], sender_name=r[5])
-            for r in sorted(rows, key=lambda r: r[2])
-        ]
+        return [self._hydrate_item((r[0], r[1], r[3], r[4], r[5], r[6])) for r in sorted(rows, key=lambda r: r[2])]
 
     def peek(self, thread_id: str) -> bool:
         with self._lock:
@@ -122,8 +133,12 @@ class SQLiteQueueRepo:
             "  source            TEXT,"
             "  sender_id         TEXT,"
             "  sender_name       TEXT,"
+            "  metadata_json     TEXT,"
             "  created_at        TEXT DEFAULT (datetime('now'))"
             ")"
         )
+        columns = {row[1] for row in self._conn.execute("PRAGMA table_info(message_queue)").fetchall()}
+        if "metadata_json" not in columns:
+            self._conn.execute("ALTER TABLE message_queue ADD COLUMN metadata_json TEXT")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mq_thread ON message_queue (thread_id, id)")
         self._conn.commit()

--- a/storage/providers/supabase/queue_repo.py
+++ b/storage/providers/supabase/queue_repo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from storage.contracts import QueueItem
@@ -20,6 +21,19 @@ class SupabaseQueueRepo:
     def _t(self) -> Any:
         return q.schema_table(self._client, "agent", _TABLE, _REPO)
 
+    def _hydrate_metadata(self, row: dict[str, Any]) -> dict[str, Any] | None:
+        raw = row.get("metadata_json")
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            return dict(raw)
+        if isinstance(raw, str):
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                raise RuntimeError("Supabase queue repo expected metadata_json to decode to an object.")
+            return parsed
+        raise RuntimeError(f"Supabase queue repo expected metadata_json object or string, got {type(raw).__name__}.")
+
     def _hydrate_item(self, row: dict[str, Any]) -> QueueItem:
         return QueueItem(
             content=str(row.get("content") or ""),
@@ -27,6 +41,7 @@ class SupabaseQueueRepo:
             source=row.get("source"),
             sender_id=row.get(_SENDER_USER_ID),
             sender_name=row.get("sender_name"),
+            metadata=self._hydrate_metadata(row),
         )
 
     def enqueue(
@@ -37,6 +52,7 @@ class SupabaseQueueRepo:
         source: str | None = None,
         sender_id: str | None = None,
         sender_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         self._t().insert(
             {
@@ -46,6 +62,7 @@ class SupabaseQueueRepo:
                 "source": source,
                 _SENDER_USER_ID: sender_id,
                 "sender_name": sender_name,
+                "metadata_json": dict(metadata or {}),
             }
         ).execute()
 
@@ -53,7 +70,9 @@ class SupabaseQueueRepo:
         head = q.rows(
             q.limit(
                 q.order(
-                    self._t().select(f"id,content,notification_type,source,{_SENDER_USER_ID},sender_name").eq("thread_id", thread_id),
+                    self._t()
+                    .select(f"id,content,notification_type,source,{_SENDER_USER_ID},sender_name,metadata_json")
+                    .eq("thread_id", thread_id),
                     "id",
                     desc=False,
                     repo=_REPO,
@@ -79,7 +98,9 @@ class SupabaseQueueRepo:
         # Fetch all rows ordered by id, then delete them all
         raw = q.rows(
             q.order(
-                self._t().select(f"id,content,notification_type,source,{_SENDER_USER_ID},sender_name").eq("thread_id", thread_id),
+                self._t()
+                .select(f"id,content,notification_type,source,{_SENDER_USER_ID},sender_name,metadata_json")
+                .eq("thread_id", thread_id),
                 "id",
                 desc=False,
                 repo=_REPO,

--- a/storage/schema/app_schema.sql
+++ b/storage/schema/app_schema.sql
@@ -558,6 +558,7 @@ CREATE TABLE agent.message_queue (
     source text,
     sender_user_id text,
     sender_name text,
+    metadata_json jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT now()
 );
 

--- a/storage/schema/app_schema_manifest.json
+++ b/storage/schema/app_schema_manifest.json
@@ -17,6 +17,7 @@
     "chat_message_delivery_scope.sql",
     "chat_workflow_state_and_tasks.sql",
     "external_user_creator.sql",
+    "message_queue_metadata.sql",
     "relationship_pair_constraint.sql",
     "relationship_request_message.sql",
     "sandbox_control_plane_supabase.sql",

--- a/storage/schema/message_queue_metadata.sql
+++ b/storage/schema/message_queue_metadata.sql
@@ -1,0 +1,4 @@
+alter table if exists agent.message_queue
+    add column if not exists metadata_json jsonb not null default '{}'::jsonb;
+
+notify pgrst, 'reload schema';

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py
@@ -211,6 +211,7 @@ async def test_native_notification_handler_converts_to_thread_input_at_runtime_b
         AgentRuntimeMessage,
         AgentRuntimeNotificationEnvelope,
         AgentRuntimeTransport,
+        AgentThreadInputEnvelope,
     )
 
     thread_input_handler = _FakeThreadInputHandler()
@@ -231,8 +232,18 @@ async def test_native_notification_handler_converts_to_thread_input_at_runtime_b
     result = await handler.dispatch_notification(envelope)
 
     assert result == AgentRuntimeNotificationResult(status="accepted", thread_id="thread-1")
-    assert thread_input_handler.called_with is not None
-    assert thread_input_handler.called_with.thread_id == "thread-1"
-    assert thread_input_handler.called_with.sender is envelope.sender
-    assert thread_input_handler.called_with.message is envelope.message
-    assert thread_input_handler.called_with.transport is envelope.transport
+    called = thread_input_handler.called_with
+    assert isinstance(called, AgentThreadInputEnvelope)
+    assert called.thread_id == "thread-1"
+    assert called.sender is envelope.sender
+    assert called.message.content == envelope.message.content
+    assert called.message.metadata == {
+        "relationship_id": "rel-1",
+        "event_type": "relationship.requested",
+        "notification_type": "relationship",
+        "runtime_protocol_version": "agent.runtime.notification.v1",
+        "delivery_id": "delivery-1",
+        "correlation_id": "corr-1",
+        "idempotency_key": "idem-1",
+    }
+    assert called.transport is envelope.transport

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from backend.threads.chat_adapters.bootstrap import build_agent_runtime_state
 from core.runtime.middleware.monitor import AgentState
-from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
+from protocols.agent_runtime import (
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+    AgentRuntimeTransport,
+    AgentThreadInputEnvelope,
+    AgentThreadInputResult,
+)
 
 
 class _FakeQueueManager:
@@ -17,8 +24,8 @@ class _FakeQueueManager:
 
 
 class _FakeRuntime:
-    def __init__(self) -> None:
-        self.current_state = AgentState.IDLE
+    def __init__(self, state: AgentState = AgentState.IDLE) -> None:
+        self.current_state = state
 
     def transition(self, next_state: AgentState) -> bool:
         self.current_state = next_state
@@ -26,8 +33,8 @@ class _FakeRuntime:
 
 
 class _FakeAgent:
-    def __init__(self) -> None:
-        self.runtime = _FakeRuntime()
+    def __init__(self, state: AgentState = AgentState.IDLE) -> None:
+        self.runtime = _FakeRuntime(state)
 
 
 def _fake_app() -> SimpleNamespace:
@@ -56,6 +63,22 @@ def _thread_input(content: str = "hello", *, enable_trajectory: bool = False) ->
         sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),
         message=AgentRuntimeMessage(content=content),
         enable_trajectory=enable_trajectory,
+    )
+
+
+def _notification_thread_input() -> AgentThreadInputEnvelope:
+    return AgentThreadInputEnvelope(
+        thread_id="thread-1",
+        sender=AgentRuntimeActor(user_id="human-1", user_type="human", display_name="Human", source="relationship"),
+        message=AgentRuntimeMessage(
+            content="relationship requested",
+            metadata={
+                "event_type": "relationship.requested",
+                "notification_type": "relationship",
+                "relationship_id": "rel-1",
+            },
+        ),
+        transport=AgentRuntimeTransport(delivery_id="delivery-1", correlation_id="corr-1", idempotency_key="idem-1"),
     )
 
 
@@ -109,3 +132,72 @@ async def test_gateway_thread_input_passes_enable_trajectory_to_start_agent_run(
         )
 
     assert start_run.call_args.kwargs["enable_trajectory"] is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_thread_input_preserves_notification_metadata_when_starting_run() -> None:
+    app = _fake_app()
+    agent = _FakeAgent()
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
+
+    with (
+        patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
+        patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=agent)),
+        patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123") as start_run,
+        patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
+    ):
+        await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(_notification_thread_input())
+
+    assert start_run.call_args.kwargs["message_metadata"] == {
+        "event_type": "relationship.requested",
+        "notification_type": "relationship",
+        "relationship_id": "rel-1",
+        "delivery_id": "delivery-1",
+        "correlation_id": "corr-1",
+        "idempotency_key": "idem-1",
+        "source": "relationship",
+        "sender_id": "human-1",
+        "sender_name": "Human",
+        "sender_avatar_url": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_thread_input_preserves_notification_metadata_when_queueing_active_run() -> None:
+    app = _fake_app()
+    agent = _FakeAgent(state=AgentState.ACTIVE)
+    typing_tracker = SimpleNamespace(start_chat=lambda *_args, **_kwargs: None)
+    enqueued: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    app.state.queue_manager = SimpleNamespace(enqueue=lambda *args, **kwargs: enqueued.append((args, kwargs)))
+
+    with (
+        patch("backend.threads.chat_adapters.bootstrap.resolve_thread_sandbox", return_value="local"),
+        patch("backend.threads.chat_adapters.bootstrap.get_or_create_agent", AsyncMock(return_value=agent)),
+        patch("backend.threads.chat_adapters.bootstrap.start_agent_run", return_value="run-123"),
+        patch("backend.threads.chat_adapters.bootstrap.clear_resource_overview_cache"),
+    ):
+        result = await build_agent_runtime_state(app, typing_tracker=typing_tracker).gateway.dispatch_thread_input(
+            _notification_thread_input()
+        )
+
+    assert result == AgentThreadInputResult(status="injected", routing="steer", thread_id="thread-1")
+    assert enqueued == [
+        (
+            ("relationship requested", "thread-1", "relationship"),
+            {
+                "source": "relationship",
+                "sender_id": "human-1",
+                "sender_name": "Human",
+                "sender_avatar_url": None,
+                "is_steer": True,
+                "metadata": {
+                    "event_type": "relationship.requested",
+                    "notification_type": "relationship",
+                    "relationship_id": "rel-1",
+                    "delivery_id": "delivery-1",
+                    "correlation_id": "corr-1",
+                    "idempotency_key": "idem-1",
+                },
+            },
+        )
+    ]

--- a/tests/Unit/core/test_message_queue_manager_wake.py
+++ b/tests/Unit/core/test_message_queue_manager_wake.py
@@ -6,20 +6,27 @@ def test_queue_manager_can_enqueue_without_waking(tmp_path) -> None:
     seen: list[str] = []
 
     manager.register_wake("thread-1", lambda item: seen.append(item.content))
-    manager.enqueue("queued only", "thread-1", notification_type="chat", wake=False)
+    manager.enqueue(
+        "queued only",
+        "thread-1",
+        notification_type="chat",
+        metadata={"event_type": "chat.message", "delivery_id": "delivery-1"},
+        wake=False,
+    )
 
     assert seen == []
     item = manager.dequeue("thread-1")
     assert item is not None
     assert item.content == "queued only"
     assert item.notification_type == "chat"
+    assert item.metadata == {"event_type": "chat.message", "delivery_id": "delivery-1"}
 
 
 def test_queue_manager_wakes_by_default(tmp_path) -> None:
     manager = MessageQueueManager(db_path=str(tmp_path / "queue.db"))
-    seen: list[str] = []
+    seen: list[tuple[str, dict | None]] = []
 
-    manager.register_wake("thread-1", lambda item: seen.append(item.content))
-    manager.enqueue("wake now", "thread-1", notification_type="chat")
+    manager.register_wake("thread-1", lambda item: seen.append((item.content, item.metadata)))
+    manager.enqueue("wake now", "thread-1", notification_type="chat", metadata={"event_type": "chat.message"})
 
-    assert seen == ["wake now"]
+    assert seen == [("wake now", {"event_type": "chat.message"})]

--- a/tests/Unit/integration_contracts/test_followup_requeue.py
+++ b/tests/Unit/integration_contracts/test_followup_requeue.py
@@ -58,6 +58,7 @@ class TestConsumeFollowupQueue:
                     "notification_type": "steer",
                     "sender_name": None,
                     "sender_avatar_url": None,
+                    "sender_id": None,
                     "is_steer": False,
                 },
             )

--- a/tests/Unit/storage/test_app_schema_applier.py
+++ b/tests/Unit/storage/test_app_schema_applier.py
@@ -32,6 +32,7 @@ def test_applier_uses_manifest_order() -> None:
         "storage/schema/chat_message_delivery_scope.sql",
         "storage/schema/chat_workflow_state_and_tasks.sql",
         "storage/schema/external_user_creator.sql",
+        "storage/schema/message_queue_metadata.sql",
         "storage/schema/relationship_pair_constraint.sql",
         "storage/schema/relationship_request_message.sql",
         "storage/schema/sandbox_control_plane_supabase.sql",

--- a/tests/Unit/storage/test_supabase_queue_repo.py
+++ b/tests/Unit/storage/test_supabase_queue_repo.py
@@ -32,11 +32,13 @@ def test_supabase_queue_repo_enqueue_persists_sender_user_id() -> None:
         source="owner",
         sender_id="user-1",
         sender_name="Alice",
+        metadata={"event_type": "thread.input", "delivery_id": "delivery-1"},
     )
 
     row = tables["agent.message_queue"][0]
     assert row["thread_id"] == "thread-1"
     assert row["sender_user_id"] == "user-1"
+    assert row["metadata_json"] == {"event_type": "thread.input", "delivery_id": "delivery-1"}
     assert "sender_id" not in row
 
 
@@ -51,6 +53,7 @@ def test_supabase_queue_repo_dequeue_maps_sender_user_id_to_sender_id() -> None:
                 "source": "owner",
                 "sender_user_id": "user-1",
                 "sender_name": "Alice",
+                "metadata_json": {"event_type": "thread.input"},
             }
         ]
     }
@@ -60,6 +63,7 @@ def test_supabase_queue_repo_dequeue_maps_sender_user_id_to_sender_id() -> None:
 
     assert item is not None
     assert item.sender_id == "user-1"
+    assert item.metadata == {"event_type": "thread.input"}
     assert tables["agent.message_queue"] == []
 
 
@@ -74,6 +78,7 @@ def test_supabase_queue_repo_drain_all_maps_sender_user_id_to_sender_id() -> Non
                 "source": "owner",
                 "sender_user_id": "user-1",
                 "sender_name": "Alice",
+                "metadata_json": {"event_type": "thread.input"},
             },
             {
                 "id": 2,
@@ -83,6 +88,7 @@ def test_supabase_queue_repo_drain_all_maps_sender_user_id_to_sender_id() -> Non
                 "source": "external",
                 "sender_user_id": "user-2",
                 "sender_name": "Bob",
+                "metadata_json": {"event_type": "agent.done"},
             },
         ]
     }
@@ -91,6 +97,7 @@ def test_supabase_queue_repo_drain_all_maps_sender_user_id_to_sender_id() -> Non
     items = repo.drain_all("thread-1")
 
     assert [item.sender_id for item in items] == ["user-1", "user-2"]
+    assert [item.metadata for item in items] == [{"event_type": "thread.input"}, {"event_type": "agent.done"}]
     assert tables["agent.message_queue"] == []
 
 


### PR DESCRIPTION
## Summary
- preserve runtime notification metadata when native notifications are converted into thread input
- carry queue metadata through SQLite/Supabase queue repos, wake handlers, steering middleware, followups, and requeue paths
- add schema baseline + manifest patch for `agent.message_queue.metadata_json`

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/core/test_message_queue_manager_wake.py tests/Unit/storage/test_supabase_queue_repo.py tests/Unit/storage/test_app_schema_applier.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/integration_contracts/test_followup_requeue.py tests/Unit/integration_contracts/test_background_task_cleanup.py`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pytest tests/Unit/core/test_runtime_side_store_defaults.py tests/Unit/storage/test_sqlite_role_paths.py`
- `uv run pytest tests/Unit/storage/test_app_schema_discipline.py tests/Unit/storage/test_app_schema_applier.py`
- `uv run pyright backend/threads/chat_adapters/notification_handler.py backend/threads/chat_adapters/thread_handler.py backend/threads/chat_adapters/runtime_metadata.py backend/threads/run/buffer_wiring.py backend/threads/run/followups.py backend/threads/run/cancellation.py core/runtime/middleware/queue/manager.py core/runtime/middleware/queue/middleware.py core/runtime/queue_metadata.py storage/providers/sqlite/queue_repo.py storage/providers/supabase/queue_repo.py storage/contracts.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/core/test_message_queue_manager_wake.py tests/Unit/storage/test_supabase_queue_repo.py tests/Unit/integration_contracts/test_followup_requeue.py tests/Unit/integration_contracts/test_background_task_cleanup.py`
- `uv run ruff check backend/threads/chat_adapters/notification_handler.py backend/threads/chat_adapters/thread_handler.py backend/threads/chat_adapters/runtime_metadata.py backend/threads/run/buffer_wiring.py backend/threads/run/followups.py backend/threads/run/cancellation.py core/runtime/queue_metadata.py core/runtime/middleware/queue/manager.py core/runtime/middleware/queue/middleware.py storage/contracts.py storage/providers/sqlite/queue_repo.py storage/providers/supabase/queue_repo.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/core/test_message_queue_manager_wake.py tests/Unit/storage/test_supabase_queue_repo.py tests/Unit/storage/test_app_schema_applier.py tests/Unit/integration_contracts/test_followup_requeue.py tests/Unit/integration_contracts/test_background_task_cleanup.py`
