### PR TITLE
Plan workflow notifications as runtime actions

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -37,16 +37,35 @@ async def dispatch_runtime_notification_action(
     thread_repo: Any,
     activity_reader: Any,
 ) -> bool:
-    envelope = plan_runtime_notification_envelope(
-        action,
+    envelopes = plan_runtime_notification_envelopes(
+        [action],
         user_repo=user_repo,
         thread_repo=thread_repo,
         activity_reader=activity_reader,
     )
-    if envelope is None:
+    if not envelopes:
         return False
-    await dispatch_runtime_notification_envelopes(app, [envelope])
+    await dispatch_runtime_notification_envelopes(app, envelopes)
     return True
+
+
+async def dispatch_runtime_notification_actions(
+    app: Any,
+    actions: Iterable[RuntimeNotificationAction],
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> None:
+    await dispatch_runtime_notification_envelopes(
+        app,
+        plan_runtime_notification_envelopes(
+            actions,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        ),
+    )
 
 
 async def dispatch_runtime_notification_envelopes(app: Any, envelopes: Iterable[AgentRuntimeNotificationEnvelope]) -> None:
@@ -56,6 +75,26 @@ async def dispatch_runtime_notification_envelopes(app: Any, envelopes: Iterable[
     gateway = get_agent_runtime_gateway(app)
     for envelope in current_envelopes:
         await gateway.dispatch_notification(envelope)
+
+
+def plan_runtime_notification_envelopes(
+    actions: Iterable[RuntimeNotificationAction],
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> list[AgentRuntimeNotificationEnvelope]:
+    envelopes: list[AgentRuntimeNotificationEnvelope] = []
+    for action in actions:
+        envelope = plan_runtime_notification_envelope(
+            action,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if envelope is not None:
+            envelopes.append(envelope)
+    return envelopes
 
 
 def plan_runtime_notification_envelope(

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -6,8 +6,7 @@ from typing import Any
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_envelopes,
-    plan_runtime_notification_envelope,
+    dispatch_runtime_notification_actions,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentRuntimeTransport
@@ -22,40 +21,32 @@ def make_workflow_event_notification_fn(
     messaging_service: Any,
 ) -> Callable[[WorkflowEventChange], None]:
     async def notify_runtime(change: WorkflowEventChange) -> None:
-        envelopes = make_workflow_event_notification_envelopes(
+        actions = make_workflow_event_notification_actions(
             change,
             messaging_service.list_chat_members(_required_str(change.event, "chat_id")),
+        )
+        await dispatch_runtime_notification_actions(
+            app,
+            actions,
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
-        await dispatch_runtime_notification_envelopes(app, envelopes)
 
     return make_sync_runtime_event_hook(notify_runtime)
 
 
-def make_workflow_event_notification_envelopes(
+def make_workflow_event_notification_actions(
     change: WorkflowEventChange,
     members: Sequence[Mapping[str, Any]],
-    *,
-    activity_reader: Any,
-    thread_repo: Any,
-    user_repo: Any,
-) -> list[Any]:
-    envelopes: list[Any] = []
+) -> list[RuntimeNotificationAction]:
+    actions: list[RuntimeNotificationAction] = []
     for member in members:
         recipient_user_id = _member_user_id(member)
         if recipient_user_id == change.actor_user_id:
             continue
-        envelope = plan_runtime_notification_envelope(
-            workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id),
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-        if envelope is not None:
-            envelopes.append(envelope)
-    return envelopes
+        actions.append(workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id))
+    return actions
 
 
 def workflow_event_runtime_notification_action(*, change: WorkflowEventChange, recipient_user_id: str) -> RuntimeNotificationAction:

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -7,6 +7,7 @@ import pytest
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_action,
+    dispatch_runtime_notification_actions,
 )
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -76,3 +77,45 @@ async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_re
     assert gateway.envelope.message.content == "Action happened."
     assert gateway.envelope.message.metadata == {"resource_id": "resource-1"}
     assert gateway.envelope.transport.delivery_id == "delivery-1"
+
+
+@pytest.mark.asyncio
+async def test_runtime_notification_actions_dispatches_only_runtime_recipients() -> None:
+    class RecordingGateway:
+        def __init__(self) -> None:
+            self.envelopes = []
+
+        async def dispatch_notification(self, envelope):
+            self.envelopes.append(envelope)
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+    gateway = RecordingGateway()
+
+    await dispatch_runtime_notification_actions(
+        _runtime_app(gateway),
+        [
+            RuntimeNotificationAction(
+                context="Test action",
+                recipient_user_id="agent-1",
+                sender_user_id="owner-1",
+                sender_source="workflow",
+                event_type="test.event",
+                notification_type="test",
+                content="Action happened.",
+            ),
+            RuntimeNotificationAction(
+                context="Test action",
+                recipient_user_id="owner-1",
+                sender_user_id="owner-1",
+                sender_source="workflow",
+                event_type="test.event",
+                notification_type="test",
+                content="Action happened.",
+            ),
+        ],
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -7,7 +7,7 @@ from typing import Literal
 import pytest
 
 from backend.threads.chat_adapters.workflow_event_inlet import (
-    make_workflow_event_notification_envelopes,
+    make_workflow_event_notification_actions,
     make_workflow_event_notification_fn,
     workflow_event_runtime_notification_action,
 )
@@ -130,7 +130,7 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
         raise AssertionError("missing workflow event identity did not fail")
 
 
-def test_workflow_event_notification_planner_selects_runtime_members() -> None:
+def test_workflow_event_notification_planner_selects_recipient_actions() -> None:
     members = [
         {"user_id": "owner-1"},
         {"user_id": "agent-1"},
@@ -139,22 +139,17 @@ def test_workflow_event_notification_planner_selects_runtime_members() -> None:
         {"user_id": "human-2"},
     ]
 
-    envelopes = make_workflow_event_notification_envelopes(
+    actions = make_workflow_event_notification_actions(
         _change("updated"),
         members,
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=_thread_repo("agent-1"),
-        user_repo=_users("agent-1", "agent-without-thread"),
     )
 
-    assert [envelope.recipient.agent_user_id for envelope in envelopes] == ["agent-1", "external-1"]
-    assert [envelope.recipient.runtime_source for envelope in envelopes] == ["mycel", "external"]
-    assert envelopes[0].recipient.thread_id == "thread-agent-1"
-    assert all(envelope.sender.user_id == "owner-1" for envelope in envelopes)
-    for envelope in envelopes:
-        assert envelope.message.metadata is not None
-        assert envelope.message.metadata["event_id"] == "event-1"
-        assert envelope.message.metadata["operation"] == "updated"
+    assert [action.recipient_user_id for action in actions] == ["agent-1", "agent-without-thread", "external-1", "human-2"]
+    assert all(action.sender_user_id == "owner-1" for action in actions)
+    for action in actions:
+        assert action.metadata is not None
+        assert action.metadata["event_id"] == "event-1"
+        assert action.metadata["operation"] == "updated"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- make workflow event fanout plan `RuntimeNotificationAction` values instead of planned protocol envelopes
- add batch runtime notification action dispatch so action-to-envelope planning stays inside the runtime action adapter
- keep workflow inlet away from gateway/protocol envelope concepts while preserving runtime recipient filtering at the adapter boundary

## Verification

- `uv run pytest tests/Unit -q`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py && uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py`

No DSL, transport, schema, polling, local daemon, retry/outbox, or durable action-attempt store was added.
