### PR TITLE
Use typed caught-up error in chat tool send

### DIFF
--- a/messaging/tools/chat_tool_service.py
+++ b/messaging/tools/chat_tool_service.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from core.runtime.registry import ToolEntry, ToolMode, ToolRegistry
 from core.runtime.tool_result import ToolResultEnvelope, tool_error
+from messaging.errors import ChatNotCaughtUpError
 
 logger = logging.getLogger(__name__)
 
@@ -107,8 +108,9 @@ class ChatToolService:
 
     def _display_user_type(self, user: Any, *, user_id: str) -> str:
         raw_type = getattr(user, "type", None)
-        if hasattr(raw_type, "value"):
-            raw_type = raw_type.value
+        raw_value = getattr(raw_type, "value", None)
+        if raw_value is not None:
+            raw_type = raw_value
         if not isinstance(raw_type, str) or not raw_type:
             raise RuntimeError(f"Chat user {user_id} is missing user type")
         return raw_type
@@ -443,6 +445,8 @@ class ChatToolService:
                 resolved_chat_id = chat["id"]
             else:
                 raise RuntimeError("Provide participant_id (for 1:1) or chat_id (for group)")
+            if resolved_chat_id is None:
+                raise RuntimeError("Resolved chat id is missing")
 
             # @@@attention-read-gate - a group reply must not be serialized behind
             # unrelated peer replies, but it still cannot skip direct, human, or
@@ -468,14 +472,11 @@ class ChatToolService:
                     mentions=mentions,
                     signal=effective_signal,
                 )
-            except RuntimeError as exc:
-                message = str(exc)
-                if message.startswith("Chat advanced after your last read."):
-                    return tool_error(
-                        message,
-                        metadata={"error_type": "chat_not_caught_up", "chat_id": resolved_chat_id},
-                    )
-                raise
+            except ChatNotCaughtUpError as exc:
+                return tool_error(
+                    str(exc),
+                    metadata={"error_type": "chat_not_caught_up", "chat_id": resolved_chat_id},
+                )
             return f"Message sent to {target_name}."
 
         registry.register(

--- a/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
+++ b/tests/Unit/integration_contracts/test_messaging_social_handle_contract.py
@@ -18,6 +18,7 @@ from messaging.delivery.contracts import ChatDeliveryRequest
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher
 from messaging.delivery.resolver import HireVisitDeliveryResolver
 from messaging.display_user import resolve_messaging_display_user
+from messaging.errors import ChatNotCaughtUpError
 from messaging.relationships.service import RelationshipActionError, RelationshipService
 from messaging.service import ChatMessageDeliveryActionError, ChatMessageEventActionError, MessagingService
 from messaging.tools.chat_tool_service import ChatToolService
@@ -2959,11 +2960,36 @@ def test_chat_tool_send_does_not_serialize_concurrent_group_replies_after_read()
     ]
 
 
-def test_chat_tool_send_returns_tool_error_when_chat_advances_after_read() -> None:
+def test_chat_tool_send_does_not_match_runtime_error_text_as_caught_up_signal() -> None:
     registry = ToolRegistry()
 
     def _send(*_args, **_kwargs):
         raise RuntimeError("Chat advanced after your last read. Call read_messages(chat_id='chat-1') first.")
+
+    ChatToolService(
+        registry=registry,
+        chat_identity_id="agent-user-1",
+        messaging_service=SimpleNamespace(
+            is_chat_member=lambda _chat_id, _user_id: True,
+            list_unread=lambda _chat_id, _user_id: [],
+            send=_send,
+        ),
+    )
+
+    send_message = registry.get("send_message")
+    assert send_message is not None
+
+    with pytest.raises(RuntimeError) as exc_info:
+        send_message.handler(content="GROUP_READ_OK", chat_id="chat-1")
+
+    assert str(exc_info.value) == "Chat advanced after your last read. Call read_messages(chat_id='chat-1') first."
+
+
+def test_chat_tool_send_maps_typed_caught_up_error_to_tool_error() -> None:
+    registry = ToolRegistry()
+
+    def _send(*_args, **_kwargs):
+        raise ChatNotCaughtUpError("Read unread messages before sending.")
 
     ChatToolService(
         registry=registry,
@@ -2983,7 +3009,8 @@ def test_chat_tool_send_returns_tool_error_when_chat_advances_after_read() -> No
     assert isinstance(result, ToolResultEnvelope)
     assert result.kind == "error"
     assert result.metadata["error_type"] == "chat_not_caught_up"
-    assert result.content == "Chat advanced after your last read. Call read_messages(chat_id='chat-1') first."
+    assert result.metadata["chat_id"] == "chat-1"
+    assert result.content == "Read unread messages before sending."
 
 
 def test_read_messages_uses_agent_user_target_name_on_no_history() -> None:


### PR DESCRIPTION
## Summary
- map `ChatNotCaughtUpError` directly in chat tool `send_message` instead of matching `RuntimeError` text
- keep unexpected runtime errors loud instead of treating message text as protocol
- tighten two chat tool type surfaces surfaced by pyright while touching this path

## Verification
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py::test_chat_tool_send_maps_typed_caught_up_error_to_tool_error -q` failed before implementation because the typed error leaked
- `uv run pytest tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q`
- `uv run pyright --pythonversion 3.12 messaging/tools/chat_tool_service.py`
- `uv run ruff check messaging/tools/chat_tool_service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py && uv run ruff format --check messaging/tools/chat_tool_service.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py`
