### PR TITLE
Rename sync callback runner

### DIFF
--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from core.event_actions import run_sync_actions
+from core.sync_callbacks import run_sync_callbacks
 from protocols import agent_runtime as agent_runtime_protocol
 
 
@@ -58,7 +58,7 @@ class ExternalRuntimeInboxHandler:
             wake=self._wake_bus is None and wake,
         )
         if self._wake_bus is not None and wake:
-            run_sync_actions(
+            run_sync_callbacks(
                 [self._wake_bus.publish],
                 inbox_id,
                 on_error=lambda _exc: ExternalRuntimeInboxActionError(inbox_id=inbox_id, notification_type=notification_type),

--- a/core/sync_callbacks.py
+++ b/core/sync_callbacks.py
@@ -4,17 +4,17 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 
-def run_sync_actions(
-    actions: Iterable[Callable[..., None]],
+def run_sync_callbacks(
+    callbacks: Iterable[Callable[..., None]],
     /,
     *args: Any,
     on_error: Callable[[Exception], Exception],
 ) -> None:
-    current_actions = list(actions)
-    if not current_actions:
+    current_callbacks = list(callbacks)
+    if not current_callbacks:
         return
     try:
-        for action in current_actions:
-            action(*args)
+        for callback in current_callbacks:
+            callback(*args)
     except Exception as exc:
         raise on_error(exc) from exc

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from core.event_actions import run_sync_actions
+from core.sync_callbacks import run_sync_callbacks
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow
 
@@ -236,7 +236,7 @@ class ChatWorkflowEventService:
         if actor_user_id is None:
             raise RuntimeError("Workflow event change requires actor_user_id")
         change = WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id)
-        run_sync_actions(
+        run_sync_callbacks(
             self._event_change_actions,
             change,
             on_error=lambda _exc: WorkflowEventActionError(operation=operation, event=event),

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.event_actions import run_sync_actions
+from core.sync_callbacks import run_sync_callbacks
 
 
 class ChatJoinRequestActionError(RuntimeError):
@@ -130,7 +130,7 @@ class ChatJoinRequestService:
             raise ChatJoinRequestActionError(action=action, row=row) from exc
 
     def _run_join_request_rejected_actions(self, row: dict[str, Any]) -> None:
-        run_sync_actions(
+        run_sync_callbacks(
             self._join_request_rejected_actions,
             row,
             on_error=lambda _exc: ChatJoinRequestActionError(action="reject", row=row),

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from core.event_actions import run_sync_actions
+from core.sync_callbacks import run_sync_callbacks
 from messaging.contracts import RelationshipEvent, RelationshipRow, RelationshipState
 from messaging.relationships.state_machine import transition
 
@@ -106,14 +106,14 @@ class RelationshipService:
         return row
 
     def _run_request_actions(self, row: RelationshipRow) -> None:
-        run_sync_actions(
+        run_sync_callbacks(
             self._relationship_request_actions,
             row,
             on_error=lambda _exc: RelationshipActionError(event="request", row=row),
         )
 
     def _run_decision_actions(self, event: RelationshipEvent, row: RelationshipRow) -> None:
-        run_sync_actions(
+        run_sync_callbacks(
             self._relationship_decision_actions,
             row,
             event,

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -16,7 +16,7 @@ from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from core.event_actions import run_sync_actions
+from core.sync_callbacks import run_sync_callbacks
 from messaging.avatars import AvatarUrlBuilder
 from messaging.contracts import ContentType, MessageType
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
@@ -321,14 +321,14 @@ class MessagingService:
         return created
 
     def _run_chat_message_event_actions(self, message: dict[str, Any]) -> None:
-        run_sync_actions(
+        run_sync_callbacks(
             self._chat_message_event_actions,
             message,
             on_error=lambda _exc: ChatMessageEventActionError(message=message),
         )
 
     def _run_chat_message_delivery_actions(self, message: dict[str, Any]) -> None:
-        run_sync_actions(
+        run_sync_callbacks(
             self._chat_message_delivery_actions,
             message,
             on_error=lambda _exc: ChatMessageDeliveryActionError(message=message),

--- a/tests/Unit/core/test_sync_callbacks.py
+++ b/tests/Unit/core/test_sync_callbacks.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from core.event_actions import run_sync_actions
+from core.sync_callbacks import run_sync_callbacks
 
 
-def test_run_sync_actions_runs_registered_actions_in_order() -> None:
+def test_run_sync_callbacks_runs_registered_callbacks_in_order() -> None:
     calls: list[tuple[str, str, int]] = []
 
     def first(value: str, version: int) -> None:
@@ -14,7 +14,7 @@ def test_run_sync_actions_runs_registered_actions_in_order() -> None:
     def second(value: str, version: int) -> None:
         calls.append(("second", value, version))
 
-    run_sync_actions([first, second], "event-1", 3, on_error=lambda _exc: RuntimeError("wrapped"))
+    run_sync_callbacks([first, second], "event-1", 3, on_error=lambda _exc: RuntimeError("wrapped"))
 
     assert calls == [
         ("first", "event-1", 3),
@@ -22,30 +22,30 @@ def test_run_sync_actions_runs_registered_actions_in_order() -> None:
     ]
 
 
-def test_run_sync_actions_wraps_first_action_failure() -> None:
+def test_run_sync_callbacks_wraps_first_callback_failure() -> None:
     def fail(_value: str) -> None:
         raise ValueError("runtime offline")
 
     with pytest.raises(RuntimeError) as exc_info:
-        run_sync_actions([fail], "event-1", on_error=lambda _exc: RuntimeError("action failed"))
+        run_sync_callbacks([fail], "event-1", on_error=lambda _exc: RuntimeError("callback failed"))
 
-    assert str(exc_info.value) == "action failed"
+    assert str(exc_info.value) == "callback failed"
     assert isinstance(exc_info.value.__cause__, ValueError)
 
 
-def test_run_sync_actions_snapshots_actions_before_running() -> None:
+def test_run_sync_callbacks_snapshots_callbacks_before_running() -> None:
     calls: list[str] = []
-    actions = []
+    callbacks = []
 
     def first() -> None:
         calls.append("first")
-        actions.append(second)
+        callbacks.append(second)
 
     def second() -> None:
         calls.append("second")
 
-    actions.append(first)
+    callbacks.append(first)
 
-    run_sync_actions(actions, on_error=lambda _exc: RuntimeError("wrapped"))
+    run_sync_callbacks(callbacks, on_error=lambda _exc: RuntimeError("wrapped"))
 
     assert calls == ["first"]


### PR DESCRIPTION
## Summary

- rename the generic synchronous event callback helper from `event_actions` to `sync_callbacks`
- update messaging, relationship, workflow, and external inbox callers to use `run_sync_callbacks`
- rename the focused unit test file and test names to match the narrower helper meaning

## Verification

- `uv run pytest tests/Unit/core/test_sync_callbacks.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q`
- `uv run ruff check core/sync_callbacks.py core/work_item/chat_workflow/service.py backend/threads/chat_adapters/external_inbox_handler.py messaging/join_requests.py messaging/relationships/service.py messaging/service.py tests/Unit/core/test_sync_callbacks.py`
- `uv run pyright --pythonversion 3.12 core/sync_callbacks.py core/work_item/chat_workflow/service.py backend/threads/chat_adapters/external_inbox_handler.py messaging/join_requests.py messaging/relationships/service.py messaging/service.py tests/Unit/core/test_sync_callbacks.py`
- `uv run pytest tests/Unit -q`
