### PR TITLE
Split runtime event runner from hook adapter

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -9,7 +9,8 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
     dispatch_runtime_chat_delivery_actions,
 )
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook, run_planned_runtime_event
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 

--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -1,17 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Callable, Coroutine
 from typing import Any
-
-
-async def run_planned_runtime_event[EventT, ActionT, ResultT](
-    event: EventT,
-    planner: Callable[[EventT], Iterable[ActionT]],
-    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, ResultT]],
-) -> ResultT:
-    actions = list(planner(event))
-    return await dispatch_actions(actions)
 
 
 def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:

--- a/backend/threads/chat_adapters/runtime_event_runner.py
+++ b/backend/threads/chat_adapters/runtime_event_runner.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine, Iterable
+from typing import Any
+
+
+async def run_planned_runtime_event[EventT, ActionT, ResultT](
+    event: EventT,
+    planner: Callable[[EventT], Iterable[ActionT]],
+    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, ResultT]],
+) -> ResultT:
+    actions = list(planner(event))
+    return await dispatch_actions(actions)

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook, run_planned_runtime_event
+from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
 from protocols.agent_runtime import (

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -6,7 +6,6 @@ import pytest
 
 from backend.threads.chat_adapters.runtime_event_hook import (
     make_sync_runtime_event_hook,
-    run_planned_runtime_event,
 )
 
 
@@ -35,30 +34,3 @@ async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> No
         hook()
 
     assert str(exc.value) == "Sync runtime event hook cannot run on its owner event loop thread"
-
-
-@pytest.mark.parametrize(
-    ("planned_actions", "dispatch_result"),
-    [
-        (["planned:event-1"], "sent"),
-        ([], "nothing-to-send"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_run_planned_runtime_event_returns_dispatch_result(
-    planned_actions: list[str],
-    dispatch_result: str,
-) -> None:
-    calls: list[list[str]] = []
-
-    def planner(_value: str) -> list[str]:
-        return planned_actions
-
-    async def dispatch(actions: list[str]) -> str:
-        calls.append(actions)
-        return dispatch_result
-
-    result = await run_planned_runtime_event("event-1", planner, dispatch)
-
-    assert result == dispatch_result
-    assert calls == [planned_actions]

--- a/tests/Unit/backend/web/services/test_runtime_event_runner.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_runner.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
+
+
+@pytest.mark.parametrize(
+    ("planned_actions", "dispatch_result"),
+    [
+        (["planned:event-1"], "sent"),
+        ([], "nothing-to-send"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_planned_runtime_event_returns_dispatch_result(
+    planned_actions: list[str],
+    dispatch_result: str,
+) -> None:
+    calls: list[list[str]] = []
+
+    def planner(_value: str) -> list[str]:
+        return planned_actions
+
+    async def dispatch(actions: list[str]) -> str:
+        calls.append(actions)
+        return dispatch_result
+
+    result = await run_planned_runtime_event("event-1", planner, dispatch)
+
+    assert result == dispatch_result
+    assert calls == [planned_actions]


### PR DESCRIPTION
## Summary

- move `run_planned_runtime_event()` into `runtime_event_runner.py`
- leave `runtime_event_hook.py` focused on the sync hook adapter
- split runner tests away from hook tests

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_event_runner.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pyright --pythonversion 3.12 backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_event_runner.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_event_runner.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pytest tests/Unit -q`
