### PR TITLE
Extract runtime chat delivery action

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -4,62 +4,52 @@ from enum import Enum
 from typing import Any
 
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
-from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_chat_delivery_recipient
-from messaging.delivery.contracts import ChatDeliveryRequest
-from protocols.agent_runtime import (
-    AgentChatContext,
-    AgentChatDeliveryEnvelope,
-    AgentRuntimeActor,
-    AgentRuntimeMessage,
+from backend.threads.chat_adapters.runtime_chat_delivery_action import (
+    RuntimeChatDeliveryAction,
+    dispatch_runtime_chat_delivery_action,
 )
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
-        raw_recipient_type = getattr(request.recipient_user, "type", None)
-        if raw_recipient_type is None:
-            raise RuntimeError(f"Chat delivery recipient is missing user type: {request.recipient_id}")
-        recipient_type = raw_recipient_type.value if isinstance(raw_recipient_type, Enum) else str(raw_recipient_type)
-        recipient_user_id = getattr(request.recipient_user, "id", None)
-        if recipient_user_id is None:
-            raise RuntimeError(f"Chat delivery recipient is missing user id: {request.recipient_id}")
-        # @@@chat-rendered-content - runtime handlers should enqueue the already rendered
-        # chat reminder content; chat-specific unread/rendering belongs on the upstream delivery path.
-        rendered_content = format_chat_notification(
-            request.sender_name,
-            request.chat_id,
-            request.unread_count,
-            signal=request.signal,
-        )
-        recipient = resolve_runtime_chat_delivery_recipient(
-            request.recipient_id,
-            recipient_type,
+        await dispatch_runtime_chat_delivery_action(
+            app,
+            chat_delivery_runtime_action(request),
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
-        if recipient is None:
-            return
-        envelope = AgentChatDeliveryEnvelope(
-            chat=AgentChatContext(chat_id=request.chat_id),
-            sender=AgentRuntimeActor(
-                user_id=request.sender_id,
-                user_type=request.sender_type,
-                display_name=request.sender_name,
-                avatar_url=request.sender_avatar_url,
-                source="chat",
-            ),
-            recipient=recipient,
-            message=AgentRuntimeMessage(content=rendered_content, signal=request.signal),
-            extensions={
-                "mycel": {
-                    "recipient_user_id": recipient_user_id,
-                    "recipient_user_type": recipient_type,
-                    "raw_content": request.content,
-                }
-            },
-        )
-        await get_agent_runtime_gateway(app).dispatch_chat(envelope)
 
     return make_sync_runtime_event_hook(deliver_to_runtime_gateway)
+
+
+def chat_delivery_runtime_action(request: ChatDeliveryRequest) -> RuntimeChatDeliveryAction:
+    raw_recipient_type = getattr(request.recipient_user, "type", None)
+    if raw_recipient_type is None:
+        raise RuntimeError(f"Chat delivery recipient is missing user type: {request.recipient_id}")
+    recipient_type = raw_recipient_type.value if isinstance(raw_recipient_type, Enum) else str(raw_recipient_type)
+    recipient_user_id = getattr(request.recipient_user, "id", None)
+    if recipient_user_id is None:
+        raise RuntimeError(f"Chat delivery recipient is missing user id: {request.recipient_id}")
+    # @@@chat-rendered-content - runtime handlers should enqueue the already rendered
+    # chat reminder content; chat-specific unread/rendering belongs on the upstream delivery path.
+    rendered_content = format_chat_notification(
+        request.sender_name,
+        request.chat_id,
+        request.unread_count,
+        signal=request.signal,
+    )
+    return RuntimeChatDeliveryAction(
+        chat_id=request.chat_id,
+        recipient_id=request.recipient_id,
+        recipient_user_id=recipient_user_id,
+        recipient_user_type=recipient_type,
+        sender_id=request.sender_id,
+        sender_type=request.sender_type,
+        sender_name=request.sender_name,
+        sender_avatar_url=request.sender_avatar_url,
+        content=rendered_content,
+        raw_content=request.content,
+        signal=request.signal,
+    )

--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_chat_delivery_recipient
+from protocols.agent_runtime import (
+    AgentChatContext,
+    AgentChatDeliveryEnvelope,
+    AgentRuntimeActor,
+    AgentRuntimeMessage,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeChatDeliveryAction:
+    chat_id: str
+    recipient_id: str
+    recipient_user_id: str
+    recipient_user_type: str
+    sender_id: str
+    sender_type: str
+    sender_name: str
+    sender_avatar_url: str | None
+    content: str
+    raw_content: str
+    signal: str | None
+
+
+async def dispatch_runtime_chat_delivery_action(
+    app: Any,
+    action: RuntimeChatDeliveryAction,
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> bool:
+    recipient = resolve_runtime_chat_delivery_recipient(
+        action.recipient_id,
+        action.recipient_user_type,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    if recipient is None:
+        return False
+    await get_agent_runtime_gateway(app).dispatch_chat(
+        AgentChatDeliveryEnvelope(
+            chat=AgentChatContext(chat_id=action.chat_id),
+            sender=AgentRuntimeActor(
+                user_id=action.sender_id,
+                user_type=action.sender_type,
+                display_name=action.sender_name,
+                avatar_url=action.sender_avatar_url,
+                source="chat",
+            ),
+            recipient=recipient,
+            message=AgentRuntimeMessage(content=action.content, signal=action.signal),
+            extensions={
+                "mycel": {
+                    "recipient_user_id": action.recipient_user_id,
+                    "recipient_user_type": action.recipient_user_type,
+                    "raw_content": action.raw_content,
+                }
+            },
+        )
+    )
+    return True

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 import pytest
 
 from backend.threads.chat_adapters import chat_inlet as owner_chat_inlet
+from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
+from backend.threads.chat_adapters.runtime_chat_delivery_action import RuntimeChatDeliveryAction
 from messaging.delivery.dispatcher import ChatDeliveryRequest
 
 
@@ -23,6 +25,37 @@ def _hook_app(gateway: object) -> SimpleNamespace:
                 list_by_agent_user=lambda uid: [default_thread] if uid == "agent-user-1" else [],
             ),
         )
+    )
+
+
+def test_chat_delivery_request_builds_runtime_action() -> None:
+    action = owner_chat_inlet.chat_delivery_runtime_action(
+        ChatDeliveryRequest(
+            recipient_id="agent-user-1",
+            recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+            content="hello",
+            sender_name="Human",
+            sender_type="human",
+            chat_id="chat-1",
+            sender_id="human-user-1",
+            sender_avatar_url=None,
+            unread_count=3,
+            signal=None,
+        )
+    )
+
+    assert action == RuntimeChatDeliveryAction(
+        chat_id="chat-1",
+        recipient_id="agent-user-1",
+        recipient_user_id="agent-user-1",
+        recipient_user_type="agent",
+        sender_id="human-user-1",
+        sender_type="human",
+        sender_name="Human",
+        sender_avatar_url=None,
+        content=format_chat_notification("Human", "chat-1", 3, signal=None),
+        raw_content="hello",
+        signal=None,
     )
 
 


### PR DESCRIPTION
## Summary
- introduce `RuntimeChatDeliveryAction` for runtime-addressable chat delivery
- route `make_chat_delivery_fn()` through `dispatch_runtime_chat_delivery_action()`
- keep existing chat delivery behavior and gateway envelopes unchanged

## Why
Notification side effects already flow through a concrete runtime action boundary. Chat delivery was still doing request projection, recipient runtime resolution, envelope construction, and gateway dispatch inside `chat_inlet`. This makes the event/action language cover notifications but not the core chat-message action.

This slice keeps the user-facing behavior unchanged and avoids DSL/retry/outbox/polling/schema work. It only separates the pure chat-delivery action from the runtime adapter that executes it.

## Verification
- Red test first: `test_chat_delivery_request_builds_runtime_action` failed because `runtime_chat_delivery_action` did not exist
- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
