### PR TITLE
Move thread input requeue behind inlet

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -42,20 +42,6 @@ def dispatch_queued_thread_input_action(queue_manager: Any, action: QueuedThread
     return {"status": "queued", "thread_id": action.thread_id}
 
 
-def requeue_thread_input_item(queue_manager: Any, thread_id: str, item: Any) -> None:
-    queue_manager.enqueue(
-        item.content,
-        thread_id,
-        notification_type=item.notification_type,
-        source=item.source,
-        sender_id=item.sender_id,
-        sender_name=item.sender_name,
-        sender_avatar_url=item.sender_avatar_url,
-        is_steer=item.is_steer,
-        metadata=item.metadata,
-    )
-
-
 def owner_runtime_thread_input_action(
     *,
     thread_id: str,

--- a/backend/threads/chat_adapters/thread_input_inlet.py
+++ b/backend/threads/chat_adapters/thread_input_inlet.py
@@ -65,3 +65,17 @@ def queue_command_thread_input(queue_manager: Any, *, thread_id: str, message: s
         queue_manager,
         queued_command_thread_input_action(thread_id=thread_id, message=message),
     )
+
+
+def requeue_thread_input_item(queue_manager: Any, *, thread_id: str, item: Any) -> None:
+    queue_manager.enqueue(
+        item.content,
+        thread_id,
+        notification_type=item.notification_type,
+        source=item.source,
+        sender_id=item.sender_id,
+        sender_name=item.sender_name,
+        sender_avatar_url=item.sender_avatar_url,
+        is_steer=item.is_steer,
+        metadata=item.metadata,
+    )

--- a/backend/threads/run/cancellation.py
+++ b/backend/threads/run/cancellation.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_thread_input_action import requeue_thread_input_item
+from backend.threads.chat_adapters.thread_input_inlet import requeue_thread_input_item
 from core.runtime.notifications import is_terminal_background_notification
 
 
@@ -115,7 +115,7 @@ async def flush_cancelled_owner_steers(
     await persist_cancelled_owner_steers(agent=agent, config=config, items=owner_steers)
 
     for item in passthrough:
-        requeue_thread_input_item(qm, thread_id, item)
+        requeue_thread_input_item(qm, thread_id=thread_id, item=item)
 
 
 async def emit_queued_terminal_followups(
@@ -130,7 +130,7 @@ async def emit_queued_terminal_followups(
         queued_items = app.state.queue_manager.drain_all(thread_id)
         extra_terminal, passthrough = partition_terminal_followups(queued_items)
         for item in passthrough:
-            requeue_thread_input_item(app.state.queue_manager, thread_id, item)
+            requeue_thread_input_item(app.state.queue_manager, thread_id=thread_id, item=item)
         for item in extra_terminal:
             await emit(
                 {

--- a/backend/threads/run/followups.py
+++ b/backend/threads/run/followups.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_thread_input_action import requeue_thread_input_item
+from backend.threads.chat_adapters.thread_input_inlet import requeue_thread_input_item
 from core.runtime.middleware.monitor import AgentState
 from core.runtime.queue_metadata import queue_item_message_metadata
 
@@ -39,6 +39,6 @@ async def consume_followup_queue(agent: Any, thread_id: str, app: Any) -> None:
         logger.exception("Failed to consume followup queue for thread %s", thread_id)
         if item:
             try:
-                requeue_thread_input_item(app.state.queue_manager, thread_id, item)
+                requeue_thread_input_item(app.state.queue_manager, thread_id=thread_id, item=item)
             except Exception:
                 logger.error("Failed to re-enqueue followup for thread %s — message lost: %.200s", thread_id, item.content)

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -91,6 +91,18 @@ def test_thread_router_does_not_import_runtime_thread_input_actions_directly() -
     assert "runtime_thread_input_action" not in text
 
 
+def test_thread_run_lifecycle_does_not_import_runtime_thread_input_actions_directly() -> None:
+    repo_root = Path(__file__).parents[5]
+    run_files = [
+        repo_root / "backend" / "threads" / "run" / "cancellation.py",
+        repo_root / "backend" / "threads" / "run" / "followups.py",
+    ]
+
+    for path in run_files:
+        text = path.read_text(encoding="utf-8")
+        assert "runtime_thread_input_action" not in text, path
+
+
 def test_runtime_actions_use_shared_actor_builder() -> None:
     repo_root = Path(__file__).parents[5]
     action_files = list((repo_root / "backend" / "threads" / "chat_adapters").glob("runtime_*_action.py"))

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -23,9 +23,9 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     plan_runtime_thread_input_envelope,
     queued_command_thread_input_action,
     queued_thread_input_action,
-    requeue_thread_input_item,
     runtime_thread_input_action_dispatcher,
 )
+from backend.threads.chat_adapters.thread_input_inlet import requeue_thread_input_item
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
 from backend.web.routers import threads as threads_router
 from core.runtime.loop import QueryLoop
@@ -368,7 +368,7 @@ def test_requeue_thread_input_item_preserves_queue_metadata() -> None:
         metadata={"reason": "passthrough"},
     )
 
-    requeue_thread_input_item(queue_manager, "thread-1", item)
+    requeue_thread_input_item(queue_manager, thread_id="thread-1", item=item)
 
     assert enqueued == [
         (


### PR DESCRIPTION
## Summary
- move `requeue_thread_input_item()` from the runtime thread-input action adapter into `thread_input_inlet.py`
- keep cancellation/followup run lifecycle modules from importing runtime action plumbing directly
- preserve queued item metadata on requeue

## Verification
- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` failed before implementation because `cancellation.py` imported `runtime_thread_input_action`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py tests/Unit/backend/thread_runtime/run/test_input_construction.py -q`
- `uv run pyright backend/threads/chat_adapters/runtime_thread_input_action.py backend/threads/chat_adapters/thread_input_inlet.py backend/threads/run/cancellation.py backend/threads/run/followups.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run ruff check backend/threads/chat_adapters/runtime_thread_input_action.py backend/threads/chat_adapters/thread_input_inlet.py backend/threads/run/cancellation.py backend/threads/run/followups.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_thread_input_action.py backend/threads/chat_adapters/thread_input_inlet.py backend/threads/run/cancellation.py backend/threads/run/followups.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run pytest tests/Unit -q` -> 2238 passed, 3 skipped, 15 warnings
- `git diff --check`
