### PR TITLE
Plan thread input envelopes before dispatch

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_identity import runtime_actor
-from protocols.agent_runtime import AgentRuntimeMessage, AgentThreadInputEnvelope
+from protocols.agent_runtime import AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
 
 
 @dataclass(frozen=True)
@@ -94,20 +95,34 @@ def internal_runtime_thread_input_action(
 
 
 async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction):
-    return await get_agent_runtime_gateway(app).dispatch_thread_input(
-        AgentThreadInputEnvelope(
-            thread_id=action.thread_id,
-            sender=runtime_actor(
-                user_id=action.sender_user_id,
-                user_type=action.sender_user_type,
-                display_name=action.sender_display_name,
-                source=action.sender_source,
-            ),
-            message=AgentRuntimeMessage(
-                content=action.content,
-                attachments=action.attachments,
-                metadata=action.metadata,
-            ),
-            enable_trajectory=action.enable_trajectory,
-        )
+    results = await dispatch_runtime_thread_input_envelopes(app, [plan_runtime_thread_input_envelope(action)])
+    return results[0]
+
+
+async def dispatch_runtime_thread_input_envelopes(
+    app: Any,
+    envelopes: Iterable[AgentThreadInputEnvelope],
+) -> list[AgentThreadInputResult]:
+    gateway = get_agent_runtime_gateway(app)
+    results = []
+    for envelope in envelopes:
+        results.append(await gateway.dispatch_thread_input(envelope))
+    return results
+
+
+def plan_runtime_thread_input_envelope(action: RuntimeThreadInputAction) -> AgentThreadInputEnvelope:
+    return AgentThreadInputEnvelope(
+        thread_id=action.thread_id,
+        sender=runtime_actor(
+            user_id=action.sender_user_id,
+            user_type=action.sender_user_type,
+            display_name=action.sender_display_name,
+            source=action.sender_source,
+        ),
+        message=AgentRuntimeMessage(
+            content=action.content,
+            attachments=action.attachments,
+            metadata=action.metadata,
+        ),
+        enable_trajectory=action.enable_trajectory,
     )

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -17,8 +17,10 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     QueuedThreadInputAction,
     RuntimeThreadInputAction,
     dispatch_queued_thread_input_action,
+    dispatch_runtime_thread_input_envelopes,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
+    plan_runtime_thread_input_envelope,
     queued_command_thread_input_action,
     queued_thread_input_action,
     requeue_thread_input_item,
@@ -242,6 +244,54 @@ def test_internal_thread_input_action_carries_followup_contract() -> None:
         metadata={"ask_user_question_answered": {"request_id": "req-1"}},
         enable_trajectory=False,
     )
+
+
+def test_runtime_thread_input_action_plans_runtime_envelope() -> None:
+    from protocols.agent_runtime import AgentRuntimeActor, AgentRuntimeMessage, AgentThreadInputEnvelope
+
+    action = owner_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="hello",
+        attachments=["file-1"],
+        enable_trajectory=True,
+    )
+
+    envelope = plan_runtime_thread_input_envelope(action)
+
+    assert envelope == AgentThreadInputEnvelope(
+        thread_id="thread-1",
+        sender=AgentRuntimeActor(user_id="owner-1", user_type="human", display_name="Owner", source="owner"),
+        message=AgentRuntimeMessage(content="hello", attachments=["file-1"]),
+        enable_trajectory=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_thread_input_envelopes_dispatch_through_gateway() -> None:
+    from protocols.agent_runtime import AgentThreadInputResult
+
+    captured: list[Any] = []
+
+    class _Gateway:
+        async def dispatch_thread_input(self, envelope: Any) -> AgentThreadInputResult:
+            captured.append(envelope)
+            return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
+
+    action = internal_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="answer",
+        metadata={"request_id": "req-1"},
+    )
+    envelope = plan_runtime_thread_input_envelope(action)
+
+    await dispatch_runtime_thread_input_envelopes(
+        SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=_Gateway()))),
+        [envelope],
+    )
+
+    assert captured == [envelope]
 
 
 def test_queued_thread_input_action_enqueues_steer_message() -> None:


### PR DESCRIPTION
## Summary

- split runtime thread input action handling into envelope planning and envelope dispatch
- keep dispatch_runtime_thread_input_action return semantics unchanged
- add contract coverage for thread input envelope planning and gateway dispatch

## Verification

- uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_runtime_thread_input_action_plans_runtime_envelope -q (red before implementation: missing import)
- uv run pytest tests/Unit/integration_contracts/test_threads_router.py::test_runtime_thread_input_action_plans_runtime_envelope tests/Unit/integration_contracts/test_threads_router.py::test_runtime_thread_input_envelopes_dispatch_through_gateway -q
- uv run pytest tests/Unit/integration_contracts/test_threads_router.py tests/Unit/backend/web/services/test_agent_runtime_gateway_thread_input.py tests/Unit/backend/web/services/test_agent_runtime_gateway_handler_split.py -q
- uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
- uv run ruff check backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py && uv run ruff format --check backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py
- uv run pytest tests/Unit -q
