### PR TITLE
Wrap external inbox wake failures after enqueue

### DIFF
--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -13,6 +13,13 @@ def external_inbox_key(user_id: str) -> str:
     return f"external:{normalized}"
 
 
+class ExternalRuntimeInboxActionError(RuntimeError):
+    def __init__(self, *, inbox_id: str, notification_type: str) -> None:
+        super().__init__(f"External runtime inbox wake failed after enqueue: {inbox_id}")
+        self.inbox_id = inbox_id
+        self.notification_type = notification_type
+
+
 class ExternalRuntimeInboxHandler:
     def __init__(self, *, queue_manager: Any, wake_bus: Any | None = None) -> None:
         self._queue_manager = queue_manager
@@ -20,22 +27,40 @@ class ExternalRuntimeInboxHandler:
 
     async def dispatch(self, envelope: agent_runtime_protocol.AgentChatDeliveryEnvelope) -> agent_runtime_protocol.AgentChatDeliveryResult:
         inbox_id = external_inbox_key(envelope.recipient.agent_user_id)
-        self._queue_manager.enqueue(
-            json.dumps(
-                {"event_type": "chat.message", "chat_id": envelope.chat.chat_id},
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ),
-            inbox_id,
-            "chat",
-            source="external",
+        self._enqueue_external_inbox_action(
+            inbox_id=inbox_id,
+            content=json.dumps({"event_type": "chat.message", "chat_id": envelope.chat.chat_id}, ensure_ascii=False, separators=(",", ":")),
+            notification_type="chat",
             sender_id=envelope.sender.user_id,
             sender_name=envelope.sender.display_name,
-            wake=self._wake_bus is None and envelope.wake,
+            wake=envelope.wake,
         )
-        if self._wake_bus is not None and envelope.wake:
-            self._wake_bus.publish(inbox_id)
         return agent_runtime_protocol.AgentChatDeliveryResult(status="accepted", thread_id=inbox_id)
+
+    def _enqueue_external_inbox_action(
+        self,
+        *,
+        inbox_id: str,
+        content: str,
+        notification_type: str,
+        sender_id: str,
+        sender_name: str,
+        wake: bool,
+    ) -> None:
+        self._queue_manager.enqueue(
+            content,
+            inbox_id,
+            notification_type,
+            source="external",
+            sender_id=sender_id,
+            sender_name=sender_name,
+            wake=self._wake_bus is None and wake,
+        )
+        if self._wake_bus is not None and wake:
+            try:
+                self._wake_bus.publish(inbox_id)
+            except Exception as exc:
+                raise ExternalRuntimeInboxActionError(inbox_id=inbox_id, notification_type=notification_type) from exc
 
     async def dispatch_notification(
         self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope
@@ -50,17 +75,14 @@ class ExternalRuntimeInboxHandler:
         if envelope.message.metadata:
             payload.update(envelope.message.metadata)
         payload.update(_transport_payload(envelope.transport))
-        self._queue_manager.enqueue(
-            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
-            inbox_id,
-            envelope.notification_type,
-            source="external",
+        self._enqueue_external_inbox_action(
+            inbox_id=inbox_id,
+            content=json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            notification_type=envelope.notification_type,
             sender_id=envelope.sender.user_id,
             sender_name=envelope.sender.display_name,
-            wake=self._wake_bus is None and envelope.wake,
+            wake=envelope.wake,
         )
-        if self._wake_bus is not None and envelope.wake:
-            self._wake_bus.publish(inbox_id)
         return agent_runtime_protocol.AgentRuntimeNotificationResult(status="accepted", thread_id=inbox_id)
 
 

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from backend.threads.chat_adapters.external_inbox_handler import ExternalRuntimeInboxHandler, external_inbox_key
+from backend.threads.chat_adapters.external_inbox_handler import (
+    ExternalRuntimeInboxActionError,
+    ExternalRuntimeInboxHandler,
+    external_inbox_key,
+)
 from protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -23,6 +27,11 @@ class _RecordingWakeBus:
 
     def publish(self, inbox_id: str) -> None:
         self.published.append(inbox_id)
+
+
+class _FailingWakeBus:
+    def publish(self, _inbox_id: str) -> None:
+        raise RuntimeError("wake publish failed")
 
 
 def _envelope() -> AgentChatDeliveryEnvelope:
@@ -61,6 +70,25 @@ async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> N
     assert payload == {"event_type": "chat.message", "chat_id": "chat-1"}
     assert wake_bus.published == ["external:external-user-1"]
     assert "managed runtime prompt must not leak" not in content
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_inbox_handler_wraps_chat_wake_failure_after_enqueue() -> None:
+    enqueued: list[tuple[str, str, str, dict]] = []
+    handler = ExternalRuntimeInboxHandler(
+        wake_bus=_FailingWakeBus(),
+        queue_manager=SimpleNamespace(
+            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
+        ),
+    )
+
+    with pytest.raises(ExternalRuntimeInboxActionError) as exc_info:
+        await handler.dispatch(_envelope())
+
+    assert len(enqueued) == 1
+    assert exc_info.value.inbox_id == "external:external-user-1"
+    assert exc_info.value.notification_type == "chat"
+    assert str(exc_info.value.__cause__) == "wake publish failed"
 
 
 @pytest.mark.asyncio
@@ -112,6 +140,33 @@ async def test_external_runtime_inbox_handler_queues_generic_runtime_notificatio
         "correlation_id": "corr-1",
         "idempotency_key": "idem-1",
     }
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_inbox_handler_wraps_notification_wake_failure_after_enqueue() -> None:
+    enqueued: list[tuple[str, str, str, dict]] = []
+    handler = ExternalRuntimeInboxHandler(
+        wake_bus=_FailingWakeBus(),
+        queue_manager=SimpleNamespace(
+            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
+        ),
+    )
+    envelope = AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="external-user-1", runtime_source="external"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human", source="relationship"),
+        message=AgentRuntimeMessage(content="Human requested a relationship with you."),
+        notification_type="relationship",
+        transport=AgentRuntimeTransport(),
+    )
+
+    with pytest.raises(ExternalRuntimeInboxActionError) as exc_info:
+        await handler.dispatch_notification(envelope)
+
+    assert len(enqueued) == 1
+    assert exc_info.value.inbox_id == "external:external-user-1"
+    assert exc_info.value.notification_type == "relationship"
+    assert str(exc_info.value.__cause__) == "wake publish failed"
 
 
 def test_external_inbox_key_rejects_blank_user_id() -> None:


### PR DESCRIPTION
## Summary
- add `ExternalRuntimeInboxActionError` for wake failures after external inbox enqueue
- share external inbox enqueue/wake handling between chat delivery and runtime notification paths
- keep queue enqueue failures unwrapped because they are not post-persist wake failures

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py::test_external_runtime_inbox_handler_wraps_chat_wake_failure_after_enqueue tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py::test_external_runtime_inbox_handler_wraps_notification_wake_failure_after_enqueue -q`
- `uv run pytest tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_wake_bus.py -q`
- `uv run ruff check backend/threads/chat_adapters/external_inbox_handler.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py && uv run ruff format --check backend/threads/chat_adapters/external_inbox_handler.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/external_inbox_handler.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py`
