### PR TITLE
Consolidate sync action registries

### DIFF
--- a/backend/threads/chat_adapters/external_inbox_handler.py
+++ b/backend/threads/chat_adapters/external_inbox_handler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from core.sync_callbacks import run_sync_callbacks
 from protocols import agent_runtime as agent_runtime_protocol
 
 
@@ -58,11 +57,10 @@ class ExternalRuntimeInboxHandler:
             wake=self._wake_bus is None and wake,
         )
         if self._wake_bus is not None and wake:
-            run_sync_callbacks(
-                [self._wake_bus.publish],
-                inbox_id,
-                on_error=lambda _exc: ExternalRuntimeInboxActionError(inbox_id=inbox_id, notification_type=notification_type),
-            )
+            try:
+                self._wake_bus.publish(inbox_id)
+            except Exception as exc:
+                raise ExternalRuntimeInboxActionError(inbox_id=inbox_id, notification_type=notification_type) from exc
 
     async def dispatch_notification(
         self, envelope: agent_runtime_protocol.AgentRuntimeNotificationEnvelope

--- a/core/sync_callbacks.py
+++ b/core/sync_callbacks.py
@@ -1,20 +1,30 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Any
 
 
-def run_sync_callbacks(
-    callbacks: Iterable[Callable[..., None]],
-    /,
-    *args: Any,
-    on_error: Callable[[Exception], Exception],
-) -> None:
-    current_callbacks = list(callbacks)
-    if not current_callbacks:
-        return
-    try:
-        for callback in current_callbacks:
-            callback(*args)
-    except Exception as exc:
-        raise on_error(exc) from exc
+class SyncActionRegistry:
+    def __init__(self) -> None:
+        self._actions: list[Callable[..., None]] = []
+
+    def add(self, action: Callable[..., None]) -> None:
+        self._actions.append(action)
+
+    def has_actions(self) -> bool:
+        return bool(self._actions)
+
+    def run(
+        self,
+        /,
+        *args: Any,
+        on_error: Callable[[Exception], Exception],
+    ) -> None:
+        current_actions = list(self._actions)
+        if not current_actions:
+            return
+        try:
+            for action in current_actions:
+                action(*args)
+        except Exception as exc:
+            raise on_error(exc) from exc

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from core.sync_callbacks import run_sync_callbacks
+from core.sync_callbacks import SyncActionRegistry
 from core.work_item.types import WorkItem
 from storage.contracts import ChatWorkflowEventRow
 
@@ -138,10 +138,10 @@ class ChatTaskService:
 class ChatWorkflowEventService:
     def __init__(self, event_repo: Any) -> None:
         self._repo = event_repo
-        self._event_change_actions: list[Callable[[WorkflowEventChange], None]] = []
+        self._event_change_actions = SyncActionRegistry()
 
     def add_event_change_action(self, action: Callable[[WorkflowEventChange], None]) -> None:
-        self._event_change_actions.append(action)
+        self._event_change_actions.add(action)
 
     def list_events(self, chat_id: str) -> list[dict[str, Any]]:
         return [_event_response(event) for event in self._repo.list_all(chat_id)]
@@ -218,7 +218,7 @@ class ChatWorkflowEventService:
         return response
 
     def _event_change_actor(self, actor_user_id: str | None, *, field: str) -> str | None:
-        if not self._event_change_actions:
+        if not self._event_change_actions.has_actions():
             return None
         if actor_user_id is None:
             raise RuntimeError(f"Workflow event change requires {field}")
@@ -231,13 +231,12 @@ class ChatWorkflowEventService:
         event: dict[str, Any],
         actor_user_id: str | None,
     ) -> None:
-        if not self._event_change_actions:
+        if not self._event_change_actions.has_actions():
             return
         if actor_user_id is None:
             raise RuntimeError("Workflow event change requires actor_user_id")
         change = WorkflowEventChange(operation=operation, event=event, actor_user_id=actor_user_id)
-        run_sync_callbacks(
-            self._event_change_actions,
+        self._event_change_actions.run(
             change,
             on_error=lambda _exc: WorkflowEventActionError(operation=operation, event=event),
         )

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.sync_callbacks import run_sync_callbacks
+from core.sync_callbacks import SyncActionRegistry
 
 
 class ChatJoinRequestActionError(RuntimeError):
@@ -26,12 +26,12 @@ class ChatJoinRequestService:
         self._members = chat_member_repo
         self._requests = chat_join_request_repo
         self._messaging = messaging_service
-        self._join_request_rejected_actions: list[Any] = []
+        self._join_request_rejected_actions = SyncActionRegistry()
         if on_join_request_rejected is not None:
             self.add_join_request_rejected_action(on_join_request_rejected)
 
     def add_join_request_rejected_action(self, action: Any) -> None:
-        self._join_request_rejected_actions.append(action)
+        self._join_request_rejected_actions.add(action)
 
     def request(self, chat_id: str, requester_user_id: str, message: str | None = None) -> dict[str, Any]:
         chat = self._require_joinable_chat(chat_id)
@@ -130,8 +130,7 @@ class ChatJoinRequestService:
             raise ChatJoinRequestActionError(action=action, row=row) from exc
 
     def _run_join_request_rejected_actions(self, row: dict[str, Any]) -> None:
-        run_sync_callbacks(
-            self._join_request_rejected_actions,
+        self._join_request_rejected_actions.run(
             row,
             on_error=lambda _exc: ChatJoinRequestActionError(action="reject", row=row),
         )

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from core.sync_callbacks import run_sync_callbacks
+from core.sync_callbacks import SyncActionRegistry
 from messaging.contracts import RelationshipEvent, RelationshipRow, RelationshipState
 from messaging.relationships.state_machine import transition
 
@@ -31,18 +31,18 @@ class RelationshipService:
         on_relationship_decided: Callable[[RelationshipRow, RelationshipEvent], None] | None = None,
     ) -> None:
         self._repo = relationship_repo
-        self._relationship_request_actions: list[Callable[[RelationshipRow], None]] = []
-        self._relationship_decision_actions: list[Callable[[RelationshipRow, RelationshipEvent], None]] = []
+        self._relationship_request_actions = SyncActionRegistry()
+        self._relationship_decision_actions = SyncActionRegistry()
         if on_relationship_requested is not None:
             self.add_relationship_request_action(on_relationship_requested)
         if on_relationship_decided is not None:
             self.add_relationship_decision_action(on_relationship_decided)
 
     def add_relationship_request_action(self, action: Callable[[RelationshipRow], None]) -> None:
-        self._relationship_request_actions.append(action)
+        self._relationship_request_actions.add(action)
 
     def add_relationship_decision_action(self, action: Callable[[RelationshipRow, RelationshipEvent], None]) -> None:
-        self._relationship_decision_actions.append(action)
+        self._relationship_decision_actions.add(action)
 
     def apply_event(
         self,
@@ -106,15 +106,13 @@ class RelationshipService:
         return row
 
     def _run_request_actions(self, row: RelationshipRow) -> None:
-        run_sync_callbacks(
-            self._relationship_request_actions,
+        self._relationship_request_actions.run(
             row,
             on_error=lambda _exc: RelationshipActionError(event="request", row=row),
         )
 
     def _run_decision_actions(self, event: RelationshipEvent, row: RelationshipRow) -> None:
-        run_sync_callbacks(
-            self._relationship_decision_actions,
+        self._relationship_decision_actions.run(
             row,
             event,
             on_error=lambda _exc: RelationshipActionError(event=event, row=row),

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -16,7 +16,7 @@ from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from core.sync_callbacks import run_sync_callbacks
+from core.sync_callbacks import SyncActionRegistry
 from messaging.avatars import AvatarUrlBuilder
 from messaging.contracts import ContentType, MessageType
 from messaging.delivery.dispatcher import ChatDeliveryDispatcher, ChatDeliveryFn
@@ -92,11 +92,12 @@ class MessagingService:
             delivery_resolver=delivery_resolver,
             delivery_fn=delivery_fn,
         )
-        self._chat_message_delivery_actions: list[Callable[[dict[str, Any]], None]] = [self._dispatch_chat_message_delivery]
+        self._chat_message_delivery_actions = SyncActionRegistry()
+        self._chat_message_delivery_actions.add(self._dispatch_chat_message_delivery)
         self._event_bus = event_bus
-        self._chat_message_event_actions: list[Callable[[dict[str, Any]], None]] = []
+        self._chat_message_event_actions = SyncActionRegistry()
         if event_bus is not None:
-            self._chat_message_event_actions.append(self._publish_chat_message_event)
+            self._chat_message_event_actions.add(self._publish_chat_message_event)
 
     def _normalize_message_row(self, row: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -168,7 +169,7 @@ class MessagingService:
         self._delivery_dispatcher.set_delivery_fn(fn)
 
     def add_chat_message_delivery_action(self, action: Callable[[dict[str, Any]], None]) -> None:
-        self._chat_message_delivery_actions.append(action)
+        self._chat_message_delivery_actions.add(action)
 
     # ------------------------------------------------------------------
     # Chat lifecycle
@@ -321,15 +322,13 @@ class MessagingService:
         return created
 
     def _run_chat_message_event_actions(self, message: dict[str, Any]) -> None:
-        run_sync_callbacks(
-            self._chat_message_event_actions,
+        self._chat_message_event_actions.run(
             message,
             on_error=lambda _exc: ChatMessageEventActionError(message=message),
         )
 
     def _run_chat_message_delivery_actions(self, message: dict[str, Any]) -> None:
-        run_sync_callbacks(
-            self._chat_message_delivery_actions,
+        self._chat_message_delivery_actions.run(
             message,
             on_error=lambda _exc: ChatMessageDeliveryActionError(message=message),
         )

--- a/tests/Unit/core/test_sync_callbacks.py
+++ b/tests/Unit/core/test_sync_callbacks.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from core.sync_callbacks import run_sync_callbacks
+from core.sync_callbacks import SyncActionRegistry
 
 
-def test_run_sync_callbacks_runs_registered_callbacks_in_order() -> None:
+def test_sync_action_registry_runs_registered_actions_in_order() -> None:
     calls: list[tuple[str, str, int]] = []
+    actions = SyncActionRegistry()
 
     def first(value: str, version: int) -> None:
         calls.append(("first", value, version))
@@ -14,7 +15,9 @@ def test_run_sync_callbacks_runs_registered_callbacks_in_order() -> None:
     def second(value: str, version: int) -> None:
         calls.append(("second", value, version))
 
-    run_sync_callbacks([first, second], "event-1", 3, on_error=lambda _exc: RuntimeError("wrapped"))
+    actions.add(first)
+    actions.add(second)
+    actions.run("event-1", 3, on_error=lambda _exc: RuntimeError("wrapped"))
 
     assert calls == [
         ("first", "event-1", 3),
@@ -22,30 +25,33 @@ def test_run_sync_callbacks_runs_registered_callbacks_in_order() -> None:
     ]
 
 
-def test_run_sync_callbacks_wraps_first_callback_failure() -> None:
+def test_sync_action_registry_wraps_first_action_failure() -> None:
+    actions = SyncActionRegistry()
+
     def fail(_value: str) -> None:
         raise ValueError("runtime offline")
 
+    actions.add(fail)
     with pytest.raises(RuntimeError) as exc_info:
-        run_sync_callbacks([fail], "event-1", on_error=lambda _exc: RuntimeError("callback failed"))
+        actions.run("event-1", on_error=lambda _exc: RuntimeError("callback failed"))
 
     assert str(exc_info.value) == "callback failed"
     assert isinstance(exc_info.value.__cause__, ValueError)
 
 
-def test_run_sync_callbacks_snapshots_callbacks_before_running() -> None:
+def test_sync_action_registry_snapshots_actions_before_running() -> None:
     calls: list[str] = []
-    callbacks = []
+    actions = SyncActionRegistry()
 
     def first() -> None:
         calls.append("first")
-        callbacks.append(second)
+        actions.add(second)
 
     def second() -> None:
         calls.append("second")
 
-    callbacks.append(first)
+    actions.add(first)
 
-    run_sync_callbacks(callbacks, on_error=lambda _exc: RuntimeError("wrapped"))
+    actions.run(on_error=lambda _exc: RuntimeError("wrapped"))
 
     assert calls == ["first"]


### PR DESCRIPTION
## Summary

- replace raw synchronous action lists with a small `SyncActionRegistry`
- migrate messaging, relationship, join request, and chat workflow services to the registry
- remove the old public `run_sync_callbacks()` helper; one-off external inbox wake publish now uses direct loud `try/except`

## Why

This keeps the event/action architecture clean: registered synchronous post-operation actions have one narrow primitive, while runtime event/action planning stays in `runtime_event_runner.py`. This is not a DSL and does not change UX, schema, polling, transport, queues, or runtime semantics.

## Verification

- `uv run pytest tests/Unit/core/test_sync_callbacks.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py -q` -> `179 passed`
- `uv run pytest tests/Unit -q` -> `2231 passed, 3 skipped, 15 warnings`
- `uv run ruff check` -> pass
- `uv run ruff format --check .` -> pass
- targeted `uv run pyright ...` on changed files -> `0 errors`

Note: full-repo `uv run pyright` currently reports 400 pre-existing errors in unrelated monitor/settings/test/fake areas, so this PR uses targeted pyright for changed files.
