### PR TITLE
Clarify workflow event action emission

### DIFF
--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -161,12 +161,7 @@ class ChatWorkflowEventService:
         final_state: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        change_fn = self._event_change_fn
-        actor_user_id: str | None = None
-        if change_fn is not None:
-            if requested_by_user_id is None:
-                raise RuntimeError("Workflow event change requires requested_by_user_id")
-            actor_user_id = requested_by_user_id
+        actor_user_id = self._event_change_actor(requested_by_user_id, field="requested_by_user_id")
         event = ChatWorkflowEventRow(
             chat_id=chat_id,
             event_id=self._repo.next_id(chat_id),
@@ -182,19 +177,7 @@ class ChatWorkflowEventService:
         )
         self._repo.insert(chat_id, event)
         response = _event_response(event)
-        if change_fn is not None:
-            if actor_user_id is None:
-                raise RuntimeError("Workflow event change requires requested_by_user_id")
-            try:
-                change_fn(
-                    WorkflowEventChange(
-                        operation="created",
-                        event=response,
-                        actor_user_id=actor_user_id,
-                    )
-                )
-            except Exception as exc:
-                raise WorkflowEventActionError(operation="created", event=response) from exc
+        self._emit_event_change(operation="created", event=response, actor_user_id=actor_user_id)
         return response
 
     def update_event(
@@ -211,12 +194,7 @@ class ChatWorkflowEventService:
         expected_state_version: int | None = None,
         updated_by_user_id: str | None = None,
     ) -> dict[str, Any] | None:
-        change_fn = self._event_change_fn
-        actor_user_id: str | None = None
-        if change_fn is not None:
-            if updated_by_user_id is None:
-                raise RuntimeError("Workflow event change requires updated_by_user_id")
-            actor_user_id = updated_by_user_id
+        actor_user_id = self._event_change_actor(updated_by_user_id, field="updated_by_user_id")
         event = self._repo.get(chat_id, event_id)
         if event is None:
             return None
@@ -235,20 +213,32 @@ class ChatWorkflowEventService:
             event.settled_at = settled_at
         updated = self._repo.update(chat_id, event, expected_state_version=expected_state_version)
         response = _event_response(updated)
-        if change_fn is not None:
-            if actor_user_id is None:
-                raise RuntimeError("Workflow event change requires updated_by_user_id")
-            try:
-                change_fn(
-                    WorkflowEventChange(
-                        operation="updated",
-                        event=response,
-                        actor_user_id=actor_user_id,
-                    )
-                )
-            except Exception as exc:
-                raise WorkflowEventActionError(operation="updated", event=response) from exc
+        self._emit_event_change(operation="updated", event=response, actor_user_id=actor_user_id)
         return response
+
+    def _event_change_actor(self, actor_user_id: str | None, *, field: str) -> str | None:
+        if self._event_change_fn is None:
+            return None
+        if actor_user_id is None:
+            raise RuntimeError(f"Workflow event change requires {field}")
+        return actor_user_id
+
+    def _emit_event_change(
+        self,
+        *,
+        operation: Literal["created", "updated"],
+        event: dict[str, Any],
+        actor_user_id: str | None,
+    ) -> None:
+        change_fn = self._event_change_fn
+        if change_fn is None:
+            return
+        if actor_user_id is None:
+            raise RuntimeError("Workflow event change requires actor_user_id")
+        try:
+            change_fn(WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id))
+        except Exception as exc:
+            raise WorkflowEventActionError(operation=operation, event=event) from exc
 
     def delete_event(self, chat_id: str, event_id: str) -> None:
         self._repo.delete(chat_id, event_id)

--- a/tests/yatu/catalog.md
+++ b/tests/yatu/catalog.md
@@ -11,6 +11,7 @@ maintained prompts.
 - `cross-owner-agent-contact.md`
 - `external-managed-agent-chat.md`
 - `external-runtime-inbox.md`
+- `provider-hook-bootstrap-matrix.md`
 
 ## Relationship And Join
 

--- a/tests/yatu/provider-hook-bootstrap-matrix.md
+++ b/tests/yatu/provider-hook-bootstrap-matrix.md
@@ -1,0 +1,67 @@
+# Provider Hook Bootstrap Matrix YATU
+
+## User Story
+
+A user launches Codex or Claude Code through `cel codex` or `cel claude` from a
+normal terminal, asks what Mycel is, and the provider already has the Mycel
+runtime guidance in its real model context. The proof must survive terminal
+differences and wrapper managers without relying on a debug-only hook command.
+
+## Entry Surfaces
+
+- Installed `cel` CLI from the SDK repo.
+- Real Mycel backend from the current app branch.
+- Real Codex CLI and Claude Code installs.
+- Real terminal surfaces such as macOS Terminal, iTerm2, WezTerm, tmux, and a
+  Linux shell. PowerShell is a later matrix row when a Windows host is
+  available.
+
+## Setup
+
+1. Use an isolated `MYCEL_HOME` for each matrix row.
+2. Log in through the public auth flow.
+3. Create or select one external-agent identity per provider.
+4. Launch the provider only through the public wrapper:
+   `cel codex ...` or `cel claude ...`.
+5. If a provider is itself launched through another wrapper manager, keep that
+   manager enabled for at least one matrix row.
+
+## User Loop
+
+For every terminal/provider row:
+
+1. Start a fresh provider session through `cel`.
+2. Ask the provider: `Do you know what Mycel is in this session?`
+3. Confirm the first real assistant answer describes the local Mycel CLI,
+   identity, chat, and hook guidance instead of guessing a public project named
+   Mycel.
+4. Send one normal Mycel chat message to the external identity from another
+   user.
+5. Trigger a supported provider hook event through ordinary interaction, not a
+   debug-only hook command.
+6. Confirm the provider receives a metadata-only Mycel notification and then
+   uses `cel chat read` before quoting message bodies.
+
+## Pass Bar
+
+- The bootstrap guidance reaches the provider's real first response.
+- `SessionStart` success alone is not sufficient; the proof must include the
+  first user prompt path.
+- Hook suppression, caching, or wrapper-manager behavior cannot make the first
+  real prompt lose Mycel guidance.
+- The same runtime identity is used by the wrapper, hook, chat read, and chat
+  send paths.
+- Provider hooks read local runtime IPC/cache and do not open a backend wait as
+  a shortcut.
+- A failed terminal row records the terminal/provider/wrapper-manager tuple so
+  the failure can be reproduced elsewhere.
+
+## Pitfalls
+
+- A provider answering from general internet knowledge about a different Mycel
+  project fails the card.
+- A one-shot `cel internal hook ...` probe is useful debugging, but it is not
+  this YATU proof.
+- Reading raw tmux or terminal scrollback as the only evidence fails the card;
+  use the visible provider answer and public Mycel chat surfaces.
+- Do not pass by editing provider prompts manually after launch.


### PR DESCRIPTION
## Summary

- collapse duplicated workflow event change emission into one helper
- keep post-write workflow action failures fail-loud and domain-local
- add a provider hook bootstrap matrix YATU for real `cel codex` / `cel claude` terminal sessions

## Verification

- `uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
- `uv run ruff check core/work_item/chat_workflow/service.py tests/yatu/catalog.md tests/yatu/provider-hook-bootstrap-matrix.md`
