### PR TITLE
Guard runtime gateway action boundary

### DIFF
--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 from typing import get_type_hints
 
 
@@ -50,3 +51,16 @@ def test_agent_runtime_gateway_handler_injection_is_typed() -> None:
     assert "app" not in constructor_hints
     assert "AgentChatRuntimeHandler" in str(constructor_hints["chat_handlers"])
     assert constructor_hints["thread_input_handler"] == gateway_module.AgentThreadInputRuntimeHandler | None
+
+
+def test_chat_inlets_do_not_dispatch_runtime_gateway_directly() -> None:
+    repo_root = Path(__file__).parents[4]
+    inlet_files = (repo_root / "backend" / "threads" / "chat_adapters").glob("*_inlet.py")
+
+    for path in inlet_files:
+        text = path.read_text(encoding="utf-8")
+        assert "get_agent_runtime_gateway" not in text, path
+        assert ".dispatch_chat(" not in text, path
+        assert ".dispatch_notification(" not in text, path
+        assert "AgentChatDeliveryEnvelope" not in text, path
+        assert "AgentRuntimeNotificationEnvelope" not in text, path


### PR DESCRIPTION
## Summary
- add an architecture boundary test for chat adapter inlets
- ensure `*_inlet.py` modules do not call the runtime gateway directly or construct chat/notification envelopes

## Why
PR #1407 moved chat delivery through a runtime action boundary. This test keeps that boundary from drifting back into inlet modules.

This is test-only. It adds no runtime logic, no DSL, no queue, no retry, no polling, and no transport change.

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q`
- `uv run ruff check tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pyright --pythonversion 3.12 tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
