### PR TITLE
Expose async runtime event entrypoints

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -9,22 +9,38 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
     dispatch_runtime_chat_delivery_actions,
 )
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook, run_planned_runtime_event
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
-    planner = chat_delivery_runtime_action_planner()
+    async def dispatch_event(request: ChatDeliveryRequest) -> None:
+        await dispatch_chat_delivery_event(
+            app,
+            request,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
 
-    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> None:
-        await dispatch_runtime_chat_delivery_actions(
+    return make_sync_runtime_event_hook(dispatch_event)
+
+
+async def dispatch_chat_delivery_event(
+    app: Any,
+    request: ChatDeliveryRequest,
+    *,
+    activity_reader: Any,
+    thread_repo: Any,
+) -> int:
+    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
+        return await dispatch_runtime_chat_delivery_actions(
             app,
             actions,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
-    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+    return await run_planned_runtime_event(request, chat_delivery_runtime_action_planner(), dispatch_actions)
 
 
 def chat_delivery_runtime_action_planner() -> Callable[[ChatDeliveryRequest], list[RuntimeChatDeliveryAction]]:

--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -28,13 +28,3 @@ def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, 
         future.result()
 
     return hook
-
-
-def make_sync_planned_runtime_event_hook[EventT, ActionT](
-    planner: Callable[[EventT], Iterable[ActionT]],
-    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, None]],
-) -> Callable[[EventT], None]:
-    async def run(event: EventT) -> None:
-        await run_planned_runtime_event(event, planner, dispatch_actions)
-
-    return make_sync_runtime_event_hook(run)

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_planned_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook, run_planned_runtime_event
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
 from protocols.agent_runtime import (
@@ -38,8 +38,30 @@ def make_runtime_notification_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> None:
-        await dispatch_runtime_notification_actions(
+    async def dispatch_event(event: EventT) -> None:
+        await dispatch_runtime_notification_event(
+            app,
+            event,
+            planner,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+
+    return make_sync_runtime_event_hook(dispatch_event)
+
+
+async def dispatch_runtime_notification_event[EventT](
+    app: Any,
+    event: EventT,
+    planner: Callable[[EventT], Iterable[RuntimeNotificationAction]],
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> int:
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> int:
+        return await dispatch_runtime_notification_actions(
             app,
             actions,
             user_repo=user_repo,
@@ -47,7 +69,7 @@ def make_runtime_notification_event_hook[EventT](
             activity_reader=activity_reader,
         )
 
-    return make_sync_planned_runtime_event_hook(planner, dispatch_actions)
+    return await run_planned_runtime_event(event, planner, dispatch_actions)
 
 
 async def dispatch_runtime_notification_action(

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -195,7 +195,7 @@ async def test_chat_delivery_hook_propagates_runtime_gateway_failures() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chat_delivery_hook_uses_request_sender_type() -> None:
+async def test_chat_delivery_event_and_hook_use_request_sender_type() -> None:
     class RecordingGateway:
         envelope = None
 
@@ -222,6 +222,18 @@ async def test_chat_delivery_hook_uses_request_sender_type() -> None:
         signal=None,
     )
 
+    dispatched_count = await owner_chat_inlet.dispatch_chat_delivery_event(
+        app,
+        request,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
+        thread_repo=app.state.thread_repo,
+    )
+
+    assert dispatched_count == 1
+    assert gateway.envelope is not None
+    assert gateway.envelope.sender.user_type == "human"
+
+    gateway.envelope = None
     await asyncio.to_thread(deliver, request)
 
     assert gateway.envelope is not None

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -5,7 +5,6 @@ import asyncio
 import pytest
 
 from backend.threads.chat_adapters.runtime_event_hook import (
-    make_sync_planned_runtime_event_hook,
     make_sync_runtime_event_hook,
     run_planned_runtime_event,
 )
@@ -63,20 +62,3 @@ async def test_run_planned_runtime_event_returns_dispatch_result(
 
     assert result == dispatch_result
     assert calls == [planned_actions]
-
-
-@pytest.mark.asyncio
-async def test_sync_planned_runtime_event_hook_plans_and_dispatches_actions_from_worker_thread() -> None:
-    calls: list[list[str]] = []
-
-    def planner(value: str) -> list[str]:
-        return [f"planned:{value}"]
-
-    async def dispatch(actions: list[str]) -> None:
-        calls.append(actions)
-
-    hook = make_sync_planned_runtime_event_hook(planner, dispatch)
-
-    await asyncio.to_thread(hook, "event-1")
-
-    assert calls == [["planned:event-1"]]

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -9,6 +9,7 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_action,
     dispatch_runtime_notification_actions,
+    dispatch_runtime_notification_event,
     make_runtime_notification_event_hook,
 )
 from protocols.agent_runtime import AgentRuntimeTransport
@@ -125,7 +126,7 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
 
 
 @pytest.mark.asyncio
-async def test_runtime_notification_event_hook_plans_and_dispatches_actions_from_worker_thread() -> None:
+async def test_runtime_notification_event_and_hook_plan_and_dispatch_actions() -> None:
     class RecordingGateway:
         def __init__(self) -> None:
             self.envelopes = []
@@ -149,6 +150,19 @@ async def test_runtime_notification_event_hook_plans_and_dispatches_actions_from
             )
         ]
 
+    dispatched_count = await dispatch_runtime_notification_event(
+        _runtime_app(gateway),
+        "event-1",
+        planner,
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert dispatched_count == 1
+    assert [envelope.message.content for envelope in gateway.envelopes] == ["Action event-1."]
+
+    gateway.envelopes.clear()
     hook = make_runtime_notification_event_hook(
         _runtime_app(gateway),
         planner,
@@ -157,6 +171,6 @@ async def test_runtime_notification_event_hook_plans_and_dispatches_actions_from
         activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
     )
 
-    await asyncio.to_thread(hook, "event-1")
+    await asyncio.to_thread(hook, "event-2")
 
-    assert [envelope.message.content for envelope in gateway.envelopes] == ["Action event-1."]
+    assert [envelope.message.content for envelope in gateway.envelopes] == ["Action event-2."]


### PR DESCRIPTION
## Summary

- expose async runtime notification and chat-delivery event entrypoints over `run_planned_runtime_event()`
- keep sync hooks as thin bridges over those async event entrypoints
- remove the now-unused `make_sync_planned_runtime_event_hook()` helper

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pytest tests/Unit -q`
