### PR TITLE
Centralize runtime actor construction

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_identity import runtime_actor
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_chat_delivery_recipient
 from protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
-    AgentRuntimeActor,
     AgentRuntimeMessage,
 )
 
@@ -46,7 +46,7 @@ async def dispatch_runtime_chat_delivery_action(
     await get_agent_runtime_gateway(app).dispatch_chat(
         AgentChatDeliveryEnvelope(
             chat=AgentChatContext(chat_id=action.chat_id),
-            sender=AgentRuntimeActor(
+            sender=runtime_actor(
                 user_id=action.sender_id,
                 user_type=action.sender_type,
                 display_name=action.sender_name,

--- a/backend/threads/chat_adapters/runtime_identity.py
+++ b/backend/threads/chat_adapters/runtime_identity.py
@@ -36,10 +36,27 @@ def make_runtime_actor(
     context: str,
     include_avatar: bool = False,
 ) -> AgentRuntimeActor:
-    return AgentRuntimeActor(
+    return runtime_actor(
         user_id=user_id,
         user_type=user_type(user, user_id, context=context),
         display_name=display_name(user, user_id, context=context),
         avatar_url=avatar_url(user_id, bool(getattr(user, "avatar", None))) if include_avatar else None,
+        source=source,
+    )
+
+
+def runtime_actor(
+    *,
+    user_id: str,
+    user_type: str,
+    display_name: str,
+    source: str,
+    avatar_url: str | None = None,
+) -> AgentRuntimeActor:
+    return AgentRuntimeActor(
+        user_id=user_id,
+        user_type=user_type,
+        display_name=display_name,
+        avatar_url=avatar_url,
         source=source,
     )

--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+from backend.threads.chat_adapters.runtime_identity import runtime_actor
+from protocols.agent_runtime import AgentRuntimeMessage, AgentThreadInputEnvelope
 
 
 @dataclass(frozen=True)
@@ -44,7 +45,7 @@ async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadIn
     return await get_agent_runtime_gateway(app).dispatch_thread_input(
         AgentThreadInputEnvelope(
             thread_id=action.thread_id,
-            sender=AgentRuntimeActor(
+            sender=runtime_actor(
                 user_id=action.sender_user_id,
                 user_type=action.sender_user_type,
                 display_name=action.sender_display_name,

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -54,8 +54,10 @@ def test_agent_runtime_gateway_handler_injection_is_typed() -> None:
 
 
 def test_chat_inlets_do_not_dispatch_runtime_gateway_directly() -> None:
-    repo_root = Path(__file__).parents[4]
-    inlet_files = (repo_root / "backend" / "threads" / "chat_adapters").glob("*_inlet.py")
+    repo_root = Path(__file__).parents[5]
+    inlet_files = list((repo_root / "backend" / "threads" / "chat_adapters").glob("*_inlet.py"))
+
+    assert inlet_files
 
     for path in inlet_files:
         text = path.read_text(encoding="utf-8")
@@ -64,3 +66,14 @@ def test_chat_inlets_do_not_dispatch_runtime_gateway_directly() -> None:
         assert ".dispatch_notification(" not in text, path
         assert "AgentChatDeliveryEnvelope" not in text, path
         assert "AgentRuntimeNotificationEnvelope" not in text, path
+
+
+def test_runtime_actions_use_shared_actor_builder() -> None:
+    repo_root = Path(__file__).parents[5]
+    action_files = list((repo_root / "backend" / "threads" / "chat_adapters").glob("runtime_*_action.py"))
+
+    assert action_files
+
+    for path in action_files:
+        text = path.read_text(encoding="utf-8")
+        assert "AgentRuntimeActor" not in text, path


### PR DESCRIPTION
## Summary

- centralize construction of AgentRuntimeActor behind runtime_identity.runtime_actor
- route chat delivery and thread input action dispatchers through the shared actor builder
- fix the runtime gateway boundary guard so it scans the repo root, fails loudly on empty globs, and prevents action modules from constructing actors directly

## Verification

- uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/integration_contracts/test_threads_router.py::test_send_message_passes_enable_trajectory_to_agent_runtime_gateway tests/Unit/integration_contracts/test_threads_router.py::test_owner_thread_input_action_carries_message_contract tests/Unit/integration_contracts/test_threads_router.py::test_resolve_ask_user_question_request_starts_followup_run_with_answers tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py -q
- uv run ruff check backend/threads/chat_adapters/runtime_identity.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
- uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_identity.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
