### PR TITLE
Extract queued thread input action

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -21,6 +21,22 @@ class RuntimeThreadInputAction:
     enable_trajectory: bool = False
 
 
+@dataclass(frozen=True)
+class QueuedThreadInputAction:
+    thread_id: str
+    content: str
+    notification_type: str = "steer"
+
+
+def queued_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadInputAction:
+    return QueuedThreadInputAction(thread_id=thread_id, content=message)
+
+
+def dispatch_queued_thread_input_action(queue_manager: Any, action: QueuedThreadInputAction) -> dict[str, str]:
+    queue_manager.enqueue(action.content, action.thread_id, notification_type=action.notification_type)
+    return {"status": "queued", "thread_id": action.thread_id}
+
+
 def owner_runtime_thread_input_action(
     *,
     thread_id: str,

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1026,8 +1026,15 @@ async def queue_message(
     """Enqueue a followup message. Will be consumed when agent reaches IDLE."""
     if not payload.message.strip():
         raise HTTPException(status_code=400, detail="message cannot be empty")
-    app.state.queue_manager.enqueue(payload.message, thread_id, notification_type="steer")
-    return {"status": "queued", "thread_id": thread_id}
+    from backend.threads.chat_adapters.runtime_thread_input_action import (
+        dispatch_queued_thread_input_action,
+        queued_thread_input_action,
+    )
+
+    return dispatch_queued_thread_input_action(
+        app.state.queue_manager,
+        queued_thread_input_action(thread_id=thread_id, message=payload.message),
+    )
 
 
 @router.get("/{thread_id}/queue")

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -14,9 +14,12 @@ from fastapi import Request
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 
 from backend.threads.chat_adapters.runtime_thread_input_action import (
+    QueuedThreadInputAction,
     RuntimeThreadInputAction,
+    dispatch_queued_thread_input_action,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
+    queued_thread_input_action,
 )
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
 from backend.web.routers import threads as threads_router
@@ -237,6 +240,20 @@ def test_internal_thread_input_action_carries_followup_contract() -> None:
         metadata={"ask_user_question_answered": {"request_id": "req-1"}},
         enable_trajectory=False,
     )
+
+
+def test_queued_thread_input_action_enqueues_steer_message() -> None:
+    enqueued: list[tuple[str, str, str]] = []
+    queue_manager = SimpleNamespace(
+        enqueue=lambda content, thread_id, notification_type: enqueued.append((content, thread_id, notification_type))
+    )
+    action = queued_thread_input_action(thread_id="thread-1", message="follow up")
+
+    result = dispatch_queued_thread_input_action(queue_manager, action)
+
+    assert action == QueuedThreadInputAction(thread_id="thread-1", content="follow up", notification_type="steer")
+    assert enqueued == [("follow up", "thread-1", "steer")]
+    assert result == {"status": "queued", "thread_id": "thread-1"}
 
 
 def _make_request(headers: dict[str, str] | None = None) -> Request:


### PR DESCRIPTION
## Summary

- add QueuedThreadInputAction for the public thread queue surface
- move steer queue policy out of the HTTP router and into the thread input action adapter
- preserve existing queue-only behavior; this does not start a runtime run, add retry/outbox, or change wake/queue storage

## Verification

- uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_send_message_passes_enable_trajectory_to_agent_runtime_gateway tests/Unit/integration_contracts/test_threads_router.py::test_owner_thread_input_action_carries_message_contract tests/Unit/integration_contracts/test_threads_router.py::test_internal_thread_input_action_carries_followup_contract tests/Unit/integration_contracts/test_threads_router.py::test_queued_thread_input_action_enqueues_steer_message tests/Unit/integration_contracts/test_threads_router.py::test_resolve_ask_user_question_request_starts_followup_run_with_answers tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/integration_contracts/test_query_loop_backend_contracts.py::test_queue_wake_handler_starts_terminal_followthrough_run -q
- uv run ruff check backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
- uv run pyright --pythonversion 3.12 backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
