### PR TITLE
Trim unused runtime dispatch helper surface

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -67,22 +67,6 @@ async def dispatch_runtime_chat_delivery_event[EventT](
     )
 
 
-async def dispatch_runtime_chat_delivery_action(
-    app: Any,
-    action: RuntimeChatDeliveryAction,
-    *,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> bool:
-    dispatched_count = await dispatch_runtime_chat_delivery_actions(
-        app,
-        [action],
-        thread_repo=thread_repo,
-        activity_reader=activity_reader,
-    )
-    return dispatched_count > 0
-
-
 async def dispatch_runtime_chat_delivery_actions(
     app: Any,
     actions: Iterable[RuntimeChatDeliveryAction],

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -90,24 +90,6 @@ def runtime_notification_action_dispatcher(
     return dispatch_actions
 
 
-async def dispatch_runtime_notification_action(
-    app: Any,
-    action: RuntimeNotificationAction,
-    *,
-    user_repo: Any,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> bool:
-    dispatched_count = await dispatch_runtime_notification_actions(
-        app,
-        [action],
-        user_repo=user_repo,
-        thread_repo=thread_repo,
-        activity_reader=activity_reader,
-    )
-    return dispatched_count > 0
-
-
 async def dispatch_runtime_notification_actions(
     app: Any,
     actions: Iterable[RuntimeNotificationAction],

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -114,6 +114,14 @@ def test_runtime_actions_use_shared_actor_builder() -> None:
         assert "AgentRuntimeActor" not in text, path
 
 
+def test_runtime_action_adapters_do_not_export_unused_single_dispatch_helpers() -> None:
+    chat_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_chat_delivery_action")
+    notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")
+
+    assert not hasattr(chat_action_module, "dispatch_runtime_chat_delivery_action")
+    assert not hasattr(notification_action_module, "dispatch_runtime_notification_action")
+
+
 def test_runtime_protocol_envelopes_are_constructed_only_at_adapter_boundaries() -> None:
     repo_root = Path(__file__).parents[5]
     backend_files = list((repo_root / "backend").rglob("*.py"))

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -37,6 +37,16 @@ def _user_repo(*users: SimpleNamespace) -> SimpleNamespace:
     return SimpleNamespace(get_by_id=lambda uid: rows.get(uid))
 
 
+def _join_request(requester_user_id: str = "agent-user-1") -> dict[str, str]:
+    return {
+        "id": f"chat_join:chat-1:{requester_user_id}",
+        "chat_id": "chat-1",
+        "requester_user_id": requester_user_id,
+        "state": "rejected",
+        "decided_by_user_id": "owner-1",
+    }
+
+
 class _RecordingGateway:
     def __init__(self) -> None:
         self.envelopes = []
@@ -56,15 +66,7 @@ def test_chat_join_rejection_notification_planner_returns_runtime_action() -> No
     user_repo = _user_repo(_user("owner-1", "human", "Owner"))
     planner = chat_join_inlet.chat_join_rejection_notification_action_planner(user_repo)
 
-    actions = planner(
-        {
-            "id": "chat_join:chat-1:agent-user-1",
-            "chat_id": "chat-1",
-            "requester_user_id": "agent-user-1",
-            "state": "rejected",
-            "decided_by_user_id": "owner-1",
-        }
-    )
+    actions = planner(_join_request())
 
     assert len(actions) == 1
     action = actions[0]
@@ -94,16 +96,7 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
         user_repo=user_repo,
     )
 
-    await asyncio.to_thread(
-        notify,
-        {
-            "id": "chat_join:chat-1:agent-user-1",
-            "chat_id": "chat-1",
-            "requester_user_id": "agent-user-1",
-            "state": "rejected",
-            "decided_by_user_id": "owner-1",
-        },
-    )
+    await asyncio.to_thread(notify, _join_request())
 
     envelope = _only_envelope(gateway)
     assert envelope.recipient.agent_user_id == "agent-user-1"
@@ -134,16 +127,7 @@ async def test_chat_join_rejection_notification_dispatches_runtime_notification_
         user_repo=user_repo,
     )
 
-    await asyncio.to_thread(
-        notify,
-        {
-            "id": "chat_join:chat-1:external-user-1",
-            "chat_id": "chat-1",
-            "requester_user_id": "external-user-1",
-            "state": "rejected",
-            "decided_by_user_id": "owner-1",
-        },
-    )
+    await asyncio.to_thread(notify, _join_request("external-user-1"))
 
     envelope = _only_envelope(gateway)
     assert envelope.recipient.agent_user_id == "external-user-1"
@@ -173,16 +157,7 @@ async def test_chat_join_rejection_notification_skips_agent_wake_when_no_runtime
         user_repo=user_repo,
     )
 
-    await asyncio.to_thread(
-        notify,
-        {
-            "id": "chat_join:chat-1:agent-user-1",
-            "chat_id": "chat-1",
-            "requester_user_id": "agent-user-1",
-            "state": "rejected",
-            "decided_by_user_id": "owner-1",
-        },
-    )
+    await asyncio.to_thread(notify, _join_request())
 
     assert gateway.envelopes == []
 
@@ -198,15 +173,6 @@ async def test_chat_join_rejection_notification_ignores_human_requester() -> Non
         user_repo=user_repo,
     )
 
-    await asyncio.to_thread(
-        notify,
-        {
-            "id": "chat_join:chat-1:human-1",
-            "chat_id": "chat-1",
-            "requester_user_id": "human-1",
-            "state": "rejected",
-            "decided_by_user_id": "owner-1",
-        },
-    )
+    await asyncio.to_thread(notify, _join_request("human-1"))
 
     assert gateway.envelopes == []

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -8,7 +8,6 @@ import pytest
 
 from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
-    dispatch_runtime_notification_action,
     dispatch_runtime_notification_actions,
     dispatch_runtime_notification_event,
     make_runtime_notification_event_hook,
@@ -68,22 +67,24 @@ def _action(**overrides) -> RuntimeNotificationAction:
 async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_recipient() -> None:
     gateway = _RecordingGateway()
 
-    dispatched = await dispatch_runtime_notification_action(
+    dispatched_count = await dispatch_runtime_notification_actions(
         _runtime_app(gateway),
-        _action(
-            metadata={"resource_id": "resource-1"},
-            transport=AgentRuntimeTransport(
-                delivery_id="delivery-1",
-                correlation_id="resource-1",
-                idempotency_key="delivery-1",
+        [
+            _action(
+                metadata={"resource_id": "resource-1"},
+                transport=AgentRuntimeTransport(
+                    delivery_id="delivery-1",
+                    correlation_id="resource-1",
+                    idempotency_key="delivery-1",
+                ),
             ),
-        ),
+        ],
         user_repo=_users(),
         thread_repo=_thread_repo(),
         activity_reader=_activity_reader(),
     )
 
-    assert dispatched is True
+    assert dispatched_count == 1
     assert len(gateway.envelopes) == 1
     envelope = gateway.envelopes[0]
     assert envelope.recipient.agent_user_id == "agent-1"

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -34,6 +34,10 @@ def _change(operation: Literal["created", "updated"] = "created") -> WorkflowEve
     )
 
 
+def _members(*user_ids: str) -> list[dict[str, str]]:
+    return [{"user_id": user_id} for user_id in user_ids]
+
+
 class _RecordingGateway:
     def __init__(self) -> None:
         self.envelopes = []
@@ -45,6 +49,10 @@ class _RecordingGateway:
 
 def _runtime_app(gateway: _RecordingGateway) -> SimpleNamespace:
     return SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+
+def _activity_reader() -> SimpleNamespace:
+    return SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
 
 
 def _users(*agent_ids: str):
@@ -132,17 +140,9 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
 
 
 def test_workflow_event_notification_planner_selects_recipient_actions() -> None:
-    members = [
-        {"user_id": "owner-1"},
-        {"user_id": "agent-1"},
-        {"user_id": "agent-without-thread"},
-        {"user_id": "external-1"},
-        {"user_id": "human-2"},
-    ]
-
     actions = make_workflow_event_notification_actions(
         _change("updated"),
-        members,
+        _members("owner-1", "agent-1", "agent-without-thread", "external-1", "human-2"),
     )
 
     assert [action.recipient_user_id for action in actions] == ["agent-1", "agent-without-thread", "external-1", "human-2"]
@@ -158,7 +158,7 @@ def test_workflow_event_notification_action_planner_reads_chat_members() -> None
 
     def list_chat_members(chat_id: str) -> list[dict[str, str]]:
         seen_chat_ids.append(chat_id)
-        return [{"user_id": "owner-1"}, {"user_id": "agent-1"}]
+        return _members("owner-1", "agent-1")
 
     planner = workflow_event_notification_action_planner(SimpleNamespace(list_chat_members=list_chat_members))
 
@@ -174,17 +174,17 @@ def test_workflow_event_notification_action_planner_reads_chat_members() -> None
 async def test_workflow_event_notification_fn_selects_runtime_members() -> None:
     gateway = _RecordingGateway()
     messaging_service = SimpleNamespace(
-        list_chat_members=lambda _chat_id: [
-            {"user_id": "owner-1"},
-            {"user_id": "agent-1"},
-            {"user_id": "agent-without-thread"},
-            {"user_id": "external-1"},
-            {"user_id": "human-2"},
-        ]
+        list_chat_members=lambda _chat_id: _members(
+            "owner-1",
+            "agent-1",
+            "agent-without-thread",
+            "external-1",
+            "human-2",
+        )
     )
     notify = make_workflow_event_notification_fn(
         _runtime_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
         thread_repo=_thread_repo("agent-1"),
         user_repo=_users("agent-1", "agent-without-thread"),
         messaging_service=messaging_service,
@@ -205,10 +205,10 @@ async def test_workflow_event_notification_fn_selects_runtime_members() -> None:
 @pytest.mark.asyncio
 async def test_workflow_event_notification_fn_keeps_identity_context() -> None:
     gateway = _RecordingGateway()
-    messaging_service = SimpleNamespace(list_chat_members=lambda _chat_id: [{"user_id": "missing-recipient"}])
+    messaging_service = SimpleNamespace(list_chat_members=lambda _chat_id: _members("missing-recipient"))
     notify = make_workflow_event_notification_fn(
         _runtime_app(gateway),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
         thread_repo=_thread_repo("agent-1"),
         user_repo=_users("agent-1"),
         messaging_service=messaging_service,
@@ -224,10 +224,10 @@ async def test_workflow_event_notification_fn_keeps_identity_context() -> None:
 
 @pytest.mark.asyncio
 async def test_workflow_event_notification_fn_skips_gateway_when_no_runtime_recipients() -> None:
-    messaging_service = SimpleNamespace(list_chat_members=lambda _chat_id: [{"user_id": "owner-1"}, {"user_id": "human-2"}])
+    messaging_service = SimpleNamespace(list_chat_members=lambda _chat_id: _members("owner-1", "human-2"))
     notify = make_workflow_event_notification_fn(
         SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace())),
-        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+        activity_reader=_activity_reader(),
         thread_repo=_thread_repo(),
         user_repo=_users(),
         messaging_service=messaging_service,


### PR DESCRIPTION
## Summary

- trim duplicated notification test fixtures without touching production behavior
- remove unused single-action runtime dispatch helpers for chat delivery and notifications
- add a boundary test keeping runtime action adapter surface small

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` failed before deletion because `dispatch_runtime_chat_delivery_action` was still exported
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q` -> `40 passed`
- `uv run pyright backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py` -> `0 errors`
- `uv run ruff check ...` -> `All checks passed`
- `uv run ruff format --check ...` -> `7 files already formatted`
- `uv run pytest tests/Unit -q` -> `2239 passed, 3 skipped, 15 warnings`
