### PR TITLE
Allow multiple workflow event actions

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -178,7 +178,7 @@ def wire_workflow_event_notifications(
     thread_repo: Any,
     user_repo: Any,
 ) -> None:
-    chat_workflow_event_service.set_event_change_fn(
+    chat_workflow_event_service.add_event_change_action(
         make_workflow_event_notification_fn(
             app,
             activity_reader=activity_reader,

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -137,10 +137,10 @@ class ChatTaskService:
 class ChatWorkflowEventService:
     def __init__(self, event_repo: Any) -> None:
         self._repo = event_repo
-        self._event_change_fn: Callable[[WorkflowEventChange], None] | None = None
+        self._event_change_actions: list[Callable[[WorkflowEventChange], None]] = []
 
-    def set_event_change_fn(self, change_fn: Callable[[WorkflowEventChange], None]) -> None:
-        self._event_change_fn = change_fn
+    def add_event_change_action(self, action: Callable[[WorkflowEventChange], None]) -> None:
+        self._event_change_actions.append(action)
 
     def list_events(self, chat_id: str) -> list[dict[str, Any]]:
         return [_event_response(event) for event in self._repo.list_all(chat_id)]
@@ -217,7 +217,7 @@ class ChatWorkflowEventService:
         return response
 
     def _event_change_actor(self, actor_user_id: str | None, *, field: str) -> str | None:
-        if self._event_change_fn is None:
+        if not self._event_change_actions:
             return None
         if actor_user_id is None:
             raise RuntimeError(f"Workflow event change requires {field}")
@@ -230,13 +230,15 @@ class ChatWorkflowEventService:
         event: dict[str, Any],
         actor_user_id: str | None,
     ) -> None:
-        change_fn = self._event_change_fn
-        if change_fn is None:
+        actions = list(self._event_change_actions)
+        if not actions:
             return
         if actor_user_id is None:
             raise RuntimeError("Workflow event change requires actor_user_id")
         try:
-            change_fn(WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id))
+            change = WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id)
+            for action in actions:
+                action(change)
         except Exception as exc:
             raise WorkflowEventActionError(operation=operation, event=event) from exc
 

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -252,25 +252,25 @@ def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(mo
     assert chat_join_request_service.notification_fn is notification_fn
 
 
-def test_wire_workflow_event_notifications_binds_change_fn(monkeypatch):
-    change_fn = object()
-    chat_workflow_event_service = SimpleNamespace(change_fn=None)
+def test_wire_workflow_event_notifications_binds_event_action(monkeypatch):
+    event_action = object()
+    chat_workflow_event_service = SimpleNamespace(event_action=None)
     messaging_service = object()
     activity_reader = object()
     thread_repo = object()
     user_repo = object()
 
-    def _set_change_fn(value):
-        chat_workflow_event_service.change_fn = value
+    def _add_event_change_action(value):
+        chat_workflow_event_service.event_action = value
 
-    chat_workflow_event_service.set_event_change_fn = _set_change_fn
+    chat_workflow_event_service.add_event_change_action = _add_event_change_action
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     monkeypatch.setattr(
         chat_bootstrap,
         "make_workflow_event_notification_fn",
-        lambda target_app, *, activity_reader, thread_repo, user_repo, messaging_service: change_fn,
+        lambda target_app, *, activity_reader, thread_repo, user_repo, messaging_service: event_action,
     )
 
     chat_bootstrap.wire_workflow_event_notifications(
@@ -282,4 +282,4 @@ def test_wire_workflow_event_notifications_binds_change_fn(monkeypatch):
         user_repo=user_repo,
     )
 
-    assert chat_workflow_event_service.change_fn is change_fn
+    assert chat_workflow_event_service.event_action is event_action

--- a/tests/Unit/core/test_chat_workflow_service.py
+++ b/tests/Unit/core/test_chat_workflow_service.py
@@ -286,7 +286,7 @@ def test_chat_workflow_event_service_emits_change_after_create_when_wired() -> N
     repo = _WorkflowEventRepo()
     changes = []
     service = ChatWorkflowEventService(repo)
-    service.set_event_change_fn(changes.append)
+    service.add_event_change_action(changes.append)
 
     event = service.create_event(
         "chat-1",
@@ -300,6 +300,27 @@ def test_chat_workflow_event_service_emits_change_after_create_when_wired() -> N
     assert changes[0].actor_user_id == "owner-1"
 
 
+def test_chat_workflow_event_service_runs_each_registered_event_action() -> None:
+    repo = _WorkflowEventRepo()
+    first_changes = []
+    second_changes = []
+    service = ChatWorkflowEventService(repo)
+    service.add_event_change_action(first_changes.append)
+    service.add_event_change_action(second_changes.append)
+
+    event = service.create_event(
+        "chat-1",
+        kind="task_proposed_review",
+        requested_by_user_id="owner-1",
+    )
+
+    assert len(first_changes) == 1
+    assert len(second_changes) == 1
+    assert first_changes[0] is second_changes[0]
+    assert first_changes[0].operation == "created"
+    assert first_changes[0].event == event
+
+
 def test_chat_workflow_event_service_reports_create_action_failure_with_persisted_event() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
@@ -307,7 +328,7 @@ def test_chat_workflow_event_service_reports_create_action_failure_with_persiste
     def _fail(_change):
         raise ValueError("runtime offline")
 
-    service.set_event_change_fn(_fail)
+    service.add_event_change_action(_fail)
 
     try:
         service.create_event(
@@ -327,7 +348,7 @@ def test_chat_workflow_event_service_reports_create_action_failure_with_persiste
 def test_chat_workflow_event_service_requires_requester_for_wired_change() -> None:
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
-    service.set_event_change_fn(lambda _change: None)
+    service.add_event_change_action(lambda _change: None)
 
     try:
         service.create_event("chat-1", kind="task_proposed_review")
@@ -343,7 +364,7 @@ def test_chat_workflow_event_service_emits_change_after_update_when_wired() -> N
     changes = []
     service = ChatWorkflowEventService(repo)
     event = service.create_event("chat-1", kind="task_proposed_review")
-    service.set_event_change_fn(changes.append)
+    service.add_event_change_action(changes.append)
 
     updated = service.update_event(
         "chat-1",
@@ -366,7 +387,7 @@ def test_chat_workflow_event_service_reports_update_action_failure_with_persiste
     def _fail(_change):
         raise ValueError("runtime offline")
 
-    service.set_event_change_fn(_fail)
+    service.add_event_change_action(_fail)
 
     try:
         service.update_event(
@@ -389,7 +410,7 @@ def test_chat_workflow_event_service_requires_actor_for_wired_update_change() ->
     repo = _WorkflowEventRepo()
     service = ChatWorkflowEventService(repo)
     event = service.create_event("chat-1", kind="task_proposed_review")
-    service.set_event_change_fn(lambda _change: None)
+    service.add_event_change_action(lambda _change: None)
 
     try:
         service.update_event("chat-1", event["event_id"], state="settled")


### PR DESCRIPTION
## Summary
- replace singular workflow event change callback with additive event actions
- let one workflow event fan out to multiple registered actions while preserving persisted-event failure semantics
- update bootstrap wiring and service tests to use action naming

## Verification
- uv run pytest tests/Unit/core/test_chat_workflow_service.py::test_chat_workflow_event_service_runs_each_registered_event_action tests/Unit/core/test_chat_workflow_service.py::test_chat_workflow_event_service_reports_create_action_failure_with_persisted_event tests/Unit/core/test_chat_workflow_service.py::test_chat_workflow_event_service_requires_requester_for_wired_change tests/Unit/backend/test_chat_bootstrap.py::test_wire_workflow_event_notifications_binds_event_action -q
- uv run pytest tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/integration_contracts/test_messaging_router.py::test_chat_workflow_event_create_returns_persisted_event_when_action_fails tests/Unit/integration_contracts/test_messaging_router.py::test_chat_workflow_event_patch_returns_persisted_event_when_action_fails -q
- uv run ruff check core/work_item/chat_workflow/service.py backend/chat/bootstrap.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py
- uv run pyright --pythonversion 3.12 core/work_item/chat_workflow/service.py backend/chat/bootstrap.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/test_chat_bootstrap.py
