### PR TITLE
Remove unused event planner helpers

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -10,7 +10,6 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     dispatch_runtime_chat_delivery_actions,
 )
 from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
-from core.event_actions import single_event_action_planner
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
@@ -29,7 +28,10 @@ def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
 
 
 def chat_delivery_runtime_action_planner() -> Callable[[ChatDeliveryRequest], list[RuntimeChatDeliveryAction]]:
-    return single_event_action_planner(chat_delivery_runtime_action)
+    def plan(request: ChatDeliveryRequest) -> list[RuntimeChatDeliveryAction]:
+        return [chat_delivery_runtime_action(request)]
+
+    return plan
 
 
 def chat_delivery_runtime_action(request: ChatDeliveryRequest) -> RuntimeChatDeliveryAction:

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -8,7 +8,6 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     make_runtime_notification_event_hook,
 )
-from core.event_actions import single_event_action_planner
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
@@ -23,10 +22,10 @@ def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, 
 
 
 def chat_join_rejection_notification_action_planner(user_repo: Any) -> Callable[[dict[str, Any]], list[RuntimeNotificationAction]]:
-    def make_action(row: dict[str, Any]) -> RuntimeNotificationAction:
-        return chat_join_rejection_notification_action(row, user_repo=user_repo)
+    def plan(row: dict[str, Any]) -> list[RuntimeNotificationAction]:
+        return [chat_join_rejection_notification_action(row, user_repo=user_repo)]
 
-    return single_event_action_planner(make_action)
+    return plan
 
 
 def chat_join_rejection_notification_action(row: dict[str, Any], *, user_repo: Any) -> RuntimeNotificationAction:

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -9,7 +9,6 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     make_runtime_notification_event_hook,
 )
-from core.event_actions import single_event_action_planner
 from messaging.contracts import RelationshipEvent, RelationshipRow
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
@@ -36,10 +35,10 @@ def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any,
 
 
 def relationship_request_notification_action_planner(user_repo: Any) -> Callable[[RelationshipRow], list[RuntimeNotificationAction]]:
-    def make_action(row: RelationshipRow) -> RuntimeNotificationAction:
-        return relationship_request_notification_action(row, user_repo=user_repo)
+    def plan(row: RelationshipRow) -> list[RuntimeNotificationAction]:
+        return [relationship_request_notification_action(row, user_repo=user_repo)]
 
-    return single_event_action_planner(make_action)
+    return plan
 
 
 def relationship_request_notification_action(row: RelationshipRow, *, user_repo: Any) -> RuntimeNotificationAction:
@@ -81,10 +80,10 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
 def relationship_decision_notification_action_planner(
     user_repo: Any,
 ) -> Callable[[RelationshipDecisionChange], list[RuntimeNotificationAction]]:
-    def make_action(change: RelationshipDecisionChange) -> RuntimeNotificationAction:
-        return relationship_decision_notification_action(change, user_repo=user_repo)
+    def plan(change: RelationshipDecisionChange) -> list[RuntimeNotificationAction]:
+        return [relationship_decision_notification_action(change, user_repo=user_repo)]
 
-    return single_event_action_planner(make_action)
+    return plan
 
 
 def relationship_decision_notification_action(change: RelationshipDecisionChange, *, user_repo: Any) -> RuntimeNotificationAction:

--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -75,24 +75,6 @@ async def dispatch_runtime_chat_delivery_envelopes(app: Any, envelopes: Iterable
         await gateway.dispatch_chat(envelope)
 
 
-def plan_runtime_chat_delivery_envelopes(
-    actions: Iterable[RuntimeChatDeliveryAction],
-    *,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> list[AgentChatDeliveryEnvelope]:
-    envelopes: list[AgentChatDeliveryEnvelope] = []
-    for action in actions:
-        envelope = plan_runtime_chat_delivery_envelope(
-            action,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-        if envelope is not None:
-            envelopes.append(envelope)
-    return envelopes
-
-
 def plan_runtime_chat_delivery_envelope(
     action: RuntimeChatDeliveryAction,
     *,

--- a/core/event_actions.py
+++ b/core/event_actions.py
@@ -4,15 +4,6 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 
-def single_event_action_planner[EventT, ActionT](
-    action: Callable[[EventT], ActionT],
-) -> Callable[[EventT], list[ActionT]]:
-    def plan(event: EventT) -> list[ActionT]:
-        return [action(event)]
-
-    return plan
-
-
 def run_sync_actions(
     actions: Iterable[Callable[..., None]],
     /,

--- a/tests/Unit/core/test_event_actions.py
+++ b/tests/Unit/core/test_event_actions.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from core.event_actions import run_sync_actions, single_event_action_planner
-
-
-def test_single_event_action_planner_wraps_one_action_value() -> None:
-    planner = single_event_action_planner(lambda value: f"action:{value}")
-
-    assert planner("event-1") == ["action:event-1"]
+from core.event_actions import run_sync_actions
 
 
 def test_run_sync_actions_runs_registered_actions_in_order() -> None:


### PR DESCRIPTION
## Summary

- remove unused chat delivery plural envelope planner
- remove single_event_action_planner and let simple inlets return their one-action list directly
- leave runtime hook semantics unchanged: one event planner returns zero or more actions

## Verification

- rg -n "single_event_action_planner|plan_runtime_chat_delivery_envelopes" core backend tests -g "*.py" (no hits)
- uv run pytest tests/Unit/core/test_event_actions.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q
- uv run ruff check core/event_actions.py backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/core/test_event_actions.py && uv run ruff format --check core/event_actions.py backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/core/test_event_actions.py
- uv run pyright --pythonversion 3.12 core/event_actions.py backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py backend/threads/chat_adapters/chat_join_inlet.py backend/threads/chat_adapters/relationship_inlet.py tests/Unit/core/test_event_actions.py
- uv run pytest tests/Unit -q
