### PR TITLE
Guard sync runtime event hook owner loop calls

### DIFF
--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -9,6 +9,12 @@ def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, 
     loop = asyncio.get_running_loop()
 
     def hook(*args: P.args, **kwargs: P.kwargs) -> None:
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if current_loop is loop:
+            raise RuntimeError("Sync runtime event hook cannot run on its owner event loop thread")
         future = asyncio.run_coroutine_threadsafe(async_fn(*args, **kwargs), loop)
         future.result()
 

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+
+
+@pytest.mark.asyncio
+async def test_sync_runtime_event_hook_runs_coroutine_from_worker_thread() -> None:
+    calls: list[str] = []
+
+    async def record(value: str) -> None:
+        calls.append(value)
+
+    hook = make_sync_runtime_event_hook(record)
+
+    await asyncio.to_thread(hook, "ok")
+
+    assert calls == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> None:
+    async def noop() -> None:
+        return None
+
+    hook = make_sync_runtime_event_hook(noop)
+
+    with pytest.raises(RuntimeError) as exc:
+        hook()
+
+    assert str(exc.value) == "Sync runtime event hook cannot run on its owner event loop thread"


### PR DESCRIPTION
## Summary
- make sync runtime event hooks fail loudly when called from their owner event loop thread
- add focused coverage for worker-thread execution and owner-loop rejection

## Verification
- uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q
- uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py
- uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py
