### PR TITLE
Return runtime notification dispatch count

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -37,16 +37,14 @@ async def dispatch_runtime_notification_action(
     thread_repo: Any,
     activity_reader: Any,
 ) -> bool:
-    envelopes = plan_runtime_notification_envelopes(
+    dispatched_count = await dispatch_runtime_notification_actions(
+        app,
         [action],
         user_repo=user_repo,
         thread_repo=thread_repo,
         activity_reader=activity_reader,
     )
-    if not envelopes:
-        return False
-    await dispatch_runtime_notification_envelopes(app, envelopes)
-    return True
+    return dispatched_count > 0
 
 
 async def dispatch_runtime_notification_actions(
@@ -56,16 +54,15 @@ async def dispatch_runtime_notification_actions(
     user_repo: Any,
     thread_repo: Any,
     activity_reader: Any,
-) -> None:
-    await dispatch_runtime_notification_envelopes(
-        app,
-        plan_runtime_notification_envelopes(
-            actions,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        ),
+) -> int:
+    envelopes = plan_runtime_notification_envelopes(
+        actions,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
     )
+    await dispatch_runtime_notification_envelopes(app, envelopes)
+    return len(envelopes)
 
 
 async def dispatch_runtime_notification_envelopes(app: Any, envelopes: Iterable[AgentRuntimeNotificationEnvelope]) -> None:

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -91,7 +91,7 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
 
     gateway = RecordingGateway()
 
-    await dispatch_runtime_notification_actions(
+    dispatched_count = await dispatch_runtime_notification_actions(
         _runtime_app(gateway),
         [
             RuntimeNotificationAction(
@@ -118,4 +118,5 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
         activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
     )
 
+    assert dispatched_count == 1
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]


### PR DESCRIPTION
## Summary

- make `dispatch_runtime_notification_actions()` return the number of runtime notifications actually dispatched
- route the single-action wrapper through the batch action dispatcher instead of duplicating envelope planning logic
- keep skipped non-runtime recipients represented as zero dispatched notifications

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_notification_action.py && uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
