### PR TITLE
Extract runtime thread input action

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+
+
+@dataclass(frozen=True)
+class RuntimeThreadInputAction:
+    thread_id: str
+    sender_user_id: str
+    sender_user_type: str
+    sender_display_name: str
+    sender_source: str
+    content: str
+    attachments: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+    enable_trajectory: bool = False
+
+
+def owner_runtime_thread_input_action(
+    *,
+    thread_id: str,
+    user_id: str,
+    message: str,
+    attachments: list[str] | None,
+    enable_trajectory: bool,
+) -> RuntimeThreadInputAction:
+    return RuntimeThreadInputAction(
+        thread_id=thread_id,
+        sender_user_id=user_id,
+        sender_user_type="human",
+        sender_display_name="Owner",
+        sender_source="owner",
+        content=message,
+        attachments=attachments,
+        enable_trajectory=enable_trajectory,
+    )
+
+
+async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction):
+    return await get_agent_runtime_gateway(app).dispatch_thread_input(
+        AgentThreadInputEnvelope(
+            thread_id=action.thread_id,
+            sender=AgentRuntimeActor(
+                user_id=action.sender_user_id,
+                user_type=action.sender_user_type,
+                display_name=action.sender_display_name,
+                source=action.sender_source,
+            ),
+            message=AgentRuntimeMessage(
+                content=action.content,
+                attachments=action.attachments,
+                metadata=action.metadata,
+            ),
+            enable_trajectory=action.enable_trajectory,
+        )
+    )

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -986,8 +986,10 @@ async def send_message(
         raise HTTPException(status_code=400, detail="message cannot be empty")
 
     from backend.threads.activity_pool_service import get_or_create_agent
-    from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-    from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+    from backend.threads.chat_adapters.runtime_thread_input_action import (
+        dispatch_runtime_thread_input_action,
+        owner_runtime_thread_input_action,
+    )
 
     message = payload.message
     # @@@attachment-wire - sync files to sandbox and prepend paths
@@ -1002,13 +1004,15 @@ async def send_message(
             agent=agent,
         )
 
-    result = await get_agent_runtime_gateway(app).dispatch_thread_input(
-        AgentThreadInputEnvelope(
+    result = await dispatch_runtime_thread_input_action(
+        app,
+        owner_runtime_thread_input_action(
             thread_id=thread_id,
-            sender=AgentRuntimeActor(user_id=user_id, user_type="human", display_name="Owner", source="owner"),
-            message=AgentRuntimeMessage(content=message, attachments=payload.attachments or None),
+            user_id=user_id,
+            message=message,
+            attachments=payload.attachments or None,
             enable_trajectory=payload.enable_trajectory,
-        )
+        ),
     )
     return result.to_response()
 
@@ -1165,8 +1169,10 @@ async def resolve_thread_permission_request(
 
     followup: dict[str, Any] | None = None
     if is_ask_user_question and payload.decision == "allow" and pending_request is not None and answers is not None:
-        from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-        from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+        from backend.threads.chat_adapters.runtime_thread_input_action import (
+            RuntimeThreadInputAction,
+            dispatch_runtime_thread_input_action,
+        )
 
         answered_payload = _build_ask_user_question_answered_payload(
             pending_request,
@@ -1174,23 +1180,20 @@ async def resolve_thread_permission_request(
             annotations=getattr(payload, "annotations", None),
         )
 
-        followup_result = await get_agent_runtime_gateway(app).dispatch_thread_input(
-            AgentThreadInputEnvelope(
+        followup_result = await dispatch_runtime_thread_input_action(
+            app,
+            RuntimeThreadInputAction(
                 thread_id=thread_id,
-                sender=AgentRuntimeActor(
-                    user_id=user_id or "internal",
-                    user_type="system",
-                    display_name="Internal",
-                    source="internal",
+                sender_user_id=user_id or "internal",
+                sender_user_type="system",
+                sender_display_name="Internal",
+                sender_source="internal",
+                content=_format_ask_user_question_followup(
+                    pending_request,
+                    answers=answers,
+                    annotations=getattr(payload, "annotations", None),
                 ),
-                message=AgentRuntimeMessage(
-                    content=_format_ask_user_question_followup(
-                        pending_request,
-                        answers=answers,
-                        annotations=getattr(payload, "annotations", None),
-                    ),
-                    metadata={"ask_user_question_answered": answered_payload},
-                ),
+                metadata={"ask_user_question_answered": answered_payload},
             ),
         )
         followup = followup_result.to_response()

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -13,6 +13,10 @@ import pytest
 from fastapi import Request
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 
+from backend.threads.chat_adapters.runtime_thread_input_action import (
+    RuntimeThreadInputAction,
+    owner_runtime_thread_input_action,
+)
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
 from backend.web.routers import threads as threads_router
 from core.runtime.loop import QueryLoop
@@ -189,6 +193,28 @@ async def test_send_message_passes_enable_trajectory_to_agent_runtime_gateway() 
 
     assert result == {"status": "started", "routing": "direct", "thread_id": "thread-1"}
     assert captured[0].enable_trajectory is True
+
+
+def test_owner_thread_input_action_carries_message_contract() -> None:
+    action = owner_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="hello",
+        attachments=["file-1"],
+        enable_trajectory=True,
+    )
+
+    assert action == RuntimeThreadInputAction(
+        thread_id="thread-1",
+        sender_user_id="owner-1",
+        sender_user_type="human",
+        sender_display_name="Owner",
+        sender_source="owner",
+        content="hello",
+        attachments=["file-1"],
+        metadata=None,
+        enable_trajectory=True,
+    )
 
 
 def _make_request(headers: dict[str, str] | None = None) -> Request:


### PR DESCRIPTION
## Summary
- add `RuntimeThreadInputAction` for owner/system thread input into agent runtime
- route `send_message` and AskUserQuestion followup through `dispatch_runtime_thread_input_action`
- keep the existing HTTP responses and runtime gateway envelope behavior intact

## Why
Runtime notification and chat delivery now have explicit action boundaries, but direct owner/system thread input still constructed `AgentThreadInputEnvelope` inside the HTTP router. This slice moves that protocol adaptation into the chat adapter runtime-action layer without adding DSL, queues, retries, polling, schema, or transport changes.

## Verification
- Red test first: `test_owner_thread_input_action_carries_message_contract` failed because `runtime_thread_input_action` did not exist
- `uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_send_message_passes_enable_trajectory_to_agent_runtime_gateway tests/Unit/integration_contracts/test_threads_router.py::test_owner_thread_input_action_carries_message_contract tests/Unit/integration_contracts/test_threads_router.py::test_resolve_ask_user_question_request_starts_followup_run_with_answers tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py -q`
- `uv run ruff check backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run pyright --pythonversion 3.12 backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py`
