### PR TITLE
Run chat message delivery through sync actions

### DIFF
--- a/messaging/service.py
+++ b/messaging/service.py
@@ -16,6 +16,7 @@ from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+from core.event_actions import run_sync_actions
 from messaging.avatars import AvatarUrlBuilder
 from messaging.contracts import ContentType, MessageType
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
@@ -85,6 +86,7 @@ class MessagingService:
             delivery_resolver=delivery_resolver,
             delivery_fn=delivery_fn,
         )
+        self._chat_message_delivery_actions: list[Callable[[dict[str, Any]], None]] = [self._dispatch_chat_message_delivery]
         self._event_bus = event_bus
 
     def _normalize_message_row(self, row: dict[str, Any]) -> dict[str, Any]:
@@ -155,6 +157,9 @@ class MessagingService:
 
     def set_delivery_fn(self, fn: ChatDeliveryFn) -> None:
         self._delivery_dispatcher.set_delivery_fn(fn)
+
+    def add_chat_message_delivery_action(self, action: Callable[[dict[str, Any]], None]) -> None:
+        self._chat_message_delivery_actions.append(action)
 
     # ------------------------------------------------------------------
     # Chat lifecycle
@@ -309,19 +314,26 @@ class MessagingService:
 
         # Deliver to agent recipients
         if _should_dispatch_chat_delivery(message_type, mentions, normalized_addressed_to):
-            try:
-                self._delivery_dispatcher.dispatch(
-                    chat_id,
-                    sender_id,
-                    content,
-                    mentions or [],
-                    signal=signal,
-                    addressed_to_user_ids=normalized_addressed_to,
-                )
-            except Exception as exc:
-                raise ChatMessageDeliveryActionError(message=created) from exc
+            self._run_chat_message_delivery_actions(created)
 
         return created
+
+    def _run_chat_message_delivery_actions(self, message: dict[str, Any]) -> None:
+        run_sync_actions(
+            self._chat_message_delivery_actions,
+            message,
+            on_error=lambda _exc: ChatMessageDeliveryActionError(message=message),
+        )
+
+    def _dispatch_chat_message_delivery(self, message: dict[str, Any]) -> None:
+        self._delivery_dispatcher.dispatch(
+            str(message["chat_id"]),
+            str(message["sender_id"]),
+            str(message["content"]),
+            list(message.get("mentioned_ids") or []),
+            signal=message.get("signal"),
+            addressed_to_user_ids=list(message.get("addressed_to_user_ids") or []),
+        )
 
     def _normalize_delivery_scope(
         self,

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -922,18 +922,15 @@ def test_messaging_service_notification_mentions_dispatch_to_agent_recipients() 
     assert delivered == ["managed-owner-1"]
 
 
-def test_messaging_service_send_delivery_failure_carries_persisted_message() -> None:
-    def fail_delivery(_request: ChatDeliveryRequest) -> None:
-        raise RuntimeError("runtime offline")
-
-    service = MessagingService(
+def _chat_delivery_action_service(*, seq: int = 7, delivery_fn: Any | None = None) -> Any:
+    return MessagingService(
         chat_repo=SimpleNamespace(),
         chat_member_repo=SimpleNamespace(
-            list_members=lambda _chat_id: [{"user_id": "agent-user-1"}],
+            list_members=lambda _chat_id: [{"user_id": "human-user-1"}, {"user_id": "agent-user-1"}],
             update_last_read=lambda _chat_id, _user_id, _seq: None,
         ),
         messages_repo=SimpleNamespace(
-            create=lambda row: {**row, "seq": 7},
+            create=lambda row: {**row, "seq": seq},
             count_unread=lambda _chat_id, _user_id: 1,
         ),
         user_repo=SimpleNamespace(
@@ -945,8 +942,15 @@ def test_messaging_service_send_delivery_failure_carries_persisted_message() -> 
                 else None
             )
         ),
-        delivery_fn=fail_delivery,
+        delivery_fn=delivery_fn or (lambda _request: None),
     )
+
+
+def test_messaging_service_send_delivery_failure_carries_persisted_message() -> None:
+    def fail_delivery(_request: ChatDeliveryRequest) -> None:
+        raise RuntimeError("runtime offline")
+
+    service = _chat_delivery_action_service(delivery_fn=fail_delivery)
 
     with pytest.raises(ChatMessageDeliveryActionError) as exc_info:
         service.send("chat-1", "human-user-1", "hello", mentions=["agent-user-1"])
@@ -957,6 +961,31 @@ def test_messaging_service_send_delivery_failure_carries_persisted_message() -> 
     assert exc_info.value.message["content"] == "hello"
     assert exc_info.value.message["seq"] == 7
     assert str(exc_info.value.__cause__) == "runtime offline"
+
+
+def test_messaging_service_send_runs_registered_delivery_actions_after_persist() -> None:
+    calls: list[tuple[str, int]] = []
+    service = _chat_delivery_action_service(delivery_fn=lambda _request: calls.append(("dispatcher", 7)))
+    service.add_chat_message_delivery_action(lambda message: calls.append(("custom", message["seq"])))
+
+    service.send("chat-1", "human-user-1", "hello", mentions=["agent-user-1"])
+
+    assert calls == [("dispatcher", 7), ("custom", 7)]
+
+
+def test_messaging_service_send_delivery_action_failure_carries_persisted_message() -> None:
+    service = _chat_delivery_action_service(seq=9)
+
+    def fail_action(_message: dict[str, Any]) -> None:
+        raise RuntimeError("custom delivery side effect failed")
+
+    service.add_chat_message_delivery_action(fail_action)
+
+    with pytest.raises(ChatMessageDeliveryActionError) as exc_info:
+        service.send("chat-1", "human-user-1", "hello", mentions=["agent-user-1"])
+
+    assert exc_info.value.message["seq"] == 9
+    assert str(exc_info.value.__cause__) == "custom delivery side effect failed"
 
 
 def test_messaging_service_send_fails_before_persisting_unknown_sender() -> None:


### PR DESCRIPTION
## Summary
- route chat message delivery through the shared `run_sync_actions()` primitive
- add `add_chat_message_delivery_action()` for post-persist chat delivery side effects
- keep the existing chat delivery dispatcher as the default registered action

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_send_delivery_failure_carries_persisted_message tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_send_runs_registered_delivery_actions_after_persist tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_send_delivery_action_failure_carries_persisted_message -q`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/messaging/test_chat_delivery_dispatcher.py tests/Unit/core/test_event_actions.py -q`
- `uv run ruff check messaging/service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run ruff format --check messaging/service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
- `uv run pyright --pythonversion 3.12 messaging/service.py core/event_actions.py`
