### PR TITLE
Route thread input requeue through action helper

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -41,6 +41,20 @@ def dispatch_queued_thread_input_action(queue_manager: Any, action: QueuedThread
     return {"status": "queued", "thread_id": action.thread_id}
 
 
+def requeue_thread_input_item(queue_manager: Any, thread_id: str, item: Any) -> None:
+    queue_manager.enqueue(
+        item.content,
+        thread_id,
+        notification_type=item.notification_type,
+        source=item.source,
+        sender_id=item.sender_id,
+        sender_name=item.sender_name,
+        sender_avatar_url=item.sender_avatar_url,
+        is_steer=item.is_steer,
+        metadata=item.metadata,
+    )
+
+
 def owner_runtime_thread_input_action(
     *,
     thread_id: str,

--- a/backend/threads/run/cancellation.py
+++ b/backend/threads/run/cancellation.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 from typing import Any
 
+from backend.threads.chat_adapters.runtime_thread_input_action import requeue_thread_input_item
 from core.runtime.notifications import is_terminal_background_notification
 
 
@@ -114,17 +115,7 @@ async def flush_cancelled_owner_steers(
     await persist_cancelled_owner_steers(agent=agent, config=config, items=owner_steers)
 
     for item in passthrough:
-        qm.enqueue(
-            item.content,
-            thread_id,
-            notification_type=item.notification_type,
-            source=item.source,
-            sender_id=item.sender_id,
-            sender_name=item.sender_name,
-            sender_avatar_url=item.sender_avatar_url,
-            is_steer=item.is_steer,
-            metadata=item.metadata,
-        )
+        requeue_thread_input_item(qm, thread_id, item)
 
 
 async def emit_queued_terminal_followups(
@@ -139,17 +130,7 @@ async def emit_queued_terminal_followups(
         queued_items = app.state.queue_manager.drain_all(thread_id)
         extra_terminal, passthrough = partition_terminal_followups(queued_items)
         for item in passthrough:
-            app.state.queue_manager.enqueue(
-                item.content,
-                thread_id,
-                notification_type=item.notification_type,
-                source=item.source,
-                sender_id=item.sender_id,
-                sender_name=item.sender_name,
-                sender_avatar_url=item.sender_avatar_url,
-                is_steer=item.is_steer,
-                metadata=item.metadata,
-            )
+            requeue_thread_input_item(app.state.queue_manager, thread_id, item)
         for item in extra_terminal:
             await emit(
                 {

--- a/backend/threads/run/followups.py
+++ b/backend/threads/run/followups.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from backend.threads.chat_adapters.runtime_thread_input_action import requeue_thread_input_item
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.queue_metadata import queue_item_message_metadata
 
@@ -38,16 +39,6 @@ async def consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
         logger.exception("Failed to consume followup queue for thread %s", thread_id)
         if item:
             try:
-                app.state.queue_manager.enqueue(
-                    item.content,
-                    thread_id,
-                    notification_type=item.notification_type,
-                    source=item.source,
-                    sender_id=item.sender_id,
-                    sender_name=item.sender_name,
-                    sender_avatar_url=item.sender_avatar_url,
-                    is_steer=item.is_steer,
-                    metadata=item.metadata,
-                )
+                requeue_thread_input_item(app.state.queue_manager, thread_id, item)
             except Exception:
                 logger.error("Failed to re-enqueue followup for thread %s — message lost: %.200s", thread_id, item.content)

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -21,6 +21,7 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     owner_runtime_thread_input_action,
     queued_command_thread_input_action,
     queued_thread_input_action,
+    requeue_thread_input_item,
 )
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
 from backend.web.routers import threads as threads_router
@@ -273,6 +274,38 @@ def test_queued_command_thread_input_action_enqueues_command_message() -> None:
     )
     assert enqueued == [("<CommandNotification />", "thread-1", "command")]
     assert result == {"status": "queued", "thread_id": "thread-1"}
+
+
+def test_requeue_thread_input_item_preserves_queue_metadata() -> None:
+    enqueued: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    queue_manager = SimpleNamespace(enqueue=lambda *args, **kwargs: enqueued.append((args, kwargs)))
+    item = SimpleNamespace(
+        content="follow up",
+        notification_type="command",
+        source="system",
+        sender_id="sender-1",
+        sender_name="Sender",
+        sender_avatar_url="https://avatar",
+        is_steer=True,
+        metadata={"reason": "passthrough"},
+    )
+
+    requeue_thread_input_item(queue_manager, "thread-1", item)
+
+    assert enqueued == [
+        (
+            ("follow up", "thread-1"),
+            {
+                "notification_type": "command",
+                "source": "system",
+                "sender_id": "sender-1",
+                "sender_name": "Sender",
+                "sender_avatar_url": "https://avatar",
+                "is_steer": True,
+                "metadata": {"reason": "passthrough"},
+            },
+        )
+    ]
 
 
 def _make_request(headers: dict[str, str] | None = None) -> Request:


### PR DESCRIPTION
## Summary

- Add requeue_thread_input_item beside queued thread input actions.
- Route followup and cancellation passthrough requeues through that helper instead of repeating queue metadata projection.
- Preserve existing queue item metadata/source/sender fields.

## Verification

- uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_requeue_thread_input_item_preserves_queue_metadata tests/Unit/integration_contracts/test_followup_requeue.py -q
- uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py::test_requeue_thread_input_item_preserves_queue_metadata tests/Unit/integration_contracts/test_followup_requeue.py tests/Unit/backend/thread_runtime/run/test_input_construction.py -q
- uv run ruff check backend/threads/chat_adapters/runtime_thread_input_action.py backend/threads/run/followups.py backend/threads/run/cancellation.py tests/Unit/integration_contracts/test_threads_router.py
- uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_thread_input_action.py backend/threads/run/followups.py backend/threads/run/cancellation.py
