### PR TITLE
Expose chat join action failure contract

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -19,6 +19,7 @@ from backend.chat.api.http.dependencies import (
     get_user_repo,
 )
 from messaging.errors import ChatNotCaughtUpError
+from messaging.join_requests import ChatJoinRequestActionError
 from messaging.user_ownership import is_owned_by_viewer
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -74,6 +75,17 @@ class ChatMemberAddBody(BaseModel):
 
 
 def _map_chat_join_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, ChatJoinRequestActionError):
+        cause = exc.__cause__
+        return HTTPException(
+            500,
+            {
+                "error": "chat_join_action_failed",
+                "action": exc.action,
+                "row": exc.row,
+                "cause": str(cause) if cause is not None else str(exc),
+            },
+        )
     if isinstance(exc, LookupError):
         return HTTPException(404, str(exc))
     if isinstance(exc, PermissionError):

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 
+class ChatJoinRequestActionError(RuntimeError):
+    def __init__(self, *, action: str, row: dict[str, Any]) -> None:
+        super().__init__(f"Chat join action failed after {action}")
+        self.action = action
+        self.row = dict(row)
+
+
 class ChatJoinRequestService:
     def __init__(
         self,
@@ -92,7 +99,10 @@ class ChatJoinRequestService:
             mentions=[requester_user_id],
         )
         if self._on_join_request_rejected is not None:
-            self._on_join_request_rejected(row)
+            try:
+                self._on_join_request_rejected(row)
+            except Exception as exc:
+                raise ChatJoinRequestActionError(action="reject", row=row) from exc
         return self._project_request(row)
 
     def _require_joinable_chat(self, chat_id: str) -> Any:
@@ -131,5 +141,6 @@ class ChatJoinRequestService:
         if requester is not None:
             projected["requester_name"] = requester.display_name
             requester_type = getattr(requester, "type", None)
-            projected["requester_type"] = requester_type.value if hasattr(requester_type, "value") else str(requester_type)
+            requester_type_value = getattr(requester_type, "value", None)
+            projected["requester_type"] = str(requester_type_value if requester_type_value is not None else requester_type)
         return projected

--- a/tests/Unit/backend/web/services/test_chat_join_action_failure.py
+++ b/tests/Unit/backend/web/services/test_chat_join_action_failure.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from backend.chat.api.http.chats_router import _map_chat_join_error
+from messaging.join_requests import ChatJoinRequestActionError
+
+
+def test_chat_join_action_failure_maps_to_structured_http_error() -> None:
+    error = ChatJoinRequestActionError(
+        action="reject",
+        row={
+            "id": "request-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "visitor-1",
+            "state": "rejected",
+        },
+    )
+
+    mapped = _map_chat_join_error(error)
+
+    assert mapped.status_code == 500
+    assert mapped.detail == {
+        "error": "chat_join_action_failed",
+        "action": "reject",
+        "row": {
+            "id": "request-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "visitor-1",
+            "state": "rejected",
+        },
+        "cause": "Chat join action failed after reject",
+    }

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from messaging.join_requests import ChatJoinRequestService
+from messaging.join_requests import ChatJoinRequestActionError, ChatJoinRequestService
 
 
 class _Members:
@@ -250,6 +250,38 @@ def test_chat_join_reject_notifies_requester_outside_chat_membership() -> None:
             "decided_by_user_id": "owner-1",
         }
     ]
+
+
+def test_chat_join_reject_wraps_post_commit_action_failure() -> None:
+    def fail_notification(_row: dict) -> None:
+        raise RuntimeError("runtime hook failed")
+
+    service, _members, _requests, messaging = _service(on_join_request_rejected=fail_notification)
+    pending = service.request("chat-1", "visitor-1", "please add me")
+
+    with pytest.raises(ChatJoinRequestActionError) as exc_info:
+        service.reject("chat-1", pending["id"], "owner-1")
+
+    exc = exc_info.value
+    assert exc.action == "reject"
+    assert exc.row == {
+        "id": "chat_join:chat-1:visitor-1",
+        "chat_id": "chat-1",
+        "requester_user_id": "visitor-1",
+        "state": "rejected",
+        "message": "please add me",
+        "created_at": 1.0,
+        "updated_at": 2.0,
+        "decided_by_user_id": "owner-1",
+    }
+    assert str(exc.__cause__) == "runtime hook failed"
+    assert messaging.sent[-1] == (
+        "chat-1",
+        "owner-1",
+        "Rejected chat join request for visitor-1.",
+        "notification",
+        ["visitor-1"],
+    )
 
 
 def test_chat_join_approve_rejects_non_owner() -> None:


### PR DESCRIPTION
## Summary

- add a concrete `ChatJoinRequestActionError` for reject-time runtime hook failures after durable state/message effects
- map that error to structured HTTP 500 detail instead of leaking a raw hook exception
- keep the contract specific to chat join requests; no generic post-commit action framework added

## Verification

- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_reject_wraps_post_commit_action_failure tests/Unit/backend/web/services/test_chat_join_action_failure.py -q`
- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/web/services/test_chat_join_action_failure.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py -q`
- `uv run ruff check messaging/join_requests.py backend/chat/api/http/chats_router.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/web/services/test_chat_join_action_failure.py`
- `uv run ruff format --check messaging/join_requests.py backend/chat/api/http/chats_router.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/web/services/test_chat_join_action_failure.py`
- `uv run pyright --pythonversion 3.12 messaging/join_requests.py backend/chat/api/http/chats_router.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/web/services/test_chat_join_action_failure.py`
