### PR TITLE
Allow multiple relationship event actions

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -123,7 +123,7 @@ def wire_relationship_request_notifications(
     thread_repo: Any,
     user_repo: Any,
 ) -> None:
-    relationship_service.set_relationship_request_notification_fn(
+    relationship_service.add_relationship_request_action(
         make_relationship_request_notification_fn(
             app,
             activity_reader=activity_reader,
@@ -141,7 +141,7 @@ def wire_relationship_decision_notifications(
     thread_repo: Any,
     user_repo: Any,
 ) -> None:
-    relationship_service.set_relationship_decision_notification_fn(
+    relationship_service.add_relationship_decision_action(
         make_relationship_decision_notification_fn(
             app,
             activity_reader=activity_reader,

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -30,14 +30,18 @@ class RelationshipService:
         on_relationship_decided: Callable[[RelationshipRow, RelationshipEvent], None] | None = None,
     ) -> None:
         self._repo = relationship_repo
-        self._on_relationship_requested = on_relationship_requested
-        self._on_relationship_decided = on_relationship_decided
+        self._relationship_request_actions: list[Callable[[RelationshipRow], None]] = []
+        self._relationship_decision_actions: list[Callable[[RelationshipRow, RelationshipEvent], None]] = []
+        if on_relationship_requested is not None:
+            self.add_relationship_request_action(on_relationship_requested)
+        if on_relationship_decided is not None:
+            self.add_relationship_decision_action(on_relationship_decided)
 
-    def set_relationship_request_notification_fn(self, fn: Callable[[RelationshipRow], None]) -> None:
-        self._on_relationship_requested = fn
+    def add_relationship_request_action(self, action: Callable[[RelationshipRow], None]) -> None:
+        self._relationship_request_actions.append(action)
 
-    def set_relationship_decision_notification_fn(self, fn: Callable[[RelationshipRow, RelationshipEvent], None]) -> None:
-        self._on_relationship_decided = fn
+    def add_relationship_decision_action(self, action: Callable[[RelationshipRow, RelationshipEvent], None]) -> None:
+        self._relationship_decision_actions.append(action)
 
     def apply_event(
         self,
@@ -87,27 +91,36 @@ class RelationshipService:
 
     def request(self, requester_id: str, target_id: str, message: str | None = None) -> RelationshipRow:
         row = self.apply_event(requester_id, target_id, "request", message=message)
-        self._run_post_commit_action("request", row, self._on_relationship_requested)
+        self._run_request_actions(row)
         return row
 
     def approve(self, approver_id: str, requester_id: str) -> RelationshipRow:
         row = self.apply_event(approver_id, requester_id, "approve")
-        self._run_post_commit_action("approve", row, self._on_relationship_decided)
+        self._run_decision_actions("approve", row)
         return row
 
     def reject(self, approver_id: str, requester_id: str) -> RelationshipRow:
         row = self.apply_event(approver_id, requester_id, "reject")
-        self._run_post_commit_action("reject", row, self._on_relationship_decided)
+        self._run_decision_actions("reject", row)
         return row
 
-    def _run_post_commit_action(self, event: RelationshipEvent, row: RelationshipRow, fn: Callable[..., None] | None) -> None:
-        if fn is None:
+    def _run_request_actions(self, row: RelationshipRow) -> None:
+        actions = list(self._relationship_request_actions)
+        if not actions:
             return
         try:
-            if event == "request":
-                fn(row)
-            else:
-                fn(row, event)
+            for action in actions:
+                action(row)
+        except Exception as exc:
+            raise RelationshipActionError(event="request", row=row) from exc
+
+    def _run_decision_actions(self, event: RelationshipEvent, row: RelationshipRow) -> None:
+        actions = list(self._relationship_decision_actions)
+        if not actions:
+            return
+        try:
+            for action in actions:
+                action(row, event)
         except Exception as exc:
             raise RelationshipActionError(event=event, row=row) from exc
 

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -159,24 +159,24 @@ def test_wire_chat_delivery_binds_delivery_fn(monkeypatch):
     assert messaging_service.delivery_fn is delivery_fn
 
 
-def test_wire_relationship_request_notifications_binds_notification_fn(monkeypatch):
-    notification_fn = object()
-    relationship_service = SimpleNamespace(notification_fn=None)
+def test_wire_relationship_request_notifications_binds_event_action(monkeypatch):
+    event_action = object()
+    relationship_service = SimpleNamespace(event_action=None)
     activity_reader = object()
     thread_repo = object()
     user_repo = object()
 
-    def _set_notification_fn(value):
-        relationship_service.notification_fn = value
+    def _add_relationship_request_action(value):
+        relationship_service.event_action = value
 
-    relationship_service.set_relationship_request_notification_fn = _set_notification_fn
+    relationship_service.add_relationship_request_action = _add_relationship_request_action
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     monkeypatch.setattr(
         chat_bootstrap,
         "make_relationship_request_notification_fn",
-        lambda target_app, *, activity_reader, thread_repo, user_repo: notification_fn,
+        lambda target_app, *, activity_reader, thread_repo, user_repo: event_action,
     )
 
     chat_bootstrap.wire_relationship_request_notifications(
@@ -187,27 +187,27 @@ def test_wire_relationship_request_notifications_binds_notification_fn(monkeypat
         user_repo=user_repo,
     )
 
-    assert relationship_service.notification_fn is notification_fn
+    assert relationship_service.event_action is event_action
 
 
-def test_wire_relationship_decision_notifications_binds_notification_fn(monkeypatch):
-    notification_fn = object()
-    relationship_service = SimpleNamespace(notification_fn=None)
+def test_wire_relationship_decision_notifications_binds_event_action(monkeypatch):
+    event_action = object()
+    relationship_service = SimpleNamespace(event_action=None)
     activity_reader = object()
     thread_repo = object()
     user_repo = object()
 
-    def _set_notification_fn(value):
-        relationship_service.notification_fn = value
+    def _add_relationship_decision_action(value):
+        relationship_service.event_action = value
 
-    relationship_service.set_relationship_decision_notification_fn = _set_notification_fn
+    relationship_service.add_relationship_decision_action = _add_relationship_decision_action
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     monkeypatch.setattr(
         chat_bootstrap,
         "make_relationship_decision_notification_fn",
-        lambda target_app, *, activity_reader, thread_repo, user_repo: notification_fn,
+        lambda target_app, *, activity_reader, thread_repo, user_repo: event_action,
     )
 
     chat_bootstrap.wire_relationship_decision_notifications(
@@ -218,7 +218,7 @@ def test_wire_relationship_decision_notifications_binds_notification_fn(monkeypa
         user_repo=user_repo,
     )
 
-    assert relationship_service.notification_fn is notification_fn
+    assert relationship_service.event_action is event_action
 
 
 def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(monkeypatch):

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -76,6 +76,26 @@ class _FakeRelationshipRepo:
         return row
 
 
+class _RequestRelationshipRepo:
+    def __init__(self) -> None:
+        self.persisted = False
+
+    def get(self, _requester_id: str, _target_id: str):
+        return None
+
+    def upsert(self, _requester_id: str, _target_id: str, **fields: Any):
+        self.persisted = True
+        return {
+            "id": "hire_visit:agent-user-1:human-user-1",
+            "user_low": "agent-user-1",
+            "user_high": "human-user-1",
+            "kind": "hire_visit",
+            "created_at": "2026-04-07T00:00:00Z",
+            "updated_at": "2026-04-07T00:00:01Z",
+            **fields,
+        }
+
+
 def _messaging_display_service(**overrides: Any) -> SimpleNamespace:
     def _resolve_display_user(uid: str) -> Any | None:
         if uid == "agent-user-1":
@@ -131,22 +151,7 @@ def test_relationship_revoke_deletes_hire_without_snapshot_side_channel() -> Non
 
 
 def test_relationship_request_uses_single_pending_state_and_initiator() -> None:
-    class _RequestRepo:
-        def get(self, _requester_id: str, _target_id: str):
-            return None
-
-        def upsert(self, _requester_id: str, _target_id: str, **fields: Any):
-            return {
-                "id": "hire_visit:agent-user-1:human-user-1",
-                "user_low": "agent-user-1",
-                "user_high": "human-user-1",
-                "kind": "hire_visit",
-                "created_at": "2026-04-07T00:00:00Z",
-                "updated_at": "2026-04-07T00:00:01Z",
-                **fields,
-            }
-
-    service = RelationshipService(_RequestRepo())
+    service = RelationshipService(_RequestRelationshipRepo())
 
     row = service.request("human-user-1", "agent-user-1")
 
@@ -155,26 +160,7 @@ def test_relationship_request_uses_single_pending_state_and_initiator() -> None:
 
 
 def test_relationship_request_notifies_after_persisting_pending_row() -> None:
-    class _RequestRepo:
-        def __init__(self) -> None:
-            self.persisted = False
-
-        def get(self, _requester_id: str, _target_id: str):
-            return None
-
-        def upsert(self, _requester_id: str, _target_id: str, **fields: Any):
-            self.persisted = True
-            return {
-                "id": "hire_visit:agent-user-1:human-user-1",
-                "user_low": "agent-user-1",
-                "user_high": "human-user-1",
-                "kind": "hire_visit",
-                "created_at": "2026-04-07T00:00:00Z",
-                "updated_at": "2026-04-07T00:00:01Z",
-                **fields,
-            }
-
-    repo = _RequestRepo()
+    repo = _RequestRelationshipRepo()
     notifications = []
     service = RelationshipService(repo, on_relationship_requested=notifications.append)
 
@@ -186,26 +172,25 @@ def test_relationship_request_notifies_after_persisting_pending_row() -> None:
     assert notifications[0].initiator_user_id == "human-user-1"
 
 
+def test_relationship_request_runs_each_registered_action_after_persisting_request() -> None:
+    repo = _RequestRelationshipRepo()
+    first_notifications = []
+    second_notifications = []
+    service = RelationshipService(repo)
+    service.add_relationship_request_action(first_notifications.append)
+    service.add_relationship_request_action(second_notifications.append)
+
+    row = service.request("human-user-1", "agent-user-1")
+
+    assert first_notifications == [row]
+    assert second_notifications == [row]
+
+
 def test_relationship_request_action_failure_carries_persisted_row() -> None:
-    class _RequestRepo:
-        def get(self, _requester_id: str, _target_id: str):
-            return None
-
-        def upsert(self, _requester_id: str, _target_id: str, **fields: Any):
-            return {
-                "id": "hire_visit:agent-user-1:human-user-1",
-                "user_low": "agent-user-1",
-                "user_high": "human-user-1",
-                "kind": "hire_visit",
-                "created_at": "2026-04-07T00:00:00Z",
-                "updated_at": "2026-04-07T00:00:01Z",
-                **fields,
-            }
-
     def fail_after_persist(_row):
         raise RuntimeError("runtime offline")
 
-    service = RelationshipService(_RequestRepo(), on_relationship_requested=fail_after_persist)
+    service = RelationshipService(_RequestRelationshipRepo(), on_relationship_requested=fail_after_persist)
 
     with pytest.raises(RelationshipActionError) as exc_info:
         service.request("human-user-1", "agent-user-1")
@@ -227,6 +212,21 @@ def test_relationship_approve_notifies_original_requester_after_persisting_decis
 
     assert row.state == "visit"
     assert notifications == [(row, "approve")]
+
+
+def test_relationship_decision_runs_each_registered_action_after_persisting_decision() -> None:
+    repo = _FakeRelationshipRepo()
+    repo._existing[("agent-user-1", "human-user-1")]["state"] = "pending"
+    first_notifications = []
+    second_notifications = []
+    service = RelationshipService(repo)
+    service.add_relationship_decision_action(lambda row, event: first_notifications.append((row, event)))
+    service.add_relationship_decision_action(lambda row, event: second_notifications.append((row, event)))
+
+    row = service.approve("agent-user-1", "human-user-1")
+
+    assert first_notifications == [(row, "approve")]
+    assert second_notifications == [(row, "approve")]
 
 
 def test_relationship_decision_action_failure_carries_persisted_row_and_event() -> None:


### PR DESCRIPTION
## Summary
- replace relationship notification setters with additive event action registration
- let relationship request and decision events run multiple post-commit actions while preserving persisted-row failure semantics
- reduce duplicated relationship request test stubs while adding request/decision fanout coverage

## Verification
- uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py -q
- uv run ruff check messaging/relationships/service.py backend/chat/bootstrap.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py
- uv run pyright --pythonversion 3.12 messaging/relationships/service.py backend/chat/bootstrap.py tests/Unit/backend/test_chat_bootstrap.py

Note: local pyright over the entire legacy integration test file still reports pre-existing unrelated test typing issues; CI's project type check remains the authority for the broader set.
