### PR TITLE
Wrap chat event publish failures after send

### DIFF
--- a/backend/chat/api/http/chats_router.py
+++ b/backend/chat/api/http/chats_router.py
@@ -20,7 +20,7 @@ from backend.chat.api.http.dependencies import (
 )
 from messaging.errors import ChatNotCaughtUpError
 from messaging.join_requests import ChatJoinRequestActionError
-from messaging.service import ChatMessageDeliveryActionError
+from messaging.service import ChatMessageDeliveryActionError, ChatMessageEventActionError
 from messaging.user_ownership import is_owned_by_viewer
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -102,6 +102,18 @@ def _chat_message_delivery_action_failure(exc: ChatMessageDeliveryActionError) -
         500,
         {
             "error": "chat_message_delivery_action_failed",
+            "message": exc.message,
+            "cause": str(cause) if cause is not None else str(exc),
+        },
+    )
+
+
+def _chat_message_event_action_failure(exc: ChatMessageEventActionError) -> HTTPException:
+    cause = exc.__cause__
+    return HTTPException(
+        500,
+        {
+            "error": "chat_message_event_action_failed",
             "message": exc.message,
             "cause": str(cause) if cause is not None else str(exc),
         },
@@ -332,6 +344,8 @@ def send_message(
         )
     except ChatNotCaughtUpError as exc:
         raise HTTPException(409, "Read unread messages before sending.") from exc
+    except ChatMessageEventActionError as exc:
+        raise _chat_message_event_action_failure(exc) from exc
     except ChatMessageDeliveryActionError as exc:
         raise _chat_message_delivery_action_failure(exc) from exc
     except ValueError as exc:

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -51,6 +51,12 @@ class ChatMessageDeliveryActionError(RuntimeError):
         self.message = dict(message)
 
 
+class ChatMessageEventActionError(RuntimeError):
+    def __init__(self, *, message: dict[str, Any]) -> None:
+        super().__init__("Chat message event action failed after send")
+        self.message = dict(message)
+
+
 class MessagingService:
     """Core messaging operations backed by Supabase repos."""
 
@@ -88,6 +94,9 @@ class MessagingService:
         )
         self._chat_message_delivery_actions: list[Callable[[dict[str, Any]], None]] = [self._dispatch_chat_message_delivery]
         self._event_bus = event_bus
+        self._chat_message_event_actions: list[Callable[[dict[str, Any]], None]] = []
+        if event_bus is not None:
+            self._chat_message_event_actions.append(self._publish_chat_message_event)
 
     def _normalize_message_row(self, row: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -303,14 +312,7 @@ class MessagingService:
         logger.debug("[messaging] send chat=%s sender=%s msg=%s type=%s", chat_id[:8], sender_id[:15], msg_id[:8], message_type)
 
         # Publish to event bus (SSE / realtime transport)
-        if self._event_bus:
-            self._event_bus.publish(
-                chat_id,
-                {
-                    "event": "message",
-                    "data": self._project_message_response(created),
-                },
-            )
+        self._run_chat_message_event_actions(created)
 
         # Deliver to agent recipients
         if _should_dispatch_chat_delivery(message_type, mentions, normalized_addressed_to):
@@ -318,11 +320,30 @@ class MessagingService:
 
         return created
 
+    def _run_chat_message_event_actions(self, message: dict[str, Any]) -> None:
+        run_sync_actions(
+            self._chat_message_event_actions,
+            message,
+            on_error=lambda _exc: ChatMessageEventActionError(message=message),
+        )
+
     def _run_chat_message_delivery_actions(self, message: dict[str, Any]) -> None:
         run_sync_actions(
             self._chat_message_delivery_actions,
             message,
             on_error=lambda _exc: ChatMessageDeliveryActionError(message=message),
+        )
+
+    def _publish_chat_message_event(self, message: dict[str, Any]) -> None:
+        event_bus = self._event_bus
+        if event_bus is None:
+            raise RuntimeError("Chat message event action registered without event bus")
+        event_bus.publish(
+            str(message["chat_id"]),
+            {
+                "event": "message",
+                "data": self._project_message_response(message),
+            },
         )
 
     def _dispatch_chat_message_delivery(self, message: dict[str, Any]) -> None:

--- a/tests/Unit/integration_contracts/test_messaging_router.py
+++ b/tests/Unit/integration_contracts/test_messaging_router.py
@@ -15,7 +15,7 @@ from backend.web.core.dependencies import get_current_user_id
 from core.work_item.chat_workflow.service import WorkflowEventActionError
 from messaging.contracts import RelationshipRow
 from messaging.relationships.service import RelationshipActionError
-from messaging.service import ChatMessageDeliveryActionError
+from messaging.service import ChatMessageDeliveryActionError, ChatMessageEventActionError
 from storage.contracts import ContactEdgeRow
 from storage.errors import (
     StaleChatWorkflowEventVersionError,
@@ -219,6 +219,43 @@ def test_send_message_action_failure_returns_persisted_message() -> None:
         "error": "chat_message_delivery_action_failed",
         "message": message,
         "cause": "runtime offline",
+    }
+
+
+def test_send_message_event_action_failure_returns_persisted_message() -> None:
+    message = {
+        "id": "msg-1",
+        "chat_id": "chat-1",
+        "sender_id": "human-user-1",
+        "content": "hello",
+        "message_type": "human",
+        "seq": 12,
+        "created_at": "2026-04-07T00:00:00Z",
+    }
+
+    def fail_send(*_args, **_kwargs):
+        error = ChatMessageEventActionError(message=message)
+        raise error from RuntimeError("event bus offline")
+
+    messaging_service = SimpleNamespace(
+        resolve_display_user=lambda uid: SimpleNamespace(id=uid, owner_user_id=None),
+        is_chat_member=lambda _chat_id, _user_id: True,
+        send=fail_send,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        chats_router.send_message(
+            "chat-1",
+            chats_router.SendMessageBody(content="hello"),
+            user_id="human-user-1",
+            messaging_service=messaging_service,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {
+        "error": "chat_message_event_action_failed",
+        "message": message,
+        "cause": "event bus offline",
     }
 
 

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -19,7 +19,7 @@ from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.display_user import resolve_messaging_display_user
 from messaging.relationships.service import RelationshipActionError, RelationshipService
-from messaging.service import ChatMessageDeliveryActionError, MessagingService
+from messaging.service import ChatMessageDeliveryActionError, ChatMessageEventActionError, MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
 from storage.contracts import ContactEdgeRow
 
@@ -867,6 +867,33 @@ def test_messaging_service_event_bus_message_uses_service_owned_projection() -> 
         "event": "message",
         "data": service.project_message_response(created),
     }
+
+
+def test_messaging_service_event_bus_failure_carries_persisted_message() -> None:
+    def fail_publish(_chat_id: str, _payload: dict[str, object]) -> None:
+        raise RuntimeError("event bus offline")
+
+    service = MessagingService(
+        chat_repo=SimpleNamespace(),
+        chat_member_repo=SimpleNamespace(list_members=lambda _chat_id: [], update_last_read=lambda _chat_id, _user_id, _seq: None),
+        messages_repo=SimpleNamespace(create=lambda row: {**row, "seq": 11}),
+        user_repo=SimpleNamespace(
+            get_by_id=lambda uid: (
+                SimpleNamespace(id=uid, display_name="Human", type="human", avatar=None) if uid == "human-user-1" else None
+            )
+        ),
+        event_bus=SimpleNamespace(publish=fail_publish),
+    )
+
+    with pytest.raises(ChatMessageEventActionError) as exc_info:
+        service.send("chat-1", "human-user-1", "hello")
+
+    assert str(exc_info.value) == "Chat message event action failed after send"
+    assert exc_info.value.message["chat_id"] == "chat-1"
+    assert exc_info.value.message["sender_id"] == "human-user-1"
+    assert exc_info.value.message["content"] == "hello"
+    assert exc_info.value.message["seq"] == 11
+    assert str(exc_info.value.__cause__) == "event bus offline"
 
 
 def test_messaging_service_notification_mentions_dispatch_to_agent_recipients() -> None:


### PR DESCRIPTION
## Summary
- add `ChatMessageEventActionError` for realtime event publish failures after a chat message has been persisted
- run chat message event publish through the same `run_sync_actions()` post-send action mechanism as delivery actions
- map event action failures to structured HTTP `chat_message_event_action_failed` responses carrying the persisted message
- keep delivery order and semantics unchanged; no retry/outbox, polling, schema, transport, local daemon, DSL, or durable action-attempt store added

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_messaging_service_event_bus_failure_carries_persisted_message -q` failed before implementation with missing `ChatMessageEventActionError`
- `uv run pytest tests/Unit/integration_contracts/test_messaging_router.py::test_send_message_event_action_failure_returns_persisted_message -q` failed before router mapping because `ChatMessageEventActionError` leaked from the route
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py tests/Unit/core/test_event_actions.py -q`
- `uv run pyright --pythonversion 3.12 messaging/service.py backend/chat/api/http/chats_router.py`
- `uv run ruff check messaging/service.py backend/chat/api/http/chats_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py && uv run ruff format --check messaging/service.py backend/chat/api/http/chats_router.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/integration_contracts/test_messaging_router.py`

## Note
A broader pyright run including `tests/Unit/integration_contracts/test_messaging_social_handle_contract.py` still reports pre-existing typing noise unrelated to this change, so this PR verifies pyright on the changed production files.
