### PR TITLE
Return planned runtime event dispatch result

### DIFF
--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -5,14 +5,13 @@ from collections.abc import Callable, Coroutine, Iterable
 from typing import Any
 
 
-async def run_planned_runtime_event[EventT, ActionT](
+async def run_planned_runtime_event[EventT, ActionT, ResultT](
     event: EventT,
     planner: Callable[[EventT], Iterable[ActionT]],
-    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, None]],
-) -> int:
+    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, ResultT]],
+) -> ResultT:
     actions = list(planner(event))
-    await dispatch_actions(actions)
-    return len(actions)
+    return await dispatch_actions(actions)
 
 
 def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -39,28 +39,29 @@ async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> No
 
 
 @pytest.mark.parametrize(
-    ("planned_actions", "expected_count"),
+    ("planned_actions", "dispatch_result"),
     [
-        (["planned:event-1"], 1),
-        ([], 0),
+        (["planned:event-1"], "sent"),
+        ([], "nothing-to-send"),
     ],
 )
 @pytest.mark.asyncio
-async def test_run_planned_runtime_event_dispatches_planned_actions(
+async def test_run_planned_runtime_event_returns_dispatch_result(
     planned_actions: list[str],
-    expected_count: int,
+    dispatch_result: str,
 ) -> None:
     calls: list[list[str]] = []
 
     def planner(_value: str) -> list[str]:
         return planned_actions
 
-    async def dispatch(actions: list[str]) -> None:
+    async def dispatch(actions: list[str]) -> str:
         calls.append(actions)
+        return dispatch_result
 
-    action_count = await run_planned_runtime_event("event-1", planner, dispatch)
+    result = await run_planned_runtime_event("event-1", planner, dispatch)
 
-    assert action_count == expected_count
+    assert result == dispatch_result
     assert calls == [planned_actions]
 
 


### PR DESCRIPTION
## Summary

- make `run_planned_runtime_event()` return the dispatcher result instead of planned action count
- keep planning and dispatch behavior unchanged
- update the runner test to prove the dispatcher owns outcome semantics, including empty action lists

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py`
- `uv run pytest tests/Unit -q`
