### PR TITLE
Add planned runtime event hook

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -9,21 +9,21 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
     dispatch_runtime_chat_delivery_actions,
 )
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
-    async def dispatch_event(request: ChatDeliveryRequest) -> None:
-        await dispatch_chat_delivery_event(
+    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
+        return await dispatch_runtime_chat_delivery_actions(
             app,
-            request,
+            actions,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(dispatch_event)
+    return make_planned_runtime_event_hook(chat_delivery_runtime_action_planner(), dispatch_actions)
 
 
 async def dispatch_chat_delivery_event(

--- a/backend/threads/chat_adapters/runtime_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_event_hook.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from typing import Any
+
+from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 
 
 def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:
@@ -19,3 +21,13 @@ def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, 
         future.result()
 
     return hook
+
+
+def make_planned_runtime_event_hook[EventT, ActionT](
+    planner: Callable[[EventT], Iterable[ActionT]],
+    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, Any]],
+) -> Callable[[EventT], None]:
+    async def dispatch_event(event: EventT) -> None:
+        await run_planned_runtime_event(event, planner, dispatch_actions)
+
+    return make_sync_runtime_event_hook(dispatch_event)

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
-from backend.threads.chat_adapters.runtime_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_hook import make_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
@@ -39,17 +39,16 @@ def make_runtime_notification_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_event(event: EventT) -> None:
-        await dispatch_runtime_notification_event(
+    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> int:
+        return await dispatch_runtime_notification_actions(
             app,
-            event,
-            planner,
+            actions,
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
-    return make_sync_runtime_event_hook(dispatch_event)
+    return make_planned_runtime_event_hook(planner, dispatch_actions)
 
 
 async def dispatch_runtime_notification_event[EventT](

--- a/tests/Unit/backend/web/services/test_runtime_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_hook.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from backend.threads.chat_adapters.runtime_event_hook import (
+    make_planned_runtime_event_hook,
     make_sync_runtime_event_hook,
 )
 
@@ -21,6 +22,23 @@ async def test_sync_runtime_event_hook_runs_coroutine_from_worker_thread() -> No
     await asyncio.to_thread(hook, "ok")
 
     assert calls == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_planned_runtime_event_hook_runs_planner_and_dispatcher_from_worker_thread() -> None:
+    calls: list[list[str]] = []
+
+    def planner(value: str) -> list[str]:
+        return [f"planned:{value}"]
+
+    async def dispatch_actions(actions: list[str]) -> None:
+        calls.append(actions)
+
+    hook = make_planned_runtime_event_hook(planner, dispatch_actions)
+
+    await asyncio.to_thread(hook, "event-1")
+
+    assert calls == [["planned:event-1"]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a generic planned runtime event hook helper: event -> planner -> actions -> dispatcher -> sync hook.
- Use it for chat delivery and runtime notification hook creation.
- Keep direct async event entrypoints and action/envelope semantics unchanged.

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py -q` failed before implementation with missing `make_planned_runtime_event_hook` import.
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q` -> 18 passed
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` -> 49 passed
- `uv run pyright backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_event_runner.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py` -> 0 errors
- `uv run ruff check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py` -> All checks passed
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_hook.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_event_hook.py` -> 4 files already formatted
- `git diff --check` -> clean
- `uv run pytest tests/Unit -q` -> 2232 passed, 3 skipped, 15 warnings
