### PR TITLE
Trim chat notification dispatcher factories

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -37,13 +37,17 @@ def make_runtime_chat_delivery_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    return RuntimeEventActionRoute(
-        planner=planner,
-        dispatch_actions=runtime_chat_delivery_action_dispatcher(
+    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
+        return await dispatch_runtime_chat_delivery_actions(
             app,
+            actions,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
-        ),
+        )
+
+    return RuntimeEventActionRoute(
+        planner=planner,
+        dispatch_actions=dispatch_actions,
     ).sync_hook()
 
 
@@ -67,23 +71,6 @@ async def dispatch_runtime_chat_delivery_actions(
         await gateway.dispatch_chat(envelope)
         dispatched_count += 1
     return dispatched_count
-
-
-def runtime_chat_delivery_action_dispatcher(
-    app: Any,
-    *,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> Callable[[list[RuntimeChatDeliveryAction]], Coroutine[Any, Any, int]]:
-    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
-        return await dispatch_runtime_chat_delivery_actions(
-            app,
-            actions,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-
-    return dispatch_actions
 
 
 def plan_runtime_chat_delivery_envelope(

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -38,24 +38,6 @@ def make_runtime_notification_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    return RuntimeEventActionRoute(
-        planner=planner,
-        dispatch_actions=runtime_notification_action_dispatcher(
-            app,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        ),
-    ).sync_hook()
-
-
-def runtime_notification_action_dispatcher(
-    app: Any,
-    *,
-    user_repo: Any,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> Callable[[list[RuntimeNotificationAction]], Coroutine[Any, Any, int]]:
     async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> int:
         return await dispatch_runtime_notification_actions(
             app,
@@ -65,7 +47,10 @@ def runtime_notification_action_dispatcher(
             activity_reader=activity_reader,
         )
 
-    return dispatch_actions
+    return RuntimeEventActionRoute(
+        planner=planner,
+        dispatch_actions=dispatch_actions,
+    ).sync_hook()
 
 
 async def dispatch_runtime_notification_actions(

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -152,6 +152,14 @@ def test_runtime_action_adapters_do_not_export_concrete_event_dispatch_helpers()
     assert not hasattr(chat_inlet_module, "dispatch_chat_delivery_event")
 
 
+def test_chat_and_notification_action_adapters_do_not_export_dispatcher_factories() -> None:
+    chat_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_chat_delivery_action")
+    notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")
+
+    assert not hasattr(chat_action_module, "runtime_chat_delivery_action_dispatcher")
+    assert not hasattr(notification_action_module, "runtime_notification_action_dispatcher")
+
+
 def test_runtime_protocol_envelopes_are_constructed_only_at_adapter_boundaries() -> None:
     repo_root = Path(__file__).parents[5]
     backend_files = list((repo_root / "backend").rglob("*.py"))

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -11,7 +11,6 @@ from backend.threads.chat_adapters.runtime_chat_delivery_action import (
     RuntimeChatDeliveryAction,
     dispatch_runtime_chat_delivery_actions,
     plan_runtime_chat_delivery_envelope,
-    runtime_chat_delivery_action_dispatcher,
 )
 from messaging.delivery.dispatcher import ChatDeliveryRequest
 
@@ -164,29 +163,6 @@ async def test_runtime_chat_delivery_actions_dispatches_prior_envelopes_before_l
         )
 
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["external-user-1"]
-
-
-@pytest.mark.asyncio
-async def test_runtime_chat_delivery_action_dispatcher_binds_runtime_dependencies() -> None:
-    class RecordingGateway:
-        def __init__(self) -> None:
-            self.envelopes = []
-
-        async def dispatch_chat(self, envelope):
-            self.envelopes.append(envelope)
-
-    gateway = RecordingGateway()
-    app = _hook_app(gateway)
-    dispatch_actions = runtime_chat_delivery_action_dispatcher(
-        app,
-        thread_repo=app.state.thread_repo,
-        activity_reader=app.state.threads_runtime_state.activity_reader,
-    )
-
-    dispatched_count = await dispatch_actions([_runtime_chat_action()])
-
-    assert dispatched_count == 1
-    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-user-1"]
 
 
 @pytest.mark.asyncio

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -10,7 +10,6 @@ from backend.threads.chat_adapters.runtime_notification_action import (
     RuntimeNotificationAction,
     dispatch_runtime_notification_actions,
     make_runtime_notification_event_hook,
-    runtime_notification_action_dispatcher,
 )
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -114,22 +113,6 @@ async def test_runtime_notification_actions_dispatches_only_runtime_recipients()
         thread_repo=_thread_repo(),
         activity_reader=_activity_reader(),
     )
-
-    assert dispatched_count == 1
-    assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]
-
-
-@pytest.mark.asyncio
-async def test_runtime_notification_action_dispatcher_binds_runtime_dependencies() -> None:
-    gateway = _RecordingGateway()
-    dispatch_actions = runtime_notification_action_dispatcher(
-        _runtime_app(gateway),
-        user_repo=_users(),
-        thread_repo=_thread_repo(),
-        activity_reader=_activity_reader(),
-    )
-
-    dispatched_count = await dispatch_actions([_action()])
 
     assert dispatched_count == 1
     assert [envelope.recipient.agent_user_id for envelope in gateway.envelopes] == ["agent-1"]


### PR DESCRIPTION
## Summary

- remove chat/notification runtime action dispatcher factory exports now that `RuntimeEventActionRoute` owns event routing
- inline the dispatch closures into the hook builders that create route instances
- keep `dispatch_runtime_*_actions()` as the action batch execution surface and leave thread-input dispatcher untouched

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
- `uv run pyright backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py`
- `uv run pytest tests/Unit -q`
