### PR TITLE
Borrow chat delivery gateway lazily

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -58,7 +58,7 @@ async def dispatch_runtime_chat_delivery_actions(
     thread_repo: Any,
     activity_reader: Any,
 ) -> int:
-    gateway = get_agent_runtime_gateway(app)
+    gateway = None
     dispatched_count = 0
     for action in actions:
         envelope = plan_runtime_chat_delivery_envelope(
@@ -68,6 +68,8 @@ async def dispatch_runtime_chat_delivery_actions(
         )
         if envelope is None:
             continue
+        if gateway is None:
+            gateway = get_agent_runtime_gateway(app)
         await gateway.dispatch_chat(envelope)
         dispatched_count += 1
     return dispatched_count

--- a/tests/Unit/backend/web/services/test_chat_delivery_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_delivery_hook.py
@@ -270,6 +270,21 @@ async def test_chat_delivery_hook_skips_agent_wake_when_no_runtime_thread() -> N
 
 
 @pytest.mark.asyncio
+async def test_chat_delivery_actions_skip_without_borrowing_gateway_when_no_runtime_thread() -> None:
+    app_without_gateway = SimpleNamespace(state=SimpleNamespace())
+    thread_repo = SimpleNamespace(get_by_user_id=lambda _uid: None, list_by_agent_user=lambda _uid: [])
+
+    dispatched_count = await dispatch_runtime_chat_delivery_actions(
+        app_without_gateway,
+        [_runtime_chat_action()],
+        thread_repo=thread_repo,
+        activity_reader=SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: []),
+    )
+
+    assert dispatched_count == 0
+
+
+@pytest.mark.asyncio
 async def test_chat_delivery_hook_routes_external_user_to_external_runtime_without_thread() -> None:
     class RecordingGateway:
         envelope = None


### PR DESCRIPTION
## Summary

- borrow the chat delivery runtime gateway only after an action plans to a dispatchable envelope
- add regression coverage for the no-runtime-thread path not requiring gateway state

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pyright backend/threads/chat_adapters/runtime_chat_delivery_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py`
- `uv run pytest tests/Unit -q`
