### PR TITLE
Unify synchronous event action dispatch

### DIFF
--- a/core/event_actions.py
+++ b/core/event_actions.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+def run_sync_actions(
+    actions: Iterable[Callable[..., None]],
+    /,
+    *args: Any,
+    on_error: Callable[[Exception], Exception],
+) -> None:
+    current_actions = list(actions)
+    if not current_actions:
+        return
+    try:
+        for action in current_actions:
+            action(*args)
+    except Exception as exc:
+        raise on_error(exc) from exc

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from core.event_actions import run_sync_actions
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow
 
@@ -230,17 +231,16 @@ class ChatWorkflowEventService:
         event: dict[str, Any],
         actor_user_id: str | None,
     ) -> None:
-        actions = list(self._event_change_actions)
-        if not actions:
+        if not self._event_change_actions:
             return
         if actor_user_id is None:
             raise RuntimeError("Workflow event change requires actor_user_id")
-        try:
-            change = WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id)
-            for action in actions:
-                action(change)
-        except Exception as exc:
-            raise WorkflowEventActionError(operation=operation, event=event) from exc
+        change = WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id)
+        run_sync_actions(
+            self._event_change_actions,
+            change,
+            on_error=lambda _exc: WorkflowEventActionError(operation=operation, event=event),
+        )
 
     def delete_event(self, chat_id: str, event_id: str) -> None:
         self._repo.delete(chat_id, event_id)

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.event_actions import run_sync_actions
+
 
 class ChatJoinRequestActionError(RuntimeError):
     def __init__(self, *, action: str, row: dict[str, Any]) -> None:
@@ -104,14 +106,11 @@ class ChatJoinRequestService:
         return self._project_request(row)
 
     def _run_join_request_rejected_actions(self, row: dict[str, Any]) -> None:
-        actions = list(self._join_request_rejected_actions)
-        if not actions:
-            return
-        try:
-            for action in actions:
-                action(row)
-        except Exception as exc:
-            raise ChatJoinRequestActionError(action="reject", row=row) from exc
+        run_sync_actions(
+            self._join_request_rejected_actions,
+            row,
+            on_error=lambda _exc: ChatJoinRequestActionError(action="reject", row=row),
+        )
 
     def _require_joinable_chat(self, chat_id: str) -> Any:
         chat = self._chats.get_by_id(chat_id)

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from core.event_actions import run_sync_actions
 from messaging.contracts import RelationshipEvent, RelationshipRow, RelationshipState
 from messaging.relationships.state_machine import transition
 
@@ -105,24 +106,19 @@ class RelationshipService:
         return row
 
     def _run_request_actions(self, row: RelationshipRow) -> None:
-        actions = list(self._relationship_request_actions)
-        if not actions:
-            return
-        try:
-            for action in actions:
-                action(row)
-        except Exception as exc:
-            raise RelationshipActionError(event="request", row=row) from exc
+        run_sync_actions(
+            self._relationship_request_actions,
+            row,
+            on_error=lambda _exc: RelationshipActionError(event="request", row=row),
+        )
 
     def _run_decision_actions(self, event: RelationshipEvent, row: RelationshipRow) -> None:
-        actions = list(self._relationship_decision_actions)
-        if not actions:
-            return
-        try:
-            for action in actions:
-                action(row, event)
-        except Exception as exc:
-            raise RelationshipActionError(event=event, row=row) from exc
+        run_sync_actions(
+            self._relationship_decision_actions,
+            row,
+            event,
+            on_error=lambda _exc: RelationshipActionError(event=event, row=row),
+        )
 
     def upgrade(self, owner_id: str, agent_id: str) -> RelationshipRow:
         return self.apply_event(owner_id, agent_id, "upgrade")

--- a/tests/Unit/core/test_event_actions.py
+++ b/tests/Unit/core/test_event_actions.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from core.event_actions import run_sync_actions
+
+
+def test_run_sync_actions_runs_registered_actions_in_order() -> None:
+    calls: list[tuple[str, str, int]] = []
+
+    def first(value: str, version: int) -> None:
+        calls.append(("first", value, version))
+
+    def second(value: str, version: int) -> None:
+        calls.append(("second", value, version))
+
+    run_sync_actions([first, second], "event-1", 3, on_error=lambda _exc: RuntimeError("wrapped"))
+
+    assert calls == [
+        ("first", "event-1", 3),
+        ("second", "event-1", 3),
+    ]
+
+
+def test_run_sync_actions_wraps_first_action_failure() -> None:
+    def fail(_value: str) -> None:
+        raise ValueError("runtime offline")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        run_sync_actions([fail], "event-1", on_error=lambda _exc: RuntimeError("action failed"))
+
+    assert str(exc_info.value) == "action failed"
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_run_sync_actions_snapshots_actions_before_running() -> None:
+    calls: list[str] = []
+    actions = []
+
+    def first() -> None:
+        calls.append("first")
+        actions.append(second)
+
+    def second() -> None:
+        calls.append("second")
+
+    actions.append(first)
+
+    run_sync_actions(actions, on_error=lambda _exc: RuntimeError("wrapped"))
+
+    assert calls == ["first"]


### PR DESCRIPTION
## Summary
- add a small `run_sync_actions()` primitive for synchronous domain event actions
- route relationship, chat-join rejection, and workflow-event action loops through it
- keep existing domain-specific error wrappers and action snapshot behavior

## Verification
- `uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q`
- `uv run ruff check core/event_actions.py messaging/relationships/service.py messaging/join_requests.py core/work_item/chat_workflow/service.py tests/Unit/core/test_event_actions.py`
- `uv run ruff format --check core/event_actions.py messaging/relationships/service.py messaging/join_requests.py core/work_item/chat_workflow/service.py tests/Unit/core/test_event_actions.py`
- `uv run pyright --pythonversion 3.12 core/event_actions.py messaging/relationships/service.py messaging/join_requests.py core/work_item/chat_workflow/service.py`
