### PR TITLE
Wrap chat join notification action failures

### DIFF
--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -39,11 +39,12 @@ class ChatJoinRequestService:
             raise ValueError("Already a participant of this chat")
         row = self._requests.upsert_request(chat_id, requester_user_id, message=message)
         owner_id = chat.created_by_user_id
-        self._messaging.send(
-            chat_id,
-            requester_user_id,
-            self._request_notification(requester_user_id, message),
-            message_type="notification",
+        self._send_notification_action(
+            action="request_notification",
+            row=row,
+            chat_id=chat_id,
+            sender_id=requester_user_id,
+            content=self._request_notification(requester_user_id, message),
             mentions=[owner_id],
         )
         return self._project_request(row)
@@ -81,11 +82,12 @@ class ChatJoinRequestService:
         requester_user_id = request["requester_user_id"]
         self._members.add_member(chat_id, requester_user_id)
         row = self._requests.set_state(request_id, state="approved", decided_by_user_id=approver_user_id)
-        self._messaging.send(
-            chat_id,
-            approver_user_id,
-            f"Approved chat join request for {requester_user_id}.",
-            message_type="notification",
+        self._send_notification_action(
+            action="approve_notification",
+            row=row,
+            chat_id=chat_id,
+            sender_id=approver_user_id,
+            content=f"Approved chat join request for {requester_user_id}.",
             mentions=[requester_user_id],
         )
         return self._project_request(row)
@@ -95,15 +97,37 @@ class ChatJoinRequestService:
         request = self._require_pending_request(chat_id, request_id)
         requester_user_id = request["requester_user_id"]
         row = self._requests.set_state(request_id, state="rejected", decided_by_user_id=rejecter_user_id)
-        self._messaging.send(
-            chat_id,
-            rejecter_user_id,
-            f"Rejected chat join request for {requester_user_id}.",
-            message_type="notification",
+        self._send_notification_action(
+            action="reject_notification",
+            row=row,
+            chat_id=chat_id,
+            sender_id=rejecter_user_id,
+            content=f"Rejected chat join request for {requester_user_id}.",
             mentions=[requester_user_id],
         )
         self._run_join_request_rejected_actions(row)
         return self._project_request(row)
+
+    def _send_notification_action(
+        self,
+        *,
+        action: str,
+        row: dict[str, Any],
+        chat_id: str,
+        sender_id: str,
+        content: str,
+        mentions: list[str],
+    ) -> None:
+        try:
+            self._messaging.send(
+                chat_id,
+                sender_id,
+                content,
+                message_type="notification",
+                mentions=mentions,
+            )
+        except Exception as exc:
+            raise ChatJoinRequestActionError(action=action, row=row) from exc
 
     def _run_join_request_rejected_actions(self, row: dict[str, Any]) -> None:
         run_sync_actions(

--- a/tests/Unit/messaging/test_chat_join_requests.py
+++ b/tests/Unit/messaging/test_chat_join_requests.py
@@ -52,8 +52,11 @@ class _Requests:
 class _Messaging:
     def __init__(self) -> None:
         self.sent: list[tuple[str, str, str, str, list[str] | None]] = []
+        self.fail_send = False
 
     def send(self, chat_id: str, sender_id: str, content: str, *, message_type: str, mentions=None) -> dict:
+        if self.fail_send:
+            raise RuntimeError("notification delivery failed")
         self.sent.append((chat_id, sender_id, content, message_type, mentions))
         return {"id": "msg-1"}
 
@@ -196,6 +199,44 @@ def test_chat_join_approve_requires_owner_and_adds_member_before_notification() 
     )
 
 
+def test_chat_join_request_wraps_notification_failure_after_pending_row() -> None:
+    service, _members, requests, messaging = _service()
+    messaging.fail_send = True
+
+    with pytest.raises(ChatJoinRequestActionError) as exc_info:
+        service.request("chat-1", "visitor-1", "please add me")
+
+    exc = exc_info.value
+    assert exc.action == "request_notification"
+    assert exc.row == {
+        "id": "chat_join:chat-1:visitor-1",
+        "chat_id": "chat-1",
+        "requester_user_id": "visitor-1",
+        "state": "pending",
+        "message": "please add me",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    assert requests.rows["chat_join:chat-1:visitor-1"]["state"] == "pending"
+    assert str(exc.__cause__) == "notification delivery failed"
+
+
+def test_chat_join_approve_wraps_notification_failure_after_member_and_row_update() -> None:
+    service, members, _requests, messaging = _service()
+    pending = service.request("chat-1", "visitor-1", "please add me")
+    messaging.fail_send = True
+
+    with pytest.raises(ChatJoinRequestActionError) as exc_info:
+        service.approve("chat-1", pending["id"], "owner-1")
+
+    exc = exc_info.value
+    assert exc.action == "approve_notification"
+    assert exc.row["state"] == "approved"
+    assert exc.row["decided_by_user_id"] == "owner-1"
+    assert members.added == [("chat-1", "visitor-1")]
+    assert str(exc.__cause__) == "notification delivery failed"
+
+
 def test_chat_owner_can_add_member_without_join_request() -> None:
     service, members, _requests, messaging = _service()
 
@@ -298,6 +339,23 @@ def test_chat_join_reject_wraps_post_commit_action_failure() -> None:
         "notification",
         ["visitor-1"],
     )
+
+
+def test_chat_join_reject_wraps_notification_failure_before_registered_actions() -> None:
+    notified: list[dict] = []
+    service, _members, _requests, messaging = _service(on_join_request_rejected=notified.append)
+    pending = service.request("chat-1", "visitor-1", "please add me")
+    messaging.fail_send = True
+
+    with pytest.raises(ChatJoinRequestActionError) as exc_info:
+        service.reject("chat-1", pending["id"], "owner-1")
+
+    exc = exc_info.value
+    assert exc.action == "reject_notification"
+    assert exc.row["state"] == "rejected"
+    assert exc.row["decided_by_user_id"] == "owner-1"
+    assert str(exc.__cause__) == "notification delivery failed"
+    assert notified == []
 
 
 def test_chat_join_approve_rejects_non_owner() -> None:


### PR DESCRIPTION
## Summary
- wrap chat-join request notification send failures in `ChatJoinRequestActionError`
- preserve the persisted join request row for request, approve, and reject notification failures
- keep existing mutation order and registered rejection-action behavior intact

## Verification
- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_request_wraps_notification_failure_after_pending_row tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_approve_wraps_notification_failure_after_member_and_row_update tests/Unit/messaging/test_chat_join_requests.py::test_chat_join_reject_wraps_notification_failure_before_registered_actions -q`
- `uv run pytest tests/Unit/messaging/test_chat_join_requests.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q`
- `uv run ruff check messaging/join_requests.py tests/Unit/messaging/test_chat_join_requests.py`
- `uv run ruff format --check messaging/join_requests.py tests/Unit/messaging/test_chat_join_requests.py`
- `uv run pyright --pythonversion 3.12 messaging/join_requests.py tests/Unit/messaging/test_chat_join_requests.py`
