### PR TITLE
Extract runtime notification recipient resolution

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user, user_type
-from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
+from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
+from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
 from protocols.agent_runtime import (
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
@@ -55,10 +55,9 @@ def plan_runtime_notification_action(
     activity_reader: Any,
 ) -> AgentRuntimeNotificationEnvelope | None:
     sender_user = require_user(user_repo, action.sender_user_id, context=action.context, role="sender")
-    recipient_user = require_user(user_repo, action.recipient_user_id, context=action.context, role="recipient")
-    recipient = select_runtime_notification_recipient(
+    recipient = resolve_runtime_notification_recipient(
         action.recipient_user_id,
-        user_type(recipient_user, action.recipient_user_id, context=action.context),
+        user_repo=user_repo,
         thread_repo=thread_repo,
         activity_reader=activity_reader,
         context=action.context,

--- a/backend/threads/chat_adapters/runtime_recipient.py
+++ b/backend/threads/chat_adapters/runtime_recipient.py
@@ -6,7 +6,29 @@ from typing import Any
 from messaging.delivery.runtime_thread_selector import select_runtime_thread_for_recipient
 from protocols.agent_runtime import AgentChatRecipient
 
+from .runtime_identity import require_user, user_type
+
 logger = logging.getLogger(__name__)
+
+
+def resolve_runtime_notification_recipient(
+    user_id: str,
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+    context: str,
+    role: str = "recipient",
+    runtime_context: str | None = None,
+) -> AgentChatRecipient | None:
+    user = require_user(user_repo, user_id, context=context, role=role)
+    return select_runtime_notification_recipient(
+        user_id,
+        user_type(user, user_id, context=context),
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+        context=runtime_context or context,
+    )
 
 
 def select_runtime_notification_recipient(

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user, user_type
-from backend.threads.chat_adapters.runtime_recipient import select_runtime_notification_recipient
+from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
+from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import (
     AgentChatRecipient,
@@ -79,13 +79,13 @@ def plan_workflow_event_runtime_notifications(
         recipient_user_id = _member_user_id(member)
         if recipient_user_id == sender_user_id:
             continue
-        recipient_user = require_user(user_repo, recipient_user_id, context="Workflow event notification", role="recipient")
-        recipient = select_runtime_notification_recipient(
+        recipient = resolve_runtime_notification_recipient(
             recipient_user_id,
-            user_type(recipient_user, recipient_user_id, context="Workflow event notification"),
+            user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-            context="workflow event",
+            context="Workflow event notification",
+            runtime_context="workflow event",
         )
         if recipient is None:
             continue

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -159,6 +159,21 @@ def test_workflow_event_notification_planner_selects_runtime_members() -> None:
         assert envelope.message.metadata["operation"] == "updated"
 
 
+def test_workflow_event_notification_planner_keeps_identity_context() -> None:
+    try:
+        plan_workflow_event_runtime_notifications(
+            change=_change("updated"),
+            members=[{"user_id": "missing-recipient"}],
+            user_repo=_users("agent-1"),
+            thread_repo=_thread_repo("agent-1"),
+            activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "Workflow event notification recipient user not found: missing-recipient"
+    else:
+        raise AssertionError("missing workflow event recipient did not fail")
+
+
 @pytest.mark.asyncio
 async def test_dispatch_workflow_event_notifications_executes_planned_envelopes() -> None:
     gateway = _RecordingGateway()


### PR DESCRIPTION
## Summary
- extract runtime notification recipient resolution into a shared chat adapter helper
- keep workflow identity-error context separate from runtime wake context
- leave workflow fanout and single-recipient notification action semantics unchanged

## Verification
- uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q
- uv run ruff check backend/threads/chat_adapters/runtime_recipient.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py
- uv run ruff format --check backend/threads/chat_adapters/runtime_recipient.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py
