### PR TITLE
Plan workflow runtime notifications before dispatch

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -36,6 +37,34 @@ async def dispatch_runtime_notification_action(
     thread_repo: Any,
     activity_reader: Any,
 ) -> bool:
+    envelope = plan_runtime_notification_envelope(
+        action,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    if envelope is None:
+        return False
+    await dispatch_runtime_notification_envelopes(app, [envelope])
+    return True
+
+
+async def dispatch_runtime_notification_envelopes(app: Any, envelopes: Iterable[AgentRuntimeNotificationEnvelope]) -> None:
+    current_envelopes = list(envelopes)
+    if not current_envelopes:
+        return
+    gateway = get_agent_runtime_gateway(app)
+    for envelope in current_envelopes:
+        await gateway.dispatch_notification(envelope)
+
+
+def plan_runtime_notification_envelope(
+    action: RuntimeNotificationAction,
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> AgentRuntimeNotificationEnvelope | None:
     sender_user = require_user(user_repo, action.sender_user_id, context=action.context, role="sender")
     recipient = resolve_runtime_notification_recipient(
         action.recipient_user_id,
@@ -46,24 +75,21 @@ async def dispatch_runtime_notification_action(
         runtime_context=action.runtime_context,
     )
     if recipient is None:
-        return False
-    await get_agent_runtime_gateway(app).dispatch_notification(
-        AgentRuntimeNotificationEnvelope(
-            event_type=action.event_type,
-            recipient=recipient,
-            sender=make_runtime_actor(
-                user_id=action.sender_user_id,
-                user=sender_user,
-                source=action.sender_source,
-                context=action.context,
-                include_avatar=action.include_sender_avatar,
-            ),
-            message=AgentRuntimeMessage(
-                content=action.content,
-                metadata=action.metadata,
-            ),
-            notification_type=action.notification_type,
-            transport=action.transport,
+        return None
+    return AgentRuntimeNotificationEnvelope(
+        event_type=action.event_type,
+        recipient=recipient,
+        sender=make_runtime_actor(
+            user_id=action.sender_user_id,
+            user=sender_user,
+            source=action.sender_source,
+            context=action.context,
+            include_avatar=action.include_sender_avatar,
         ),
+        message=AgentRuntimeMessage(
+            content=action.content,
+            metadata=action.metadata,
+        ),
+        notification_type=action.notification_type,
+        transport=action.transport,
     )
-    return True

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_action,
+    dispatch_runtime_notification_envelopes,
+    plan_runtime_notification_envelope,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentRuntimeTransport
@@ -21,19 +22,40 @@ def make_workflow_event_notification_fn(
     messaging_service: Any,
 ) -> Callable[[WorkflowEventChange], None]:
     async def notify_runtime(change: WorkflowEventChange) -> None:
-        for member in messaging_service.list_chat_members(_required_str(change.event, "chat_id")):
-            recipient_user_id = _member_user_id(member)
-            if recipient_user_id == change.actor_user_id:
-                continue
-            await dispatch_runtime_notification_action(
-                app,
-                workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id),
-                user_repo=user_repo,
-                thread_repo=thread_repo,
-                activity_reader=activity_reader,
-            )
+        envelopes = make_workflow_event_notification_envelopes(
+            change,
+            messaging_service.list_chat_members(_required_str(change.event, "chat_id")),
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        await dispatch_runtime_notification_envelopes(app, envelopes)
 
     return make_sync_runtime_event_hook(notify_runtime)
+
+
+def make_workflow_event_notification_envelopes(
+    change: WorkflowEventChange,
+    members: Sequence[Mapping[str, Any]],
+    *,
+    activity_reader: Any,
+    thread_repo: Any,
+    user_repo: Any,
+) -> list[Any]:
+    envelopes: list[Any] = []
+    for member in members:
+        recipient_user_id = _member_user_id(member)
+        if recipient_user_id == change.actor_user_id:
+            continue
+        envelope = plan_runtime_notification_envelope(
+            workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id),
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if envelope is not None:
+            envelopes.append(envelope)
+    return envelopes
 
 
 def workflow_event_runtime_notification_action(*, change: WorkflowEventChange, recipient_user_id: str) -> RuntimeNotificationAction:

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -7,6 +7,7 @@ from typing import Literal
 import pytest
 
 from backend.threads.chat_adapters.workflow_event_inlet import (
+    make_workflow_event_notification_envelopes,
     make_workflow_event_notification_fn,
     workflow_event_runtime_notification_action,
 )
@@ -129,6 +130,33 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
         raise AssertionError("missing workflow event identity did not fail")
 
 
+def test_workflow_event_notification_planner_selects_runtime_members() -> None:
+    members = [
+        {"user_id": "owner-1"},
+        {"user_id": "agent-1"},
+        {"user_id": "agent-without-thread"},
+        {"user_id": "external-1"},
+        {"user_id": "human-2"},
+    ]
+
+    envelopes = make_workflow_event_notification_envelopes(
+        _change("updated"),
+        members,
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=_thread_repo("agent-1"),
+        user_repo=_users("agent-1", "agent-without-thread"),
+    )
+
+    assert [envelope.recipient.agent_user_id for envelope in envelopes] == ["agent-1", "external-1"]
+    assert [envelope.recipient.runtime_source for envelope in envelopes] == ["mycel", "external"]
+    assert envelopes[0].recipient.thread_id == "thread-agent-1"
+    assert all(envelope.sender.user_id == "owner-1" for envelope in envelopes)
+    for envelope in envelopes:
+        assert envelope.message.metadata is not None
+        assert envelope.message.metadata["event_id"] == "event-1"
+        assert envelope.message.metadata["operation"] == "updated"
+
+
 @pytest.mark.asyncio
 async def test_workflow_event_notification_fn_selects_runtime_members() -> None:
     gateway = _RecordingGateway()
@@ -180,6 +208,20 @@ async def test_workflow_event_notification_fn_keeps_identity_context() -> None:
         assert str(exc) == "Workflow event notification recipient user not found: missing-recipient"
     else:
         raise AssertionError("missing workflow event recipient did not fail")
+
+
+@pytest.mark.asyncio
+async def test_workflow_event_notification_fn_skips_gateway_when_no_runtime_recipients() -> None:
+    messaging_service = SimpleNamespace(list_chat_members=lambda _chat_id: [{"user_id": "owner-1"}, {"user_id": "human-2"}])
+    notify = make_workflow_event_notification_fn(
+        SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace())),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        thread_repo=_thread_repo(),
+        user_repo=_users(),
+        messaging_service=messaging_service,
+    )
+
+    await asyncio.to_thread(notify, _change("updated"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- split runtime notification execution into a reusable envelope planner plus gateway dispatch
- make workflow event notifications plan runtime envelopes from chat members before dispatching
- keep no-runtime-recipient behavior unchanged by skipping gateway access when the plan is empty

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py && uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py`

No DSL, transport, schema, polling, local daemon, or durable action-attempt store was added.
