### PR TITLE
Extract planned runtime event runner

### DIFF
--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -5,7 +5,17 @@ from collections.abc import Callable, Coroutine, Iterable
 from typing import Any
 
 
-def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, None]]) -> Callable[P, None]:
+async def run_planned_runtime_event[EventT, ActionT](
+    event: EventT,
+    planner: Callable[[EventT], Iterable[ActionT]],
+    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, None]],
+) -> int:
+    actions = list(planner(event))
+    await dispatch_actions(actions)
+    return len(actions)
+
+
+def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:
     loop = asyncio.get_running_loop()
 
     def hook(*args: P.args, **kwargs: P.kwargs) -> None:
@@ -26,7 +36,6 @@ def make_sync_planned_runtime_event_hook[EventT, ActionT](
     dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, None]],
 ) -> Callable[[EventT], None]:
     async def run(event: EventT) -> None:
-        actions = list(planner(event))
-        await dispatch_actions(actions)
+        await run_planned_runtime_event(event, planner, dispatch_actions)
 
     return make_sync_runtime_event_hook(run)

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -4,7 +4,11 @@ import asyncio
 
 import pytest
 
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook, make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import (
+    make_sync_planned_runtime_event_hook,
+    make_sync_runtime_event_hook,
+    run_planned_runtime_event,
+)
 
 
 @pytest.mark.asyncio
@@ -32,6 +36,32 @@ async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> No
         hook()
 
     assert str(exc.value) == "Sync runtime event hook cannot run on its owner event loop thread"
+
+
+@pytest.mark.parametrize(
+    ("planned_actions", "expected_count"),
+    [
+        (["planned:event-1"], 1),
+        ([], 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_planned_runtime_event_dispatches_planned_actions(
+    planned_actions: list[str],
+    expected_count: int,
+) -> None:
+    calls: list[list[str]] = []
+
+    def planner(_value: str) -> list[str]:
+        return planned_actions
+
+    async def dispatch(actions: list[str]) -> None:
+        calls.append(actions)
+
+    action_count = await run_planned_runtime_event("event-1", planner, dispatch)
+
+    assert action_count == expected_count
+    assert calls == [planned_actions]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- extract `run_planned_runtime_event()` as the async event -> actions -> dispatch runner
- keep `make_sync_planned_runtime_event_hook()` as a sync hook adapter over that runner
- preserve existing semantics, including dispatching an empty planned action list

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run pytest tests/Unit -q`
