### PR TITLE
Hide planned runtime events behind chat delivery actions

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -7,21 +7,18 @@ from typing import Any
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
 from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
-    runtime_chat_delivery_action_dispatcher,
+    dispatch_runtime_chat_delivery_event,
+    make_runtime_chat_delivery_event_hook,
 )
-from backend.threads.chat_adapters.runtime_event_hook import make_planned_runtime_event_hook
-from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any):
-    return make_planned_runtime_event_hook(
+    return make_runtime_chat_delivery_event_hook(
+        app,
         chat_delivery_runtime_action_planner(),
-        runtime_chat_delivery_action_dispatcher(
-            app,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        ),
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
     )
 
 
@@ -32,14 +29,12 @@ async def dispatch_chat_delivery_event(
     activity_reader: Any,
     thread_repo: Any,
 ) -> int:
-    return await run_planned_runtime_event(
+    return await dispatch_runtime_chat_delivery_event(
+        app,
         request,
         chat_delivery_runtime_action_planner(),
-        runtime_chat_delivery_action_dispatcher(
-            app,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        ),
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
     )
 
 

--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_event_hook import make_planned_runtime_event_hook
+from backend.threads.chat_adapters.runtime_event_runner import run_planned_runtime_event
 from backend.threads.chat_adapters.runtime_identity import runtime_actor
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_chat_delivery_recipient
 from protocols.agent_runtime import (
@@ -27,6 +29,42 @@ class RuntimeChatDeliveryAction:
     content: str
     raw_content: str
     signal: str | None
+
+
+def make_runtime_chat_delivery_event_hook[EventT](
+    app: Any,
+    planner: Callable[[EventT], Iterable[RuntimeChatDeliveryAction]],
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> Callable[[EventT], None]:
+    return make_planned_runtime_event_hook(
+        planner,
+        runtime_chat_delivery_action_dispatcher(
+            app,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        ),
+    )
+
+
+async def dispatch_runtime_chat_delivery_event[EventT](
+    app: Any,
+    event: EventT,
+    planner: Callable[[EventT], Iterable[RuntimeChatDeliveryAction]],
+    *,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> int:
+    return await run_planned_runtime_event(
+        event,
+        planner,
+        runtime_chat_delivery_action_dispatcher(
+            app,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        ),
+    )
 
 
 async def dispatch_runtime_chat_delivery_action(

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -68,6 +68,20 @@ def test_chat_inlets_do_not_dispatch_runtime_gateway_directly() -> None:
         assert "AgentRuntimeNotificationEnvelope" not in text, path
 
 
+def test_chat_inlets_do_not_compose_planned_runtime_events_directly() -> None:
+    repo_root = Path(__file__).parents[5]
+    inlet_files = list((repo_root / "backend" / "threads" / "chat_adapters").glob("*_inlet.py"))
+
+    assert inlet_files
+
+    for path in inlet_files:
+        text = path.read_text(encoding="utf-8")
+        assert "runtime_event_hook" not in text, path
+        assert "runtime_event_runner" not in text, path
+        assert "make_planned_runtime_event_hook" not in text, path
+        assert "run_planned_runtime_event" not in text, path
+
+
 def test_runtime_actions_use_shared_actor_builder() -> None:
     repo_root = Path(__file__).parents[5]
     action_files = list((repo_root / "backend" / "threads" / "chat_adapters").glob("runtime_*_action.py"))


### PR DESCRIPTION
## Summary
- move chat delivery planned-event hook/direct dispatch composition into the runtime chat delivery action adapter
- keep chat inlet responsible only for product request-to-action planning
- add a boundary contract so inlets do not directly import planned runtime event plumbing

## Verification
- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` failed before implementation because `chat_inlet.py` imported `runtime_event_hook` / `runtime_event_runner`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_event_hook.py tests/Unit/backend/web/services/test_runtime_event_runner.py -q`
- `uv run pyright backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/chat_inlet.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pytest tests/Unit -q` -> 2236 passed, 3 skipped, 15 warnings
- `git diff --check`
