### PR TITLE
Align background cleanup test fake close signature

### DIFF
--- a/tests/Unit/integration_contracts/test_background_task_cleanup.py
+++ b/tests/Unit/integration_contracts/test_background_task_cleanup.py
@@ -62,7 +62,7 @@ class _SlowChildAgent:
     async def _cleanup_background_runs(self):
         pass
 
-    def close(self, _cleanup_sandbox: bool = True):
+    def close(self, cleanup_sandbox: bool = True):
         self.closed = True
 
 
@@ -86,7 +86,7 @@ class _CompleteChildAgent:
     async def _cleanup_background_runs(self):
         pass
 
-    def close(self, _cleanup_sandbox: bool = True):
+    def close(self, cleanup_sandbox: bool = True):
         self.closed = True
 
 


### PR DESCRIPTION
## Summary

- align background cleanup child-agent test fakes with the production close(cleanup_sandbox=...) call shape
- fixes the latent Windows CI timeout path exposed after the #1437 dev merge

## Verification

- uv run pytest tests/Unit/integration_contracts/test_background_task_cleanup.py -q
- uv run ruff check tests/Unit/integration_contracts/test_background_task_cleanup.py && uv run ruff format --check tests/Unit/integration_contracts/test_background_task_cleanup.py
- uv run pyright --pythonversion 3.12 tests/Unit/integration_contracts/test_background_task_cleanup.py
