### PR TITLE
Bind runtime thread input dispatcher

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -94,9 +94,21 @@ def internal_runtime_thread_input_action(
     )
 
 
-async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction):
-    results = await dispatch_runtime_thread_input_envelopes(app, [plan_runtime_thread_input_envelope(action)])
+async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction) -> AgentThreadInputResult:
+    results = await runtime_thread_input_action_dispatcher(app)([action])
     return results[0]
+
+
+def runtime_thread_input_action_dispatcher(
+    app: Any,
+) -> Callable[[list[RuntimeThreadInputAction]], Coroutine[Any, Any, list[AgentThreadInputResult]]]:
+    async def dispatch_actions(actions: list[RuntimeThreadInputAction]) -> list[AgentThreadInputResult]:
+        return await dispatch_runtime_thread_input_envelopes(
+            app,
+            [plan_runtime_thread_input_envelope(action) for action in actions],
+        )
+
+    return dispatch_actions
 
 
 async def dispatch_runtime_thread_input_envelopes(

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -24,6 +24,7 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     queued_command_thread_input_action,
     queued_thread_input_action,
     requeue_thread_input_item,
+    runtime_thread_input_action_dispatcher,
 )
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
 from backend.web.routers import threads as threads_router
@@ -292,6 +293,33 @@ async def test_runtime_thread_input_envelopes_dispatch_through_gateway() -> None
     )
 
     assert captured == [envelope]
+
+
+@pytest.mark.asyncio
+async def test_runtime_thread_input_action_dispatcher_binds_runtime_gateway() -> None:
+    from protocols.agent_runtime import AgentThreadInputResult
+
+    captured: list[Any] = []
+
+    class _Gateway:
+        async def dispatch_thread_input(self, envelope: Any) -> AgentThreadInputResult:
+            captured.append(envelope)
+            return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
+
+    action = internal_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="answer",
+        metadata={"request_id": "req-1"},
+    )
+    dispatch_actions = runtime_thread_input_action_dispatcher(
+        SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=_Gateway()))),
+    )
+
+    results = await dispatch_actions([action])
+
+    assert [result.to_response() for result in results] == [{"status": "started", "routing": "direct", "thread_id": "thread-1"}]
+    assert captured == [plan_runtime_thread_input_envelope(action)]
 
 
 def test_queued_thread_input_action_enqueues_steer_message() -> None:


### PR DESCRIPTION
## Summary

- Add a bound runtime thread input action dispatcher.
- Route single thread input action dispatch through the same dispatcher shape.
- Keep router UX and thread input envelope/gateway behavior unchanged.

## Verification

- RED: `uv run pytest tests/Unit/integration_contracts/test_threads_router.py -q` failed before implementation because `runtime_thread_input_action_dispatcher` was missing.
- `uv run pytest tests/Unit/integration_contracts/test_threads_router.py -q` -> 37 passed
- `uv run pytest tests/Unit/integration_contracts/test_threads_router.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q` -> 57 passed
- `uv run pyright backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py` -> 0 errors
- `uv run ruff check backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py` -> All checks passed
- `uv run ruff format --check backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/integration_contracts/test_threads_router.py` -> 2 files already formatted
- `git diff --check` -> clean
- `uv run pytest tests/Unit -q` -> 2235 passed, 3 skipped, 15 warnings
