### PR TITLE
Allow multiple join request rejection actions

### DIFF
--- a/backend/chat/bootstrap.py
+++ b/backend/chat/bootstrap.py
@@ -159,7 +159,7 @@ def wire_chat_join_request_notifications(
     thread_repo: Any,
     user_repo: Any,
 ) -> None:
-    chat_join_request_service.set_join_request_rejected_notification_fn(
+    chat_join_request_service.add_join_request_rejected_action(
         make_chat_join_rejection_notification_fn(
             app,
             activity_reader=activity_reader,

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -24,10 +24,12 @@ class ChatJoinRequestService:
         self._members = chat_member_repo
         self._requests = chat_join_request_repo
         self._messaging = messaging_service
-        self._on_join_request_rejected = on_join_request_rejected
+        self._join_request_rejected_actions: list[Any] = []
+        if on_join_request_rejected is not None:
+            self.add_join_request_rejected_action(on_join_request_rejected)
 
-    def set_join_request_rejected_notification_fn(self, fn: Any) -> None:
-        self._on_join_request_rejected = fn
+    def add_join_request_rejected_action(self, action: Any) -> None:
+        self._join_request_rejected_actions.append(action)
 
     def request(self, chat_id: str, requester_user_id: str, message: str | None = None) -> dict[str, Any]:
         chat = self._require_joinable_chat(chat_id)
@@ -98,12 +100,18 @@ class ChatJoinRequestService:
             message_type="notification",
             mentions=[requester_user_id],
         )
-        if self._on_join_request_rejected is not None:
-            try:
-                self._on_join_request_rejected(row)
-            except Exception as exc:
-                raise ChatJoinRequestActionError(action="reject", row=row) from exc
+        self._run_join_request_rejected_actions(row)
         return self._project_request(row)
+
+    def _run_join_request_rejected_actions(self, row: dict[str, Any]) -> None:
+        actions = list(self._join_request_rejected_actions)
+        if not actions:
+            return
+        try:
+            for action in actions:
+                action(row)
+        except Exception as exc:
+            raise ChatJoinRequestActionError(action="reject", row=row) from exc
 
     def _require_joinable_chat(self, chat_id: str) -> Any:
         chat = self._chats.get_by_id(chat_id)

--- a/tests/Unit/backend/test_chat_bootstrap.py
+++ b/tests/Unit/backend/test_chat_bootstrap.py
@@ -221,24 +221,24 @@ def test_wire_relationship_decision_notifications_binds_event_action(monkeypatch
     assert relationship_service.event_action is event_action
 
 
-def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(monkeypatch):
-    notification_fn = object()
-    chat_join_request_service = SimpleNamespace(notification_fn=None)
+def test_wire_chat_join_request_notifications_binds_rejection_action(monkeypatch):
+    event_action = object()
+    chat_join_request_service = SimpleNamespace(event_action=None)
     activity_reader = object()
     thread_repo = object()
     user_repo = object()
 
-    def _set_notification_fn(value):
-        chat_join_request_service.notification_fn = value
+    def _add_join_request_rejected_action(value):
+        chat_join_request_service.event_action = value
 
-    chat_join_request_service.set_join_request_rejected_notification_fn = _set_notification_fn
+    chat_join_request_service.add_join_request_rejected_action = _add_join_request_rejected_action
 
     app = SimpleNamespace(state=SimpleNamespace())
 
     monkeypatch.setattr(
         chat_bootstrap,
         "make_chat_join_rejection_notification_fn",
-        lambda target_app, *, activity_reader, thread_repo, user_repo: notification_fn,
+        lambda target_app, *, activity_reader, thread_repo, user_repo: event_action,
     )
 
     chat_bootstrap.wire_chat_join_request_notifications(
@@ -249,7 +249,7 @@ def test_wire_chat_join_request_notifications_binds_rejection_notification_fn(mo
         user_repo=user_repo,
     )
 
-    assert chat_join_request_service.notification_fn is notification_fn
+    assert chat_join_request_service.event_action is event_action
 
 
 def test_wire_workflow_event_notifications_binds_event_action(monkeypatch):

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -252,6 +252,22 @@ def test_chat_join_reject_notifies_requester_outside_chat_membership() -> None:
     ]
 
 
+def test_chat_join_reject_runs_each_registered_rejection_action() -> None:
+    first_notifications: list[dict] = []
+    second_notifications: list[dict] = []
+    service, _members, _requests, _messaging = _service()
+    service.add_join_request_rejected_action(first_notifications.append)
+    service.add_join_request_rejected_action(second_notifications.append)
+    pending = service.request("chat-1", "visitor-1", "please add me")
+
+    row = service.reject("chat-1", pending["id"], "owner-1")
+
+    assert row["state"] == "rejected"
+    assert first_notifications == second_notifications
+    assert first_notifications[0]["state"] == "rejected"
+    assert first_notifications[0]["decided_by_user_id"] == "owner-1"
+
+
 def test_chat_join_reject_wraps_post_commit_action_failure() -> None:
     def fail_notification(_row: dict) -> None:
         raise RuntimeError("runtime hook failed")


### PR DESCRIPTION
## Summary
- replace the chat join rejection notification setter with additive rejected-action registration
- let a rejected join request run multiple post-commit actions while preserving existing failure wrapping
- update bootstrap wiring and tests to use event-action naming

## Verification
- uv run pytest tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_reject_runs_each_registered_rejection_action tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_reject_notifies_requester_outside_chat_membership tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_reject_wraps_post_commit_action_failure tests/Unit/backend/test_chat_bootstrap.py::test_wire_chat_join_request_notifications_binds_rejection_action -q
- uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/backend/test_web_lifespan_ordering.py -q
- uv run ruff check messaging/join_requests.py backend/chat/bootstrap.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/backend/test_chat_bootstrap.py
- uv run pyright --pythonversion 3.12 messaging/join_requests.py backend/chat/bootstrap.py tests/Unit/backend/test_chat_bootstrap.py tests/Unit/messaging/test_chat_join_requests.py
