### PR TITLE
Route notification inlets through event planners

### DIFF
--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,46 +1,60 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_action,
+    dispatch_runtime_notification_actions,
 )
+from core.event_actions import plan_event_actions
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
+    planner = chat_join_rejection_notification_action_planner(user_repo)
+
     async def notify_runtime(row: dict[str, Any]) -> None:
-        requester_id = _required_str(row, "requester_user_id")
-        decider_id = _required_str(row, "decided_by_user_id")
-        chat_id = _required_str(row, "chat_id")
-        decider = require_user(user_repo, decider_id, context="Chat join rejection", role="decider")
-        await dispatch_runtime_notification_action(
+        actions = plan_event_actions([planner], row)
+        await dispatch_runtime_notification_actions(
             app,
-            RuntimeNotificationAction(
-                context="Chat join rejection",
-                recipient_user_id=requester_id,
-                sender_user_id=decider_id,
-                sender_source="chat_join",
-                event_type="chat.join.rejected",
-                notification_type="chat_join",
-                content=(
-                    f"{display_name(decider, decider_id, context='Chat join rejection')} rejected your request to join chat {chat_id}."
-                ),
-                metadata={
-                    "chat_join_request_id": _required_str(row, "id"),
-                    "chat_id": chat_id,
-                    "state": "rejected",
-                },
-                include_sender_avatar=True,
-            ),
+            actions,
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
     return make_sync_runtime_event_hook(notify_runtime)
+
+
+def chat_join_rejection_notification_action_planner(user_repo: Any) -> Callable[[dict[str, Any]], list[RuntimeNotificationAction]]:
+    def plan(row: dict[str, Any]) -> list[RuntimeNotificationAction]:
+        return [chat_join_rejection_notification_action(row, user_repo=user_repo)]
+
+    return plan
+
+
+def chat_join_rejection_notification_action(row: dict[str, Any], *, user_repo: Any) -> RuntimeNotificationAction:
+    requester_id = _required_str(row, "requester_user_id")
+    decider_id = _required_str(row, "decided_by_user_id")
+    chat_id = _required_str(row, "chat_id")
+    decider = require_user(user_repo, decider_id, context="Chat join rejection", role="decider")
+    return RuntimeNotificationAction(
+        context="Chat join rejection",
+        recipient_user_id=requester_id,
+        sender_user_id=decider_id,
+        sender_source="chat_join",
+        event_type="chat.join.rejected",
+        notification_type="chat_join",
+        content=f"{display_name(decider, decider_id, context='Chat join rejection')} rejected your request to join chat {chat_id}.",
+        metadata={
+            "chat_join_request_id": _required_str(row, "id"),
+            "chat_id": chat_id,
+            "state": "rejected",
+        },
+        include_sender_avatar=True,
+    )
 
 
 def _required_str(row: dict[str, Any], key: str) -> str:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_action,
+    dispatch_runtime_notification_actions,
 )
+from core.event_actions import plan_event_actions
 from messaging.contracts import RelationshipEvent, RelationshipRow
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
@@ -16,64 +19,102 @@ _DECISION_VERBS: dict[RelationshipEvent, str] = {
 }
 
 
+@dataclass(frozen=True)
+class RelationshipDecisionChange:
+    row: RelationshipRow
+    event: RelationshipEvent
+
+
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
+    planner = relationship_request_notification_action_planner(user_repo)
+
     async def notify_runtime(row: RelationshipRow) -> None:
-        requester_id = _requester_id(row)
-        target_id = _target_id(row, requester_id)
-        requester = require_user(user_repo, requester_id, context="Relationship request", role="requester")
-        await dispatch_runtime_notification_action(
+        actions = plan_event_actions([planner], row)
+        await dispatch_runtime_notification_actions(
             app,
-            RuntimeNotificationAction(
-                context="Relationship request",
-                recipient_user_id=target_id,
-                sender_user_id=requester_id,
-                sender_source="relationship",
-                event_type="relationship.requested",
-                notification_type="relationship",
-                content=_notification_content(
-                    display_name(requester, requester_id, context="Relationship request"),
-                    row.message,
-                ),
-                metadata={"relationship_id": row.id},
-                include_sender_avatar=True,
-            ),
+            actions,
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
     return make_sync_runtime_event_hook(notify_runtime)
+
+
+def relationship_request_notification_action_planner(user_repo: Any) -> Callable[[RelationshipRow], list[RuntimeNotificationAction]]:
+    def plan(row: RelationshipRow) -> list[RuntimeNotificationAction]:
+        return [relationship_request_notification_action(row, user_repo=user_repo)]
+
+    return plan
+
+
+def relationship_request_notification_action(row: RelationshipRow, *, user_repo: Any) -> RuntimeNotificationAction:
+    requester_id = _requester_id(row)
+    target_id = _target_id(row, requester_id)
+    requester = require_user(user_repo, requester_id, context="Relationship request", role="requester")
+    return RuntimeNotificationAction(
+        context="Relationship request",
+        recipient_user_id=target_id,
+        sender_user_id=requester_id,
+        sender_source="relationship",
+        event_type="relationship.requested",
+        notification_type="relationship",
+        content=_notification_content(
+            display_name(requester, requester_id, context="Relationship request"),
+            row.message,
+        ),
+        metadata={"relationship_id": row.id},
+        include_sender_avatar=True,
+    )
 
 
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
+    planner = relationship_decision_notification_action_planner(user_repo)
+
     async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
-        requester_id = _requester_id(row)
-        decider_id = _target_id(row, requester_id)
-        verb = _decision_verb(event)
-        decider = require_user(user_repo, decider_id, context="Relationship request", role="decider")
-        await dispatch_runtime_notification_action(
+        actions = plan_event_actions([planner], RelationshipDecisionChange(row=row, event=event))
+        await dispatch_runtime_notification_actions(
             app,
-            RuntimeNotificationAction(
-                context="Relationship request",
-                recipient_user_id=requester_id,
-                sender_user_id=decider_id,
-                sender_source="relationship",
-                event_type=f"relationship.{verb}",
-                notification_type="relationship",
-                content=(f"{display_name(decider, decider_id, context='Relationship request')} {verb} your relationship request."),
-                metadata={
-                    "relationship_id": row.id,
-                    "event": event,
-                    "state": row.state,
-                },
-                include_sender_avatar=True,
-            ),
+            actions,
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
     return make_sync_runtime_event_hook(notify_runtime)
+
+
+def relationship_decision_notification_action_planner(
+    user_repo: Any,
+) -> Callable[[RelationshipDecisionChange], list[RuntimeNotificationAction]]:
+    def plan(change: RelationshipDecisionChange) -> list[RuntimeNotificationAction]:
+        return [relationship_decision_notification_action(change, user_repo=user_repo)]
+
+    return plan
+
+
+def relationship_decision_notification_action(change: RelationshipDecisionChange, *, user_repo: Any) -> RuntimeNotificationAction:
+    row = change.row
+    event = change.event
+    requester_id = _requester_id(row)
+    decider_id = _target_id(row, requester_id)
+    verb = _decision_verb(event)
+    decider = require_user(user_repo, decider_id, context="Relationship request", role="decider")
+    return RuntimeNotificationAction(
+        context="Relationship request",
+        recipient_user_id=requester_id,
+        sender_user_id=decider_id,
+        sender_source="relationship",
+        event_type=f"relationship.{verb}",
+        notification_type="relationship",
+        content=f"{display_name(decider, decider_id, context='Relationship request')} {verb} your relationship request.",
+        metadata={
+            "relationship_id": row.id,
+            "event": event,
+            "state": row.state,
+        },
+        include_sender_avatar=True,
+    )
 
 
 def _requester_id(row: RelationshipRow) -> str:

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -20,6 +20,41 @@ def _thread_repo() -> SimpleNamespace:
     )
 
 
+def test_chat_join_rejection_notification_planner_returns_runtime_action() -> None:
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+        }.get(uid)
+    )
+    planner = chat_join_inlet.chat_join_rejection_notification_action_planner(user_repo)
+
+    actions = planner(
+        {
+            "id": "chat_join:chat-1:agent-user-1",
+            "chat_id": "chat-1",
+            "requester_user_id": "agent-user-1",
+            "state": "rejected",
+            "decided_by_user_id": "owner-1",
+        }
+    )
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.context == "Chat join rejection"
+    assert action.recipient_user_id == "agent-user-1"
+    assert action.sender_user_id == "owner-1"
+    assert action.sender_source == "chat_join"
+    assert action.event_type == "chat.join.rejected"
+    assert action.notification_type == "chat_join"
+    assert action.content == "Owner rejected your request to join chat chat-1."
+    assert action.metadata == {
+        "chat_join_request_id": "chat_join:chat-1:agent-user-1",
+        "chat_id": "chat-1",
+        "state": "rejected",
+    }
+    assert action.include_sender_avatar is True
+
+
 @pytest.mark.asyncio
 async def test_chat_join_rejection_notification_dispatches_runtime_notification_to_agent_requester() -> None:
     class RecordingGateway:

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -44,6 +44,64 @@ def _thread_repo() -> SimpleNamespace:
     )
 
 
+def test_relationship_request_notification_planner_returns_runtime_action() -> None:
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+        }.get(uid)
+    )
+    planner = relationship_inlet.relationship_request_notification_action_planner(user_repo)
+
+    actions = planner(_relationship_row(message="Please add me."))
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.context == "Relationship request"
+    assert action.recipient_user_id == "agent-user-1"
+    assert action.sender_user_id == "human-user-1"
+    assert action.sender_source == "relationship"
+    assert action.event_type == "relationship.requested"
+    assert action.notification_type == "relationship"
+    assert action.content == (
+        "Human requested a relationship with you. Message: Please add me. "
+        "Review the pending relationship request in Mycel, then approve or reject it."
+    )
+    assert action.metadata == {"relationship_id": "hire_visit:agent-user-1:human-user-1"}
+    assert action.include_sender_avatar is True
+
+
+def test_relationship_decision_notification_planner_returns_runtime_action() -> None:
+    user_repo = SimpleNamespace(
+        get_by_id=lambda uid: {
+            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
+        }.get(uid)
+    )
+    planner = relationship_inlet.relationship_decision_notification_action_planner(user_repo)
+
+    actions = planner(
+        relationship_inlet.RelationshipDecisionChange(
+            row=_relationship_row(initiator_user_id="agent-user-1", state="visit"),
+            event="approve",
+        )
+    )
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.context == "Relationship request"
+    assert action.recipient_user_id == "agent-user-1"
+    assert action.sender_user_id == "human-user-1"
+    assert action.sender_source == "relationship"
+    assert action.event_type == "relationship.approved"
+    assert action.notification_type == "relationship"
+    assert action.content == "Human approved your relationship request."
+    assert action.metadata == {
+        "relationship_id": "hire_visit:agent-user-1:human-user-1",
+        "event": "approve",
+        "state": "visit",
+    }
+    assert action.include_sender_avatar is True
+
+
 @pytest.mark.asyncio
 async def test_relationship_request_notification_dispatches_runtime_notification_to_agent_target() -> None:
     class RecordingGateway:


### PR DESCRIPTION
## Summary
- route chat join rejection notifications through `plan_event_actions()` before runtime dispatch
- route relationship request and decision notifications through named event planners before runtime dispatch
- keep runtime recipient resolution and gateway dispatch inside the runtime notification action adapter

## Test Plan
- Red first: targeted notification tests failed on missing planner names
- `uv run pytest tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py`
- `uv run ruff check backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py && uv run ruff format --check backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py`
- `uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q`
- `uv run pytest tests/Unit -q`

## Scope
- No DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
