### PR TITLE
Add event action planner primitive

### DIFF
--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -8,6 +8,7 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
 )
+from core.event_actions import plan_event_actions
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -20,11 +21,10 @@ def make_workflow_event_notification_fn(
     user_repo: Any,
     messaging_service: Any,
 ) -> Callable[[WorkflowEventChange], None]:
+    planner = workflow_event_notification_action_planner(messaging_service)
+
     async def notify_runtime(change: WorkflowEventChange) -> None:
-        actions = make_workflow_event_notification_actions(
-            change,
-            messaging_service.list_chat_members(_required_str(change.event, "chat_id")),
-        )
+        actions = plan_event_actions([planner], change)
         await dispatch_runtime_notification_actions(
             app,
             actions,
@@ -34,6 +34,16 @@ def make_workflow_event_notification_fn(
         )
 
     return make_sync_runtime_event_hook(notify_runtime)
+
+
+def workflow_event_notification_action_planner(messaging_service: Any) -> Callable[[WorkflowEventChange], list[RuntimeNotificationAction]]:
+    def plan(change: WorkflowEventChange) -> list[RuntimeNotificationAction]:
+        return make_workflow_event_notification_actions(
+            change,
+            messaging_service.list_chat_members(_required_str(change.event, "chat_id")),
+        )
+
+    return plan
 
 
 def make_workflow_event_notification_actions(

--- a/core/event_actions.py
+++ b/core/event_actions.py
@@ -4,6 +4,19 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 
+def plan_event_actions[EventT, ActionT](
+    planners: Iterable[Callable[[EventT], Iterable[ActionT]]],
+    event: EventT,
+) -> list[ActionT]:
+    current_planners = list(planners)
+    if not current_planners:
+        return []
+    planned_actions: list[ActionT] = []
+    for planner in current_planners:
+        planned_actions.extend(planner(event))
+    return planned_actions
+
+
 def run_sync_actions(
     actions: Iterable[Callable[..., None]],
     /,

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -9,6 +9,7 @@ import pytest
 from backend.threads.chat_adapters.workflow_event_inlet import (
     make_workflow_event_notification_actions,
     make_workflow_event_notification_fn,
+    workflow_event_notification_action_planner,
     workflow_event_runtime_notification_action,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
@@ -150,6 +151,23 @@ def test_workflow_event_notification_planner_selects_recipient_actions() -> None
         assert action.metadata is not None
         assert action.metadata["event_id"] == "event-1"
         assert action.metadata["operation"] == "updated"
+
+
+def test_workflow_event_notification_action_planner_reads_chat_members() -> None:
+    seen_chat_ids: list[str] = []
+
+    def list_chat_members(chat_id: str) -> list[dict[str, str]]:
+        seen_chat_ids.append(chat_id)
+        return [{"user_id": "owner-1"}, {"user_id": "agent-1"}]
+
+    planner = workflow_event_notification_action_planner(SimpleNamespace(list_chat_members=list_chat_members))
+
+    actions = planner(_change("updated"))
+
+    assert seen_chat_ids == ["chat-1"]
+    assert [action.recipient_user_id for action in actions] == ["agent-1"]
+    assert actions[0].metadata is not None
+    assert actions[0].metadata["operation"] == "updated"
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/core/test_event_actions.py
+++ b/tests/Unit/core/test_event_actions.py
@@ -2,7 +2,36 @@ from __future__ import annotations
 
 import pytest
 
-from core.event_actions import run_sync_actions
+from core.event_actions import plan_event_actions, run_sync_actions
+
+
+def test_plan_event_actions_flattens_planners_in_order() -> None:
+    def first(value: str) -> list[str]:
+        return [f"first:{value}", f"first-again:{value}"]
+
+    def second(value: str) -> list[str]:
+        return [f"second:{value}"]
+
+    actions = plan_event_actions([first, second], "event-1")
+
+    assert actions == ["first:event-1", "first-again:event-1", "second:event-1"]
+
+
+def test_plan_event_actions_snapshots_planners_before_running() -> None:
+    planners = []
+
+    def first(value: str) -> list[str]:
+        planners.append(second)
+        return [f"first:{value}"]
+
+    def second(value: str) -> list[str]:
+        return [f"second:{value}"]
+
+    planners.append(first)
+
+    actions = plan_event_actions(planners, "event-1")
+
+    assert actions == ["first:event-1"]
 
 
 def test_run_sync_actions_runs_registered_actions_in_order() -> None:


### PR DESCRIPTION
## Summary
- add a small `plan_event_actions()` primitive for turning one event into ordered action values
- route workflow event notifications through a named planner before runtime action dispatch
- keep dispatch, runtime reachability, gateway access, and notification semantics unchanged

## Test Plan
- Red first: `uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q` failed on missing `plan_event_actions` and `workflow_event_notification_action_planner`
- `uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q`
- `uv run pyright --pythonversion 3.12 core/event_actions.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff check core/event_actions.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_workflow_event_notification.py && uv run ruff format --check core/event_actions.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit -q`

## Scope
- No DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
