### PR TITLE
Inline runtime event sync hook

### DIFF
--- a/backend/threads/chat_adapters/runtime_event_action_route.py
+++ b/backend/threads/chat_adapters/runtime_event_action_route.py
@@ -6,22 +6,6 @@ from dataclasses import dataclass
 from typing import Any
 
 
-def _make_sync_runtime_event_hook[**P](async_fn: Callable[P, Coroutine[Any, Any, Any]]) -> Callable[P, None]:
-    loop = asyncio.get_running_loop()
-
-    def hook(*args: P.args, **kwargs: P.kwargs) -> None:
-        try:
-            current_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            current_loop = None
-        if current_loop is loop:
-            raise RuntimeError("Sync runtime event hook cannot run on its owner event loop thread")
-        future = asyncio.run_coroutine_threadsafe(async_fn(*args, **kwargs), loop)
-        future.result()
-
-    return hook
-
-
 @dataclass(frozen=True)
 class RuntimeEventActionRoute[EventT, ActionT, ResultT]:
     planner: Callable[[EventT], Iterable[ActionT]]
@@ -32,7 +16,19 @@ class RuntimeEventActionRoute[EventT, ActionT, ResultT]:
         return await self.dispatch_actions(actions)
 
     def sync_hook(self) -> Callable[[EventT], None]:
+        loop = asyncio.get_running_loop()
+
         async def dispatch_event(event: EventT) -> None:
             await self.dispatch(event)
 
-        return _make_sync_runtime_event_hook(dispatch_event)
+        def hook(event: EventT) -> None:
+            try:
+                current_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                current_loop = None
+            if current_loop is loop:
+                raise RuntimeError("Sync runtime event hook cannot run on its owner event loop thread")
+            future = asyncio.run_coroutine_threadsafe(dispatch_event(event), loop)
+            future.result()
+
+        return hook

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -171,6 +171,7 @@ def test_runtime_event_action_route_does_not_export_sync_hook_helper() -> None:
     route_module = importlib.import_module("backend.threads.chat_adapters.runtime_event_action_route")
 
     assert not hasattr(route_module, "make_sync_runtime_event_hook")
+    assert not hasattr(route_module, "_make_sync_runtime_event_hook")
 
 
 def test_runtime_protocol_envelopes_are_constructed_only_at_adapter_boundaries() -> None:


### PR DESCRIPTION
## Summary
- inline the private sync-hook helper into `RuntimeEventActionRoute.sync_hook()`
- keep the route module focused on one primitive instead of a helper plus wrapper
- extend the boundary test so helper-shaped sync hook APIs do not reappear

## Verification
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py::test_runtime_event_action_route_does_not_export_sync_hook_helper tests/Unit/backend/web/services/test_runtime_event_action_route.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_action_route.py tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_action_route.py tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pyright backend/threads/chat_adapters/runtime_event_action_route.py tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pytest tests/Unit -q`
