### PR TITLE
Route command notices through queued thread input action

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -32,6 +32,10 @@ def queued_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadI
     return QueuedThreadInputAction(thread_id=thread_id, content=message)
 
 
+def queued_command_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadInputAction:
+    return QueuedThreadInputAction(thread_id=thread_id, content=message, notification_type="command")
+
+
 def dispatch_queued_thread_input_action(queue_manager: Any, action: QueuedThreadInputAction) -> dict[str, str]:
     queue_manager.enqueue(action.content, action.thread_id, notification_type=action.notification_type)
     return {"status": "queued", "thread_id": action.thread_id}

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -1553,6 +1553,11 @@ async def _notify_task_cancelled(app: Any, thread_id: str, task_id: str, run: An
         agent = _get_agent_for_thread(app, thread_id)
         qm = getattr(agent, "queue_manager", None) if agent else None
         if qm:
+            from backend.threads.chat_adapters.runtime_thread_input_action import (
+                dispatch_queued_thread_input_action,
+                queued_command_thread_input_action,
+            )
+
             description = getattr(run, "description", "") or ""
             command = getattr(run, "command", "") or ""
             label = description or command[:80] or f"Task {task_id}"
@@ -1563,6 +1568,9 @@ async def _notify_task_cancelled(app: Any, thread_id: str, task_id: str, run: An
                 + (f"<CommandLine>{command[:200]}</CommandLine>" if command else "")
                 + "</CommandNotification>"
             )
-            qm.enqueue(notification, thread_id, notification_type="command")
+            dispatch_queued_thread_input_action(
+                qm,
+                queued_command_thread_input_action(thread_id=thread_id, message=notification),
+            )
     except Exception:
         logger.warning("Failed to enqueue cancellation notice for task %s", task_id, exc_info=True)

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -19,6 +19,7 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     dispatch_queued_thread_input_action,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
+    queued_command_thread_input_action,
     queued_thread_input_action,
 )
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
@@ -253,6 +254,24 @@ def test_queued_thread_input_action_enqueues_steer_message() -> None:
 
     assert action == QueuedThreadInputAction(thread_id="thread-1", content="follow up", notification_type="steer")
     assert enqueued == [("follow up", "thread-1", "steer")]
+    assert result == {"status": "queued", "thread_id": "thread-1"}
+
+
+def test_queued_command_thread_input_action_enqueues_command_message() -> None:
+    enqueued: list[tuple[str, str, str]] = []
+    queue_manager = SimpleNamespace(
+        enqueue=lambda content, thread_id, notification_type: enqueued.append((content, thread_id, notification_type))
+    )
+    action = queued_command_thread_input_action(thread_id="thread-1", message="<CommandNotification />")
+
+    result = dispatch_queued_thread_input_action(queue_manager, action)
+
+    assert action == QueuedThreadInputAction(
+        thread_id="thread-1",
+        content="<CommandNotification />",
+        notification_type="command",
+    )
+    assert enqueued == [("<CommandNotification />", "thread-1", "command")]
     assert result == {"status": "queued", "thread_id": "thread-1"}
 
 


### PR DESCRIPTION
## Summary

- add queued_command_thread_input_action for command follow-up notices
- route task cancellation command notices through the queued thread input action dispatcher
- preserve cancellation notice content and follow-through behavior

## Verification

- uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_queued_thread_input_action_enqueues_steer_message tests/Unit/integration_contracts/test_threads_router.py::test_queued_command_thread_input_action_enqueues_command_message tests/Unit/integration_contracts/test_query_loop_backend_contracts.py::test_cancelled_task_notification_wakes_followthrough_run tests/Unit/integration_contracts/test_query_loop_backend_contracts.py::test_queue_wake_handler_starts_terminal_followthrough_run -q
- uv run ruff check backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
- uv run pyright --pythonversion 3.12 backend/web/routers/threads.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
