### PR TITLE
Bind runtime action dispatchers

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -7,7 +7,7 @@ from typing import Any
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
 from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
-    dispatch_runtime_chat_delivery_actions,
+    runtime_chat_delivery_action_dispatcher,
 )
 from backend.threads.chat_adapters.runtime_event_hook import make_planned_runtime_event_hook
 from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
@@ -15,15 +15,14 @@ from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
-    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
-        return await dispatch_runtime_chat_delivery_actions(
+    return make_planned_runtime_event_hook(
+        chat_delivery_runtime_action_planner(),
+        runtime_chat_delivery_action_dispatcher(
             app,
-            actions,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-        )
-
-    return make_planned_runtime_event_hook(chat_delivery_runtime_action_planner(), dispatch_actions)
+        ),
+    )
 
 
 async def dispatch_chat_delivery_event(
@@ -33,15 +32,15 @@ async def dispatch_chat_delivery_event(
     activity_reader: Any,
     thread_repo: Any,
 ) -> int:
-    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
-        return await dispatch_runtime_chat_delivery_actions(
+    return await run_planned_runtime_event(
+        request,
+        chat_delivery_runtime_action_planner(),
+        runtime_chat_delivery_action_dispatcher(
             app,
-            actions,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-        )
-
-    return await run_planned_runtime_event(request, chat_delivery_runtime_action_planner(), dispatch_actions)
+        ),
+    )
 
 
 def chat_delivery_runtime_action_planner() -> Callable[[ChatDeliveryRequest], list[RuntimeChatDeliveryAction]]:

--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -64,6 +64,23 @@ async def dispatch_runtime_chat_delivery_actions(
         await dispatch_runtime_chat_delivery_envelopes(app, [envelope])
         dispatched_count += 1
     return dispatched_count
+
+
+def runtime_chat_delivery_action_dispatcher(
+    app: Any,
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> Callable[[list[RuntimeChatDeliveryAction]], Coroutine[Any, Any, int]]:
+    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
+        return await dispatch_runtime_chat_delivery_actions(
+            app,
+            actions,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+
+    return dispatch_actions
 
 
 async def dispatch_runtime_chat_delivery_envelopes(app: Any, envelopes: Iterable[AgentChatDeliveryEnvelope]) -> None:

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -39,16 +39,15 @@ def make_runtime_notification_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> int:
-        return await dispatch_runtime_notification_actions(
+    return make_planned_runtime_event_hook(
+        planner,
+        runtime_notification_action_dispatcher(
             app,
-            actions,
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-        )
-
-    return make_planned_runtime_event_hook(planner, dispatch_actions)
+        ),
+    )
 
 
 async def dispatch_runtime_notification_event[EventT](
@@ -60,6 +59,25 @@ async def dispatch_runtime_notification_event[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> int:
+    return await run_planned_runtime_event(
+        event,
+        planner,
+        runtime_notification_action_dispatcher(
+            app,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        ),
+    )
+
+
+def runtime_notification_action_dispatcher(
+    app: Any,
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> Callable[[list[RuntimeNotificationAction]], Coroutine[Any, Any, int]]:
     async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> int:
         return await dispatch_runtime_notification_actions(
             app,
@@ -69,7 +87,7 @@ async def dispatch_runtime_notification_event[EventT](
             activity_reader=activity_reader,
         )
 
-    return await run_planned_runtime_event(event, planner, dispatch_actions)
+    return dispatch_actions
 
 
 async def dispatch_runtime_notification_action(

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -11,6 +11,7 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
     dispatch_runtime_chat_delivery_actions,
     plan_runtime_chat_delivery_envelope,
+    runtime_chat_delivery_action_dispatcher,
 )
 from messaging.delivery.dispatcher import ChatDeliveryRequest
 
@@ -163,6 +164,29 @@ async def test_runtime_chat_delivery_actions_dispatches_prior_envelopes_before_l
         )
 
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["external-user-1"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_chat_delivery_action_dispatcher_binds_runtime_dependencies() -> None:
+    class RecordingGateway:
+        def __init__(self) -> None:
+            self.envelopes = []
+
+        async def dispatch_chat(self, envelope):
+            self.envelopes.append(envelope)
+
+    gateway = RecordingGateway()
+    app = _hook_app(gateway)
+    dispatch_actions = runtime_chat_delivery_action_dispatcher(
+        app,
+        thread_repo=app.state.thread_repo,
+        activity_reader=app.state.threads_runtime_state.activity_reader,
+    )
+
+    dispatched_count = await dispatch_actions([_runtime_chat_action()])
+
+    assert dispatched_count == 1
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-user-1"]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -11,6 +11,7 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     dispatch_runtime_notification_actions,
     dispatch_runtime_notification_event,
     make_runtime_notification_event_hook,
+    runtime_notification_action_dispatcher,
 )
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -119,6 +120,42 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
         user_repo=_users(),
         thread_repo=_thread_repo(),
         activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert dispatched_count == 1
+    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_notification_action_dispatcher_binds_runtime_dependencies() -> None:
+    class RecordingGateway:
+        def __init__(self) -> None:
+            self.envelopes = []
+
+        async def dispatch_notification(self, envelope):
+            self.envelopes.append(envelope)
+            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+    gateway = RecordingGateway()
+    dispatch_actions = runtime_notification_action_dispatcher(
+        _runtime_app(gateway),
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    dispatched_count = await dispatch_actions(
+        [
+            RuntimeNotificationAction(
+                context="Test action",
+                recipient_user_id="agent-1",
+                sender_user_id="owner-1",
+                sender_source="workflow",
+                event_type="test.event",
+                notification_type="test",
+                content="Action happened.",
+            )
+        ]
     )
 
     assert dispatched_count == 1


### PR DESCRIPTION
## Summary

- Add bound runtime action dispatcher factories for notification and chat delivery actions.
- Use those factories from hook/direct event entrypoints instead of duplicating local `dispatch_actions` closures.
- Preserve existing action planning, envelope planning order, and gateway dispatch semantics.

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q` failed before implementation because both dispatcher factory imports were missing.
- `uv run pytest tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py -q` -> 22 passed
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` -> 51 passed
- `uv run pyright backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py` -> 0 errors
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py` -> All checks passed
- `uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py` -> 5 files already formatted
- `git diff --check` -> clean
- `uv run pytest tests/Unit -q` -> 2234 passed, 3 skipped, 15 warnings
