### PR TITLE
Trim notification batch envelope planner

### DIFF
--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -76,27 +76,8 @@ async def dispatch_runtime_notification_actions(
     thread_repo: Any,
     activity_reader: Any,
 ) -> int:
-    envelopes = plan_runtime_notification_envelopes(
-        actions,
-        user_repo=user_repo,
-        thread_repo=thread_repo,
-        activity_reader=activity_reader,
-    )
-    if envelopes:
-        gateway = get_agent_runtime_gateway(app)
-        for envelope in envelopes:
-            await gateway.dispatch_notification(envelope)
-    return len(envelopes)
-
-
-def plan_runtime_notification_envelopes(
-    actions: Iterable[RuntimeNotificationAction],
-    *,
-    user_repo: Any,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> list[AgentRuntimeNotificationEnvelope]:
-    envelopes: list[AgentRuntimeNotificationEnvelope] = []
+    gateway = None
+    dispatched_count = 0
     for action in actions:
         envelope = plan_runtime_notification_envelope(
             action,
@@ -104,9 +85,13 @@ def plan_runtime_notification_envelopes(
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
-        if envelope is not None:
-            envelopes.append(envelope)
-    return envelopes
+        if envelope is None:
+            continue
+        if gateway is None:
+            gateway = get_agent_runtime_gateway(app)
+        await gateway.dispatch_notification(envelope)
+        dispatched_count += 1
+    return dispatched_count
 
 
 def plan_runtime_notification_envelope(

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -132,6 +132,16 @@ def test_runtime_action_adapters_do_not_export_envelope_dispatch_helpers() -> No
     assert not hasattr(thread_input_action_module, "dispatch_runtime_thread_input_envelopes")
 
 
+def test_runtime_action_adapters_do_not_export_batch_envelope_planners() -> None:
+    chat_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_chat_delivery_action")
+    notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")
+    thread_input_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_thread_input_action")
+
+    assert not hasattr(chat_action_module, "plan_runtime_chat_delivery_envelopes")
+    assert not hasattr(notification_action_module, "plan_runtime_notification_envelopes")
+    assert not hasattr(thread_input_action_module, "plan_runtime_thread_input_envelopes")
+
+
 def test_runtime_action_adapters_do_not_export_concrete_event_dispatch_helpers() -> None:
     chat_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_chat_delivery_action")
     notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")


### PR DESCRIPTION
## Summary

- remove the last batch envelope planner helper from runtime action adapters
- dispatch notification actions by planning one envelope at a time and lazily borrowing the runtime gateway only when an envelope exists
- add a boundary test preventing `plan_runtime_*_envelopes` helpers from becoming public adapter surface again

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py::test_workflow_event_notification_fn_skips_gateway_when_no_runtime_recipients tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pyright backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_workflow_event_notification.py`
- `uv run pytest tests/Unit -q`
