### PR TITLE
Expose workflow action failure contract

### DIFF
--- a/backend/chat/api/http/chat_workflow_router.py
+++ b/backend/chat/api/http/chat_workflow_router.py
@@ -14,6 +14,7 @@ from backend.chat.api.http.dependencies import (
     get_current_user_id,
     get_messaging_service,
 )
+from core.work_item.chat_workflow.service import WorkflowEventActionError
 from storage.errors import (
     StaleChatWorkflowEventVersionError,
     StaleChatWorkflowVersionError,
@@ -152,6 +153,19 @@ def list_chat_workflow_events(
     return chat_workflow_event_service.list_events(chat_id)
 
 
+def _workflow_event_action_failure(exc: WorkflowEventActionError) -> HTTPException:
+    cause = exc.__cause__
+    return HTTPException(
+        500,
+        {
+            "error": "workflow_event_action_failed",
+            "operation": exc.operation,
+            "event": exc.event,
+            "cause": str(cause) if cause is not None else str(exc),
+        },
+    )
+
+
 @router.post("/{chat_id}/workflow/events")
 def create_chat_workflow_event(
     chat_id: str,
@@ -162,16 +176,19 @@ def create_chat_workflow_event(
     chat_workflow_event_service: Annotated[Any, Depends(get_chat_workflow_event_service)],
 ):
     get_accessible_chat_or_404(chat_repo, messaging_service, chat_id, user_id)
-    return chat_workflow_event_service.create_event(
-        chat_id,
-        kind=body.kind,
-        resource_refs=body.resource_refs,
-        requested_by_user_id=body.requested_by_user_id or user_id,
-        decision_states=body.decision_states,
-        rationales=body.rationales,
-        final_state=body.final_state,
-        metadata=body.metadata,
-    )
+    try:
+        return chat_workflow_event_service.create_event(
+            chat_id,
+            kind=body.kind,
+            resource_refs=body.resource_refs,
+            requested_by_user_id=body.requested_by_user_id or user_id,
+            decision_states=body.decision_states,
+            rationales=body.rationales,
+            final_state=body.final_state,
+            metadata=body.metadata,
+        )
+    except WorkflowEventActionError as exc:
+        raise _workflow_event_action_failure(exc) from exc
 
 
 @router.get("/{chat_id}/workflow/events/{event_id}")
@@ -214,6 +231,8 @@ def update_chat_workflow_event(
             expected_state_version=body.expected_state_version,
             updated_by_user_id=user_id,
         )
+    except WorkflowEventActionError as exc:
+        raise _workflow_event_action_failure(exc) from exc
     except StaleChatWorkflowEventVersionError as exc:
         raise HTTPException(
             409,

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -16,6 +16,13 @@ class WorkflowEventChange:
     actor_user_id: str
 
 
+class WorkflowEventActionError(RuntimeError):
+    def __init__(self, *, operation: Literal["created", "updated"], event: dict[str, Any]) -> None:
+        super().__init__(f"Workflow event action failed after {operation}")
+        self.operation = operation
+        self.event = event
+
+
 class ChatWorkflowService:
     def __init__(self, workflow_repo: Any) -> None:
         self._repo = workflow_repo
@@ -178,13 +185,16 @@ class ChatWorkflowEventService:
         if change_fn is not None:
             if actor_user_id is None:
                 raise RuntimeError("Workflow event change requires requested_by_user_id")
-            change_fn(
-                WorkflowEventChange(
-                    operation="created",
-                    event=response,
-                    actor_user_id=actor_user_id,
+            try:
+                change_fn(
+                    WorkflowEventChange(
+                        operation="created",
+                        event=response,
+                        actor_user_id=actor_user_id,
+                    )
                 )
-            )
+            except Exception as exc:
+                raise WorkflowEventActionError(operation="created", event=response) from exc
         return response
 
     def update_event(
@@ -228,13 +238,16 @@ class ChatWorkflowEventService:
         if change_fn is not None:
             if actor_user_id is None:
                 raise RuntimeError("Workflow event change requires updated_by_user_id")
-            change_fn(
-                WorkflowEventChange(
-                    operation="updated",
-                    event=response,
-                    actor_user_id=actor_user_id,
+            try:
+                change_fn(
+                    WorkflowEventChange(
+                        operation="updated",
+                        event=response,
+                        actor_user_id=actor_user_id,
+                    )
                 )
-            )
+            except Exception as exc:
+                raise WorkflowEventActionError(operation="updated", event=response) from exc
         return response
 
     def delete_event(self, chat_id: str, event_id: str) -> None:

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -6,6 +6,7 @@ from core.work_item.chat_workflow.service import (
     ChatTaskService,
     ChatWorkflowEventService,
     ChatWorkflowService,
+    WorkflowEventActionError,
 )
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow, ChatWorkflowRow
@@ -299,6 +300,30 @@ def test_chat_workflow_event_service_emits_change_after_create_when_wired() -> N
     assert changes[0].actor_user_id == "owner-1"
 
 
+def test_chat_workflow_event_service_reports_create_action_failure_with_persisted_event() -> None:
+    repo = _WorkflowEventRepo()
+    service = ChatWorkflowEventService(repo)
+
+    def _fail(_change):
+        raise ValueError("runtime offline")
+
+    service.set_event_change_fn(_fail)
+
+    try:
+        service.create_event(
+            "chat-1",
+            kind="task_proposed_review",
+            requested_by_user_id="owner-1",
+        )
+    except WorkflowEventActionError as exc:
+        assert str(exc) == "Workflow event action failed after created"
+        assert exc.operation == "created"
+        assert exc.event == service.get_event("chat-1", "1")
+        assert type(exc.__cause__) is ValueError
+    else:
+        raise AssertionError("workflow event action failure did not surface")
+
+
 def test_chat_workflow_event_service_requires_requester_for_wired_change() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
@@ -331,6 +356,33 @@ def test_chat_workflow_event_service_emits_change_after_update_when_wired() -> N
     assert changes[0].operation == "updated"
     assert changes[0].event == updated
     assert changes[0].actor_user_id == "reviewer-1"
+
+
+def test_chat_workflow_event_service_reports_update_action_failure_with_persisted_event() -> None:
+    repo = _WorkflowEventRepo()
+    service = ChatWorkflowEventService(repo)
+    event = service.create_event("chat-1", kind="task_proposed_review")
+
+    def _fail(_change):
+        raise ValueError("runtime offline")
+
+    service.set_event_change_fn(_fail)
+
+    try:
+        service.update_event(
+            "chat-1",
+            event["event_id"],
+            state="settled",
+            updated_by_user_id="reviewer-1",
+        )
+    except WorkflowEventActionError as exc:
+        assert str(exc) == "Workflow event action failed after updated"
+        assert exc.operation == "updated"
+        assert exc.event == service.get_event("chat-1", event["event_id"])
+        assert exc.event["state"] == "settled"
+        assert type(exc.__cause__) is ValueError
+    else:
+        raise AssertionError("workflow event action failure did not surface")
 
 
 def test_chat_workflow_event_service_requires_actor_for_wired_update_change() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from backend.chat.api.http import chat_workflow_router, chats_router, relationships_router
 from backend.identity.avatar.urls import avatar_url
 from backend.web.core.dependencies import get_current_user_id
+from core.work_item.chat_workflow.service import WorkflowEventActionError
 from storage.contracts import ContactEdgeRow
 from storage.errors import (
     StaleChatWorkflowEventVersionError,
@@ -30,7 +31,8 @@ def _chat(chat_id: str) -> SimpleNamespace:
 
 def _route_test_app(state: SimpleNamespace) -> FastAPI:
     app = FastAPI()
-    app.state = state
+    for key, value in vars(state).items():
+        setattr(app.state, key, value)
     app.include_router(chats_router.router)
     app.dependency_overrides[get_current_user_id] = lambda: "human-user-1"
     return app
@@ -623,6 +625,38 @@ def test_chat_workflow_event_create_defaults_requester_to_authenticated_user(mon
     ]
 
 
+def test_chat_workflow_event_create_returns_persisted_event_when_action_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = {"chat_id": "chat-1", "event_id": "evt-1", "kind": "task_proposed_review"}
+
+    def create_event(_chat_id: str, **_kwargs):
+        raise WorkflowEventActionError(operation="created", event=event) from RuntimeError("runtime offline")
+
+    app = FastAPI()
+    app.include_router(chat_workflow_router.router)
+    app.dependency_overrides[chat_workflow_router.get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[chat_workflow_router.get_chat_repo] = lambda: SimpleNamespace(name="chat-repo")
+    app.dependency_overrides[chat_workflow_router.get_messaging_service] = lambda: SimpleNamespace(name="messaging")
+    app.dependency_overrides[chat_workflow_router.get_chat_workflow_event_service] = lambda: SimpleNamespace(create_event=create_event)
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/chats/chat-1/workflow/events",
+                json={"kind": "task_proposed_review"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "error": "workflow_event_action_failed",
+        "operation": "created",
+        "event": event,
+        "cause": "runtime offline",
+    }
+
+
 def test_chat_workflow_event_patch_carries_expected_version_and_returns_conflict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -679,6 +713,38 @@ def test_chat_workflow_event_patch_carries_expected_version_and_returns_conflict
             "updated_by_user_id": "user-1",
         }
     ]
+
+
+def test_chat_workflow_event_patch_returns_persisted_event_when_action_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = {"chat_id": "chat-1", "event_id": "evt-1", "kind": "task_proposed_review", "state": "settled"}
+
+    def update_event(_chat_id: str, _event_id: str, **_kwargs):
+        raise WorkflowEventActionError(operation="updated", event=event) from RuntimeError("runtime offline")
+
+    app = FastAPI()
+    app.include_router(chat_workflow_router.router)
+    app.dependency_overrides[chat_workflow_router.get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[chat_workflow_router.get_chat_repo] = lambda: SimpleNamespace(name="chat-repo")
+    app.dependency_overrides[chat_workflow_router.get_messaging_service] = lambda: SimpleNamespace(name="messaging")
+    app.dependency_overrides[chat_workflow_router.get_chat_workflow_event_service] = lambda: SimpleNamespace(update_event=update_event)
+    monkeypatch.setattr(chat_workflow_router, "get_accessible_chat_or_404", lambda *_args: _chat("chat-1"))
+
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.patch(
+                "/api/chats/chat-1/workflow/events/evt-1",
+                json={"state": "settled"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "error": "workflow_event_action_failed",
+        "operation": "updated",
+        "event": event,
+        "cause": "runtime offline",
+    }
 
 
 def test_resolve_display_user_delegates_to_messaging_service(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Add `WorkflowEventActionError` to distinguish post-event action failure from pre-mutation validation failure.
- Include the persisted workflow event and operation in action failure errors.
- Map workflow event create/update action failures to structured HTTP 500 details so callers can recover by event id.

## Test Plan
- `uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/backend/test_chat_bootstrap.py -q`
- `uv run pyright core/work_item/chat_workflow/service.py backend/chat/api/http/chat_workflow_router.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check core/work_item/chat_workflow/service.py backend/chat/api/http/chat_workflow_router.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/backend/web/services/test_workflow_event_notification.py`

## Follow-up
This does not add retry/outbox semantics. The next decision is where retryable workflow actions live without adding polling, shadow local state, or a second transport.
