### PR TITLE
Run external inbox wake through sync actions

### DIFF
--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from core.event_actions import run_sync_actions
 from protocols import agent_runtime as agent_runtime_protocol
 
 
@@ -57,10 +58,11 @@ class ExternalRuntimeInboxHandler:
             wake=self._wake_bus is None and wake,
         )
         if self._wake_bus is not None and wake:
-            try:
-                self._wake_bus.publish(inbox_id)
-            except Exception as exc:
-                raise ExternalRuntimeInboxActionError(inbox_id=inbox_id, notification_type=notification_type) from exc
+            run_sync_actions(
+                [self._wake_bus.publish],
+                inbox_id,
+                on_error=lambda _exc: ExternalRuntimeInboxActionError(inbox_id=inbox_id, notification_type=notification_type),
+            )
 
     async def dispatch_notification(
         self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope


### PR DESCRIPTION
## Summary
- run external runtime inbox wake publish through `run_sync_actions()`
- preserve the existing `ExternalRuntimeInboxActionError` post-enqueue failure contract
- keep enqueue behavior, wake behavior, and public runtime inbox payloads unchanged

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py -q` before refactor: 5 passed
- `uv run pytest tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/backend/web/services/test_runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_wake_bus.py tests/Unit/core/test_event_actions.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/external_inbox_handler.py core/event_actions.py`
- `uv run ruff check backend/threads/chat_adapters/external_inbox_handler.py core/event_actions.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py && uv run ruff format --check backend/threads/chat_adapters/external_inbox_handler.py core/event_actions.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py`

## Note
This is a consolidation slice, not a new delivery mechanism: no retry/outbox, polling, schema, transport, local daemon, DSL, or durable action-attempt store was added.
