### PR TITLE
Expose relationship action failure contract

### DIFF
--- a/backend/chat/api/http/relationships_router.py
+++ b/backend/chat/api/http/relationships_router.py
@@ -11,6 +11,7 @@ from backend.chat.api.http.dependencies import (
     get_relationship_service,
 )
 from messaging.contracts import RelationshipRow
+from messaging.relationships.service import RelationshipActionError
 from messaging.relationships.state_machine import TransitionError
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,18 @@ def _row_to_dict(row: RelationshipRow, viewer_id: str) -> dict:
     }
 
 
+def _relationship_action_failure(exc: RelationshipActionError, viewer_id: str) -> HTTPException:
+    return HTTPException(
+        500,
+        {
+            "error": "relationship_action_failed",
+            "event": exc.event,
+            "relationship": _row_to_dict(exc.row, viewer_id),
+            "cause": str(exc.__cause__) if exc.__cause__ is not None else str(exc),
+        },
+    )
+
+
 @router.get("")
 def list_relationships(
     user_id: Annotated[str, Depends(get_current_user_id)],
@@ -79,6 +92,8 @@ def request_relationship(
     try:
         row = relationship_service.request(user_id, body.target_user_id, body.message)
         return _row_to_dict(row, user_id)
+    except RelationshipActionError as e:
+        raise _relationship_action_failure(e, user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -96,6 +111,8 @@ def approve_relationship(
         raise HTTPException(409, "Cannot approve your own request")
     try:
         return _row_to_dict(relationship_service.approve(user_id, requester_id), user_id)
+    except RelationshipActionError as e:
+        raise _relationship_action_failure(e, user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 
@@ -113,6 +130,8 @@ def reject_relationship(
         raise HTTPException(409, "Cannot reject your own request")
     try:
         return _row_to_dict(relationship_service.reject(user_id, requester_id), user_id)
+    except RelationshipActionError as e:
+        raise _relationship_action_failure(e, user_id)
     except TransitionError as e:
         raise HTTPException(409, str(e))
 

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -12,6 +12,13 @@ from messaging.relationships.state_machine import transition
 logger = logging.getLogger(__name__)
 
 
+class RelationshipActionError(RuntimeError):
+    def __init__(self, *, event: RelationshipEvent, row: RelationshipRow) -> None:
+        super().__init__(f"Relationship action failed after {event}")
+        self.event = event
+        self.row = row
+
+
 class RelationshipService:
     """Manages Hire/Visit relationships between users."""
 
@@ -80,21 +87,29 @@ class RelationshipService:
 
     def request(self, requester_id: str, target_id: str, message: str | None = None) -> RelationshipRow:
         row = self.apply_event(requester_id, target_id, "request", message=message)
-        if self._on_relationship_requested is not None:
-            self._on_relationship_requested(row)
+        self._run_post_commit_action("request", row, self._on_relationship_requested)
         return row
 
     def approve(self, approver_id: str, requester_id: str) -> RelationshipRow:
         row = self.apply_event(approver_id, requester_id, "approve")
-        if self._on_relationship_decided is not None:
-            self._on_relationship_decided(row, "approve")
+        self._run_post_commit_action("approve", row, self._on_relationship_decided)
         return row
 
     def reject(self, approver_id: str, requester_id: str) -> RelationshipRow:
         row = self.apply_event(approver_id, requester_id, "reject")
-        if self._on_relationship_decided is not None:
-            self._on_relationship_decided(row, "reject")
+        self._run_post_commit_action("reject", row, self._on_relationship_decided)
         return row
+
+    def _run_post_commit_action(self, event: RelationshipEvent, row: RelationshipRow, fn: Callable[..., None] | None) -> None:
+        if fn is None:
+            return
+        try:
+            if event == "request":
+                fn(row)
+            else:
+                fn(row, event)
+        except Exception as exc:
+            raise RelationshipActionError(event=event, row=row) from exc
 
     def upgrade(self, owner_id: str, agent_id: str) -> RelationshipRow:
         return self.apply_event(owner_id, agent_id, "upgrade")

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +13,8 @@ from backend.chat.api.http import chat_workflow_router, chats_router, relationsh
 from backend.identity.avatar.urls import avatar_url
 from backend.web.core.dependencies import get_current_user_id
 from core.work_item.chat_workflow.service import WorkflowEventActionError
+from messaging.contracts import RelationshipRow
+from messaging.relationships.service import RelationshipActionError
 from storage.contracts import ContactEdgeRow
 from storage.errors import (
     StaleChatWorkflowEventVersionError,
@@ -139,6 +142,46 @@ def test_relationship_bodies_do_not_accept_identity_fields() -> None:
         relationships_router.RelationshipActionBody.model_validate({"requester_user_id": "user-1"})
     with pytest.raises(ValidationError):
         relationships_router.RelationshipRequestBody.model_validate({"target_user_id": "user-2", "actor_" + "user_id": "user-1"})
+
+
+def test_request_relationship_action_failure_returns_persisted_relationship() -> None:
+    row = RelationshipRow(
+        id="hire_visit:human-user-1:agent-user-1",
+        user_low="agent-user-1",
+        user_high="human-user-1",
+        state="pending",
+        initiator_user_id="human-user-1",
+        message="hi",
+        created_at=datetime(2026, 4, 7, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 0, 0, 1, tzinfo=UTC),
+    )
+
+    def fail_request(_requester_id: str, _target_id: str, _message: str | None):
+        error = RelationshipActionError(event="request", row=row)
+        raise error from RuntimeError("runtime offline")
+
+    with pytest.raises(HTTPException) as exc_info:
+        relationships_router.request_relationship(
+            relationships_router.RelationshipRequestBody(target_user_id="agent-user-1", message="hi"),
+            user_id="human-user-1",
+            relationship_service=SimpleNamespace(request=fail_request),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {
+        "error": "relationship_action_failed",
+        "event": "request",
+        "relationship": {
+            "id": "hire_visit:human-user-1:agent-user-1",
+            "other_user_id": "agent-user-1",
+            "state": "pending",
+            "is_requester": True,
+            "message": "hi",
+            "created_at": "2026-04-07T00:00:00+00:00",
+            "updated_at": "2026-04-07T00:00:01+00:00",
+        },
+        "cause": "runtime offline",
+    }
 
 
 def test_chat_join_request_bodies_do_not_accept_identity_fields() -> None:

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -18,7 +18,7 @@ from messaging.delivery.contracts import ChatDeliveryRequest
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.display_user import resolve_messaging_display_user
-from messaging.relationships.service import RelationshipService
+from messaging.relationships.service import RelationshipActionError, RelationshipService
 from messaging.service import MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
 from storage.contracts import ContactEdgeRow
@@ -186,6 +186,37 @@ def test_relationship_request_notifies_after_persisting_pending_row() -> None:
     assert notifications[0].initiator_user_id == "human-user-1"
 
 
+def test_relationship_request_action_failure_carries_persisted_row() -> None:
+    class _RequestRepo:
+        def get(self, _requester_id: str, _target_id: str):
+            return None
+
+        def upsert(self, _requester_id: str, _target_id: str, **fields: Any):
+            return {
+                "id": "hire_visit:agent-user-1:human-user-1",
+                "user_low": "agent-user-1",
+                "user_high": "human-user-1",
+                "kind": "hire_visit",
+                "created_at": "2026-04-07T00:00:00Z",
+                "updated_at": "2026-04-07T00:00:01Z",
+                **fields,
+            }
+
+    def fail_after_persist(_row):
+        raise RuntimeError("runtime offline")
+
+    service = RelationshipService(_RequestRepo(), on_relationship_requested=fail_after_persist)
+
+    with pytest.raises(RelationshipActionError) as exc_info:
+        service.request("human-user-1", "agent-user-1")
+
+    assert str(exc_info.value) == "Relationship action failed after request"
+    assert exc_info.value.event == "request"
+    assert exc_info.value.row.state == "pending"
+    assert exc_info.value.row.initiator_user_id == "human-user-1"
+    assert str(exc_info.value.__cause__) == "runtime offline"
+
+
 def test_relationship_approve_notifies_original_requester_after_persisting_decision() -> None:
     repo = _FakeRelationshipRepo()
     repo._existing[("agent-user-1", "human-user-1")]["state"] = "pending"
@@ -196,6 +227,24 @@ def test_relationship_approve_notifies_original_requester_after_persisting_decis
 
     assert row.state == "visit"
     assert notifications == [(row, "approve")]
+
+
+def test_relationship_decision_action_failure_carries_persisted_row_and_event() -> None:
+    repo = _FakeRelationshipRepo()
+    repo._existing[("agent-user-1", "human-user-1")]["state"] = "pending"
+
+    def fail_after_persist(_row, _event):
+        raise RuntimeError("runtime offline")
+
+    service = RelationshipService(repo, on_relationship_decided=fail_after_persist)
+
+    with pytest.raises(RelationshipActionError) as exc_info:
+        service.approve("agent-user-1", "human-user-1")
+
+    assert str(exc_info.value) == "Relationship action failed after approve"
+    assert exc_info.value.event == "approve"
+    assert exc_info.value.row.state == "visit"
+    assert str(exc_info.value.__cause__) == "runtime offline"
 
 
 def test_relationship_reject_notifies_original_requester_after_persisting_decision() -> None:


### PR DESCRIPTION
## Summary

- Add `RelationshipActionError` for post-commit relationship notification/action failures.
- Preserve the persisted relationship row and failed event when request/approve/reject hooks fail.
- Map relationship action failures to structured HTTP 500 details so callers can recover from the persisted relationship id/state.

## Verification

- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q -k "relationship_request_action_failure or relationship_decision_action_failure"`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_router.py -q -k "request_relationship_action_failure"`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/messaging/test_relationship_tool_service.py -q`
- `uv run pyright messaging/relationships/service.py backend/chat/api/http/relationships_router.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run ruff check messaging/relationships/service.py backend/chat/api/http/relationships_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run ruff format --check messaging/relationships/service.py backend/chat/api/http/relationships_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py`
- `git diff --check`
