### PR TITLE
Accept runtime inbox websocket bearer subprotocol

### DIFF
--- a/backend/chat/api/http/runtime_inbox_router.py
+++ b/backend/chat/api/http/runtime_inbox_router.py
@@ -130,7 +130,8 @@ def _runtime_inbox_parts_for_websocket(websocket: WebSocket) -> tuple[Any, Any, 
 
 async def _websocket_user_id(websocket: WebSocket) -> str:
     authorization = str(websocket.headers.get("authorization") or "")
-    token = _authorization_bearer_token(authorization)
+    protocol = str(websocket.headers.get("sec-websocket-protocol") or "")
+    token = _authorization_bearer_token(authorization) or _subprotocol_bearer_token(protocol)
     if not token:
         raise RuntimeError("Missing runtime inbox websocket bearer token")
     auth_service = getattr(getattr(websocket.app.state, "auth_runtime_state", None), "auth_service", None)
@@ -152,6 +153,14 @@ def _authorization_bearer_token(authorization: str) -> str | None:
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() == "bearer" and token:
         return token
+    return None
+
+
+def _subprotocol_bearer_token(protocol: str) -> str | None:
+    for value in protocol.split(","):
+        candidate = value.strip()
+        if candidate.startswith("bearer.") and len(candidate) > len("bearer."):
+            return candidate[len("bearer.") :]
     return None
 
 

--- a/tests/Unit/backend/web/services/test_runtime_inbox_router.py
+++ b/tests/Unit/backend/web/services/test_runtime_inbox_router.py
@@ -588,6 +588,29 @@ def test_runtime_inbox_websocket_streams_existing_queue_item_on_subscribe(tmp_pa
     }
 
 
+def test_runtime_inbox_websocket_accepts_bearer_subprotocol_token(tmp_path) -> None:
+    app, queue_manager, _wake_bus = _runtime_ws_test_app("external-user-1", tmp_path)
+    queue_manager.enqueue(
+        '{"event_type":"relationship.requested","summary":"Human requested contact."}',
+        "external:external-user-1",
+        notification_type="relationship",
+        source="external",
+        sender_id="human-user-1",
+        sender_name="Human",
+        wake=False,
+    )
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/api/runtime/inbox/subscribe",
+            subprotocols=["bearer.tok-1"],
+        ) as websocket:
+            frame = websocket.receive_json()
+
+    assert frame["type"] == "notify"
+    assert frame["metadata"]["event_type"] == "relationship.requested"
+
+
 def test_runtime_inbox_websocket_replays_after_resume(tmp_path) -> None:
     app, queue_manager, wake_bus = _runtime_ws_test_app("external-user-1", tmp_path)
 


### PR DESCRIPTION
## Summary
- accept `Sec-WebSocket-Protocol: bearer.<token>` auth for runtime inbox WebSocket subscribe
- keep `Authorization: Bearer ...` as the first auth source
- add WebSocket coverage for browser-style subprotocol auth receiving queued runtime inbox state

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_runtime_inbox_router.py -q`
- `uv run ruff check backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py`
- `uv run ruff format --check backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py`
- `uv run pyright backend/chat/api/http/runtime_inbox_router.py tests/Unit/backend/web/services/test_runtime_inbox_router.py`
- `uv run pytest tests/Unit -q`
