### PR TITLE
Route chat delivery through event planner

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -1,27 +1,39 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import Enum
 from typing import Any
 
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
 from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
-    dispatch_runtime_chat_delivery_action,
+    dispatch_runtime_chat_delivery_actions,
 )
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from core.event_actions import plan_event_actions
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
+    planner = chat_delivery_runtime_action_planner()
+
     async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
-        await dispatch_runtime_chat_delivery_action(
+        actions = plan_event_actions([planner], request)
+        await dispatch_runtime_chat_delivery_actions(
             app,
-            chat_delivery_runtime_action(request),
+            actions,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
     return make_sync_runtime_event_hook(deliver_to_runtime_gateway)
+
+
+def chat_delivery_runtime_action_planner() -> Callable[[ChatDeliveryRequest], list[RuntimeChatDeliveryAction]]:
+    def plan(request: ChatDeliveryRequest) -> list[RuntimeChatDeliveryAction]:
+        return [chat_delivery_runtime_action(request)]
+
+    return plan
 
 
 def chat_delivery_runtime_action(request: ChatDeliveryRequest) -> RuntimeChatDeliveryAction:

--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -29,6 +30,41 @@ class RuntimeChatDeliveryAction:
 
 
 async def dispatch_runtime_chat_delivery_action(
+    app: Any,
+    action: RuntimeChatDeliveryAction,
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> bool:
+    dispatched_count = await dispatch_runtime_chat_delivery_actions(
+        app,
+        [action],
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    return dispatched_count > 0
+
+
+async def dispatch_runtime_chat_delivery_actions(
+    app: Any,
+    actions: Iterable[RuntimeChatDeliveryAction],
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> int:
+    dispatched_count = 0
+    for action in actions:
+        if await _dispatch_runtime_chat_delivery_action(
+            app,
+            action,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        ):
+            dispatched_count += 1
+    return dispatched_count
+
+
+async def _dispatch_runtime_chat_delivery_action(
     app: Any,
     action: RuntimeChatDeliveryAction,
     *,

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -59,6 +59,30 @@ def test_chat_delivery_request_builds_runtime_action() -> None:
     )
 
 
+def test_chat_delivery_action_planner_returns_runtime_action() -> None:
+    planner = owner_chat_inlet.chat_delivery_runtime_action_planner()
+
+    actions = planner(
+        ChatDeliveryRequest(
+            recipient_id="agent-user-1",
+            recipient_user=SimpleNamespace(id="agent-user-1", type="agent"),
+            content="hello",
+            sender_name="Human",
+            sender_type="human",
+            chat_id="chat-1",
+            sender_id="human-user-1",
+            sender_avatar_url=None,
+            unread_count=2,
+            signal=None,
+        )
+    )
+
+    assert len(actions) == 1
+    assert actions[0].recipient_user_id == "agent-user-1"
+    assert actions[0].content == format_chat_notification("Human", "chat-1", 2, signal=None)
+    assert actions[0].raw_content == "hello"
+
+
 @pytest.mark.asyncio
 async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
     class FailingGateway:


### PR DESCRIPTION
## Summary
- route chat message delivery through `plan_event_actions()` before runtime dispatch
- add batch chat delivery dispatch so the inlet does not execute action lists itself
- keep single chat delivery dispatch as a wrapper over the batch primitive

## Test Plan
- Red first: chat delivery hook test failed on missing `chat_delivery_runtime_action_planner`
- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff check backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py && uv run ruff format --check backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/core/test_event_actions.py -q`
- `uv run pytest tests/Unit -q`

## Scope
- No DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
