### PR TITLE
Preserve sync action registry signatures

### DIFF
--- a/core/sync_callbacks.py
+++ b/core/sync_callbacks.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 
-class SyncActionRegistry:
+class SyncActionRegistry[**P]:
     def __init__(self) -> None:
-        self._actions: list[Callable[..., None]] = []
+        self._actions: list[Callable[P, None]] = []
 
-    def add(self, action: Callable[..., None]) -> None:
+    def add(self, action: Callable[P, None]) -> None:
         self._actions.append(action)
 
     def has_actions(self) -> bool:
@@ -25,6 +25,6 @@ class SyncActionRegistry:
             return
         try:
             for action in current_actions:
-                action(*args)
+                cast(Callable[..., None], action)(*args)
         except Exception as exc:
             raise on_error(exc) from exc

--- a/core/work_item/chat_workflow/service.py
+++ b/core/work_item/chat_workflow/service.py
@@ -138,7 +138,7 @@ class ChatTaskService:
 class ChatWorkflowEventService:
     def __init__(self, event_repo: Any) -> None:
         self._repo = event_repo
-        self._event_change_actions = SyncActionRegistry()
+        self._event_change_actions: SyncActionRegistry[[WorkflowEventChange]] = SyncActionRegistry()
 
     def add_event_change_action(self, action: Callable[[WorkflowEventChange], None]) -> None:
         self._event_change_actions.add(action)

--- a/messaging/join_requests.py
+++ b/messaging/join_requests.py
@@ -26,7 +26,7 @@ class ChatJoinRequestService:
         self._members = chat_member_repo
         self._requests = chat_join_request_repo
         self._messaging = messaging_service
-        self._join_request_rejected_actions = SyncActionRegistry()
+        self._join_request_rejected_actions: SyncActionRegistry[[dict[str, Any]]] = SyncActionRegistry()
         if on_join_request_rejected is not None:
             self.add_join_request_rejected_action(on_join_request_rejected)
 

--- a/messaging/relationships/service.py
+++ b/messaging/relationships/service.py
@@ -31,8 +31,8 @@ class RelationshipService:
         on_relationship_decided: Callable[[RelationshipRow, RelationshipEvent], None] | None = None,
     ) -> None:
         self._repo = relationship_repo
-        self._relationship_request_actions = SyncActionRegistry()
-        self._relationship_decision_actions = SyncActionRegistry()
+        self._relationship_request_actions: SyncActionRegistry[[RelationshipRow]] = SyncActionRegistry()
+        self._relationship_decision_actions: SyncActionRegistry[[RelationshipRow, RelationshipEvent]] = SyncActionRegistry()
         if on_relationship_requested is not None:
             self.add_relationship_request_action(on_relationship_requested)
         if on_relationship_decided is not None:

--- a/messaging/service.py
+++ b/messaging/service.py
@@ -92,10 +92,10 @@ class MessagingService:
             delivery_resolver=delivery_resolver,
             delivery_fn=delivery_fn,
         )
-        self._chat_message_delivery_actions = SyncActionRegistry()
+        self._chat_message_delivery_actions: SyncActionRegistry[[dict[str, Any]]] = SyncActionRegistry()
         self._chat_message_delivery_actions.add(self._dispatch_chat_message_delivery)
         self._event_bus = event_bus
-        self._chat_message_event_actions = SyncActionRegistry()
+        self._chat_message_event_actions: SyncActionRegistry[[dict[str, Any]]] = SyncActionRegistry()
         if event_bus is not None:
             self._chat_message_event_actions.add(self._publish_chat_message_event)
 


### PR DESCRIPTION
## Summary

- Make SyncActionRegistry generic over the registered callback signature.
- Add explicit registry signatures at current service ownership points.
- Keep run() behavior and on_error calling shape unchanged; the dynamic boundary remains execution-only.

## Verification

- RED: service registry annotations failed before the generic registry with `Expected no type arguments for class "SyncActionRegistry"`.
- `uv run pyright core/sync_callbacks.py core/work_item/chat_workflow/service.py messaging/service.py messaging/relationships/service.py messaging/join_requests.py tests/Unit/core/test_sync_callbacks.py` -> 0 errors
- `uv run pytest tests/Unit/core/test_sync_callbacks.py tests/Unit/core/test_chat_workflow_service.py tests/Unit/messaging/test_chat_join_requests.py tests/Unit/integration_contracts/test_messaging_social_handle_contract.py -q` -> 174 passed
- `uv run ruff check core/sync_callbacks.py core/work_item/chat_workflow/service.py messaging/service.py messaging/relationships/service.py messaging/join_requests.py` -> All checks passed
- `uv run ruff format --check core/sync_callbacks.py core/work_item/chat_workflow/service.py messaging/service.py messaging/relationships/service.py messaging/join_requests.py` -> 5 files already formatted
- `git diff --check` -> clean
- `uv run pytest tests/Unit -q` -> 2231 passed, 3 skipped, 15 warnings
