### PR TITLE
Add planned runtime event hook

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -9,16 +9,15 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
     dispatch_runtime_chat_delivery_actions,
 )
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
-from core.event_actions import plan_event_actions, single_event_action_planner
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
+from core.event_actions import single_event_action_planner
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
     planner = chat_delivery_runtime_action_planner()
 
-    async def deliver_to_runtime_gateway(request: ChatDeliveryRequest) -> None:
-        actions = plan_event_actions([planner], request)
+    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> None:
         await dispatch_runtime_chat_delivery_actions(
             app,
             actions,
@@ -26,7 +25,7 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(deliver_to_runtime_gateway)
+    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
 
 
 def chat_delivery_runtime_action_planner() -> Callable[[ChatDeliveryRequest], list[RuntimeChatDeliveryAction]]:

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -3,20 +3,19 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
 )
-from core.event_actions import plan_event_actions, single_event_action_planner
+from core.event_actions import single_event_action_planner
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = chat_join_rejection_notification_action_planner(user_repo)
 
-    async def notify_runtime(row: dict[str, Any]) -> None:
-        actions = plan_event_actions([planner], row)
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
         await dispatch_runtime_notification_actions(
             app,
             actions,
@@ -25,7 +24,7 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(notify_runtime)
+    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
 
 
 def chat_join_rejection_notification_action_planner(user_repo: Any) -> Callable[[dict[str, Any]], list[RuntimeNotificationAction]]:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -4,13 +4,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
 )
-from core.event_actions import plan_event_actions, single_event_action_planner
+from core.event_actions import single_event_action_planner
 from messaging.contracts import RelationshipEvent, RelationshipRow
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
@@ -28,8 +28,7 @@ class RelationshipDecisionChange:
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = relationship_request_notification_action_planner(user_repo)
 
-    async def notify_runtime(row: RelationshipRow) -> None:
-        actions = plan_event_actions([planner], row)
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
         await dispatch_runtime_notification_actions(
             app,
             actions,
@@ -38,7 +37,7 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(notify_runtime)
+    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
 
 
 def relationship_request_notification_action_planner(user_repo: Any) -> Callable[[RelationshipRow], list[RuntimeNotificationAction]]:
@@ -71,8 +70,7 @@ def relationship_request_notification_action(row: RelationshipRow, *, user_repo:
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = relationship_decision_notification_action_planner(user_repo)
 
-    async def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
-        actions = plan_event_actions([planner], RelationshipDecisionChange(row=row, event=event))
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
         await dispatch_runtime_notification_actions(
             app,
             actions,
@@ -81,7 +79,12 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(notify_runtime)
+    planned_hook = make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+
+    def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
+        planned_hook(RelationshipDecisionChange(row=row, event=event))
+
+    return notify_runtime
 
 
 def relationship_decision_notification_action_planner(

--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from typing import Any
+
+from core.event_actions import plan_event_actions
 
 
 def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, None]]) -> Callable[P, None]:
@@ -19,3 +21,14 @@ def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, 
         future.result()
 
     return hook
+
+
+def make_sync_planned_runtime_event_hook[EventT, ActionT](
+    planner: Callable[[EventT], Iterable[ActionT]],
+    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, None]],
+) -> Callable[[EventT], None]:
+    async def run(event: EventT) -> None:
+        actions = plan_event_actions([planner], event)
+        await dispatch_actions(actions)
+
+    return make_sync_runtime_event_hook(run)

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
 )
-from core.event_actions import plan_event_actions
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -23,8 +22,7 @@ def make_workflow_event_notification_fn(
 ) -> Callable[[WorkflowEventChange], None]:
     planner = workflow_event_notification_action_planner(messaging_service)
 
-    async def notify_runtime(change: WorkflowEventChange) -> None:
-        actions = plan_event_actions([planner], change)
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
         await dispatch_runtime_notification_actions(
             app,
             actions,
@@ -33,7 +31,7 @@ def make_workflow_event_notification_fn(
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(notify_runtime)
+    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
 
 
 def workflow_event_notification_action_planner(messaging_service: Any) -> Callable[[WorkflowEventChange], list[RuntimeNotificationAction]]:

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook, make_sync_runtime_event_hook
 
 
 @pytest.mark.asyncio
@@ -32,3 +32,20 @@ async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> No
         hook()
 
     assert str(exc.value) == "Sync runtime event hook cannot run on its owner event loop thread"
+
+
+@pytest.mark.asyncio
+async def test_sync_planned_runtime_event_hook_plans_and_dispatches_actions_from_worker_thread() -> None:
+    calls: list[list[str]] = []
+
+    def planner(value: str) -> list[str]:
+        return [f"planned:{value}"]
+
+    async def dispatch(actions: list[str]) -> None:
+        calls.append(actions)
+
+    hook = make_sync_planned_runtime_event_hook(planner, dispatch)
+
+    await asyncio.to_thread(hook, "event-1")
+
+    assert calls == [["planned:event-1"]]


### PR DESCRIPTION
## Summary
- add `make_sync_planned_runtime_event_hook()` for the repeated plan-then-dispatch runtime hook shape
- route chat delivery, chat join, relationship, and workflow runtime hooks through the shared planned hook
- keep domain action builders and runtime adapter dispatch helpers explicit

## Test Plan
- Red first: runtime hook test failed on missing `make_sync_planned_runtime_event_hook`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py && uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run pytest tests/Unit -q`

## Scope
- No DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
