### PR TITLE
Add single event action planner helper

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -10,7 +10,7 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     dispatch_runtime_chat_delivery_actions,
 )
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from core.event_actions import plan_event_actions
+from core.event_actions import plan_event_actions, single_event_action_planner
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
@@ -30,10 +30,7 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
 
 
 def chat_delivery_runtime_action_planner() -> Callable[[ChatDeliveryRequest], list[RuntimeChatDeliveryAction]]:
-    def plan(request: ChatDeliveryRequest) -> list[RuntimeChatDeliveryAction]:
-        return [chat_delivery_runtime_action(request)]
-
-    return plan
+    return single_event_action_planner(chat_delivery_runtime_action)
 
 
 def chat_delivery_runtime_action(request: ChatDeliveryRequest) -> RuntimeChatDeliveryAction:

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -9,7 +9,7 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
 )
-from core.event_actions import plan_event_actions
+from core.event_actions import plan_event_actions, single_event_action_planner
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -29,10 +29,10 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
 
 
 def chat_join_rejection_notification_action_planner(user_repo: Any) -> Callable[[dict[str, Any]], list[RuntimeNotificationAction]]:
-    def plan(row: dict[str, Any]) -> list[RuntimeNotificationAction]:
-        return [chat_join_rejection_notification_action(row, user_repo=user_repo)]
+    def make_action(row: dict[str, Any]) -> RuntimeNotificationAction:
+        return chat_join_rejection_notification_action(row, user_repo=user_repo)
 
-    return plan
+    return single_event_action_planner(make_action)
 
 
 def chat_join_rejection_notification_action(row: dict[str, Any], *, user_repo: Any) -> RuntimeNotificationAction:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -10,7 +10,7 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
 )
-from core.event_actions import plan_event_actions
+from core.event_actions import plan_event_actions, single_event_action_planner
 from messaging.contracts import RelationshipEvent, RelationshipRow
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
@@ -42,10 +42,10 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
 
 
 def relationship_request_notification_action_planner(user_repo: Any) -> Callable[[RelationshipRow], list[RuntimeNotificationAction]]:
-    def plan(row: RelationshipRow) -> list[RuntimeNotificationAction]:
-        return [relationship_request_notification_action(row, user_repo=user_repo)]
+    def make_action(row: RelationshipRow) -> RuntimeNotificationAction:
+        return relationship_request_notification_action(row, user_repo=user_repo)
 
-    return plan
+    return single_event_action_planner(make_action)
 
 
 def relationship_request_notification_action(row: RelationshipRow, *, user_repo: Any) -> RuntimeNotificationAction:
@@ -87,10 +87,10 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
 def relationship_decision_notification_action_planner(
     user_repo: Any,
 ) -> Callable[[RelationshipDecisionChange], list[RuntimeNotificationAction]]:
-    def plan(change: RelationshipDecisionChange) -> list[RuntimeNotificationAction]:
-        return [relationship_decision_notification_action(change, user_repo=user_repo)]
+    def make_action(change: RelationshipDecisionChange) -> RuntimeNotificationAction:
+        return relationship_decision_notification_action(change, user_repo=user_repo)
 
-    return plan
+    return single_event_action_planner(make_action)
 
 
 def relationship_decision_notification_action(change: RelationshipDecisionChange, *, user_repo: Any) -> RuntimeNotificationAction:

--- a/core/event_actions.py
+++ b/core/event_actions.py
@@ -17,6 +17,15 @@ def plan_event_actions[EventT, ActionT](
     return planned_actions
 
 
+def single_event_action_planner[EventT, ActionT](
+    action: Callable[[EventT], ActionT],
+) -> Callable[[EventT], list[ActionT]]:
+    def plan(event: EventT) -> list[ActionT]:
+        return [action(event)]
+
+    return plan
+
+
 def run_sync_actions(
     actions: Iterable[Callable[..., None]],
     /,

--- a/tests/Unit/core/test_event_actions.py
+++ b/tests/Unit/core/test_event_actions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from core.event_actions import plan_event_actions, run_sync_actions
+from core.event_actions import plan_event_actions, run_sync_actions, single_event_action_planner
 
 
 def test_plan_event_actions_flattens_planners_in_order() -> None:
@@ -32,6 +32,12 @@ def test_plan_event_actions_snapshots_planners_before_running() -> None:
     actions = plan_event_actions(planners, "event-1")
 
     assert actions == ["first:event-1"]
+
+
+def test_single_event_action_planner_wraps_one_action_value() -> None:
+    planner = single_event_action_planner(lambda value: f"action:{value}")
+
+    assert planner("event-1") == ["action:event-1"]
 
 
 def test_run_sync_actions_runs_registered_actions_in_order() -> None:


### PR DESCRIPTION
## Summary
- add `single_event_action_planner()` for the common one-event -> one-action case
- replace repeated one-action planner wrappers in chat delivery, chat join, and relationship inlets
- keep explicit domain action builders and typed planner return surfaces

## Test Plan
- Red first: core event action test failed on missing `single_event_action_planner`
- `uv run pytest tests/Unit/core/test_event_actions.py -q`
- `uv run pyright --pythonversion 3.12 core/event_actions.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py`
- `uv run ruff check core/event_actions.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py && uv run ruff format --check core/event_actions.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py`
- `uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q`
- `uv run pytest tests/Unit -q`

## Scope
- No DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
