### PR TITLE
Trim runtime envelope dispatch helper surface

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -74,6 +74,7 @@ async def dispatch_runtime_chat_delivery_actions(
     thread_repo: Any,
     activity_reader: Any,
 ) -> int:
+    gateway = get_agent_runtime_gateway(app)
     dispatched_count = 0
     for action in actions:
         envelope = plan_runtime_chat_delivery_envelope(
@@ -83,7 +84,7 @@ async def dispatch_runtime_chat_delivery_actions(
         )
         if envelope is None:
             continue
-        await dispatch_runtime_chat_delivery_envelopes(app, [envelope])
+        await gateway.dispatch_chat(envelope)
         dispatched_count += 1
     return dispatched_count
 
@@ -103,15 +104,6 @@ def runtime_chat_delivery_action_dispatcher(
         )
 
     return dispatch_actions
-
-
-async def dispatch_runtime_chat_delivery_envelopes(app: Any, envelopes: Iterable[AgentChatDeliveryEnvelope]) -> None:
-    current_envelopes = list(envelopes)
-    if not current_envelopes:
-        return
-    gateway = get_agent_runtime_gateway(app)
-    for envelope in current_envelopes:
-        await gateway.dispatch_chat(envelope)
 
 
 def plan_runtime_chat_delivery_envelope(

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -104,17 +104,11 @@ async def dispatch_runtime_notification_actions(
         thread_repo=thread_repo,
         activity_reader=activity_reader,
     )
-    await dispatch_runtime_notification_envelopes(app, envelopes)
+    if envelopes:
+        gateway = get_agent_runtime_gateway(app)
+        for envelope in envelopes:
+            await gateway.dispatch_notification(envelope)
     return len(envelopes)
-
-
-async def dispatch_runtime_notification_envelopes(app: Any, envelopes: Iterable[AgentRuntimeNotificationEnvelope]) -> None:
-    current_envelopes = list(envelopes)
-    if not current_envelopes:
-        return
-    gateway = get_agent_runtime_gateway(app)
-    for envelope in current_envelopes:
-        await gateway.dispatch_notification(envelope)
 
 
 def plan_runtime_notification_envelopes(

--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
 
@@ -89,23 +89,13 @@ def runtime_thread_input_action_dispatcher(
     app: Any,
 ) -> Callable[[list[RuntimeThreadInputAction]], Coroutine[Any, Any, list[AgentThreadInputResult]]]:
     async def dispatch_actions(actions: list[RuntimeThreadInputAction]) -> list[AgentThreadInputResult]:
-        return await dispatch_runtime_thread_input_envelopes(
-            app,
-            [plan_runtime_thread_input_envelope(action) for action in actions],
-        )
+        gateway = get_agent_runtime_gateway(app)
+        results = []
+        for action in actions:
+            results.append(await gateway.dispatch_thread_input(plan_runtime_thread_input_envelope(action)))
+        return results
 
     return dispatch_actions
-
-
-async def dispatch_runtime_thread_input_envelopes(
-    app: Any,
-    envelopes: Iterable[AgentThreadInputEnvelope],
-) -> list[AgentThreadInputResult]:
-    gateway = get_agent_runtime_gateway(app)
-    results = []
-    for envelope in envelopes:
-        results.append(await gateway.dispatch_thread_input(envelope))
-    return results
 
 
 def plan_runtime_thread_input_envelope(action: RuntimeThreadInputAction) -> AgentThreadInputEnvelope:

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -122,6 +122,16 @@ def test_runtime_action_adapters_do_not_export_unused_single_dispatch_helpers() 
     assert not hasattr(notification_action_module, "dispatch_runtime_notification_action")
 
 
+def test_runtime_action_adapters_do_not_export_envelope_dispatch_helpers() -> None:
+    chat_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_chat_delivery_action")
+    notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")
+    thread_input_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_thread_input_action")
+
+    assert not hasattr(chat_action_module, "dispatch_runtime_chat_delivery_envelopes")
+    assert not hasattr(notification_action_module, "dispatch_runtime_notification_envelopes")
+    assert not hasattr(thread_input_action_module, "dispatch_runtime_thread_input_envelopes")
+
+
 def test_runtime_protocol_envelopes_are_constructed_only_at_adapter_boundaries() -> None:
     repo_root = Path(__file__).parents[5]
     backend_files = list((repo_root / "backend").rglob("*.py"))

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -17,7 +17,6 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     QueuedThreadInputAction,
     RuntimeThreadInputAction,
     dispatch_queued_thread_input_action,
-    dispatch_runtime_thread_input_envelopes,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
     plan_runtime_thread_input_envelope,
@@ -266,33 +265,6 @@ def test_runtime_thread_input_action_plans_runtime_envelope() -> None:
         message=AgentRuntimeMessage(content="hello", attachments=["file-1"]),
         enable_trajectory=True,
     )
-
-
-@pytest.mark.asyncio
-async def test_runtime_thread_input_envelopes_dispatch_through_gateway() -> None:
-    from protocols.agent_runtime import AgentThreadInputResult
-
-    captured: list[Any] = []
-
-    class _Gateway:
-        async def dispatch_thread_input(self, envelope: Any) -> AgentThreadInputResult:
-            captured.append(envelope)
-            return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
-
-    action = internal_runtime_thread_input_action(
-        thread_id="thread-1",
-        user_id="owner-1",
-        message="answer",
-        metadata={"request_id": "req-1"},
-    )
-    envelope = plan_runtime_thread_input_envelope(action)
-
-    await dispatch_runtime_thread_input_envelopes(
-        SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=_Gateway()))),
-        [envelope],
-    )
-
-    assert captured == [envelope]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- remove unused envelope-level dispatch helper exports from runtime action adapters
- keep gateway dispatch inside each adapter action dispatcher
- add a boundary test to keep envelope dispatch helpers internal

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q` failed before implementation because `dispatch_runtime_chat_delivery_envelopes` was still exported
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/integration_contracts/test_threads_router.py -q` -> `65 passed`
- `uv run pyright backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py` -> `0 errors`
- `uv run ruff check backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/integration_contracts/test_threads_router.py` -> `All checks passed`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py` -> `5 files already formatted`
- `uv run pytest tests/Unit -q` -> `2239 passed, 3 skipped, 15 warnings`
