### PR TITLE
Extract runtime notification action

### DIFF
--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from backend.threads.chat_adapters.runtime_identity import display_name, make_runtime_actor, require_user, user_type
-from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
-from protocols.agent_runtime import (
-    AgentRuntimeMessage,
-    AgentRuntimeNotificationEnvelope,
+from backend.threads.chat_adapters.runtime_identity import display_name, require_user
+from backend.threads.chat_adapters.runtime_notification_action import (
+    RuntimeNotificationAction,
+    dispatch_runtime_notification_action,
 )
 
 
@@ -17,41 +15,29 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
         requester_id = _required_str(row, "requester_user_id")
         decider_id = _required_str(row, "decided_by_user_id")
         chat_id = _required_str(row, "chat_id")
-        requester = require_user(user_repo, requester_id, context="Chat join rejection", role="requester")
         decider = require_user(user_repo, decider_id, context="Chat join rejection", role="decider")
-        requester_type = user_type(requester, requester_id, context="Chat join rejection")
-        content = f"{display_name(decider, decider_id, context='Chat join rejection')} rejected your request to join chat {chat_id}."
-        metadata = {
-            "chat_join_request_id": _required_str(row, "id"),
-            "chat_id": chat_id,
-            "state": "rejected",
-        }
-        recipient = select_runtime_notification_recipient(
-            requester_id,
-            requester_type,
+        await dispatch_runtime_notification_action(
+            app,
+            RuntimeNotificationAction(
+                context="Chat join rejection",
+                recipient_user_id=requester_id,
+                sender_user_id=decider_id,
+                sender_source="chat_join",
+                event_type="chat.join.rejected",
+                notification_type="chat_join",
+                content=(
+                    f"{display_name(decider, decider_id, context='Chat join rejection')} rejected your request to join chat {chat_id}."
+                ),
+                metadata={
+                    "chat_join_request_id": _required_str(row, "id"),
+                    "chat_id": chat_id,
+                    "state": "rejected",
+                },
+                include_sender_avatar=True,
+            ),
+            user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-            context="chat join",
-        )
-        if recipient is None:
-            return
-        await get_agent_runtime_gateway(app).dispatch_notification(
-            AgentRuntimeNotificationEnvelope(
-                event_type="chat.join.rejected",
-                recipient=recipient,
-                sender=make_runtime_actor(
-                    user_id=decider_id,
-                    user=decider,
-                    source="chat_join",
-                    context="Chat join rejection",
-                    include_avatar=True,
-                ),
-                message=AgentRuntimeMessage(
-                    content=content,
-                    metadata=metadata,
-                ),
-                notification_type="chat_join",
-            )
         )
 
     return make_sync_runtime_event_hook(notify_runtime)

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from backend.threads.chat_adapters.runtime_identity import display_name, make_runtime_actor, require_user, user_type
-from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
-from messaging.contracts import RelationshipEvent, RelationshipRow
-from protocols.agent_runtime import (
-    AgentChatRecipient,
-    AgentRuntimeActor,
-    AgentRuntimeMessage,
-    AgentRuntimeNotificationEnvelope,
+from backend.threads.chat_adapters.runtime_identity import display_name, require_user
+from backend.threads.chat_adapters.runtime_notification_action import (
+    RuntimeNotificationAction,
+    dispatch_runtime_notification_action,
 )
+from messaging.contracts import RelationshipEvent, RelationshipRow
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
     "approve": "approved",
@@ -25,35 +21,25 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
         requester_id = _requester_id(row)
         target_id = _target_id(row, requester_id)
         requester = require_user(user_repo, requester_id, context="Relationship request", role="requester")
-        target = require_user(user_repo, target_id, context="Relationship request", role="target")
-        target_type = user_type(target, target_id, context="Relationship request")
-        recipient = select_runtime_notification_recipient(
-            target_id,
-            target_type,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-            context="relationship request",
-        )
-        if recipient is None:
-            return
-        await _dispatch_notification(
+        await dispatch_runtime_notification_action(
             app,
-            recipient=recipient,
-            sender=make_runtime_actor(
-                user_id=requester_id,
-                user=requester,
-                source="relationship",
+            RuntimeNotificationAction(
                 context="Relationship request",
-                include_avatar=True,
-            ),
-            message=AgentRuntimeMessage(
+                recipient_user_id=target_id,
+                sender_user_id=requester_id,
+                sender_source="relationship",
+                event_type="relationship.requested",
+                notification_type="relationship",
                 content=_notification_content(
                     display_name(requester, requester_id, context="Relationship request"),
                     row.message,
                 ),
                 metadata={"relationship_id": row.id},
+                include_sender_avatar=True,
             ),
-            event_type="relationship.requested",
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
         )
 
     return make_sync_runtime_event_hook(notify_runtime)
@@ -63,62 +49,31 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
     async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
         requester_id = _requester_id(row)
         decider_id = _target_id(row, requester_id)
-        requester = require_user(user_repo, requester_id, context="Relationship request", role="requester")
+        verb = _decision_verb(event)
         decider = require_user(user_repo, decider_id, context="Relationship request", role="decider")
-        requester_type = user_type(requester, requester_id, context="Relationship request")
-        recipient = select_runtime_notification_recipient(
-            requester_id,
-            requester_type,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-            context="relationship decision",
-        )
-        if recipient is None:
-            return
-        await _dispatch_notification(
+        await dispatch_runtime_notification_action(
             app,
-            recipient=recipient,
-            sender=make_runtime_actor(
-                user_id=decider_id,
-                user=decider,
-                source="relationship",
+            RuntimeNotificationAction(
                 context="Relationship request",
-                include_avatar=True,
-            ),
-            message=AgentRuntimeMessage(
-                content=(
-                    f"{display_name(decider, decider_id, context='Relationship request')} "
-                    f"{_decision_verb(event)} your relationship request."
-                ),
+                recipient_user_id=requester_id,
+                sender_user_id=decider_id,
+                sender_source="relationship",
+                event_type=f"relationship.{verb}",
+                notification_type="relationship",
+                content=(f"{display_name(decider, decider_id, context='Relationship request')} {verb} your relationship request."),
                 metadata={
                     "relationship_id": row.id,
                     "event": event,
                     "state": row.state,
                 },
+                include_sender_avatar=True,
             ),
-            event_type=f"relationship.{_decision_verb(event)}",
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
         )
 
     return make_sync_runtime_event_hook(notify_runtime)
-
-
-async def _dispatch_notification(
-    app: Any,
-    *,
-    recipient: AgentChatRecipient,
-    sender: AgentRuntimeActor,
-    message: AgentRuntimeMessage,
-    event_type: str,
-) -> None:
-    await get_agent_runtime_gateway(app).dispatch_notification(
-        AgentRuntimeNotificationEnvelope(
-            event_type=event_type,
-            recipient=recipient,
-            sender=sender,
-            message=message,
-            notification_type="relationship",
-        )
-    )
 
 
 def _requester_id(row: RelationshipRow) -> str:

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user, user_type
+from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
+from protocols.agent_runtime import (
+    AgentRuntimeMessage,
+    AgentRuntimeNotificationEnvelope,
+    AgentRuntimeTransport,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeNotificationAction:
+    context: str
+    recipient_user_id: str
+    sender_user_id: str
+    sender_source: str
+    event_type: str
+    notification_type: str
+    content: str
+    metadata: dict[str, Any] | None = None
+    transport: AgentRuntimeTransport = AgentRuntimeTransport()
+    include_sender_avatar: bool = False
+
+
+async def dispatch_runtime_notification_action(
+    app: Any,
+    action: RuntimeNotificationAction,
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> bool:
+    envelope = plan_runtime_notification_action(
+        action,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    if envelope is None:
+        return False
+    await get_agent_runtime_gateway(app).dispatch_notification(envelope)
+    return True
+
+
+def plan_runtime_notification_action(
+    action: RuntimeNotificationAction,
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> AgentRuntimeNotificationEnvelope | None:
+    sender_user = require_user(user_repo, action.sender_user_id, context=action.context, role="sender")
+    recipient_user = require_user(user_repo, action.recipient_user_id, context=action.context, role="recipient")
+    recipient = select_runtime_notification_recipient(
+        action.recipient_user_id,
+        user_type(recipient_user, action.recipient_user_id, context=action.context),
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+        context=action.context,
+    )
+    if recipient is None:
+        return None
+    return AgentRuntimeNotificationEnvelope(
+        event_type=action.event_type,
+        recipient=recipient,
+        sender=make_runtime_actor(
+            user_id=action.sender_user_id,
+            user=sender_user,
+            source=action.sender_source,
+            context=action.context,
+            include_avatar=action.include_sender_avatar,
+        ),
+        message=AgentRuntimeMessage(
+            content=action.content,
+            metadata=action.metadata,
+        ),
+        notification_type=action.notification_type,
+        transport=action.transport,
+    )

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.threads.chat_adapters.runtime_notification_action import (
+    RuntimeNotificationAction,
+    dispatch_runtime_notification_action,
+)
+from protocols.agent_runtime import AgentRuntimeTransport
+
+
+def _runtime_app(gateway: object) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+
+def _users() -> SimpleNamespace:
+    rows = {
+        "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+        "agent-1": SimpleNamespace(id="agent-1", type="agent", display_name="Worker", avatar=None),
+    }
+    return SimpleNamespace(get_by_id=lambda uid: rows.get(uid))
+
+
+def _thread_repo() -> SimpleNamespace:
+    thread = {"id": "thread-agent-1", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0}
+    return SimpleNamespace(
+        get_by_user_id=lambda uid: thread if uid == "agent-1" else None,
+        list_by_agent_user=lambda uid: [thread] if uid == "agent-1" else [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_recipient() -> None:
+    class RecordingGateway:
+        envelope = None
+
+        async def dispatch_notification(self, envelope):
+            self.envelope = envelope
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+    gateway = RecordingGateway()
+
+    dispatched = await dispatch_runtime_notification_action(
+        _runtime_app(gateway),
+        RuntimeNotificationAction(
+            context="Test action",
+            recipient_user_id="agent-1",
+            sender_user_id="owner-1",
+            sender_source="workflow",
+            event_type="test.event",
+            notification_type="test",
+            content="Action happened.",
+            metadata={"resource_id": "resource-1"},
+            transport=AgentRuntimeTransport(
+                delivery_id="delivery-1",
+                correlation_id="resource-1",
+                idempotency_key="delivery-1",
+            ),
+        ),
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert dispatched is True
+    assert gateway.envelope is not None
+    assert gateway.envelope.recipient.agent_user_id == "agent-1"
+    assert gateway.envelope.recipient.runtime_source == "mycel"
+    assert gateway.envelope.recipient.thread_id == "thread-agent-1"
+    assert gateway.envelope.sender.user_id == "owner-1"
+    assert gateway.envelope.sender.source == "workflow"
+    assert gateway.envelope.event_type == "test.event"
+    assert gateway.envelope.notification_type == "test"
+    assert gateway.envelope.message.content == "Action happened."
+    assert gateway.envelope.message.metadata == {"resource_id": "resource-1"}
+    assert gateway.envelope.transport.delivery_id == "delivery-1"


### PR DESCRIPTION
## Summary

- add `RuntimeNotificationAction` as the shared runtime notification action boundary
- migrate relationship and chat-join one-to-one notification inlets to the shared action dispatcher
- keep workflow fanout on its existing planner until the group/fanout primitive is decided

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/test_chat_bootstrap.py -q`
- `uv run pyright backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/chat_join_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/chat_join_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py`
