### PR TITLE
Plan workflow notifications through runtime action

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -25,6 +25,7 @@ class RuntimeNotificationAction:
     metadata: dict[str, Any] | None = None
     transport: AgentRuntimeTransport = AgentRuntimeTransport()
     include_sender_avatar: bool = False
+    runtime_context: str | None = None
 
 
 async def dispatch_runtime_notification_action(
@@ -61,6 +62,7 @@ def plan_runtime_notification_action(
         thread_repo=thread_repo,
         activity_reader=activity_reader,
         context=action.context,
+        runtime_context=action.runtime_context,
     )
     if recipient is None:
         return None

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -5,16 +5,9 @@ from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
-from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction, plan_runtime_notification_action
 from core.work_item.chat_workflow.service import WorkflowEventChange
-from protocols.agent_runtime import (
-    AgentChatRecipient,
-    AgentRuntimeActor,
-    AgentRuntimeMessage,
-    AgentRuntimeNotificationEnvelope,
-    AgentRuntimeTransport,
-)
+from protocols.agent_runtime import AgentRuntimeNotificationEnvelope, AgentRuntimeTransport
 
 
 def make_workflow_event_notification_fn(
@@ -67,44 +60,24 @@ def plan_workflow_event_runtime_notifications(
     activity_reader: Any,
 ) -> list[AgentRuntimeNotificationEnvelope]:
     sender_user_id = change.actor_user_id
-    sender_user = require_user(user_repo, sender_user_id, context="Workflow event notification", role="sender")
-    sender = make_runtime_actor(
-        user_id=sender_user_id,
-        user=sender_user,
-        source="workflow",
-        context="Workflow event notification",
-    )
     envelopes: list[AgentRuntimeNotificationEnvelope] = []
     for member in members:
         recipient_user_id = _member_user_id(member)
         if recipient_user_id == sender_user_id:
             continue
-        recipient = resolve_runtime_notification_recipient(
-            recipient_user_id,
+        envelope = plan_runtime_notification_action(
+            workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id),
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-            context="Workflow event notification",
-            runtime_context="workflow event",
         )
-        if recipient is None:
+        if envelope is None:
             continue
-        envelopes.append(
-            make_workflow_event_notification_envelope(
-                change=change,
-                recipient=recipient,
-                sender=sender,
-            )
-        )
+        envelopes.append(envelope)
     return envelopes
 
 
-def make_workflow_event_notification_envelope(
-    *,
-    change: WorkflowEventChange,
-    recipient: AgentChatRecipient,
-    sender: AgentRuntimeActor,
-) -> AgentRuntimeNotificationEnvelope:
+def workflow_event_runtime_notification_action(*, change: WorkflowEventChange, recipient_user_id: str) -> RuntimeNotificationAction:
     event = change.event
     chat_id = _required_str(event, "chat_id")
     event_id = _required_str(event, "event_id")
@@ -112,29 +85,30 @@ def make_workflow_event_notification_envelope(
     state = _required_str(event, "state")
     state_version = _required_int(event, "state_version")
     delivery_key = f"workflow:{chat_id}:{event_id}:{state_version}"
-    return AgentRuntimeNotificationEnvelope(
+    return RuntimeNotificationAction(
+        context="Workflow event notification",
+        recipient_user_id=recipient_user_id,
+        sender_user_id=change.actor_user_id,
+        sender_source="workflow",
         event_type="chat.workflow.event",
-        recipient=recipient,
-        sender=sender,
-        message=AgentRuntimeMessage(
-            content=f"Workflow event {kind} was {change.operation} and is {state}.",
-            metadata={
-                "chat_id": chat_id,
-                "event_id": event_id,
-                "kind": kind,
-                "operation": change.operation,
-                "actor_user_id": change.actor_user_id,
-                "resource_refs": _resource_refs(event),
-                "state": state,
-                "state_version": state_version,
-            },
-        ),
         notification_type="workflow_event",
+        content=f"Workflow event {kind} was {change.operation} and is {state}.",
+        metadata={
+            "chat_id": chat_id,
+            "event_id": event_id,
+            "kind": kind,
+            "operation": change.operation,
+            "actor_user_id": change.actor_user_id,
+            "resource_refs": _resource_refs(event),
+            "state": state,
+            "state_version": state_version,
+        },
         transport=AgentRuntimeTransport(
             delivery_id=delivery_key,
             correlation_id=f"workflow:{chat_id}:{event_id}",
             idempotency_key=delivery_key,
         ),
+        runtime_context="workflow event",
     )
 
 

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -8,12 +8,10 @@ import pytest
 
 from backend.threads.chat_adapters.workflow_event_inlet import (
     dispatch_workflow_event_notifications,
-    make_workflow_event_notification_envelope,
     make_workflow_event_notification_fn,
     plan_workflow_event_runtime_notifications,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
-from protocols.agent_runtime import AgentChatRecipient, AgentRuntimeActor
 
 
 def _event() -> dict[str, object]:
@@ -71,7 +69,7 @@ def _thread_repo(*agent_ids: str) -> SimpleNamespace:
 
 
 def test_workflow_event_notification_is_metadata_only() -> None:
-    envelope = make_workflow_event_notification_envelope(
+    envelopes = plan_workflow_event_runtime_notifications(
         change=WorkflowEventChange(
             operation="created",
             event={
@@ -86,13 +84,18 @@ def test_workflow_event_notification_is_metadata_only() -> None:
             },
             actor_user_id="owner-1",
         ),
-        recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
-        sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
+        members=[{"user_id": "agent-1"}],
+        user_repo=_users("agent-1"),
+        thread_repo=_thread_repo("agent-1"),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
     )
 
+    assert len(envelopes) == 1
+    envelope = envelopes[0]
     assert envelope.event_type == "chat.workflow.event"
     assert envelope.notification_type == "workflow_event"
     assert envelope.recipient.agent_user_id == "agent-1"
+    assert envelope.recipient.thread_id == "thread-agent-1"
     assert envelope.sender.user_id == "owner-1"
     assert envelope.message.content == "Workflow event task_proposed_review was created and is open."
     assert envelope.message.metadata == {
@@ -113,7 +116,7 @@ def test_workflow_event_notification_is_metadata_only() -> None:
 
 def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
     try:
-        make_workflow_event_notification_envelope(
+        plan_workflow_event_runtime_notifications(
             change=WorkflowEventChange(
                 operation="created",
                 event={
@@ -125,8 +128,10 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
                 },
                 actor_user_id="owner-1",
             ),
-            recipient=AgentChatRecipient(agent_user_id="agent-1", runtime_source="mycel", thread_id="thread-1"),
-            sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="workflow"),
+            members=[{"user_id": "agent-1"}],
+            user_repo=_users("agent-1"),
+            thread_repo=_thread_repo("agent-1"),
+            activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
         )
     except RuntimeError as exc:
         assert str(exc) == "Workflow event notification is missing event_id"


### PR DESCRIPTION
## Summary

- Route workflow event fanout through `RuntimeNotificationAction` planning.
- Delete the workflow-specific runtime envelope builder and manual sender/recipient assembly.
- Keep workflow-specific payload/transport construction local to a workflow action factory.

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/integration_contracts/test_messaging_router.py -q`
- `uv run pyright backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff format --check backend/threads/chat_adapters/workflow_event_inlet.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `git diff --check`
