### PR TITLE
Inline runtime notification action planning

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -36,25 +36,6 @@ async def dispatch_runtime_notification_action(
     thread_repo: Any,
     activity_reader: Any,
 ) -> bool:
-    envelope = plan_runtime_notification_action(
-        action,
-        user_repo=user_repo,
-        thread_repo=thread_repo,
-        activity_reader=activity_reader,
-    )
-    if envelope is None:
-        return False
-    await get_agent_runtime_gateway(app).dispatch_notification(envelope)
-    return True
-
-
-def plan_runtime_notification_action(
-    action: RuntimeNotificationAction,
-    *,
-    user_repo: Any,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> AgentRuntimeNotificationEnvelope | None:
     sender_user = require_user(user_repo, action.sender_user_id, context=action.context, role="sender")
     recipient = resolve_runtime_notification_recipient(
         action.recipient_user_id,
@@ -65,21 +46,24 @@ def plan_runtime_notification_action(
         runtime_context=action.runtime_context,
     )
     if recipient is None:
-        return None
-    return AgentRuntimeNotificationEnvelope(
-        event_type=action.event_type,
-        recipient=recipient,
-        sender=make_runtime_actor(
-            user_id=action.sender_user_id,
-            user=sender_user,
-            source=action.sender_source,
-            context=action.context,
-            include_avatar=action.include_sender_avatar,
+        return False
+    await get_agent_runtime_gateway(app).dispatch_notification(
+        AgentRuntimeNotificationEnvelope(
+            event_type=action.event_type,
+            recipient=recipient,
+            sender=make_runtime_actor(
+                user_id=action.sender_user_id,
+                user=sender_user,
+                source=action.sender_source,
+                context=action.context,
+                include_avatar=action.include_sender_avatar,
+            ),
+            message=AgentRuntimeMessage(
+                content=action.content,
+                metadata=action.metadata,
+            ),
+            notification_type=action.notification_type,
+            transport=action.transport,
         ),
-        message=AgentRuntimeMessage(
-            content=action.content,
-            metadata=action.metadata,
-        ),
-        notification_type=action.notification_type,
-        transport=action.transport,
     )
+    return True


### PR DESCRIPTION
## Summary

- inline the now-private runtime notification action planner into dispatch
- remove the stale `plan_runtime_notification_action` surface
- keep `dispatch_runtime_notification_action` as the single runtime notification action execution boundary

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
