### PR TITLE
Expose chat message delivery action failure

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -20,6 +20,7 @@ from backend.chat.api.http.dependencies import (
 )
 from messaging.errors import ChatNotCaughtUpError
 from messaging.join_requests import ChatJoinRequestActionError
+from messaging.service import ChatMessageDeliveryActionError
 from messaging.user_ownership import is_owned_by_viewer
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -93,6 +94,18 @@ def _map_chat_join_error(exc: Exception) -> HTTPException:
     if isinstance(exc, ValueError):
         return HTTPException(409, str(exc))
     raise exc
+
+
+def _chat_message_delivery_action_failure(exc: ChatMessageDeliveryActionError) -> HTTPException:
+    cause = exc.__cause__
+    return HTTPException(
+        500,
+        {
+            "error": "chat_message_delivery_action_failed",
+            "message": exc.message,
+            "cause": str(cause) if cause is not None else str(exc),
+        },
+    )
 
 
 def _verify_user_ownership(messaging_service: Any, sender_id: str, user_id: str) -> None:
@@ -319,6 +332,8 @@ def send_message(
         )
     except ChatNotCaughtUpError as exc:
         raise HTTPException(409, "Read unread messages before sending.") from exc
+    except ChatMessageDeliveryActionError as exc:
+        raise _chat_message_delivery_action_failure(exc) from exc
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
     return messaging_service.project_message_response(msg)

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -44,6 +44,12 @@ def _max_message_seq(messages: list[dict[str, Any]]) -> int:
     return max(seqs)
 
 
+class ChatMessageDeliveryActionError(RuntimeError):
+    def __init__(self, *, message: dict[str, Any]) -> None:
+        super().__init__("Chat message delivery action failed after send")
+        self.message = dict(message)
+
+
 class MessagingService:
     """Core messaging operations backed by Supabase repos."""
 
@@ -303,14 +309,17 @@ class MessagingService:
 
         # Deliver to agent recipients
         if _should_dispatch_chat_delivery(message_type, mentions, normalized_addressed_to):
-            self._delivery_dispatcher.dispatch(
-                chat_id,
-                sender_id,
-                content,
-                mentions or [],
-                signal=signal,
-                addressed_to_user_ids=normalized_addressed_to,
-            )
+            try:
+                self._delivery_dispatcher.dispatch(
+                    chat_id,
+                    sender_id,
+                    content,
+                    mentions or [],
+                    signal=signal,
+                    addressed_to_user_ids=normalized_addressed_to,
+                )
+            except Exception as exc:
+                raise ChatMessageDeliveryActionError(message=created) from exc
 
         return created
 

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -15,6 +15,7 @@ from backend.web.core.dependencies import get_current_user_id
 from core.work_item.chat_workflow.service import WorkflowEventActionError
 from messaging.contracts import RelationshipRow
 from messaging.relationships.service import RelationshipActionError
+from messaging.service import ChatMessageDeliveryActionError
 from storage.contracts import ContactEdgeRow
 from storage.errors import (
     StaleChatWorkflowEventVersionError,
@@ -180,6 +181,43 @@ def test_request_relationship_action_failure_returns_persisted_relationship() ->
             "created_at": "2026-04-07T00:00:00+00:00",
             "updated_at": "2026-04-07T00:00:01+00:00",
         },
+        "cause": "runtime offline",
+    }
+
+
+def test_send_message_action_failure_returns_persisted_message() -> None:
+    message = {
+        "id": "msg-1",
+        "chat_id": "chat-1",
+        "sender_id": "human-user-1",
+        "content": "hello",
+        "message_type": "human",
+        "seq": 12,
+        "created_at": "2026-04-07T00:00:00Z",
+    }
+
+    def fail_send(*_args, **_kwargs):
+        error = ChatMessageDeliveryActionError(message=message)
+        raise error from RuntimeError("runtime offline")
+
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: SimpleNamespace(id=uid, owner_user_id=None),
+        is_chat_member=lambda _chat_id, _user_id: True,
+        send=fail_send,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        chats_router.send_message(
+            "chat-1",
+            chats_router.SendMessageBody(content="hello"),
+            user_id="human-user-1",
+            messaging_service=messaging_service,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {
+        "error": "chat_message_delivery_action_failed",
+        "message": message,
         "cause": "runtime offline",
     }
 

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -19,7 +19,7 @@ from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.display_user import resolve_messaging_display_user
 from messaging.relationships.service import RelationshipActionError, RelationshipService
-from messaging.service import MessagingService
+from messaging.service import ChatMessageDeliveryActionError, MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
 from storage.contracts import ContactEdgeRow
 
@@ -920,6 +920,43 @@ def test_messaging_service_notification_mentions_dispatch_to_agent_recipients() 
     )
 
     assert delivered == ["managed-owner-1"]
+
+
+def test_messaging_service_send_delivery_failure_carries_persisted_message() -> None:
+    def fail_delivery(_request: ChatDeliveryRequest) -> None:
+        raise RuntimeError("runtime offline")
+
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(
+            list_members=lambda _chat_id: [{"user_id": "agent-user-1"}],
+            update_last_read=lambda _chat_id, _user_id, _seq: None,
+        ),
+        messages_repo=SimpleNamespace(
+            create=lambda row: {**row, "seq": 7},
+            count_unread=lambda _chat_id, _user_id: 1,
+        ),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id="human-user-1", display_name="Human", type="human", avatar=None)
+                if uid == "human-user-1"
+                else SimpleNamespace(id="agent-user-1", display_name="Agent", type="agent", avatar=None, owner_user_id="human-user-1")
+                if uid == "agent-user-1"
+                else None
+            )
+        ),
+        delivery_fn=fail_delivery,
+    )
+
+    with pytest.raises(ChatMessageDeliveryActionError) as exc_info:
+        service.send("chat-1", "human-user-1", "hello", mentions=["agent-user-1"])
+
+    assert str(exc_info.value) == "Chat message delivery action failed after send"
+    assert exc_info.value.message["chat_id"] == "chat-1"
+    assert exc_info.value.message["sender_id"] == "human-user-1"
+    assert exc_info.value.message["content"] == "hello"
+    assert exc_info.value.message["seq"] == 7
+    assert str(exc_info.value.__cause__) == "runtime offline"
 
 
 def test_messaging_service_send_fails_before_persisting_unknown_sender() -> None:


### PR DESCRIPTION
## Summary
- add `ChatMessageDeliveryActionError` for post-persist chat delivery failures
- wrap runtime delivery dispatch failures with the persisted chat message
- map message-send action failure to structured HTTP 500 detail

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_send_delivery_failure_carries_persisted_message tests/Unit/integration_contracts/test_messaging_router.py::test_send_message_action_failure_returns_persisted_message -q`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py -q`
- `uv run ruff check messaging/service.py backend/chat/api/http/chats_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py && uv run ruff format --check messaging/service.py backend/chat/api/http/chats_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py`
- `uv run pyright --pythonversion 3.12 messaging/service.py backend/chat/api/http/chats_router.py`
