### PR TITLE
Plan chat delivery envelopes before dispatch

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -54,23 +54,51 @@ async def dispatch_runtime_chat_delivery_actions(
 ) -> int:
     dispatched_count = 0
     for action in actions:
-        if await _dispatch_runtime_chat_delivery_action(
-            app,
+        envelope = plan_runtime_chat_delivery_envelope(
             action,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-        ):
-            dispatched_count += 1
+        )
+        if envelope is None:
+            continue
+        await dispatch_runtime_chat_delivery_envelopes(app, [envelope])
+        dispatched_count += 1
     return dispatched_count
 
 
-async def _dispatch_runtime_chat_delivery_action(
-    app: Any,
+async def dispatch_runtime_chat_delivery_envelopes(app: Any, envelopes: Iterable[AgentChatDeliveryEnvelope]) -> None:
+    current_envelopes = list(envelopes)
+    if not current_envelopes:
+        return
+    gateway = get_agent_runtime_gateway(app)
+    for envelope in current_envelopes:
+        await gateway.dispatch_chat(envelope)
+
+
+def plan_runtime_chat_delivery_envelopes(
+    actions: Iterable[RuntimeChatDeliveryAction],
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> list[AgentChatDeliveryEnvelope]:
+    envelopes: list[AgentChatDeliveryEnvelope] = []
+    for action in actions:
+        envelope = plan_runtime_chat_delivery_envelope(
+            action,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if envelope is not None:
+            envelopes.append(envelope)
+    return envelopes
+
+
+def plan_runtime_chat_delivery_envelope(
     action: RuntimeChatDeliveryAction,
     *,
     thread_repo: Any,
     activity_reader: Any,
-) -> bool:
+) -> AgentChatDeliveryEnvelope | None:
     recipient = resolve_runtime_chat_delivery_recipient(
         action.recipient_id,
         action.recipient_user_type,
@@ -78,26 +106,23 @@ async def _dispatch_runtime_chat_delivery_action(
         activity_reader=activity_reader,
     )
     if recipient is None:
-        return False
-    await get_agent_runtime_gateway(app).dispatch_chat(
-        AgentChatDeliveryEnvelope(
-            chat=AgentChatContext(chat_id=action.chat_id),
-            sender=runtime_actor(
-                user_id=action.sender_id,
-                user_type=action.sender_type,
-                display_name=action.sender_name,
-                avatar_url=action.sender_avatar_url,
-                source="chat",
-            ),
-            recipient=recipient,
-            message=AgentRuntimeMessage(content=action.content, signal=action.signal),
-            extensions={
-                "mycel": {
-                    "recipient_user_id": action.recipient_user_id,
-                    "recipient_user_type": action.recipient_user_type,
-                    "raw_content": action.raw_content,
-                }
-            },
-        )
+        return None
+    return AgentChatDeliveryEnvelope(
+        chat=AgentChatContext(chat_id=action.chat_id),
+        sender=runtime_actor(
+            user_id=action.sender_id,
+            user_type=action.sender_type,
+            display_name=action.sender_name,
+            avatar_url=action.sender_avatar_url,
+            source="chat",
+        ),
+        recipient=recipient,
+        message=AgentRuntimeMessage(content=action.content, signal=action.signal),
+        extensions={
+            "mycel": {
+                "recipient_user_id": action.recipient_user_id,
+                "recipient_user_type": action.recipient_user_type,
+                "raw_content": action.raw_content,
+            }
+        },
     )
-    return True

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -7,7 +7,11 @@ import pytest
 
 from backend.threads.chat_adapters import chat_inlet as owner_chat_inlet
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
-from backend.threads.chat_adapters.runtime_chat_delivery_action import RuntimeChatDeliveryAction
+from backend.threads.chat_adapters.runtime_chat_delivery_action import (
+    RuntimeChatDeliveryAction,
+    dispatch_runtime_chat_delivery_actions,
+    plan_runtime_chat_delivery_envelope,
+)
 from messaging.delivery.dispatcher import ChatDeliveryRequest
 
 
@@ -26,6 +30,24 @@ def _hook_app(gateway: object) -> SimpleNamespace:
             ),
         )
     )
+
+
+def _runtime_chat_action(**overrides) -> RuntimeChatDeliveryAction:
+    values = {
+        "chat_id": "chat-1",
+        "recipient_id": "agent-user-1",
+        "recipient_user_id": "agent-user-1",
+        "recipient_user_type": "agent",
+        "sender_id": "human-user-1",
+        "sender_type": "human",
+        "sender_name": "Human",
+        "sender_avatar_url": None,
+        "content": "rendered chat reminder",
+        "raw_content": "raw chat message",
+        "signal": None,
+    }
+    values.update(overrides)
+    return RuntimeChatDeliveryAction(**values)
 
 
 def test_chat_delivery_request_builds_runtime_action() -> None:
@@ -81,6 +103,66 @@ def test_chat_delivery_action_planner_returns_runtime_action() -> None:
     assert actions[0].recipient_user_id == "agent-user-1"
     assert actions[0].content == format_chat_notification("Human", "chat-1", 2, signal=None)
     assert actions[0].raw_content == "hello"
+
+
+def test_runtime_chat_delivery_action_plans_runtime_envelope() -> None:
+    action = _runtime_chat_action(signal="urgent")
+
+    envelope = plan_runtime_chat_delivery_envelope(
+        action,
+        thread_repo=_hook_app(object()).state.thread_repo,
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert envelope is not None
+    assert envelope.chat.chat_id == "chat-1"
+    assert envelope.recipient.agent_user_id == "agent-user-1"
+    assert envelope.recipient.thread_id == "thread-1"
+    assert envelope.sender.user_id == "human-user-1"
+    assert envelope.sender.source == "chat"
+    assert envelope.message.content == "rendered chat reminder"
+    assert envelope.message.signal == "urgent"
+    assert envelope.extensions == {
+        "mycel": {
+            "recipient_user_id": "agent-user-1",
+            "recipient_user_type": "agent",
+            "raw_content": "raw chat message",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_chat_delivery_actions_dispatches_prior_envelopes_before_later_planning_failure() -> None:
+    class RecordingGateway:
+        def __init__(self) -> None:
+            self.envelopes = []
+
+        async def dispatch_chat(self, envelope):
+            self.envelopes.append(envelope)
+
+    gateway = RecordingGateway()
+
+    with pytest.raises(RuntimeError, match="Managed agent runtime is unavailable for chat delivery to agent-user-1"):
+        await dispatch_runtime_chat_delivery_actions(
+            _hook_app(gateway),
+            [
+                _runtime_chat_action(
+                    recipient_id="external-user-1",
+                    recipient_user_id="external-user-1",
+                    recipient_user_type="external",
+                    content="external reminder",
+                    raw_content="raw external",
+                ),
+                _runtime_chat_action(
+                    content="agent reminder",
+                    raw_content="raw agent",
+                ),
+            ],
+            thread_repo=object(),
+            activity_reader=None,
+        )
+
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["external-user-1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- split chat delivery runtime actions into action -> envelope planning and envelope dispatch boundaries
- keep batch dispatch semantics loud and ordered by planning/dispatching one action at a time
- add coverage for the planned chat delivery envelope and for preserving prior dispatch before a later planning failure

## Test Plan
- Red first: `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q` failed on missing `plan_runtime_chat_delivery_envelope`
- Red semantics guard: `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py::test_runtime_chat_delivery_actions_dispatches_prior_envelopes_before_later_planning_failure -q` failed while batch planning happened before dispatch
- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_agent_runtime_gateway_chat_delivery.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py -q`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py && uv run ruff format --check backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pytest tests/Unit -q`

## Scope
- No chat delivery hook helper added.
- No UX, DSL, retry/outbox, polling, schema, transport, local daemon, or durable action-attempt store added.
