### PR TITLE
Trim thread input dispatcher factory

### DIFF
--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
 
@@ -81,21 +80,8 @@ def internal_runtime_thread_input_action(
 
 
 async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction) -> AgentThreadInputResult:
-    results = await runtime_thread_input_action_dispatcher(app)([action])
-    return results[0]
-
-
-def runtime_thread_input_action_dispatcher(
-    app: Any,
-) -> Callable[[list[RuntimeThreadInputAction]], Coroutine[Any, Any, list[AgentThreadInputResult]]]:
-    async def dispatch_actions(actions: list[RuntimeThreadInputAction]) -> list[AgentThreadInputResult]:
-        gateway = get_agent_runtime_gateway(app)
-        results = []
-        for action in actions:
-            results.append(await gateway.dispatch_thread_input(plan_runtime_thread_input_envelope(action)))
-        return results
-
-    return dispatch_actions
+    gateway = get_agent_runtime_gateway(app)
+    return await gateway.dispatch_thread_input(plan_runtime_thread_input_envelope(action))
 
 
 def plan_runtime_thread_input_envelope(action: RuntimeThreadInputAction) -> AgentThreadInputEnvelope:

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -152,12 +152,14 @@ def test_runtime_action_adapters_do_not_export_concrete_event_dispatch_helpers()
     assert not hasattr(chat_inlet_module, "dispatch_chat_delivery_event")
 
 
-def test_chat_and_notification_action_adapters_do_not_export_dispatcher_factories() -> None:
+def test_runtime_action_adapters_do_not_export_dispatcher_factories() -> None:
     chat_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_chat_delivery_action")
     notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")
+    thread_input_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_thread_input_action")
 
     assert not hasattr(chat_action_module, "runtime_chat_delivery_action_dispatcher")
     assert not hasattr(notification_action_module, "runtime_notification_action_dispatcher")
+    assert not hasattr(thread_input_action_module, "runtime_thread_input_action_dispatcher")
 
 
 def test_runtime_protocol_envelopes_are_constructed_only_at_adapter_boundaries() -> None:

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -22,7 +22,6 @@ from backend.threads.chat_adapters.runtime_thread_input_action import (
     plan_runtime_thread_input_envelope,
     queued_command_thread_input_action,
     queued_thread_input_action,
-    runtime_thread_input_action_dispatcher,
 )
 from backend.threads.chat_adapters.thread_input_inlet import requeue_thread_input_item
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest
@@ -265,33 +264,6 @@ def test_runtime_thread_input_action_plans_runtime_envelope() -> None:
         message=AgentRuntimeMessage(content="hello", attachments=["file-1"]),
         enable_trajectory=True,
     )
-
-
-@pytest.mark.asyncio
-async def test_runtime_thread_input_action_dispatcher_binds_runtime_gateway() -> None:
-    from protocols.agent_runtime import AgentThreadInputResult
-
-    captured: list[Any] = []
-
-    class _Gateway:
-        async def dispatch_thread_input(self, envelope: Any) -> AgentThreadInputResult:
-            captured.append(envelope)
-            return AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
-
-    action = internal_runtime_thread_input_action(
-        thread_id="thread-1",
-        user_id="owner-1",
-        message="answer",
-        metadata={"request_id": "req-1"},
-    )
-    dispatch_actions = runtime_thread_input_action_dispatcher(
-        SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=_Gateway()))),
-    )
-
-    results = await dispatch_actions([action])
-
-    assert [result.to_response() for result in results] == [{"status": "started", "routing": "direct", "thread_id": "thread-1"}]
-    assert captured == [plan_runtime_thread_input_envelope(action)]
 
 
 def test_queued_thread_input_action_enqueues_steer_message() -> None:


### PR DESCRIPTION
## Summary

- remove the final `runtime_*_action_dispatcher` factory from thread input
- dispatch single thread input actions directly through the planned envelope and runtime gateway
- extend the boundary test so runtime action adapters do not export dispatcher factories

## Verification

- RED: `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run pyright backend/threads/chat_adapters/runtime_thread_input_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/integration_contracts/test_threads_router.py`
- `uv run pytest tests/Unit -q`
