### PR TITLE
Privatize sync runtime event hook helper

### DIFF
--- a/backend/threads/chat_adapters/runtime_event_action_route.py
+++ b/backend/threads/chat_adapters/runtime_event_action_route.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 
-def make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:
+def _make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:
     loop = asyncio.get_running_loop()
 
     def hook(*args: P.args, **kwargs: P.kwargs) -> None:
@@ -35,4 +35,4 @@ class RuntimeEventActionRoute[EventT, ActionT, ResultT]:
         async def dispatch_event(event: EventT) -> None:
             await self.dispatch(event)
 
-        return make_sync_runtime_event_hook(dispatch_event)
+        return _make_sync_runtime_event_hook(dispatch_event)

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -167,6 +167,12 @@ def test_runtime_event_action_route_is_not_published_from_hook_module() -> None:
     assert importlib.util.find_spec("backend.threads.chat_adapters.runtime_event_hook") is None
 
 
+def test_runtime_event_action_route_does_not_export_sync_hook_helper() -> None:
+    route_module = importlib.import_module("backend.threads.chat_adapters.runtime_event_action_route")
+
+    assert not hasattr(route_module, "make_sync_runtime_event_hook")
+
+
 def test_runtime_protocol_envelopes_are_constructed_only_at_adapter_boundaries() -> None:
     repo_root = Path(__file__).parents[5]
     backend_files = list((repo_root / "backend").rglob("*.py"))

--- a/tests/Unit/backend/web/services/test_runtime_event_action_route.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_action_route.py
@@ -4,24 +4,7 @@ import asyncio
 
 import pytest
 
-from backend.threads.chat_adapters.runtime_event_action_route import (
-    RuntimeEventActionRoute,
-    make_sync_runtime_event_hook,
-)
-
-
-@pytest.mark.asyncio
-async def test_sync_runtime_event_hook_runs_coroutine_from_worker_thread() -> None:
-    calls: list[str] = []
-
-    async def record(value: str) -> None:
-        calls.append(value)
-
-    hook = make_sync_runtime_event_hook(record)
-
-    await asyncio.to_thread(hook, "ok")
-
-    assert calls == ["ok"]
+from backend.threads.chat_adapters.runtime_event_action_route import RuntimeEventActionRoute
 
 
 @pytest.mark.asyncio
@@ -61,13 +44,16 @@ async def test_runtime_event_action_route_sync_hook_runs_from_worker_thread() ->
 
 
 @pytest.mark.asyncio
-async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> None:
-    async def noop() -> None:
+async def test_runtime_event_action_route_sync_hook_fails_loudly_on_owner_loop_thread() -> None:
+    def planner(value: str) -> list[str]:
+        return [value]
+
+    async def dispatch_actions(_actions: list[str]) -> None:
         return None
 
-    hook = make_sync_runtime_event_hook(noop)
+    hook = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions).sync_hook()
 
     with pytest.raises(RuntimeError) as exc:
-        hook()
+        hook("event-1")
 
     assert str(exc.value) == "Sync runtime event hook cannot run on its owner event loop thread"


### PR DESCRIPTION
## Summary
- make the sync runtime event hook helper private
- keep `RuntimeEventActionRoute.sync_hook()` as the only public sync hook surface
- update tests to exercise the route surface and prevent the helper from reappearing publicly

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py::test_runtime_event_action_route_does_not_export_sync_hook_helper tests/Unit/backend/web/services/test_runtime_event_action_route.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_action_route.py tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_action_route.py tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pyright backend/threads/chat_adapters/runtime_event_action_route.py tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pytest tests/Unit -q`
