### PR TITLE
Add runtime notification event hook

### DIFF
--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -3,28 +3,23 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_actions,
+    make_runtime_notification_event_hook,
 )
 from core.event_actions import single_event_action_planner
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = chat_join_rejection_notification_action_planner(user_repo)
-
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
-        await dispatch_runtime_notification_actions(
-            app,
-            actions,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-
-    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+    return make_runtime_notification_event_hook(
+        app,
+        planner,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
 
 
 def chat_join_rejection_notification_action_planner(user_repo: Any) -> Callable[[dict[str, Any]], list[RuntimeNotificationAction]]:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -4,11 +4,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_actions,
+    make_runtime_notification_event_hook,
 )
 from core.event_actions import single_event_action_planner
 from messaging.contracts import RelationshipEvent, RelationshipRow
@@ -27,17 +26,13 @@ class RelationshipDecisionChange:
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = relationship_request_notification_action_planner(user_repo)
-
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
-        await dispatch_runtime_notification_actions(
-            app,
-            actions,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-
-    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+    return make_runtime_notification_event_hook(
+        app,
+        planner,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
 
 
 def relationship_request_notification_action_planner(user_repo: Any) -> Callable[[RelationshipRow], list[RuntimeNotificationAction]]:
@@ -69,17 +64,13 @@ def relationship_request_notification_action(row: RelationshipRow, *, user_repo:
 
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = relationship_decision_notification_action_planner(user_repo)
-
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
-        await dispatch_runtime_notification_actions(
-            app,
-            actions,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-
-    planned_hook = make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+    planned_hook = make_runtime_notification_event_hook(
+        app,
+        planner,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
 
     def notify_runtime(row: RelationshipRow, event: RelationshipEvent) -> None:
         planned_hook(RelationshipDecisionChange(row=row, event=event))

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
 from protocols.agent_runtime import (
@@ -27,6 +28,26 @@ class RuntimeNotificationAction:
     transport: AgentRuntimeTransport = AgentRuntimeTransport()
     include_sender_avatar: bool = False
     runtime_context: str | None = None
+
+
+def make_runtime_notification_event_hook[EventT](
+    app: Any,
+    planner: Callable[[EventT], Iterable[RuntimeNotificationAction]],
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> Callable[[EventT], None]:
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
+        await dispatch_runtime_notification_actions(
+            app,
+            actions,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+
+    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
 
 
 async def dispatch_runtime_notification_action(

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_actions,
+    make_runtime_notification_event_hook,
 )
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentRuntimeTransport
@@ -21,17 +20,13 @@ def make_workflow_event_notification_fn(
     messaging_service: Any,
 ) -> Callable[[WorkflowEventChange], None]:
     planner = workflow_event_notification_action_planner(messaging_service)
-
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
-        await dispatch_runtime_notification_actions(
-            app,
-            actions,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-
-    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+    return make_runtime_notification_event_hook(
+        app,
+        planner,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
 
 
 def workflow_event_notification_action_planner(messaging_service: Any) -> Callable[[WorkflowEventChange], list[RuntimeNotificationAction]]:

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -8,6 +9,7 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_action,
     dispatch_runtime_notification_actions,
+    make_runtime_notification_event_hook,
 )
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -120,3 +122,41 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
 
     assert dispatched_count == 1
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_notification_event_hook_plans_and_dispatches_actions_from_worker_thread() -> None:
+    class RecordingGateway:
+        def __init__(self) -> None:
+            self.envelopes = []
+
+        async def dispatch_notification(self, envelope):
+            self.envelopes.append(envelope)
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+    gateway = RecordingGateway()
+
+    def planner(value: str) -> list[RuntimeNotificationAction]:
+        return [
+            RuntimeNotificationAction(
+                context="Test hook",
+                recipient_user_id="agent-1",
+                sender_user_id="owner-1",
+                sender_source="workflow",
+                event_type="test.event",
+                notification_type="test",
+                content=f"Action {value}.",
+            )
+        ]
+
+    hook = make_runtime_notification_event_hook(
+        _runtime_app(gateway),
+        planner,
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    await asyncio.to_thread(hook, "event-1")
+
+    assert [envelope.message.content for envelope in gateway.envelopes] == ["Action event-1."]

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -191,7 +191,6 @@ async def test_workflow_event_notification_fn_selects_runtime_members() -> None:
     )
 
     await asyncio.to_thread(notify, _change("updated"))
-
     envelopes = gateway.envelopes
     assert [envelope.recipient.agent_user_id for envelope in envelopes] == ["agent-1", "external-1"]
     assert [envelope.recipient.runtime_source for envelope in envelopes] == ["mycel", "external"]
@@ -235,24 +234,3 @@ async def test_workflow_event_notification_fn_skips_gateway_when_no_runtime_reci
     )
 
     await asyncio.to_thread(notify, _change("updated"))
-
-
-@pytest.mark.asyncio
-async def test_workflow_event_notification_fn_reads_members_and_schedules_runtime_delivery() -> None:
-    gateway = _RecordingGateway()
-    messaging_service = SimpleNamespace(list_chat_members=lambda chat_id: [{"user_id": "owner-1"}, {"user_id": "agent-1"}])
-    notify = make_workflow_event_notification_fn(
-        _runtime_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=_thread_repo("agent-1"),
-        user_repo=_users("agent-1"),
-        messaging_service=messaging_service,
-    )
-
-    await asyncio.to_thread(
-        notify,
-        _change(),
-    )
-
-    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
-    assert gateway.envelopes[0].transport.delivery_id == "workflow:chat-1:event-1:3"

--- a/tests/Unit/integration_contracts/test_background_task_cleanup.py
+++ b/tests/Unit/integration_contracts/test_background_task_cleanup.py
@@ -62,7 +62,7 @@ class _SlowChildAgent:
     async def _cleanup_background_runs(self):
         pass
 
-    def close(self):
+    def close(self, _cleanup_sandbox: bool = True):
         self.closed = True
 
 
@@ -86,7 +86,7 @@ class _CompleteChildAgent:
     async def _cleanup_background_runs(self):
         pass
 
-    def close(self):
+    def close(self, _cleanup_sandbox: bool = True):
         self.closed = True
 
 


### PR DESCRIPTION
## Summary
- add a runtime notification event hook helper that combines planned event actions with the existing runtime notification dispatcher
- route chat join, relationship, and workflow notification inlets through that helper
- remove one duplicated workflow notification hook test now covered by planner/action tests plus the shared runtime notification hook test
- align background task cleanup test fakes with the production `close(cleanup_sandbox=...)` call that Windows CI exposed

## Test Plan
- Red first: `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py -q` failed on missing `make_runtime_notification_event_hook`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/integration_contracts/test_background_task_cleanup.py::test_background_agent_completion_notification_waits_for_followthrough_run -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/integration_contracts/test_background_task_cleanup.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/integration_contracts/test_background_task_cleanup.py && uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/integration_contracts/test_background_task_cleanup.py`
- `uv run pytest tests/Unit -q`

## Scope
- No DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
- Chat delivery and failure contracts are unchanged.
