### PR TITLE
Route thread input through an inlet boundary

### DIFF
--- a/backend/threads/chat_adapters/thread_input_inlet.py
+++ b/backend/threads/chat_adapters/thread_input_inlet.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from backend.threads.chat_adapters.runtime_thread_input_action import (
+    dispatch_queued_thread_input_action,
+    dispatch_runtime_thread_input_action,
+    internal_runtime_thread_input_action,
+    owner_runtime_thread_input_action,
+    queued_command_thread_input_action,
+    queued_thread_input_action,
+)
+from protocols.agent_runtime import AgentThreadInputResult
+
+
+async def dispatch_owner_thread_input(
+    app: Any,
+    *,
+    thread_id: str,
+    user_id: str,
+    message: str,
+    attachments: list[str] | None,
+    enable_trajectory: bool,
+) -> AgentThreadInputResult:
+    return await dispatch_runtime_thread_input_action(
+        app,
+        owner_runtime_thread_input_action(
+            thread_id=thread_id,
+            user_id=user_id,
+            message=message,
+            attachments=attachments,
+            enable_trajectory=enable_trajectory,
+        ),
+    )
+
+
+async def dispatch_internal_thread_input(
+    app: Any,
+    *,
+    thread_id: str,
+    user_id: str,
+    message: str,
+    metadata: dict[str, Any] | None = None,
+) -> AgentThreadInputResult:
+    return await dispatch_runtime_thread_input_action(
+        app,
+        internal_runtime_thread_input_action(
+            thread_id=thread_id,
+            user_id=user_id,
+            message=message,
+            metadata=metadata,
+        ),
+    )
+
+
+def queue_thread_input(queue_manager: Any, *, thread_id: str, message: str) -> dict[str, str]:
+    return dispatch_queued_thread_input_action(
+        queue_manager,
+        queued_thread_input_action(thread_id=thread_id, message=message),
+    )
+
+
+def queue_command_thread_input(queue_manager: Any, *, thread_id: str, message: str) -> dict[str, str]:
+    return dispatch_queued_thread_input_action(
+        queue_manager,
+        queued_command_thread_input_action(thread_id=thread_id, message=message),
+    )

--- a/backend/web/routers/threads.py
+++ b/backend/web/routers/threads.py
@@ -986,10 +986,7 @@ async def send_message(
         raise HTTPException(status_code=400, detail="message cannot be empty")
 
     from backend.threads.activity_pool_service import get_or_create_agent
-    from backend.threads.chat_adapters.runtime_thread_input_action import (
-        dispatch_runtime_thread_input_action,
-        owner_runtime_thread_input_action,
-    )
+    from backend.threads.chat_adapters.thread_input_inlet import dispatch_owner_thread_input
 
     message = payload.message
     # @@@attachment-wire - sync files to sandbox and prepend paths
@@ -1004,15 +1001,13 @@ async def send_message(
             agent=agent,
         )
 
-    result = await dispatch_runtime_thread_input_action(
+    result = await dispatch_owner_thread_input(
         app,
-        owner_runtime_thread_input_action(
-            thread_id=thread_id,
-            user_id=user_id,
-            message=message,
-            attachments=payload.attachments or None,
-            enable_trajectory=payload.enable_trajectory,
-        ),
+        thread_id=thread_id,
+        user_id=user_id,
+        message=message,
+        attachments=payload.attachments or None,
+        enable_trajectory=payload.enable_trajectory,
     )
     return result.to_response()
 
@@ -1026,15 +1021,9 @@ async def queue_message(
     """Enqueue a followup message. Will be consumed when agent reaches IDLE."""
     if not payload.message.strip():
         raise HTTPException(status_code=400, detail="message cannot be empty")
-    from backend.threads.chat_adapters.runtime_thread_input_action import (
-        dispatch_queued_thread_input_action,
-        queued_thread_input_action,
-    )
+    from backend.threads.chat_adapters.thread_input_inlet import queue_thread_input
 
-    return dispatch_queued_thread_input_action(
-        app.state.queue_manager,
-        queued_thread_input_action(thread_id=thread_id, message=payload.message),
-    )
+    return queue_thread_input(app.state.queue_manager, thread_id=thread_id, message=payload.message)
 
 
 @router.get("/{thread_id}/queue")
@@ -1176,10 +1165,7 @@ async def resolve_thread_permission_request(
 
     followup: dict[str, Any] | None = None
     if is_ask_user_question and payload.decision == "allow" and pending_request is not None and answers is not None:
-        from backend.threads.chat_adapters.runtime_thread_input_action import (
-            dispatch_runtime_thread_input_action,
-            internal_runtime_thread_input_action,
-        )
+        from backend.threads.chat_adapters.thread_input_inlet import dispatch_internal_thread_input
 
         answered_payload = _build_ask_user_question_answered_payload(
             pending_request,
@@ -1187,18 +1173,16 @@ async def resolve_thread_permission_request(
             annotations=getattr(payload, "annotations", None),
         )
 
-        followup_result = await dispatch_runtime_thread_input_action(
+        followup_result = await dispatch_internal_thread_input(
             app,
-            internal_runtime_thread_input_action(
-                thread_id=thread_id,
-                user_id=user_id or "internal",
-                message=_format_ask_user_question_followup(
-                    pending_request,
-                    answers=answers,
-                    annotations=getattr(payload, "annotations", None),
-                ),
-                metadata={"ask_user_question_answered": answered_payload},
+            thread_id=thread_id,
+            user_id=user_id or "internal",
+            message=_format_ask_user_question_followup(
+                pending_request,
+                answers=answers,
+                annotations=getattr(payload, "annotations", None),
             ),
+            metadata={"ask_user_question_answered": answered_payload},
         )
         followup = followup_result.to_response()
 
@@ -1553,10 +1537,7 @@ async def _notify_task_cancelled(app: Any, thread_id: str, task_id: str, run: An
         agent = _get_agent_for_thread(app, thread_id)
         qm = getattr(agent, "queue_manager", None) if agent else None
         if qm:
-            from backend.threads.chat_adapters.runtime_thread_input_action import (
-                dispatch_queued_thread_input_action,
-                queued_command_thread_input_action,
-            )
+            from backend.threads.chat_adapters.thread_input_inlet import queue_command_thread_input
 
             description = getattr(run, "description", "") or ""
             command = getattr(run, "command", "") or ""
@@ -1568,9 +1549,6 @@ async def _notify_task_cancelled(app: Any, thread_id: str, task_id: str, run: An
                 + (f"<CommandLine>{command[:200]}</CommandLine>" if command else "")
                 + "</CommandNotification>"
             )
-            dispatch_queued_thread_input_action(
-                qm,
-                queued_command_thread_input_action(thread_id=thread_id, message=notification),
-            )
+            queue_command_thread_input(qm, thread_id=thread_id, message=notification)
     except Exception:
         logger.warning("Failed to enqueue cancellation notice for task %s", task_id, exc_info=True)

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -82,6 +82,15 @@ def test_chat_inlets_do_not_compose_planned_runtime_events_directly() -> None:
         assert "run_planned_runtime_event" not in text, path
 
 
+def test_thread_router_does_not_import_runtime_thread_input_actions_directly() -> None:
+    repo_root = Path(__file__).parents[5]
+    router_path = repo_root / "backend" / "web" / "routers" / "threads.py"
+
+    text = router_path.read_text(encoding="utf-8")
+
+    assert "runtime_thread_input_action" not in text
+
+
 def test_runtime_actions_use_shared_actor_builder() -> None:
     repo_root = Path(__file__).parents[5]
     action_files = list((repo_root / "backend" / "threads" / "chat_adapters").glob("runtime_*_action.py"))

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -20,12 +20,40 @@ def _thread_repo() -> SimpleNamespace:
     )
 
 
+def _empty_thread_repo() -> SimpleNamespace:
+    return SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: [])
+
+
+def _activity_reader() -> SimpleNamespace:
+    return SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+
+
+def _user(user_id: str, user_type: str, display_name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=user_id, type=user_type, display_name=display_name, avatar=None)
+
+
+def _user_repo(*users: SimpleNamespace) -> SimpleNamespace:
+    rows = {user.id: user for user in users}
+    return SimpleNamespace(get_by_id=lambda uid: rows.get(uid))
+
+
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.envelopes = []
+
+    async def dispatch_notification(self, envelope):
+        self.envelopes.append(envelope)
+        thread_id = envelope.recipient.thread_id or f"external:{envelope.recipient.agent_user_id}"
+        return SimpleNamespace(status="accepted", thread_id=thread_id)
+
+
+def _only_envelope(gateway: _RecordingGateway):
+    assert len(gateway.envelopes) == 1
+    return gateway.envelopes[0]
+
+
 def test_chat_join_rejection_notification_planner_returns_runtime_action() -> None:
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
-        }.get(uid)
-    )
+    user_repo = _user_repo(_user("owner-1", "human", "Owner"))
     planner = chat_join_inlet.chat_join_rejection_notification_action_planner(user_repo)
 
     actions = planner(
@@ -57,23 +85,11 @@ def test_chat_join_rejection_notification_planner_returns_runtime_action() -> No
 
 @pytest.mark.asyncio
 async def test_chat_join_rejection_notification_dispatches_runtime_notification_to_agent_requester() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
-            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("owner-1", "human", "Owner"), _user("agent-user-1", "agent", "Agent"))
     notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
         thread_repo=_thread_repo(),
         user_repo=user_repo,
     )
@@ -89,18 +105,18 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
         },
     )
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "agent-user-1"
-    assert gateway.envelope.recipient.runtime_source == "mycel"
-    assert gateway.envelope.recipient.thread_id == "thread-main"
-    assert gateway.envelope.sender.user_id == "owner-1"
-    assert gateway.envelope.sender.user_type == "human"
-    assert gateway.envelope.sender.display_name == "Owner"
-    assert gateway.envelope.sender.source == "chat_join"
-    assert gateway.envelope.event_type == "chat.join.rejected"
-    assert gateway.envelope.notification_type == "chat_join"
-    assert "Owner rejected your request to join chat chat-1." in gateway.envelope.message.content
-    assert gateway.envelope.message.metadata == {
+    envelope = _only_envelope(gateway)
+    assert envelope.recipient.agent_user_id == "agent-user-1"
+    assert envelope.recipient.runtime_source == "mycel"
+    assert envelope.recipient.thread_id == "thread-main"
+    assert envelope.sender.user_id == "owner-1"
+    assert envelope.sender.user_type == "human"
+    assert envelope.sender.display_name == "Owner"
+    assert envelope.sender.source == "chat_join"
+    assert envelope.event_type == "chat.join.rejected"
+    assert envelope.notification_type == "chat_join"
+    assert "Owner rejected your request to join chat chat-1." in envelope.message.content
+    assert envelope.message.metadata == {
         "chat_join_request_id": "chat_join:chat-1:agent-user-1",
         "chat_id": "chat-1",
         "state": "rejected",
@@ -109,24 +125,12 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
 
 @pytest.mark.asyncio
 async def test_chat_join_rejection_notification_dispatches_runtime_notification_to_external_requester() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=f"external:{envelope.recipient.agent_user_id}")
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
-            "external-user-1": SimpleNamespace(id="external-user-1", type="external", display_name="External", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("owner-1", "human", "Owner"), _user("external-user-1", "external", "External"))
     notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
         _hook_app(gateway),
         activity_reader=None,
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -141,17 +145,17 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
         },
     )
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
-    assert gateway.envelope.recipient.runtime_source == "external"
-    assert gateway.envelope.sender.user_id == "owner-1"
-    assert gateway.envelope.sender.user_type == "human"
-    assert gateway.envelope.sender.display_name == "Owner"
-    assert gateway.envelope.sender.source == "chat_join"
-    assert gateway.envelope.event_type == "chat.join.rejected"
-    assert gateway.envelope.notification_type == "chat_join"
-    assert "Owner rejected your request to join chat chat-1." in gateway.envelope.message.content
-    assert gateway.envelope.message.metadata == {
+    envelope = _only_envelope(gateway)
+    assert envelope.recipient.agent_user_id == "external-user-1"
+    assert envelope.recipient.runtime_source == "external"
+    assert envelope.sender.user_id == "owner-1"
+    assert envelope.sender.user_type == "human"
+    assert envelope.sender.display_name == "Owner"
+    assert envelope.sender.source == "chat_join"
+    assert envelope.event_type == "chat.join.rejected"
+    assert envelope.notification_type == "chat_join"
+    assert "Owner rejected your request to join chat chat-1." in envelope.message.content
+    assert envelope.message.metadata == {
         "chat_join_request_id": "chat_join:chat-1:external-user-1",
         "chat_id": "chat-1",
         "state": "rejected",
@@ -160,23 +164,12 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
 
 @pytest.mark.asyncio
 async def test_chat_join_rejection_notification_skips_agent_wake_when_no_runtime_thread() -> None:
-    class RecordingGateway:
-        called = False
-
-        async def dispatch_notification(self, _envelope):
-            self.called = True
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
-            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("owner-1", "human", "Owner"), _user("agent-user-1", "agent", "Agent"))
     notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        activity_reader=_activity_reader(),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -191,31 +184,17 @@ async def test_chat_join_rejection_notification_skips_agent_wake_when_no_runtime
         },
     )
 
-    assert gateway.called is False
+    assert gateway.envelopes == []
 
 
 @pytest.mark.asyncio
 async def test_chat_join_rejection_notification_ignores_human_requester() -> None:
-    class RecordingGateway:
-        called = False
-
-        async def dispatch_thread_input(self, _envelope):
-            self.called = True
-
-        async def dispatch_notification(self, _envelope):
-            self.called = True
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
-            "human-1": SimpleNamespace(id="human-1", type="human", display_name="Human", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("owner-1", "human", "Owner"), _user("human-1", "human", "Human"))
     notify = chat_join_inlet.make_chat_join_rejection_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        activity_reader=_activity_reader(),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -230,4 +209,4 @@ async def test_chat_join_rejection_notification_ignores_human_requester() -> Non
         },
     )
 
-    assert gateway.called is False
+    assert gateway.envelopes == []

--- a/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
+++ b/tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py
@@ -43,16 +43,36 @@ def _envelope() -> AgentChatDeliveryEnvelope:
     )
 
 
-@pytest.mark.asyncio
-async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> None:
+def _queueing_handler(wake_bus: object) -> tuple[ExternalRuntimeInboxHandler, list[tuple[str, str, str, dict]]]:
     enqueued: list[tuple[str, str, str, dict]] = []
-    wake_bus = _RecordingWakeBus()
     handler = ExternalRuntimeInboxHandler(
         wake_bus=wake_bus,
         queue_manager=SimpleNamespace(
             enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
         ),
     )
+    return handler, enqueued
+
+
+def _notification_envelope(
+    *,
+    message: AgentRuntimeMessage,
+    transport: AgentRuntimeTransport | None = None,
+) -> AgentRuntimeNotificationEnvelope:
+    return AgentRuntimeNotificationEnvelope(
+        event_type="relationship.requested",
+        recipient=AgentChatRecipient(agent_user_id="external-user-1", runtime_source="external"),
+        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human", source="relationship"),
+        message=message,
+        notification_type="relationship",
+        transport=transport or AgentRuntimeTransport(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> None:
+    wake_bus = _RecordingWakeBus()
+    handler, enqueued = _queueing_handler(wake_bus)
 
     result = await handler.dispatch(_envelope())
 
@@ -74,13 +94,7 @@ async def test_external_runtime_inbox_handler_queues_chat_wake_token_only() -> N
 
 @pytest.mark.asyncio
 async def test_external_runtime_inbox_handler_wraps_chat_wake_failure_after_enqueue() -> None:
-    enqueued: list[tuple[str, str, str, dict]] = []
-    handler = ExternalRuntimeInboxHandler(
-        wake_bus=_FailingWakeBus(),
-        queue_manager=SimpleNamespace(
-            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
-        ),
-    )
+    handler, enqueued = _queueing_handler(_FailingWakeBus())
 
     with pytest.raises(ExternalRuntimeInboxActionError) as exc_info:
         await handler.dispatch(_envelope())
@@ -93,23 +107,13 @@ async def test_external_runtime_inbox_handler_wraps_chat_wake_failure_after_enqu
 
 @pytest.mark.asyncio
 async def test_external_runtime_inbox_handler_queues_generic_runtime_notification() -> None:
-    enqueued: list[tuple[str, str, str, dict]] = []
     wake_bus = _RecordingWakeBus()
-    handler = ExternalRuntimeInboxHandler(
-        wake_bus=wake_bus,
-        queue_manager=SimpleNamespace(
-            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
-        ),
-    )
-    envelope = AgentRuntimeNotificationEnvelope(
-        event_type="relationship.requested",
-        recipient=AgentChatRecipient(agent_user_id="external-user-1", runtime_source="external"),
-        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human", source="relationship"),
+    handler, enqueued = _queueing_handler(wake_bus)
+    envelope = _notification_envelope(
         message=AgentRuntimeMessage(
             content="Human requested a relationship with you.",
             metadata={"relationship_id": "hire_visit:external-user-1:human-user-1"},
         ),
-        notification_type="relationship",
         transport=AgentRuntimeTransport(
             delivery_id="delivery-1",
             correlation_id="corr-1",
@@ -144,20 +148,9 @@ async def test_external_runtime_inbox_handler_queues_generic_runtime_notificatio
 
 @pytest.mark.asyncio
 async def test_external_runtime_inbox_handler_wraps_notification_wake_failure_after_enqueue() -> None:
-    enqueued: list[tuple[str, str, str, dict]] = []
-    handler = ExternalRuntimeInboxHandler(
-        wake_bus=_FailingWakeBus(),
-        queue_manager=SimpleNamespace(
-            enqueue=lambda content, thread_id, notification_type, **meta: enqueued.append((content, thread_id, notification_type, meta))
-        ),
-    )
-    envelope = AgentRuntimeNotificationEnvelope(
-        event_type="relationship.requested",
-        recipient=AgentChatRecipient(agent_user_id="external-user-1", runtime_source="external"),
-        sender=AgentRuntimeActor(user_id="human-user-1", user_type="human", display_name="Human", source="relationship"),
+    handler, enqueued = _queueing_handler(_FailingWakeBus())
+    envelope = _notification_envelope(
         message=AgentRuntimeMessage(content="Human requested a relationship with you."),
-        notification_type="relationship",
-        transport=AgentRuntimeTransport(),
     )
 
     with pytest.raises(ExternalRuntimeInboxActionError) as exc_info:

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -44,12 +44,40 @@ def _thread_repo() -> SimpleNamespace:
     )
 
 
+def _empty_thread_repo() -> SimpleNamespace:
+    return SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: [])
+
+
+def _activity_reader() -> SimpleNamespace:
+    return SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+
+
+def _user(user_id: str, user_type: str, display_name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=user_id, type=user_type, display_name=display_name, avatar=None)
+
+
+def _user_repo(*users: SimpleNamespace) -> SimpleNamespace:
+    rows = {user.id: user for user in users}
+    return SimpleNamespace(get_by_id=lambda uid: rows.get(uid))
+
+
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.envelopes = []
+
+    async def dispatch_notification(self, envelope):
+        self.envelopes.append(envelope)
+        thread_id = envelope.recipient.thread_id or f"external:{envelope.recipient.agent_user_id}"
+        return SimpleNamespace(status="accepted", thread_id=thread_id)
+
+
+def _only_envelope(gateway: _RecordingGateway):
+    assert len(gateway.envelopes) == 1
+    return gateway.envelopes[0]
+
+
 def test_relationship_request_notification_planner_returns_runtime_action() -> None:
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-        }.get(uid)
-    )
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"))
     planner = relationship_inlet.relationship_request_notification_action_planner(user_repo)
 
     actions = planner(_relationship_row(message="Please add me."))
@@ -71,11 +99,7 @@ def test_relationship_request_notification_planner_returns_runtime_action() -> N
 
 
 def test_relationship_decision_notification_planner_returns_runtime_action() -> None:
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-        }.get(uid)
-    )
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"))
     planner = relationship_inlet.relationship_decision_notification_action_planner(user_repo)
 
     actions = planner(
@@ -104,84 +128,40 @@ def test_relationship_decision_notification_planner_returns_runtime_action() -> 
 
 @pytest.mark.asyncio
 async def test_relationship_request_notification_dispatches_runtime_notification_to_agent_target() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(
-                id="human-user-1",
-                type="human",
-                display_name="Human",
-                avatar=None,
-            ),
-            "agent-user-1": SimpleNamespace(
-                id="agent-user-1",
-                type="agent",
-                display_name="Toad",
-                avatar=None,
-            ),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("agent-user-1", "agent", "Agent"))
     notify = relationship_inlet.make_relationship_request_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
         thread_repo=_thread_repo(),
         user_repo=user_repo,
     )
 
     await asyncio.to_thread(notify, _relationship_row(message="Please add me to the planning chat."))
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "agent-user-1"
-    assert gateway.envelope.recipient.runtime_source == "mycel"
-    assert gateway.envelope.recipient.thread_id == "thread-main"
-    assert gateway.envelope.sender.user_id == "human-user-1"
-    assert gateway.envelope.sender.user_type == "human"
-    assert gateway.envelope.sender.display_name == "Human"
-    assert gateway.envelope.sender.source == "relationship"
-    assert gateway.envelope.event_type == "relationship.requested"
-    assert gateway.envelope.notification_type == "relationship"
-    assert "Human requested a relationship with you." in gateway.envelope.message.content
-    assert "Please add me to the planning chat." in gateway.envelope.message.content
-    assert gateway.envelope.message.metadata == {"relationship_id": "hire_visit:agent-user-1:human-user-1"}
+    envelope = _only_envelope(gateway)
+    assert envelope.recipient.agent_user_id == "agent-user-1"
+    assert envelope.recipient.runtime_source == "mycel"
+    assert envelope.recipient.thread_id == "thread-main"
+    assert envelope.sender.user_id == "human-user-1"
+    assert envelope.sender.user_type == "human"
+    assert envelope.sender.display_name == "Human"
+    assert envelope.sender.source == "relationship"
+    assert envelope.event_type == "relationship.requested"
+    assert envelope.notification_type == "relationship"
+    assert "Human requested a relationship with you." in envelope.message.content
+    assert "Please add me to the planning chat." in envelope.message.content
+    assert envelope.message.metadata == {"relationship_id": "hire_visit:agent-user-1:human-user-1"}
 
 
 @pytest.mark.asyncio
 async def test_relationship_request_notification_dispatches_external_runtime_notification_to_external_target() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=f"external:{envelope.recipient.agent_user_id}")
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(
-                id="human-user-1",
-                type="human",
-                display_name="Human",
-                avatar=None,
-            ),
-            "external-user-1": SimpleNamespace(
-                id="external-user-1",
-                type="external",
-                display_name="External",
-                avatar=None,
-            ),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("external-user-1", "external", "External"))
     notify = relationship_inlet.make_relationship_request_notification_fn(
         _hook_app(gateway),
         activity_reader=None,
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -195,35 +175,24 @@ async def test_relationship_request_notification_dispatches_external_runtime_not
         ),
     )
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
-    assert gateway.envelope.recipient.runtime_source == "external"
-    assert gateway.envelope.sender.user_id == "human-user-1"
-    assert gateway.envelope.sender.source == "relationship"
-    assert gateway.envelope.event_type == "relationship.requested"
-    assert "Human requested a relationship with you." in gateway.envelope.message.content
-    assert gateway.envelope.message.metadata == {"relationship_id": "hire_visit:external-user-1:human-user-1"}
+    envelope = _only_envelope(gateway)
+    assert envelope.recipient.agent_user_id == "external-user-1"
+    assert envelope.recipient.runtime_source == "external"
+    assert envelope.sender.user_id == "human-user-1"
+    assert envelope.sender.source == "relationship"
+    assert envelope.event_type == "relationship.requested"
+    assert "Human requested a relationship with you." in envelope.message.content
+    assert envelope.message.metadata == {"relationship_id": "hire_visit:external-user-1:human-user-1"}
 
 
 @pytest.mark.asyncio
 async def test_relationship_request_notification_does_not_dispatch_to_non_agent_target() -> None:
-    class RecordingGateway:
-        called = False
-
-        async def dispatch_notification(self, _envelope):
-            self.called = True
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-            "human-user-2": SimpleNamespace(id="human-user-2", type="human", display_name="Other", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("human-user-2", "human", "Other"))
     notify = relationship_inlet.make_relationship_request_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        activity_reader=_activity_reader(),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -232,55 +201,32 @@ async def test_relationship_request_notification_does_not_dispatch_to_non_agent_
         _relationship_row(user_low="human-user-1", user_high="human-user-2", initiator_user_id="human-user-1"),
     )
 
-    assert gateway.called is False
+    assert gateway.envelopes == []
 
 
 @pytest.mark.asyncio
 async def test_relationship_request_notification_skips_agent_wake_when_no_runtime_thread() -> None:
-    class RecordingGateway:
-        called = False
-
-        async def dispatch_notification(self, _envelope):
-            self.called = True
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("agent-user-1", "agent", "Agent"))
     notify = relationship_inlet.make_relationship_request_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        activity_reader=_activity_reader(),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
     await asyncio.to_thread(notify, _relationship_row())
 
-    assert gateway.called is False
+    assert gateway.envelopes == []
 
 
 @pytest.mark.asyncio
 async def test_relationship_decision_notification_dispatches_runtime_notification_to_agent_requester() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("agent-user-1", "agent", "Agent"))
     notify = relationship_inlet.make_relationship_decision_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
         thread_repo=_thread_repo(),
         user_repo=user_repo,
     )
@@ -296,18 +242,18 @@ async def test_relationship_decision_notification_dispatches_runtime_notificatio
         "approve",
     )
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "agent-user-1"
-    assert gateway.envelope.recipient.runtime_source == "mycel"
-    assert gateway.envelope.recipient.thread_id == "thread-main"
-    assert gateway.envelope.sender.user_id == "human-user-1"
-    assert gateway.envelope.sender.user_type == "human"
-    assert gateway.envelope.sender.display_name == "Human"
-    assert gateway.envelope.sender.source == "relationship"
-    assert gateway.envelope.event_type == "relationship.approved"
-    assert gateway.envelope.notification_type == "relationship"
-    assert "Human approved your relationship request." in gateway.envelope.message.content
-    assert gateway.envelope.message.metadata == {
+    envelope = _only_envelope(gateway)
+    assert envelope.recipient.agent_user_id == "agent-user-1"
+    assert envelope.recipient.runtime_source == "mycel"
+    assert envelope.recipient.thread_id == "thread-main"
+    assert envelope.sender.user_id == "human-user-1"
+    assert envelope.sender.user_type == "human"
+    assert envelope.sender.display_name == "Human"
+    assert envelope.sender.source == "relationship"
+    assert envelope.event_type == "relationship.approved"
+    assert envelope.notification_type == "relationship"
+    assert "Human approved your relationship request." in envelope.message.content
+    assert envelope.message.metadata == {
         "relationship_id": "hire_visit:agent-user-1:human-user-1",
         "event": "approve",
         "state": "visit",
@@ -316,24 +262,12 @@ async def test_relationship_decision_notification_dispatches_runtime_notificatio
 
 @pytest.mark.asyncio
 async def test_relationship_decision_notification_dispatches_external_runtime_notification_to_external_requester() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=f"external:{envelope.recipient.agent_user_id}")
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-            "external-user-1": SimpleNamespace(id="external-user-1", type="external", display_name="External", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("external-user-1", "external", "External"))
     notify = relationship_inlet.make_relationship_decision_notification_fn(
         _hook_app(gateway),
         activity_reader=None,
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -348,14 +282,14 @@ async def test_relationship_decision_notification_dispatches_external_runtime_no
         "approve",
     )
 
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "external-user-1"
-    assert gateway.envelope.recipient.runtime_source == "external"
-    assert gateway.envelope.sender.user_id == "human-user-1"
-    assert gateway.envelope.sender.source == "relationship"
-    assert gateway.envelope.event_type == "relationship.approved"
-    assert "Human approved your relationship request." in gateway.envelope.message.content
-    assert gateway.envelope.message.metadata == {
+    envelope = _only_envelope(gateway)
+    assert envelope.recipient.agent_user_id == "external-user-1"
+    assert envelope.recipient.runtime_source == "external"
+    assert envelope.sender.user_id == "human-user-1"
+    assert envelope.sender.source == "relationship"
+    assert envelope.event_type == "relationship.approved"
+    assert "Human approved your relationship request." in envelope.message.content
+    assert envelope.message.metadata == {
         "relationship_id": "hire_visit:external-user-1:human-user-1",
         "event": "approve",
         "state": "visit",
@@ -364,23 +298,12 @@ async def test_relationship_decision_notification_dispatches_external_runtime_no
 
 @pytest.mark.asyncio
 async def test_relationship_decision_notification_ignores_non_agent_requester() -> None:
-    class RecordingGateway:
-        called = False
-
-        async def dispatch_notification(self, _envelope):
-            self.called = True
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-            "human-user-2": SimpleNamespace(id="human-user-2", type="human", display_name="Other", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("human-user-2", "human", "Other"))
     notify = relationship_inlet.make_relationship_decision_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        activity_reader=_activity_reader(),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -390,28 +313,17 @@ async def test_relationship_decision_notification_ignores_non_agent_requester() 
         "reject",
     )
 
-    assert gateway.called is False
+    assert gateway.envelopes == []
 
 
 @pytest.mark.asyncio
 async def test_relationship_decision_notification_skips_agent_wake_when_no_runtime_thread() -> None:
-    class RecordingGateway:
-        called = False
-
-        async def dispatch_notification(self, _envelope):
-            self.called = True
-
-    gateway = RecordingGateway()
-    user_repo = SimpleNamespace(
-        get_by_id=lambda uid: {
-            "human-user-1": SimpleNamespace(id="human-user-1", type="human", display_name="Human", avatar=None),
-            "agent-user-1": SimpleNamespace(id="agent-user-1", type="agent", display_name="Toad", avatar=None),
-        }.get(uid)
-    )
+    gateway = _RecordingGateway()
+    user_repo = _user_repo(_user("human-user-1", "human", "Human"), _user("agent-user-1", "agent", "Agent"))
     notify = relationship_inlet.make_relationship_decision_notification_fn(
         _hook_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
-        thread_repo=SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: []),
+        activity_reader=_activity_reader(),
+        thread_repo=_empty_thread_repo(),
         user_repo=user_repo,
     )
 
@@ -426,4 +338,4 @@ async def test_relationship_decision_notification_skips_agent_wake_when_no_runti
         "approve",
     )
 
-    assert gateway.called is False
+    assert gateway.envelopes == []

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -36,27 +37,40 @@ def _thread_repo() -> SimpleNamespace:
     )
 
 
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.envelopes = []
+
+    async def dispatch_notification(self, envelope):
+        self.envelopes.append(envelope)
+        return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
+
+
+def _activity_reader() -> SimpleNamespace:
+    return SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+
+
+def _action(**overrides) -> RuntimeNotificationAction:
+    payload: dict[str, Any] = {
+        "context": "Test action",
+        "recipient_user_id": "agent-1",
+        "sender_user_id": "owner-1",
+        "sender_source": "workflow",
+        "event_type": "test.event",
+        "notification_type": "test",
+        "content": "Action happened.",
+    }
+    payload.update(overrides)
+    return RuntimeNotificationAction(**payload)
+
+
 @pytest.mark.asyncio
 async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_recipient() -> None:
-    class RecordingGateway:
-        envelope = None
-
-        async def dispatch_notification(self, envelope):
-            self.envelope = envelope
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
+    gateway = _RecordingGateway()
 
     dispatched = await dispatch_runtime_notification_action(
         _runtime_app(gateway),
-        RuntimeNotificationAction(
-            context="Test action",
-            recipient_user_id="agent-1",
-            sender_user_id="owner-1",
-            sender_source="workflow",
-            event_type="test.event",
-            notification_type="test",
-            content="Action happened.",
+        _action(
             metadata={"resource_id": "resource-1"},
             transport=AgentRuntimeTransport(
                 delivery_id="delivery-1",
@@ -66,60 +80,39 @@ async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_re
         ),
         user_repo=_users(),
         thread_repo=_thread_repo(),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
     )
 
     assert dispatched is True
-    assert gateway.envelope is not None
-    assert gateway.envelope.recipient.agent_user_id == "agent-1"
-    assert gateway.envelope.recipient.runtime_source == "mycel"
-    assert gateway.envelope.recipient.thread_id == "thread-agent-1"
-    assert gateway.envelope.sender.user_id == "owner-1"
-    assert gateway.envelope.sender.source == "workflow"
-    assert gateway.envelope.event_type == "test.event"
-    assert gateway.envelope.notification_type == "test"
-    assert gateway.envelope.message.content == "Action happened."
-    assert gateway.envelope.message.metadata == {"resource_id": "resource-1"}
-    assert gateway.envelope.transport.delivery_id == "delivery-1"
+    assert len(gateway.envelopes) == 1
+    envelope = gateway.envelopes[0]
+    assert envelope.recipient.agent_user_id == "agent-1"
+    assert envelope.recipient.runtime_source == "mycel"
+    assert envelope.recipient.thread_id == "thread-agent-1"
+    assert envelope.sender.user_id == "owner-1"
+    assert envelope.sender.source == "workflow"
+    assert envelope.event_type == "test.event"
+    assert envelope.notification_type == "test"
+    assert envelope.message.content == "Action happened."
+    assert envelope.message.metadata == {"resource_id": "resource-1"}
+    assert envelope.transport.delivery_id == "delivery-1"
 
 
 @pytest.mark.asyncio
 async def test_runtime_notification_actions_dispatches_only_runtime_recipients() -> None:
-    class RecordingGateway:
-        def __init__(self) -> None:
-            self.envelopes = []
-
-        async def dispatch_notification(self, envelope):
-            self.envelopes.append(envelope)
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
+    gateway = _RecordingGateway()
 
     dispatched_count = await dispatch_runtime_notification_actions(
         _runtime_app(gateway),
         [
-            RuntimeNotificationAction(
-                context="Test action",
-                recipient_user_id="agent-1",
-                sender_user_id="owner-1",
-                sender_source="workflow",
-                event_type="test.event",
-                notification_type="test",
-                content="Action happened.",
-            ),
-            RuntimeNotificationAction(
-                context="Test action",
+            _action(),
+            _action(
                 recipient_user_id="owner-1",
-                sender_user_id="owner-1",
-                sender_source="workflow",
-                event_type="test.event",
-                notification_type="test",
-                content="Action happened.",
             ),
         ],
         user_repo=_users(),
         thread_repo=_thread_repo(),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
     )
 
     assert dispatched_count == 1
@@ -128,35 +121,15 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
 
 @pytest.mark.asyncio
 async def test_runtime_notification_action_dispatcher_binds_runtime_dependencies() -> None:
-    class RecordingGateway:
-        def __init__(self) -> None:
-            self.envelopes = []
-
-        async def dispatch_notification(self, envelope):
-            self.envelopes.append(envelope)
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
+    gateway = _RecordingGateway()
     dispatch_actions = runtime_notification_action_dispatcher(
         _runtime_app(gateway),
         user_repo=_users(),
         thread_repo=_thread_repo(),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
     )
 
-    dispatched_count = await dispatch_actions(
-        [
-            RuntimeNotificationAction(
-                context="Test action",
-                recipient_user_id="agent-1",
-                sender_user_id="owner-1",
-                sender_source="workflow",
-                event_type="test.event",
-                notification_type="test",
-                content="Action happened.",
-            )
-        ]
-    )
+    dispatched_count = await dispatch_actions([_action()])
 
     assert dispatched_count == 1
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
@@ -164,28 +137,10 @@ async def test_runtime_notification_action_dispatcher_binds_runtime_dependencies
 
 @pytest.mark.asyncio
 async def test_runtime_notification_event_and_hook_plan_and_dispatch_actions() -> None:
-    class RecordingGateway:
-        def __init__(self) -> None:
-            self.envelopes = []
-
-        async def dispatch_notification(self, envelope):
-            self.envelopes.append(envelope)
-            return SimpleNamespace(status="accepted", thread_id=envelope.recipient.thread_id)
-
-    gateway = RecordingGateway()
+    gateway = _RecordingGateway()
 
     def planner(value: str) -> list[RuntimeNotificationAction]:
-        return [
-            RuntimeNotificationAction(
-                context="Test hook",
-                recipient_user_id="agent-1",
-                sender_user_id="owner-1",
-                sender_source="workflow",
-                event_type="test.event",
-                notification_type="test",
-                content=f"Action {value}.",
-            )
-        ]
+        return [_action(context="Test hook", content=f"Action {value}.")]
 
     dispatched_count = await dispatch_runtime_notification_event(
         _runtime_app(gateway),
@@ -193,7 +148,7 @@ async def test_runtime_notification_event_and_hook_plan_and_dispatch_actions() -
         planner,
         user_repo=_users(),
         thread_repo=_thread_repo(),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
     )
 
     assert dispatched_count == 1
@@ -205,7 +160,7 @@ async def test_runtime_notification_event_and_hook_plan_and_dispatch_actions() -
         planner,
         user_repo=_users(),
         thread_repo=_thread_repo(),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
     )
 
     await asyncio.to_thread(hook, "event-2")


### PR DESCRIPTION
## Summary
- add a thread input inlet so HTTP thread routes no longer import runtime thread-input action plumbing directly
- keep owner/internal dispatch and queued steer/command behavior unchanged
- trim repeated runtime notification/inbox test fixtures in a separate semantic commit

## Verification
- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` failed before implementation because `threads.py` imported `runtime_thread_input_action`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py -q`
- `uv run pyright backend/threads/chat_adapters/thread_input_inlet.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py`
- `uv run ruff check backend/threads/chat_adapters/thread_input_inlet.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py`
- `uv run ruff format --check backend/threads/chat_adapters/thread_input_inlet.py backend/web/routers/threads.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_relationship_request_notification_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_external_runtime_inbox_handler.py`
- `uv run pytest tests/Unit -q` -> 2237 passed, 3 skipped, 15 warnings
- `git diff --check`
