### PR TITLE
Remove unused multi-planner event helper

### DIFF
--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -4,8 +4,6 @@ import asyncio
 from collections.abc import Callable, Coroutine, Iterable
 from typing import Any
 
-from core.event_actions import plan_event_actions
-
 
 def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, None]]) -> Callable[P, None]:
     loop = asyncio.get_running_loop()
@@ -28,7 +26,7 @@ def make_sync_planned_runtime_event_hook[EventT, ActionT](
     dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, None]],
 ) -> Callable[[EventT], None]:
     async def run(event: EventT) -> None:
-        actions = plan_event_actions([planner], event)
+        actions = list(planner(event))
         await dispatch_actions(actions)
 
     return make_sync_runtime_event_hook(run)

--- a/core/event_actions.py
+++ b/core/event_actions.py
@@ -4,19 +4,6 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 
-def plan_event_actions[EventT, ActionT](
-    planners: Iterable[Callable[[EventT], Iterable[ActionT]]],
-    event: EventT,
-) -> list[ActionT]:
-    current_planners = list(planners)
-    if not current_planners:
-        return []
-    planned_actions: list[ActionT] = []
-    for planner in current_planners:
-        planned_actions.extend(planner(event))
-    return planned_actions
-
-
 def single_event_action_planner[EventT, ActionT](
     action: Callable[[EventT], ActionT],
 ) -> Callable[[EventT], list[ActionT]]:

--- a/tests/Unit/core/test_event_actions.py
+++ b/tests/Unit/core/test_event_actions.py
@@ -2,36 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from core.event_actions import plan_event_actions, run_sync_actions, single_event_action_planner
-
-
-def test_plan_event_actions_flattens_planners_in_order() -> None:
-    def first(value: str) -> list[str]:
-        return [f"first:{value}", f"first-again:{value}"]
-
-    def second(value: str) -> list[str]:
-        return [f"second:{value}"]
-
-    actions = plan_event_actions([first, second], "event-1")
-
-    assert actions == ["first:event-1", "first-again:event-1", "second:event-1"]
-
-
-def test_plan_event_actions_snapshots_planners_before_running() -> None:
-    planners = []
-
-    def first(value: str) -> list[str]:
-        planners.append(second)
-        return [f"first:{value}"]
-
-    def second(value: str) -> list[str]:
-        return [f"second:{value}"]
-
-    planners.append(first)
-
-    actions = plan_event_actions(planners, "event-1")
-
-    assert actions == ["first:event-1"]
+from core.event_actions import run_sync_actions, single_event_action_planner
 
 
 def test_single_event_action_planner_wraps_one_action_value() -> None:


### PR DESCRIPTION
## Summary

- remove unused plan_event_actions multi-planner helper
- have planned runtime hooks call their single planner directly
- delete tests for unsupported multi-planner width that no production code used

## Verification

- rg -n "plan_event_actions" core backend tests -g "*.py" (no hits)
- uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_runtime_event_hook.py -q
- uv run pyright --pythonversion 3.12 core/event_actions.py backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/core/test_event_actions.py
- uv run ruff check core/event_actions.py backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/core/test_event_actions.py && uv run ruff format --check core/event_actions.py backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/core/test_event_actions.py
- uv run pytest tests/Unit -q
