### PR TITLE
Extract internal thread input action factory

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -41,6 +41,24 @@ def owner_runtime_thread_input_action(
     )
 
 
+def internal_runtime_thread_input_action(
+    *,
+    thread_id: str,
+    user_id: str,
+    message: str,
+    metadata: dict[str, Any] | None = None,
+) -> RuntimeThreadInputAction:
+    return RuntimeThreadInputAction(
+        thread_id=thread_id,
+        sender_user_id=user_id,
+        sender_user_type="system",
+        sender_display_name="Internal",
+        sender_source="internal",
+        content=message,
+        metadata=metadata,
+    )
+
+
 async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction):
     return await get_agent_runtime_gateway(app).dispatch_thread_input(
         AgentThreadInputEnvelope(

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1170,8 +1170,8 @@ async def resolve_thread_permission_request(
     followup: dict[str, Any] | None = None
     if is_ask_user_question and payload.decision == "allow" and pending_request is not None and answers is not None:
         from backend.threads.chat_adapters.runtime_thread_input_action import (
-            RuntimeThreadInputAction,
             dispatch_runtime_thread_input_action,
+            internal_runtime_thread_input_action,
         )
 
         answered_payload = _build_ask_user_question_answered_payload(
@@ -1182,13 +1182,10 @@ async def resolve_thread_permission_request(
 
         followup_result = await dispatch_runtime_thread_input_action(
             app,
-            RuntimeThreadInputAction(
+            internal_runtime_thread_input_action(
                 thread_id=thread_id,
-                sender_user_id=user_id or "internal",
-                sender_user_type="system",
-                sender_display_name="Internal",
-                sender_source="internal",
-                content=_format_ask_user_question_followup(
+                user_id=user_id or "internal",
+                message=_format_ask_user_question_followup(
                     pending_request,
                     answers=answers,
                     annotations=getattr(payload, "annotations", None),

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -15,6 +15,7 @@ from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 
 from backend.threads.chat_adapters.runtime_thread_input_action import (
     RuntimeThreadInputAction,
+    internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
 )
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
@@ -214,6 +215,27 @@ def test_owner_thread_input_action_carries_message_contract() -> None:
         attachments=["file-1"],
         metadata=None,
         enable_trajectory=True,
+    )
+
+
+def test_internal_thread_input_action_carries_followup_contract() -> None:
+    action = internal_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="answer",
+        metadata={"ask_user_question_answered": {"request_id": "req-1"}},
+    )
+
+    assert action == RuntimeThreadInputAction(
+        thread_id="thread-1",
+        sender_user_id="owner-1",
+        sender_user_type="system",
+        sender_display_name="Internal",
+        sender_source="internal",
+        content="answer",
+        attachments=None,
+        metadata={"ask_user_question_answered": {"request_id": "req-1"}},
+        enable_trajectory=False,
     )
 
 


### PR DESCRIPTION
## Summary

- add internal_runtime_thread_input_action for system/internal follow-up messages
- route AskUserQuestion follow-up resolution through the thread input action factory
- keep HTTP router out of runtime actor field policy

## Verification

- uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_send_message_passes_enable_trajectory_to_agent_runtime_gateway tests/Unit/integration_contracts/test_threads_router.py::test_owner_thread_input_action_carries_message_contract tests/Unit/integration_contracts/test_threads_router.py::test_internal_thread_input_action_carries_followup_contract tests/Unit/integration_contracts/test_threads_router.py::test_resolve_ask_user_question_request_starts_followup_run_with_answers tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py -q
- uv run ruff check backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
- uv run pyright --pythonversion 3.12 backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
